### PR TITLE
feat(codex): add native GLM parent profile

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -1,6 +1,7 @@
 import {
   EventId,
   ProviderDriverKind,
+  ProviderInstanceId,
   RuntimeTaskId,
   ThreadId,
   type ProviderRuntimeEvent,
@@ -16,6 +17,31 @@ const base = {
 };
 
 describe("runtimeEventToActivities task progress", () => {
+  it("persists modelProvider on typed agent lifecycle rows", () => {
+    const event = {
+      ...base,
+      type: "task.started",
+      eventId: EventId.make("evt-agent-provider"),
+      providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+      payload: {
+        taskId: RuntimeTaskId.make("glm-child-1"),
+        title: "glm_worker_1",
+        role: "researcher",
+        modelProvider: "openrouter",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const [activity] = runtimeEventToActivities(event);
+    expect(activity?.payload).toMatchObject({
+      agentKind: "agent",
+      modelProvider: "openrouter",
+      model: "z-ai/glm-5.3-flash",
+      effort: "max",
+    });
+  });
+
   it("persists usage independently from replaceable activity", () => {
     const taskId = RuntimeTaskId.make("agent-1");
     const usageOnly = {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -336,6 +336,7 @@ function taskLinkageActivityFields(payload: Record<string, unknown>): Record<str
     "agentId",
     "title",
     "role",
+    "modelProvider",
     "model",
     "effort",
     "toolUseId",

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -36,6 +36,10 @@ import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeCodexAdapter } from "../Layers/CodexAdapter.ts";
+import {
+  applyCodexNativeProfileModelCapabilities,
+  codexNativeProfilePolicy,
+} from "../Layers/CodexNativeProfile.ts";
 import { checkCodexProviderStatus, makePendingCodexProvider } from "../Layers/CodexProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
@@ -100,6 +104,7 @@ const withInstanceIdentity =
   }) =>
   (snapshot: ServerProviderDraft): ServerProvider => ({
     ...snapshot,
+    models: applyCodexNativeProfileModelCapabilities(input.instanceId, snapshot.models),
     instanceId: input.instanceId,
     driver: DRIVER_KIND,
     ...(input.displayName ? { displayName: input.displayName } : {}),
@@ -175,7 +180,12 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const checkProvider = modelManifest.refreshInBackground.pipe(
         Effect.andThen(
           Effect.zipWith(
-            checkCodexProviderStatus(effectiveConfig, undefined, processEnv),
+            checkCodexProviderStatus(
+              effectiveConfig,
+              undefined,
+              processEnv,
+              codexNativeProfilePolicy(instanceId) !== undefined,
+            ),
             modelManifest.current,
             (draft, manifest) =>
               stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -6,6 +6,7 @@ import * as NodePath from "node:path";
 import {
   ApprovalRequestId,
   CodexSettings,
+  EnvironmentId,
   EventId,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -37,6 +38,7 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { ProviderAdapterValidationError } from "../Errors.ts";
 import type { CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
@@ -47,6 +49,12 @@ import {
   type CodexThreadSnapshot,
 } from "./CodexSessionRuntime.ts";
 import { makeCodexAdapter } from "./CodexAdapter.ts";
+import {
+  CODEX_GLM53_INSTANCE_ID,
+  CODEX_GLM53_MODEL,
+  CODEX_GLM53_NATIVE_PROFILE,
+  codexNativeProfileLaunchArgs,
+} from "./CodexNativeProfile.ts";
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 // Test-local service tag so the rest of the file can keep using `yield* CodexAdapter`.
@@ -271,6 +279,27 @@ validationLayer("CodexAdapterLive validation", (it) => {
       NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 0);
     }),
   );
+  it.effect("preserves catalog-discovered provider-namespaced models on ordinary Codex", () =>
+    Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-namespaced-model"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("codex"),
+          "z-ai/glm-5.3-flash",
+        ),
+        runtimeMode: "full-access",
+      });
+
+      NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 1);
+      NodeAssert.equal(
+        validationRuntimeFactory.factory.mock.calls[0]?.[0].model,
+        "z-ai/glm-5.3-flash",
+      );
+    }),
+  );
   it.effect("maps codex model options before starting a session", () =>
     Effect.gen(function* () {
       validationRuntimeFactory.factory.mockClear();
@@ -296,6 +325,173 @@ validationLayer("CodexAdapterLive validation", (it) => {
         runtimeMode: "full-access",
       });
     }),
+  );
+});
+
+const GLM_TEST_HOME = "/srv/codex/glm53";
+const glmRuntimeFactory = makeRuntimeFactory();
+const glmLayer = it.layer(
+  Layer.effect(
+    CodexAdapter,
+    Effect.gen(function* () {
+      const codexConfig = decodeCodexSettings({
+        customModels: [CODEX_GLM53_MODEL],
+        homePath: GLM_TEST_HOME,
+      });
+      return yield* makeCodexAdapter(codexConfig, {
+        instanceId: CODEX_GLM53_INSTANCE_ID,
+        makeRuntime: glmRuntimeFactory.factory,
+      });
+    }),
+  ).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(ServerSettingsService.layerTest()),
+    Layer.provideMerge(providerSessionDirectoryTestLayer),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+const invalidGlmHomeRuntimeFactory = makeRuntimeFactory();
+const invalidGlmHomeLayer = it.layer(
+  Layer.effect(
+    CodexAdapter,
+    Effect.gen(function* () {
+      const codexConfig = decodeCodexSettings({
+        customModels: [CODEX_GLM53_MODEL],
+        homePath: "/",
+      });
+      return yield* makeCodexAdapter(codexConfig, {
+        instanceId: CODEX_GLM53_INSTANCE_ID,
+        makeRuntime: invalidGlmHomeRuntimeFactory.factory,
+      });
+    }),
+  ).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(ServerSettingsService.layerTest()),
+    Layer.provideMerge(providerSessionDirectoryTestLayer),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+invalidGlmHomeLayer("CodexAdapterLive invalid GLM home", (it) => {
+  it.effect("returns a typed validation error instead of throwing a launch defect", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const result = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("codex"),
+          threadId: asThreadId("thread-glm-invalid-home"),
+          modelSelection: createModelSelection(CODEX_GLM53_INSTANCE_ID, CODEX_GLM53_MODEL),
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        NodeAssert.equal(result.failure._tag, "ProviderAdapterValidationError");
+        NodeAssert.match(result.failure.issue, /cannot use a filesystem root/);
+      }
+      NodeAssert.equal(invalidGlmHomeRuntimeFactory.factory.mock.calls.length, 0);
+    }),
+  );
+});
+
+glmLayer("CodexAdapterLive GLM native profile", (it) => {
+  it.effect("pins launch capacity and the effective profile before starting the parent", () =>
+    Effect.gen(function* () {
+      glmRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-glm-parent");
+      const selection = createModelSelection(CODEX_GLM53_INSTANCE_ID, CODEX_GLM53_MODEL);
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        modelSelection: selection,
+        runtimeMode: "full-access",
+      });
+      NodeAssert.deepStrictEqual(glmRuntimeFactory.factory.mock.calls[0]?.[0], {
+        binaryPath: "codex",
+        cwd: process.cwd(),
+        launchArgs: yield* codexNativeProfileLaunchArgs(
+          CODEX_GLM53_NATIVE_PROFILE,
+          "",
+          GLM_TEST_HOME,
+        ),
+        homePath: GLM_TEST_HOME,
+        model: CODEX_GLM53_MODEL,
+        providerInstanceId: CODEX_GLM53_INSTANCE_ID,
+        expectedProfile: CODEX_GLM53_NATIVE_PROFILE.effectiveProfile,
+        expectedChildProfile: CODEX_GLM53_NATIVE_PROFILE.authorizedChildProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "use native children",
+        attachments: [],
+        modelSelection: selection,
+      });
+      NodeAssert.deepStrictEqual(glmRuntimeFactory.lastRuntime?.sendTurnImpl.mock.calls[0]?.[0], {
+        input: "use native children",
+        model: CODEX_GLM53_MODEL,
+        effort: "max",
+      });
+
+      const highSelection = createModelSelection(CODEX_GLM53_INSTANCE_ID, CODEX_GLM53_MODEL, [
+        { id: "reasoningEffort", value: "high" },
+      ]);
+      const highThreadId = asThreadId("thread-glm-parent-high");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: highThreadId,
+        modelSelection: highSelection,
+        runtimeMode: "full-access",
+      });
+      NodeAssert.equal(
+        glmRuntimeFactory.factory.mock.calls[1]?.[0].expectedProfile?.reasoningEffort,
+        "high",
+      );
+      yield* adapter.sendTurn({
+        threadId: highThreadId,
+        input: "use a high-effort native child",
+        attachments: [],
+        modelSelection: highSelection,
+      });
+      NodeAssert.equal(
+        glmRuntimeFactory.lastRuntime?.sendTurnImpl.mock.calls[0]?.[0].effort,
+        "high",
+      );
+    }),
+  );
+
+  it.effect("does not inject or advertise T3 MCP credentials for the GLM profile", () =>
+    Effect.gen(function* () {
+      glmRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-glm-no-mcp");
+      McpProviderSession.setMcpProviderSession({
+        environmentId: EnvironmentId.make("local"),
+        threadId,
+        providerSessionId: "provider-session",
+        providerInstanceId: CODEX_GLM53_INSTANCE_ID,
+        endpoint: "http://127.0.0.1:12345/mcp",
+        authorizationHeader: "Bearer test-only-token",
+      });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => McpProviderSession.clearMcpProviderSession(threadId)),
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        modelSelection: createModelSelection(CODEX_GLM53_INSTANCE_ID, CODEX_GLM53_MODEL),
+        runtimeMode: "full-access",
+      });
+      const options = glmRuntimeFactory.factory.mock.calls[0]?.[0];
+      NodeAssert.equal(options?.appServerArgs, undefined);
+      NodeAssert.equal(options?.environment, undefined);
+    }).pipe(Effect.scoped),
   );
 });
 
@@ -557,7 +753,47 @@ function startLifecycleRuntime() {
 }
 
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
-  it.effect("carries child model metadata through every task event", () =>
+  it.effect("maps a typed child profile-proof failure without dropping its provider", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const eventFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 1)).pipe(
+        Effect.forkChild,
+      );
+      yield* runtime.emit({
+        id: asEventId("evt-child-proof-failed"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "collabAgent/profileProofFailed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        payload: {
+          agentThreadId: "native-glm-child-thread",
+          nickname: "glm_research",
+          modelProvider: "openrouter",
+          model: "z-ai/glm-5.3-flash",
+          effort: "max",
+          error: "Codex native child profile proof failed",
+          errorTag: "TimeoutException",
+        },
+      });
+
+      const [event] = Array.from(yield* Fiber.join(eventFiber));
+      NodeAssert.deepStrictEqual(event?.payload, {
+        taskId: "native-glm-child-thread",
+        status: "failed",
+        error: "Codex native child profile proof failed",
+        role: "general-purpose",
+        title: "glm_research",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+        modelProvider: "openrouter",
+        timelineBypass: true,
+      });
+    }),
+  );
+
+  it.effect("carries GLM child metadata and lifecycle through every task event", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();
       const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 10)).pipe(
@@ -567,13 +803,16 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
       const cases = [
         ["collabAgent/started", {}],
         ["collabAgent/activity", { activityKind: "started" }],
+        ["collabAgent/metadataUpdated", {}],
         ["collabAgent/turnStarted", {}],
+        [
+          "collabAgent/statusChanged",
+          { status: { type: "active", activeFlags: ["waitingOnUserInput"] } },
+        ],
         ["collabAgent/turnCompleted", { turn: { status: "completed" } }],
-        ["collabAgent/statusChanged", { status: { type: "active", activeFlags: [] } }],
         ["collabAgent/tokenUsage", { tokenUsage: { total: { totalTokens: 42 } } }],
         ["collabAgent/item", { item: { type: "commandExecution", command: "pwd" } }],
         ["collabAgent/closed", {}],
-        ["collabAgent/metadataUpdated", {}],
       ] as const;
 
       for (const [index, [method, extra]] of cases.entries()) {
@@ -586,10 +825,12 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
           threadId: asThreadId("thread-1"),
           turnId: asTurnId("turn-1"),
           payload: {
-            agentThreadId: "child-model",
-            agentPath: "/root/model-check",
-            model: " gpt-5.6-sol ",
-            effort: " high ",
+            agentThreadId: "native-glm-child-thread",
+            nickname: "glm_research",
+            agentPath: "/root/glm_research",
+            modelProvider: " openrouter ",
+            model: " z-ai/glm-5.3-flash ",
+            effort: " max ",
             ...extra,
           },
         });
@@ -603,7 +844,7 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
         threadId: asThreadId("thread-1"),
         turnId: asTurnId("turn-1"),
         payload: {
-          agentThreadId: "child-model",
+          agentThreadId: "native-glm-child-thread",
           model: "  ",
           effort: "",
         },
@@ -618,20 +859,30 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
           "task.updated",
           "task.updated",
           "task.updated",
-          "task.progress",
-          "task.progress",
           "task.updated",
+          "task.progress",
+          "task.progress",
           "task.updated",
           "task.updated",
         ],
       );
       for (const event of events.slice(0, -1)) {
         const payload = event.payload as Record<string, unknown>;
-        NodeAssert.equal(payload.model, "gpt-5.6-sol");
-        NodeAssert.equal(payload.effort, "high");
+        NodeAssert.equal(payload.taskId, "native-glm-child-thread");
+        NodeAssert.equal(payload.modelProvider, "openrouter");
+        NodeAssert.equal(payload.model, "z-ai/glm-5.3-flash");
+        NodeAssert.equal(payload.effort, "max");
+        NodeAssert.equal(payload.timelineBypass, true);
       }
 
-      const metadataPayload = events[8]?.payload as Record<string, unknown>;
+      NodeAssert.deepStrictEqual(
+        events
+          .filter((event) => event.type === "task.updated" && "status" in event.payload)
+          .map((event) => (event.payload as { readonly status: string }).status),
+        ["running", "waiting", "idle", "interrupted"],
+      );
+
+      const metadataPayload = events[2]?.payload as Record<string, unknown>;
       NodeAssert.equal("status" in metadataPayload, false);
       const blankMetadataPayload = events[9]?.payload as Record<string, unknown>;
       NodeAssert.equal("status" in blankMetadataPayload, false);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -11,6 +11,7 @@ import {
   type CanonicalItemType,
   type CanonicalRequestType,
   type CodexSettings,
+  type ModelSelection,
   ProviderDriverKind,
   type ProviderEvent,
   ProviderInstanceId,
@@ -54,6 +55,7 @@ import {
 import { type CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
+import { isProviderNamespacedModelSlug } from "../providerSnapshot.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
@@ -63,6 +65,13 @@ import {
   type CodexSessionRuntimeOptions,
   type CodexSessionRuntimeShape,
 } from "./CodexSessionRuntime.ts";
+import {
+  codexNativeProfileExpectedParent,
+  codexNativeProfileHomeIssue,
+  codexNativeProfileLaunchArgs,
+  codexNativeProfilePolicy,
+  codexNativeProfileSelectionIssue,
+} from "./CodexNativeProfile.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 import { resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 const isCodexAppServerProcessExitedError = Schema.is(CodexErrors.CodexAppServerProcessExitedError);
@@ -537,6 +546,8 @@ function mapCollabAgentEvent(
   const title = knownName ?? agentThreadId;
   const model = typeof payload.model === "string" ? payload.model.trim() : "";
   const effort = typeof payload.effort === "string" ? payload.effort.trim() : "";
+  const modelProvider =
+    typeof payload.modelProvider === "string" ? payload.modelProvider.trim() : "";
   // Identity repeated on every status patch so rows are self-describing when
   // the start row ages out of activity retention (review finding: a
   // reconstructed agent had a UUID name and no role/path).
@@ -545,6 +556,7 @@ function mapCollabAgentEvent(
     ...(knownName ? { title: knownName } : {}),
     ...(model ? { model } : {}),
     ...(effort ? { effort } : {}),
+    ...(modelProvider ? { modelProvider } : {}),
     ...(agentPath ? { agentPath } : {}),
     timelineBypass: true,
   } as const;
@@ -572,6 +584,23 @@ function mapCollabAgentEvent(
           ...base,
           type: "task.updated",
           payload: { taskId, ...linkage },
+        },
+      ];
+    case "collabAgent/profileMismatch":
+    case "collabAgent/profileProofFailed":
+      return [
+        {
+          ...base,
+          type: "task.updated",
+          payload: {
+            taskId,
+            status: "failed",
+            error:
+              typeof payload.error === "string"
+                ? payload.error
+                : "Native child profile proof failed.",
+            ...linkage,
+          },
         },
       ];
     case "collabAgent/activity": {
@@ -1662,6 +1691,44 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
+  const nativeProfilePolicy = codexNativeProfilePolicy(boundInstanceId);
+  const customModelSlugs = new Set(codexConfig.customModels.map((model) => model.trim()));
+  const validateModelSelection = (
+    operation: "startSession" | "sendTurn",
+    selection: ModelSelection | undefined,
+  ): ProviderAdapterValidationError | undefined => {
+    if (nativeProfilePolicy) {
+      const homeIssue = codexNativeProfileHomeIssue(nativeProfilePolicy, codexConfig.homePath);
+      if (homeIssue) {
+        return new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation,
+          issue: homeIssue,
+        });
+      }
+      const issue = codexNativeProfileSelectionIssue(nativeProfilePolicy, selection);
+      if (issue) {
+        return new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation,
+          issue,
+        });
+      }
+    }
+    if (
+      nativeProfilePolicy === undefined ||
+      selection?.instanceId !== boundInstanceId ||
+      !isProviderNamespacedModelSlug(selection.model) ||
+      customModelSlugs.has(selection.model)
+    ) {
+      return undefined;
+    }
+    return new ProviderAdapterValidationError({
+      provider: PROVIDER,
+      operation,
+      issue: `Provider-namespaced model '${selection.model}' is not configured on instance '${boundInstanceId}'.`,
+    });
+  };
 
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
@@ -1674,6 +1741,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           });
         }
 
+        const modelSelectionError = validateModelSelection("startSession", input.modelSelection);
+        if (modelSelectionError) {
+          return yield* modelSelectionError;
+        }
+
         const existing = sessions.get(input.threadId);
         if (existing && !existing.stopped) {
           yield* Effect.suspend(() => stopSessionInternal(existing));
@@ -1683,19 +1755,50 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           input.modelSelection?.instanceId === boundInstanceId
             ? getCodexServiceTierOptionValue(input.modelSelection)
             : undefined;
-        const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+        // The GLM isolated home intentionally has no T3 MCP credential path.
+        // Do not advertise or inject a bearer token until that path is reviewed.
+        const mcpSession = nativeProfilePolicy
+          ? undefined
+          : McpProviderSession.readMcpProviderSession(input.threadId);
+        const resolvedLaunchArgs = resolveCodexLaunchArgs(
+          codexConfig.launchArgs,
+          options?.environment,
+        );
+        const launchArgs = yield* codexNativeProfileLaunchArgs(
+          nativeProfilePolicy,
+          resolvedLaunchArgs,
+          codexConfig.homePath,
+        ).pipe(
+          Effect.mapError(
+            (error) =>
+              new ProviderAdapterValidationError({
+                provider: PROVIDER,
+                operation: "startSession",
+                issue: error.issue,
+              }),
+          ),
+        );
         const runtimeInput: CodexSessionRuntimeOptions = {
           threadId: input.threadId,
           providerInstanceId: boundInstanceId,
           cwd: input.cwd ?? process.cwd(),
           binaryPath: codexConfig.binaryPath,
-          launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
+          launchArgs,
           ...(options?.environment ? { environment: options.environment } : {}),
           ...(codexConfig.homePath ? { homePath: codexConfig.homePath } : {}),
           ...(isCodexResumeCursorSchema(input.resumeCursor)
             ? { resumeCursor: input.resumeCursor }
             : {}),
           runtimeMode: input.runtimeMode,
+          ...(nativeProfilePolicy
+            ? {
+                expectedProfile: codexNativeProfileExpectedParent(
+                  nativeProfilePolicy,
+                  input.modelSelection,
+                ),
+                expectedChildProfile: nativeProfilePolicy.authorizedChildProfile,
+              }
+            : {}),
           ...(input.modelSelection?.instanceId === boundInstanceId
             ? { model: input.modelSelection.model }
             : {}),
@@ -1822,6 +1925,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   });
 
   const sendTurn: CodexAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
+    const modelSelectionError = validateModelSelection("sendTurn", input.modelSelection);
+    if (modelSelectionError) {
+      return yield* modelSelectionError;
+    }
+
     // Codex ingests images only. Anything else would be base64-encoded as an
     // image and rejected or misread; generic files reach the agent through the
     // path line ProviderService puts in the prompt.
@@ -1834,7 +1942,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     const session = yield* requireSession(input.threadId);
     const reasoningEffort =
       input.modelSelection?.instanceId === boundInstanceId
-        ? getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort")
+        ? (getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort") ??
+          nativeProfilePolicy?.effectiveProfile.reasoningEffort)
         : undefined;
     const serviceTier =
       input.modelSelection?.instanceId === boundInstanceId

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -13,7 +13,12 @@ import * as NodePath from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
-import { type ProviderApprovalDecision, type ProviderEvent, ThreadId } from "@t3tools/contracts";
+import {
+  type ProviderApprovalDecision,
+  type ProviderEvent,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -27,6 +32,16 @@ import { makeCodexSessionRuntime } from "./CodexSessionRuntime.ts";
 const ROOT = wireFixture.rootThreadId;
 const [CHILD_A, CHILD_B] = wireFixture.childThreadIds as [string, string];
 const MEMORY = "memory-consolidation-thread";
+const GLM_PROFILE = {
+  modelProvider: "openrouter",
+  model: "z-ai/glm-5.3-flash",
+  reasoningEffort: "max",
+} as const;
+const GLM_CHILD_PROFILE = {
+  modelProvider: GLM_PROFILE.modelProvider,
+  model: GLM_PROFILE.model,
+  reasoningEfforts: ["high", "max"],
+} as const;
 const decodeMcpElicitationResponse = Schema.decodeUnknownEffect(
   Schema.fromJsonString(
     Schema.Struct({
@@ -129,7 +144,32 @@ function capturedSpawnedThread(childId = CHILD_A) {
   };
 }
 
-function childSettings(threadId: string, model: string, effort: string) {
+function capturedTurnStarted(childId = CHILD_A) {
+  const captured = wireFixture.notifications.find(
+    (entry) =>
+      entry.method === "turn/started" &&
+      (entry.params as { threadId?: string }).threadId === CHILD_A,
+  );
+  assert.isDefined(captured);
+  return {
+    ...captured,
+    params: {
+      ...captured.params,
+      threadId: childId,
+      turn: {
+        ...captured.params.turn,
+        id: `${childId}-turn-profile-proof`,
+      },
+    },
+  };
+}
+
+function childSettings(
+  threadId: string,
+  model: string,
+  effort: string,
+  modelProvider: string | null = "openai",
+) {
   return {
     method: "thread/settings/updated",
     params: {
@@ -141,7 +181,7 @@ function childSettings(threadId: string, model: string, effort: string) {
         cwd: "/workspace/repo",
         effort,
         model,
-        modelProvider: "openai",
+        ...(modelProvider ? { modelProvider } : {}),
         sandboxPolicy: { type: "dangerFullAccess" },
       },
     },
@@ -156,6 +196,26 @@ function readRecordedRequests() {
     .map((line) => JSON.parse(line) as { method: string; params: Record<string, unknown> });
 }
 
+function readRecordedArchives() {
+  const archivePath = `${scriptPath}.archives`;
+  if (!NodeFS.existsSync(archivePath)) return [];
+  return NodeFS.readFileSync(archivePath, "utf8")
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as { threadId: string });
+}
+
+function readRecordedSidecar<T>(suffix: string): ReadonlyArray<T> {
+  const sidecarPath = `${scriptPath}.${suffix}`;
+  if (!NodeFS.existsSync(sidecarPath)) return [];
+  return NodeFS.readFileSync(sidecarPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as T);
+}
+
 const scriptPath = NodePath.join(import.meta.dirname, "../testFixtures/.collab-script.json");
 const peerPath = NodePath.join(import.meta.dirname, "../testFixtures/codexCollabMockPeer.sh");
 
@@ -164,7 +224,13 @@ describe("CodexSessionRuntime collab integration", () => {
     Effect.gen(function* () {
       const script = {
         rootThreadId: ROOT,
+        recordArchives: true,
         recordRequests: true,
+        rootProfile: {
+          modelProvider: "openrouter",
+          model: "z-ai/glm-5.3-flash",
+          reasoningEffort: "max",
+        },
         notifications: [
           capturedStartedActivity(),
           capturedStartedActivity(),
@@ -179,24 +245,37 @@ describe("CodexSessionRuntime collab integration", () => {
           capturedSpawnedThread(ROOT),
         ],
         childResumeSnapshots: {
-          [CHILD_A]: { model: "gpt-5.6-luna", reasoningEffort: "low" },
+          [CHILD_A]: {
+            modelProvider: "openrouter",
+            model: "z-ai/glm-5.3-flash",
+            reasoningEffort: "max",
+          },
         },
       };
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      NodeFS.rmSync(`${scriptPath}.archives`, { force: true });
       NodeFS.rmSync(`${scriptPath}.requests`, { force: true });
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {
           NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(`${scriptPath}.archives`, { force: true });
           NodeFS.rmSync(`${scriptPath}.requests`, { force: true });
         }),
       );
 
       const runtime = yield* makeCodexSessionRuntime({
         threadId: ThreadId.make("thread-collab-model-activity"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
         binaryPath: peerPath,
         cwd: "/tmp",
         runtimeMode: "full-access",
+        model: "z-ai/glm-5.3-flash",
+        expectedProfile: {
+          modelProvider: "openrouter",
+          model: "z-ai/glm-5.3-flash",
+          reasoningEffort: "max",
+        },
         environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
       });
       const metadataFiber = yield* runtime.events.pipe(
@@ -211,14 +290,16 @@ describe("CodexSessionRuntime collab integration", () => {
       );
 
       const session = yield* runtime.start();
-      assert.equal(session.model, "gpt-5.6-sol");
+      assert.equal(session.model, "z-ai/glm-5.3-flash");
       yield* runtime.sendTurn({ input: "start one child" });
       const metadataEvents = Array.from(yield* Fiber.join(metadataFiber));
       assert.deepInclude(metadataEvents[0]?.payload, {
         agentThreadId: CHILD_A,
-        model: "gpt-5.6-luna",
-        effort: "low",
+        modelProvider: "openrouter",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
       });
+      assert.equal(metadataEvents[0]?.providerInstanceId, "codex_glm53");
       assert.deepEqual(readRecordedRequests(), [
         {
           method: "thread/resume",
@@ -334,6 +415,526 @@ describe("CodexSessionRuntime collab integration", () => {
       );
       assert.equal(readRecordedRequests().length, 1);
 
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("fails the parent closed when Codex reports a different effective profile", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [],
+        rootProfile: {
+          modelProvider: "openai",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+        },
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(scriptPath, { force: true })),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-glm-parent-profile-mismatch"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        model: GLM_PROFILE.model,
+        expectedProfile: GLM_PROFILE,
+        expectedChildProfile: GLM_CHILD_PROFILE,
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const result = yield* runtime.start().pipe(Effect.result);
+      if (result._tag !== "Failure") {
+        assert.fail("the mismatched parent profile must fail before the session becomes ready");
+      }
+      assert.equal(result.failure._tag, "CodexSessionRuntimeProfileMismatchError");
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("verifies High and Max from authoritative parent turn readback", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        rootProfile: GLM_PROFILE,
+        notifications: [],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(scriptPath, { force: true })),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-glm-parent-high-max"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        model: GLM_PROFILE.model,
+        expectedProfile: { ...GLM_PROFILE, reasoningEffort: "high" },
+        expectedChildProfile: GLM_CHILD_PROFILE,
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "high turn", effort: "high" });
+      yield* runtime.sendTurn({ input: "max turn", effort: "max" });
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  for (const [name, firstAttempt] of [
+    ["transient error", { error: "profile readback temporarily unavailable" }],
+    ["malformed response", { malformed: true }],
+    ["timed-out response", { hang: true }],
+  ] as const) {
+    it.live(
+      `retries a ${name} while proving the parent turn profile`,
+      () =>
+        Effect.gen(function* () {
+          const script = {
+            rootThreadId: ROOT,
+            rootProfile: GLM_PROFILE,
+            recordRootReadbacks: true,
+            rootTurnReadbackAttempts: [[firstAttempt, {}]],
+            notifications: [],
+          };
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
+          NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+          NodeFS.rmSync(`${scriptPath}.root-readbacks`, { force: true });
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              NodeFS.rmSync(scriptPath, { force: true });
+              NodeFS.rmSync(`${scriptPath}.root-readbacks`, { force: true });
+            }),
+          );
+
+          const runtime = yield* makeCodexSessionRuntime({
+            threadId: ThreadId.make(`thread-glm-parent-${name.replaceAll(" ", "-")}`),
+            providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+            binaryPath: peerPath,
+            cwd: "/tmp",
+            runtimeMode: "full-access",
+            model: GLM_PROFILE.model,
+            expectedProfile: GLM_PROFILE,
+            expectedChildProfile: GLM_CHILD_PROFILE,
+            environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+          });
+
+          yield* runtime.start();
+          yield* runtime.sendTurn({ input: `recover from ${name}`, effort: "max" });
+          assert.lengthOf(
+            readRecordedSidecar<{ turnIndex: number; resumeAttempt: number }>("root-readbacks"),
+            2,
+          );
+          yield* runtime.sendTurn({ input: `continue after ${name}`, effort: "max" });
+          assert.lengthOf(
+            readRecordedSidecar<{ turnIndex: number; resumeAttempt: number }>("root-readbacks"),
+            3,
+          );
+          yield* runtime.close;
+        }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+      { timeout: 10_000 },
+    );
+  }
+
+  it.live(
+    "fails the parent closed after the bounded profile proof window expires",
+    () =>
+      Effect.gen(function* () {
+        const script = {
+          rootThreadId: ROOT,
+          rootProfile: GLM_PROFILE,
+          recordRootReadbacks: true,
+          rootTurnReadbackAttempts: [[{ hang: true }, { hang: true }, { hang: true }]],
+          notifications: [],
+        };
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+        NodeFS.rmSync(`${scriptPath}.root-readbacks`, { force: true });
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            NodeFS.rmSync(scriptPath, { force: true });
+            NodeFS.rmSync(`${scriptPath}.root-readbacks`, { force: true });
+          }),
+        );
+
+        const runtime = yield* makeCodexSessionRuntime({
+          threadId: ThreadId.make("thread-glm-parent-proof-timeout"),
+          providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+          binaryPath: peerPath,
+          cwd: "/tmp",
+          runtimeMode: "full-access",
+          model: GLM_PROFILE.model,
+          expectedProfile: GLM_PROFILE,
+          expectedChildProfile: GLM_CHILD_PROFILE,
+          environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+        });
+
+        yield* runtime.start();
+        const result = yield* runtime
+          .sendTurn({ input: "must not hang without parent proof", effort: "max" })
+          .pipe(Effect.result);
+        assert.equal(result._tag, "Failure");
+        if (result._tag === "Failure") {
+          assert.equal(result.failure._tag, "CodexSessionRuntimeProfileProofError");
+          if (result.failure._tag === "CodexSessionRuntimeProfileProofError") {
+            assert.equal(result.failure.operation, "thread/resume");
+            assert.match(result.failure.causeTag, /Timeout/);
+            assert.ok(result.failure.cause);
+          }
+        }
+        assert.lengthOf(
+          readRecordedSidecar<{ turnIndex: number; resumeAttempt: number }>("root-readbacks"),
+          3,
+        );
+        yield* runtime.close;
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    { timeout: 10_000 },
+  );
+
+  it.effect("returns a typed proof error for persistently malformed parent readback", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        rootProfile: GLM_PROFILE,
+        rootTurnReadbackAttempts: [[{ malformed: true }, { malformed: true }, { malformed: true }]],
+        notifications: [],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(scriptPath, { force: true })),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-glm-parent-proof-malformed"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        model: GLM_PROFILE.model,
+        expectedProfile: GLM_PROFILE,
+        expectedChildProfile: GLM_CHILD_PROFILE,
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+
+      yield* runtime.start();
+      const result = yield* runtime
+        .sendTurn({ input: "reject malformed proof", effort: "max" })
+        .pipe(Effect.result);
+      assert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        assert.equal(result.failure._tag, "CodexSessionRuntimeProfileProofError");
+        if (result.failure._tag === "CodexSessionRuntimeProfileProofError") {
+          assert.equal(result.failure.operation, "thread/resume");
+          assert.equal(result.failure.causeTag, "SchemaError");
+          assert.ok(result.failure.cause);
+        }
+      }
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  for (const [name, readback] of [
+    ["missing", { ...GLM_PROFILE, omitReasoningEffort: true }],
+    ["wrong", { ...GLM_PROFILE, reasoningEffort: "medium" }],
+  ] as const) {
+    it.effect(`fails a parent turn with ${name} authoritative effort`, () =>
+      Effect.gen(function* () {
+        const script = {
+          rootThreadId: ROOT,
+          rootProfile: GLM_PROFILE,
+          rootTurnReadbacks: [readback],
+          notifications: [],
+        };
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => NodeFS.rmSync(scriptPath, { force: true })),
+        );
+
+        const runtime = yield* makeCodexSessionRuntime({
+          threadId: ThreadId.make(`thread-glm-parent-${name}-effort`),
+          providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+          binaryPath: peerPath,
+          cwd: "/tmp",
+          runtimeMode: "full-access",
+          model: GLM_PROFILE.model,
+          expectedProfile: { ...GLM_PROFILE, reasoningEffort: "high" },
+          expectedChildProfile: GLM_CHILD_PROFILE,
+          environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+        });
+
+        yield* runtime.start();
+        const result = yield* runtime
+          .sendTurn({ input: "must verify high", effort: "high" })
+          .pipe(Effect.result);
+        assert.equal(result._tag, "Failure");
+        if (result._tag === "Failure") {
+          assert.equal(result.failure._tag, "CodexSessionRuntimeProfileMismatchError");
+        }
+        yield* runtime.close;
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  it.effect("fails and archives only a child with the wrong provider", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        rootProfile: GLM_PROFILE,
+        recordArchives: true,
+        notifications: [capturedStartedActivity()],
+        childResumeSnapshots: {
+          [CHILD_A]: {
+            ...GLM_PROFILE,
+            modelProvider: "openai",
+          },
+        },
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      NodeFS.rmSync(`${scriptPath}.archives`, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(`${scriptPath}.archives`, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-glm-child-profile-mismatch"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        model: GLM_PROFILE.model,
+        expectedProfile: GLM_PROFILE,
+        expectedChildProfile: GLM_CHILD_PROFILE,
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const mismatchFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "collabAgent/profileMismatch"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "start one child" });
+      const [mismatch] = Array.from(yield* Fiber.join(mismatchFiber));
+      assert.ok(mismatch);
+      assert.deepInclude(mismatch.payload, {
+        agentThreadId: CHILD_A,
+        modelProvider: "openai",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+      });
+      assert.match(
+        (mismatch.payload as { error?: string }).error ?? "",
+        /expected openrouter\/z-ai\/glm-5\.3-flash\/high\|max/,
+      );
+      assert.deepEqual(readRecordedArchives(), [{ threadId: CHILD_A }]);
+      yield* runtime.sendTurn({ input: "parent remains live", effort: "max" });
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("accepts delayed authoritative child metadata after the former one-second cutoff", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        rootProfile: GLM_PROFILE,
+        notifications: [
+          capturedStartedActivity(),
+          childSettings(CHILD_A, GLM_PROFILE.model, "high", null),
+        ],
+        childResumeSnapshots: {
+          [CHILD_A]: { ...GLM_PROFILE, reasoningEffort: "high", delayMs: 1_200 },
+        },
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(scriptPath, { force: true })),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-glm-child-settings-race"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        model: GLM_PROFILE.model,
+        expectedProfile: GLM_PROFILE,
+        expectedChildProfile: GLM_CHILD_PROFILE,
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const firstProfileEventFiber = yield* runtime.events.pipe(
+        Stream.filter(
+          (event) =>
+            event.method === "collabAgent/profileMismatch" ||
+            event.method === "collabAgent/metadataUpdated",
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "start one child" });
+      const [firstProfileEvent] = Array.from(yield* Fiber.join(firstProfileEventFiber));
+      assert.equal(
+        firstProfileEvent?.method,
+        "collabAgent/metadataUpdated",
+        JSON.stringify(firstProfileEvent?.payload),
+      );
+      assert.deepInclude(firstProfileEvent?.payload, {
+        agentThreadId: CHILD_A,
+        modelProvider: "openrouter",
+        model: GLM_PROFILE.model,
+        effort: "high",
+      });
+      // A second turn succeeding proves the provisional notification did
+      // not kill the valid app-server while thread/resume was delayed.
+      yield* runtime.sendTurn({ input: "continue after profile verification" });
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("fails, interrupts, and archives only a persistently unverified native child", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        rootProfile: GLM_PROFILE,
+        recordArchives: true,
+        notifications: [capturedTurnStarted(), capturedStartedActivity()],
+        childResumeSnapshots: { [CHILD_A]: { error: "profile unavailable" } },
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      NodeFS.rmSync(`${scriptPath}.archives`, { force: true });
+      NodeFS.rmSync(`${scriptPath}.interrupts`, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(`${scriptPath}.archives`, { force: true });
+          NodeFS.rmSync(`${scriptPath}.interrupts`, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-glm-child-profile-unavailable"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        model: GLM_PROFILE.model,
+        expectedProfile: GLM_PROFILE,
+        expectedChildProfile: GLM_CHILD_PROFILE,
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const proofFailureFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "collabAgent/profileProofFailed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "start one child" });
+      const [proofFailure] = Array.from(yield* Fiber.join(proofFailureFiber));
+      assert.ok(proofFailure);
+      assert.match(
+        (proofFailure.payload as { error?: string }).error ?? "",
+        /profile proof failed during thread\/resume after bounded retries/,
+      );
+      assert.match((proofFailure.payload as { errorTag?: string }).errorTag ?? "", /RequestError/);
+      assert.deepEqual(readRecordedArchives(), [{ threadId: CHILD_A }]);
+      assert.deepEqual(readRecordedSidecar<{ threadId: string; turnId: string }>("interrupts"), [
+        { threadId: CHILD_A, turnId: `${CHILD_A}-turn-profile-proof` },
+      ]);
+      yield* runtime.sendTurn({ input: "parent remains live after child proof failure" });
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("emits ten inherited GLM child profiles from native v2 events", () =>
+    Effect.gen(function* () {
+      const childIds = Array.from({ length: 10 }, (_, index) => `glm-child-${index + 1}`);
+      const script = {
+        rootThreadId: ROOT,
+        recordRequests: true,
+        rootProfile: GLM_PROFILE,
+        notifications: childIds.map((childId) => capturedStartedActivity(childId)),
+        childResumeSnapshots: Object.fromEntries(
+          childIds.map((childId, index) => [
+            childId,
+            {
+              ...GLM_PROFILE,
+              reasoningEffort: index % 2 === 0 ? "max" : "high",
+              ...(index === 0 ? { transientErrors: 1 } : {}),
+            },
+          ]),
+        ),
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      NodeFS.rmSync(`${scriptPath}.requests`, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(`${scriptPath}.requests`, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-glm-ten-children"),
+        providerInstanceId: ProviderInstanceId.make("codex_glm53"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        model: GLM_PROFILE.model,
+        expectedProfile: GLM_PROFILE,
+        expectedChildProfile: GLM_CHILD_PROFILE,
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const metadataFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "collabAgent/metadataUpdated"),
+        Stream.take(10),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "start ten children" });
+      const metadataEvents = Array.from(yield* Fiber.join(metadataFiber));
+      assert.equal(metadataEvents.length, 10);
+      assert.deepEqual(
+        metadataEvents
+          .map((event) => (event.payload as { agentThreadId: string }).agentThreadId)
+          .toSorted(),
+        childIds.toSorted(),
+      );
+      for (const event of metadataEvents) {
+        const childId = (event.payload as { agentThreadId: string }).agentThreadId;
+        const childNumber = Number(childId.slice("glm-child-".length));
+        assert.equal(event.providerInstanceId, "codex_glm53");
+        assert.deepInclude(event.payload, {
+          modelProvider: "openrouter",
+          model: "z-ai/glm-5.3-flash",
+          effort: childNumber % 2 === 1 ? "max" : "high",
+        });
+      }
+      assert.equal(readRecordedRequests().length, 11);
+      assert.deepEqual(readRecordedArchives(), []);
+      yield* runtime.sendTurn({ input: "all verified siblings remain live", effort: "max" });
       yield* runtime.close;
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );

--- a/apps/server/src/provider/Layers/CodexNativeProfile.test.ts
+++ b/apps/server/src/provider/Layers/CodexNativeProfile.test.ts
@@ -1,0 +1,164 @@
+import * as NodeAssert from "node:assert/strict";
+
+import { createModelSelection } from "@t3tools/shared/model";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { describe, it as vitestIt } from "vite-plus/test";
+
+import { codexAppServerArgs } from "./codexLaunchArgs.ts";
+import {
+  CODEX_GLM53_INSTANCE_ID,
+  CODEX_GLM53_MAX_RESIDENT_THREADS,
+  CODEX_GLM53_MAX_WORKERS,
+  CODEX_GLM53_MODEL,
+  CODEX_GLM53_MODEL_CATALOG_FILENAME,
+  CODEX_GLM53_NATIVE_PROFILE,
+  CODEX_GLM53_REASONING_EFFORTS,
+  applyCodexNativeProfileModelCapabilities,
+  codexNativeProfileCatalogPath,
+  codexNativeProfileExpectedParent,
+  codexNativeProfileHomeIssue,
+  codexNativeProfileLaunchArgs,
+  codexNativeProfileSelectionIssue,
+} from "./CodexNativeProfile.ts";
+
+describe("Codex GLM native profile", () => {
+  const homePath = "/srv/codex/glm53";
+  const catalogPath = `${homePath}/${CODEX_GLM53_MODEL_CATALOG_FILENAME}`;
+
+  it.effect("configures root plus ten resident workers on multi-agent v2", () =>
+    Effect.gen(function* () {
+      const launchArgs = yield* codexNativeProfileLaunchArgs(
+        CODEX_GLM53_NATIVE_PROFILE,
+        "",
+        homePath,
+      );
+      NodeAssert.equal(CODEX_GLM53_MAX_WORKERS, 10);
+      NodeAssert.equal(CODEX_GLM53_MAX_RESIDENT_THREADS, 11);
+      NodeAssert.deepStrictEqual(codexAppServerArgs(launchArgs), [
+        "app-server",
+        "--strict-config",
+        "-c",
+        'features.multi_agent_v2={ enabled = true, tool_namespace = "agents", max_concurrent_threads_per_session = 11, expose_spawn_agent_model_overrides = true }',
+        "-c",
+        'shell_environment_policy={ inherit = "core", ignore_default_excludes = false }',
+        "-c",
+        `model_catalog_json="${catalogPath}"`,
+      ]);
+    }),
+  );
+
+  it.effect(
+    "keeps existing provider-scoped launch arguments while pinning native inheritance",
+    () =>
+      Effect.gen(function* () {
+        const launchArgs = yield* codexNativeProfileLaunchArgs(
+          CODEX_GLM53_NATIVE_PROFILE,
+          '-c model_provider="openrouter"',
+          homePath,
+        );
+        NodeAssert.deepStrictEqual(codexAppServerArgs(launchArgs), [
+          "app-server",
+          "-c",
+          "model_provider=openrouter",
+          "--strict-config",
+          "-c",
+          'features.multi_agent_v2={ enabled = true, tool_namespace = "agents", max_concurrent_threads_per_session = 11, expose_spawn_agent_model_overrides = true }',
+          "-c",
+          'shell_environment_policy={ inherit = "core", ignore_default_excludes = false }',
+          "-c",
+          `model_catalog_json="${catalogPath}"`,
+        ]);
+      }),
+  );
+
+  it.effect("derives and safely quotes the catalog path from a non-Victor home", () =>
+    Effect.gen(function* () {
+      const spacedHome = "/srv/T3 homes/glm'53";
+      const launchArgs = yield* codexNativeProfileLaunchArgs(
+        CODEX_GLM53_NATIVE_PROFILE,
+        "",
+        spacedHome,
+      );
+      NodeAssert.equal(
+        codexNativeProfileCatalogPath(CODEX_GLM53_NATIVE_PROFILE, spacedHome),
+        `/srv/T3 homes/glm'53/${CODEX_GLM53_MODEL_CATALOG_FILENAME}`,
+      );
+      NodeAssert.deepStrictEqual(codexAppServerArgs(launchArgs).slice(-2), [
+        "-c",
+        `model_catalog_json="/srv/T3 homes/glm'53/${CODEX_GLM53_MODEL_CATALOG_FILENAME}"`,
+      ]);
+    }),
+  );
+
+  it.effect("rejects missing, relative, root, and control-character homes", () =>
+    Effect.gen(function* () {
+      for (const unsafeHome of [undefined, "", "relative/home", "/", "/safe\nhome"]) {
+        NodeAssert.ok(codexNativeProfileHomeIssue(CODEX_GLM53_NATIVE_PROFILE, unsafeHome));
+        const result = yield* codexNativeProfileLaunchArgs(
+          CODEX_GLM53_NATIVE_PROFILE,
+          "",
+          unsafeHome,
+        ).pipe(Effect.result);
+        NodeAssert.equal(result._tag, "Failure");
+      }
+    }),
+  );
+
+  vitestIt("accepts only High or Max and resolves the exact selected parent profile", () => {
+    const exact = createModelSelection(CODEX_GLM53_INSTANCE_ID, CODEX_GLM53_MODEL, [
+      { id: "reasoningEffort", value: "max" },
+    ]);
+    NodeAssert.equal(
+      codexNativeProfileSelectionIssue(CODEX_GLM53_NATIVE_PROFILE, exact),
+      undefined,
+    );
+    const high = createModelSelection(CODEX_GLM53_INSTANCE_ID, CODEX_GLM53_MODEL, [
+      { id: "reasoningEffort", value: "high" },
+    ]);
+    NodeAssert.equal(codexNativeProfileSelectionIssue(CODEX_GLM53_NATIVE_PROFILE, high), undefined);
+    NodeAssert.equal(
+      codexNativeProfileExpectedParent(CODEX_GLM53_NATIVE_PROFILE, high).reasoningEffort,
+      "high",
+    );
+    NodeAssert.deepStrictEqual(CODEX_GLM53_REASONING_EFFORTS, ["high", "max"]);
+    NodeAssert.match(
+      codexNativeProfileSelectionIssue(
+        CODEX_GLM53_NATIVE_PROFILE,
+        createModelSelection(CODEX_GLM53_INSTANCE_ID, CODEX_GLM53_MODEL, [
+          { id: "reasoningEffort", value: "medium" },
+        ]),
+      ) ?? "",
+      /requires reasoning effort 'high' or 'max'/,
+    );
+    NodeAssert.match(
+      codexNativeProfileSelectionIssue(
+        CODEX_GLM53_NATIVE_PROFILE,
+        createModelSelection(CODEX_GLM53_INSTANCE_ID, "gpt-5.6-sol"),
+      ) ?? "",
+      /requires model 'z-ai\/glm-5\.3-flash'/,
+    );
+  });
+
+  vitestIt("shows High and Max in the GLM picker with Max as the default", () => {
+    const [model] = applyCodexNativeProfileModelCapabilities(CODEX_GLM53_INSTANCE_ID, [
+      {
+        slug: CODEX_GLM53_MODEL,
+        name: CODEX_GLM53_MODEL,
+        isCustom: true,
+        capabilities: null,
+      },
+    ]);
+    NodeAssert.deepStrictEqual(model?.capabilities?.optionDescriptors, [
+      {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "high", label: "High" },
+          { id: "max", label: "Max", isDefault: true },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/server/src/provider/Layers/CodexNativeProfile.ts
+++ b/apps/server/src/provider/Layers/CodexNativeProfile.ts
@@ -1,0 +1,202 @@
+import * as NodePath from "node:path";
+
+import {
+  type ModelSelection,
+  ProviderInstanceId,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import { createModelCapabilities, getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { expandHomePath } from "../../pathExpansion.ts";
+
+export interface CodexEffectiveProfile {
+  readonly modelProvider: string;
+  readonly model: string;
+  readonly reasoningEffort: string;
+}
+
+export interface CodexAuthorizedChildProfile {
+  readonly modelProvider: string;
+  readonly model: string;
+  readonly reasoningEfforts: ReadonlyArray<string>;
+}
+
+export interface CodexNativeProfilePolicy {
+  readonly instanceId: ProviderInstanceId;
+  readonly effectiveProfile: CodexEffectiveProfile;
+  readonly authorizedChildProfile: CodexAuthorizedChildProfile;
+  readonly maxWorkers: number;
+  readonly maxResidentThreads: number;
+  readonly appServerLaunchArgs: string;
+}
+
+export class CodexNativeProfileConfigurationError extends Schema.TaggedErrorClass<CodexNativeProfileConfigurationError>()(
+  "CodexNativeProfileConfigurationError",
+  {
+    instanceId: ProviderInstanceId,
+    issue: Schema.String,
+  },
+) {
+  override get message(): string {
+    return this.issue;
+  }
+}
+
+export const CODEX_GLM53_INSTANCE_ID = ProviderInstanceId.make("codex_glm53");
+export const CODEX_GLM53_MODEL = "z-ai/glm-5.3-flash";
+export const CODEX_GLM53_MODEL_PROVIDER = "openrouter";
+export const CODEX_GLM53_REASONING_EFFORT = "max";
+export const CODEX_GLM53_REASONING_EFFORTS = ["high", "max"] as const;
+export const CODEX_GLM53_MAX_WORKERS = 10;
+export const CODEX_GLM53_MAX_RESIDENT_THREADS = CODEX_GLM53_MAX_WORKERS + 1;
+export const CODEX_GLM53_MODEL_CATALOG_FILENAME = "glm53-model-catalog.json";
+
+const GLM53_APP_SERVER_LAUNCH_ARGS = `--strict-config -c 'features.multi_agent_v2={ enabled = true, tool_namespace = "agents", max_concurrent_threads_per_session = ${CODEX_GLM53_MAX_RESIDENT_THREADS}, expose_spawn_agent_model_overrides = true }' -c 'shell_environment_policy={ inherit = "core", ignore_default_excludes = false }'`;
+
+export const CODEX_GLM53_NATIVE_PROFILE: CodexNativeProfilePolicy = {
+  instanceId: CODEX_GLM53_INSTANCE_ID,
+  effectiveProfile: {
+    modelProvider: CODEX_GLM53_MODEL_PROVIDER,
+    model: CODEX_GLM53_MODEL,
+    reasoningEffort: CODEX_GLM53_REASONING_EFFORT,
+  },
+  authorizedChildProfile: {
+    modelProvider: CODEX_GLM53_MODEL_PROVIDER,
+    model: CODEX_GLM53_MODEL,
+    reasoningEfforts: CODEX_GLM53_REASONING_EFFORTS,
+  },
+  maxWorkers: CODEX_GLM53_MAX_WORKERS,
+  maxResidentThreads: CODEX_GLM53_MAX_RESIDENT_THREADS,
+  appServerLaunchArgs: GLM53_APP_SERVER_LAUNCH_ARGS,
+};
+
+export function codexNativeProfilePolicy(
+  instanceId: ProviderInstanceId,
+): CodexNativeProfilePolicy | undefined {
+  return instanceId === CODEX_GLM53_INSTANCE_ID ? CODEX_GLM53_NATIVE_PROFILE : undefined;
+}
+
+export function codexNativeProfileSelectionIssue(
+  policy: CodexNativeProfilePolicy,
+  selection: ModelSelection | undefined,
+): string | undefined {
+  if (selection?.instanceId !== policy.instanceId) {
+    return `Instance '${policy.instanceId}' requires its own model selection.`;
+  }
+  if (selection.model !== policy.effectiveProfile.model) {
+    return `Instance '${policy.instanceId}' requires model '${policy.effectiveProfile.model}'.`;
+  }
+  const selectedEffort = getModelSelectionStringOptionValue(selection, "reasoningEffort");
+  if (selectedEffort && !policy.authorizedChildProfile.reasoningEfforts.includes(selectedEffort)) {
+    return `Instance '${policy.instanceId}' requires reasoning effort 'high' or 'max'.`;
+  }
+  return undefined;
+}
+
+export function codexNativeProfileExpectedParent(
+  policy: CodexNativeProfilePolicy,
+  selection: ModelSelection | undefined,
+): CodexEffectiveProfile {
+  return {
+    ...policy.effectiveProfile,
+    reasoningEffort:
+      getModelSelectionStringOptionValue(selection, "reasoningEffort") ??
+      policy.effectiveProfile.reasoningEffort,
+  };
+}
+
+export const codexNativeProfileLaunchArgs = Effect.fn("codexNativeProfileLaunchArgs")(function* (
+  policy: CodexNativeProfilePolicy | undefined,
+  launchArgs: string,
+  homePath?: string,
+): Effect.fn.Return<string, CodexNativeProfileConfigurationError> {
+  if (!policy) return launchArgs;
+  const catalogPath = codexNativeProfileCatalogPath(policy, homePath);
+  if (!catalogPath) {
+    return yield* new CodexNativeProfileConfigurationError({
+      instanceId: policy.instanceId,
+      issue:
+        codexNativeProfileHomeIssue(policy, homePath) ??
+        `Instance '${policy.instanceId}' has an invalid Codex home path.`,
+    });
+  }
+  const catalogConfig = `model_catalog_json=${JSON.stringify(catalogPath)}`;
+  const quotedCatalogConfig = `"${catalogConfig
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("$", "\\$")
+    .replaceAll("`", "\\`")}"`;
+  return [launchArgs.trim(), policy.appServerLaunchArgs, "-c", quotedCatalogConfig]
+    .filter(Boolean)
+    .join(" ");
+});
+
+export function codexNativeProfileHomeIssue(
+  policy: CodexNativeProfilePolicy,
+  homePath?: string,
+): string | undefined {
+  const rawHomePath = homePath?.trim() ?? "";
+  if (!rawHomePath) {
+    return `Instance '${policy.instanceId}' requires a non-empty absolute Codex home path.`;
+  }
+  if (rawHomePath.includes("\0") || rawHomePath.includes("\r") || rawHomePath.includes("\n")) {
+    return `Instance '${policy.instanceId}' has an unsafe Codex home path.`;
+  }
+  const expandedHomePath = expandHomePath(rawHomePath);
+  if (!NodePath.isAbsolute(expandedHomePath)) {
+    return `Instance '${policy.instanceId}' requires an absolute Codex home path.`;
+  }
+  const normalizedHomePath = NodePath.resolve(expandedHomePath);
+  if (normalizedHomePath === NodePath.parse(normalizedHomePath).root) {
+    return `Instance '${policy.instanceId}' cannot use a filesystem root as its Codex home.`;
+  }
+  return undefined;
+}
+
+export function codexNativeProfileCatalogPath(
+  policy: CodexNativeProfilePolicy,
+  homePath?: string,
+): string | undefined {
+  if (codexNativeProfileHomeIssue(policy, homePath)) return undefined;
+  return NodePath.join(
+    NodePath.resolve(expandHomePath(homePath!.trim())),
+    CODEX_GLM53_MODEL_CATALOG_FILENAME,
+  );
+}
+
+export function applyCodexNativeProfileModelCapabilities(
+  instanceId: ProviderInstanceId,
+  models: ReadonlyArray<ServerProviderModel>,
+): ReadonlyArray<ServerProviderModel> {
+  const policy = codexNativeProfilePolicy(instanceId);
+  if (!policy) return models;
+  return models.map((model) =>
+    model.slug === policy.effectiveProfile.model
+      ? {
+          ...model,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              {
+                id: "reasoningEffort",
+                label: "Reasoning",
+                type: "select",
+                options: [
+                  {
+                    id: "high",
+                    label: "High",
+                  },
+                  {
+                    id: policy.effectiveProfile.reasoningEffort,
+                    label: "Max",
+                    isDefault: true,
+                  },
+                ],
+              },
+            ],
+          }),
+        }
+      : model,
+  );
+}

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,11 @@
 import { assert, it } from "@effect/vitest";
+import type { ServerProviderModel } from "@t3tools/contracts";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  scopeCodexModelsToInstance,
+} from "./CodexProvider.ts";
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -134,6 +139,77 @@ it("keeps Codex's own default when no preferred model is available", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+it("preserves ordinary namespaced catalog models but scopes native profiles", () => {
+  const openAiModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    capabilities: null,
+  };
+  const openRouterModel: ServerProviderModel = {
+    slug: "z-ai/glm-5.3-flash",
+    name: "GLM-5.3-Flash",
+    isCustom: false,
+    capabilities: { optionDescriptors: [] },
+  };
+  const catalog = [openAiModel, openRouterModel];
+
+  assert.deepStrictEqual(
+    scopeCodexModelsToInstance(catalog, []).map((model) => model.slug),
+    ["gpt-5.6-sol", "z-ai/glm-5.3-flash"],
+  );
+  assert.deepStrictEqual(scopeCodexModelsToInstance(catalog, [], true), [openAiModel]);
+  assert.deepStrictEqual(scopeCodexModelsToInstance(catalog, ["z-ai/glm-5.3-flash"], true), [
+    openAiModel,
+    {
+      ...openRouterModel,
+      isCustom: true,
+    },
+  ]);
+});
+
+it("does not infer capabilities for custom models absent from the catalog", () => {
+  const catalogModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    capabilities: {
+      optionDescriptors: [
+        {
+          id: "reasoningEffort",
+          label: "Reasoning",
+          type: "select",
+          options: [{ id: "xhigh", label: "xhigh" }],
+        },
+      ],
+    },
+  };
+
+  assert.deepStrictEqual(scopeCodexModelsToInstance([catalogModel], ["z-ai/glm-5.3-flash"]), [
+    catalogModel,
+    {
+      slug: "z-ai/glm-5.3-flash",
+      name: "z-ai/glm-5.3-flash",
+      isCustom: true,
+      capabilities: null,
+    },
+  ]);
+});
+
+it("preserves first-party catalog metadata when a custom slug shadows it", () => {
+  const firstPartyModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    isLegacy: true,
+    capabilities: null,
+  };
+
+  assert.deepStrictEqual(scopeCodexModelsToInstance([firstPartyModel], [firstPartyModel.slug]), [
+    firstPartyModel,
+  ]);
 });
 
 it("ignores custom models that shadow a preferred slug", () => {

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -30,6 +30,7 @@ import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts
 import {
   AUTH_PROBE_TIMEOUT_MS,
   buildServerProvider,
+  isProviderNamespacedModelSlug,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
@@ -224,31 +225,50 @@ export function applyPreferredCodexDefaultModel(
   });
 }
 
-function appendCustomCodexModels(
+/**
+ * Native profiles use isolated homes and an explicit custom-model allowlist,
+ * so a provider-namespaced catalog entry must also be declared there. Ordinary
+ * Codex instances keep catalog-discovered namespaced models for compatibility.
+ */
+export function scopeCodexModelsToInstance(
   models: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
+  restrictProviderNamespacedModels = false,
 ): ReadonlyArray<ServerProviderModel> {
-  if (customModels.length === 0) {
-    return models;
+  const customSlugs = new Set(customModels.map((model) => model.trim()).filter(Boolean));
+  const scopedModels: ServerProviderModel[] = [];
+  const seen = new Set<string>();
+
+  for (const model of models) {
+    if (isProviderNamespacedModelSlug(model.slug)) {
+      if (!restrictProviderNamespacedModels) {
+        scopedModels.push(model);
+        seen.add(model.slug);
+      } else if (customSlugs.has(model.slug)) {
+        const { isLegacy: _isLegacy, ...rest } = model;
+        scopedModels.push({ ...rest, isCustom: true });
+        seen.add(model.slug);
+      }
+      continue;
+    }
+
+    scopedModels.push(model);
+    seen.add(model.slug);
   }
 
-  const seen = new Set(models.map((model) => model.slug));
-  const fallbackCapabilities = models.find((model) => model.capabilities)?.capabilities ?? null;
-  const customEntries: ServerProviderModel[] = [];
-  for (const rawModel of customModels) {
-    const slug = rawModel.trim();
-    if (!slug || seen.has(slug)) {
+  for (const slug of customSlugs) {
+    if (seen.has(slug)) {
       continue;
     }
     seen.add(slug);
-    customEntries.push({
+    scopedModels.push({
       slug,
       name: slug,
       isCustom: true,
-      capabilities: fallbackCapabilities,
+      capabilities: null,
     });
   }
-  return customEntries.length === 0 ? models : [...models, ...customEntries];
+  return scopedModels;
 }
 
 function parseCodexSkillsListResponse(
@@ -324,6 +344,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   readonly launchArgs?: string;
   readonly cwd: string;
   readonly customModels?: ReadonlyArray<string>;
+  readonly restrictProviderNamespacedModels?: boolean;
   readonly environment?: NodeJS.ProcessEnv;
 }) {
   // `~` is not shell-expanded when env vars are set via `child_process.spawn`,
@@ -389,7 +410,11 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     return {
       account: accountResponse,
       version,
-      models: appendCustomCodexModels([], input.customModels ?? []),
+      models: scopeCodexModelsToInstance(
+        [],
+        input.customModels ?? [],
+        input.restrictProviderNamespacedModels,
+      ),
       skills: [],
     } satisfies CodexAppServerProviderSnapshot;
   }
@@ -408,7 +433,11 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     account: accountResponse,
     version,
     models: applyPreferredCodexDefaultModel(
-      appendCustomCodexModels(models, input.customModels ?? []),
+      scopeCodexModelsToInstance(
+        models,
+        input.customModels ?? [],
+        input.restrictProviderNamespacedModels,
+      ),
     ),
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),
   } satisfies CodexAppServerProviderSnapshot;
@@ -507,6 +536,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     readonly launchArgs?: string;
     readonly cwd: string;
     readonly customModels: ReadonlyArray<string>;
+    readonly restrictProviderNamespacedModels?: boolean;
     readonly environment?: NodeJS.ProcessEnv;
   }) => Effect.Effect<
     CodexAppServerProviderSnapshot,
@@ -514,6 +544,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
   > = probeCodexAppServerProvider,
   environment?: NodeJS.ProcessEnv,
+  restrictProviderNamespacedModels = false,
 ): Effect.fn.Return<
   ServerProviderDraft,
   ServerSettingsError,
@@ -546,6 +577,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     launchArgs: resolveCodexLaunchArgs(codexSettings.launchArgs, resolvedEnvironment),
     cwd: process.cwd(),
     customModels: codexSettings.customModels,
+    restrictProviderNamespacedModels,
     environment: resolvedEnvironment,
   }).pipe(
     Effect.scoped,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -17,6 +17,8 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  codexChildProfileMismatch,
+  codexProfileMismatch,
   describeMcpElicitation,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
@@ -39,6 +41,53 @@ describe("CodexSessionRuntimeIdentifierGenerationError", () => {
     NodeAssert.equal(
       error.message,
       "Failed to generate Codex App Server identifier for provider-event.",
+    );
+  });
+});
+
+describe("Codex effective profile verification", () => {
+  const expected = {
+    modelProvider: "openrouter",
+    model: "z-ai/glm-5.3-flash",
+    reasoningEffort: "max",
+  } as const;
+
+  it("accepts only the exact provider, model, and effort", () => {
+    NodeAssert.equal(
+      codexProfileMismatch({ scope: "parent", expected, actual: expected }),
+      undefined,
+    );
+    const mismatch = codexProfileMismatch({
+      scope: "native child 'child-1'",
+      expected,
+      actual: { ...expected, reasoningEffort: "high" },
+    });
+    NodeAssert.equal(mismatch?._tag, "CodexSessionRuntimeProfileMismatchError");
+    NodeAssert.match(mismatch?.message ?? "", /received openrouter\/z-ai\/glm-5\.3-flash\/high/);
+  });
+
+  it("accepts High or Max for native same-model children and rejects other efforts", () => {
+    const childProfile = {
+      modelProvider: expected.modelProvider,
+      model: expected.model,
+      reasoningEfforts: ["high", "max"],
+    } as const;
+    NodeAssert.equal(
+      codexChildProfileMismatch({
+        scope: "native child 'child-1'",
+        expected: childProfile,
+        actual: { ...expected, reasoningEffort: "high" },
+      }),
+      undefined,
+    );
+    const mismatch = codexChildProfileMismatch({
+      scope: "native child 'child-2'",
+      expected: childProfile,
+      actual: { ...expected, reasoningEffort: "medium" },
+    });
+    NodeAssert.match(
+      mismatch?.message ?? "",
+      /expected openrouter\/z-ai\/glm-5\.3-flash\/high\|max/,
     );
   });
 });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -38,6 +38,7 @@ import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import { buildCodexInitializeParams } from "./CodexProvider.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
+import type { CodexAuthorizedChildProfile, CodexEffectiveProfile } from "./CodexNativeProfile.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
 const decodeV2TurnStartResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartResponse);
@@ -139,10 +140,19 @@ const decodeCodexTurnStartParamsWithCollaborationMode = Schema.decodeUnknownEffe
 );
 const CodexChildResumeMetadata = Schema.Struct({
   thread: Schema.Struct({ id: Schema.String }),
-  model: Schema.String,
+  modelProvider: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  model: Schema.optionalKey(Schema.NullOr(Schema.String)),
   reasoningEffort: Schema.optionalKey(Schema.NullOr(Schema.String)),
 });
 const decodeCodexChildResumeMetadata = Schema.decodeUnknownEffect(CodexChildResumeMetadata);
+
+// Profile proof reads are control-plane RPCs against a local app-server. Give
+// each parent read two seconds and each child read three seconds, with two
+// retries. This tolerates one slow or malformed response while bounding the
+// parent blast radius at six seconds and an individual child at nine seconds.
+const CODEX_PARENT_PROFILE_PROOF_ATTEMPT_TIMEOUT = "2 seconds" as const;
+const CODEX_CHILD_PROFILE_PROOF_ATTEMPT_TIMEOUT = "3 seconds" as const;
+const CODEX_PROFILE_PROOF_RETRIES = 2;
 
 export type CodexTurnStartParamsWithCollaborationMode =
   typeof CodexTurnStartParamsWithCollaborationMode.Type;
@@ -166,6 +176,8 @@ export interface CodexSessionRuntimeOptions {
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly resumeCursor?: CodexResumeCursor;
   readonly appServerArgs?: ReadonlyArray<string>;
+  readonly expectedProfile?: CodexEffectiveProfile;
+  readonly expectedChildProfile?: CodexAuthorizedChildProfile;
 }
 
 export interface CodexSessionRuntimeSendTurnInput {
@@ -221,7 +233,152 @@ export type CodexSessionRuntimeError =
   | CodexSessionRuntimePendingApprovalNotFoundError
   | CodexSessionRuntimePendingUserInputNotFoundError
   | CodexSessionRuntimeInvalidUserInputAnswersError
-  | CodexSessionRuntimeThreadIdMissingError;
+  | CodexSessionRuntimeThreadIdMissingError
+  | CodexSessionRuntimeProfileMismatchError
+  | CodexSessionRuntimeProfileProofError;
+
+export class CodexSessionRuntimeProfileProofError extends Schema.TaggedErrorClass<CodexSessionRuntimeProfileProofError>()(
+  "CodexSessionRuntimeProfileProofError",
+  {
+    scope: Schema.String,
+    operation: Schema.String,
+    causeTag: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Codex ${this.scope} profile proof failed during ${this.operation} after bounded retries (${this.causeTag})`;
+  }
+}
+
+function codexProfileProofCauseTag(cause: unknown): string {
+  if (typeof cause === "object" && cause !== null && "_tag" in cause) {
+    const tag = (cause as { readonly _tag?: unknown })._tag;
+    if (typeof tag === "string" && tag.length > 0) return tag;
+  }
+  if (cause instanceof Error && cause.name.length > 0) return cause.name;
+  return "UnknownProfileProofError";
+}
+
+function codexProfileProofError(
+  scope: string,
+  cause: unknown,
+): CodexSessionRuntimeProfileProofError {
+  return new CodexSessionRuntimeProfileProofError({
+    scope,
+    operation: "thread/resume",
+    causeTag: codexProfileProofCauseTag(cause),
+    cause,
+  });
+}
+
+export class CodexSessionRuntimeProfileMismatchError extends Schema.TaggedErrorClass<CodexSessionRuntimeProfileMismatchError>()(
+  "CodexSessionRuntimeProfileMismatchError",
+  {
+    scope: Schema.String,
+    expectedModelProvider: Schema.String,
+    expectedModel: Schema.String,
+    expectedReasoningEffort: Schema.String,
+    actualModelProvider: Schema.String,
+    actualModel: Schema.String,
+    actualReasoningEffort: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Codex ${this.scope} profile mismatch: expected ${this.expectedModelProvider}/${this.expectedModel}/${this.expectedReasoningEffort}, received ${this.actualModelProvider}/${this.actualModel}/${this.actualReasoningEffort}`;
+  }
+}
+
+export function codexProfileMismatch(input: {
+  readonly scope: string;
+  readonly expected: CodexEffectiveProfile;
+  readonly actual: {
+    readonly modelProvider: string | null | undefined;
+    readonly model: string | null | undefined;
+    readonly reasoningEffort: string | null | undefined;
+  };
+}): CodexSessionRuntimeProfileMismatchError | undefined {
+  const actualModelProvider = nonEmptyMetadataValue(input.actual.modelProvider) ?? "<missing>";
+  const actualModel = nonEmptyMetadataValue(input.actual.model) ?? "<missing>";
+  const actualReasoningEffort = nonEmptyMetadataValue(input.actual.reasoningEffort) ?? "<missing>";
+  if (
+    actualModelProvider === input.expected.modelProvider &&
+    actualModel === input.expected.model &&
+    actualReasoningEffort === input.expected.reasoningEffort
+  ) {
+    return undefined;
+  }
+  return new CodexSessionRuntimeProfileMismatchError({
+    scope: input.scope,
+    expectedModelProvider: input.expected.modelProvider,
+    expectedModel: input.expected.model,
+    expectedReasoningEffort: input.expected.reasoningEffort,
+    actualModelProvider,
+    actualModel,
+    actualReasoningEffort,
+  });
+}
+
+export function codexChildProfileMismatch(input: {
+  readonly scope: string;
+  readonly expected: CodexAuthorizedChildProfile;
+  readonly actual: {
+    readonly modelProvider: string | null | undefined;
+    readonly model: string | null | undefined;
+    readonly reasoningEffort: string | null | undefined;
+  };
+}): CodexSessionRuntimeProfileMismatchError | undefined {
+  const actualModelProvider = nonEmptyMetadataValue(input.actual.modelProvider) ?? "<missing>";
+  const actualModel = nonEmptyMetadataValue(input.actual.model) ?? "<missing>";
+  const actualReasoningEffort = nonEmptyMetadataValue(input.actual.reasoningEffort) ?? "<missing>";
+  if (
+    actualModelProvider === input.expected.modelProvider &&
+    actualModel === input.expected.model &&
+    input.expected.reasoningEfforts.includes(actualReasoningEffort)
+  ) {
+    return undefined;
+  }
+  return new CodexSessionRuntimeProfileMismatchError({
+    scope: input.scope,
+    expectedModelProvider: input.expected.modelProvider,
+    expectedModel: input.expected.model,
+    expectedReasoningEffort: input.expected.reasoningEfforts.join("|"),
+    actualModelProvider,
+    actualModel,
+    actualReasoningEffort,
+  });
+}
+
+export function codexParentOpenProfileMismatch(input: {
+  readonly expected: CodexEffectiveProfile;
+  readonly authorizedReasoningEfforts: ReadonlyArray<string>;
+  readonly actual: {
+    readonly modelProvider: string | null | undefined;
+    readonly model: string | null | undefined;
+    readonly reasoningEffort: string | null | undefined;
+  };
+}): CodexSessionRuntimeProfileMismatchError | undefined {
+  const actualModelProvider = nonEmptyMetadataValue(input.actual.modelProvider) ?? "<missing>";
+  const actualModel = nonEmptyMetadataValue(input.actual.model) ?? "<missing>";
+  const actualReasoningEffort = nonEmptyMetadataValue(input.actual.reasoningEffort);
+  if (
+    actualModelProvider === input.expected.modelProvider &&
+    actualModel === input.expected.model &&
+    (actualReasoningEffort === undefined ||
+      input.authorizedReasoningEfforts.includes(actualReasoningEffort))
+  ) {
+    return undefined;
+  }
+  return new CodexSessionRuntimeProfileMismatchError({
+    scope: "parent open",
+    expectedModelProvider: input.expected.modelProvider,
+    expectedModel: input.expected.model,
+    expectedReasoningEffort: input.authorizedReasoningEfforts.join("|"),
+    actualModelProvider,
+    actualModel,
+    actualReasoningEffort: actualReasoningEffort ?? "<missing>",
+  });
+}
 
 export class CodexSessionRuntimePendingApprovalNotFoundError extends Schema.TaggedErrorClass<CodexSessionRuntimePendingApprovalNotFoundError>()(
   "CodexSessionRuntimePendingApprovalNotFoundError",
@@ -913,6 +1070,7 @@ interface CollabChildAgentState {
 }
 
 interface CollabChildMetadataState {
+  readonly modelProvider: string | undefined;
   readonly model: string | undefined;
   readonly effort: string | undefined;
   readonly lookupStarted: boolean;
@@ -928,6 +1086,7 @@ function collabChildIdentity(
     ...(child.nickname ? { nickname: child.nickname } : {}),
     ...(child.role ? { role: child.role } : {}),
     ...(child.agentPath ? { agentPath: child.agentPath } : {}),
+    ...(metadata?.modelProvider ? { modelProvider: metadata.modelProvider } : {}),
     ...(metadata?.model ? { model: metadata.model } : {}),
     ...(metadata?.effort ? { effort: metadata.effort } : {}),
   };
@@ -1206,6 +1365,7 @@ export const makeCodexSessionRuntime = (
             }),
         ),
       );
+    const appServerProcess = child;
 
     const clientContext = yield* CodexClient.layerChildProcess(child).pipe(
       Layer.build,
@@ -1264,32 +1424,45 @@ export const makeCodexSessionRuntime = (
 
     const updateCollabChildMetadata = (
       agentThreadId: string,
-      update: { readonly model?: string; readonly effort?: string },
+      update: {
+        readonly modelProvider?: string;
+        readonly model?: string;
+        readonly effort?: string;
+      },
       overwriteKnown: boolean,
     ) =>
       Ref.modify(collabChildMetadataRef, (current) => {
         const previous = current.get(agentThreadId) ?? {
+          modelProvider: undefined,
           model: undefined,
           effort: undefined,
           lookupStarted: false,
           closed: false,
         };
+        const modelProvider =
+          update.modelProvider && (overwriteKnown || !previous.modelProvider)
+            ? update.modelProvider
+            : previous.modelProvider;
         const model =
           update.model && (overwriteKnown || !previous.model) ? update.model : previous.model;
         const effort =
           update.effort && (overwriteKnown || !previous.effort) ? update.effort : previous.effort;
-        const changed = model !== previous.model || effort !== previous.effort;
+        const changed =
+          modelProvider !== previous.modelProvider ||
+          model !== previous.model ||
+          effort !== previous.effort;
         if (!changed) {
           return [false, current] as const;
         }
         const next = new Map(current);
-        next.set(agentThreadId, { ...previous, model, effort });
+        next.set(agentThreadId, { ...previous, modelProvider, model, effort });
         return [true, next] as const;
       });
 
     const markCollabChildClosed = (agentThreadId: string) =>
       Ref.update(collabChildMetadataRef, (current) => {
         const previous = current.get(agentThreadId) ?? {
+          modelProvider: undefined,
           model: undefined,
           effort: undefined,
           lookupStarted: false,
@@ -1331,11 +1504,107 @@ export const makeCodexSessionRuntime = (
       });
     });
 
+    const terminateUnverifiedCollabChild = Effect.fn(
+      "CodexSessionRuntime.terminateUnverifiedCollabChild",
+    )(function* (agentThreadId: string) {
+      const child = (yield* Ref.get(collabChildAgentsRef)).get(agentThreadId);
+      const metadata = (yield* Ref.get(collabChildMetadataRef)).get(agentThreadId);
+      const liveTurnId = (yield* Ref.get(collabChildLiveTurnsRef)).get(agentThreadId);
+      if (liveTurnId) {
+        yield* client
+          .request("turn/interrupt", { threadId: agentThreadId, turnId: liveTurnId })
+          .pipe(Effect.timeoutOption("1 second"), Effect.ignore);
+      }
+      // thread/archive is the narrow app-server operation addressed to one
+      // thread. It prevents an unverified child from remaining resident while
+      // preserving the parent and verified siblings.
+      yield* client
+        .request("thread/archive", { threadId: agentThreadId })
+        .pipe(Effect.timeoutOption("1 second"), Effect.retry({ times: 1 }), Effect.ignore);
+      yield* markCollabChildClosed(agentThreadId);
+      yield* Ref.update(collabChildLiveTurnsRef, (current) => {
+        const next = new Map(current);
+        next.delete(agentThreadId);
+        return next;
+      });
+      return { child, metadata } as const;
+    });
+
+    const failClosedCollabChildProfile = Effect.fn(
+      "CodexSessionRuntime.failClosedCollabChildProfile",
+    )(function* (
+      agentThreadId: string,
+      actual: {
+        readonly modelProvider?: string;
+        readonly model?: string;
+        readonly effort?: string;
+      },
+      authoritative = true,
+    ) {
+      if (!options.expectedChildProfile) return false;
+      if (!authoritative) {
+        const knownFieldMismatch =
+          (actual.modelProvider !== undefined &&
+            actual.modelProvider !== options.expectedChildProfile.modelProvider) ||
+          (actual.model !== undefined && actual.model !== options.expectedChildProfile.model) ||
+          (actual.effort !== undefined &&
+            !options.expectedChildProfile.reasoningEfforts.includes(actual.effort));
+        const allFieldsPresent =
+          actual.modelProvider !== undefined &&
+          actual.model !== undefined &&
+          actual.effort !== undefined;
+        if (!knownFieldMismatch && !allFieldsPresent) return false;
+      }
+      const mismatch = codexChildProfileMismatch({
+        scope: `native child '${agentThreadId}'`,
+        expected: options.expectedChildProfile,
+        actual: {
+          modelProvider: actual.modelProvider,
+          model: actual.model,
+          reasoningEffort: actual.effort,
+        },
+      });
+      if (!mismatch) return false;
+      const { child, metadata } = yield* terminateUnverifiedCollabChild(agentThreadId);
+      yield* emitEvent({
+        kind: "notification",
+        threadId: options.threadId,
+        ...(child?.spawnTurnId ? { turnId: child.spawnTurnId } : {}),
+        method: "collabAgent/profileMismatch",
+        payload: {
+          ...(child ? collabChildIdentity(child, metadata) : { agentThreadId }),
+          ...actual,
+          error: mismatch.message,
+        },
+      });
+      return true;
+    });
+
+    const failClosedCollabChildProfileProof = Effect.fn(
+      "CodexSessionRuntime.failClosedCollabChildProfileProof",
+    )(function* (agentThreadId: string, cause: unknown) {
+      if (!options.expectedChildProfile) return;
+      const proofError = codexProfileProofError(`native child '${agentThreadId}'`, cause);
+      const { child, metadata } = yield* terminateUnverifiedCollabChild(agentThreadId);
+      yield* emitEvent({
+        kind: "notification",
+        threadId: options.threadId,
+        ...(child?.spawnTurnId ? { turnId: child.spawnTurnId } : {}),
+        method: "collabAgent/profileProofFailed",
+        payload: {
+          ...(child ? collabChildIdentity(child, metadata) : { agentThreadId }),
+          error: proofError.message,
+          errorTag: proofError.causeTag,
+        },
+      });
+    });
+
     const startCollabChildMetadataLookup = Effect.fn(
       "CodexSessionRuntime.startCollabChildMetadataLookup",
     )(function* (agentThreadId: string) {
       const shouldStart = yield* Ref.modify(collabChildMetadataRef, (current) => {
         const previous = current.get(agentThreadId) ?? {
+          modelProvider: undefined,
           model: undefined,
           effort: undefined,
           lookupStarted: false,
@@ -1354,11 +1623,10 @@ export const makeCodexSessionRuntime = (
 
       // The child is already loaded. This rejoins it without starting a turn,
       // and excludeTurns avoids loading or replaying its history.
-      yield* client.raw
+      const lookup = client.raw
         .request("thread/resume", { threadId: agentThreadId, excludeTurns: true })
         .pipe(
           Effect.flatMap(decodeCodexChildResumeMetadata),
-          Effect.timeout("5 seconds"),
           Effect.flatMap((response) =>
             Effect.gen(function* () {
               if (response.thread.id !== agentThreadId) {
@@ -1369,11 +1637,22 @@ export const makeCodexSessionRuntime = (
               if (!child || metadata?.closed) {
                 return;
               }
+              const modelProvider = nonEmptyMetadataValue(response.modelProvider);
               const model = nonEmptyMetadataValue(response.model);
               const effort = nonEmptyMetadataValue(response.reasoningEffort);
+              if (
+                yield* failClosedCollabChildProfile(agentThreadId, {
+                  ...(modelProvider ? { modelProvider } : {}),
+                  ...(model ? { model } : {}),
+                  ...(effort ? { effort } : {}),
+                })
+              ) {
+                return;
+              }
               const changed = yield* updateCollabChildMetadata(
                 agentThreadId,
                 {
+                  ...(modelProvider ? { modelProvider } : {}),
                   ...(model ? { model } : {}),
                   ...(effort ? { effort } : {}),
                 },
@@ -1384,9 +1663,18 @@ export const makeCodexSessionRuntime = (
               }
             }),
           ),
-          Effect.catch(() => Effect.void),
-          Effect.forkIn(runtimeScope),
         );
+      yield* (
+        options.expectedChildProfile
+          ? lookup.pipe(
+              Effect.timeout(CODEX_CHILD_PROFILE_PROOF_ATTEMPT_TIMEOUT),
+              Effect.retry({ times: CODEX_PROFILE_PROOF_RETRIES }),
+            )
+          : lookup.pipe(Effect.timeout("5 seconds"))
+      ).pipe(
+        Effect.catch((cause) => failClosedCollabChildProfileProof(agentThreadId, cause)),
+        Effect.forkIn(runtimeScope),
+      );
     });
 
     const settlePendingApprovals = (decision: ProviderApprovalDecision) =>
@@ -1563,13 +1851,34 @@ export const makeCodexSessionRuntime = (
               ? notification.params.threadSettings.model
               : notification.params.toModel,
           );
+          const previousMetadata = (yield* Ref.get(collabChildMetadataRef)).get(
+            providerConversationId,
+          );
           const effort =
             notification.method === "thread/settings/updated"
               ? nonEmptyMetadataValue(notification.params.threadSettings.effort)
-              : undefined;
+              : previousMetadata?.effort;
+          const modelProvider =
+            notification.method === "thread/settings/updated"
+              ? nonEmptyMetadataValue(notification.params.threadSettings.modelProvider)
+              : previousMetadata?.modelProvider;
+          if (
+            yield* failClosedCollabChildProfile(
+              providerConversationId,
+              {
+                ...(modelProvider ? { modelProvider } : {}),
+                ...(model ? { model } : {}),
+                ...(effort ? { effort } : {}),
+              },
+              false,
+            )
+          ) {
+            return true;
+          }
           const changed = yield* updateCollabChildMetadata(
             providerConversationId,
             {
+              ...(modelProvider ? { modelProvider } : {}),
               ...(model ? { model } : {}),
               ...(effort ? { effort } : {}),
             },
@@ -2246,6 +2555,22 @@ export const makeCodexSessionRuntime = (
       });
 
       const providerThreadId = opened.thread.id;
+      const mismatch = options.expectedProfile
+        ? codexParentOpenProfileMismatch({
+            expected: options.expectedProfile,
+            authorizedReasoningEfforts: options.expectedChildProfile?.reasoningEfforts ?? [
+              options.expectedProfile.reasoningEffort,
+            ],
+            actual: {
+              modelProvider: opened.modelProvider,
+              model: opened.model,
+              reasoningEffort: opened.reasoningEffort,
+            },
+          })
+        : undefined;
+      if (mismatch) {
+        return yield* mismatch;
+      }
       const session = {
         ...(yield* Ref.get(sessionRef)),
         status: "ready",
@@ -2333,6 +2658,52 @@ export const makeCodexSessionRuntime = (
             ),
           );
           const turnId = TurnId.make(response.turn.id);
+          if (options.expectedProfile) {
+            const expectedTurnProfile: CodexEffectiveProfile = {
+              modelProvider: options.expectedProfile.modelProvider,
+              model: normalizedModel ?? options.expectedProfile.model,
+              reasoningEffort: input.effort ?? options.expectedProfile.reasoningEffort,
+            };
+            const readback = yield* client.raw
+              .request("thread/resume", {
+                threadId: providerThreadId,
+                excludeTurns: true,
+              })
+              .pipe(
+                Effect.flatMap(decodeCodexChildResumeMetadata),
+                Effect.timeout(CODEX_PARENT_PROFILE_PROOF_ATTEMPT_TIMEOUT),
+                Effect.retry({ times: CODEX_PROFILE_PROOF_RETRIES }),
+                Effect.result,
+              );
+            if (readback._tag === "Failure") {
+              yield* appServerProcess
+                .kill({ killSignal: "SIGTERM", forceKillAfter: "1 second" })
+                .pipe(Effect.ignore);
+              return yield* codexProfileProofError(`parent turn '${turnId}'`, readback.failure);
+            }
+            const mismatch = codexProfileMismatch({
+              scope: `parent turn '${turnId}'`,
+              expected: expectedTurnProfile,
+              actual:
+                readback.success.thread.id === providerThreadId
+                  ? {
+                      modelProvider: readback.success.modelProvider,
+                      model: readback.success.model,
+                      reasoningEffort: readback.success.reasoningEffort,
+                    }
+                  : {
+                      modelProvider: undefined,
+                      model: undefined,
+                      reasoningEffort: undefined,
+                    },
+            });
+            if (mismatch) {
+              yield* appServerProcess
+                .kill({ killSignal: "SIGTERM", forceKillAfter: "1 second" })
+                .pipe(Effect.ignore);
+              return yield* mismatch;
+            }
+          }
           yield* updateSession(sessionRef, (session) => ({
             status: "running",
             // Codex accepts follow-ups while the current turn is still

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -603,6 +603,85 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ]);
       });
 
+      it("retains ordinary namespaced Codex models on probe failure but isolates GLM", () => {
+        const namespacedModel = {
+          slug: "z-ai/glm-5.3-flash",
+          name: "GLM-5.3-Flash",
+          isCustom: false,
+          capabilities: codexModelCapabilities,
+        } as const;
+        const previousProvider = {
+          instanceId: ProviderInstanceId.make("codex"),
+          driver: ProviderDriverKind.make("codex"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-08-28T00:00:00.000Z",
+          version: "1.0.0",
+          models: [namespacedModel],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const failedRefresh = {
+          ...previousProvider,
+          status: "error",
+          checkedAt: "2026-08-28T00:01:00.000Z",
+          models: [],
+        } as const satisfies ServerProvider;
+
+        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, failedRefresh).models, [
+          namespacedModel,
+        ]);
+
+        const previousGlm = {
+          ...previousProvider,
+          instanceId: ProviderInstanceId.make("codex_glm53"),
+        } satisfies ServerProvider;
+        const failedGlmRefresh = {
+          ...failedRefresh,
+          instanceId: ProviderInstanceId.make("codex_glm53"),
+        } satisfies ServerProvider;
+        assert.deepStrictEqual(mergeProviderSnapshot(previousGlm, failedGlmRefresh).models, []);
+      });
+
+      it("drops a removed provider-namespaced GLM custom model", () => {
+        const firstPartyModel = {
+          slug: "gpt-5.6-sol",
+          name: "GPT-5.6-Sol",
+          isCustom: false,
+          capabilities: codexModelCapabilities,
+        } as const;
+        const removedCustomModel = {
+          slug: "z-ai/glm-5.3-flash",
+          name: "GLM-5.3-Flash",
+          isCustom: true,
+          capabilities: codexModelCapabilities,
+        } as const;
+        const previousProvider = {
+          instanceId: ProviderInstanceId.make("codex_glm53"),
+          driver: ProviderDriverKind.make("codex"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-08-28T00:00:00.000Z",
+          version: "1.0.0",
+          models: [firstPartyModel, removedCustomModel],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-08-28T00:01:00.000Z",
+          models: [],
+        } satisfies ServerProvider;
+
+        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
+          firstPartyModel,
+        ]);
+      });
+
       it("drops stale OpenCode models missing from a successful refresh", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("opencode"),

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -41,6 +41,7 @@ import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
 
 import { ServerConfig } from "../../config.ts";
+import { codexNativeProfilePolicy } from "./CodexNativeProfile.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
 import {
@@ -53,6 +54,7 @@ import {
 } from "../providerStatusCache.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import { isProviderNamespacedModelSlug } from "../providerSnapshot.ts";
 import type { ProviderSnapshotSource } from "../builtInProviderCatalog.ts";
 
 const loadProviders = (
@@ -101,9 +103,17 @@ const mergeProviderModels = (
   nextModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const shouldRetainMissingModels = shouldRetainMissingProviderModels(provider);
+  const restrictProviderNamespacedModels =
+    codexNativeProfilePolicy(provider.instanceId) !== undefined;
+  const retainablePreviousModels = previousModels.filter(
+    (model) =>
+      provider.driver !== ProviderDriverKind.make("codex") ||
+      !restrictProviderNamespacedModels ||
+      !isProviderNamespacedModelSlug(model.slug),
+  );
 
   if (shouldRetainMissingModels && nextModels.length === 0 && previousModels.length > 0) {
-    return previousModels;
+    return retainablePreviousModels;
   }
 
   const previousBySlug = new Map(previousModels.map((model) => [model.slug, model] as const));
@@ -119,7 +129,7 @@ const mergeProviderModels = (
   });
   const nextSlugs = new Set(nextModels.map((model) => model.slug));
   return shouldRetainMissingModels
-    ? [...mergedModels, ...previousModels.filter((model) => !nextSlugs.has(model.slug))]
+    ? [...mergedModels, ...retainablePreviousModels.filter((model) => !nextSlugs.has(model.slug))]
     : mergedModels;
 };
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -67,6 +67,10 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+export function isProviderNamespacedModelSlug(slug: string): boolean {
+  return slug.includes("/");
+}
+
 export function isCommandMissingCause(error: unknown): boolean {
   if (isProviderCommandNotFoundError(error)) return true;
   return error instanceof PlatformError.PlatformError && error.reason._tag === "NotFound";

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -205,6 +205,47 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
     );
   });
 
+  it("hydrates ordinary namespaced Codex models but isolates the native GLM cache", () => {
+    const namespacedModel = {
+      slug: "z-ai/glm-5.3-flash",
+      name: "GLM-5.3-Flash",
+      isCustom: false,
+      capabilities: emptyCapabilities,
+    } as const;
+    const cachedCodex = makeProvider(CODEX_DRIVER, { models: [namespacedModel] });
+    const fallbackCodex = makeProvider(CODEX_DRIVER);
+
+    assert.deepStrictEqual(
+      hydrateCachedProvider({ cachedProvider: cachedCodex, fallbackProvider: fallbackCodex })
+        .models,
+      [namespacedModel],
+    );
+
+    const glmInstanceId = ProviderInstanceId.make("codex_glm53");
+    const cachedGlm = makeProvider(CODEX_DRIVER, {
+      instanceId: glmInstanceId,
+      models: [namespacedModel],
+    });
+    const fallbackGlm = makeProvider(CODEX_DRIVER, { instanceId: glmInstanceId });
+    assert.deepStrictEqual(
+      hydrateCachedProvider({ cachedProvider: cachedGlm, fallbackProvider: fallbackGlm }).models,
+      [],
+    );
+
+    const declaredModel = { ...namespacedModel, isCustom: true } as const;
+    const declaredFallback = makeProvider(CODEX_DRIVER, {
+      instanceId: glmInstanceId,
+      models: [declaredModel],
+    });
+    assert.deepStrictEqual(
+      hydrateCachedProvider({
+        cachedProvider: cachedGlm,
+        fallbackProvider: declaredFallback,
+      }).models,
+      [declaredModel],
+    );
+  });
+
   it("rejects cached snapshots that are not correlated to the fallback instance", () => {
     const fallbackCodex = makeProvider(CODEX_DRIVER, {
       models: [

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -11,17 +11,31 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import { writeFileStringAtomically } from "../atomicWrite.ts";
+import { codexNativeProfilePolicy } from "./Layers/CodexNativeProfile.ts";
+import { isProviderNamespacedModelSlug } from "./providerSnapshot.ts";
 
 const decodeProviderStatusCache = Schema.decodeUnknownEffect(
   Schema.fromJsonString(ServerProviderSchema),
 );
 
 const mergeProviderModels = (
+  driver: ProviderDriverKind,
+  instanceId: ProviderInstanceId,
   fallbackModels: ReadonlyArray<ServerProvider["models"][number]>,
   cachedModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const fallbackSlugs = new Set(fallbackModels.map((model) => model.slug));
-  return [...fallbackModels, ...cachedModels.filter((model) => !fallbackSlugs.has(model.slug))];
+  const restrictProviderNamespacedModels = codexNativeProfilePolicy(instanceId) !== undefined;
+  return [
+    ...fallbackModels,
+    ...cachedModels.filter(
+      (model) =>
+        !fallbackSlugs.has(model.slug) &&
+        (driver !== "codex" ||
+          !restrictProviderNamespacedModels ||
+          !isProviderNamespacedModelSlug(model.slug)),
+    ),
+  ];
 };
 
 export const orderProviderSnapshots = (
@@ -59,7 +73,12 @@ export const hydrateCachedProvider = (input: {
   const { message: _fallbackMessage, ...fallbackWithoutMessage } = input.fallbackProvider;
   const hydratedProvider: ServerProvider = {
     ...fallbackWithoutMessage,
-    models: mergeProviderModels(input.fallbackProvider.models, input.cachedProvider.models),
+    models: mergeProviderModels(
+      input.fallbackProvider.driver,
+      input.fallbackProvider.instanceId,
+      input.fallbackProvider.models,
+      input.cachedProvider.models,
+    ),
     installed: input.cachedProvider.installed,
     version: input.cachedProvider.version,
     status: input.cachedProvider.status,

--- a/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
+++ b/apps/server/src/provider/testFixtures/codexCollabMockPeer.mjs
@@ -18,6 +18,9 @@ const script = JSON.parse(NodeFS.readFileSync(process.env.T3_CODEX_COLLAB_SCRIPT
 const write = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
 let turnStartCount = 0;
 let activeTurn;
+let lastTurnProfile;
+const childResumeAttempts = new Map();
+const rootResumeAttempts = new Map();
 
 const rl = NodeReadline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {
@@ -58,18 +61,73 @@ rl.on("line", (line) => {
     return;
   }
   if (method === "thread/start") {
-    write({ id, result: fixture.responses.threadStart });
+    write({
+      id,
+      result: {
+        ...fixture.responses.threadStart,
+        ...script.rootProfile,
+      },
+    });
     return;
   }
   if (method === "thread/resume") {
+    const threadId = message.params?.threadId;
+    const childSnapshot = script.childResumeSnapshots?.[threadId];
+    if (threadId === script.rootThreadId && lastTurnProfile) {
+      const turnIndex = turnStartCount - 1;
+      const resumeAttempt = (rootResumeAttempts.get(turnIndex) ?? 0) + 1;
+      rootResumeAttempts.set(turnIndex, resumeAttempt);
+      if (script.recordRootReadbacks) {
+        NodeFS.appendFileSync(
+          `${process.env.T3_CODEX_COLLAB_SCRIPT}.root-readbacks`,
+          `${JSON.stringify({ turnIndex, resumeAttempt })}\n`,
+        );
+      }
+      const attempt = script.rootTurnReadbackAttempts?.[turnIndex]?.[resumeAttempt - 1];
+      if (attempt?.hang) {
+        return;
+      }
+      if (attempt?.error) {
+        write({ id, error: { code: -32000, message: attempt.error } });
+        return;
+      }
+      if (attempt?.malformed) {
+        write({ id, result: { thread: { id: 42 } } });
+        return;
+      }
+      const scriptedReadback = attempt?.profile ?? script.rootTurnReadbacks?.[turnIndex];
+      const profile = scriptedReadback ?? {
+        ...script.rootProfile,
+        model: lastTurnProfile.model ?? script.rootProfile?.model,
+        reasoningEffort: lastTurnProfile.reasoningEffort ?? script.rootProfile?.reasoningEffort,
+      };
+      const result = {
+        ...fixture.responses.threadStart,
+        ...script.rootProfile,
+        ...profile,
+        thread: {
+          ...fixture.responses.threadStart.thread,
+          id: threadId,
+          sessionId: threadId,
+        },
+      };
+      if (profile.omitReasoningEffort) {
+        delete result.reasoningEffort;
+      }
+      const writeReadback = () => write({ id, result });
+      if (attempt?.delayMs > 0) {
+        setTimeout(writeReadback, attempt.delayMs);
+      } else {
+        writeReadback();
+      }
+      return;
+    }
     if (script.recordRequests) {
       NodeFS.appendFileSync(
         `${process.env.T3_CODEX_COLLAB_SCRIPT}.requests`,
         `${JSON.stringify({ method, params: message.params })}\n`,
       );
     }
-    const threadId = message.params?.threadId;
-    const childSnapshot = script.childResumeSnapshots?.[threadId];
     if (script.resumeRequestMarker) {
       write({
         jsonrpc: "2.0",
@@ -83,26 +141,41 @@ rl.on("line", (line) => {
     if (childSnapshot?.hang) {
       return;
     }
+    const resumeAttempt = (childResumeAttempts.get(threadId) ?? 0) + 1;
+    childResumeAttempts.set(threadId, resumeAttempt);
+    if (resumeAttempt <= (childSnapshot?.transientErrors ?? 0)) {
+      write({ id, error: { code: -32000, message: "transient profile readback failure" } });
+      return;
+    }
     if (childSnapshot?.error) {
       write({ id, error: { code: -32000, message: childSnapshot.error } });
       return;
     }
     if (childSnapshot) {
-      write({
-        id,
-        result: {
-          ...fixture.responses.threadStart,
-          model: childSnapshot.model,
-          reasoningEffort: childSnapshot.reasoningEffort,
-          thread: {
-            ...fixture.responses.threadStart.thread,
-            id: threadId,
-            sessionId: threadId,
+      const writeSnapshot = () => {
+        write({
+          id,
+          result: {
+            ...fixture.responses.threadStart,
+            modelProvider:
+              childSnapshot.modelProvider ?? fixture.responses.threadStart.modelProvider,
+            model: childSnapshot.model,
+            reasoningEffort: childSnapshot.reasoningEffort,
+            thread: {
+              ...fixture.responses.threadStart.thread,
+              id: threadId,
+              sessionId: threadId,
+            },
           },
-        },
-      });
-      for (const notification of childSnapshot.notifications ?? []) {
-        write({ jsonrpc: "2.0", method: notification.method, params: notification.params });
+        });
+        for (const notification of childSnapshot.notifications ?? []) {
+          write({ jsonrpc: "2.0", method: notification.method, params: notification.params });
+        }
+      };
+      if (childSnapshot.delayMs > 0) {
+        setTimeout(writeSnapshot, childSnapshot.delayMs);
+      } else {
+        writeSnapshot();
       }
       return;
     }
@@ -110,6 +183,10 @@ rl.on("line", (line) => {
     return;
   }
   if (method === "turn/start") {
+    lastTurnProfile = {
+      model: message.params?.model,
+      reasoningEffort: message.params?.effort,
+    };
     const turnId = script.turnIds?.[turnStartCount];
     const turn = turnId
       ? { ...fixture.responses.turnStart.turn, id: turnId }
@@ -174,6 +251,16 @@ rl.on("line", (line) => {
       // Never respond: simulates a wedged child whose RPC neither resolves
       // nor rejects. The runtime's bounded deadline must move on.
       return;
+    }
+    write({ id, result: {} });
+    return;
+  }
+  if (method === "thread/archive") {
+    if (script.recordArchives) {
+      NodeFS.appendFileSync(
+        `${process.env.T3_CODEX_COLLAB_SCRIPT}.archives`,
+        `${JSON.stringify({ threadId: message.params?.threadId })}\n`,
+      );
     }
     write({ id, result: {} });
     return;

--- a/apps/web/src/components/AgentsPanel.test.tsx
+++ b/apps/web/src/components/AgentsPanel.test.tsx
@@ -1,0 +1,89 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+import {
+  deriveAgentPanelModel,
+  foldSubagentActivities,
+} from "@t3tools/client-runtime/state/subagentRuntime";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { AgentsPanel } from "./AgentsPanel";
+
+function childActivity(
+  status: "running" | "waiting" | "idle",
+  index = 1,
+  model: string | null = "z-ai/glm-5.3-flash",
+): OrchestrationThreadActivity {
+  return {
+    id: `glm-child-${index}-${status}`,
+    tone: "info",
+    kind: status === "running" ? "task.started" : "task.updated",
+    summary: "Native GLM child",
+    payload: {
+      taskId: `native-glm-child-thread-${index}`,
+      agentKind: "agent",
+      title: `glm_worker_${index}`,
+      role: "researcher",
+      modelProvider: "openrouter",
+      model,
+      effort: "max",
+      status,
+      timelineBypass: true,
+    },
+    turnId: null,
+    createdAt: `2026-08-29T12:00:0${status === "running" ? 0 : status === "waiting" ? 1 : 2}.000Z`,
+  } as unknown as OrchestrationThreadActivity;
+}
+
+function panelMarkup(activities: ReadonlyArray<OrchestrationThreadActivity>): string {
+  const model = deriveAgentPanelModel({ agents: foldSubagentActivities(activities) });
+  return renderToStaticMarkup(<AgentsPanel model={model} />);
+}
+
+describe("AgentsPanel native GLM child", () => {
+  it("renders running and waiting as Working, then renders the resumable child as idle", () => {
+    const running = panelMarkup([childActivity("running")]);
+    expect(running).toContain("glm_worker_1");
+    expect(running).toContain("openrouter · z-ai/glm-5.3-flash · max");
+    expect(running).toContain("Working");
+    expect(running).toContain("1 working");
+
+    const waiting = panelMarkup([childActivity("running"), childActivity("waiting")]);
+    expect(waiting).toContain("Working");
+    expect(waiting).toContain("1 working");
+
+    const idle = panelMarkup([
+      childActivity("running"),
+      childActivity("waiting"),
+      childActivity("idle"),
+    ]);
+    expect(idle).toContain("glm_worker_1");
+    expect(idle).toContain("openrouter · z-ai/glm-5.3-flash · max");
+    expect(idle).toContain("Idle · resumable");
+    expect(idle).toContain("1 idle");
+    expect(idle).not.toContain("1 working");
+  });
+
+  it("keeps a provider session with no native child events out of the roster", () => {
+    const markup = panelMarkup([]);
+    expect(markup).toContain("No agents yet");
+    expect(markup).not.toContain("glm_worker_1");
+  });
+
+  it("does not render a provider label before the child model is known", () => {
+    const markup = panelMarkup([childActivity("running", 1, null)]);
+    expect(markup).toContain("glm_worker_1");
+    expect(markup).not.toContain("openrouter");
+    expect(markup).not.toContain(" · max");
+  });
+
+  it("renders ten simultaneous native children without collapsing the roster", () => {
+    const markup = panelMarkup(
+      Array.from({ length: 10 }, (_, index) => childActivity("running", index + 1)),
+    );
+    expect(markup).toContain("10 working");
+    for (let index = 1; index <= 10; index++) {
+      expect(markup).toContain(`glm_worker_${index}`);
+    }
+    expect(markup.match(/openrouter · z-ai\/glm-5\.3-flash · max/g)).toHaveLength(10);
+  });
+});

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -141,7 +141,12 @@ function agentActivityText(agent: RuntimeSubagent): string | null {
 function AgentRow({ agent }: { agent: RuntimeSubagent }) {
   const visuals = STATUS_VISUALS[agent.status];
   const activity = agentActivityText(agent);
-  const modelLabel = formatSubagentModelLabel(agent.model, agent.effort);
+  const formattedModel = formatSubagentModelLabel(agent.model, agent.effort);
+  const modelLabel = formattedModel
+    ? [agent.modelProvider, formattedModel]
+        .filter((value): value is string => value !== null)
+        .join(" · ")
+    : null;
   const role =
     agent.role?.trim().toLocaleLowerCase() === agent.title.trim().toLocaleLowerCase()
       ? null

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -586,6 +586,69 @@ describe("formatSubagentTokenCount", () => {
 });
 
 describe("model and effort attribution", () => {
+  it("keeps a native GLM child's identity and max effort through running, waiting, and idle", () => {
+    const rows = [
+      activity("task.started", {
+        taskId: "native-glm-child-thread",
+        title: "glm_research",
+        role: "researcher",
+        modelProvider: "openrouter",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+        timelineBypass: true,
+      }),
+      activity("task.updated", {
+        taskId: "native-glm-child-thread",
+        status: "running",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+        timelineBypass: true,
+      }),
+      activity("task.updated", {
+        taskId: "native-glm-child-thread",
+        status: "waiting",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+        timelineBypass: true,
+      }),
+      activity("task.updated", {
+        taskId: "native-glm-child-thread",
+        status: "idle",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+        timelineBypass: true,
+      }),
+    ];
+
+    const running = deriveAgentPanelModel({ agents: fold(rows.slice(0, 2)) });
+    expect(running.directAgents[0]).toMatchObject({
+      id: "native-glm-child-thread",
+      title: "glm_research",
+      modelProvider: "openrouter",
+      model: "z-ai/glm-5.3-flash",
+      effort: "max",
+      status: "running",
+    });
+    expect(running.runningCount).toBe(1);
+
+    const waiting = deriveAgentPanelModel({ agents: fold(rows.slice(0, 3)) });
+    expect(waiting.directAgents[0]?.status).toBe("waiting");
+    expect(waiting.waitingCount).toBe(1);
+
+    const idle = deriveAgentPanelModel({ agents: fold(rows) });
+    expect(idle.directAgents[0]).toMatchObject({
+      id: "native-glm-child-thread",
+      modelProvider: "openrouter",
+      model: "z-ai/glm-5.3-flash",
+      effort: "max",
+      status: "idle",
+    });
+    expect(idle.idleCount).toBe(1);
+    expect(
+      formatSubagentModelLabel(idle.directAgents[0]!.model, idle.directAgents[0]!.effort),
+    ).toBe("z-ai/glm-5.3-flash · max");
+  });
+
   it("carries model/effort from start rows and refines model from later rows", () => {
     const agents = fold([
       activity("task.started", {

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -61,6 +61,7 @@ export interface RuntimeSubagent {
   readonly kind: "subagent" | "workflow" | "workflow_agent";
   readonly title: string;
   readonly role: string | null;
+  readonly modelProvider: string | null;
   readonly model: string | null;
   readonly effort: string | null;
   readonly status: RuntimeSubagentStatus;
@@ -230,6 +231,7 @@ interface MutableAgent {
   kind: RuntimeSubagent["kind"];
   title: string;
   role: string | null;
+  modelProvider: string | null;
   model: string | null;
   effort: string | null;
   status: RuntimeSubagentStatus;
@@ -284,6 +286,7 @@ function getOrCreate(
     kind: kindFromPayload(payload, id),
     title: asString(payload.title) ?? asString(payload.detail) ?? id,
     role: asString(payload.role) ?? null,
+    modelProvider: asString(payload.modelProvider) ?? null,
     model: asString(payload.model) ?? null,
     effort: asString(payload.effort) ?? null,
     status: "pending",
@@ -318,6 +321,8 @@ function fillMetadata(agent: MutableAgent, payload: Record<string, unknown>): vo
   if (title) agent.title = title;
   const role = asString(payload.role);
   if (role) agent.role = role;
+  const modelProvider = asString(payload.modelProvider);
+  if (modelProvider) agent.modelProvider = modelProvider;
   const model = asString(payload.model);
   if (model) agent.model = model;
   const effort = asString(payload.effort);

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -6,6 +6,29 @@ import { classifyTaskAgentKind, ProviderRuntimeEvent } from "./providerRuntime.t
 const decodeRuntimeEvent = Schema.decodeUnknownSync(ProviderRuntimeEvent);
 
 describe("ProviderRuntimeEvent", () => {
+  it("decodes modelProvider on typed task agent linkage", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "task.started",
+      eventId: "event-agent-provider",
+      provider: "codex",
+      providerInstanceId: "codex_glm53",
+      createdAt: "2026-08-29T00:00:00.000Z",
+      threadId: "thread-1",
+      payload: {
+        taskId: "glm-child-1",
+        agentKind: "agent",
+        title: "glm_worker_1",
+        modelProvider: "openrouter",
+        model: "z-ai/glm-5.3-flash",
+        effort: "max",
+      },
+    });
+
+    expect(parsed.type).toBe("task.started");
+    if (parsed.type !== "task.started") throw new Error("expected task.started");
+    expect(parsed.payload.modelProvider).toBe("openrouter");
+  });
+
   it("accepts fork-provided driver kinds as branded slugs", () => {
     const parsed = decodeRuntimeEvent({
       type: "session.started",

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -566,6 +566,8 @@ const taskAgentLinkageFields = {
   agentId: Schema.optional(TrimmedNonEmptyStringSchema),
   title: Schema.optional(TrimmedNonEmptyStringSchema),
   role: Schema.optional(TrimmedNonEmptyStringSchema),
+  /** Effective model-provider id when a runtime reports it (for example, "openrouter"). */
+  modelProvider: Schema.optional(TrimmedNonEmptyStringSchema),
   model: Schema.optional(TrimmedNonEmptyStringSchema),
   /** Reasoning effort when known (e.g. "high"). Open string: provider vocabularies differ. */
   effort: Schema.optional(TrimmedNonEmptyStringSchema),

--- a/packages/effect-codex-app-server/src/client.ts
+++ b/packages/effect-codex-app-server/src/client.ts
@@ -29,6 +29,7 @@ export interface CodexAppServerClientOptions {
 interface CodexAppServerClientRaw {
   readonly notifications: CodexProtocol.CodexAppServerPatchedProtocol["incomingNotifications"];
   readonly requests: CodexProtocol.CodexAppServerPatchedProtocol["incomingRequests"];
+  readonly pendingRequestCount: CodexProtocol.CodexAppServerPatchedProtocol["pendingRequestCount"];
   readonly request: CodexProtocol.CodexAppServerPatchedProtocol["request"];
   readonly notify: CodexProtocol.CodexAppServerPatchedProtocol["notify"];
   readonly respond: CodexProtocol.CodexAppServerPatchedProtocol["respond"];
@@ -222,6 +223,7 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
     raw: {
       notifications: transport.incomingNotifications,
       requests: transport.incomingRequests,
+      pendingRequestCount: transport.pendingRequestCount,
       request: transport.request,
       notify: transport.notify,
       respond: transport.respond,

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -34,6 +34,31 @@ const decodeConsumeRateLimitResetCreditResponse = Schema.decodeUnknownEffect(
 );
 
 it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
+  it.effect("removes an interrupted request from the pending map", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const transport = yield* CodexProtocol.makeCodexAppServerPatchedProtocol({ stdio });
+      const requestFiber = yield* transport
+        .request("thread/resume", { threadId: "child-1" })
+        .pipe(Effect.forkScoped);
+
+      assert.deepEqual(yield* decodeJson(yield* Queue.take(output)), {
+        id: 1,
+        method: "thread/resume",
+        params: { threadId: "child-1" },
+      });
+      assert.equal(yield* transport.pendingRequestCount, 1);
+
+      yield* Fiber.interrupt(requestFiber);
+      assert.equal(yield* transport.pendingRequestCount, 0);
+
+      // A late peer response to the cancelled id stays a no-op.
+      yield* Queue.offer(input, encodeJsonl({ id: 1, result: { thread: { id: "child-1" } } }));
+      yield* Effect.yieldNow;
+      assert.equal(yield* transport.pendingRequestCount, 0);
+    }).pipe(Effect.scoped),
+  );
+
   it.effect("maps account usage responses to the upstream token usage schema", () =>
     Effect.gen(function* () {
       assert.strictEqual(

--- a/packages/effect-codex-app-server/src/protocol.ts
+++ b/packages/effect-codex-app-server/src/protocol.ts
@@ -49,6 +49,8 @@ export interface CodexAppServerPatchedProtocolOptions {
 export interface CodexAppServerPatchedProtocol {
   readonly incomingNotifications: Stream.Stream<CodexAppServerIncomingNotification>;
   readonly incomingRequests: Stream.Stream<CodexAppServerIncomingRequest>;
+  /** In-flight client requests awaiting a response. Primarily a lifecycle diagnostic. */
+  readonly pendingRequestCount: Effect.Effect<number>;
   readonly request: (
     method: string,
     payload?: unknown,
@@ -414,6 +416,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
     return {
       incomingNotifications: Stream.fromQueue(incomingNotifications),
       incomingRequests: Stream.fromQueue(incomingRequests),
+      pendingRequestCount: Ref.get(pending).pipe(Effect.map((current) => current.size)),
       request,
       notify,
       respond,


### PR DESCRIPTION
CI mirror for the authoritative Buzz second-lineage revision-2. Review and merge ownership remain on Buzz.

- Buzz issue: `963683531ca84864246f7e19955acff00a316a19bc074c503f1ba6383e6fd7cb`
- Buzz PR: `cfeecdb7bd0b6891f7fba7e9d50d80f8e187921568a5a354b17caa9c707104cf`
- Buzz revision-2 event: `744ef4ab5ea38b300bac4d0eac26bf12c56ac56a7773a9d60f5d2e986c46aea4`
- Buzz base/main: `018d7f2775daabd2ef07898af29586915a0b7f67`
- Frozen revision-2 head: `651d2bc64e9cb3fc3f529e89fa0ee5f92ce5b375`
- Revision-2 tree: `ba9a04eed3b4413a6e17d48c3b44fa247e4b1506`
- Superseded head: `3cc11e3f6caa122914da337da49388fc0140ef08`

The candidate adds the isolated `codex_glm53` profile, native parent/child profile verification, native child provider/model/effort attribution, and the runtime protocol metadata needed to preserve that evidence through ingestion. The full manifest contains 27 paths.

The frozen worktree is clean, its sole parent is the unchanged Buzz main, and `git diff --check` passes. This PR exists only to run GitHub checks on the byte-identical Buzz head.

Do not merge, publish, release, deploy, activate, restart T3, change credentials, mutate source, or run inference from this PR.

<!-- buzz-ci-mirror
BUZZ_REPO=30617:4a34c131ec5cb5dd9a200bac619bbd103c0793e068fad278d1de59203d05b97d:t3code
BUZZ_ISSUE_ID=963683531ca84864246f7e19955acff00a316a19bc074c503f1ba6383e6fd7cb
BUZZ_PR_ID=cfeecdb7bd0b6891f7fba7e9d50d80f8e187921568a5a354b17caa9c707104cf
BUZZ_PR_REVISION_2=744ef4ab5ea38b300bac4d0eac26bf12c56ac56a7773a9d60f5d2e986c46aea4
BASE_SHA=018d7f2775daabd2ef07898af29586915a0b7f67
HEAD_SHA=651d2bc64e9cb3fc3f529e89fa0ee5f92ce5b375
TREE_SHA=ba9a04eed3b4413a6e17d48c3b44fa247e4b1506
SUPERSEDED_HEAD=3cc11e3f6caa122914da337da49388fc0140ef08
-->

Published with Codex GPT-5.6 Sol at high reasoning effort.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native GLM-5.3 parent profile to `CodexAdapter` with profile enforcement and model scoping
> - Introduces [CodexNativeProfile.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-458dc60846afa76dd605a87bda470fbfc7a69ef0646ef37b58d31a9126effd68) defining the `CODEX_GLM53_NATIVE_PROFILE` policy, validation helpers (`codexNativeProfileSelectionIssue`, `codexNativeProfileHomeIssue`), launch-args builder (`codexNativeProfileLaunchArgs`), and `applyCodexNativeProfileModelCapabilities` for augmenting the model catalog with `reasoningEffort` options (high/max, default max).
> - [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) runs model-selection validation in `startSession` and `sendTurn`, disables MCP credential injection for native profiles, resolves launch args via `codexNativeProfileLaunchArgs`, and passes `expectedProfile`/`expectedChildProfile` into the runtime.
> - [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) enforces parent and child profile verification: it validates parent profile at open time, performs bounded-retry proof readback after each turn (killing the app server on mismatch or proof failure), and closes unverified child threads with `collabAgent/profileMismatch` or `collabAgent/profileProofFailed` events.
> - [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) replaces `appendCustomCodexModels` with `scopeCodexModelsToInstance`, which optionally excludes provider-namespaced models unless allowlisted and creates unknown custom slugs with `null` capabilities; [ProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-5c33694fd7889294ecb21a88beafee2debe92f779baab4629651d4c8be8a9a97) and [providerStatusCache.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-6de08e2cd95df6ffd1cc93a059448e8a80f0392091e10e0d7aabd9b6b01dbb07) drop provider-namespaced models for native-profile instances during merge and cache hydration.
> - Propagates `modelProvider` through `taskAgentLinkageFields` in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7), subagent runtime in [subagentRuntime.ts](https://github.com/pingdotgg/t3code/pull/8674/files#diff-b28278fe62e259afab164f07d2e56800ca49f60942f6b12da5f748e9415c8259), and the Agents panel UI in [AgentsPanel.tsx](https://github.com/pingdotgg/t3code/pull/8674/files#diff-10464442e3a11a770b2b1a5718e7a452453347c492f6aa0533f267063e2c6494).
> - Risk: native-profile instances (`codex_glm53`) now reject provider-namespaced models not in `customModels`; any existing config relying on cached namespaced models for these instances will see them dropped on refresh. Parent turn proof failures terminate the app server process, so a persistently failing readback kills the session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 651d2bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->