### PR TITLE
feat(mcp): fork existing conversations

### DIFF
--- a/apps/server/src/mcp/ConversationTransferMcpService.test.ts
+++ b/apps/server/src/mcp/ConversationTransferMcpService.test.ts
@@ -1,0 +1,174 @@
+import { assert, describe, it } from "@effect/vitest";
+import {
+  EnvironmentId,
+  type OrchestrationV2Run,
+  ProviderInstanceId,
+  type OrchestrationV2ThreadProjection,
+  ProjectId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+import { ThreadManagementService } from "../orchestration-v2/ThreadManagementService.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+import * as ConversationTransfer from "./ConversationTransferMcpService.ts";
+
+const projectId = ProjectId.make("project:conversation-transfer");
+const parentThreadId = ThreadId.make("thread:conversation-transfer-parent");
+const sourceThreadId = ThreadId.make("thread:conversation-transfer-source");
+
+function projection(input: {
+  readonly threadId: ThreadId;
+  readonly runtimeMode: "approval-required" | "full-access";
+  readonly interactionMode: "plan" | "default";
+}): OrchestrationV2ThreadProjection {
+  return {
+    thread: {
+      id: input.threadId,
+      projectId,
+      runtimeMode: input.runtimeMode,
+      interactionMode: input.interactionMode,
+    },
+    runs: [],
+    contextTransfers: [],
+  } as unknown as OrchestrationV2ThreadProjection;
+}
+
+const scope = (capabilities: ReadonlyArray<"orchestration"> = ["orchestration"]) =>
+  ({
+    environmentId: EnvironmentId.make("environment:conversation-transfer"),
+    threadId: parentThreadId,
+    providerSessionId: "provider-session:conversation-transfer",
+    providerInstanceId: ProviderInstanceId.make("codex"),
+    capabilities: new Set(capabilities),
+    issuedAt: 1,
+  }) satisfies McpInvocationScope;
+
+function testLayer(input: {
+  readonly parent: OrchestrationV2ThreadProjection;
+  readonly source: OrchestrationV2ThreadProjection;
+  readonly dispatch: ThreadManagementService["Service"]["dispatch"];
+}) {
+  return ConversationTransfer.layer.pipe(
+    Layer.provide(
+      Layer.mock(ThreadManagementService)({
+        getThreadProjection: () => Effect.succeed(input.parent),
+        getProjectThread: ({ threadId }) =>
+          Effect.succeed(threadId === parentThreadId ? input.parent : input.source),
+        dispatch: input.dispatch,
+      }),
+    ),
+  );
+}
+
+describe("ConversationTransferMcpService", () => {
+  it("reports a selected durable source run as a turn-specific native fork without a native turn ref", () => {
+    const run = {
+      providerThreadId: "provider-thread:source",
+    } as unknown as OrchestrationV2Run;
+    const source = {
+      providerThreads: [
+        {
+          id: "provider-thread:source",
+          providerSessionId: "provider-session:source",
+          nativeThreadRef: { strength: "strong" },
+        },
+      ],
+      providerSessions: [
+        {
+          id: "provider-session:source",
+          capabilities: {
+            threads: { canForkThread: true, canForkFromTurn: false },
+            identity: { nativeThreadIds: "strong" },
+          },
+        },
+      ],
+    } as unknown as OrchestrationV2ThreadProjection;
+    assert.equal(
+      ConversationTransfer.conversationForkNativeEligibility(source, run),
+      "provider_does_not_support_turn_fork",
+    );
+  });
+
+  it.effect("rejects missing stable runs and inherited permission escalation before dispatch", () =>
+    Effect.gen(function* () {
+      const dispatched = yield* Ref.make(0);
+      const parent = projection({
+        threadId: parentThreadId,
+        runtimeMode: "approval-required",
+        interactionMode: "plan",
+      });
+      const source = projection({
+        threadId: sourceThreadId,
+        runtimeMode: "full-access",
+        interactionMode: "default",
+      });
+      const escalation = yield* Effect.gen(function* () {
+        const service = yield* ConversationTransfer.ConversationTransferMcpService;
+        return yield* service
+          .fork(scope(), {
+            sourceThreadId,
+            sourcePoint: { type: "latest_stable" },
+            clientRequestId: "permission-ceiling",
+          })
+          .pipe(Effect.flip);
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            parent,
+            source,
+            dispatch: () =>
+              Ref.update(dispatched, (count) => count + 1).pipe(Effect.as({} as never)),
+          }),
+        ),
+      );
+      assert.equal(escalation.code, "runtime_mode_escalation_denied");
+
+      const noRun = yield* Effect.gen(function* () {
+        const service = yield* ConversationTransfer.ConversationTransferMcpService;
+        return yield* service
+          .fork(scope(), {
+            sourcePoint: { type: "run", runId: "run:missing" as never },
+            clientRequestId: "missing-run",
+          })
+          .pipe(Effect.flip);
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            parent,
+            source: parent,
+            dispatch: () =>
+              Ref.update(dispatched, (count) => count + 1).pipe(Effect.as({} as never)),
+          }),
+        ),
+      );
+      assert.equal(noRun.code, "run_not_found");
+      assert.equal(yield* Ref.get(dispatched), 0);
+    }),
+  );
+
+  it.effect("denies transfer reads without orchestration capability", () =>
+    Effect.gen(function* () {
+      const parent = projection({
+        threadId: parentThreadId,
+        runtimeMode: "full-access",
+        interactionMode: "default",
+      });
+      const error = yield* Effect.gen(function* () {
+        const service = yield* ConversationTransfer.ConversationTransferMcpService;
+        return yield* service.list(scope([]), {}).pipe(Effect.flip);
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            parent,
+            source: parent,
+            dispatch: () => Effect.die("dispatch should not run"),
+          }),
+        ),
+      );
+      assert.equal(error.code, "capability_denied");
+    }),
+  );
+});

--- a/apps/server/src/mcp/ConversationTransferMcpService.test.ts
+++ b/apps/server/src/mcp/ConversationTransferMcpService.test.ts
@@ -11,6 +11,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 
+import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts";
 import { ThreadManagementService } from "../orchestration-v2/ThreadManagementService.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
 import * as ConversationTransfer from "./ConversationTransferMcpService.ts";
@@ -50,11 +51,12 @@ function testLayer(input: {
   readonly parent: OrchestrationV2ThreadProjection;
   readonly source: OrchestrationV2ThreadProjection;
   readonly dispatch: ThreadManagementService["Service"]["dispatch"];
+  readonly getThreadProjection?: ThreadManagementService["Service"]["getThreadProjection"];
 }) {
   return ConversationTransfer.layer.pipe(
     Layer.provide(
       Layer.mock(ThreadManagementService)({
-        getThreadProjection: () => Effect.succeed(input.parent),
+        getThreadProjection: input.getThreadProjection ?? (() => Effect.succeed(input.parent)),
         getProjectThread: ({ threadId }) =>
           Effect.succeed(threadId === parentThreadId ? input.parent : input.source),
         dispatch: input.dispatch,
@@ -170,5 +172,50 @@ describe("ConversationTransferMcpService", () => {
       );
       assert.equal(error.code, "capability_denied");
     }),
+  );
+
+  it.effect(
+    "does not treat an operational target projection failure as an absent fork target",
+    () =>
+      Effect.gen(function* () {
+        const dispatched = yield* Ref.make(0);
+        const parent = projection({
+          threadId: parentThreadId,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+        });
+        const error = yield* Effect.gen(function* () {
+          const service = yield* ConversationTransfer.ConversationTransferMcpService;
+          return yield* service
+            .fork(scope(), {
+              sourcePoint: { type: "latest_stable" },
+              clientRequestId: "projection-read-failure",
+            })
+            .pipe(Effect.flip);
+        }).pipe(
+          Effect.provide(
+            testLayer({
+              parent,
+              source: parent,
+              getThreadProjection: (threadId) =>
+                threadId === parentThreadId
+                  ? Effect.succeed(parent)
+                  : Effect.fail(
+                      new OrchestratorProjectionError({
+                        threadId,
+                        cause: new Error("storage unavailable"),
+                      }),
+                    ),
+              dispatch: () =>
+                Ref.update(dispatched, (count) => count + 1).pipe(
+                  Effect.andThen(Effect.die("dispatch must not run after a failed target read")),
+                ),
+            }),
+          ),
+        );
+
+        assert.equal(error.code, "orchestration_error");
+        assert.equal(yield* Ref.get(dispatched), 0);
+      }),
   );
 });

--- a/apps/server/src/mcp/ConversationTransferMcpService.ts
+++ b/apps/server/src/mcp/ConversationTransferMcpService.ts
@@ -1,0 +1,367 @@
+import {
+  CommandId,
+  type ConversationForkInput,
+  type ConversationForkNativeEligibility,
+  type ConversationForkResult,
+  type ConversationTransferListInput,
+  type ConversationTransferListResult,
+  type ConversationTransferReceipt,
+  type OrchestrationV2ContextTransfer,
+  type OrchestrationV2Run,
+  type OrchestrationV2ThreadForkSourcePoint,
+  type OrchestrationV2ThreadProjection,
+  OrchestratorMcpFailure,
+  type ProviderInteractionMode,
+  type RuntimeMode,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import type { OrchestratorV2DispatchResult } from "../orchestration-v2/Orchestrator.ts";
+import {
+  ThreadManagementService,
+  ThreadManagementThreadNotFoundError,
+} from "../orchestration-v2/ThreadManagementService.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+
+export class ConversationTransferMcpService extends Context.Service<
+  ConversationTransferMcpService,
+  {
+    readonly list: (
+      scope: McpInvocationScope,
+      input: ConversationTransferListInput,
+    ) => Effect.Effect<ConversationTransferListResult, OrchestratorMcpFailure>;
+    readonly fork: (
+      scope: McpInvocationScope,
+      input: ConversationForkInput,
+    ) => Effect.Effect<ConversationForkResult, OrchestratorMcpFailure>;
+  }
+>()("t3/mcp/ConversationTransferMcpService") {}
+
+const isThreadNotFound = Schema.is(ThreadManagementThreadNotFoundError);
+
+function failure(code: OrchestratorMcpFailure["code"], message: string): OrchestratorMcpFailure {
+  return new OrchestratorMcpFailure({ code, message });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function runtimeModeRank(mode: RuntimeMode): number {
+  switch (mode) {
+    case "approval-required":
+      return 0;
+    case "auto-accept-edits":
+      return 1;
+    case "auto":
+      return 2;
+    case "full-access":
+      return 3;
+  }
+}
+
+function interactionModeRank(mode: ProviderInteractionMode): number {
+  return mode === "plan" ? 0 : 1;
+}
+
+function stablePart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function targetThreadId(scope: McpInvocationScope, requestKey: string): ThreadId {
+  return ThreadId.make(
+    `thread:mcp:${stablePart(scope.providerSessionId)}:conversation-fork:target:${stablePart(requestKey)}`,
+  );
+}
+
+function forkCommandId(scope: McpInvocationScope, requestKey: string): CommandId {
+  return CommandId.make(
+    `command:mcp:${stablePart(scope.providerSessionId)}:thread-fork:${stablePart(requestKey)}`,
+  );
+}
+
+function sourceRun(
+  projection: OrchestrationV2ThreadProjection,
+  point: OrchestrationV2ThreadForkSourcePoint,
+): OrchestrationV2Run | undefined {
+  switch (point.type) {
+    case "latest_stable":
+      return projection.runs
+        .filter((run) => run.status === "completed" && run.checkpointId !== null)
+        .toSorted((left, right) => right.ordinal - left.ordinal)[0];
+    case "run":
+      return projection.runs.find((run) => run.id === point.runId);
+    case "checkpoint":
+      const checkpoint = projection.checkpoints.find(
+        (candidate) => candidate.id === point.checkpointId,
+      );
+      return checkpoint?.runId === null || checkpoint === undefined
+        ? undefined
+        : projection.runs.find((run) => run.id === checkpoint.runId);
+  }
+}
+
+export function conversationForkNativeEligibility(
+  projection: OrchestrationV2ThreadProjection,
+  run: OrchestrationV2Run,
+): ConversationForkNativeEligibility {
+  const providerThread = projection.providerThreads.find(
+    (candidate) => candidate.id === run.providerThreadId,
+  );
+  const session = projection.providerSessions.find(
+    (candidate) => candidate.id === providerThread?.providerSessionId,
+  );
+  if (session === undefined) return "source_provider_session_unavailable";
+  if (!session.capabilities.threads.canForkThread) return "provider_does_not_support_fork";
+  if (!session.capabilities.threads.canForkFromTurn) {
+    return "provider_does_not_support_turn_fork";
+  }
+  if (
+    providerThread?.nativeThreadRef?.strength !== "strong" ||
+    session.capabilities.identity.nativeThreadIds !== "strong"
+  ) {
+    return "strong_native_source_unavailable";
+  }
+  return "eligible";
+}
+
+function receipt(result: OrchestratorV2DispatchResult, commandId: CommandId) {
+  return {
+    commandId,
+    commandType: "thread.fork",
+    sequence: result.sequence,
+    eventIds: result.storedEvents.map((stored) => stored.event.id),
+  } satisfies ConversationTransferReceipt;
+}
+
+function forkTransfer(
+  result: OrchestratorV2DispatchResult,
+  targetThreadId: ThreadId,
+): OrchestrationV2ContextTransfer | undefined {
+  for (const stored of result.storedEvents) {
+    if (
+      stored.event.type === "context-transfer.created" &&
+      stored.event.payload.type === "fork" &&
+      stored.event.payload.targetThreadId === targetThreadId
+    ) {
+      return stored.event.payload;
+    }
+  }
+  return undefined;
+}
+
+export const make = Effect.gen(function* () {
+  const threads = yield* ThreadManagementService;
+
+  const requireCapability = (scope: McpInvocationScope) =>
+    scope.capabilities.has("orchestration")
+      ? Effect.void
+      : Effect.fail(failure("capability_denied", "This MCP credential cannot control threads."));
+
+  const loadScoped = Effect.fn("ConversationTransferMcpService.loadScoped")(function* (
+    scope: McpInvocationScope,
+    requestedThreadId: ThreadId | undefined,
+  ) {
+    yield* requireCapability(scope);
+    const parent = yield* threads
+      .getThreadProjection(scope.threadId)
+      .pipe(
+        Effect.mapError((error) =>
+          failure(
+            "orchestration_error",
+            `Unable to load the calling thread: ${errorMessage(error)}`,
+          ),
+        ),
+      );
+    const threadId = requestedThreadId ?? scope.threadId;
+    const target = yield* threads
+      .getProjectThread({ projectId: parent.thread.projectId, threadId })
+      .pipe(
+        Effect.mapError((error) =>
+          isThreadNotFound(error)
+            ? failure(
+                "thread_not_found",
+                `Thread ${threadId} was not found in the calling project.`,
+              )
+            : failure(
+                "orchestration_error",
+                `Unable to load thread ${threadId}: ${errorMessage(error)}`,
+              ),
+        ),
+      );
+    return { parent, target };
+  });
+
+  const resultFromDispatch = Effect.fn("ConversationTransferMcpService.resultFromDispatch")(
+    function* (input: {
+      readonly request: ConversationForkInput;
+      readonly commandId: CommandId;
+      readonly targetThreadId: ThreadId;
+      readonly dispatched: OrchestratorV2DispatchResult;
+      readonly source: OrchestrationV2ThreadProjection | undefined;
+    }) {
+      const transfer = forkTransfer(input.dispatched, input.targetThreadId);
+      if (transfer === undefined) {
+        return yield* failure(
+          "orchestration_error",
+          "The fork command committed without returning its context-transfer event.",
+        );
+      }
+      const run =
+        input.source === undefined || transfer.sourcePoint.runId === undefined
+          ? undefined
+          : input.source.runs.find((candidate) => candidate.id === transfer.sourcePoint.runId);
+      return {
+        sourceThreadId: transfer.sourceThreadId,
+        targetThreadId: input.targetThreadId,
+        scope: "conversation_through_source_point",
+        requestedSourcePoint: input.request.sourcePoint,
+        canonicalSourcePoint: transfer.sourcePoint,
+        transfer,
+        providerSupport: {
+          sourceProviderInstanceId: transfer.sourceProviderInstanceId,
+          nativeForkEligibility:
+            input.source === undefined || run === undefined
+              ? "source_provider_session_unavailable"
+              : conversationForkNativeEligibility(input.source, run),
+          resolutionTiming: "first_target_turn",
+          fallback: "provider_context_capabilities_checked_on_first_target_turn",
+        },
+        receipt: receipt(input.dispatched, input.commandId),
+      } satisfies ConversationForkResult;
+    },
+  );
+
+  return ConversationTransferMcpService.of({
+    list: (scope, input) =>
+      Effect.gen(function* () {
+        const { target } = yield* loadScoped(scope, input.threadId);
+        const limit = input.limit ?? 50;
+        const matching = target.contextTransfers
+          .filter((transfer) => input.type === undefined || transfer.type === input.type)
+          .toSorted(
+            (left, right) =>
+              DateTime.toEpochMillis(right.updatedAt) - DateTime.toEpochMillis(left.updatedAt),
+          );
+        return {
+          threadId: target.thread.id,
+          scope: "current_project",
+          transfers: matching.slice(0, limit),
+          hasMore: matching.length > limit,
+        };
+      }),
+    fork: (scope, input) =>
+      Effect.gen(function* () {
+        yield* requireCapability(scope);
+        const commandId = forkCommandId(scope, input.clientRequestId);
+        const targetId = targetThreadId(scope, input.clientRequestId);
+        const existingTarget = yield* Effect.option(threads.getThreadProjection(targetId));
+        const existingTransfer = Option.isSome(existingTarget)
+          ? existingTarget.value.contextTransfers.find(
+              (transfer) => transfer.type === "fork" && transfer.targetThreadId === targetId,
+            )
+          : undefined;
+        if (existingTransfer !== undefined) {
+          const replayed = yield* threads
+            .dispatch({
+              type: "thread.fork",
+              createdBy: "agent",
+              creationSource: "mcp",
+              commandId,
+              sourceThreadId: input.sourceThreadId ?? scope.threadId,
+              targetThreadId: targetId,
+              sourcePoint: input.sourcePoint,
+              ...(input.title === undefined ? {} : { title: input.title }),
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                failure(
+                  "orchestration_error",
+                  `Unable to replay the fork receipt: ${errorMessage(error)}`,
+                ),
+              ),
+            );
+          const replaySource = yield* Effect.option(
+            threads.getThreadProjection(existingTransfer.sourceThreadId),
+          );
+          return yield* resultFromDispatch({
+            request: input,
+            commandId,
+            targetThreadId: targetId,
+            dispatched: replayed,
+            source: Option.getOrUndefined(replaySource),
+          });
+        }
+
+        const { parent, target: source } = yield* loadScoped(scope, input.sourceThreadId);
+        if (
+          runtimeModeRank(source.thread.runtimeMode) > runtimeModeRank(parent.thread.runtimeMode)
+        ) {
+          return yield* failure(
+            "runtime_mode_escalation_denied",
+            `The source thread's ${source.thread.runtimeMode} runtime mode exceeds the calling thread's ${parent.thread.runtimeMode} ceiling.`,
+          );
+        }
+        if (
+          interactionModeRank(source.thread.interactionMode) >
+          interactionModeRank(parent.thread.interactionMode)
+        ) {
+          return yield* failure(
+            "interaction_mode_escalation_denied",
+            `The source thread's ${source.thread.interactionMode} interaction mode exceeds the calling thread's ${parent.thread.interactionMode} ceiling.`,
+          );
+        }
+        const run = sourceRun(source, input.sourcePoint);
+        if (run === undefined) {
+          return yield* failure(
+            "run_not_found",
+            `No run in thread ${source.thread.id} matches source point ${input.sourcePoint.type}.`,
+          );
+        }
+        if (run.status !== "completed") {
+          return yield* failure(
+            "invalid_request",
+            `Fork source run ${run.id} is ${run.status}; only completed runs are stable fork sources.`,
+          );
+        }
+
+        const dispatched = yield* threads
+          .dispatch({
+            type: "thread.fork",
+            createdBy: "agent",
+            creationSource: "mcp",
+            commandId,
+            sourceThreadId: source.thread.id,
+            targetThreadId: targetId,
+            sourcePoint: input.sourcePoint,
+            ...(input.title === undefined ? {} : { title: input.title }),
+            policyCeiling: {
+              callerThreadId: parent.thread.id,
+              runtimeMode: parent.thread.runtimeMode,
+              interactionMode: parent.thread.interactionMode,
+            },
+          })
+          .pipe(
+            Effect.mapError((error) =>
+              failure("orchestration_error", `Unable to fork the thread: ${errorMessage(error)}`),
+            ),
+          );
+        return yield* resultFromDispatch({
+          request: input,
+          commandId,
+          targetThreadId: targetId,
+          dispatched,
+          source,
+        });
+      }),
+  });
+});
+
+export const layer: Layer.Layer<ConversationTransferMcpService, never, ThreadManagementService> =
+  Layer.effect(ConversationTransferMcpService, make);

--- a/apps/server/src/mcp/ConversationTransferMcpService.ts
+++ b/apps/server/src/mcp/ConversationTransferMcpService.ts
@@ -20,6 +20,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
 import * as Schema from "effect/Schema";
 
 import type { OrchestratorV2DispatchResult } from "../orchestration-v2/Orchestrator.ts";
@@ -44,6 +45,14 @@ export class ConversationTransferMcpService extends Context.Service<
 >()("t3/mcp/ConversationTransferMcpService") {}
 
 const isThreadNotFound = Schema.is(ThreadManagementThreadNotFoundError);
+
+function isProjectionNotFound(error: unknown): boolean {
+  return (
+    Predicate.hasProperty(error, "cause") &&
+    Predicate.hasProperty(error.cause, "_tag") &&
+    error.cause._tag === "ProjectionStoreThreadNotFoundError"
+  );
+}
 
 function failure(code: OrchestratorMcpFailure["code"], message: string): OrchestratorMcpFailure {
   return new OrchestratorMcpFailure({ code, message });
@@ -261,7 +270,19 @@ export const make = Effect.gen(function* () {
         yield* requireCapability(scope);
         const commandId = forkCommandId(scope, input.clientRequestId);
         const targetId = targetThreadId(scope, input.clientRequestId);
-        const existingTarget = yield* Effect.option(threads.getThreadProjection(targetId));
+        const existingTarget = yield* threads.getThreadProjection(targetId).pipe(
+          Effect.map(Option.some),
+          Effect.catch((error) =>
+            isProjectionNotFound(error)
+              ? Effect.succeed(Option.none())
+              : Effect.fail(
+                  failure(
+                    "orchestration_error",
+                    `Unable to inspect the fork target before dispatch: ${errorMessage(error)}`,
+                  ),
+                ),
+          ),
+        );
         const existingTransfer = Option.isSome(existingTarget)
           ? existingTarget.value.contextTransfers.find(
               (transfer) => transfer.type === "fork" && transfer.targetThreadId === targetId,

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -11,6 +11,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 
 import packageJson from "../../package.json" with { type: "json" };
 import * as McpInvocationContext from "./McpInvocationContext.ts";
+import * as ConversationTransferMcpService from "./ConversationTransferMcpService.ts";
 import * as OrchestratorMcpService from "./OrchestratorMcpService.ts";
 import * as ThreadMetadataMcpService from "./ThreadMetadataMcpService.ts";
 import * as McpSessionRegistry from "./McpSessionRegistry.ts";
@@ -224,6 +225,7 @@ export const PreviewToolkitRegistrationLive = Layer.mergeAll(
 
 export const OrchestratorToolkitRegistrationLive = McpServer.toolkit(OrchestratorToolkit).pipe(
   Layer.provide(OrchestratorToolkitHandlersLive),
+  Layer.provide(ConversationTransferMcpService.layer),
   Layer.provide(OrchestratorMcpService.layer),
   Layer.provide(ThreadMetadataMcpService.layer),
 );

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -2,6 +2,8 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import {
   CommandId,
+  ConversationForkResult,
+  ConversationTransferListResult,
   EnvironmentId,
   IsoDateTime,
   MessageId,
@@ -37,6 +39,7 @@ import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PubSub from "effect/PubSub";
@@ -50,6 +53,10 @@ import { CodexProviderCapabilitiesV2 } from "../orchestration-v2/Adapters/CodexA
 import { CodexOrchestratorReplayHarness } from "../orchestration-v2/Adapters/CodexAdapterV2.testkit.ts";
 import { OrchestratorV2, type OrchestratorV2Shape } from "../orchestration-v2/Orchestrator.ts";
 import { layer as threadManagementServiceLayer } from "../orchestration-v2/ThreadManagementService.ts";
+import {
+  layer as threadForkServiceLayer,
+  ThreadForkServiceV2,
+} from "../orchestration-v2/ThreadForkService.ts";
 import {
   type ProviderAdapterV2Event,
   ProviderAdapterProtocolError,
@@ -91,6 +98,10 @@ const queuedFollowupPrompt = "Complete the queued follow-up and return the final
 const queuedFollowupResult = "Queued delegated follow-up completed.";
 
 const decodeCreateThreadsResult = Schema.decodeUnknownEffect(OrchestratorMcpCreateThreadsResult);
+const decodeConversationForkResult = Schema.decodeUnknownEffect(ConversationForkResult);
+const decodeConversationTransferListResult = Schema.decodeUnknownEffect(
+  ConversationTransferListResult,
+);
 const decodeCreatedThread = Schema.decodeUnknownEffect(OrchestratorMcpCreatedThread);
 const decodeDelegateTaskResult = Schema.decodeUnknownEffect(OrchestratorMcpDelegateTaskResult);
 const decodeTaskCancelResult = Schema.decodeUnknownEffect(OrchestratorMcpTaskCancelResult);
@@ -517,6 +528,23 @@ describe("orchestrator MCP toolkit", () => {
               Ref.update(continuationOffers, (existing) => [...existing, request]),
             take: Effect.never,
           });
+          const forkPlanEntered = yield* Deferred.make<void>();
+          const releaseForkPlan = yield* Deferred.make<void>();
+          const gatedThreadForkServiceLayer = Layer.effect(
+            ThreadForkServiceV2,
+            Effect.gen(function* () {
+              const service = yield* ThreadForkServiceV2;
+              return ThreadForkServiceV2.of({
+                plan: (input) =>
+                  input.title === "Race-gated fork"
+                    ? Deferred.succeed(forkPlanEntered, undefined).pipe(
+                        Effect.andThen(Deferred.await(releaseForkPlan)),
+                        Effect.andThen(service.plan(input)),
+                      )
+                    : service.plan(input),
+              });
+            }),
+          ).pipe(Layer.provide(threadForkServiceLayer));
           // Offers land after the finalize projection writes, so poll briefly
           // instead of asserting counts immediately.
           const waitForContinuationOffers = (count: number) =>
@@ -553,6 +581,7 @@ describe("orchestrator MCP toolkit", () => {
               },
             },
             registryLayer,
+            { threadForkServiceLayer: gatedThreadForkServiceLayer },
           ).pipe(Layer.provide(continuationProbeLayer));
           const orchestrationLayer = Layer.merge(
             orchestratorLayer,
@@ -1952,17 +1981,255 @@ describe("orchestrator MCP toolkit", () => {
               `Claude completed: ${createdThreadPrompt}`,
             );
 
-            const forkedThreadId = ThreadId.make("thread:mcp-orchestrator-inherited-read");
+            const collisionCreate = yield* decodeCreateThreadsResult(
+              (yield* invoke("create_threads", {
+                clientRequestId: "fork",
+                threads: [{ title: "Create namespace collision sentinel" }],
+              })).structuredContent,
+            ).pipe(Effect.orDie);
+            const collisionFork = yield* decodeConversationForkResult(
+              (yield* invoke("t3_thread_fork", {
+                sourceThreadId: promptedThread.threadId,
+                sourcePoint: { type: "latest_stable" },
+                clientRequestId: "0",
+              })).structuredContent,
+            ).pipe(Effect.orDie);
+            expect(collisionCreate.threads[0]?.threadId).not.toBe(collisionFork.targetThreadId);
+            expect(
+              (yield* orchestrator.getThreadProjection(collisionCreate.threads[0]!.threadId)).thread
+                .title,
+            ).toBe("Create namespace collision sentinel");
+            expect(
+              (yield* orchestrator.getThreadProjection(collisionFork.targetThreadId)).thread
+                .lineage,
+            ).toMatchObject({
+              parentThreadId: promptedThread.threadId,
+              relationshipToParent: "fork",
+            });
+
+            const occupiedForkTargetId = ThreadId.make(
+              "thread:mcp:mcp-provider-session-parent:conversation-fork:target:occupied-target",
+            );
             yield* orchestrator.dispatch({
-              type: "thread.fork",
+              type: "thread.create",
               createdBy: "user",
               creationSource: "web",
-              commandId: CommandId.make("command:mcp-orchestrator-inherited-read"),
+              commandId: CommandId.make("command:mcp-fork:occupied-target-create"),
+              threadId: occupiedForkTargetId,
+              projectId,
+              title: "Existing target must survive",
+              modelSelection: codexSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              branch: null,
+              worktreePath: cwd,
+            });
+            const occupiedForkCall = yield* invoke("t3_thread_fork", {
               sourceThreadId: promptedThread.threadId,
-              targetThreadId: forkedThreadId,
+              sourcePoint: { type: "latest_stable" },
+              clientRequestId: "occupied-target",
+            });
+            expect(occupiedForkCall.structuredContent).toMatchObject({
+              _tag: "OrchestratorMcpFailure",
+              code: "orchestration_error",
+            });
+            const occupiedForkTarget =
+              yield* orchestrator.getThreadProjection(occupiedForkTargetId);
+            expect(occupiedForkTarget.thread.title).toBe("Existing target must survive");
+            expect(occupiedForkTarget.contextTransfers).toEqual([]);
+
+            const deletedOccupiedForkTargetId = ThreadId.make(
+              "thread:mcp:mcp-provider-session-parent:conversation-fork:target:deleted-occupied-target",
+            );
+            yield* orchestrator.dispatch({
+              type: "thread.create",
+              createdBy: "user",
+              creationSource: "web",
+              commandId: CommandId.make("command:mcp-fork:deleted-occupied-target-create"),
+              threadId: deletedOccupiedForkTargetId,
+              projectId,
+              title: "Deleted target must stay deleted",
+              modelSelection: codexSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              branch: null,
+              worktreePath: cwd,
+            });
+            yield* orchestrator.dispatch({
+              type: "thread.delete",
+              commandId: CommandId.make("command:mcp-fork:deleted-occupied-target-delete"),
+              threadId: deletedOccupiedForkTargetId,
+            });
+            const deletedOccupiedForkCall = yield* invoke("t3_thread_fork", {
+              sourceThreadId: promptedThread.threadId,
+              sourcePoint: { type: "latest_stable" },
+              clientRequestId: "deleted-occupied-target",
+            });
+            expect(deletedOccupiedForkCall.structuredContent).toMatchObject({
+              _tag: "OrchestratorMcpFailure",
+              code: "orchestration_error",
+            });
+            const deletedOccupiedForkTarget = yield* orchestrator.getThreadProjection(
+              deletedOccupiedForkTargetId,
+            );
+            expect(deletedOccupiedForkTarget.thread.title).toBe("Deleted target must stay deleted");
+            expect(deletedOccupiedForkTarget.thread.deletedAt).not.toBeNull();
+            expect(deletedOccupiedForkTarget.contextTransfers).toEqual([]);
+
+            const racingForkFiber = yield* Effect.forkChild(
+              invoke("t3_thread_fork", {
+                sourceThreadId: promptedThread.threadId,
+                sourcePoint: { type: "latest_stable" },
+                title: "Race-gated fork",
+                clientRequestId: "orchestrator-race-gated-fork",
+              }),
+            );
+            yield* Deferred.await(forkPlanEntered);
+            const sourceWriterStarted = yield* Deferred.make<void>();
+            const callerWriterStarted = yield* Deferred.make<void>();
+            const sourceWriterFiber = yield* Effect.forkChild(
+              Deferred.succeed(sourceWriterStarted, undefined).pipe(
+                Effect.andThen(
+                  orchestrator.dispatch({
+                    type: "thread.runtime-mode.set",
+                    commandId: CommandId.make("command:mcp-fork:race-source-runtime"),
+                    threadId: promptedThread.threadId,
+                    runtimeMode: "approval-required",
+                  }),
+                ),
+              ),
+            );
+            const callerWriterFiber = yield* Effect.forkChild(
+              Deferred.succeed(callerWriterStarted, undefined).pipe(
+                Effect.andThen(
+                  orchestrator.dispatch({
+                    type: "thread.interaction-mode.set",
+                    commandId: CommandId.make("command:mcp-fork:race-caller-interaction"),
+                    threadId: parentThreadId,
+                    interactionMode: "plan",
+                  }),
+                ),
+              ),
+            );
+            yield* Deferred.await(sourceWriterStarted);
+            yield* Deferred.await(callerWriterStarted);
+            yield* Effect.yieldNow;
+            yield* Deferred.succeed(releaseForkPlan, undefined);
+            const racingForkCall = yield* Fiber.join(racingForkFiber);
+            const sourceWriter = yield* Fiber.join(sourceWriterFiber);
+            const callerWriter = yield* Fiber.join(callerWriterFiber);
+            const racingFork = yield* decodeConversationForkResult(
+              racingForkCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(racingFork.receipt.sequence).toBeLessThan(sourceWriter.sequence);
+            expect(racingFork.receipt.sequence).toBeLessThan(callerWriter.sequence);
+            expect(
+              (yield* orchestrator.getThreadProjection(racingFork.targetThreadId)).thread,
+            ).toMatchObject({ runtimeMode: "full-access", interactionMode: "default" });
+            yield* orchestrator.dispatch({
+              type: "thread.runtime-mode.set",
+              commandId: CommandId.make("command:mcp-fork:race-restore-source-runtime"),
+              threadId: promptedThread.threadId,
+              runtimeMode: "full-access",
+            });
+            yield* orchestrator.dispatch({
+              type: "thread.interaction-mode.set",
+              commandId: CommandId.make("command:mcp-fork:race-restore-caller-interaction"),
+              threadId: parentThreadId,
+              interactionMode: "default",
+            });
+
+            const deniedFork = yield* orchestrator
+              .dispatch({
+                type: "thread.fork",
+                createdBy: "agent",
+                creationSource: "mcp",
+                commandId: CommandId.make("command:mcp-fork:denied-policy-ceiling"),
+                sourceThreadId: promptedThread.threadId,
+                targetThreadId: ThreadId.make("thread:mcp-fork:denied-policy-ceiling"),
+                sourcePoint: { type: "latest_stable" },
+                policyCeiling: {
+                  callerThreadId: parentThreadId,
+                  runtimeMode: "approval-required",
+                  interactionMode: "plan",
+                },
+              })
+              .pipe(Effect.flip);
+            expect(deniedFork._tag).toBe("OrchestratorDispatchError");
+
+            const forkCall = yield* invoke("t3_thread_fork", {
+              sourceThreadId: promptedThread.threadId,
               sourcePoint: { type: "latest_stable" },
               title: "Inherited read thread",
+              clientRequestId: "orchestrator-inherited-read",
             });
+            expect(forkCall.isError).toBe(false);
+            const forked = yield* decodeConversationForkResult(forkCall.structuredContent).pipe(
+              Effect.orDie,
+            );
+            const forkedThreadId = forked.targetThreadId;
+            expect(forked).toMatchObject({
+              sourceThreadId: promptedThread.threadId,
+              scope: "conversation_through_source_point",
+              requestedSourcePoint: { type: "latest_stable" },
+              transfer: { type: "fork", status: "pending" },
+              providerSupport: { resolutionTiming: "first_target_turn" },
+              receipt: { commandType: "thread.fork" },
+            });
+            expect(forked.canonicalSourcePoint.runId).toBeDefined();
+            const forkCheckpointId = forked.canonicalSourcePoint.checkpointId;
+            if (forkCheckpointId === undefined) {
+              return yield* Effect.die(new Error("Stable fork source checkpoint missing."));
+            }
+            const checkpointForkCall = yield* invoke("t3_thread_fork", {
+              sourceThreadId: promptedThread.threadId,
+              sourcePoint: { type: "checkpoint", checkpointId: forkCheckpointId },
+              clientRequestId: "orchestrator-checkpoint-fork",
+            });
+            const checkpointFork = yield* decodeConversationForkResult(
+              checkpointForkCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(checkpointFork.canonicalSourcePoint.runId).toBe(
+              forked.canonicalSourcePoint.runId,
+            );
+
+            yield* orchestrator.dispatch({
+              type: "thread.runtime-mode.set",
+              commandId: CommandId.make("command:mcp-fork:lower-caller-runtime"),
+              threadId: parentThreadId,
+              runtimeMode: "approval-required",
+            });
+            yield* orchestrator.dispatch({
+              type: "thread.interaction-mode.set",
+              commandId: CommandId.make("command:mcp-fork:lower-caller-interaction"),
+              threadId: parentThreadId,
+              interactionMode: "plan",
+            });
+
+            const repeatedForkCall = yield* invoke("t3_thread_fork", {
+              sourceThreadId: promptedThread.threadId,
+              sourcePoint: { type: "latest_stable" },
+              title: "Inherited read thread",
+              clientRequestId: "orchestrator-inherited-read",
+            });
+            const repeatedFork = yield* decodeConversationForkResult(
+              repeatedForkCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(repeatedFork.targetThreadId).toBe(forkedThreadId);
+            expect(repeatedFork.receipt).toEqual(forked.receipt);
+            yield* orchestrator.dispatch({
+              type: "thread.runtime-mode.set",
+              commandId: CommandId.make("command:mcp-fork:restore-caller-runtime"),
+              threadId: parentThreadId,
+              runtimeMode: "full-access",
+            });
+            yield* orchestrator.dispatch({
+              type: "thread.interaction-mode.set",
+              commandId: CommandId.make("command:mcp-fork:restore-caller-interaction"),
+              threadId: parentThreadId,
+              interactionMode: "default",
+            });
+
             const forkedProjection = yield* orchestrator.getThreadProjection(forkedThreadId);
             expect(forkedProjection.messages).toEqual([]);
             expect(
@@ -1985,6 +2252,21 @@ describe("orchestrator MCP toolkit", () => {
               sourceThreadId: promptedThread.threadId,
               createdBy: "agent",
               creationSource: "mcp",
+            });
+
+            const transfersCall = yield* invoke("t3_thread_transfers", {
+              threadId: forkedThreadId,
+              type: "fork",
+              limit: 1,
+            });
+            const transfers = yield* decodeConversationTransferListResult(
+              transfersCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(transfers).toMatchObject({
+              threadId: forkedThreadId,
+              scope: "current_project",
+              hasMore: false,
+              transfers: [{ id: forked.transfer.id, type: "fork", status: "pending" }],
             });
 
             const ordinaryLoopPrompt = "Run an ordinary thread loop iteration.";

--- a/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
@@ -2,6 +2,7 @@ import { OrchestratorToolkit } from "./tools.ts";
 import * as Effect from "effect/Effect";
 
 import { McpInvocationContext } from "../../McpInvocationContext.ts";
+import { ConversationTransferMcpService } from "../../ConversationTransferMcpService.ts";
 import { OrchestratorMcpService } from "../../OrchestratorMcpService.ts";
 import { ThreadMetadataMcpService } from "../../ThreadMetadataMcpService.ts";
 
@@ -115,6 +116,18 @@ const handlers = {
       const scope = yield* McpInvocationContext;
       const service = yield* OrchestratorMcpService;
       return yield* service.interruptThread(scope, input);
+    }),
+  t3_thread_transfers: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* ConversationTransferMcpService;
+      return yield* service.list(scope, input);
+    }),
+  t3_thread_fork: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* ConversationTransferMcpService;
+      return yield* service.fork(scope, input);
     }),
 } satisfies Parameters<typeof OrchestratorToolkit.toLayer>[0];
 

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.test.ts
@@ -5,6 +5,8 @@ import {
   CreateThreadsTool,
   DelegateTaskTool,
   ScheduleTaskTool,
+  ThreadForkTool,
+  ThreadTransfersTool,
   ThreadUpdateTool,
 } from "./tools.ts";
 
@@ -76,5 +78,29 @@ describe("orchestrator MCP tool guidance", () => {
       "clientRequestId",
     ]);
     assert.include(ThreadUpdateTool.description ?? "", "Workspace and branch changes");
+  });
+
+  it("publishes discoverable root-object schemas for conversation transfers", () => {
+    const forkSchema = Tool.getJsonSchema(ThreadForkTool) as {
+      readonly type?: unknown;
+      readonly properties?: Readonly<Record<string, unknown>>;
+      readonly required?: ReadonlyArray<string>;
+    };
+    const transfersSchema = Tool.getJsonSchema(ThreadTransfersTool) as {
+      readonly type?: unknown;
+      readonly properties?: Readonly<Record<string, unknown>>;
+    };
+
+    assert.equal(forkSchema.type, "object");
+    assert.hasAllKeys(forkSchema.properties ?? {}, [
+      "sourceThreadId",
+      "sourcePoint",
+      "title",
+      "clientRequestId",
+    ]);
+    assert.include(forkSchema.required ?? [], "sourcePoint");
+    assert.include(forkSchema.required ?? [], "clientRequestId");
+    assert.equal(transfersSchema.type, "object");
+    assert.hasAllKeys(transfersSchema.properties ?? {}, ["threadId", "type", "limit"]);
   });
 });

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.ts
@@ -1,4 +1,8 @@
 import {
+  ConversationForkInput,
+  ConversationForkResult,
+  ConversationTransferListInput,
+  ConversationTransferListResult,
   OrchestratorMcpCapabilitiesResult,
   OrchestratorMcpCreatedThread,
   OrchestratorMcpCreateThreadsInput,
@@ -32,6 +36,7 @@ import {
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { ConversationTransferMcpService } from "../../ConversationTransferMcpService.ts";
 import { OrchestratorMcpService } from "../../OrchestratorMcpService.ts";
 import { ThreadMetadataMcpService } from "../../ThreadMetadataMcpService.ts";
 
@@ -39,6 +44,10 @@ const dependencies = [McpInvocationContext.McpInvocationContext, OrchestratorMcp
 const threadMetadataDependencies = [
   McpInvocationContext.McpInvocationContext,
   ThreadMetadataMcpService,
+];
+const transferDependencies = [
+  McpInvocationContext.McpInvocationContext,
+  ConversationTransferMcpService,
 ];
 
 export const OrchestratorCapabilitiesTool = Tool.make("orchestrator_capabilities", {
@@ -249,6 +258,32 @@ export const ThreadInterruptTool = Tool.make("t3_thread_interrupt", {
   .annotate(Tool.Title, "Interrupt a T3 thread")
   .annotate(Tool.Destructive, true);
 
+export const ThreadTransfersTool = Tool.make("t3_thread_transfers", {
+  description:
+    "List up to 100 durable context transfers recorded on a T3 thread in the calling project, newest first. Omit threadId for this thread. Filter by transfer type to inspect fork, provider handoff, merge-back, or delegated-task provenance and resolution status.",
+  parameters: ConversationTransferListInput,
+  success: ConversationTransferListResult,
+  failure: OrchestratorMcpFailure,
+  failureMode: "return",
+  dependencies: transferDependencies,
+})
+  .annotate(Tool.Title, "List thread context transfers")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, true);
+
+export const ThreadForkTool = Tool.make("t3_thread_fork", {
+  description:
+    "Create a durable T3 conversation fork in the calling project from an explicit completed run, checkpoint, or latest stable run. Omit sourceThreadId for this thread. The new thread inherits the source configuration within the caller's permission ceiling. Native provider fork eligibility is reported now; native-fork or portable-context resolution happens truthfully on the first target turn. Reuse the required clientRequestId for retries.",
+  parameters: ConversationForkInput,
+  success: ConversationForkResult,
+  failure: OrchestratorMcpFailure,
+  failureMode: "return",
+  dependencies: transferDependencies,
+})
+  .annotate(Tool.Title, "Fork a T3 conversation")
+  .annotate(Tool.Destructive, true);
+
 export const OrchestratorToolkit = Toolkit.make(
   OrchestratorCapabilitiesTool,
   DelegateTaskTool,
@@ -266,4 +301,6 @@ export const OrchestratorToolkit = Toolkit.make(
   ThreadSendTool,
   ThreadWaitTool,
   ThreadInterruptTool,
+  ThreadTransfersTool,
+  ThreadForkTool,
 );

--- a/apps/server/src/mcp/toolkits/worktree/registration.test.ts
+++ b/apps/server/src/mcp/toolkits/worktree/registration.test.ts
@@ -114,6 +114,8 @@ it.effect("production mcp layer lists worktree tools over http", () =>
       // than replacing them.
       expect(toolNames).toContain("preview_status");
       expect(toolNames).toContain("delegate_task");
+      expect(toolNames).toContain("t3_thread_transfers");
+      expect(toolNames).toContain("t3_thread_fork");
 
       // The handoff tool mutates thread state, reaches the network (origin
       // fetch), and runs project setup scripts, so its MCP hints must not
@@ -125,6 +127,11 @@ it.effect("production mcp layer lists worktree tools over http", () =>
       const status = tools.find((tool) => tool.name === "t3_worktree_status");
       expect(status?.annotations?.readOnlyHint).toBe(true);
       expect(status?.annotations?.destructiveHint).toBe(false);
+      const transfers = tools.find((tool) => tool.name === "t3_thread_transfers");
+      expect(transfers?.annotations?.readOnlyHint).toBe(true);
+      expect(transfers?.annotations?.destructiveHint).toBe(false);
+      const fork = tools.find((tool) => tool.name === "t3_thread_fork");
+      expect(fork?.annotations?.destructiveHint).toBe(true);
 
       // MCP requires every tool input schema to be a top-level object schema.
       // A non-object schema (e.g. the anyOf produced by an empty

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -807,6 +807,7 @@ export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
   "mcp__t3-code__orchestrator_capabilities",
   "mcp__t3-code__list_scheduled_tasks",
   "mcp__t3-code__t3_thread_list",
+  "mcp__t3-code__t3_thread_transfers",
   "mcp__t3-code__t3_thread_wait",
 ];
 

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -371,6 +371,23 @@ function nextQueuedRun(
   return queuedRunsInDeliveryOrder(projection)[0];
 }
 
+function runtimeModeRank(mode: OrchestrationV2AppThread["runtimeMode"]): number {
+  switch (mode) {
+    case "approval-required":
+      return 0;
+    case "auto-accept-edits":
+      return 1;
+    case "auto":
+      return 2;
+    case "full-access":
+      return 3;
+  }
+}
+
+function interactionModeRank(mode: OrchestrationV2AppThread["interactionMode"]): number {
+  return mode === "plan" ? 0 : 1;
+}
+
 function latestStableRun(projection: OrchestrationV2ThreadProjection): OrchestrationV2Run | null {
   return (
     projection.runs
@@ -2034,6 +2051,67 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
             }),
         ),
       );
+    const targetIdentityExists = yield* projectionStore
+      .getThreadProjection(command.targetThreadId)
+      .pipe(
+        Effect.as(true),
+        Effect.catchTags({
+          ProjectionStoreThreadNotFoundError: () => Effect.succeed(false),
+        }),
+        Effect.mapError(
+          (cause) =>
+            new OrchestratorProjectionError({
+              threadId: command.targetThreadId,
+              cause,
+            }),
+        ),
+      );
+    if (targetIdentityExists) {
+      return yield* new OrchestratorDispatchError({
+        commandId: command.commandId,
+        commandType: command.type,
+        cause: `Fork target thread ${command.targetThreadId} already exists.`,
+      });
+    }
+
+    if (command.policyCeiling !== undefined) {
+      const callerProjection =
+        command.policyCeiling.callerThreadId === command.sourceThreadId
+          ? sourceProjection
+          : yield* projectionStore.getThreadProjection(command.policyCeiling.callerThreadId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new OrchestratorProjectionError({
+                    threadId: command.policyCeiling!.callerThreadId,
+                    cause,
+                  }),
+              ),
+            );
+      if (
+        runtimeModeRank(sourceProjection.thread.runtimeMode) >
+          runtimeModeRank(command.policyCeiling.runtimeMode) ||
+        runtimeModeRank(sourceProjection.thread.runtimeMode) >
+          runtimeModeRank(callerProjection.thread.runtimeMode)
+      ) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: `Fork source runtime mode ${sourceProjection.thread.runtimeMode} exceeds the caller ceiling.`,
+        });
+      }
+      if (
+        interactionModeRank(sourceProjection.thread.interactionMode) >
+          interactionModeRank(command.policyCeiling.interactionMode) ||
+        interactionModeRank(sourceProjection.thread.interactionMode) >
+          interactionModeRank(callerProjection.thread.interactionMode)
+      ) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: `Fork source interaction mode ${sourceProjection.thread.interactionMode} exceeds the caller ceiling.`,
+        });
+      }
+    }
 
     const sourceRun = runForSourcePoint(sourceProjection, command.sourcePoint);
 
@@ -7183,8 +7261,32 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
     } satisfies OrchestratorV2DispatchResult;
   });
 
+  const dispatchLockKeys = (command: OrchestrationV2Command): ReadonlyArray<ThreadId> => {
+    const keys =
+      command.type === "thread.fork"
+        ? [
+            command.sourceThreadId,
+            command.targetThreadId,
+            ...(command.policyCeiling === undefined ? [] : [command.policyCeiling.callerThreadId]),
+          ]
+        : command.type === "thread.merge_back"
+          ? [command.sourceThreadId, command.targetThreadId]
+          : [commandThreadId(command)];
+    return [...new Set(keys)].toSorted((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+  };
+
+  const withDispatchLocks = <A, E, R>(
+    keys: ReadonlyArray<ThreadId>,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const [key, ...remaining] = keys;
+    return key === undefined
+      ? effect
+      : threadDispatch.withLock(key, withDispatchLocks(remaining, effect));
+  };
+
   const dispatchWithReceipt = (command: OrchestrationV2Command) =>
-    threadDispatch.withLock(commandThreadId(command), dispatchWithReceiptEffect(command));
+    withDispatchLocks(dispatchLockKeys(command), dispatchWithReceiptEffect(command));
 
   const handleTerminalRun = (stored: OrchestrationV2StoredEvent) =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
+++ b/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
@@ -53,7 +53,10 @@ import {
 } from "../RuntimePolicy.ts";
 import { layer as turnItemPositionStoreLayer } from "../TurnItemPositionStore.ts";
 import { layer as runtimeRequestServiceLayer } from "../RuntimeRequestService.ts";
-import { layer as threadForkServiceLayer } from "../ThreadForkService.ts";
+import {
+  layer as defaultThreadForkServiceLayer,
+  ThreadForkServiceV2,
+} from "../ThreadForkService.ts";
 import {
   runOrchestratorV2Scenario,
   type OrchestratorV2ScenarioStepError,
@@ -180,6 +183,7 @@ export function runOrchestratorV2ProviderReplayScenario<
     >;
     readonly enableLegacyTokenStreaming?: boolean;
     readonly runEffectWorker?: boolean;
+    readonly threadForkServiceLayer?: Layer.Layer<ThreadForkServiceV2>;
   } = {},
 ): Effect.Effect<
   OrchestratorV2ScenarioResult,
@@ -220,6 +224,7 @@ export function makeOrchestratorV2ProviderReplayLayer<
     readonly enableLegacyTokenStreaming?: boolean;
     readonly runEffectWorker?: boolean;
     readonly replayGate?: ProviderReplayGate;
+    readonly threadForkServiceLayer?: Layer.Layer<ThreadForkServiceV2>;
   } = {},
 ): Layer.Layer<OrchestratorV2, Error | MigrationError | PlatformError.PlatformError | SqlError> {
   const registryLayer = harness.makeProviderAdapterRegistryLayer(
@@ -239,6 +244,7 @@ export function makeOrchestratorV2ReplayLayerWithRegistry<Error>(
     >;
     readonly enableLegacyTokenStreaming?: boolean;
     readonly runEffectWorker?: boolean;
+    readonly threadForkServiceLayer?: Layer.Layer<ThreadForkServiceV2>;
   } = {},
 ): Layer.Layer<OrchestratorV2, Error | MigrationError | PlatformError.PlatformError | SqlError> {
   const serverConfigLayer = Layer.effect(
@@ -392,7 +398,7 @@ export function makeOrchestratorV2ReplayLayerWithRegistry<Error>(
         providerSessionManagerProvided,
         providerSwitchServiceProvided,
         runExecutionServiceProvided,
-        threadForkServiceLayer,
+        options.threadForkServiceLayer ?? defaultThreadForkServiceLayer,
       ),
     ),
   );

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -327,6 +327,24 @@ Without `runId`, it selects the newest interruptible run. A terminal run is
 returned unchanged, and a thread with no active provider turn returns
 `no_active_run`.
 
+### Conversation forks and transfer discovery
+
+`t3_thread_fork` dispatches the existing `thread.fork` command through
+`ThreadManagementService`, including its project admission and deleted-source
+checks. The request names a stable source point and supplies an idempotency key;
+the target thread ID and command ID are stable for that key. The response is
+derived from the committed `thread.created` and `context-transfer.created`
+events rather than an optional final projection read.
+
+Fork creation records lineage and a pending context transfer. Native eligibility
+is reported from the source provider session and strong provider refs, but
+resolution remains deferred to the first target turn. The existing provider
+turn planner then chooses native fork or checks portable-context capabilities.
+
+`t3_thread_transfers` exposes a bounded, newest-first view of one current-project
+thread's durable context-transfer records. It is the read path for fork
+provenance and later resolution or consumption.
+
 ## Delegated Task Lifecycle
 
 The MCP server is a command ingress into V2. It does not call provider adapters

--- a/docs/user/conversation-forks.md
+++ b/docs/user/conversation-forks.md
@@ -1,0 +1,11 @@
+# Fork conversations with agents
+
+Agents connected through T3 Code's built-in MCP server can create a durable conversation fork without changing Git branches or workspaces.
+
+`t3_thread_fork` requires an explicit stable source point: the latest completed run, a specific completed run, or a checkpoint belonging to a completed run. Omitting `sourceThreadId` uses the current conversation. The new conversation stays in the same project and inherits the source conversation's provider selection and modes, limited by the calling agent's permission ceiling.
+
+The result identifies the source and new conversation, the requested and canonical source points, and the durable fork transfer. It also says whether a native provider fork is currently eligible. The transfer remains pending until the new conversation's first turn, when T3 Code chooses native fork or portable context using the active provider's capabilities. A pending result does not mean provider context has already moved.
+
+Use `t3_thread_transfers` to inspect fork and other context-transfer records on a conversation. Results are newest first and can be filtered by transfer type.
+
+`clientRequestId` is required for forks. Reusing it returns the original thread and command receipt instead of creating another fork.

--- a/packages/contracts/src/conversationTransferMcp.test.ts
+++ b/packages/contracts/src/conversationTransferMcp.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+
+import { ConversationForkInput, ConversationTransferListInput } from "./conversationTransferMcp.ts";
+
+const decodeFork = Schema.decodeUnknownEffect(ConversationForkInput);
+const decodeList = Schema.decodeUnknownEffect(ConversationTransferListInput);
+
+it.effect("requires an explicit stable fork source and a well-formed retry key", () =>
+  Effect.gen(function* () {
+    const valid = yield* decodeFork({
+      sourcePoint: { type: "run", runId: "run:completed" },
+      clientRequestId: "fork-completed-run",
+    });
+    const missingPoint = yield* Effect.result(
+      decodeFork({ clientRequestId: "fork-without-point" }),
+    );
+    const malformedKey = yield* Effect.result(
+      decodeFork({ sourcePoint: { type: "latest_stable" }, clientRequestId: "fork-\ud800" }),
+    );
+
+    expect(valid.sourcePoint).toEqual({ type: "run", runId: "run:completed" });
+    expect(Result.isFailure(missingPoint)).toBe(true);
+    expect(Result.isFailure(malformedKey)).toBe(true);
+  }),
+);
+
+it.effect("bounds transfer result pages", () =>
+  Effect.gen(function* () {
+    const valid = yield* decodeList({ limit: 100 });
+    const tooLarge = yield* Effect.result(decodeList({ limit: 101 }));
+
+    expect(valid.limit).toBe(100);
+    expect(Result.isFailure(tooLarge)).toBe(true);
+  }),
+);

--- a/packages/contracts/src/conversationTransferMcp.ts
+++ b/packages/contracts/src/conversationTransferMcp.ts
@@ -1,0 +1,112 @@
+import * as Schema from "effect/Schema";
+
+import { CommandId, NonNegativeInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import {
+  OrchestrationV2ContextSourcePoint,
+  OrchestrationV2ContextTransfer,
+  OrchestrationV2ContextTransferType,
+  OrchestrationV2ThreadForkSourcePoint,
+} from "./orchestrationV2.ts";
+import { ProviderInstanceId } from "./providerInstance.ts";
+
+function hasWellFormedUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      if (index + 1 >= value.length) return false;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const WellFormedRequestKey = Schema.String.check(
+  Schema.makeFilter(
+    (value: string) =>
+      (value.length > 0 && value === value.trim()) ||
+      "The request key must be non-empty and must not have surrounding whitespace.",
+  ),
+  Schema.isMaxLength(256),
+  Schema.makeFilter(
+    (value: string) =>
+      hasWellFormedUnicode(value) ||
+      "The request key must not contain unpaired Unicode surrogates.",
+  ),
+).annotate({ description: "Stable idempotency key to reuse when retrying this mutation." });
+
+const TransferPageLimit = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 100 }));
+
+export const ConversationTransferListInput = Schema.Struct({
+  threadId: Schema.optional(
+    ThreadId.annotate({
+      description: "Thread in the calling project; defaults to this thread.",
+    }),
+  ),
+  type: Schema.optional(OrchestrationV2ContextTransferType),
+  limit: Schema.optional(TransferPageLimit),
+});
+export type ConversationTransferListInput = typeof ConversationTransferListInput.Type;
+
+export const ConversationTransferListResult = Schema.Struct({
+  threadId: ThreadId,
+  scope: Schema.Literal("current_project"),
+  transfers: Schema.Array(OrchestrationV2ContextTransfer),
+  hasMore: Schema.Boolean,
+});
+export type ConversationTransferListResult = typeof ConversationTransferListResult.Type;
+
+export const ConversationForkInput = Schema.Struct({
+  sourceThreadId: Schema.optional(
+    ThreadId.annotate({
+      description: "Source thread in the calling project; defaults to this thread.",
+    }),
+  ),
+  sourcePoint: OrchestrationV2ThreadForkSourcePoint.annotate({
+    description:
+      "Explicit stable source: the latest completed run, one completed run id, or a checkpoint on a completed run.",
+  }),
+  title: Schema.optional(TrimmedNonEmptyString),
+  clientRequestId: WellFormedRequestKey,
+});
+export type ConversationForkInput = typeof ConversationForkInput.Type;
+
+export const ConversationForkNativeEligibility = Schema.Literals([
+  "eligible",
+  "provider_does_not_support_fork",
+  "provider_does_not_support_turn_fork",
+  "strong_native_source_unavailable",
+  "source_provider_session_unavailable",
+]);
+export type ConversationForkNativeEligibility = typeof ConversationForkNativeEligibility.Type;
+
+export const ConversationForkProviderSupport = Schema.Struct({
+  sourceProviderInstanceId: Schema.NullOr(ProviderInstanceId),
+  nativeForkEligibility: ConversationForkNativeEligibility,
+  resolutionTiming: Schema.Literal("first_target_turn"),
+  fallback: Schema.Literal("provider_context_capabilities_checked_on_first_target_turn"),
+});
+export type ConversationForkProviderSupport = typeof ConversationForkProviderSupport.Type;
+
+export const ConversationTransferReceipt = Schema.Struct({
+  commandId: CommandId,
+  commandType: Schema.Literals(["thread.fork", "thread.merge_back"]),
+  sequence: NonNegativeInt,
+  eventIds: Schema.Array(Schema.String),
+});
+export type ConversationTransferReceipt = typeof ConversationTransferReceipt.Type;
+
+export const ConversationForkResult = Schema.Struct({
+  sourceThreadId: ThreadId,
+  targetThreadId: ThreadId,
+  scope: Schema.Literal("conversation_through_source_point"),
+  requestedSourcePoint: OrchestrationV2ThreadForkSourcePoint,
+  canonicalSourcePoint: OrchestrationV2ContextSourcePoint,
+  transfer: OrchestrationV2ContextTransfer,
+  providerSupport: ConversationForkProviderSupport,
+  receipt: ConversationTransferReceipt,
+});
+export type ConversationForkResult = typeof ConversationForkResult.Type;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -33,6 +33,7 @@ export * from "./orchestrationProject.ts";
 export * from "./orchestrationV2.ts";
 export * from "./applicationEvent.ts";
 export * from "./orchestratorMcp.ts";
+export * from "./conversationTransferMcp.ts";
 export * from "./threadMetadataMcp.ts";
 export * from "./orchestration.ts";
 export * from "./t3ProjectFile.ts";

--- a/packages/contracts/src/orchestrationV2.ts
+++ b/packages/contracts/src/orchestrationV2.ts
@@ -2283,6 +2283,14 @@ export const OrchestrationV2Command = Schema.Union([
     targetThreadId: ThreadId,
     sourcePoint: OrchestrationV2ThreadForkSourcePoint,
     title: Schema.optional(TrimmedNonEmptyString),
+    /** Optional caller ceiling enforced with the current source and caller projections. */
+    policyCeiling: Schema.optional(
+      Schema.Struct({
+        callerThreadId: ThreadId,
+        runtimeMode: RuntimeMode,
+        interactionMode: ProviderInteractionMode,
+      }),
+    ),
     createdAt: Schema.optional(Schema.DateTimeUtc),
   }),
   Schema.Struct({

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -49,6 +49,8 @@ const T3_MCP_TOOLS: Record<
   t3_thread_list: { displayName: "List T3 threads", summaryAction: "thread-list" },
   t3_thread_read: { displayName: "Read a T3 thread", summaryAction: "thread-read" },
   t3_thread_update: { displayName: "Update T3 thread metadata" },
+  t3_thread_transfers: { displayName: "List T3 thread context transfers" },
+  t3_thread_fork: { displayName: "Fork a T3 conversation" },
   t3_thread_send: { displayName: "Send to a T3 thread", summaryAction: "thread-send" },
   t3_thread_wait: { displayName: "Wait for a T3 thread", summaryAction: "thread-wait" },
   t3_thread_interrupt: { displayName: "Interrupt a T3 thread", summaryAction: "thread-interrupt" },


### PR DESCRIPTION
## Problem

Agents could create ordinary or delegated threads, but could not create a durable T3 conversation fork from a precise stable source or inspect its context-transfer provenance.

## Change

Add current-project `t3_thread_fork` and bounded `t3_thread_transfers` tools backed by a focused service and the existing `thread.fork` V2 command through `ThreadManagementService`.

## Behavior

Forks require a completed run, checkpoint, or latest stable source plus a retry key. Results return the committed transfer and receipt, inherited-permission enforcement, and truthful native-fork eligibility while leaving native or portable resolution to the first target turn. Derived target identities use a fork-specific namespace and cannot overwrite existing or soft-deleted threads.

## Focused validation

- transfer contract, service, root-schema, production MCP, and real V2/provider-adapter tests
- retry, inherited history, caller/source race, identity collision, occupied-target, and projection-failure coverage
- 5 focused files / 16 tests passed across the complete native stack
- server and contracts scoped typechecks, targeted formatting, and `git diff --check`

## Dependency

Bottom layer of native stack 8776, based on `t3code/codex-turn-mapping` at the pinned rollout target. [#8697](https://github.com/pingdotgg/t3code/pull/8697) consumes this transfer contract and service for merge-back.

Implemented by GPT-5.6-Sol via Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP conversation fork and transfer list tools
> - Adds `ConversationTransferMcpService` exposing `t3_thread_transfers` for bounded read-only transfer listing and `t3_thread_fork` for conversation mutations.
> - `Orchestrator` `thread.fork` dispatch validates caller policy ceilings (runtime and interaction modes) and checks target projection existence before issuing fork commands.
> - Replaces the single command-thread lock with recursive multi-key dispatch locks (`withDispatchLocks`) so forks coordinate on source, target, and caller threads.
> - Contracts package adds `ConversationForkInput`, `ConversationForkResult`, and `TransferPageLimit` schemas with strict validation (e.g., Unicode well-formedness for retry keys).
> - Risk: `thread.fork` dispatch now fails when target projection exists or source runtime/interaction mode exceeds the caller ceiling; `withDispatchLocks` changes dispatch lock acquisition to multiple sorted keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ad23c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->