### PR TITLE
feat(mcp): organize thread state

### DIFF
--- a/apps/server/src/mcp/OrchestratorMcpService.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.test.ts
@@ -309,7 +309,7 @@ describe("OrchestratorMcpService", () => {
         title: "Archived agent work",
         createdBy: "user",
         creationSource: "web",
-        status: "completed",
+        status: "failed",
         activityRunStatus: null,
         latestRunId: RunId.make("run:mcp-list-archived"),
         latestRunCompletedAt: completedAt,
@@ -388,9 +388,16 @@ describe("OrchestratorMcpService", () => {
           snoozedUntil: now,
           snoozedAt: now,
           archivedAt: null,
-          lastVisitedAt: null,
+          lastVisitedAt: DateTime.makeUnsafe("2026-08-29T11:00:00.000Z"),
         },
-        runs: [],
+        runs: [
+          {
+            id: RunId.make("run:mcp-organize-cancelled"),
+            ordinal: 1,
+            status: "cancelled",
+            completedAt: now,
+          },
+        ],
         runtimeRequests: [],
       } as unknown as OrchestrationV2ThreadProjection);
       const dispatched = yield* Ref.make<ReadonlyArray<unknown>>([]);
@@ -449,8 +456,100 @@ describe("OrchestratorMcpService", () => {
           settledOverride: "active",
           settledAt: null,
           snoozedUntil: null,
+          readState: "unread",
         });
         assert.equal((yield* Ref.get(dispatched)).length, 1);
+      }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
+    }),
+  );
+
+  it.effect("uses only the latest run completion watermark for read state", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("thread:mcp-read-latest-run");
+      const projectId = ProjectId.make("project:mcp-read-latest-run");
+      const createdAt = DateTime.makeUnsafe("2026-08-29T09:00:00.000Z");
+      const completedAt = DateTime.makeUnsafe("2026-08-29T11:00:00.000Z");
+      const activeAt = DateTime.makeUnsafe("2026-08-29T12:00:00.000Z");
+      const projection = {
+        thread: {
+          id: threadId,
+          projectId,
+          title: "Latest run watermark",
+          createdBy: "user",
+          creationSource: "web",
+          modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.6-sol" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          linkedPullRequest: null,
+          lineage: { parentThreadId: null, relationshipToParent: null },
+          archivedAt: null,
+          settledOverride: null,
+          settledAt: null,
+          snoozedUntil: null,
+          snoozedAt: null,
+          pinnedAt: null,
+          pinOrderKey: null,
+          lastVisitedAt: DateTime.makeUnsafe("2026-08-29T10:00:00.000Z"),
+          createdAt,
+          updatedAt: activeAt,
+        },
+        runs: [
+          {
+            id: RunId.make("run:mcp-read-completed"),
+            ordinal: 1,
+            status: "completed",
+            completedAt,
+            requestedAt: createdAt,
+            startedAt: createdAt,
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("codex"),
+              model: "gpt-5.6-sol",
+            },
+          },
+          {
+            id: RunId.make("run:mcp-read-running"),
+            ordinal: 2,
+            status: "running",
+            completedAt: null,
+            requestedAt: activeAt,
+            startedAt: activeAt,
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("codex"),
+              model: "gpt-5.6-sol",
+            },
+          },
+        ],
+        runtimeRequests: [],
+        visibleTurnItems: [],
+        messages: [],
+        subagents: [],
+        contextTransfers: [],
+        updatedAt: activeAt,
+      } as unknown as OrchestrationV2ThreadProjection;
+      const dependencies = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(ThreadManagementService)({
+          getThreadProjection: () => Effect.succeed(projection),
+        }),
+        Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+        Layer.mock(ScheduledTaskService)({}),
+      );
+      const scope: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:mcp-read-latest-run"),
+        threadId,
+        providerSessionId: "provider-session:mcp-read-latest-run",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+
+      yield* Effect.gen(function* () {
+        const service = yield* OrchestratorMcpService.OrchestratorMcpService;
+        const result = yield* service.readThread(scope, { threadId });
+        assert.equal(result.thread.latestRunId, "run:mcp-read-running");
+        assert.equal(result.thread.readState, "read");
       }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
     }),
   );

--- a/apps/server/src/mcp/OrchestratorMcpService.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.test.ts
@@ -3,11 +3,14 @@ import { assert, describe, it } from "@effect/vitest";
 import {
   EnvironmentId,
   NodeId,
+  ProjectId,
   ProviderInstanceId,
   RunId,
   ThreadId,
   type OrchestrationV2ThreadProjection,
+  type OrchestrationV2ThreadShell,
 } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
@@ -286,6 +289,168 @@ describe("OrchestratorMcpService", () => {
           (yield* Ref.get(dispatched)).map((command) => (command as { type: string }).type),
           ["run.interrupt", "delegated_task.completion-delivery.dispose"],
         );
+      }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
+    }),
+  );
+
+  it.effect("lists archived shells with organization metadata without loading transcripts", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("thread:mcp-list-archived");
+      const projectId = ProjectId.make("project:mcp-list-archived");
+      const now = DateTime.makeUnsafe("2026-08-29T12:00:00.000Z");
+      const completedAt = DateTime.makeUnsafe("2026-08-29T11:00:00.000Z");
+      const visitedAt = DateTime.makeUnsafe("2026-08-29T10:00:00.000Z");
+      const parentProjection = {
+        thread: { id: threadId, projectId },
+      } as unknown as OrchestrationV2ThreadProjection;
+      const shell = {
+        id: threadId,
+        projectId,
+        title: "Archived agent work",
+        createdBy: "user",
+        creationSource: "web",
+        status: "completed",
+        activityRunStatus: null,
+        latestRunId: RunId.make("run:mcp-list-archived"),
+        latestRunCompletedAt: completedAt,
+        modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.6-sol" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: "agents/archived",
+        worktreePath: "/tmp/archived",
+        linkedPullRequest: {
+          projectId,
+          repository: "pingdotgg/t3code",
+          number: 9001,
+          url: "https://github.com/pingdotgg/t3code/pull/9001",
+        },
+        pinnedAt: null,
+        pinOrderKey: null,
+        settledOverride: "settled",
+        settledAt: completedAt,
+        snoozedUntil: null,
+        snoozedAt: null,
+        archivedAt: now,
+        lastVisitedAt: visitedAt,
+        lineage: { parentThreadId: null, relationshipToParent: null },
+        visibleItemCount: 4,
+        createdAt: visitedAt,
+        updatedAt: now,
+      } as unknown as OrchestrationV2ThreadShell;
+      const dependencies = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(ThreadManagementService)({
+          getThreadProjection: () => Effect.succeed(parentProjection),
+          listProjectThreads: () => Effect.succeed([shell]),
+        }),
+        Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+        Layer.mock(ScheduledTaskService)({}),
+      );
+      const scope: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:mcp-list-archived"),
+        threadId,
+        providerSessionId: "provider-session:mcp-list-archived",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+
+      yield* Effect.gen(function* () {
+        const service = yield* OrchestratorMcpService.OrchestratorMcpService;
+        const result = yield* service.listThreads(scope, { archived: true, unread: true });
+        assert.equal(result.total, 1);
+        assert.deepInclude(result.threads[0], {
+          threadId,
+          archived: true,
+          archivedAt: "2026-08-29T12:00:00.000Z",
+          settledOverride: "settled",
+          readState: "unread",
+          branch: "agents/archived",
+          worktreePath: "/tmp/archived",
+        });
+      }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
+    }),
+  );
+
+  it.effect("organizes the calling thread and returns the resultant durable state", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("thread:mcp-organize-self");
+      const projectId = ProjectId.make("project:mcp-organize-self");
+      const now = DateTime.makeUnsafe("2026-08-29T12:00:00.000Z");
+      const projection = yield* Ref.make({
+        thread: {
+          id: threadId,
+          projectId,
+          pinnedAt: null,
+          pinOrderKey: null,
+          settledOverride: "settled",
+          settledAt: now,
+          snoozedUntil: now,
+          snoozedAt: now,
+          archivedAt: null,
+          lastVisitedAt: null,
+        },
+        runs: [],
+        runtimeRequests: [],
+      } as unknown as OrchestrationV2ThreadProjection);
+      const dispatched = yield* Ref.make<ReadonlyArray<unknown>>([]);
+      const dependencies = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(ThreadManagementService)({
+          getThreadProjection: () => Ref.get(projection),
+          dispatch: (command) =>
+            Ref.update(dispatched, (commands) => [...commands, command]).pipe(
+              Effect.andThen(
+                command.type === "thread.pin"
+                  ? Ref.update(projection, (current) => ({
+                      ...current,
+                      thread: {
+                        ...current.thread,
+                        pinnedAt: now,
+                        pinOrderKey: command.orderKey ?? null,
+                        settledOverride: "active" as const,
+                        settledAt: null,
+                        snoozedUntil: null,
+                        snoozedAt: null,
+                      },
+                    }))
+                  : Effect.void,
+              ),
+              Effect.as({} as never),
+            ),
+        }),
+        Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+        Layer.mock(ScheduledTaskService)({}),
+      );
+      const scope: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:mcp-organize-self"),
+        threadId,
+        providerSessionId: "provider-session:mcp-organize-self",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+
+      yield* Effect.gen(function* () {
+        const service = yield* OrchestratorMcpService.OrchestratorMcpService;
+        const result = yield* service.organizeThreads(scope, {
+          action: { type: "pin", orderKey: "m0" },
+          clientRequestId: "pin-self",
+        });
+        assert.deepInclude(result.outcomes[0], {
+          threadId,
+          action: "pin",
+          status: "applied",
+          error: null,
+        });
+        assert.deepInclude(result.outcomes[0]?.state, {
+          pinnedAt: "2026-08-29T12:00:00.000Z",
+          pinOrderKey: "m0",
+          settledOverride: "active",
+          settledAt: null,
+          snoozedUntil: null,
+        });
+        assert.equal((yield* Ref.get(dispatched)).length, 1);
       }).pipe(Effect.provide(OrchestratorMcpService.layer.pipe(Layer.provide(dependencies))));
     }),
   );

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -1782,9 +1782,9 @@ const make = Effect.gen(function* () {
         yield* requireCapability(scope);
         const key = yield* requestKey(input.clientRequestId);
         const items =
-          "items" in input
+          input.items !== undefined
             ? input.items
-            : [{ threadId: input.threadId ?? scope.threadId, action: input.action }];
+            : [{ threadId: input.threadId ?? scope.threadId, action: input.action! }];
         const outcomes = yield* Effect.forEach(
           items,
           (item, index) =>

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -5,6 +5,7 @@ import {
   type ModelSelection,
   NodeId,
   type OrchestrationV2Run,
+  type OrchestrationV2Command,
   type OrchestrationV2Subagent,
   type OrchestrationV2ThreadProjection,
   type OrchestrationV2ThreadShell,
@@ -31,11 +32,18 @@ import {
   type OrchestratorMcpThreadDetail,
   type OrchestratorMcpThreadInterruptInput,
   type OrchestratorMcpThreadInterruptResult,
+  type OrchestratorMcpThreadDeleteInput,
+  type OrchestratorMcpThreadDeleteResult,
   type OrchestratorMcpThreadListInput,
   type OrchestratorMcpThreadListItem,
   type OrchestratorMcpThreadListResult,
   type OrchestratorMcpThreadReadInput,
   type OrchestratorMcpThreadReadResult,
+  type OrchestratorMcpThreadOrganizeAction,
+  type OrchestratorMcpThreadOrganizeInput,
+  type OrchestratorMcpThreadOrganizeOutcome,
+  type OrchestratorMcpThreadOrganizeResult,
+  type OrchestratorMcpThreadOrganizationState,
   type OrchestratorMcpThreadRun,
   type OrchestratorMcpThreadSendInput,
   type OrchestratorMcpThreadSendResult,
@@ -146,6 +154,14 @@ export interface OrchestratorMcpServiceShape {
     scope: McpInvocationScope,
     input: OrchestratorMcpThreadInterruptInput,
   ) => Effect.Effect<OrchestratorMcpThreadInterruptResult, OrchestratorMcpFailure>;
+  readonly organizeThreads: (
+    scope: McpInvocationScope,
+    input: OrchestratorMcpThreadOrganizeInput,
+  ) => Effect.Effect<OrchestratorMcpThreadOrganizeResult, OrchestratorMcpFailure>;
+  readonly deleteThread: (
+    scope: McpInvocationScope,
+    input: OrchestratorMcpThreadDeleteInput,
+  ) => Effect.Effect<OrchestratorMcpThreadDeleteResult, OrchestratorMcpFailure>;
 }
 
 export class OrchestratorMcpService extends Context.Service<
@@ -537,6 +553,28 @@ function taskPrompt(input: OrchestratorMcpDelegateTaskInput): string {
     : `Act as the ${input.role} sub-agent for this task.\n\n${input.task}`;
 }
 
+function readState(input: {
+  readonly completedAt: DateTime.Utc | null | undefined;
+  readonly lastVisitedAt: DateTime.Utc | null | undefined;
+}): "read" | "unread" | "unknown" {
+  if (input.lastVisitedAt == null) return "unknown";
+  return input.completedAt != null &&
+    DateTime.toEpochMillis(input.completedAt) > DateTime.toEpochMillis(input.lastVisitedAt)
+    ? "unread"
+    : "read";
+}
+
+function iso(value: DateTime.Utc | null | undefined): string | null {
+  return value == null ? null : DateTime.formatIso(value);
+}
+
+function shellReadState(shell: OrchestrationV2ThreadShell): "read" | "unread" | "unknown" {
+  return readState({
+    completedAt: shell.latestRunCompletedAt,
+    lastVisitedAt: shell.lastVisitedAt,
+  });
+}
+
 function listItemFromShell(shell: OrchestrationV2ThreadShell): OrchestratorMcpThreadListItem {
   return {
     threadId: shell.id,
@@ -549,7 +587,19 @@ function listItemFromShell(shell: OrchestrationV2ThreadShell): OrchestratorMcpTh
     model: shell.modelSelection.model,
     runtimeMode: shell.runtimeMode,
     interactionMode: shell.interactionMode,
+    branch: shell.branch,
+    worktreePath: shell.worktreePath,
     linkedPullRequest: shell.linkedPullRequest ?? null,
+    pinnedAt: iso(shell.pinnedAt),
+    pinOrderKey: shell.pinOrderKey ?? null,
+    settledOverride: shell.settledOverride,
+    settledAt: iso(shell.settledAt),
+    snoozedUntil: iso(shell.snoozedUntil),
+    snoozedAt: iso(shell.snoozedAt),
+    archived: shell.archivedAt !== null,
+    archivedAt: iso(shell.archivedAt),
+    readState: shellReadState(shell),
+    lastVisitedAt: iso(shell.lastVisitedAt),
     parentThreadId: shell.lineage.parentThreadId,
     relationshipToParent: shell.lineage.relationshipToParent,
     itemCount: shell.visibleItemCount,
@@ -593,9 +643,82 @@ function threadDetail(projection: OrchestrationV2ThreadProjection): Orchestrator
       (request) => request.status === "pending",
     ).length,
     archived: projection.thread.archivedAt !== null,
+    linkedPullRequest: projection.thread.linkedPullRequest ?? null,
+    archivedAt: iso(projection.thread.archivedAt),
+    pinnedAt: iso(projection.thread.pinnedAt),
+    pinOrderKey: projection.thread.pinOrderKey ?? null,
+    settledOverride: projection.thread.settledOverride,
+    settledAt: iso(projection.thread.settledAt),
+    snoozedUntil: iso(projection.thread.snoozedUntil),
+    snoozedAt: iso(projection.thread.snoozedAt),
+    readState: readState({
+      completedAt: projection.runs.findLast((run) => run.status === "completed")?.completedAt,
+      lastVisitedAt: projection.thread.lastVisitedAt,
+    }),
+    lastVisitedAt: iso(projection.thread.lastVisitedAt),
     createdAt: DateTime.formatIso(projection.thread.createdAt),
     updatedAt: DateTime.formatIso(projection.updatedAt),
   };
+}
+
+function organizationState(
+  projection: OrchestrationV2ThreadProjection,
+): OrchestratorMcpThreadOrganizationState {
+  return {
+    threadId: projection.thread.id,
+    pinnedAt: iso(projection.thread.pinnedAt),
+    pinOrderKey: projection.thread.pinOrderKey ?? null,
+    settledOverride: projection.thread.settledOverride,
+    settledAt: iso(projection.thread.settledAt),
+    snoozedUntil: iso(projection.thread.snoozedUntil),
+    snoozedAt: iso(projection.thread.snoozedAt),
+    archivedAt: iso(projection.thread.archivedAt),
+    readState: readState({
+      completedAt: projection.runs.findLast((run) => run.status === "completed")?.completedAt,
+      lastVisitedAt: projection.thread.lastVisitedAt,
+    }),
+    lastVisitedAt: iso(projection.thread.lastVisitedAt),
+  };
+}
+
+function organizationCommand(input: {
+  readonly action: OrchestratorMcpThreadOrganizeAction;
+  readonly commandId: CommandId;
+  readonly target: OrchestrationV2ThreadProjection;
+}): OrchestrationV2Command {
+  const base = { commandId: input.commandId, threadId: input.target.thread.id } as const;
+  switch (input.action.type) {
+    case "pin":
+      return {
+        type: "thread.pin",
+        ...base,
+        ...(input.action.orderKey === undefined ? {} : { orderKey: input.action.orderKey }),
+      };
+    case "unpin":
+      return { type: "thread.unpin", ...base };
+    case "reorder":
+      return { type: "thread.pin.reorder", ...base, orderKey: input.action.orderKey };
+    case "snooze":
+      return { type: "thread.snooze", ...base, snoozedUntil: input.action.until };
+    case "unsnooze":
+      return { type: "thread.unsnooze", ...base, reason: "user" };
+    case "settle":
+      return { type: "thread.settle", ...base };
+    case "unsettle":
+      return { type: "thread.unsettle", ...base, reason: "user" };
+    case "archive":
+      return { type: "thread.archive", ...base };
+    case "unarchive":
+      return { type: "thread.unarchive", ...base };
+    case "mark_read":
+      return {
+        type: "thread.visit",
+        ...base,
+        visitedAt: DateTime.formatIso(input.target.updatedAt),
+      };
+    case "mark_unread":
+      return { type: "thread.mark-unread", ...base };
+  }
 }
 
 function threadRun(run: OrchestrationV2Run): OrchestratorMcpThreadRun {
@@ -1541,6 +1664,7 @@ const make = Effect.gen(function* () {
           .listProjectThreads({
             projectId: parent.thread.projectId,
             includeSubagents: input.includeSubagents !== false,
+            includeArchived: input.archived === true,
           })
           .pipe(
             Effect.mapError((error) =>
@@ -1558,6 +1682,31 @@ const make = Effect.gen(function* () {
             (thread) =>
               titleContains === undefined ||
               thread.title.toLocaleLowerCase().includes(titleContains),
+          )
+          .filter(
+            (thread) =>
+              input.archived === undefined || (thread.archivedAt !== null) === input.archived,
+          )
+          .filter(
+            (thread) => input.pinned === undefined || (thread.pinnedAt != null) === input.pinned,
+          )
+          .filter(
+            (thread) =>
+              input.settled === undefined ||
+              (thread.settledOverride === "settled") === input.settled,
+          )
+          .filter(
+            (thread) =>
+              input.snoozed === undefined || (thread.snoozedUntil != null) === input.snoozed,
+          )
+          .filter(
+            (thread) =>
+              input.unread === undefined || (shellReadState(thread) === "unread") === input.unread,
+          )
+          .filter(
+            (thread) =>
+              input.hasLinkedPullRequest === undefined ||
+              (thread.linkedPullRequest != null) === input.hasLinkedPullRequest,
           );
         const cursor = input.cursor ?? 0;
         const limit = input.limit ?? DEFAULT_THREAD_LIST_LIMIT;
@@ -1626,6 +1775,108 @@ const make = Effect.gen(function* () {
           nextPosition: page.at(-1)?.position ?? null,
           hasMore: page.length < matching.length,
         } satisfies OrchestratorMcpThreadReadResult;
+      }),
+    organizeThreads: (scope, input) =>
+      Effect.gen(function* () {
+        yield* requireCapability(scope);
+        const key = yield* requestKey(input.clientRequestId);
+        const items =
+          "items" in input
+            ? input.items
+            : [{ threadId: input.threadId ?? scope.threadId, action: input.action }];
+        const outcomes = yield* Effect.forEach(
+          items,
+          (item, index) =>
+            Effect.gen(function* () {
+              const { target } = yield* loadScopedThread(scope, item.threadId);
+              if (
+                item.action.type === "archive" &&
+                target.runtimeRequests.some((request) => request.status === "pending")
+              ) {
+                return yield* failure(
+                  "orchestration_error",
+                  `Thread ${item.threadId} has a pending approval or user-input request and cannot be archived.`,
+                );
+              }
+              yield* threadManagement
+                .dispatch(
+                  organizationCommand({
+                    action: item.action,
+                    target,
+                    commandId: stableCommandId({
+                      scope,
+                      requestKey: key,
+                      operation: `thread-organize-${item.action.type}`,
+                      index,
+                    }),
+                  }),
+                )
+                .pipe(
+                  Effect.mapError((error) =>
+                    failure(
+                      "orchestration_error",
+                      `Unable to ${item.action.type} thread ${item.threadId}: ${errorMessage(error)}`,
+                    ),
+                  ),
+                );
+              const result = yield* loadScopedThread(scope, item.threadId);
+              return {
+                threadId: item.threadId,
+                action: item.action.type,
+                status: "applied",
+                state: organizationState(result.target),
+                error: null,
+              } satisfies OrchestratorMcpThreadOrganizeOutcome;
+            }).pipe(
+              Effect.catch((error) =>
+                Effect.succeed({
+                  threadId: item.threadId,
+                  action: item.action.type,
+                  status: "failed",
+                  state: null,
+                  error: error.message,
+                } satisfies OrchestratorMcpThreadOrganizeOutcome),
+              ),
+            ),
+          { concurrency: 1 },
+        );
+        return { outcomes } satisfies OrchestratorMcpThreadOrganizeResult;
+      }),
+    deleteThread: (scope, input) =>
+      Effect.gen(function* () {
+        const threadId = input.threadId ?? scope.threadId;
+        yield* requireCapability(scope);
+        const parent = yield* loadProjection(scope.threadId);
+        const target = threadId === scope.threadId ? parent : yield* loadProjection(threadId);
+        if (target.thread.projectId !== parent.thread.projectId) {
+          return yield* failure(
+            "thread_not_found",
+            `Thread ${threadId} was not found in the calling project.`,
+          );
+        }
+        if (target.thread.deletedAt !== null) {
+          return { threadId, deleted: true } satisfies OrchestratorMcpThreadDeleteResult;
+        }
+        const key = yield* requestKey(input.clientRequestId);
+        yield* threadManagement
+          .dispatch({
+            type: "thread.delete",
+            commandId: stableCommandId({
+              scope,
+              requestKey: key,
+              operation: "thread-delete",
+            }),
+            threadId,
+          })
+          .pipe(
+            Effect.mapError((error) =>
+              failure(
+                "orchestration_error",
+                `Unable to delete thread ${threadId}: ${errorMessage(error)}`,
+              ),
+            ),
+          );
+        return { threadId, deleted: true } satisfies OrchestratorMcpThreadDeleteResult;
       }),
     sendToThread: (scope, input) =>
       Effect.gen(function* () {

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -652,7 +652,7 @@ function threadDetail(projection: OrchestrationV2ThreadProjection): Orchestrator
     snoozedUntil: iso(projection.thread.snoozedUntil),
     snoozedAt: iso(projection.thread.snoozedAt),
     readState: readState({
-      completedAt: projection.runs.findLast((run) => run.status === "completed")?.completedAt,
+      completedAt: latest?.completedAt,
       lastVisitedAt: projection.thread.lastVisitedAt,
     }),
     lastVisitedAt: iso(projection.thread.lastVisitedAt),
@@ -674,7 +674,7 @@ function organizationState(
     snoozedAt: iso(projection.thread.snoozedAt),
     archivedAt: iso(projection.thread.archivedAt),
     readState: readState({
-      completedAt: projection.runs.findLast((run) => run.status === "completed")?.completedAt,
+      completedAt: latestRun(projection)?.completedAt,
       lastVisitedAt: projection.thread.lastVisitedAt,
     }),
     lastVisitedAt: iso(projection.thread.lastVisitedAt),
@@ -707,7 +707,7 @@ function organizationCommand(input: {
     case "unsettle":
       return { type: "thread.unsettle", ...base, reason: "user" };
     case "archive":
-      return { type: "thread.archive", ...base };
+      return { type: "thread.archive", ...base, requireNoPendingRuntimeRequests: true };
     case "unarchive":
       return { type: "thread.unarchive", ...base };
     case "mark_read":
@@ -1692,12 +1692,13 @@ const make = Effect.gen(function* () {
           )
           .filter(
             (thread) =>
-              input.settled === undefined ||
-              (thread.settledOverride === "settled") === input.settled,
+              input.explicitlySettled === undefined ||
+              (thread.settledOverride === "settled") === input.explicitlySettled,
           )
           .filter(
             (thread) =>
-              input.snoozed === undefined || (thread.snoozedUntil != null) === input.snoozed,
+              input.hasSnoozeMarker === undefined ||
+              (thread.snoozedUntil != null) === input.hasSnoozeMarker,
           )
           .filter(
             (thread) =>
@@ -1789,15 +1790,6 @@ const make = Effect.gen(function* () {
           (item, index) =>
             Effect.gen(function* () {
               const { target } = yield* loadScopedThread(scope, item.threadId);
-              if (
-                item.action.type === "archive" &&
-                target.runtimeRequests.some((request) => request.status === "pending")
-              ) {
-                return yield* failure(
-                  "orchestration_error",
-                  `Thread ${item.threadId} has a pending approval or user-input request and cannot be archived.`,
-                );
-              }
               yield* threadManagement
                 .dispatch(
                   organizationCommand({

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -643,7 +643,6 @@ function threadDetail(projection: OrchestrationV2ThreadProjection): Orchestrator
       (request) => request.status === "pending",
     ).length,
     archived: projection.thread.archivedAt !== null,
-    linkedPullRequest: projection.thread.linkedPullRequest ?? null,
     archivedAt: iso(projection.thread.archivedAt),
     pinnedAt: iso(projection.thread.pinnedAt),
     pinOrderKey: projection.thread.pinOrderKey ?? null,

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -15,8 +15,10 @@ import {
   OrchestratorMcpDelegateTaskResult,
   OrchestratorMcpTaskCancelResult,
   OrchestratorMcpThreadInterruptResult,
+  OrchestratorMcpThreadDeleteResult,
   OrchestratorMcpThreadListResult,
   OrchestratorMcpThreadReadResult,
+  OrchestratorMcpThreadOrganizeResult,
   OrchestratorMcpThreadSendResult,
   OrchestratorMcpThreadWaitResult,
   ProjectId,
@@ -97,8 +99,10 @@ const decodeTaskCancelResult = Schema.decodeUnknownEffect(OrchestratorMcpTaskCan
 const decodeThreadInterruptResult = Schema.decodeUnknownEffect(
   OrchestratorMcpThreadInterruptResult,
 );
+const decodeThreadDeleteResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadDeleteResult);
 const decodeThreadListResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadListResult);
 const decodeThreadReadResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadReadResult);
+const decodeThreadOrganizeResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadOrganizeResult);
 const decodeThreadSendResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadSendResult);
 const decodeThreadWaitResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadWaitResult);
 const decodeThreadUpdateResult = Schema.decodeUnknownEffect(ThreadMetadataMcpUpdateResult);
@@ -1215,6 +1219,14 @@ describe("orchestrator MCP toolkit", () => {
               _tag: "OrchestratorMcpFailure",
               code: "capability_denied",
             });
+            const threadOrganizeTool = server.tools.find(
+              ({ tool }) => tool.name === "t3_thread_organize",
+            );
+            expect(threadOrganizeTool?.tool.annotations?.destructiveHint).toBe(true);
+            const threadDeleteTool = server.tools.find(
+              ({ tool }) => tool.name === "t3_thread_delete",
+            );
+            expect(threadDeleteTool?.tool.annotations?.destructiveHint).toBe(true);
             const threadSendTool = server.tools.find(({ tool }) => tool.name === "t3_thread_send");
             expect(threadSendTool?.tool.annotations?.destructiveHint).toBe(true);
             const threadWaitTool = server.tools.find(({ tool }) => tool.name === "t3_thread_wait");
@@ -2170,6 +2182,111 @@ describe("orchestrator MCP toolkit", () => {
             expect(
               listed.threads.some((thread) => thread.relationshipToParent === "subagent"),
             ).toBe(false);
+
+            const partialOrganizeCall = yield* invoke("t3_thread_organize", {
+              items: [
+                { threadId: emptyThread.threadId, action: { type: "pin", orderKey: "m0" } },
+                { threadId: foreignThreadId, action: { type: "unpin" } },
+              ],
+              clientRequestId: "organize-partial-scope",
+            });
+            const partialOrganize = yield* decodeThreadOrganizeResult(
+              partialOrganizeCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(partialOrganize.outcomes).toMatchObject([
+              { threadId: emptyThread.threadId, status: "applied", action: "pin" },
+              { threadId: foreignThreadId, status: "failed", action: "unpin", state: null },
+            ]);
+
+            const archiveCall = yield* invoke("t3_thread_organize", {
+              threadId: emptyThread.threadId,
+              action: { type: "archive" },
+              clientRequestId: "organize-archive-discovery",
+            });
+            const archiveResult = yield* decodeThreadOrganizeResult(
+              archiveCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(archiveResult.outcomes[0]).toMatchObject({
+              status: "applied",
+              state: { archivedAt: expect.any(String) },
+            });
+            const activeAfterArchive = yield* decodeThreadListResult(
+              (yield* invoke("t3_thread_list", { limit: 100 })).structuredContent,
+            ).pipe(Effect.orDie);
+            expect(
+              activeAfterArchive.threads.some((thread) => thread.threadId === emptyThread.threadId),
+            ).toBe(false);
+            const archivedOnly = yield* decodeThreadListResult(
+              (yield* invoke("t3_thread_list", { archived: true, limit: 100 })).structuredContent,
+            ).pipe(Effect.orDie);
+            expect(
+              archivedOnly.threads.some((thread) => thread.threadId === emptyThread.threadId),
+            ).toBe(true);
+
+            const unarchiveCall = yield* invoke("t3_thread_organize", {
+              threadId: emptyThread.threadId,
+              action: { type: "unarchive" },
+              clientRequestId: "organize-unarchive-discovery",
+            });
+            const unarchiveResult = yield* decodeThreadOrganizeResult(
+              unarchiveCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(unarchiveResult.outcomes[0]).toMatchObject({
+              status: "applied",
+              state: { archivedAt: null },
+            });
+
+            const blockedThreadCall = yield* invoke("create_threads", {
+              threads: [{ prompt: cancellationPrompt, title: "Organization blockers" }],
+              clientRequestId: "organize-blockers-create",
+            });
+            const blockedThread = (yield* decodeCreateThreadsResult(
+              blockedThreadCall.structuredContent,
+            ).pipe(Effect.orDie)).threads[0]!;
+            yield* waitForProjection(orchestrator, blockedThread.threadId, (projection) =>
+              projection.runs.some((run) => run.status === "running"),
+            );
+            yield* invoke("t3_thread_send", {
+              threadId: blockedThread.threadId,
+              message: "Queue this behind the active run.",
+              mode: "queue",
+              clientRequestId: "organize-blockers-queue",
+            });
+            const blockedOrganize = yield* decodeThreadOrganizeResult(
+              (yield* invoke("t3_thread_organize", {
+                items: [
+                  { threadId: blockedThread.threadId, action: { type: "settle" } },
+                  {
+                    threadId: blockedThread.threadId,
+                    action: { type: "snooze", until: "2099-08-29T12:00:00.000Z" },
+                  },
+                ],
+                clientRequestId: "organize-blockers",
+              })).structuredContent,
+            ).pipe(Effect.orDie);
+            expect(blockedOrganize.outcomes.map((outcome) => outcome.status)).toEqual([
+              "failed",
+              "failed",
+            ]);
+            yield* invoke("t3_thread_delete", {
+              threadId: blockedThread.threadId,
+              clientRequestId: "organize-blockers-delete",
+            });
+
+            const firstDelete = yield* decodeThreadDeleteResult(
+              (yield* invoke("t3_thread_delete", {
+                threadId: emptyThread.threadId,
+                clientRequestId: "organize-delete-retry",
+              })).structuredContent,
+            ).pipe(Effect.orDie);
+            const retryDelete = yield* decodeThreadDeleteResult(
+              (yield* invoke("t3_thread_delete", {
+                threadId: emptyThread.threadId,
+                clientRequestId: "organize-delete-retry",
+              })).structuredContent,
+            ).pipe(Effect.orDie);
+            expect(firstDelete).toEqual({ threadId: emptyThread.threadId, deleted: true });
+            expect(retryDelete).toEqual(firstDelete);
 
             // A wait-mode delegation whose blocking wait times out no longer
             // owns delivery, so delegate_task upgrades the task to "always".

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -180,6 +180,7 @@ function makeDeterministicAdapter(input: {
   readonly capabilities: OrchestrationV2ProviderCapabilities;
   readonly capturedTurns: Ref.Ref<ReadonlyArray<CapturedTurn>>;
   readonly shouldComplete: (turn: ProviderAdapterV2TurnInput) => boolean;
+  readonly startedGate?: (turn: ProviderAdapterV2TurnInput) => Deferred.Deferred<void> | undefined;
   readonly terminalGate?: (turn: ProviderAdapterV2TurnInput) => Deferred.Deferred<void> | undefined;
   readonly response: (turn: ProviderAdapterV2TurnInput) => string;
 }): ProviderAdapterV2Shape {
@@ -282,6 +283,10 @@ function makeDeterministicAdapter(input: {
                   },
                 },
               ]);
+              const startedGate = input.startedGate?.(turnInput);
+              if (startedGate !== undefined) {
+                yield* Deferred.succeed(startedGate, undefined);
+              }
               const terminalGate = input.terminalGate?.(turnInput);
               if (terminalGate !== undefined) {
                 yield* Deferred.await(terminalGate);
@@ -477,6 +482,7 @@ describe("orchestrator MCP toolkit", () => {
         Effect.gen(function* () {
           const cwd = yield* checkpointWorkspace("orchestrator-mcp-toolkit");
           const capturedTurns = yield* Ref.make<ReadonlyArray<CapturedTurn>>([]);
+          const providerStartGates = new Map<string, Deferred.Deferred<void>>();
           const parentTerminalGates = new Map<ThreadId, Deferred.Deferred<void>>();
           const deliveryTerminalGates = new Map<ThreadId, Deferred.Deferred<void>>();
           const registryLayer = makeProviderAdapterRegistryLayer([
@@ -487,6 +493,7 @@ describe("orchestrator MCP toolkit", () => {
               capturedTurns,
               shouldComplete: (turn) =>
                 turn.threadId !== parentThreadId && turn.message.text !== cancellationPrompt,
+              startedGate: (turn) => providerStartGates.get(turn.message.text),
               terminalGate: (turn) =>
                 turn.message.text.startsWith("Delegated task") ||
                 turn.message.text.startsWith("Delegated tasks")
@@ -2236,6 +2243,8 @@ describe("orchestrator MCP toolkit", () => {
               state: { archivedAt: null },
             });
 
+            const blockedThreadStarted = yield* Deferred.make<void>();
+            providerStartGates.set(cancellationPrompt, blockedThreadStarted);
             const blockedThreadCall = yield* invoke("create_threads", {
               threads: [{ prompt: cancellationPrompt, title: "Organization blockers" }],
               clientRequestId: "organize-blockers-create",
@@ -2243,9 +2252,8 @@ describe("orchestrator MCP toolkit", () => {
             const blockedThread = (yield* decodeCreateThreadsResult(
               blockedThreadCall.structuredContent,
             ).pipe(Effect.orDie)).threads[0]!;
-            yield* waitForProjection(orchestrator, blockedThread.threadId, (projection) =>
-              projection.runs.some((run) => run.status === "running"),
-            );
+            yield* Deferred.await(blockedThreadStarted);
+            providerStartGates.delete(cancellationPrompt);
             yield* invoke("t3_thread_send", {
               threadId: blockedThread.threadId,
               message: "Queue this behind the active run.",

--- a/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
@@ -98,6 +98,18 @@ const handlers = {
       const service = yield* ThreadMetadataMcpService;
       return yield* service.update(scope, input);
     }),
+  t3_thread_organize: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* OrchestratorMcpService;
+      return yield* service.organizeThreads(scope, input);
+    }),
+  t3_thread_delete: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* OrchestratorMcpService;
+      return yield* service.deleteThread(scope, input);
+    }),
   t3_thread_send: (input) =>
     Effect.gen(function* () {
       const scope = yield* McpInvocationContext;

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.ts
@@ -17,10 +17,14 @@ import {
   OrchestratorMcpTaskStatusInput,
   OrchestratorMcpThreadInterruptInput,
   OrchestratorMcpThreadInterruptResult,
+  OrchestratorMcpThreadDeleteInput,
+  OrchestratorMcpThreadDeleteResult,
   OrchestratorMcpThreadListInput,
   OrchestratorMcpThreadListResult,
   OrchestratorMcpThreadReadInput,
   OrchestratorMcpThreadReadResult,
+  OrchestratorMcpThreadOrganizeInput,
+  OrchestratorMcpThreadOrganizeResult,
   OrchestratorMcpThreadSendInput,
   OrchestratorMcpThreadSendResult,
   OrchestratorMcpThreadStartInput,
@@ -210,6 +214,30 @@ export const ThreadUpdateTool = Tool.make("t3_thread_update", {
   .annotate(Tool.Destructive, true)
   .annotate(Tool.Idempotent, false);
 
+export const ThreadOrganizeTool = Tool.make("t3_thread_organize", {
+  description:
+    "Organize one T3 thread in the calling project, defaulting to this thread, or apply up to 20 operations with explicit per-item outcomes. Actions pin, unpin, reorder, snooze, unsnooze, settle, unsettle, archive, unarchive, and mark read or unread. The result returns the durable organization state after each successful action. clientRequestId makes retries idempotent.",
+  parameters: OrchestratorMcpThreadOrganizeInput,
+  success: OrchestratorMcpThreadOrganizeResult,
+  failure: OrchestratorMcpFailure,
+  failureMode: "return",
+  dependencies,
+})
+  .annotate(Tool.Title, "Organize T3 threads")
+  .annotate(Tool.Destructive, true);
+
+export const ThreadDeleteTool = Tool.make("t3_thread_delete", {
+  description:
+    "Permanently delete one T3 thread in the calling project, defaulting to this thread. This cancels its active work and removes it from thread listings. clientRequestId makes retries idempotent.",
+  parameters: OrchestratorMcpThreadDeleteInput,
+  success: OrchestratorMcpThreadDeleteResult,
+  failure: OrchestratorMcpFailure,
+  failureMode: "return",
+  dependencies,
+})
+  .annotate(Tool.Title, "Delete a T3 thread")
+  .annotate(Tool.Destructive, true);
+
 export const ThreadSendTool = Tool.make("t3_thread_send", {
   description:
     "Send a message to a T3 thread in the calling project. mode='auto' starts an idle thread, steers a fully active turn, or queues behind a turn that is not yet steerable. Use queue for a separate follow-up turn, steer for an in-flight update, or restart to interrupt-and-restart the active turn. clientRequestId makes retries idempotent.",
@@ -263,6 +291,8 @@ export const OrchestratorToolkit = Toolkit.make(
   ThreadListTool,
   ThreadReadTool,
   ThreadUpdateTool,
+  ThreadOrganizeTool,
+  ThreadDeleteTool,
   ThreadSendTool,
   ThreadWaitTool,
   ThreadInterruptTool,

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -1494,6 +1494,17 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         cause: `Thread ${command.threadId} is already archived.`,
       });
     }
+    if (
+      command.type === "thread.archive" &&
+      command.requireNoPendingRuntimeRequests === true &&
+      projection.runtimeRequests.some((request) => request.status === "pending")
+    ) {
+      return yield* new OrchestratorDispatchError({
+        commandId: command.commandId,
+        commandType: command.type,
+        cause: `Thread ${command.threadId} has a pending approval or user-input request and cannot be archived.`,
+      });
+    }
     if (command.type === "thread.unarchive" && thread.archivedAt === null) {
       return yield* new OrchestratorDispatchError({
         commandId: command.commandId,

--- a/apps/server/src/orchestration-v2/ThreadManagementService.ts
+++ b/apps/server/src/orchestration-v2/ThreadManagementService.ts
@@ -288,6 +288,7 @@ export interface ThreadManagementServiceShape {
   readonly listProjectThreads: (input: {
     readonly projectId: ProjectId;
     readonly includeSubagents: boolean;
+    readonly includeArchived?: boolean;
   }) => Effect.Effect<ReadonlyArray<OrchestrationV2ThreadShell>, ThreadManagementError>;
   readonly sendToThread: (
     input: ThreadManagementSendInput,
@@ -463,7 +464,7 @@ const make = Effect.gen(function* () {
           }),
       ),
       Effect.map((snapshot) =>
-        snapshot.threads
+        [...snapshot.threads, ...(input.includeArchived === true ? snapshot.archivedThreads : [])]
           .filter((thread) => thread.projectId === input.projectId)
           .filter(
             (thread) =>

--- a/apps/server/src/orchestration-v2/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.test.ts
@@ -16,7 +16,6 @@ import {
   ProviderInstanceId,
   ProviderThreadId,
   RunId,
-  RuntimeRequestId,
   ThreadId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";

--- a/apps/server/src/orchestration-v2/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.test.ts
@@ -16,6 +16,7 @@ import {
   ProviderInstanceId,
   ProviderThreadId,
   RunId,
+  RuntimeRequestId,
   ThreadId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
@@ -1369,6 +1370,66 @@ it.layer(TestLayer)("OrchestrationV2LayerLive lifecycle", (it) => {
 
       const afterPromotion = yield* orchestrator.getThreadProjection(threadId);
       assert.equal(afterPromotion.runs.find((run) => run.id === queuedRun.id)?.status, "cancelled");
+    }),
+  );
+
+  it.effect("atomically rejects constrained archive when a runtime request is pending", () =>
+    Effect.gen(function* () {
+      const orchestrator = yield* OrchestratorV2;
+      const eventSink = yield* EventSinkV2;
+      const threadId = ThreadId.make("runtime-layer-constrained-archive-thread");
+      const now = yield* DateTime.now;
+
+      yield* orchestrator.dispatch({
+        type: "thread.create",
+        createdBy: "user",
+        creationSource: "web",
+        commandId: CommandId.make("runtime-layer-constrained-archive-create"),
+        threadId,
+        projectId: ProjectId.make("runtime-layer-constrained-archive-project"),
+        title: "Constrained archive",
+        modelSelection,
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+      });
+      yield* eventSink.write({
+        events: [
+          {
+            id: EventId.make("event:runtime-layer-constrained-archive-request"),
+            type: "runtime-request.updated",
+            threadId,
+            occurredAt: now,
+            payload: {
+              id: RuntimeRequestId.make("request:runtime-layer-constrained-archive"),
+              nodeId: NodeId.make("node:runtime-layer-constrained-archive"),
+              providerTurnId: null,
+              nativeRequestRef: null,
+              kind: "user_input",
+              status: "pending",
+              responseCapability: { type: "not_resumable", reason: "test request" },
+              createdAt: now,
+              resolvedAt: null,
+            },
+          },
+        ],
+      });
+
+      const error = yield* orchestrator
+        .dispatch({
+          type: "thread.archive",
+          commandId: CommandId.make("runtime-layer-constrained-archive"),
+          threadId,
+          requireNoPendingRuntimeRequests: true,
+        })
+        .pipe(Effect.flip);
+
+      assert.equal(error._tag, "OrchestratorDispatchError");
+      assert.match(error.message, /archive/);
+      const projection = yield* orchestrator.getThreadProjection(threadId);
+      assert.isNull(projection.thread.archivedAt);
+      assert.equal(projection.runtimeRequests[0]?.status, "pending");
     }),
   );
 

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -266,12 +266,16 @@ retry the request.
 
 Lists durable thread shells in the calling thread's project, newest first.
 Callers can filter by title, run status, archive state, pin state, explicit
-settlement, snooze state, unread completion, linked pull request, and whether
+settlement, stored snooze marker, unread completion, linked pull request, and whether
 app-owned sub-agent threads are included. Results include raw organization
 timestamps, pin order, read state, linked pull request, branch, and workspace
 path. Results are bounded and offset-paginated. The server pages shell
 snapshots, including archived shells when requested, without loading thread
 transcripts. Deleted threads and threads from other projects are never exposed.
+`explicitlySettled` checks only `settledOverride`; it does not reproduce
+client-local automatic settlement. `hasSnoozeMarker` reports stored snooze
+timestamps, which remain after timer expiry or an early wake and do not mean
+the sidebar still hides the thread.
 
 ### `t3_thread_read`
 

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -274,8 +274,9 @@ snapshots, including archived shells when requested, without loading thread
 transcripts. Deleted threads and threads from other projects are never exposed.
 `explicitlySettled` checks only `settledOverride`; it does not reproduce
 client-local automatic settlement. `hasSnoozeMarker` reports stored snooze
-timestamps, which remain after timer expiry or an early wake and do not mean
-the sidebar still hides the thread.
+timestamps. Timer expiry and derived raised-hand wakes leave those timestamps
+in place, so a marker does not mean the sidebar still hides the thread. Explicit
+unsnooze operations and new user messages clear the marker.
 
 ### `t3_thread_read`
 

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -265,9 +265,13 @@ retry the request.
 ### `t3_thread_list`
 
 Lists durable thread shells in the calling thread's project, newest first.
-Callers can filter by title, run status, and whether app-owned sub-agent threads
-are included. Results are bounded and offset-paginated. Deleted threads and
-threads from other projects are never exposed.
+Callers can filter by title, run status, archive state, pin state, explicit
+settlement, snooze state, unread completion, linked pull request, and whether
+app-owned sub-agent threads are included. Results include raw organization
+timestamps, pin order, read state, linked pull request, branch, and workspace
+path. Results are bounded and offset-paginated. The server pages shell
+snapshots, including archived shells when requested, without loading thread
+transcripts. Deleted threads and threads from other projects are never exposed.
 
 ### `t3_thread_read`
 
@@ -297,6 +301,31 @@ resultant title, title-regeneration marker, and linked pull request. Reusing a
 `clientRequestId` for the same action and thread replays the same command
 receipt. Thread list and read results expose the linked pull request, and thread
 detail also exposes an in-flight title regeneration.
+
+The thread detail includes the same raw organization fields as
+`t3_thread_list`. This lets an agent verify a mutation without inferring sidebar
+state from run status.
+
+### `t3_thread_organize`
+
+Runs the existing V2 organization commands for a thread in the calling
+project. A single operation defaults to the calling thread. A batch accepts up
+to 20 thread and action pairs and returns an applied or failed outcome for each
+pair. Supported actions are pin, unpin, reorder, snooze, unsnooze, settle,
+unsettle, archive, unarchive, mark read, and mark unread.
+
+The V2 decider remains authoritative. Pinning clears snooze and explicit
+settlement, settling clears the pin, and threads with active or blocked work
+cannot settle. A pending approval or user-input request also blocks archive
+through MCP. Every successful outcome returns the resulting durable
+organization state.
+
+### `t3_thread_delete`
+
+Permanently deletes one thread in the calling project and defaults to the
+calling thread when `threadId` is omitted. The tool is separate from
+`t3_thread_organize` so clients can identify and confirm the destructive
+operation.
 
 ### `t3_thread_send`
 

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -37,6 +37,11 @@ rename a thread, regenerate its title, or link and unlink a pull request. These 
 appear on web, desktop, and mobile without requiring the originating browser to remain
 open.
 
+Agents connected through T3 Code can organize threads too. They can pin, snooze,
+settle, archive, or change read state in the current project. T3 Code applies the
+same rules as the sidebar. For example, an agent cannot settle a thread while work
+or a user request is still pending.
+
 ## Settle finished work
 
 Choose **Settle thread** from its menu to move finished work out of the active list

--- a/packages/contracts/src/orchestrationV2.ts
+++ b/packages/contracts/src/orchestrationV2.ts
@@ -2042,6 +2042,7 @@ export const OrchestrationV2Command = Schema.Union([
     type: Schema.Literal("thread.archive"),
     commandId: CommandId,
     threadId: ThreadId,
+    requireNoPendingRuntimeRequests: Schema.optional(Schema.Literal(true)),
   }),
   Schema.Struct({
     type: Schema.Literal("thread.unarchive"),

--- a/packages/contracts/src/orchestratorMcp.test.ts
+++ b/packages/contracts/src/orchestratorMcp.test.ts
@@ -140,6 +140,8 @@ describe("orchestrator MCP contracts", () => {
       decodeThreadListInput({
         statuses: ["running", "completed"],
         includeSubagents: false,
+        explicitlySettled: true,
+        hasSnoozeMarker: false,
         limit: 25,
       }).statuses,
     ).toEqual(["running", "completed"]);

--- a/packages/contracts/src/orchestratorMcp.test.ts
+++ b/packages/contracts/src/orchestratorMcp.test.ts
@@ -201,5 +201,18 @@ describe("orchestrator MCP contracts", () => {
         })),
       }),
     ).toThrow();
+    expect(() => decodeThreadOrganizeInput({})).toThrow();
+    expect(() =>
+      decodeThreadOrganizeInput({
+        action: { type: "settle" },
+        items: [{ threadId: "thread-a", action: { type: "unpin" } }],
+      }),
+    ).toThrow();
+    expect(() =>
+      decodeThreadOrganizeInput({
+        threadId: "thread-a",
+        items: [{ threadId: "thread-b", action: { type: "unpin" } }],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/contracts/src/orchestratorMcp.test.ts
+++ b/packages/contracts/src/orchestratorMcp.test.ts
@@ -7,6 +7,7 @@ import {
   OrchestratorMcpDelegateTaskResult,
   OrchestratorMcpThreadInterruptInput,
   OrchestratorMcpThreadListInput,
+  OrchestratorMcpThreadOrganizeInput,
   OrchestratorMcpThreadReadInput,
   OrchestratorMcpThreadSendInput,
   OrchestratorMcpThreadStartInput,
@@ -18,6 +19,7 @@ const decodeDelegateTaskInput = Schema.decodeUnknownSync(OrchestratorMcpDelegate
 const decodeDelegateTaskResult = Schema.decodeUnknownSync(OrchestratorMcpDelegateTaskResult);
 const decodeThreadInterruptInput = Schema.decodeUnknownSync(OrchestratorMcpThreadInterruptInput);
 const decodeThreadListInput = Schema.decodeUnknownSync(OrchestratorMcpThreadListInput);
+const decodeThreadOrganizeInput = Schema.decodeUnknownSync(OrchestratorMcpThreadOrganizeInput);
 const decodeThreadReadInput = Schema.decodeUnknownSync(OrchestratorMcpThreadReadInput);
 const decodeThreadSendInput = Schema.decodeUnknownSync(OrchestratorMcpThreadSendInput);
 const decodeThreadStartInput = Schema.decodeUnknownSync(OrchestratorMcpThreadStartInput);
@@ -169,5 +171,33 @@ describe("orchestrator MCP contracts", () => {
         reason: "Loop converged.",
       }).reason,
     ).toBe("Loop converged.");
+  });
+
+  it("decodes single-thread and bounded batch organization requests", () => {
+    expect(
+      decodeThreadOrganizeInput({
+        action: { type: "settle" },
+        clientRequestId: "settle-this-thread",
+      }),
+    ).toMatchObject({ action: { type: "settle" } });
+    expect(
+      decodeThreadOrganizeInput({
+        items: [
+          { threadId: "thread-a", action: { type: "pin", orderKey: "a0" } },
+          {
+            threadId: "thread-b",
+            action: { type: "snooze", until: "2026-08-30T10:00:00.000Z" },
+          },
+        ],
+      }),
+    ).toMatchObject({ items: [{ threadId: "thread-a" }, { threadId: "thread-b" }] });
+    expect(() =>
+      decodeThreadOrganizeInput({
+        items: Array.from({ length: 21 }, (_, index) => ({
+          threadId: `thread-${index}`,
+          action: { type: "unpin" },
+        })),
+      }),
+    ).toThrow();
   });
 });

--- a/packages/contracts/src/orchestratorMcp.ts
+++ b/packages/contracts/src/orchestratorMcp.ts
@@ -478,20 +478,29 @@ export const OrchestratorMcpThreadOrganizeItem = Schema.Struct({
 });
 export type OrchestratorMcpThreadOrganizeItem = typeof OrchestratorMcpThreadOrganizeItem.Type;
 
-export const OrchestratorMcpThreadOrganizeInput = Schema.Union([
-  Schema.Struct({
-    threadId: Schema.optional(ThreadId),
-    action: OrchestratorMcpThreadOrganizeAction,
-    clientRequestId: Schema.optional(OrchestratorMcpClientRequestId),
-  }),
-  Schema.Struct({
-    items: Schema.Array(OrchestratorMcpThreadOrganizeItem).check(
+export const OrchestratorMcpThreadOrganizeInput = Schema.Struct({
+  threadId: Schema.optional(ThreadId),
+  action: Schema.optional(OrchestratorMcpThreadOrganizeAction),
+  items: Schema.optional(
+    Schema.Array(OrchestratorMcpThreadOrganizeItem).check(
       Schema.isMinLength(1),
       Schema.isMaxLength(20),
     ),
-    clientRequestId: Schema.optional(OrchestratorMcpClientRequestId),
+  ),
+  clientRequestId: Schema.optional(OrchestratorMcpClientRequestId),
+}).check(
+  Schema.makeFilter((input) => {
+    const hasAction = input.action !== undefined;
+    const hasItems = input.items !== undefined;
+    if (hasAction === hasItems) {
+      return "Provide exactly one of action or items.";
+    }
+    if (hasItems && input.threadId !== undefined) {
+      return "threadId is accepted only with a single action; batch items carry their own IDs.";
+    }
+    return true;
   }),
-]);
+);
 export type OrchestratorMcpThreadOrganizeInput = typeof OrchestratorMcpThreadOrganizeInput.Type;
 
 export const OrchestratorMcpThreadOrganizationState = Schema.Struct({

--- a/packages/contracts/src/orchestratorMcp.ts
+++ b/packages/contracts/src/orchestratorMcp.ts
@@ -389,7 +389,6 @@ export const OrchestratorMcpThreadDetail = Schema.Struct({
   itemCount: NonNegativeInt,
   pendingRequestCount: NonNegativeInt,
   archived: Schema.Boolean,
-  linkedPullRequest: Schema.NullOr(ThreadLinkedPullRequest),
   archivedAt: Schema.NullOr(IsoDateTime),
   pinnedAt: Schema.NullOr(IsoDateTime),
   pinOrderKey: Schema.NullOr(Schema.String),

--- a/packages/contracts/src/orchestratorMcp.ts
+++ b/packages/contracts/src/orchestratorMcp.ts
@@ -29,6 +29,7 @@ import {
   OrchestrationV2RunStatus,
   OrchestrationV2TurnItemStatus,
 } from "./orchestrationV2.ts";
+import { ThreadLinkedPullRequest } from "./orchestration.ts";
 import {
   ProviderOptionDescriptor,
   ProviderOptionSelection,
@@ -294,6 +295,12 @@ export const OrchestratorMcpThreadListInput = Schema.Struct({
   ),
   titleContains: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(256))),
   includeSubagents: Schema.optional(Schema.Boolean),
+  archived: Schema.optional(Schema.Boolean),
+  pinned: Schema.optional(Schema.Boolean),
+  settled: Schema.optional(Schema.Boolean),
+  snoozed: Schema.optional(Schema.Boolean),
+  unread: Schema.optional(Schema.Boolean),
+  hasLinkedPullRequest: Schema.optional(Schema.Boolean),
   cursor: Schema.optional(NonNegativeInt),
   limit: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(100))),
 });
@@ -310,7 +317,19 @@ export const OrchestratorMcpThreadListItem = Schema.Struct({
   model: Schema.String,
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode,
+  branch: Schema.NullOr(Schema.String),
+  worktreePath: Schema.NullOr(Schema.String),
   linkedPullRequest: Schema.NullOr(ThreadLinkedPullRequest),
+  pinnedAt: Schema.NullOr(IsoDateTime),
+  pinOrderKey: Schema.NullOr(Schema.String),
+  settledOverride: Schema.NullOr(Schema.Literals(["settled", "active"])),
+  settledAt: Schema.NullOr(IsoDateTime),
+  snoozedUntil: Schema.NullOr(IsoDateTime),
+  snoozedAt: Schema.NullOr(IsoDateTime),
+  archived: Schema.Boolean,
+  archivedAt: Schema.NullOr(IsoDateTime),
+  readState: Schema.Literals(["read", "unread", "unknown"]),
+  lastVisitedAt: Schema.NullOr(IsoDateTime),
   parentThreadId: Schema.NullOr(ThreadId),
   relationshipToParent: Schema.NullOr(Schema.Literals(["fork", "subagent"])),
   itemCount: NonNegativeInt,
@@ -361,6 +380,16 @@ export const OrchestratorMcpThreadDetail = Schema.Struct({
   itemCount: NonNegativeInt,
   pendingRequestCount: NonNegativeInt,
   archived: Schema.Boolean,
+  linkedPullRequest: Schema.NullOr(ThreadLinkedPullRequest),
+  archivedAt: Schema.NullOr(IsoDateTime),
+  pinnedAt: Schema.NullOr(IsoDateTime),
+  pinOrderKey: Schema.NullOr(Schema.String),
+  settledOverride: Schema.NullOr(Schema.Literals(["settled", "active"])),
+  settledAt: Schema.NullOr(IsoDateTime),
+  snoozedUntil: Schema.NullOr(IsoDateTime),
+  snoozedAt: Schema.NullOr(IsoDateTime),
+  readState: Schema.Literals(["read", "unread", "unknown"]),
+  lastVisitedAt: Schema.NullOr(IsoDateTime),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });
@@ -404,6 +433,97 @@ export const OrchestratorMcpThreadReadResult = Schema.Struct({
   hasMore: Schema.Boolean,
 });
 export type OrchestratorMcpThreadReadResult = typeof OrchestratorMcpThreadReadResult.Type;
+
+export const OrchestratorMcpThreadOrganizeAction = Schema.Union([
+  Schema.Struct({ type: Schema.Literal("pin"), orderKey: Schema.optional(TrimmedNonEmptyString) }),
+  Schema.Struct({ type: Schema.Literal("unpin") }),
+  Schema.Struct({ type: Schema.Literal("reorder"), orderKey: TrimmedNonEmptyString }),
+  Schema.Struct({ type: Schema.Literal("snooze"), until: IsoDateTime }),
+  Schema.Struct({ type: Schema.Literal("unsnooze") }),
+  Schema.Struct({ type: Schema.Literal("settle") }),
+  Schema.Struct({ type: Schema.Literal("unsettle") }),
+  Schema.Struct({ type: Schema.Literal("archive") }),
+  Schema.Struct({ type: Schema.Literal("unarchive") }),
+  Schema.Struct({ type: Schema.Literal("mark_read") }),
+  Schema.Struct({ type: Schema.Literal("mark_unread") }),
+]);
+export type OrchestratorMcpThreadOrganizeAction = typeof OrchestratorMcpThreadOrganizeAction.Type;
+export const OrchestratorMcpThreadOrganizeActionType = Schema.Literals([
+  "pin",
+  "unpin",
+  "reorder",
+  "snooze",
+  "unsnooze",
+  "settle",
+  "unsettle",
+  "archive",
+  "unarchive",
+  "mark_read",
+  "mark_unread",
+]);
+
+export const OrchestratorMcpThreadOrganizeItem = Schema.Struct({
+  threadId: ThreadId,
+  action: OrchestratorMcpThreadOrganizeAction,
+});
+export type OrchestratorMcpThreadOrganizeItem = typeof OrchestratorMcpThreadOrganizeItem.Type;
+
+export const OrchestratorMcpThreadOrganizeInput = Schema.Union([
+  Schema.Struct({
+    threadId: Schema.optional(ThreadId),
+    action: OrchestratorMcpThreadOrganizeAction,
+    clientRequestId: Schema.optional(OrchestratorMcpClientRequestId),
+  }),
+  Schema.Struct({
+    items: Schema.Array(OrchestratorMcpThreadOrganizeItem).check(
+      Schema.isMinLength(1),
+      Schema.isMaxLength(20),
+    ),
+    clientRequestId: Schema.optional(OrchestratorMcpClientRequestId),
+  }),
+]);
+export type OrchestratorMcpThreadOrganizeInput = typeof OrchestratorMcpThreadOrganizeInput.Type;
+
+export const OrchestratorMcpThreadOrganizationState = Schema.Struct({
+  threadId: ThreadId,
+  pinnedAt: Schema.NullOr(IsoDateTime),
+  pinOrderKey: Schema.NullOr(Schema.String),
+  settledOverride: Schema.NullOr(Schema.Literals(["settled", "active"])),
+  settledAt: Schema.NullOr(IsoDateTime),
+  snoozedUntil: Schema.NullOr(IsoDateTime),
+  snoozedAt: Schema.NullOr(IsoDateTime),
+  archivedAt: Schema.NullOr(IsoDateTime),
+  readState: Schema.Literals(["read", "unread", "unknown"]),
+  lastVisitedAt: Schema.NullOr(IsoDateTime),
+});
+export type OrchestratorMcpThreadOrganizationState =
+  typeof OrchestratorMcpThreadOrganizationState.Type;
+
+export const OrchestratorMcpThreadOrganizeOutcome = Schema.Struct({
+  threadId: ThreadId,
+  action: OrchestratorMcpThreadOrganizeActionType,
+  status: Schema.Literals(["applied", "failed"]),
+  state: Schema.NullOr(OrchestratorMcpThreadOrganizationState),
+  error: Schema.NullOr(Schema.String),
+});
+export type OrchestratorMcpThreadOrganizeOutcome = typeof OrchestratorMcpThreadOrganizeOutcome.Type;
+
+export const OrchestratorMcpThreadOrganizeResult = Schema.Struct({
+  outcomes: Schema.Array(OrchestratorMcpThreadOrganizeOutcome),
+});
+export type OrchestratorMcpThreadOrganizeResult = typeof OrchestratorMcpThreadOrganizeResult.Type;
+
+export const OrchestratorMcpThreadDeleteInput = Schema.Struct({
+  threadId: Schema.optional(ThreadId),
+  clientRequestId: Schema.optional(OrchestratorMcpClientRequestId),
+});
+export type OrchestratorMcpThreadDeleteInput = typeof OrchestratorMcpThreadDeleteInput.Type;
+
+export const OrchestratorMcpThreadDeleteResult = Schema.Struct({
+  threadId: ThreadId,
+  deleted: Schema.Boolean,
+});
+export type OrchestratorMcpThreadDeleteResult = typeof OrchestratorMcpThreadDeleteResult.Type;
 
 export const OrchestratorMcpThreadSendInput = Schema.Struct({
   threadId: ThreadId,

--- a/packages/contracts/src/orchestratorMcp.ts
+++ b/packages/contracts/src/orchestratorMcp.ts
@@ -297,8 +297,18 @@ export const OrchestratorMcpThreadListInput = Schema.Struct({
   includeSubagents: Schema.optional(Schema.Boolean),
   archived: Schema.optional(Schema.Boolean),
   pinned: Schema.optional(Schema.Boolean),
-  settled: Schema.optional(Schema.Boolean),
-  snoozed: Schema.optional(Schema.Boolean),
+  explicitlySettled: Schema.optional(
+    Schema.Boolean.annotate({
+      description:
+        "Filter the raw settledOverride field only. This does not include client-derived automatic settlement.",
+    }),
+  ),
+  hasSnoozeMarker: Schema.optional(
+    Schema.Boolean.annotate({
+      description:
+        "Filter whether raw snooze timestamps are stored. A true value can be expired or woken and does not guarantee the sidebar currently hides the thread.",
+    }),
+  ),
   unread: Schema.optional(Schema.Boolean),
   hasLinkedPullRequest: Schema.optional(Schema.Boolean),
   cursor: Schema.optional(NonNegativeInt),

--- a/packages/contracts/src/orchestratorMcp.ts
+++ b/packages/contracts/src/orchestratorMcp.ts
@@ -29,7 +29,6 @@ import {
   OrchestrationV2RunStatus,
   OrchestrationV2TurnItemStatus,
 } from "./orchestrationV2.ts";
-import { ThreadLinkedPullRequest } from "./orchestration.ts";
 import {
   ProviderOptionDescriptor,
   ProviderOptionSelection,

--- a/packages/shared/src/t3McpToolPresentation.test.ts
+++ b/packages/shared/src/t3McpToolPresentation.test.ts
@@ -8,6 +8,10 @@ describe("resolveT3McpToolPresentation", () => {
       displayName: "Read a T3 thread",
       logo: "t3-code",
     });
+    expect(resolveT3McpToolPresentation("mcp__t3-code__t3_thread_organize")).toEqual({
+      displayName: "Organize T3 threads",
+      logo: "t3-code",
+    });
   });
 
   it("pretty prints Codex T3 MCP tool names", () => {

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -49,6 +49,8 @@ const T3_MCP_TOOLS: Record<
   t3_thread_list: { displayName: "List T3 threads", summaryAction: "thread-list" },
   t3_thread_read: { displayName: "Read a T3 thread", summaryAction: "thread-read" },
   t3_thread_update: { displayName: "Update T3 thread metadata" },
+  t3_thread_organize: { displayName: "Organize T3 threads" },
+  t3_thread_delete: { displayName: "Delete a T3 thread" },
   t3_thread_send: { displayName: "Send to a T3 thread", summaryAction: "thread-send" },
   t3_thread_wait: { displayName: "Wait for a T3 thread", summaryAction: "thread-wait" },
   t3_thread_interrupt: { displayName: "Interrupt a T3 thread", summaryAction: "thread-interrupt" },


### PR DESCRIPTION
Agents can inspect thread run state through MCP, but they cannot see or change the organization state users manage in the sidebar.

This change adds shell-backed organization fields and filters to thread list/read, plus typed tools for pinning, snoozing, settling, archiving, read state, and deletion. Mutations use the existing serialized V2 commands and return durable resulting state. Archived discovery stays on the shell snapshot path without loading transcripts.

Behavior remains current-project scoped. The V2 decider owns lifecycle rules, and MCP refuses to archive a thread with a pending approval or user-input request. The current V2 settlement behavior, including snooze wake-up ordering, is preserved.

Focused validation:

- 51 focused tests across contracts, MCP service/toolkit, runtime wiring, presentation, and `ThreadSettlementService`
- `vp run --filter t3 typecheck`
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter @t3tools/shared typecheck`
- Targeted `vp lint`, `vp fmt --check`, and `git diff --check`

Review base: `t3code/codex-turn-mapping` at `415ed0f73b97f1655b6282492f81d0b2bba3a9cc`. Native stack: [#8676](https://github.com/pingdotgg/t3code/pull/8676) → [#8683](https://github.com/pingdotgg/t3code/pull/8683).

Implemented by GPT-5.6-Sol via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3_thread_organize` and `t3_thread_delete` MCP tools and extend thread listing with organization state
> - Adds MCP tools for pin, snooze, settle, archive, reorder, and mark-read/unread actions on threads, supporting single or batched requests (max 20 items) with per-item success/failure outcomes
> - Adds `t3_thread_delete` with idempotent handling and calling-project scope enforcement
> - Extends `t3_thread_list` and `t3_thread_read` responses with branch, workspace, pin, settlement, snooze, archive, and read-state fields; read state is computed from the latest run completion watermark without loading transcripts
> - Adds a dispatch guard in `makeOrchestrator` that rejects constrained `thread.archive` commands when pending runtime requests exist, leaving archive state and request status unchanged
> - Behavioral Change: `listProjectThreads` in [ThreadManagementService.ts](https://github.com/pingdotgg/t3code/pull/8676/files#diff-4bc3c30459f73120ea1eb6d76f809275562c4e368223865f071a79e530aadb7b) gains an optional `includeArchived` parameter; default listing still returns active shells only. Archive commands carrying `requireNoPendingRuntimeRequests` will now raise `OrchestratorDispatchError` when pending approval or user-input runtime requests exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35dfd51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->