### PR TITLE
feat(mcp): update thread metadata

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -12,6 +12,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import packageJson from "../../package.json" with { type: "json" };
 import * as McpInvocationContext from "./McpInvocationContext.ts";
 import * as OrchestratorMcpService from "./OrchestratorMcpService.ts";
+import * as ThreadMetadataMcpService from "./ThreadMetadataMcpService.ts";
 import * as McpSessionRegistry from "./McpSessionRegistry.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
 import { OrchestratorToolkitHandlersLive } from "./toolkits/orchestrator/handlers.ts";
@@ -224,6 +225,7 @@ export const PreviewToolkitRegistrationLive = Layer.mergeAll(
 export const OrchestratorToolkitRegistrationLive = McpServer.toolkit(OrchestratorToolkit).pipe(
   Layer.provide(OrchestratorToolkitHandlersLive),
   Layer.provide(OrchestratorMcpService.layer),
+  Layer.provide(ThreadMetadataMcpService.layer),
 );
 
 export const WorktreeToolkitRegistrationLive = McpServer.toolkit(WorktreeToolkit).pipe(

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -549,6 +549,7 @@ function listItemFromShell(shell: OrchestrationV2ThreadShell): OrchestratorMcpTh
     model: shell.modelSelection.model,
     runtimeMode: shell.runtimeMode,
     interactionMode: shell.interactionMode,
+    linkedPullRequest: shell.linkedPullRequest ?? null,
     parentThreadId: shell.lineage.parentThreadId,
     relationshipToParent: shell.lineage.relationshipToParent,
     itemCount: shell.visibleItemCount,
@@ -573,6 +574,15 @@ function threadDetail(projection: OrchestrationV2ThreadProjection): Orchestrator
     model: projection.thread.modelSelection.model,
     runtimeMode: projection.thread.runtimeMode,
     interactionMode: projection.thread.interactionMode,
+    linkedPullRequest: projection.thread.linkedPullRequest ?? null,
+    titleRegeneration:
+      projection.thread.titleRegeneration === undefined ||
+      projection.thread.titleRegeneration === null
+        ? null
+        : {
+            requestId: projection.thread.titleRegeneration.requestId,
+            startedAt: DateTime.formatIso(projection.thread.titleRegeneration.startedAt),
+          },
     branch: projection.thread.branch,
     worktreePath: projection.thread.worktreePath,
     parentThreadId: projection.thread.lineage.parentThreadId,

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -30,6 +30,7 @@ import {
   type ScheduledTaskUpsertInput,
   type ServerProvider,
   ThreadId,
+  ThreadMetadataMcpUpdateResult,
   TurnItemId,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
@@ -100,6 +101,7 @@ const decodeThreadListResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadL
 const decodeThreadReadResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadReadResult);
 const decodeThreadSendResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadSendResult);
 const decodeThreadWaitResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadWaitResult);
+const decodeThreadUpdateResult = Schema.decodeUnknownEffect(ThreadMetadataMcpUpdateResult);
 
 const codexSelection = {
   instanceId: codexInstanceId,
@@ -667,13 +669,19 @@ describe("orchestrator MCP toolkit", () => {
               capabilities: new Set(["orchestration"]),
               issuedAt: 1,
             };
-            const invoke = (name: string, args: Record<string, unknown>) =>
+            const invokeAs = (
+              callScope: McpInvocationContext.McpInvocationScope,
+              name: string,
+              args: Record<string, unknown>,
+            ) =>
               server
                 .callTool({ name, arguments: args })
                 .pipe(
-                  Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+                  Effect.provideService(McpInvocationContext.McpInvocationContext, callScope),
                   Effect.provideService(McpSchema.McpServerClient, client),
                 );
+            const invoke = (name: string, args: Record<string, unknown>) =>
+              invokeAs(invocation, name, args);
 
             if (parentRun === undefined || parentRun.rootNodeId === null) {
               return yield* Effect.die(new Error("Parent run missing."));
@@ -1185,6 +1193,28 @@ describe("orchestrator MCP toolkit", () => {
             expect(threadListTool?.tool.annotations?.idempotentHint).toBe(true);
             const threadReadTool = server.tools.find(({ tool }) => tool.name === "t3_thread_read");
             expect(threadReadTool?.tool.annotations?.readOnlyHint).toBe(false);
+            const threadUpdateTool = server.tools.find(
+              ({ tool }) => tool.name === "t3_thread_update",
+            );
+            expect(threadUpdateTool?.tool.annotations?.destructiveHint).toBe(true);
+            expect(threadUpdateTool?.tool.annotations?.idempotentHint).toBe(true);
+            expect(threadUpdateTool?.tool.inputSchema).toMatchObject({
+              type: "object",
+              properties: {
+                action: expect.any(Object),
+                title: expect.any(Object),
+                pullRequest: expect.any(Object),
+              },
+            });
+            const deniedThreadUpdate = yield* invokeAs(
+              { ...invocation, capabilities: new Set() },
+              "t3_thread_update",
+              { action: "rename", title: "Denied title" },
+            );
+            expect(deniedThreadUpdate.structuredContent).toMatchObject({
+              _tag: "OrchestratorMcpFailure",
+              code: "capability_denied",
+            });
             const threadSendTool = server.tools.find(({ tool }) => tool.name === "t3_thread_send");
             expect(threadSendTool?.tool.annotations?.destructiveHint).toBe(true);
             const threadWaitTool = server.tools.find(({ tool }) => tool.name === "t3_thread_wait");
@@ -1728,6 +1758,111 @@ describe("orchestrator MCP toolkit", () => {
             });
             expect(emptyProjection.thread.forkedFrom).toBeNull();
             expect(emptyProjection.runs).toEqual([]);
+
+            const defaultRenameCall = yield* invoke("t3_thread_update", {
+              action: "rename",
+              title: "MCP parent metadata",
+              clientRequestId: "metadata-default-thread-1",
+            });
+            const defaultRenamed = yield* decodeThreadUpdateResult(
+              defaultRenameCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(defaultRenamed).toMatchObject({
+              threadId: parentThreadId,
+              action: "rename",
+              title: "MCP parent metadata",
+            });
+
+            const renameCall = yield* invoke("t3_thread_update", {
+              threadId: emptyThread.threadId,
+              action: "rename",
+              title: "Metadata-managed thread",
+              clientRequestId: "metadata-rename-1",
+            });
+            const renamed = yield* decodeThreadUpdateResult(renameCall.structuredContent).pipe(
+              Effect.orDie,
+            );
+            expect(renamed).toMatchObject({
+              threadId: emptyThread.threadId,
+              action: "rename",
+              title: "Metadata-managed thread",
+              linkedPullRequest: null,
+            });
+            const repeatedRenameCall = yield* invoke("t3_thread_update", {
+              threadId: emptyThread.threadId,
+              action: "rename",
+              title: "Metadata-managed thread",
+              clientRequestId: "metadata-rename-1",
+            });
+            const repeatedRename = yield* decodeThreadUpdateResult(
+              repeatedRenameCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(repeatedRename.commandId).toBe(renamed.commandId);
+            expect(repeatedRename.sequence).toBe(renamed.sequence);
+
+            const linkedCall = yield* invoke("t3_thread_update", {
+              threadId: emptyThread.threadId,
+              action: "link_pull_request",
+              pullRequest: {
+                repository: "pingdotgg/t3code",
+                number: 8689,
+                url: "https://github.com/pingdotgg/t3code/pull/8689",
+              },
+              clientRequestId: "metadata-link-1",
+            });
+            const linked = yield* decodeThreadUpdateResult(linkedCall.structuredContent).pipe(
+              Effect.orDie,
+            );
+            expect(linked.linkedPullRequest).toEqual({
+              projectId,
+              repository: "pingdotgg/t3code",
+              number: 8689,
+              url: "https://github.com/pingdotgg/t3code/pull/8689",
+            });
+            const metadataReadCall = yield* invoke("t3_thread_read", {
+              threadId: emptyThread.threadId,
+            });
+            const metadataRead = yield* decodeThreadReadResult(
+              metadataReadCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(metadataRead.thread).toMatchObject({
+              title: "Metadata-managed thread",
+              linkedPullRequest: linked.linkedPullRequest,
+            });
+            const metadataListCall = yield* invoke("t3_thread_list", { limit: 100 });
+            const metadataList = yield* decodeThreadListResult(
+              metadataListCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(
+              metadataList.threads.find((thread) => thread.threadId === emptyThread.threadId),
+            ).toMatchObject({
+              title: "Metadata-managed thread",
+              linkedPullRequest: linked.linkedPullRequest,
+            });
+
+            const unlinkedCall = yield* invoke("t3_thread_update", {
+              threadId: emptyThread.threadId,
+              action: "unlink_pull_request",
+              clientRequestId: "metadata-unlink-1",
+            });
+            const unlinked = yield* decodeThreadUpdateResult(unlinkedCall.structuredContent).pipe(
+              Effect.orDie,
+            );
+            expect(unlinked.linkedPullRequest).toBeNull();
+
+            const regenerateCall = yield* invoke("t3_thread_update", {
+              threadId: emptyThread.threadId,
+              action: "regenerate_title",
+              clientRequestId: "metadata-regenerate-title-1",
+            });
+            const regenerating = yield* decodeThreadUpdateResult(
+              regenerateCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(regenerating).toMatchObject({
+              threadId: emptyThread.threadId,
+              action: "regenerate_title",
+              titleRegeneration: { requestId: regenerating.commandId },
+            });
             const promptedProjection = yield* waitForProjection(
               orchestrator,
               promptedThread.threadId,
@@ -1995,6 +2130,15 @@ describe("orchestrator MCP toolkit", () => {
               threadId: foreignThreadId,
             });
             expect(foreignReadCall.structuredContent).toMatchObject({
+              _tag: "OrchestratorMcpFailure",
+              code: "thread_not_found",
+            });
+            const foreignUpdateCall = yield* invoke("t3_thread_update", {
+              threadId: foreignThreadId,
+              action: "rename",
+              title: "Should stay foreign",
+            });
+            expect(foreignUpdateCall.structuredContent).toMatchObject({
               _tag: "OrchestratorMcpFailure",
               code: "thread_not_found",
             });

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -1197,7 +1197,7 @@ describe("orchestrator MCP toolkit", () => {
               ({ tool }) => tool.name === "t3_thread_update",
             );
             expect(threadUpdateTool?.tool.annotations?.destructiveHint).toBe(true);
-            expect(threadUpdateTool?.tool.annotations?.idempotentHint).toBe(true);
+            expect(threadUpdateTool?.tool.annotations?.idempotentHint).toBe(false);
             expect(threadUpdateTool?.tool.inputSchema).toMatchObject({
               type: "object",
               properties: {

--- a/apps/server/src/mcp/ThreadMetadataMcpService.test.ts
+++ b/apps/server/src/mcp/ThreadMetadataMcpService.test.ts
@@ -1,0 +1,77 @@
+import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
+import { expect, it } from "@effect/vitest";
+import { EnvironmentId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts";
+import { ThreadManagementService } from "../orchestration-v2/ThreadManagementService.ts";
+import type * as McpInvocationContext from "./McpInvocationContext.ts";
+import {
+  layer as threadMetadataMcpServiceLayer,
+  ThreadMetadataMcpService,
+} from "./ThreadMetadataMcpService.ts";
+
+const threadId = ThreadId.make("thread:metadata-caller");
+const scope: McpInvocationContext.McpInvocationScope = {
+  environmentId: EnvironmentId.make("environment:metadata-test"),
+  threadId,
+  providerSessionId: "provider-session:metadata-test",
+  providerInstanceId: ProviderInstanceId.make("codex"),
+  capabilities: new Set(["orchestration"]),
+  issuedAt: 1,
+};
+
+function serviceLayer(getThreadShell: ThreadManagementService["Service"]["getThreadShell"]) {
+  return threadMetadataMcpServiceLayer.pipe(
+    Layer.provide(
+      Layer.merge(
+        Layer.mock(ThreadManagementService)({
+          getThreadShell,
+          getThreadProjection: () => Effect.die("projection must not load after shell failure"),
+        } satisfies Partial<ThreadManagementService["Service"]>),
+        NodeCrypto.layer,
+      ),
+    ),
+  );
+}
+
+const updateCallingThread = Effect.gen(function* () {
+  const service = yield* ThreadMetadataMcpService;
+  return yield* service.update(scope, {
+    action: "rename",
+    title: "Renamed thread",
+    clientRequestId: "metadata-caller-classification",
+  });
+});
+
+it.effect("reports an absent calling thread as thread_not_found", () =>
+  Effect.gen(function* () {
+    const error = yield* updateCallingThread.pipe(
+      Effect.provide(serviceLayer(() => Effect.succeed(null))),
+      Effect.flip,
+    );
+
+    expect(error.code).toBe("thread_not_found");
+  }),
+);
+
+it.effect("keeps calling-thread storage failures as orchestration errors", () =>
+  Effect.gen(function* () {
+    const error = yield* updateCallingThread.pipe(
+      Effect.provide(
+        serviceLayer(() =>
+          Effect.fail(
+            new OrchestratorProjectionError({
+              threadId,
+              cause: new Error("storage unavailable"),
+            }),
+          ),
+        ),
+      ),
+      Effect.flip,
+    );
+
+    expect(error.code).toBe("orchestration_error");
+  }),
+);

--- a/apps/server/src/mcp/ThreadMetadataMcpService.test.ts
+++ b/apps/server/src/mcp/ThreadMetadataMcpService.test.ts
@@ -5,12 +5,9 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts";
-import { ThreadManagementService } from "../orchestration-v2/ThreadManagementService.ts";
+import * as ThreadManagement from "../orchestration-v2/ThreadManagementService.ts";
 import type * as McpInvocationContext from "./McpInvocationContext.ts";
-import {
-  layer as threadMetadataMcpServiceLayer,
-  ThreadMetadataMcpService,
-} from "./ThreadMetadataMcpService.ts";
+import * as ThreadMetadataMcp from "./ThreadMetadataMcpService.ts";
 
 const threadId = ThreadId.make("thread:metadata-caller");
 const scope: McpInvocationContext.McpInvocationScope = {
@@ -22,14 +19,16 @@ const scope: McpInvocationContext.McpInvocationScope = {
   issuedAt: 1,
 };
 
-function serviceLayer(getThreadShell: ThreadManagementService["Service"]["getThreadShell"]) {
-  return threadMetadataMcpServiceLayer.pipe(
+function serviceLayer(
+  getThreadShell: ThreadManagement.ThreadManagementService["Service"]["getThreadShell"],
+) {
+  return ThreadMetadataMcp.layer.pipe(
     Layer.provide(
       Layer.merge(
-        Layer.mock(ThreadManagementService)({
+        Layer.mock(ThreadManagement.ThreadManagementService)({
           getThreadShell,
           getThreadProjection: () => Effect.die("projection must not load after shell failure"),
-        } satisfies Partial<ThreadManagementService["Service"]>),
+        } satisfies Partial<ThreadManagement.ThreadManagementService["Service"]>),
         NodeCrypto.layer,
       ),
     ),
@@ -37,7 +36,7 @@ function serviceLayer(getThreadShell: ThreadManagementService["Service"]["getThr
 }
 
 const updateCallingThread = Effect.gen(function* () {
-  const service = yield* ThreadMetadataMcpService;
+  const service = yield* ThreadMetadataMcp.ThreadMetadataMcpService;
   return yield* service.update(scope, {
     action: "rename",
     title: "Renamed thread",

--- a/apps/server/src/mcp/ThreadMetadataMcpService.ts
+++ b/apps/server/src/mcp/ThreadMetadataMcpService.ts
@@ -1,0 +1,220 @@
+import {
+  CommandId,
+  OrchestratorMcpFailure,
+  type OrchestrationV2AppThread,
+  type OrchestrationV2Command,
+  type ThreadMetadataMcpAction,
+  type ThreadMetadataMcpUpdateInput,
+  type ThreadMetadataMcpUpdateResult,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import {
+  ThreadManagementError,
+  ThreadManagementService,
+} from "../orchestration-v2/ThreadManagementService.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+
+export interface ThreadMetadataMcpServiceShape {
+  readonly update: (
+    scope: McpInvocationScope,
+    input: ThreadMetadataMcpUpdateInput,
+  ) => Effect.Effect<ThreadMetadataMcpUpdateResult, OrchestratorMcpFailure>;
+}
+
+export class ThreadMetadataMcpService extends Context.Service<
+  ThreadMetadataMcpService,
+  ThreadMetadataMcpServiceShape
+>()("t3/mcp/ThreadMetadataMcpService") {}
+
+function failure(code: OrchestratorMcpFailure["code"], message: string): OrchestratorMcpFailure {
+  return new OrchestratorMcpFailure({ code, message });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function threadLookupFailure(error: ThreadManagementError): OrchestratorMcpFailure {
+  return error._tag === "ThreadManagementThreadNotFoundError"
+    ? failure("thread_not_found", error.message)
+    : failure("orchestration_error", error.message);
+}
+
+function stablePart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function commandId(input: {
+  readonly scope: McpInvocationScope;
+  readonly threadId: ThreadId;
+  readonly action: ThreadMetadataMcpAction;
+  readonly requestKey: string;
+}): CommandId {
+  return CommandId.make(
+    [
+      "command",
+      "mcp",
+      stablePart(input.scope.providerSessionId),
+      "thread-update",
+      stablePart(input.threadId),
+      stablePart(input.action),
+      stablePart(input.requestKey),
+    ].join(":"),
+  );
+}
+
+function metadataCommand(input: {
+  readonly commandId: CommandId;
+  readonly threadId: ThreadId;
+  readonly projectId: OrchestrationV2AppThread["projectId"];
+  readonly update: ThreadMetadataMcpUpdateInput;
+}): Extract<OrchestrationV2Command, { readonly type: "thread.metadata.update" }> {
+  switch (input.update.action) {
+    case "rename":
+      return {
+        type: "thread.metadata.update",
+        commandId: input.commandId,
+        threadId: input.threadId,
+        title: input.update.title!,
+      };
+    case "regenerate_title":
+      return {
+        type: "thread.metadata.update",
+        commandId: input.commandId,
+        threadId: input.threadId,
+        regenerateTitle: true,
+      };
+    case "link_pull_request":
+      return {
+        type: "thread.metadata.update",
+        commandId: input.commandId,
+        threadId: input.threadId,
+        linkedPullRequest: {
+          projectId: input.projectId,
+          ...input.update.pullRequest!,
+        },
+      };
+    case "unlink_pull_request":
+      return {
+        type: "thread.metadata.update",
+        commandId: input.commandId,
+        threadId: input.threadId,
+        linkedPullRequest: null,
+      };
+  }
+}
+
+function resultFromThread(input: {
+  readonly action: ThreadMetadataMcpAction;
+  readonly commandId: CommandId;
+  readonly sequence: number;
+  readonly thread: OrchestrationV2AppThread;
+}): ThreadMetadataMcpUpdateResult {
+  return {
+    threadId: input.thread.id,
+    action: input.action,
+    commandId: input.commandId,
+    sequence: input.sequence,
+    title: input.thread.title,
+    titleRegeneration:
+      input.thread.titleRegeneration === undefined || input.thread.titleRegeneration === null
+        ? null
+        : {
+            requestId: input.thread.titleRegeneration.requestId,
+            startedAt: DateTime.formatIso(input.thread.titleRegeneration.startedAt),
+          },
+    linkedPullRequest: input.thread.linkedPullRequest ?? null,
+    updatedAt: DateTime.formatIso(input.thread.updatedAt),
+  };
+}
+
+const make = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const threadManagement = yield* ThreadManagementService;
+
+  const update = Effect.fn("ThreadMetadataMcpService.update")(function* (
+    scope: McpInvocationScope,
+    input: ThreadMetadataMcpUpdateInput,
+  ) {
+    if (!scope.capabilities.has("orchestration")) {
+      return yield* failure(
+        "capability_denied",
+        "This MCP credential does not grant orchestration capabilities.",
+      );
+    }
+
+    const parent = yield* threadManagement
+      .getThreadProjection(scope.threadId)
+      .pipe(
+        Effect.mapError((error) =>
+          failure(
+            "orchestration_error",
+            `Unable to read calling thread ${scope.threadId}: ${errorMessage(error)}`,
+          ),
+        ),
+      );
+    const threadId = input.threadId ?? scope.threadId;
+    const target =
+      threadId === scope.threadId
+        ? parent
+        : yield* threadManagement
+            .getProjectThread({ projectId: parent.thread.projectId, threadId })
+            .pipe(Effect.mapError(threadLookupFailure));
+    const requestKey =
+      input.clientRequestId === undefined
+        ? yield* crypto.randomUUIDv4.pipe(Effect.orDie)
+        : input.clientRequestId;
+    const updateCommandId = commandId({
+      scope,
+      threadId,
+      action: input.action,
+      requestKey,
+    });
+    const dispatched = yield* threadManagement
+      .dispatch(
+        metadataCommand({
+          commandId: updateCommandId,
+          threadId,
+          projectId: target.thread.projectId,
+          update: input,
+        }),
+      )
+      .pipe(
+        Effect.mapError((error) =>
+          failure(
+            "orchestration_error",
+            `Unable to ${input.action} for thread ${threadId}: ${errorMessage(error)}`,
+          ),
+        ),
+      );
+    const metadataEvent = dispatched.storedEvents.find(
+      (stored) => stored.event.type === "thread.metadata-updated",
+    );
+    if (metadataEvent === undefined || metadataEvent.event.type !== "thread.metadata-updated") {
+      return yield* failure(
+        "orchestration_error",
+        `Thread ${threadId} metadata update completed without a resultant state.`,
+      );
+    }
+    return resultFromThread({
+      action: input.action,
+      commandId: updateCommandId,
+      sequence: dispatched.sequence,
+      thread: metadataEvent.event.payload,
+    });
+  });
+
+  return ThreadMetadataMcpService.of({ update });
+});
+
+export const layer: Layer.Layer<
+  ThreadMetadataMcpService,
+  never,
+  Crypto.Crypto | ThreadManagementService
+> = Layer.effect(ThreadMetadataMcpService, make);

--- a/apps/server/src/mcp/ThreadMetadataMcpService.ts
+++ b/apps/server/src/mcp/ThreadMetadataMcpService.ts
@@ -20,16 +20,14 @@ import {
 } from "../orchestration-v2/ThreadManagementService.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
 
-export interface ThreadMetadataMcpServiceShape {
-  readonly update: (
-    scope: McpInvocationScope,
-    input: ThreadMetadataMcpUpdateInput,
-  ) => Effect.Effect<ThreadMetadataMcpUpdateResult, OrchestratorMcpFailure>;
-}
-
 export class ThreadMetadataMcpService extends Context.Service<
   ThreadMetadataMcpService,
-  ThreadMetadataMcpServiceShape
+  {
+    readonly update: (
+      scope: McpInvocationScope,
+      input: ThreadMetadataMcpUpdateInput,
+    ) => Effect.Effect<ThreadMetadataMcpUpdateResult, OrchestratorMcpFailure>;
+  }
 >()("t3/mcp/ThreadMetadataMcpService") {}
 
 function failure(code: OrchestratorMcpFailure["code"], message: string): OrchestratorMcpFailure {

--- a/apps/server/src/mcp/ThreadMetadataMcpService.ts
+++ b/apps/server/src/mcp/ThreadMetadataMcpService.ts
@@ -147,6 +147,19 @@ const make = Effect.gen(function* () {
       );
     }
 
+    const parentShell = yield* threadManagement
+      .getThreadShell(scope.threadId)
+      .pipe(
+        Effect.mapError((error) =>
+          failure(
+            "orchestration_error",
+            `Unable to locate calling thread ${scope.threadId}: ${errorMessage(error)}`,
+          ),
+        ),
+      );
+    if (parentShell === null) {
+      return yield* failure("thread_not_found", `Calling thread ${scope.threadId} was not found.`);
+    }
     const parent = yield* threadManagement
       .getThreadProjection(scope.threadId)
       .pipe(

--- a/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 
 import { McpInvocationContext } from "../../McpInvocationContext.ts";
 import { OrchestratorMcpService } from "../../OrchestratorMcpService.ts";
+import { ThreadMetadataMcpService } from "../../ThreadMetadataMcpService.ts";
 
 const handlers = {
   orchestrator_capabilities: () =>
@@ -90,6 +91,12 @@ const handlers = {
       const scope = yield* McpInvocationContext;
       const service = yield* OrchestratorMcpService;
       return yield* service.readThread(scope, input);
+    }),
+  t3_thread_update: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* ThreadMetadataMcpService;
+      return yield* service.update(scope, input);
     }),
   t3_thread_send: (input) =>
     Effect.gen(function* () {

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.test.ts
@@ -1,7 +1,12 @@
 import { assert, describe, it } from "@effect/vitest";
 import { Tool } from "effect/unstable/ai";
 
-import { CreateThreadsTool, DelegateTaskTool, ScheduleTaskTool } from "./tools.ts";
+import {
+  CreateThreadsTool,
+  DelegateTaskTool,
+  ScheduleTaskTool,
+  ThreadUpdateTool,
+} from "./tools.ts";
 
 describe("orchestrator MCP tool guidance", () => {
   it("directs subagent requests to delegation instead of ordinary threads", () => {
@@ -54,5 +59,22 @@ describe("orchestrator MCP tool guidance", () => {
     assert.isAtLeast(schema.properties?.schedule?.anyOf?.length ?? 0, 2);
     assert.include(ScheduleTaskTool.description ?? "", "STRUCTURED OBJECT");
     assert.include(ScheduleTaskTool.description ?? "", "nextRunAt");
+  });
+
+  it("publishes thread metadata actions from an object-root schema", () => {
+    const schema = Tool.getJsonSchema(ThreadUpdateTool) as {
+      readonly type?: unknown;
+      readonly properties?: Readonly<Record<string, unknown>>;
+    };
+
+    assert.equal(schema.type, "object");
+    assert.hasAllKeys(schema.properties ?? {}, [
+      "threadId",
+      "action",
+      "title",
+      "pullRequest",
+      "clientRequestId",
+    ]);
+    assert.include(ThreadUpdateTool.description ?? "", "Workspace and branch changes");
   });
 });

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.ts
@@ -208,7 +208,7 @@ export const ThreadUpdateTool = Tool.make("t3_thread_update", {
 })
   .annotate(Tool.Title, "Update T3 thread metadata")
   .annotate(Tool.Destructive, true)
-  .annotate(Tool.Idempotent, true);
+  .annotate(Tool.Idempotent, false);
 
 export const ThreadSendTool = Tool.make("t3_thread_send", {
   description:

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.ts
@@ -26,13 +26,20 @@ import {
   OrchestratorMcpThreadStartInput,
   OrchestratorMcpThreadWaitInput,
   OrchestratorMcpThreadWaitResult,
+  ThreadMetadataMcpUpdateInput,
+  ThreadMetadataMcpUpdateResult,
 } from "@t3tools/contracts";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import { OrchestratorMcpService } from "../../OrchestratorMcpService.ts";
+import { ThreadMetadataMcpService } from "../../ThreadMetadataMcpService.ts";
 
 const dependencies = [McpInvocationContext.McpInvocationContext, OrchestratorMcpService];
+const threadMetadataDependencies = [
+  McpInvocationContext.McpInvocationContext,
+  ThreadMetadataMcpService,
+];
 
 export const OrchestratorCapabilitiesTool = Tool.make("orchestrator_capabilities", {
   description:
@@ -190,6 +197,19 @@ export const ThreadReadTool = Tool.make("t3_thread_read", {
   .annotate(Tool.Destructive, false)
   .annotate(Tool.Idempotent, true);
 
+export const ThreadUpdateTool = Tool.make("t3_thread_update", {
+  description:
+    "Update metadata for a thread in the calling project. Omit threadId to update this thread. Use action='rename' with title, action='regenerate_title' with no extra field, action='link_pull_request' with pullRequest, or action='unlink_pull_request'. Workspace and branch changes are intentionally not supported. clientRequestId makes retries idempotent.",
+  parameters: ThreadMetadataMcpUpdateInput,
+  success: ThreadMetadataMcpUpdateResult,
+  failure: OrchestratorMcpFailure,
+  failureMode: "return",
+  dependencies: threadMetadataDependencies,
+})
+  .annotate(Tool.Title, "Update T3 thread metadata")
+  .annotate(Tool.Destructive, true)
+  .annotate(Tool.Idempotent, true);
+
 export const ThreadSendTool = Tool.make("t3_thread_send", {
   description:
     "Send a message to a T3 thread in the calling project. mode='auto' starts an idle thread, steers a fully active turn, or queues behind a turn that is not yet steerable. Use queue for a separate follow-up turn, steer for an in-flight update, or restart to interrupt-and-restart the active turn. clientRequestId makes retries idempotent.",
@@ -242,6 +262,7 @@ export const OrchestratorToolkit = Toolkit.make(
   ThreadStartTool,
   ThreadListTool,
   ThreadReadTool,
+  ThreadUpdateTool,
   ThreadSendTool,
   ThreadWaitTool,
   ThreadInterruptTool,

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -10,6 +10,7 @@ agent can use this endpoint to:
 - cancel an active delegated task; and
 - create one or more ordinary top-level T3 threads;
 - list and incrementally read project threads;
+- rename threads, regenerate titles, and link or unlink pull requests;
 - send or steer follow-up messages; and
 - wait for or interrupt ordinary thread runs.
 
@@ -283,6 +284,20 @@ and `creationSource: "mcp"`; provider output uses `creationSource: "provider"`.
 Actor and ingress are separate so agent-authored user-role messages remain
 distinguishable from human-authored messages.
 
+### `t3_thread_update`
+
+Updates metadata for the calling thread or another thread in the same project.
+The typed actions are `rename`, `regenerate_title`, `link_pull_request`, and
+`unlink_pull_request`. A link input supplies the repository, number, and URL;
+the server records the target thread's project ID. Branch and workspace changes
+are outside this tool.
+
+The result includes the command ID and durable event sequence together with the
+resultant title, title-regeneration marker, and linked pull request. Reusing a
+`clientRequestId` for the same action and thread replays the same command
+receipt. Thread list and read results expose the linked pull request, and thread
+detail also exposes an in-flight title regeneration.
+
 ### `t3_thread_send`
 
 Sends a message to an ordinary or delegated thread in the calling project:
@@ -386,7 +401,8 @@ orchestration_error
 ## Code Ownership
 
 - Shared schemas: `packages/contracts/src/orchestratorMcp.ts`
-- MCP service: `apps/server/src/mcp/OrchestratorMcpService.ts`
+- MCP services: `apps/server/src/mcp/OrchestratorMcpService.ts` and the focused
+  `apps/server/src/mcp/ThreadMetadataMcpService.ts`
 - Tool definitions and handlers:
   `apps/server/src/mcp/toolkits/orchestrator/`
 - HTTP registration and authentication:

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -400,7 +400,8 @@ orchestration_error
 
 ## Code Ownership
 
-- Shared schemas: `packages/contracts/src/orchestratorMcp.ts`
+- Shared schemas: `packages/contracts/src/orchestratorMcp.ts` and
+  `packages/contracts/src/threadMetadataMcp.ts`
 - MCP services: `apps/server/src/mcp/OrchestratorMcpService.ts` and the focused
   `apps/server/src/mcp/ThreadMetadataMcpService.ts`
 - Tool definitions and handlers:

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -28,6 +28,15 @@ The order syncs across devices.
 
 Pinning does not prevent automatic settlement. Settling a thread removes its pin.
 
+To generate a fresh title from the conversation, open a thread's menu and choose
+**Regenerate title**. The action is unavailable while title generation is in progress
+or when the connected environment needs a server update.
+
+Agents connected through T3 Code can use the same server-owned metadata workflow to
+rename a thread, regenerate its title, or link and unlink a pull request. These changes
+appear on web, desktop, and mobile without requiring the originating browser to remain
+open.
+
 ## Settle finished work
 
 Choose **Settle thread** from its menu to move finished work out of the active list

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -33,6 +33,7 @@ export * from "./orchestrationProject.ts";
 export * from "./orchestrationV2.ts";
 export * from "./applicationEvent.ts";
 export * from "./orchestratorMcp.ts";
+export * from "./threadMetadataMcp.ts";
 export * from "./orchestration.ts";
 export * from "./t3ProjectFile.ts";
 export * from "./editor.ts";

--- a/packages/contracts/src/orchestratorMcp.ts
+++ b/packages/contracts/src/orchestratorMcp.ts
@@ -22,6 +22,7 @@ import {
   ScheduledTaskUpsertSchedule,
 } from "./scheduledTask.ts";
 import { ProviderInteractionMode, RuntimeMode } from "./providerPolicy.ts";
+import { ThreadLinkedPullRequest, ThreadTitleRegeneration } from "./orchestration.ts";
 import {
   OrchestrationV2Actor,
   OrchestrationV2CreationSource,
@@ -309,6 +310,7 @@ export const OrchestratorMcpThreadListItem = Schema.Struct({
   model: Schema.String,
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode,
+  linkedPullRequest: Schema.NullOr(ThreadLinkedPullRequest),
   parentThreadId: Schema.NullOr(ThreadId),
   relationshipToParent: Schema.NullOr(Schema.Literals(["fork", "subagent"])),
   itemCount: NonNegativeInt,
@@ -349,6 +351,8 @@ export const OrchestratorMcpThreadDetail = Schema.Struct({
   model: Schema.String,
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode,
+  linkedPullRequest: Schema.NullOr(ThreadLinkedPullRequest),
+  titleRegeneration: Schema.NullOr(ThreadTitleRegeneration),
   branch: Schema.NullOr(Schema.String),
   worktreePath: Schema.NullOr(Schema.String),
   parentThreadId: Schema.NullOr(ThreadId),

--- a/packages/contracts/src/threadMetadataMcp.test.ts
+++ b/packages/contracts/src/threadMetadataMcp.test.ts
@@ -56,4 +56,45 @@ describe("ThreadMetadataMcpUpdateInput", () => {
   it("rejects unknown actions", () => {
     assert.throws(() => decodeUpdate({ action: "move_workspace" }));
   });
+
+  it("rejects malformed client request ids without normalizing valid keys", () => {
+    const validKey = "metadata-\ud83d\ude80-1";
+    assert.equal(
+      decodeUpdate({ action: "regenerate_title", clientRequestId: validKey }).clientRequestId,
+      validKey,
+    );
+    assert.throws(() =>
+      decodeUpdate({ action: "regenerate_title", clientRequestId: "metadata-\ud800" }),
+    );
+    assert.throws(() =>
+      decodeUpdate({ action: "regenerate_title", clientRequestId: "metadata-\udc00" }),
+    );
+  });
+
+  it("accepts HTTP(S) pull request URLs and rejects other or malformed URLs", () => {
+    assert.deepEqual(
+      decodeUpdate({
+        action: "link_pull_request",
+        pullRequest: {
+          repository: "engineering/t3code",
+          number: 42,
+          url: "https://git.corp.example/engineering/t3code/pulls/42",
+        },
+      }).pullRequest,
+      {
+        repository: "engineering/t3code",
+        number: 42,
+        url: "https://git.corp.example/engineering/t3code/pulls/42",
+      },
+    );
+
+    for (const url of ["not a URL", "javascript:alert(1)", "file:///tmp/pull-request"]) {
+      assert.throws(() =>
+        decodeUpdate({
+          action: "link_pull_request",
+          pullRequest: { repository: "pingdotgg/t3code", number: 8690, url },
+        }),
+      );
+    }
+  });
 });

--- a/packages/contracts/src/threadMetadataMcp.test.ts
+++ b/packages/contracts/src/threadMetadataMcp.test.ts
@@ -1,0 +1,59 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Schema from "effect/Schema";
+
+import { ThreadMetadataMcpUpdateInput } from "./threadMetadataMcp.ts";
+
+const decodeUpdate = Schema.decodeUnknownSync(ThreadMetadataMcpUpdateInput);
+
+describe("ThreadMetadataMcpUpdateInput", () => {
+  it("decodes each metadata action with only its required fields", () => {
+    assert.deepEqual(decodeUpdate({ action: "rename", title: "Release follow-up" }), {
+      action: "rename",
+      title: "Release follow-up",
+    });
+    assert.deepEqual(decodeUpdate({ action: "regenerate_title" }), {
+      action: "regenerate_title",
+    });
+    assert.deepEqual(
+      decodeUpdate({
+        action: "link_pull_request",
+        pullRequest: {
+          repository: "pingdotgg/t3code",
+          number: 8689,
+          url: "https://github.com/pingdotgg/t3code/pull/8689",
+        },
+      }),
+      {
+        action: "link_pull_request",
+        pullRequest: {
+          repository: "pingdotgg/t3code",
+          number: 8689,
+          url: "https://github.com/pingdotgg/t3code/pull/8689",
+        },
+      },
+    );
+    assert.deepEqual(decodeUpdate({ action: "unlink_pull_request" }), {
+      action: "unlink_pull_request",
+    });
+  });
+
+  it("rejects missing action data and fields from another action", () => {
+    assert.throws(() => decodeUpdate({ action: "rename" }));
+    assert.throws(() => decodeUpdate({ action: "regenerate_title", title: "Not allowed" }));
+    assert.throws(() => decodeUpdate({ action: "link_pull_request" }));
+    assert.throws(() =>
+      decodeUpdate({
+        action: "unlink_pull_request",
+        pullRequest: {
+          repository: "pingdotgg/t3code",
+          number: 8689,
+          url: "https://github.com/pingdotgg/t3code/pull/8689",
+        },
+      }),
+    );
+  });
+
+  it("rejects unknown actions", () => {
+    assert.throws(() => decodeUpdate({ action: "move_workspace" }));
+  });
+});

--- a/packages/contracts/src/threadMetadataMcp.ts
+++ b/packages/contracts/src/threadMetadataMcp.ts
@@ -1,0 +1,82 @@
+import * as Schema from "effect/Schema";
+
+import {
+  CommandId,
+  IsoDateTime,
+  NonNegativeInt,
+  PositiveInt,
+  ThreadId,
+  TrimmedNonEmptyString,
+} from "./baseSchemas.ts";
+import { ThreadLinkedPullRequest, ThreadTitleRegeneration } from "./orchestration.ts";
+
+const ThreadMetadataTitle = TrimmedNonEmptyString.check(Schema.isMaxLength(512)).annotate({
+  description: "New concise display title. Required only when action is rename.",
+});
+
+const ThreadMetadataClientRequestId = TrimmedNonEmptyString.check(Schema.isMaxLength(256)).annotate(
+  { description: "Stable idempotency key to reuse when retrying this mutation." },
+);
+
+export const ThreadMetadataMcpAction = Schema.Literals([
+  "rename",
+  "regenerate_title",
+  "link_pull_request",
+  "unlink_pull_request",
+]).annotate({
+  description:
+    "Metadata mutation: rename, regenerate_title, link_pull_request, or unlink_pull_request.",
+});
+export type ThreadMetadataMcpAction = typeof ThreadMetadataMcpAction.Type;
+
+export const ThreadMetadataMcpPullRequest = Schema.Struct({
+  repository: TrimmedNonEmptyString.annotate({
+    description: "Repository name as owner/name.",
+  }),
+  number: PositiveInt.annotate({ description: "Pull request number." }),
+  url: TrimmedNonEmptyString.annotate({ description: "Canonical pull request URL." }),
+});
+export type ThreadMetadataMcpPullRequest = typeof ThreadMetadataMcpPullRequest.Type;
+
+export const ThreadMetadataMcpUpdateInput = Schema.Struct({
+  threadId: Schema.optional(ThreadId).annotate({
+    description: "Thread in the calling project. Omit to update the calling thread.",
+  }),
+  action: ThreadMetadataMcpAction,
+  title: Schema.optional(ThreadMetadataTitle),
+  pullRequest: Schema.optional(ThreadMetadataMcpPullRequest).annotate({
+    description: "Pull request to link. Required only when action is link_pull_request.",
+  }),
+  clientRequestId: Schema.optional(ThreadMetadataClientRequestId),
+}).check(
+  Schema.makeFilter((input) => {
+    switch (input.action) {
+      case "rename":
+        return input.title !== undefined && input.pullRequest === undefined
+          ? true
+          : "rename requires title and does not accept pullRequest.";
+      case "link_pull_request":
+        return input.pullRequest !== undefined && input.title === undefined
+          ? true
+          : "link_pull_request requires pullRequest and does not accept title.";
+      case "regenerate_title":
+      case "unlink_pull_request":
+        return input.title === undefined && input.pullRequest === undefined
+          ? true
+          : `${input.action} does not accept title or pullRequest.`;
+    }
+  }),
+);
+export type ThreadMetadataMcpUpdateInput = typeof ThreadMetadataMcpUpdateInput.Type;
+
+export const ThreadMetadataMcpUpdateResult = Schema.Struct({
+  threadId: ThreadId,
+  action: ThreadMetadataMcpAction,
+  commandId: CommandId,
+  sequence: NonNegativeInt,
+  title: Schema.String,
+  titleRegeneration: Schema.NullOr(ThreadTitleRegeneration),
+  linkedPullRequest: Schema.NullOr(ThreadLinkedPullRequest),
+  updatedAt: IsoDateTime,
+});
+export type ThreadMetadataMcpUpdateResult = typeof ThreadMetadataMcpUpdateResult.Type;

--- a/packages/contracts/src/threadMetadataMcp.ts
+++ b/packages/contracts/src/threadMetadataMcp.ts
@@ -10,13 +10,52 @@ import {
 } from "./baseSchemas.ts";
 import { ThreadLinkedPullRequest, ThreadTitleRegeneration } from "./orchestration.ts";
 
+function hasOnlyPairedSurrogates(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = value.charCodeAt(index + 1);
+      if (index + 1 >= value.length || nextCodeUnit < 0xdc00 || nextCodeUnit > 0xdfff) {
+        return false;
+      }
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 const ThreadMetadataTitle = TrimmedNonEmptyString.check(Schema.isMaxLength(512)).annotate({
   description: "New concise display title. Required only when action is rename.",
 });
 
-const ThreadMetadataClientRequestId = TrimmedNonEmptyString.check(Schema.isMaxLength(256)).annotate(
-  { description: "Stable idempotency key to reuse when retrying this mutation." },
-);
+const ThreadMetadataClientRequestId = TrimmedNonEmptyString.check(Schema.isMaxLength(256))
+  .check(
+    Schema.makeFilter((value) =>
+      hasOnlyPairedSurrogates(value)
+        ? true
+        : "clientRequestId must contain valid paired Unicode surrogates.",
+    ),
+  )
+  .annotate({ description: "Stable idempotency key to reuse when retrying this mutation." });
+
+const ThreadMetadataMcpPullRequestUrl = TrimmedNonEmptyString.check(
+  Schema.makeFilter((value) =>
+    isHttpUrl(value) ? true : "Pull request URL must be a well-formed HTTP(S) URL.",
+  ),
+).annotate({
+  description: "Canonical HTTP(S) pull request URL, including self-hosted repository URLs.",
+});
 
 export const ThreadMetadataMcpAction = Schema.Literals([
   "rename",
@@ -34,7 +73,7 @@ export const ThreadMetadataMcpPullRequest = Schema.Struct({
     description: "Repository name as owner/name.",
   }),
   number: PositiveInt.annotate({ description: "Pull request number." }),
-  url: TrimmedNonEmptyString.annotate({ description: "Canonical pull request URL." }),
+  url: ThreadMetadataMcpPullRequestUrl,
 });
 export type ThreadMetadataMcpPullRequest = typeof ThreadMetadataMcpPullRequest.Type;
 

--- a/packages/shared/src/t3McpToolPresentation.test.ts
+++ b/packages/shared/src/t3McpToolPresentation.test.ts
@@ -17,6 +17,13 @@ describe("resolveT3McpToolPresentation", () => {
     });
   });
 
+  it("pretty prints thread metadata updates", () => {
+    expect(resolveT3McpToolPresentation("mcp__t3-code__t3_thread_update")).toEqual({
+      displayName: "Update T3 thread metadata",
+      logo: "t3-code",
+    });
+  });
+
   it("pretty prints bare T3 MCP toolkit names", () => {
     expect(resolveT3McpToolPresentation("list_scheduled_tasks")).toEqual({
       displayName: "List scheduled tasks",

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -48,6 +48,7 @@ const T3_MCP_TOOLS: Record<
   t3_thread_start: { displayName: "Start a T3 thread", summaryAction: "thread-create" },
   t3_thread_list: { displayName: "List T3 threads", summaryAction: "thread-list" },
   t3_thread_read: { displayName: "Read a T3 thread", summaryAction: "thread-read" },
+  t3_thread_update: { displayName: "Update T3 thread metadata" },
   t3_thread_send: { displayName: "Send to a T3 thread", summaryAction: "thread-send" },
   t3_thread_wait: { displayName: "Wait for a T3 thread", summaryAction: "thread-wait" },
   t3_thread_interrupt: { displayName: "Interrupt a T3 thread", summaryAction: "thread-interrupt" },


### PR DESCRIPTION
## Problem

Provider agents can read thread history but cannot safely rename a thread, regenerate its title, or link and unlink a pull request through the app-owned MCP workflow.

## Change

Add `t3_thread_update` with a provider-compatible object-root schema and typed metadata actions. A focused service keeps updates in the current project, uses V2 commands and idempotent receipts, and returns committed title, title-regeneration, and linked-PR state. Thread list/read expose the corresponding read path; docs and tool presentation cover the user-visible behavior.

## Behavior

`threadId` defaults to the calling thread. Rename requires `title`; link requires repository, number, and URL; regenerate and unlink take no action-specific payload. Branch and workspace mutations remain outside this tool.

## Validation

- Focused contracts, toolkit schema, presentation, and real MCP/V2 integration tests (4 files, 14 tests)
- Targeted lint for changed TypeScript files
- Contracts, shared, and server package typechecks

## Dependency

Depends on #8689, which fixes V2 linked-pull-request persistence. Native stack #8709: #8689 → #8690, rooted at `agents/mcp-controls/base-490318a`. It remains independent from thread organization stack #8708.

Implemented by GPT-5.6-Sol via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3_thread_update` MCP tool for thread metadata actions
> - Introduces `ThreadMetadataMcpService` and the `t3_thread_update` orchestrator MCP tool supporting four actions: rename, title regeneration, pull-request link, and pull-request unlink
> - Defines validated contracts in [threadMetadataMcp.ts](https://github.com/pingdotgg/t3code/pull/8690/files#diff-f33e572489204f77607cb25bd93b4e4ea5697076434c257f8746b95d51d04bfb) requiring action-specific fields, HTTP(S)-only PR URLs, bounded client request IDs, and non-empty titles up to 512 chars
> - Updates `thread.metadata.update` command handling in [Orchestrator.ts](https://github.com/pingdotgg/t3code/pull/8690/files#diff-8747d8bd671948fc866dd5d05e74fa07e196b1f397fa7895aa5095e3186cd570) to persist or clear a linked pull request field in the resulting event
> - Thread list and detail responses now include nullable linked pull request and title-regeneration state; determinstic command IDs enable idempotent client-request retries
> - Behavioral Change: `OrchestratorMcpThreadListItem` and `OrchestratorMcpThreadDetail` schemas in [orchestratorMcp.ts](https://github.com/pingdotgg/t3code/pull/8690/files#diff-30fbd4867ef75aeb0387d7659bcc37b66ae287fb1356db374bd78ac363599dd3) gain new nullable fields; existing MCP consumers that validate strictly against these schemas must accept the added fields
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aeabb89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new mutating MCP surface that dispatches durable orchestration commands and links external PR metadata; mistakes in scoping or validation could affect thread metadata across a project.
> 
> **Overview**
> Adds **`t3_thread_update`** so provider agents can mutate thread metadata through the orchestrator MCP toolkit: **rename**, **regenerate title**, **link pull request**, and **unlink pull request**. Workspace/branch changes stay out of scope.
> 
> A new **`ThreadMetadataMcpService`** enforces orchestration capability, resolves the target thread in the calling project (defaulting to the caller), builds stable **`thread.metadata.update`** commands with **`clientRequestId`** idempotency, and returns committed title, **`titleRegeneration`**, and **`linkedPullRequest`** state. **`OrchestratorMcpService`** thread list/detail responses now surface **`linkedPullRequest`** (and in-flight title regeneration on read).
> 
> Contracts live in **`threadMetadataMcp.ts`** with action-specific validation (HTTP(S) PR URLs, title length, surrogate-safe idempotency keys). Docs, UI tool presentation, and integration/unit tests cover the new tool and read path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeabb8905cb9f78653fc8841f269242411a059ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

