### PR TITLE
feat(mcp): restore durable checkpoints

### DIFF
--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -147,6 +147,55 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(yield* git(tmp, ["status", "--short"])).toContain("new-file.txt");
       }),
     );
+
+    it.effect("tracks staged-only changes without modifying the user's index", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const readme = NodePath.join(tmp, "README.md");
+
+        const initial = yield* checkpointStore.readWorkspaceFingerprint(tmp);
+        yield* writeTextFile(readme, "# staged\n");
+        yield* git(tmp, ["add", "README.md"]);
+        yield* writeTextFile(readme, "# test\n");
+        const stagedBefore = yield* git(tmp, ["diff", "--cached", "--", "README.md"]);
+        const stagedOnly = yield* checkpointStore.readWorkspaceFingerprint(tmp);
+        const stagedAfter = yield* git(tmp, ["diff", "--cached", "--", "README.md"]);
+
+        expect(stagedOnly).not.toBe(initial);
+        expect(stagedAfter).toBe(stagedBefore);
+        expect(yield* git(tmp, ["diff", "--", "README.md"])).not.toBe("");
+      }),
+    );
+
+    it.effect("limits staged-state fingerprints to a nested restore cwd", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const nested = NodePath.join(tmp, "packages", "nested");
+        const sibling = NodePath.join(tmp, "sibling.txt");
+        const nestedFile = NodePath.join(nested, "file.txt");
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.makeDirectory(nested, { recursive: true });
+        yield* writeTextFile(nestedFile, "nested\n");
+        yield* writeTextFile(sibling, "sibling\n");
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "nested files"]);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        const initial = yield* checkpointStore.readWorkspaceFingerprint(nested);
+        yield* writeTextFile(sibling, "sibling staged\n");
+        yield* git(tmp, ["add", "sibling.txt"]);
+        yield* writeTextFile(sibling, "sibling\n");
+        expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).toBe(initial);
+
+        yield* writeTextFile(nestedFile, "nested staged\n");
+        yield* git(tmp, ["add", "packages/nested/file.txt"]);
+        yield* writeTextFile(nestedFile, "nested\n");
+        expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).not.toBe(initial);
+      }),
+    );
   });
 
   describe("diffCheckpoints", () => {

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -128,6 +128,27 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
     }),
   );
 
+  describe("readWorkspaceFingerprint", () => {
+    it.effect("tracks the exact tracked and untracked tree affected by restore", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        const initial = yield* checkpointStore.readWorkspaceFingerprint(tmp);
+        yield* writeTextFile(NodePath.join(tmp, "README.md"), "# changed\n");
+        const trackedChange = yield* checkpointStore.readWorkspaceFingerprint(tmp);
+        yield* writeTextFile(NodePath.join(tmp, "new-file.txt"), "new\n");
+        const untrackedChange = yield* checkpointStore.readWorkspaceFingerprint(tmp);
+
+        expect(trackedChange).not.toBe(initial);
+        expect(untrackedChange).not.toBe(trackedChange);
+        expect(yield* git(tmp, ["status", "--short"])).toContain("README.md");
+        expect(yield* git(tmp, ["status", "--short"])).toContain("new-file.txt");
+      }),
+    );
+  });
+
   describe("diffCheckpoints", () => {
     it.effect("returns full oversized checkpoint diffs without truncation", () =>
       Effect.gen(function* () {

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -169,6 +169,29 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
       }),
     );
 
+    it.effect("fingerprints an index whose staged listing exceeds the process output cap", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const initial = yield* checkpointStore.readWorkspaceFingerprint(tmp);
+        const fileSystem = yield* FileSystem.FileSystem;
+
+        yield* Effect.forEach(
+          Array.from({ length: 4_000 }, (_, index) => index),
+          (index) =>
+            fileSystem.writeFileString(
+              NodePath.join(tmp, `${String(index).padStart(4, "0")}-${"x".repeat(220)}.txt`),
+              "staged\n",
+            ),
+          { concurrency: 64, discard: true },
+        );
+        yield* git(tmp, ["add", "."]);
+
+        expect(yield* checkpointStore.readWorkspaceFingerprint(tmp)).not.toBe(initial);
+      }),
+    );
+
     it.effect("limits staged-state fingerprints to a nested restore cwd", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -71,6 +71,35 @@ function git(
   });
 }
 
+function gitAllowNonZero(cwd: string, args: ReadonlyArray<string>) {
+  return Effect.gen(function* () {
+    const process = yield* VcsProcess.VcsProcess;
+    return yield* process.run({
+      operation: "CheckpointStore.test.gitAllowNonZero",
+      command: "git",
+      cwd,
+      args,
+      timeoutMs: 10_000,
+      allowNonZeroExit: true,
+    });
+  });
+}
+
+function gitWithStdin(cwd: string, args: ReadonlyArray<string>, stdin: string) {
+  return Effect.gen(function* () {
+    const process = yield* VcsProcess.VcsProcess;
+    const result = yield* process.run({
+      operation: "CheckpointStore.test.gitWithStdin",
+      command: "git",
+      cwd,
+      args,
+      stdin,
+      timeoutMs: 10_000,
+    });
+    return result.stdout.trim();
+  });
+}
+
 function initRepoWithCommit(
   cwd: string,
 ): Effect.Effect<
@@ -166,6 +195,11 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(stagedOnly).not.toBe(initial);
         expect(stagedAfter).toBe(stagedBefore);
         expect(yield* git(tmp, ["diff", "--", "README.md"])).not.toBe("");
+
+        const oddPath = "odd\tname\n.txt";
+        yield* writeTextFile(NodePath.join(tmp, oddPath), "odd staged path\n");
+        yield* git(tmp, ["add", "--", oddPath]);
+        expect(yield* checkpointStore.readWorkspaceFingerprint(tmp)).not.toBe(stagedOnly);
       }),
     );
 
@@ -189,6 +223,80 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         yield* git(tmp, ["add", "."]);
 
         expect(yield* checkpointStore.readWorkspaceFingerprint(tmp)).not.toBe(initial);
+      }),
+    );
+
+    it.effect("ignores unmerged index stages outside a nested restore cwd", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const nested = NodePath.join(tmp, "packages", "nested");
+        const sibling = NodePath.join(tmp, "sibling.txt");
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.makeDirectory(nested, { recursive: true });
+        yield* writeTextFile(NodePath.join(nested, "file.txt"), "nested\n");
+        yield* writeTextFile(sibling, "base\n");
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "add scoped files"]);
+        const baseBranch = yield* git(tmp, ["branch", "--show-current"]);
+
+        yield* git(tmp, ["checkout", "-b", "conflict-side"]);
+        yield* writeTextFile(sibling, "side\n");
+        yield* git(tmp, ["commit", "-am", "change sibling on side"]);
+        yield* git(tmp, ["checkout", baseBranch]);
+        yield* writeTextFile(sibling, "main\n");
+        yield* git(tmp, ["commit", "-am", "change sibling on main"]);
+
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const beforeConflict = yield* checkpointStore.readWorkspaceFingerprint(nested);
+        const merge = yield* gitAllowNonZero(tmp, ["merge", "conflict-side"]);
+        expect(merge.exitCode).not.toBe(0);
+        expect(yield* git(tmp, ["ls-files", "--unmerged", "--", "sibling.txt"])).not.toBe("");
+        expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).toBe(beforeConflict);
+      }),
+    );
+
+    it.effect("changes when an in-scope conflict stage changes", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const nested = NodePath.join(tmp, "packages", "nested");
+        const nestedFile = NodePath.join(nested, "file.txt");
+        const replacement = NodePath.join(tmp, "replacement-stage.txt");
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.makeDirectory(nested, { recursive: true });
+        yield* writeTextFile(nestedFile, "base\n");
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "add nested conflict file"]);
+        const baseBranch = yield* git(tmp, ["branch", "--show-current"]);
+
+        yield* git(tmp, ["checkout", "-b", "nested-conflict-side"]);
+        yield* writeTextFile(nestedFile, "side\n");
+        yield* git(tmp, ["commit", "-am", "change nested file on side"]);
+        yield* git(tmp, ["checkout", baseBranch]);
+        yield* writeTextFile(nestedFile, "main\n");
+        yield* git(tmp, ["commit", "-am", "change nested file on main"]);
+        expect((yield* gitAllowNonZero(tmp, ["merge", "nested-conflict-side"])).exitCode).not.toBe(
+          0,
+        );
+
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const beforeStageChange = yield* checkpointStore.readWorkspaceFingerprint(nested);
+        const stages = (yield* git(tmp, ["ls-files", "--stage", "--", "packages/nested/file.txt"]))
+          .split("\n")
+          .filter((line) => line.length > 0);
+        expect(stages).toHaveLength(3);
+        expect(stages.map((line) => line.split(/\s+/, 3)[2])).toEqual(["1", "2", "3"]);
+
+        yield* writeTextFile(replacement, "replacement stage two\n");
+        const replacementOid = yield* git(tmp, ["hash-object", "-w", "--", replacement]);
+        yield* gitWithStdin(
+          tmp,
+          ["update-index", "--index-info"],
+          `100644 ${replacementOid} 2\tpackages/nested/file.txt\n`,
+        );
+
+        expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).not.toBe(beforeStageChange);
       }),
     );
 

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -321,9 +321,32 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         yield* writeTextFile(sibling, "sibling\n");
         expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).toBe(initial);
 
+        yield* git(tmp, ["commit", "-m", "change committed sibling"]);
+        expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).toBe(initial);
+
         yield* writeTextFile(nestedFile, "nested staged\n");
         yield* git(tmp, ["add", "packages/nested/file.txt"]);
         yield* writeTextFile(nestedFile, "nested\n");
+        expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).not.toBe(initial);
+      }),
+    );
+
+    it.effect("fingerprints an absent nested worktree subtree", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const nested = NodePath.join(tmp, "packages", "nested");
+        const nestedFile = NodePath.join(nested, "file.txt");
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.makeDirectory(nested, { recursive: true });
+        yield* writeTextFile(nestedFile, "nested\n");
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "add nested subtree"]);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        const initial = yield* checkpointStore.readWorkspaceFingerprint(nested);
+        yield* fileSystem.remove(nestedFile);
+
         expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).not.toBe(initial);
       }),
     );

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -350,6 +350,26 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).not.toBe(initial);
       }),
     );
+
+    it.effect("fingerprints a nested cwd containing a tab", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const nested = NodePath.join(tmp, "packages", "nested\tworkspace");
+        const nestedFile = NodePath.join(nested, "file.txt");
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.makeDirectory(nested, { recursive: true });
+        yield* writeTextFile(nestedFile, "nested\n");
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "add tabbed nested workspace"]);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        const initial = yield* checkpointStore.readWorkspaceFingerprint(nested);
+        yield* writeTextFile(nestedFile, "changed\n");
+
+        expect(yield* checkpointStore.readWorkspaceFingerprint(nested)).not.toBe(initial);
+      }),
+    );
   });
 
   describe("diffCheckpoints", () => {

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -56,6 +56,9 @@ export class CheckpointStore extends Context.Service<
     /** Check whether cwd is inside a Git worktree. */
     readonly isGitRepository: (cwd: string) => Effect.Effect<boolean, CheckpointStoreError>;
 
+    /** Hash the tracked and untracked workspace state affected by restore. */
+    readonly readWorkspaceFingerprint: (cwd: string) => Effect.Effect<string, CheckpointStoreError>;
+
     /**
      * Capture a checkpoint commit and store it at the provided checkpoint ref.
      *
@@ -123,6 +126,15 @@ export const make = Effect.gen(function* () {
       .detect({ cwd, requestedKind: "git" })
       .pipe(Effect.map((repository) => repository !== null));
 
+  const readWorkspaceFingerprint: CheckpointStore["Service"]["readWorkspaceFingerprint"] =
+    Effect.fn("readWorkspaceFingerprint")(function* (cwd) {
+      const checkpoints = yield* resolveCheckpoints(
+        "CheckpointStore.readWorkspaceFingerprint",
+        cwd,
+      );
+      return yield* checkpoints.readWorkspaceFingerprint(cwd);
+    });
+
   const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
     "captureCheckpoint",
   )(function* (input) {
@@ -163,6 +175,7 @@ export const make = Effect.gen(function* () {
 
   return CheckpointStore.of({
     isGitRepository,
+    readWorkspaceFingerprint,
     captureCheckpoint,
     hasCheckpointRef,
     restoreCheckpoint,

--- a/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
@@ -25,15 +25,18 @@ import {
   ThreadId,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
 import { ServerConfig } from "../config.ts";
-import { layer as mcpSessionRegistryTestLayer } from "./McpSessionRegistry.testkit.ts";
+import * as McpSessionRegistryTestkit from "./McpSessionRegistry.testkit.ts";
 import { ProviderInstanceRegistry } from "../provider/Services/ProviderInstanceRegistry.ts";
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
@@ -43,7 +46,10 @@ import * as VcsProcess from "../vcs/VcsProcess.ts";
 import { CodexProviderCapabilitiesV2 } from "../orchestration-v2/Adapters/CodexAdapterV2.ts";
 import { OrchestrationEffectWorkerV2 } from "../orchestration-v2/EffectWorker.ts";
 import { EventSinkV2 } from "../orchestration-v2/EventSink.ts";
-import { OrchestratorV2 } from "../orchestration-v2/Orchestrator.ts";
+import {
+  OrchestratorCheckpointRollbackTargetUnsupportedError,
+  OrchestratorV2,
+} from "../orchestration-v2/Orchestrator.ts";
 import {
   ProviderAdapterRollbackThreadError,
   type ProviderAdapterV2SessionRuntime,
@@ -54,15 +60,13 @@ import {
   OrchestrationV2LayerLive,
 } from "../orchestration-v2/runtimeLayer.ts";
 import { checkpointWorkspace } from "../orchestration-v2/testkit/ReplayFixtureWorkspace.ts";
-import {
-  CheckpointMcpService,
-  layer as checkpointMcpServiceLayer,
-} from "./CheckpointMcpService.ts";
+import * as CheckpointMcp from "./CheckpointMcpService.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
 
 const driver = ProviderDriverKind.make("codex");
 const providerInstanceId = ProviderInstanceId.make("codex-checkpoint-restore-test");
 const modelSelection = { instanceId: providerInstanceId, model: "gpt-test" };
+const isRollbackTargetUnsupported = Schema.is(OrchestratorCheckpointRollbackTargetUnsupportedError);
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-checkpoint-mcp-restore-",
 });
@@ -135,6 +139,10 @@ function makeAdapter(input: {
 function makeIntegrationLayer(input: {
   readonly rollbackCount: Ref.Ref<number>;
   readonly failProviderRollback: boolean;
+  readonly fingerprintGate?: {
+    readonly entered: Deferred.Deferred<void>;
+    readonly release: Deferred.Deferred<void>;
+  };
 }) {
   const adapter = makeAdapter(input);
   const providerInstance = {
@@ -160,9 +168,34 @@ function makeIntegrationLayer(input: {
     Layer.provide(ServerConfigLayer),
     Layer.provide(NodeServices.layer),
   );
-  const checkpointStore = CheckpointStore.layer.pipe(Layer.provide(vcsRegistry));
+  const checkpointStoreLive = CheckpointStore.layer.pipe(Layer.provide(vcsRegistry));
+  const fingerprintGate = input.fingerprintGate;
+  const checkpointStore =
+    fingerprintGate === undefined
+      ? checkpointStoreLive
+      : Layer.effect(
+          CheckpointStore.CheckpointStore,
+          Effect.gen(function* () {
+            const store = yield* CheckpointStore.CheckpointStore;
+            let fingerprintReads = 0;
+            return CheckpointStore.CheckpointStore.of({
+              ...store,
+              readWorkspaceFingerprint: (cwd) =>
+                store.readWorkspaceFingerprint(cwd).pipe(
+                  Effect.tap(() => {
+                    fingerprintReads += 1;
+                    return fingerprintReads === 2
+                      ? Deferred.succeed(fingerprintGate.entered, undefined).pipe(
+                          Effect.andThen(Deferred.await(fingerprintGate.release)),
+                        )
+                      : Effect.void;
+                  }),
+                ),
+            });
+          }),
+        ).pipe(Layer.provide(checkpointStoreLive));
   const runtime = Layer.merge(OrchestrationV2LayerLive, OrchestrationV2EventSinkLayerLive).pipe(
-    Layer.provide(mcpSessionRegistryTestLayer),
+    Layer.provide(McpSessionRegistryTestkit.layer),
     Layer.provide(SqlitePersistenceMemory),
     Layer.provideMerge(checkpointStore),
     Layer.provide(ServerConfigLayer),
@@ -170,7 +203,7 @@ function makeIntegrationLayer(input: {
     Layer.provide(providerRegistry),
     Layer.provide(NodeServices.layer),
   );
-  return checkpointMcpServiceLayer.pipe(
+  return CheckpointMcp.layer.pipe(
     Layer.provideMerge(runtime),
     Layer.provideMerge(NodeServices.layer),
   );
@@ -186,6 +219,7 @@ function seedRollbackProjection(input: {
   readonly checkpointId: CheckpointId;
   readonly checkpointRef: CheckpointRef;
   readonly cwd: string;
+  readonly checkpointOrdinal?: number;
 }) {
   return Effect.gen(function* () {
     const now = yield* DateTime.now;
@@ -278,9 +312,9 @@ function seedRollbackProjection(input: {
           nodeId: scopeNodeId,
           parentScopeId: null,
           providerThreadId: input.providerThreadId,
-          kind: "manual",
+          kind: "root_run",
           ordinalWithinParent: 0,
-          advancesAppRunCount: false,
+          advancesAppRunCount: true,
           cwd: input.cwd,
           createdAt: now,
         },
@@ -299,7 +333,7 @@ function seedRollbackProjection(input: {
           runId: null,
           nodeId: scopeNodeId,
           parentCheckpointId: null,
-          ordinalWithinScope: 0,
+          ordinalWithinScope: input.checkpointOrdinal ?? 0,
           appRunOrdinal: null,
           ref: input.checkpointRef,
           status: "ready",
@@ -316,6 +350,11 @@ function restoreScenario(
   input: {
     readonly failProviderRollback: boolean;
     readonly admitRunBeforeWorker?: boolean;
+    readonly raceMessageDuringRestore?: boolean;
+    readonly fingerprintGate?: {
+      readonly entered: Deferred.Deferred<void>;
+      readonly release: Deferred.Deferred<void>;
+    };
   },
   rollbackCount: Ref.Ref<number>,
 ) {
@@ -333,7 +372,7 @@ function restoreScenario(
       const orchestrator = yield* OrchestratorV2;
       const eventSink = yield* EventSinkV2;
       const worker = yield* OrchestrationEffectWorkerV2;
-      const service = yield* CheckpointMcpService;
+      const service = yield* CheckpointMcp.CheckpointMcpService;
       const threadId = ThreadId.make(
         input.admitRunBeforeWorker
           ? "thread:checkpoint-restore:concurrent-run"
@@ -440,7 +479,37 @@ function restoreScenario(
         });
       }
 
-      assert.isTrue(yield* worker.runOnce);
+      if (input.raceMessageDuringRestore === true) {
+        if (input.fingerprintGate === undefined) {
+          return yield* Effect.die("fingerprint gate is required for the admission race");
+        }
+        const workerFiber = yield* worker.runOnce.pipe(Effect.forkChild);
+        yield* Deferred.await(input.fingerprintGate.entered);
+        const messageFiber = yield* orchestrator
+          .dispatch({
+            type: "message.dispatch",
+            createdBy: "user",
+            creationSource: "mcp",
+            commandId: CommandId.make(`command:message-during-restore:${threadId}`),
+            threadId,
+            messageId: MessageId.make(`message:during-restore:${threadId}`),
+            text: "Run after checkpoint restoration.",
+            attachments: [],
+            modelSelection,
+            dispatchMode: { type: "start_immediately" },
+          })
+          .pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+        assert.isTrue(
+          messageFiber.pollUnsafe() === undefined,
+          "same-thread message admission must wait for the guarded restore",
+        );
+        yield* Deferred.succeed(input.fingerprintGate.release, undefined);
+        assert.isTrue(yield* Fiber.join(workerFiber));
+        yield* Fiber.join(messageFiber);
+      } else {
+        assert.isTrue(yield* worker.runOnce);
+      }
       const settled = yield* service.restore(invocation, restoreInput);
       assert.equal(
         settled.status,
@@ -456,7 +525,7 @@ function restoreScenario(
         input.admitRunBeforeWorker === true,
       );
       assert.lengthOf(yield* orchestrator.listCommandEffects(requested.commandId), 1);
-      if (input.admitRunBeforeWorker !== true) {
+      if (input.admitRunBeforeWorker !== true && input.raceMessageDuringRestore !== true) {
         assert.isFalse(yield* worker.runOnce);
       }
     }),
@@ -487,6 +556,89 @@ it.effect("rejects work admitted after acceptance at the worker workspace bounda
     return yield* restoreScenario(
       { failProviderRollback: false, admitRunBeforeWorker: true },
       rollbackCount,
+    ).pipe(Effect.provide(makeIntegrationLayer({ rollbackCount, failProviderRollback: false })));
+  }),
+);
+
+it.effect("serializes message admission across the guarded restore critical section", () =>
+  Effect.gen(function* () {
+    const rollbackCount = yield* Ref.make(0);
+    const fingerprintGate = {
+      entered: yield* Deferred.make<void>(),
+      release: yield* Deferred.make<void>(),
+    };
+    return yield* restoreScenario(
+      {
+        failProviderRollback: false,
+        raceMessageDuringRestore: true,
+        fingerprintGate,
+      },
+      rollbackCount,
+    ).pipe(
+      Effect.provide(
+        makeIntegrationLayer({
+          rollbackCount,
+          failProviderRollback: false,
+          fingerprintGate,
+        }),
+      ),
+    );
+  }),
+);
+
+it.effect("rejects a nonzero materialized baseline in the serialized command decision", () =>
+  Effect.gen(function* () {
+    const rollbackCount = yield* Ref.make(0);
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const cwd = yield* checkpointWorkspace("mcp-restore-ambiguous-baseline");
+        const orchestrator = yield* OrchestratorV2;
+        const eventSink = yield* EventSinkV2;
+        const threadId = ThreadId.make("thread:checkpoint-restore:ambiguous-baseline");
+        const providerSessionId = ProviderSessionId.make(`provider-session:${threadId}`);
+        const providerThreadId = ProviderThreadId.make(`provider-thread:${threadId}`);
+        const scopeId = CheckpointScopeId.make(`scope:${threadId}`);
+        const checkpointId = CheckpointId.make(`checkpoint:${threadId}`);
+        yield* orchestrator.dispatch({
+          type: "thread.create",
+          createdBy: "user",
+          creationSource: "web",
+          commandId: CommandId.make(`command:create:${threadId}`),
+          threadId,
+          projectId: ProjectId.make("project:checkpoint-restore"),
+          title: "Ambiguous checkpoint baseline",
+          modelSelection,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: cwd,
+        });
+        yield* seedRollbackProjection({
+          eventSink,
+          threadId,
+          providerSessionId,
+          providerThreadId,
+          runId: RunId.make(`run:${threadId}:completed`),
+          scopeId,
+          checkpointId,
+          checkpointRef: CheckpointRef.make("refs/t3/test/ambiguous-baseline"),
+          cwd,
+          checkpointOrdinal: 2,
+        });
+
+        const error = yield* orchestrator
+          .dispatch({
+            type: "checkpoint.rollback",
+            commandId: CommandId.make(`command:rollback:${threadId}`),
+            threadId,
+            scopeId,
+            checkpointId,
+            expectedIdle: true,
+            expectedWorkspaceFingerprint: "workspace-before",
+          })
+          .pipe(Effect.flip);
+        assert.isTrue(isRollbackTargetUnsupported(error));
+      }),
     ).pipe(Effect.provide(makeIntegrationLayer({ rollbackCount, failProviderRollback: false })));
   }),
 );

--- a/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
@@ -1,0 +1,492 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import {
+  CheckpointId,
+  CheckpointRef,
+  CheckpointScopeId,
+  CommandId,
+  EnvironmentId,
+  EventId,
+  MessageId,
+  NodeId,
+  type OrchestrationV2DomainEvent,
+  type OrchestrationV2ProviderSession,
+  type OrchestrationV2ProviderThread,
+  type OrchestrationV2Run,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ProviderSessionId,
+  ProviderThreadId,
+  RunId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+
+import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
+import { ServerConfig } from "../config.ts";
+import { layer as mcpSessionRegistryTestLayer } from "./McpSessionRegistry.testkit.ts";
+import { ProviderInstanceRegistry } from "../provider/Services/ProviderInstanceRegistry.ts";
+import type { ProviderInstance } from "../provider/ProviderDriver.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import { CodexProviderCapabilitiesV2 } from "../orchestration-v2/Adapters/CodexAdapterV2.ts";
+import { OrchestrationEffectWorkerV2 } from "../orchestration-v2/EffectWorker.ts";
+import { EventSinkV2 } from "../orchestration-v2/EventSink.ts";
+import { OrchestratorV2 } from "../orchestration-v2/Orchestrator.ts";
+import {
+  ProviderAdapterRollbackThreadError,
+  type ProviderAdapterV2SessionRuntime,
+  type ProviderAdapterV2Shape,
+} from "../orchestration-v2/ProviderAdapter.ts";
+import {
+  OrchestrationV2EventSinkLayerLive,
+  OrchestrationV2LayerLive,
+} from "../orchestration-v2/runtimeLayer.ts";
+import { checkpointWorkspace } from "../orchestration-v2/testkit/ReplayFixtureWorkspace.ts";
+import {
+  CheckpointMcpService,
+  layer as checkpointMcpServiceLayer,
+} from "./CheckpointMcpService.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+
+const driver = ProviderDriverKind.make("codex");
+const providerInstanceId = ProviderInstanceId.make("codex-checkpoint-restore-test");
+const modelSelection = { instanceId: providerInstanceId, model: "gpt-test" };
+const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-checkpoint-mcp-restore-",
+});
+
+function makeAdapter(input: {
+  readonly rollbackCount: Ref.Ref<number>;
+  readonly failProviderRollback: boolean;
+}): ProviderAdapterV2Shape {
+  return {
+    instanceId: providerInstanceId,
+    driver,
+    getCapabilities: () => Effect.succeed(CodexProviderCapabilitiesV2),
+    planSelectionTransition: () => Effect.succeed({ type: "apply_on_next_turn" }),
+    openSession: (openInput) =>
+      Effect.gen(function* () {
+        const now = yield* DateTime.now;
+        const providerSession: OrchestrationV2ProviderSession = {
+          id: openInput.providerSessionId,
+          driver,
+          providerInstanceId,
+          status: "ready",
+          cwd: openInput.runtimePolicy.cwd ?? "/repo",
+          model: openInput.modelSelection.model,
+          capabilities: CodexProviderCapabilitiesV2,
+          createdAt: now,
+          updatedAt: now,
+          lastError: null,
+        };
+        return {
+          instanceId: providerInstanceId,
+          driver,
+          providerSessionId: openInput.providerSessionId,
+          providerSession,
+          events: Stream.empty,
+          ensureThread: () => Effect.die("ensureThread is unused in checkpoint restore"),
+          resumeThread: ({ providerThread }) => Effect.succeed(providerThread),
+          startTurn: () => Effect.die("startTurn is unused in checkpoint restore"),
+          steerTurn: () => Effect.die("steerTurn is unused in checkpoint restore"),
+          interruptTurn: () => Effect.die("interruptTurn is unused in checkpoint restore"),
+          respondToRuntimeRequest: () =>
+            Effect.die("respondToRuntimeRequest is unused in checkpoint restore"),
+          readThreadSnapshot: () =>
+            Effect.die("readThreadSnapshot is unused in checkpoint restore"),
+          rollbackThread: ({ providerThread, target }) =>
+            Ref.update(input.rollbackCount, (count) => count + 1).pipe(
+              Effect.andThen(
+                input.failProviderRollback
+                  ? Effect.fail(
+                      new ProviderAdapterRollbackThreadError({
+                        driver,
+                        providerThreadId: providerThread.id,
+                        checkpointId: target.checkpointId,
+                        cause: "simulated provider rollback failure",
+                      }),
+                    )
+                  : Effect.succeed({
+                      providerThread,
+                      providerTurns: [],
+                      messages: [],
+                      runtimeRequests: [],
+                    }),
+              ),
+            ),
+          forkThread: () => Effect.die("forkThread is unused in checkpoint restore"),
+        } satisfies ProviderAdapterV2SessionRuntime;
+      }),
+  };
+}
+
+function makeIntegrationLayer(input: {
+  readonly rollbackCount: Ref.Ref<number>;
+  readonly failProviderRollback: boolean;
+}) {
+  const adapter = makeAdapter(input);
+  const providerInstance = {
+    instanceId: providerInstanceId,
+    driverKind: driver,
+    continuationIdentity: { driverKind: driver, continuationKey: "codex:checkpoint-restore" },
+    displayName: "Checkpoint restore provider",
+    enabled: true,
+    snapshot: {} as ProviderInstance["snapshot"],
+    orchestrationAdapter: adapter,
+    textGeneration: {} as ProviderInstance["textGeneration"],
+  } satisfies ProviderInstance;
+  const providerRegistry = Layer.succeed(ProviderInstanceRegistry, {
+    getInstance: (instanceId) =>
+      Effect.succeed(instanceId === providerInstance.instanceId ? providerInstance : undefined),
+    listInstances: Effect.succeed([providerInstance]),
+    listUnavailable: Effect.succeed([]),
+    streamChanges: Stream.empty,
+    subscribeChanges: Effect.never,
+  });
+  const vcsRegistry = VcsDriverRegistry.layer.pipe(
+    Layer.provide(VcsProcess.layer),
+    Layer.provide(ServerConfigLayer),
+    Layer.provide(NodeServices.layer),
+  );
+  const checkpointStore = CheckpointStore.layer.pipe(Layer.provide(vcsRegistry));
+  const runtime = Layer.merge(OrchestrationV2LayerLive, OrchestrationV2EventSinkLayerLive).pipe(
+    Layer.provide(mcpSessionRegistryTestLayer),
+    Layer.provide(SqlitePersistenceMemory),
+    Layer.provideMerge(checkpointStore),
+    Layer.provide(ServerConfigLayer),
+    Layer.provide(ServerSettingsService.layerTest()),
+    Layer.provide(providerRegistry),
+    Layer.provide(NodeServices.layer),
+  );
+  return checkpointMcpServiceLayer.pipe(
+    Layer.provideMerge(runtime),
+    Layer.provideMerge(NodeServices.layer),
+  );
+}
+
+function seedRollbackProjection(input: {
+  readonly eventSink: EventSinkV2["Service"];
+  readonly threadId: ThreadId;
+  readonly providerSessionId: ProviderSessionId;
+  readonly providerThreadId: ProviderThreadId;
+  readonly runId: RunId;
+  readonly scopeId: CheckpointScopeId;
+  readonly checkpointId: CheckpointId;
+  readonly checkpointRef: CheckpointRef;
+  readonly cwd: string;
+}) {
+  return Effect.gen(function* () {
+    const now = yield* DateTime.now;
+    const providerSession: OrchestrationV2ProviderSession = {
+      id: input.providerSessionId,
+      driver,
+      providerInstanceId,
+      status: "ready",
+      cwd: input.cwd,
+      model: modelSelection.model,
+      capabilities: CodexProviderCapabilitiesV2,
+      createdAt: now,
+      updatedAt: now,
+      lastError: null,
+    };
+    const providerThread: OrchestrationV2ProviderThread = {
+      id: input.providerThreadId,
+      driver,
+      providerInstanceId,
+      providerSessionId: input.providerSessionId,
+      appThreadId: input.threadId,
+      ownerNodeId: null,
+      nativeThreadRef: { driver, nativeId: "native-checkpoint-thread", strength: "strong" },
+      nativeConversationHeadRef: null,
+      status: "idle",
+      firstRunOrdinal: 1,
+      lastRunOrdinal: 1,
+      handoffIds: [],
+      forkedFrom: null,
+      pendingBackgroundTasks: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    const completedRun: OrchestrationV2Run = {
+      id: input.runId,
+      threadId: input.threadId,
+      ordinal: 1,
+      providerInstanceId,
+      modelSelection,
+      providerThreadId: input.providerThreadId,
+      userMessageId: MessageId.make("message:checkpoint-restore:completed"),
+      rootNodeId: null,
+      activeAttemptId: null,
+      status: "completed",
+      queuePosition: null,
+      requestedAt: now,
+      startedAt: now,
+      completedAt: now,
+      checkpointId: null,
+      contextHandoffId: null,
+    };
+    const scopeNodeId = NodeId.make("node:checkpoint-restore:scope");
+    const events: ReadonlyArray<OrchestrationV2DomainEvent> = [
+      {
+        id: EventId.make("event:checkpoint-restore:provider-session"),
+        type: "provider-session.attached",
+        threadId: input.threadId,
+        providerInstanceId,
+        occurredAt: now,
+        payload: providerSession,
+      },
+      {
+        id: EventId.make("event:checkpoint-restore:provider-thread"),
+        type: "provider-thread.updated",
+        threadId: input.threadId,
+        providerInstanceId,
+        occurredAt: now,
+        payload: providerThread,
+      },
+      {
+        id: EventId.make("event:checkpoint-restore:completed-run"),
+        type: "run.created",
+        threadId: input.threadId,
+        runId: input.runId,
+        providerInstanceId,
+        occurredAt: now,
+        payload: completedRun,
+      },
+      {
+        id: EventId.make("event:checkpoint-restore:scope"),
+        type: "checkpoint-scope.created",
+        threadId: input.threadId,
+        nodeId: scopeNodeId,
+        providerInstanceId,
+        occurredAt: now,
+        payload: {
+          id: input.scopeId,
+          threadId: input.threadId,
+          runId: null,
+          nodeId: scopeNodeId,
+          parentScopeId: null,
+          providerThreadId: input.providerThreadId,
+          kind: "manual",
+          ordinalWithinParent: 0,
+          advancesAppRunCount: false,
+          cwd: input.cwd,
+          createdAt: now,
+        },
+      },
+      {
+        id: EventId.make("event:checkpoint-restore:checkpoint"),
+        type: "checkpoint.captured",
+        threadId: input.threadId,
+        nodeId: scopeNodeId,
+        providerInstanceId,
+        occurredAt: now,
+        payload: {
+          id: input.checkpointId,
+          threadId: input.threadId,
+          scopeId: input.scopeId,
+          runId: null,
+          nodeId: scopeNodeId,
+          parentCheckpointId: null,
+          ordinalWithinScope: 0,
+          appRunOrdinal: null,
+          ref: input.checkpointRef,
+          status: "ready",
+          files: [],
+          capturedAt: now,
+        },
+      },
+    ];
+    yield* input.eventSink.write({ events });
+  });
+}
+
+function restoreScenario(
+  input: {
+    readonly failProviderRollback: boolean;
+    readonly admitRunBeforeWorker?: boolean;
+  },
+  rollbackCount: Ref.Ref<number>,
+) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const cwd = yield* checkpointWorkspace(
+        input.admitRunBeforeWorker
+          ? "mcp-restore-concurrent-run"
+          : input.failProviderRollback
+            ? "mcp-restore-partial"
+            : "mcp-restore-applied",
+      );
+      const fileSystem = yield* FileSystem.FileSystem;
+      const checkpointStore = yield* CheckpointStore.CheckpointStore;
+      const orchestrator = yield* OrchestratorV2;
+      const eventSink = yield* EventSinkV2;
+      const worker = yield* OrchestrationEffectWorkerV2;
+      const service = yield* CheckpointMcpService;
+      const threadId = ThreadId.make(
+        input.admitRunBeforeWorker
+          ? "thread:checkpoint-restore:concurrent-run"
+          : input.failProviderRollback
+            ? "thread:checkpoint-restore:partial"
+            : "thread:checkpoint-restore:applied",
+      );
+      const providerSessionId = ProviderSessionId.make(`provider-session:${threadId}`);
+      const providerThreadId = ProviderThreadId.make(`provider-thread:${threadId}`);
+      const runId = RunId.make(`run:${threadId}:completed`);
+      const scopeId = CheckpointScopeId.make(`scope:${threadId}`);
+      const checkpointId = CheckpointId.make(`checkpoint:${threadId}`);
+      const checkpointRef = CheckpointRef.make(
+        input.admitRunBeforeWorker
+          ? "refs/t3/test/checkpoint-restore-concurrent-run"
+          : input.failProviderRollback
+            ? "refs/t3/test/checkpoint-restore-partial"
+            : "refs/t3/test/checkpoint-restore-applied",
+      );
+      const readmePath = NodePath.join(cwd, "README.md");
+
+      yield* fileSystem.writeFileString(readmePath, "checkpoint contents\n");
+      yield* checkpointStore.captureCheckpoint({ cwd, checkpointRef });
+      yield* fileSystem.writeFileString(readmePath, "current unsaved contents\n");
+      yield* fileSystem.writeFileString(NodePath.join(cwd, "untracked.txt"), "remove me\n");
+      yield* orchestrator.dispatch({
+        type: "thread.create",
+        createdBy: "user",
+        creationSource: "web",
+        commandId: CommandId.make(`command:create:${threadId}`),
+        threadId,
+        projectId: ProjectId.make("project:checkpoint-restore"),
+        title: "Checkpoint restore integration",
+        modelSelection,
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: "feature/checkpoint-restore",
+        worktreePath: cwd,
+      });
+      yield* seedRollbackProjection({
+        eventSink,
+        threadId,
+        providerSessionId,
+        providerThreadId,
+        runId,
+        scopeId,
+        checkpointId,
+        checkpointRef,
+        cwd,
+      });
+
+      const invocation: McpInvocationScope = {
+        environmentId: EnvironmentId.make("environment:checkpoint-restore"),
+        threadId,
+        providerSessionId: `mcp-session:${threadId}`,
+        providerInstanceId,
+        capabilities: new Set(["orchestration"]),
+        issuedAt: 1,
+      };
+      const restoreInput = {
+        scopeId,
+        checkpointId,
+        discardChanges: true as const,
+        clientRequestId: "restore-integration-key",
+      };
+      const requested = yield* service.restore(invocation, restoreInput);
+      const acceptedRetry = yield* service.restore(invocation, restoreInput);
+      assert.equal(requested.status, "REQUESTED");
+      assert.equal(acceptedRetry.commandId, requested.commandId);
+      assert.lengthOf(yield* orchestrator.listCommandEffects(requested.commandId), 1);
+
+      if (input.admitRunBeforeWorker === true) {
+        const now = yield* DateTime.now;
+        const queuedRunId = RunId.make(`run:concurrent:${threadId}`);
+        yield* eventSink.write({
+          events: [
+            {
+              id: EventId.make(`event:concurrent-run:${threadId}`),
+              type: "run.created",
+              threadId,
+              runId: queuedRunId,
+              providerInstanceId,
+              occurredAt: now,
+              payload: {
+                id: queuedRunId,
+                threadId,
+                ordinal: 2,
+                providerInstanceId,
+                modelSelection,
+                providerThreadId,
+                userMessageId: MessageId.make(`message:concurrent-run:${threadId}`),
+                rootNodeId: null,
+                activeAttemptId: null,
+                status: "queued",
+                queuePosition: 1,
+                requestedAt: now,
+                startedAt: null,
+                completedAt: null,
+                checkpointId: null,
+                contextHandoffId: null,
+              },
+            },
+          ],
+        });
+      }
+
+      assert.isTrue(yield* worker.runOnce);
+      const settled = yield* service.restore(invocation, restoreInput);
+      assert.equal(
+        settled.status,
+        input.admitRunBeforeWorker ? "FAILED" : input.failProviderRollback ? "PARTIAL" : "APPLIED",
+      );
+      assert.equal(yield* Ref.get(rollbackCount), input.admitRunBeforeWorker ? 0 : 1);
+      assert.equal(
+        yield* fileSystem.readFileString(readmePath),
+        input.admitRunBeforeWorker ? "current unsaved contents\n" : "checkpoint contents\n",
+      );
+      assert.equal(
+        yield* fileSystem.exists(NodePath.join(cwd, "untracked.txt")),
+        input.admitRunBeforeWorker === true,
+      );
+      assert.lengthOf(yield* orchestrator.listCommandEffects(requested.commandId), 1);
+      if (input.admitRunBeforeWorker !== true) {
+        assert.isFalse(yield* worker.runOnce);
+      }
+    }),
+  );
+}
+
+it.effect("restores temporary Git state once through real V2 and reports applied", () =>
+  Effect.gen(function* () {
+    const rollbackCount = yield* Ref.make(0);
+    return yield* restoreScenario({ failProviderRollback: false }, rollbackCount).pipe(
+      Effect.provide(makeIntegrationLayer({ rollbackCount, failProviderRollback: false })),
+    );
+  }),
+);
+
+it.effect("reports provider failure after real filesystem restore as partial without retry", () =>
+  Effect.gen(function* () {
+    const rollbackCount = yield* Ref.make(0);
+    return yield* restoreScenario({ failProviderRollback: true }, rollbackCount).pipe(
+      Effect.provide(makeIntegrationLayer({ rollbackCount, failProviderRollback: true })),
+    );
+  }),
+);
+
+it.effect("rejects work admitted after acceptance at the worker workspace boundary", () =>
+  Effect.gen(function* () {
+    const rollbackCount = yield* Ref.make(0);
+    return yield* restoreScenario(
+      { failProviderRollback: false, admitRunBeforeWorker: true },
+      rollbackCount,
+    ).pipe(Effect.provide(makeIntegrationLayer({ rollbackCount, failProviderRollback: false })));
+  }),
+);

--- a/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
@@ -47,6 +47,10 @@ import { CodexProviderCapabilitiesV2 } from "../orchestration-v2/Adapters/CodexA
 import { OrchestrationEffectWorkerV2 } from "../orchestration-v2/EffectWorker.ts";
 import { EventSinkV2 } from "../orchestration-v2/EventSink.ts";
 import {
+  ThreadDispatchLockV2,
+  threadDispatchLockLayer,
+} from "../orchestration-v2/KeyedSerialExecutor.ts";
+import {
   OrchestratorCheckpointRollbackTargetUnsupportedError,
   OrchestratorV2,
 } from "../orchestration-v2/Orchestrator.ts";
@@ -203,8 +207,9 @@ function makeIntegrationLayer(input: {
     Layer.provide(providerRegistry),
     Layer.provide(NodeServices.layer),
   );
+  const runtimeWithDispatchLock = Layer.merge(runtime, threadDispatchLockLayer);
   return CheckpointMcp.layer.pipe(
-    Layer.provideMerge(runtime),
+    Layer.provideMerge(runtimeWithDispatchLock),
     Layer.provideMerge(NodeServices.layer),
   );
 }
@@ -371,6 +376,7 @@ function restoreScenario(
       const checkpointStore = yield* CheckpointStore.CheckpointStore;
       const orchestrator = yield* OrchestratorV2;
       const eventSink = yield* EventSinkV2;
+      const threadDispatch = yield* ThreadDispatchLockV2;
       const worker = yield* OrchestrationEffectWorkerV2;
       const service = yield* CheckpointMcp.CheckpointMcpService;
       const threadId = ThreadId.make(
@@ -483,30 +489,46 @@ function restoreScenario(
         if (input.fingerprintGate === undefined) {
           return yield* Effect.die("fingerprint gate is required for the admission race");
         }
-        const workerFiber = yield* worker.runOnce.pipe(Effect.forkChild);
+        const completionOrder = yield* Ref.make<ReadonlyArray<"restore" | "message">>([]);
+        const workerFiber = yield* worker.runOnce.pipe(
+          Effect.tap(() => Ref.update(completionOrder, (order) => [...order, "restore" as const])),
+          Effect.forkChild,
+        );
         yield* Deferred.await(input.fingerprintGate.entered);
-        const messageFiber = yield* orchestrator
-          .dispatch({
-            type: "message.dispatch",
-            createdBy: "user",
-            creationSource: "mcp",
-            commandId: CommandId.make(`command:message-during-restore:${threadId}`),
-            threadId,
-            messageId: MessageId.make(`message:during-restore:${threadId}`),
-            text: "Run after checkpoint restoration.",
-            attachments: [],
-            modelSelection,
-            dispatchMode: { type: "start_immediately" },
-          })
+        const lockProbe = yield* threadDispatch
+          .withLock(threadId, Effect.void)
           .pipe(Effect.forkChild);
         yield* Effect.yieldNow;
         assert.isTrue(
-          messageFiber.pollUnsafe() === undefined,
-          "same-thread message admission must wait for the guarded restore",
+          lockProbe.pollUnsafe() === undefined,
+          "the guarded restore worker must hold the shared thread admission lock",
         );
+        const dispatchEntered = yield* Deferred.make<void>();
+        const messageFiber = yield* Deferred.succeed(dispatchEntered, undefined).pipe(
+          Effect.andThen(
+            orchestrator.dispatch({
+              type: "message.dispatch",
+              createdBy: "user",
+              creationSource: "mcp",
+              commandId: CommandId.make(`command:message-during-restore:${threadId}`),
+              threadId,
+              messageId: MessageId.make(`message:during-restore:${threadId}`),
+              text: "Run after checkpoint restoration.",
+              attachments: [],
+              modelSelection,
+              dispatchMode: { type: "start_immediately" },
+            }),
+          ),
+          Effect.tap(() => Ref.update(completionOrder, (order) => [...order, "message" as const])),
+          Effect.forkChild,
+        );
+        yield* Deferred.await(dispatchEntered);
+        yield* Effect.yieldNow;
         yield* Deferred.succeed(input.fingerprintGate.release, undefined);
         assert.isTrue(yield* Fiber.join(workerFiber));
+        yield* Fiber.join(lockProbe);
         yield* Fiber.join(messageFiber);
+        assert.deepEqual(yield* Ref.get(completionOrder), ["restore", "message"]);
       } else {
         assert.isTrue(yield* worker.runOnce);
       }

--- a/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
@@ -63,6 +63,7 @@ import {
   OrchestrationV2EventSinkLayerLive,
   OrchestrationV2LayerLive,
 } from "../orchestration-v2/runtimeLayer.ts";
+import { worktreeRepairDependenciesTestLayer } from "../orchestration-v2/ProviderTurnStartService.testkit.ts";
 import { checkpointWorkspace } from "../orchestration-v2/testkit/ReplayFixtureWorkspace.ts";
 import * as CheckpointMcp from "./CheckpointMcpService.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
@@ -205,6 +206,7 @@ function makeIntegrationLayer(input: {
     Layer.provide(ServerConfigLayer),
     Layer.provide(ServerSettingsService.layerTest()),
     Layer.provide(providerRegistry),
+    Layer.provide(worktreeRepairDependenciesTestLayer),
     Layer.provide(NodeServices.layer),
   );
   const runtimeWithDispatchLock = Layer.merge(runtime, threadDispatchLockLayer);

--- a/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpRestore.integration.test.ts
@@ -47,9 +47,9 @@ import { CodexProviderCapabilitiesV2 } from "../orchestration-v2/Adapters/CodexA
 import { OrchestrationEffectWorkerV2 } from "../orchestration-v2/EffectWorker.ts";
 import { EventSinkV2 } from "../orchestration-v2/EventSink.ts";
 import {
-  ThreadDispatchLockV2,
-  threadDispatchLockLayer,
-} from "../orchestration-v2/KeyedSerialExecutor.ts";
+  ThreadCommandExecutor,
+  layer as threadCommandExecutorLayer,
+} from "../orchestration-v2/ThreadCommandExecutor.ts";
 import {
   OrchestratorCheckpointRollbackTargetUnsupportedError,
   OrchestratorV2,
@@ -209,7 +209,7 @@ function makeIntegrationLayer(input: {
     Layer.provide(worktreeRepairDependenciesTestLayer),
     Layer.provide(NodeServices.layer),
   );
-  const runtimeWithDispatchLock = Layer.merge(runtime, threadDispatchLockLayer);
+  const runtimeWithDispatchLock = Layer.merge(runtime, threadCommandExecutorLayer);
   return CheckpointMcp.layer.pipe(
     Layer.provideMerge(runtimeWithDispatchLock),
     Layer.provideMerge(NodeServices.layer),
@@ -378,7 +378,7 @@ function restoreScenario(
       const checkpointStore = yield* CheckpointStore.CheckpointStore;
       const orchestrator = yield* OrchestratorV2;
       const eventSink = yield* EventSinkV2;
-      const threadDispatch = yield* ThreadDispatchLockV2;
+      const threadDispatch = yield* ThreadCommandExecutor;
       const worker = yield* OrchestrationEffectWorkerV2;
       const service = yield* CheckpointMcp.CheckpointMcpService;
       const threadId = ThreadId.make(

--- a/apps/server/src/mcp/CheckpointMcpService.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpService.test.ts
@@ -3,16 +3,21 @@ import {
   CheckpointId,
   CheckpointRef,
   CheckpointScopeId,
+  CommandId,
   EnvironmentId,
+  EventId,
+  MessageId,
   NodeId,
   type OrchestrationV2AppThread,
   type OrchestrationV2Checkpoint,
   type OrchestrationV2CheckpointScope,
+  type OrchestrationV2Run,
   type OrchestrationV2ThreadProjection,
   ProjectId,
   ProviderInstanceId,
   ProviderSessionId,
   ProviderThreadId,
+  RunId,
   ThreadId,
   VcsDriverKind,
   VcsProcessOutputLimitError,
@@ -21,18 +26,20 @@ import {
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
 import {
   CLAUDE_PROVIDER,
   ClaudeProviderCapabilitiesV2,
 } from "../orchestration-v2/Adapters/ClaudeAdapterV2.ts";
+import type { OrchestrationEffectV2 } from "../orchestration-v2/EffectOutbox.ts";
+import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts";
 import {
   ThreadManagementProjectionLoadError,
   ThreadManagementService,
   ThreadManagementThreadNotFoundError,
 } from "../orchestration-v2/ThreadManagementService.ts";
-import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts";
 import {
   ProjectionStoreReadError,
   ProjectionStoreThreadNotFoundError,
@@ -192,6 +199,9 @@ function makeHarness(
     readonly targetError?: ThreadManagementProjectionLoadError;
     readonly hasCheckpointRef?: CheckpointStore.CheckpointStore["Service"]["hasCheckpointRef"];
     readonly diffCheckpoints?: CheckpointStore.CheckpointStore["Service"]["diffCheckpoints"];
+    readonly readWorkspaceFingerprint?: CheckpointStore.CheckpointStore["Service"]["readWorkspaceFingerprint"];
+    readonly effectStatus?: OrchestrationEffectV2["status"];
+    readonly effectError?: string | null;
   } = {},
 ) {
   const projection = input.projection ?? makeProjection();
@@ -199,7 +209,38 @@ function makeHarness(
   const diffCheckpoints = vi.fn(
     input.diffCheckpoints ?? (() => Effect.succeed("diff --git a/file b/file")),
   );
-  const dispatch = vi.fn(() => Effect.die("Checkpoint MCP read tests do not dispatch commands."));
+  const readWorkspaceFingerprint = vi.fn(
+    input.readWorkspaceFingerprint ?? (() => Effect.succeed("tree:checkpoint-mcp")),
+  );
+  let acceptedCommandId: CommandId | undefined;
+  const dispatch = vi.fn(
+    (command: Parameters<ThreadManagementService["Service"]["dispatch"]>[0]) =>
+      command.type !== "checkpoint.rollback"
+        ? Effect.die("Checkpoint MCP test only dispatches checkpoint.rollback")
+        : Effect.sync(() => {
+            acceptedCommandId = command.commandId;
+            return {
+              sequence: 7,
+              storedEvents: [
+                {
+                  sequence: 7,
+                  commandId: command.commandId,
+                  event: {
+                    id: EventId.make(`event:${command.commandId}`),
+                    type: "checkpoint.rollback-requested" as const,
+                    threadId: command.threadId,
+                    occurredAt: now,
+                    payload: {
+                      scopeId: command.scopeId,
+                      checkpointId: command.checkpointId,
+                      requestedAt: now,
+                    },
+                  },
+                },
+              ],
+            };
+          }),
+  );
   const serviceLayer = layer.pipe(
     Layer.provide(
       Layer.mergeAll(
@@ -220,12 +261,55 @@ function makeHarness(
                     }),
                   ),
           dispatch,
+          getCommandReceipt: (commandId) =>
+            Effect.succeed(
+              acceptedCommandId === commandId
+                ? Option.some({
+                    commandId,
+                    threadId: projection.thread.id,
+                    commandType: "checkpoint.rollback",
+                    acceptedAt: now,
+                    resultSequence: 7,
+                    status: "accepted",
+                    error: null,
+                  })
+                : Option.none(),
+            ),
+          listCommandEffects: (commandId) =>
+            Effect.succeed([
+              {
+                id: `effect:${commandId}:rollback`,
+                commandId,
+                threadId: projection.thread.id,
+                request: {
+                  type: "provider-thread.rollback",
+                  providerThreadId,
+                  checkpointId: makeCheckpoint(0).id,
+                  scopeId,
+                  expectedIdle: true,
+                  expectedWorkspaceFingerprint: "tree:checkpoint-mcp",
+                },
+                status: input.effectStatus ?? "pending",
+                attemptCount: 0,
+                availableAt: "2026-08-29T12:00:00.000Z",
+                leaseOwner: null,
+                leaseExpiresAt: null,
+                createdAt: "2026-08-29T12:00:00.000Z",
+                updatedAt: "2026-08-29T12:00:00.000Z",
+                completedAt: null,
+                lastError: input.effectError ?? null,
+              },
+            ]),
         }),
-        Layer.mock(CheckpointStore.CheckpointStore)({ hasCheckpointRef, diffCheckpoints }),
+        Layer.mock(CheckpointStore.CheckpointStore)({
+          hasCheckpointRef,
+          diffCheckpoints,
+          readWorkspaceFingerprint,
+        }),
       ),
     ),
   );
-  return { serviceLayer, hasCheckpointRef, diffCheckpoints, dispatch };
+  return { serviceLayer, hasCheckpointRef, diffCheckpoints, readWorkspaceFingerprint, dispatch };
 }
 
 it.effect("pages before checking checkpoint refs and bounds file summaries", () => {
@@ -477,5 +561,140 @@ it.effect("distinguishes caller projection failures from missing target threads"
     const error = yield* service.list(invocation, {}).pipe(Effect.flip);
     assert.equal(error.code, "operation_failed");
     assert.include(error.message, "Unable to load calling thread");
+  }).pipe(Effect.provide(harness.serviceLayer));
+});
+
+it.effect("accepts an exact restore and reuses the same command identity", () => {
+  const harness = makeHarness();
+  const checkpointId = makeCheckpoint(0).id;
+  return Effect.gen(function* () {
+    const service = yield* CheckpointMcpService;
+    const input = {
+      scopeId,
+      checkpointId,
+      discardChanges: true as const,
+      clientRequestId: "restore-exact-target",
+    };
+    const first = yield* service.restore(invocation, input);
+    const retry = yield* service.restore(invocation, input);
+    const conflict = yield* service
+      .restore(invocation, {
+        ...input,
+        checkpointId: CheckpointId.make("checkpoint:checkpoint-mcp:different"),
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(first.status, "REQUESTED");
+    assert.equal(first.effectStatus, "pending");
+    assert.equal(retry.commandId, first.commandId);
+    assert.equal(conflict.code, "idempotency_conflict");
+    assert.equal(harness.dispatch.mock.calls.length, 1);
+    assert.equal(harness.dispatch.mock.calls[0]?.[0].type, "checkpoint.rollback");
+    assert.deepInclude(harness.dispatch.mock.calls[0]?.[0], {
+      expectedIdle: true,
+      expectedWorkspaceFingerprint: "tree:checkpoint-mcp",
+    });
+  }).pipe(Effect.provide(harness.serviceLayer));
+});
+
+it.effect("rejects missing checkpoints and unsupported provider rollback", () => {
+  const missingHarness = makeHarness({
+    projection: makeProjection({
+      checkpoints: [makeCheckpoint(0, { status: "missing" })],
+    }),
+    hasCheckpointRef: () => Effect.succeed(false),
+  });
+  const supportedProjection = makeProjection();
+  const unsupportedHarness = makeHarness({
+    projection: {
+      ...supportedProjection,
+      providerSessions: supportedProjection.providerSessions.map((session) => ({
+        ...session,
+        capabilities: {
+          ...session.capabilities,
+          threads: { ...session.capabilities.threads, canRollbackThread: false },
+        },
+      })),
+    },
+  });
+  const restoreInput = {
+    scopeId,
+    checkpointId: makeCheckpoint(0).id,
+    discardChanges: true as const,
+    clientRequestId: "restore-unavailable",
+  };
+  return Effect.gen(function* () {
+    const missingService = yield* CheckpointMcpService;
+    const missing = yield* missingService.restore(invocation, restoreInput).pipe(Effect.flip);
+    assert.equal(missing.code, "checkpoint_unavailable");
+  }).pipe(
+    Effect.provide(missingHarness.serviceLayer),
+    Effect.andThen(
+      Effect.gen(function* () {
+        const unsupportedService = yield* CheckpointMcpService;
+        const unsupported = yield* unsupportedService
+          .restore(invocation, { ...restoreInput, clientRequestId: "restore-unsupported" })
+          .pipe(Effect.flip);
+        assert.equal(unsupported.code, "unsupported");
+      }).pipe(Effect.provide(unsupportedHarness.serviceLayer)),
+    ),
+  );
+});
+
+it.effect("rejects queued work before capturing or dispatching a restore", () => {
+  const queuedRun: OrchestrationV2Run = {
+    id: RunId.make("run:checkpoint-mcp:queued"),
+    threadId,
+    ordinal: 1,
+    providerInstanceId,
+    modelSelection: { instanceId: providerInstanceId, model: "claude-sonnet" },
+    providerThreadId,
+    userMessageId: MessageId.make("message:checkpoint-mcp:queued"),
+    rootNodeId: null,
+    activeAttemptId: null,
+    status: "queued",
+    queuePosition: 1,
+    requestedAt: now,
+    startedAt: null,
+    completedAt: null,
+    checkpointId: null,
+    contextHandoffId: null,
+  };
+  const harness = makeHarness({
+    projection: { ...makeProjection(), runs: [queuedRun] },
+  });
+  return Effect.gen(function* () {
+    const service = yield* CheckpointMcpService;
+    const error = yield* service
+      .restore(invocation, {
+        scopeId,
+        checkpointId: makeCheckpoint(0).id,
+        discardChanges: true,
+        clientRequestId: "restore-while-queued",
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(error.code, "thread_active");
+    assert.equal(harness.readWorkspaceFingerprint.mock.calls.length, 0);
+    assert.equal(harness.dispatch.mock.calls.length, 0);
+  }).pipe(Effect.provide(harness.serviceLayer));
+});
+
+it.effect("reports provider failure after filesystem restore as partial", () => {
+  const harness = makeHarness({
+    effectStatus: "failed",
+    effectError:
+      "Provider conversation rollback failed after the filesystem checkpoint was restored; the result is partial.",
+  });
+  return Effect.gen(function* () {
+    const service = yield* CheckpointMcpService;
+    const result = yield* service.restore(invocation, {
+      scopeId,
+      checkpointId: makeCheckpoint(0).id,
+      discardChanges: true,
+      clientRequestId: "restore-partial",
+    });
+    assert.equal(result.status, "PARTIAL");
+    assert.equal(result.effectStatus, "failed");
   }).pipe(Effect.provide(harness.serviceLayer));
 });

--- a/apps/server/src/mcp/CheckpointMcpService.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpService.test.ts
@@ -718,7 +718,7 @@ it.effect("reports provider failure after filesystem restore as partial", () => 
     effectStatus: "failed",
     effectFailureCode: "checkpoint_restore_partial",
     effectError:
-      "Provider conversation rollback failed after the filesystem checkpoint was restored; the result is partial.",
+      "private /Users/example/worktree path and provider stderr must not leave the server",
   });
   return Effect.gen(function* () {
     const service = yield* CheckpointMcpService;
@@ -730,5 +730,8 @@ it.effect("reports provider failure after filesystem restore as partial", () => 
     });
     assert.equal(result.status, "PARTIAL");
     assert.equal(result.effectStatus, "failed");
+    assert.include(result.detail ?? "", "may have changed filesystem or provider state");
+    assert.notInclude(result.detail ?? "", "/Users/example/worktree");
+    assert.notInclude(result.detail ?? "", "provider stderr");
   }).pipe(Effect.provide(harness.serviceLayer));
 });

--- a/apps/server/src/mcp/CheckpointMcpService.test.ts
+++ b/apps/server/src/mcp/CheckpointMcpService.test.ts
@@ -34,6 +34,7 @@ import {
   ClaudeProviderCapabilitiesV2,
 } from "../orchestration-v2/Adapters/ClaudeAdapterV2.ts";
 import type { OrchestrationEffectV2 } from "../orchestration-v2/EffectOutbox.ts";
+import { CommandReceiptStoreReadError } from "../orchestration-v2/CommandReceiptStore.ts";
 import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts";
 import {
   ThreadManagementProjectionLoadError,
@@ -202,6 +203,8 @@ function makeHarness(
     readonly readWorkspaceFingerprint?: CheckpointStore.CheckpointStore["Service"]["readWorkspaceFingerprint"];
     readonly effectStatus?: OrchestrationEffectV2["status"];
     readonly effectError?: string | null;
+    readonly effectFailureCode?: OrchestrationEffectV2["failureCode"];
+    readonly receiptReadFailsAfterDispatch?: boolean;
   } = {},
 ) {
   const projection = input.projection ?? makeProjection();
@@ -262,19 +265,26 @@ function makeHarness(
                   ),
           dispatch,
           getCommandReceipt: (commandId) =>
-            Effect.succeed(
-              acceptedCommandId === commandId
-                ? Option.some({
+            input.receiptReadFailsAfterDispatch === true && acceptedCommandId !== undefined
+              ? Effect.fail(
+                  new CommandReceiptStoreReadError({
                     commandId,
-                    threadId: projection.thread.id,
-                    commandType: "checkpoint.rollback",
-                    acceptedAt: now,
-                    resultSequence: 7,
-                    status: "accepted",
-                    error: null,
-                  })
-                : Option.none(),
-            ),
+                    cause: "simulated receipt read failure",
+                  }),
+                )
+              : Effect.succeed(
+                  acceptedCommandId === commandId
+                    ? Option.some({
+                        commandId,
+                        threadId: projection.thread.id,
+                        commandType: "checkpoint.rollback",
+                        acceptedAt: now,
+                        resultSequence: 7,
+                        status: "accepted",
+                        error: null,
+                      })
+                    : Option.none(),
+                ),
           listCommandEffects: (commandId) =>
             Effect.succeed([
               {
@@ -298,6 +308,9 @@ function makeHarness(
                 updatedAt: "2026-08-29T12:00:00.000Z",
                 completedAt: null,
                 lastError: input.effectError ?? null,
+                ...(input.effectFailureCode === undefined
+                  ? {}
+                  : { failureCode: input.effectFailureCode }),
               },
             ]),
         }),
@@ -597,6 +610,26 @@ it.effect("accepts an exact restore and reuses the same command identity", () =>
   }).pipe(Effect.provide(harness.serviceLayer));
 });
 
+it.effect("keeps the accepted outcome when post-commit observation fails", () => {
+  const harness = makeHarness({ receiptReadFailsAfterDispatch: true });
+  return Effect.gen(function* () {
+    const service = yield* CheckpointMcpService;
+    const result = yield* service.restore(invocation, {
+      scopeId,
+      checkpointId: makeCheckpoint(0).id,
+      discardChanges: true,
+      clientRequestId: "restore-observation-unavailable",
+    });
+
+    assert.equal(result.status, "REQUESTED");
+    assert.equal(result.effectStatus, "unavailable");
+    assert.equal(result.receipt.sequence, 7);
+    assert.include(result.detail ?? "", "was accepted");
+    assert.include(result.detail ?? "", "same clientRequestId");
+    assert.equal(harness.dispatch.mock.calls.length, 1);
+  }).pipe(Effect.provide(harness.serviceLayer));
+});
+
 it.effect("rejects missing checkpoints and unsupported provider rollback", () => {
   const missingHarness = makeHarness({
     projection: makeProjection({
@@ -683,6 +716,7 @@ it.effect("rejects queued work before capturing or dispatching a restore", () =>
 it.effect("reports provider failure after filesystem restore as partial", () => {
   const harness = makeHarness({
     effectStatus: "failed",
+    effectFailureCode: "checkpoint_restore_partial",
     effectError:
       "Provider conversation rollback failed after the filesystem checkpoint was restored; the result is partial.",
   });

--- a/apps/server/src/mcp/CheckpointMcpService.ts
+++ b/apps/server/src/mcp/CheckpointMcpService.ts
@@ -22,7 +22,12 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
-import { OrchestratorProjectionError } from "../orchestration-v2/Orchestrator.ts";
+import {
+  OrchestratorCheckpointRollbackNotIdleError,
+  OrchestratorCheckpointRollbackTargetUnsupportedError,
+  OrchestratorCommandIdConflictError,
+  OrchestratorProjectionError,
+} from "../orchestration-v2/Orchestrator.ts";
 import { ProjectionStoreThreadNotFoundError } from "../orchestration-v2/ProjectionStore.ts";
 import {
   ThreadManagementProjectionLoadError,
@@ -313,7 +318,7 @@ export const make = Effect.gen(function* () {
       rollbackEffect.status === "succeeded"
         ? ("APPLIED" as const)
         : rollbackEffect.status === "failed" &&
-            rollbackEffect.lastError?.includes("result is partial") === true
+            rollbackEffect.failureCode === "checkpoint_restore_partial"
           ? ("PARTIAL" as const)
           : rollbackEffect.status === "failed" || rollbackEffect.status === "cancelled"
             ? ("FAILED" as const)
@@ -608,6 +613,7 @@ export const make = Effect.gen(function* () {
           "provider_rollback_unsupported",
           "provider_snapshot_unsupported",
           "provider_turn_missing",
+          "rollback_target_ambiguous",
         ].includes(blocker),
       );
       return yield* failure(
@@ -637,21 +643,27 @@ export const make = Effect.gen(function* () {
         expectedWorkspaceFingerprint,
       })
       .pipe(
-        Effect.mapError((error) => {
-          const message = errorMessage(error);
-          const tag =
-            typeof error === "object" && error !== null && "_tag" in error
-              ? String(error._tag)
-              : "";
-          return failure(
-            tag.includes("CommandIdConflict")
-              ? "idempotency_conflict"
-              : message.includes("requires an idle thread")
-                ? "thread_active"
-                : "operation_failed",
-            `Checkpoint restore was not accepted: ${message}`,
-          );
+        Effect.catchTags({
+          OrchestratorCommandIdConflictError: (error: OrchestratorCommandIdConflictError) =>
+            failure(
+              "idempotency_conflict",
+              `Checkpoint restore was not accepted: ${error.message}`,
+            ),
+          OrchestratorCheckpointRollbackNotIdleError: (
+            error: OrchestratorCheckpointRollbackNotIdleError,
+          ) => failure("thread_active", `Checkpoint restore was not accepted: ${error.message}`),
+          OrchestratorCheckpointRollbackTargetUnsupportedError: (
+            error: OrchestratorCheckpointRollbackTargetUnsupportedError,
+          ) => failure("unsupported", `Checkpoint restore was not accepted: ${error.message}`),
         }),
+        Effect.mapError((error) =>
+          isCheckpointMcpFailure(error)
+            ? error
+            : failure(
+                "operation_failed",
+                `Checkpoint restore was not accepted: ${errorMessage(error)}`,
+              ),
+        ),
       );
     const rollbackEvent = dispatched.storedEvents.find(
       (stored) => stored.event.type === "checkpoint.rollback-requested",
@@ -667,12 +679,36 @@ export const make = Effect.gen(function* () {
       );
     }
 
-    const accepted = yield* readAcceptedRestore(scope, input, commandId);
-    if (Option.isSome(accepted)) return accepted.value;
-    return yield* failure(
-      "operation_failed",
-      `Accepted checkpoint restore '${commandId}' has no durable accepted receipt.`,
+    const observation = yield* readAcceptedRestore(scope, input, commandId).pipe(
+      Effect.match({
+        onFailure: (error) => ({ type: "unavailable" as const, error }),
+        onSuccess: (accepted) => ({ type: "available" as const, accepted }),
+      }),
     );
+    if (observation.type === "available" && Option.isSome(observation.accepted)) {
+      return observation.accepted.value;
+    }
+    if (observation.type === "unavailable" && observation.error.code === "idempotency_conflict") {
+      return yield* observation.error;
+    }
+    const observationDetail =
+      observation.type === "unavailable"
+        ? observation.error.message
+        : "The durable command receipt was not yet readable.";
+    return {
+      commandId,
+      threadId: projection.thread.id,
+      scopeId: checkpointScope.id,
+      checkpointId: checkpoint.id,
+      status: "REQUESTED",
+      receipt: {
+        status: "accepted",
+        acceptedAt: DateTime.formatIso(rollbackEvent.event.occurredAt),
+        sequence: dispatched.sequence,
+      },
+      effectStatus: "unavailable",
+      detail: `Checkpoint restore was accepted, but its effect status is unavailable: ${observationDetail} Reuse the same clientRequestId to observe this request.`,
+    };
   });
 
   return CheckpointMcpService.of({ list, diff, restore });

--- a/apps/server/src/mcp/CheckpointMcpService.ts
+++ b/apps/server/src/mcp/CheckpointMcpService.ts
@@ -78,6 +78,20 @@ function isMissingThreadProjection(error: unknown): boolean {
   return isOrchestratorProjectionError(error) && isProjectionStoreThreadNotFoundError(error.cause);
 }
 
+function restoreEffectDetail(input: {
+  readonly status: "pending" | "running" | "succeeded" | "failed" | "cancelled";
+  readonly failureCode?: "checkpoint_restore_rejected" | "checkpoint_restore_partial";
+}): string | null {
+  if (input.status !== "failed" && input.status !== "cancelled") return null;
+  if (input.failureCode === "checkpoint_restore_partial") {
+    return "The restore may have changed filesystem or provider state. Inspect the current thread and workspace before retrying.";
+  }
+  if (input.failureCode === "checkpoint_restore_rejected") {
+    return "The restore was rejected before a verified filesystem change.";
+  }
+  return "The restore did not complete. Inspect the current thread and workspace before retrying.";
+}
+
 function providerTurnForRun(projection: OrchestrationV2ThreadProjection, runOrdinal: number) {
   const run = projection.runs.find((candidate) => candidate.ordinal === runOrdinal);
   if (run?.activeAttemptId === null || run === undefined) return undefined;
@@ -336,7 +350,7 @@ export const make = Effect.gen(function* () {
         sequence: receipt.resultSequence,
       },
       effectStatus: rollbackEffect.status,
-      detail: rollbackEffect.lastError,
+      detail: restoreEffectDetail(rollbackEffect),
     });
   });
 

--- a/apps/server/src/mcp/CheckpointMcpService.ts
+++ b/apps/server/src/mcp/CheckpointMcpService.ts
@@ -1,4 +1,5 @@
 import {
+  CommandId,
   CheckpointMcpFailure,
   checkpointRollbackAppRunOrdinal,
   type CheckpointMcpDiffInput,
@@ -6,6 +7,8 @@ import {
   type CheckpointMcpListInput,
   type CheckpointMcpListResult,
   type CheckpointMcpRestoreBlocker,
+  type CheckpointMcpRestoreInput,
+  type CheckpointMcpRestoreResult,
   type CheckpointMcpSummary,
   type OrchestrationV2Checkpoint,
   type OrchestrationV2CheckpointScope,
@@ -15,6 +18,7 @@ import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as CheckpointStore from "../checkpointing/CheckpointStore.ts";
@@ -42,6 +46,10 @@ export class CheckpointMcpService extends Context.Service<
       scope: McpInvocationScope,
       input: CheckpointMcpDiffInput,
     ) => Effect.Effect<CheckpointMcpDiffResult, CheckpointMcpFailure>;
+    readonly restore: (
+      scope: McpInvocationScope,
+      input: CheckpointMcpRestoreInput,
+    ) => Effect.Effect<CheckpointMcpRestoreResult, CheckpointMcpFailure>;
   }
 >()("t3/mcp/CheckpointMcpService") {}
 
@@ -260,6 +268,73 @@ export const make = Effect.gen(function* () {
       );
   });
 
+  const readAcceptedRestore = Effect.fn("CheckpointMcpService.readAcceptedRestore")(function* (
+    scope: McpInvocationScope,
+    input: CheckpointMcpRestoreInput,
+    commandId: CommandId,
+  ) {
+    const receiptOption = yield* threadManagement
+      .getCommandReceipt(commandId)
+      .pipe(
+        Effect.mapError((error) =>
+          failure("operation_failed", `Unable to read restore receipt: ${errorMessage(error)}`),
+        ),
+      );
+    if (Option.isNone(receiptOption)) return Option.none<CheckpointMcpRestoreResult>();
+    if (receiptOption.value.status !== "accepted") {
+      return yield* failure(
+        "operation_failed",
+        `Checkpoint restore '${commandId}' has no durable accepted receipt.`,
+      );
+    }
+    const effects = yield* threadManagement
+      .listCommandEffects(commandId)
+      .pipe(
+        Effect.mapError((error) =>
+          failure("operation_failed", `Unable to read restore effect: ${errorMessage(error)}`),
+        ),
+      );
+    const rollbackEffect = effects.find(
+      (effect) => effect.request.type === "provider-thread.rollback",
+    );
+    const intendedThreadId = input.threadId ?? scope.threadId;
+    if (
+      rollbackEffect?.request.type !== "provider-thread.rollback" ||
+      rollbackEffect.threadId !== intendedThreadId ||
+      rollbackEffect.request.scopeId !== input.scopeId ||
+      rollbackEffect.request.checkpointId !== input.checkpointId
+    ) {
+      return yield* failure(
+        "idempotency_conflict",
+        `clientRequestId '${input.clientRequestId}' was already accepted for a different checkpoint restore.`,
+      );
+    }
+    const status =
+      rollbackEffect.status === "succeeded"
+        ? ("APPLIED" as const)
+        : rollbackEffect.status === "failed" &&
+            rollbackEffect.lastError?.includes("result is partial") === true
+          ? ("PARTIAL" as const)
+          : rollbackEffect.status === "failed" || rollbackEffect.status === "cancelled"
+            ? ("FAILED" as const)
+            : ("REQUESTED" as const);
+    const receipt = receiptOption.value;
+    return Option.some<CheckpointMcpRestoreResult>({
+      commandId,
+      threadId: rollbackEffect.threadId,
+      scopeId: rollbackEffect.request.scopeId,
+      checkpointId: rollbackEffect.request.checkpointId,
+      status,
+      receipt: {
+        status: "accepted",
+        acceptedAt: DateTime.formatIso(receipt.acceptedAt),
+        sequence: receipt.resultSequence,
+      },
+      effectStatus: rollbackEffect.status,
+      detail: rollbackEffect.lastError,
+    });
+  });
+
   const list: CheckpointMcpService["Service"]["list"] = Effect.fn("CheckpointMcpService.list")(
     function* (scope, input) {
       yield* requireCapability(scope);
@@ -461,7 +536,146 @@ export const make = Effect.gen(function* () {
     },
   );
 
-  return CheckpointMcpService.of({ list, diff });
+  const restore: CheckpointMcpService["Service"]["restore"] = Effect.fn(
+    "CheckpointMcpService.restore",
+  )(function* (scope, input) {
+    yield* requireCapability(scope);
+    const commandId = CommandId.make(
+      [
+        "command",
+        "mcp",
+        encodeURIComponent(scope.providerSessionId),
+        "checkpoint-restore",
+        encodeURIComponent(input.clientRequestId),
+      ].join(":"),
+    );
+    const acceptedRestore = yield* readAcceptedRestore(scope, input, commandId);
+    if (Option.isSome(acceptedRestore)) return acceptedRestore.value;
+
+    const projection = yield* loadThread(scope, input.threadId);
+    const checkpointScope = projection.checkpointScopes.find(
+      (candidate) => candidate.id === input.scopeId && candidate.threadId === projection.thread.id,
+    );
+    if (checkpointScope === undefined) {
+      return yield* failure(
+        "scope_mismatch",
+        `Checkpoint scope '${input.scopeId}' does not belong to thread '${projection.thread.id}'.`,
+      );
+    }
+    const checkpoint = projection.checkpoints.find(
+      (candidate) => candidate.id === input.checkpointId,
+    );
+    if (checkpoint === undefined || checkpoint.threadId !== projection.thread.id) {
+      return yield* failure(
+        "checkpoint_not_found",
+        `Checkpoint '${input.checkpointId}' was not found on thread '${projection.thread.id}'.`,
+      );
+    }
+    if (checkpoint.scopeId !== checkpointScope.id) {
+      return yield* failure(
+        "scope_mismatch",
+        `Checkpoint '${checkpoint.id}' belongs to scope '${checkpoint.scopeId}', not '${checkpointScope.id}'.`,
+      );
+    }
+    const refAvailable = yield* checkpointStore
+      .hasCheckpointRef({ cwd: checkpointScope.cwd, checkpointRef: checkpoint.ref })
+      .pipe(
+        Effect.mapError((error) =>
+          failure(
+            "operation_failed",
+            `Unable to verify checkpoint availability: ${errorMessage(error)}`,
+          ),
+        ),
+      );
+    const blockers = restoreBlockers({
+      projection,
+      checkpoint,
+      scope: checkpointScope,
+      refAvailable,
+    });
+    if (blockers.includes("thread_active")) {
+      return yield* failure(
+        "thread_active",
+        `Thread '${projection.thread.id}' must be idle with no queued runs before restore.`,
+      );
+    }
+    if (blockers.length > 0) {
+      const unsupported = blockers.some((blocker) =>
+        [
+          "active_provider_thread_missing",
+          "provider_thread_mismatch",
+          "provider_session_missing",
+          "provider_rollback_unsupported",
+          "provider_snapshot_unsupported",
+          "provider_turn_missing",
+        ].includes(blocker),
+      );
+      return yield* failure(
+        unsupported ? "unsupported" : "checkpoint_unavailable",
+        `Checkpoint '${checkpoint.id}' cannot be restored: ${blockers.join(", ")}.`,
+      );
+    }
+
+    const expectedWorkspaceFingerprint = yield* checkpointStore
+      .readWorkspaceFingerprint(checkpointScope.cwd)
+      .pipe(
+        Effect.mapError((error) =>
+          failure(
+            "operation_failed",
+            `Unable to capture the current workspace guard: ${errorMessage(error)}`,
+          ),
+        ),
+      );
+    const dispatched = yield* threadManagement
+      .dispatch({
+        type: "checkpoint.rollback",
+        commandId,
+        threadId: projection.thread.id,
+        scopeId: checkpointScope.id,
+        checkpointId: checkpoint.id,
+        expectedIdle: true,
+        expectedWorkspaceFingerprint,
+      })
+      .pipe(
+        Effect.mapError((error) => {
+          const message = errorMessage(error);
+          const tag =
+            typeof error === "object" && error !== null && "_tag" in error
+              ? String(error._tag)
+              : "";
+          return failure(
+            tag.includes("CommandIdConflict")
+              ? "idempotency_conflict"
+              : message.includes("requires an idle thread")
+                ? "thread_active"
+                : "operation_failed",
+            `Checkpoint restore was not accepted: ${message}`,
+          );
+        }),
+      );
+    const rollbackEvent = dispatched.storedEvents.find(
+      (stored) => stored.event.type === "checkpoint.rollback-requested",
+    );
+    if (
+      rollbackEvent?.event.type !== "checkpoint.rollback-requested" ||
+      rollbackEvent.event.payload.scopeId !== checkpointScope.id ||
+      rollbackEvent.event.payload.checkpointId !== checkpoint.id
+    ) {
+      return yield* failure(
+        "idempotency_conflict",
+        `clientRequestId '${input.clientRequestId}' was already accepted for a different checkpoint restore.`,
+      );
+    }
+
+    const accepted = yield* readAcceptedRestore(scope, input, commandId);
+    if (Option.isSome(accepted)) return accepted.value;
+    return yield* failure(
+      "operation_failed",
+      `Accepted checkpoint restore '${commandId}' has no durable accepted receipt.`,
+    );
+  });
+
+  return CheckpointMcpService.of({ list, diff, restore });
 });
 
 export const layer: Layer.Layer<

--- a/apps/server/src/mcp/toolkits/checkpoint/handlers.ts
+++ b/apps/server/src/mcp/toolkits/checkpoint/handlers.ts
@@ -17,6 +17,12 @@ const handlers = {
       const service = yield* CheckpointMcpService;
       return yield* service.diff(scope, input);
     }),
+  t3_checkpoint_restore: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* CheckpointMcpService;
+      return yield* service.restore(scope, input);
+    }),
 } satisfies Parameters<typeof CheckpointToolkit.toLayer>[0];
 
 export const CheckpointToolkitHandlersLive = CheckpointToolkit.toLayer(handlers);

--- a/apps/server/src/mcp/toolkits/checkpoint/tools.ts
+++ b/apps/server/src/mcp/toolkits/checkpoint/tools.ts
@@ -4,6 +4,8 @@ import {
   CheckpointMcpFailure,
   CheckpointMcpListInput,
   CheckpointMcpListResult,
+  CheckpointMcpRestoreInput,
+  CheckpointMcpRestoreResult,
 } from "@t3tools/contracts";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
@@ -42,4 +44,23 @@ export const CheckpointDiffTool = Tool.make("t3_checkpoint_diff", {
   .annotate(Tool.Idempotent, true)
   .annotate(Tool.OpenWorld, false);
 
-export const CheckpointToolkit = Toolkit.make(CheckpointListTool, CheckpointDiffTool);
+export const CheckpointRestoreTool = Tool.make("t3_checkpoint_restore", {
+  description:
+    "Request restoration of an exact durable checkpoint through the serialized V2 checkpoint.rollback workflow. This discards current tracked and untracked workspace changes covered by Git restore, so discardChanges must be true. The thread must be idle with no queued work, the provider must support conversation rollback, and the workspace must remain unchanged between preflight and the locked restore. Reuse the exact clientRequestId to read the original accepted command/effect status without repeating it. REQUESTED means accepted but not yet applied; PARTIAL means the filesystem was restored but provider conversation rollback failed.",
+  parameters: CheckpointMcpRestoreInput,
+  success: CheckpointMcpRestoreResult,
+  failure: CheckpointMcpFailure,
+  failureMode: "return",
+  dependencies,
+})
+  .annotate(Tool.Title, "Restore a thread checkpoint")
+  .annotate(Tool.Readonly, false)
+  .annotate(Tool.Destructive, true)
+  .annotate(Tool.Idempotent, true)
+  .annotate(Tool.OpenWorld, true);
+
+export const CheckpointToolkit = Toolkit.make(
+  CheckpointListTool,
+  CheckpointDiffTool,
+  CheckpointRestoreTool,
+);

--- a/apps/server/src/mcp/toolkits/checkpoint/tools.ts
+++ b/apps/server/src/mcp/toolkits/checkpoint/tools.ts
@@ -31,7 +31,7 @@ export const CheckpointListTool = Tool.make("t3_checkpoint_list", {
 
 export const CheckpointDiffTool = Tool.make("t3_checkpoint_diff", {
   description:
-    "Read a bounded patch between two durable checkpoints in one thread checkpoint scope. Use t3_checkpoint_list first to select stable checkpointId and scopeId values. The thread and both checkpoint identities are validated before an empty diff is returned; arbitrary filesystem paths or Git refs are not accepted. Pagination cursors count UTF-16 code units.",
+    "Read a bounded patch between two durable checkpoints in one thread checkpoint scope. Use t3_checkpoint_list first to select stable checkpointId and scopeId values. The thread and both checkpoint identities are validated before an empty diff is returned; arbitrary filesystem paths or Git refs are not accepted. Pagination cursors count UTF-16 code units, and a page can exceed its requested limit by one code unit to avoid splitting a surrogate pair.",
   parameters: CheckpointMcpDiffInput,
   success: CheckpointMcpDiffResult,
   failure: CheckpointMcpFailure,
@@ -46,7 +46,7 @@ export const CheckpointDiffTool = Tool.make("t3_checkpoint_diff", {
 
 export const CheckpointRestoreTool = Tool.make("t3_checkpoint_restore", {
   description:
-    "Request restoration of an exact durable checkpoint through the serialized V2 checkpoint.rollback workflow. This discards current tracked and untracked workspace changes covered by Git restore, so discardChanges must be true. The thread must be idle with no queued work, the provider must support conversation rollback, and the workspace must remain unchanged between preflight and the locked restore. Reuse the exact clientRequestId to read the original accepted command/effect status without repeating it. REQUESTED means accepted but not yet applied; PARTIAL means the filesystem was restored but provider conversation rollback failed.",
+    "Request restoration of an exact durable checkpoint through the serialized V2 checkpoint.rollback workflow. This discards current tracked, untracked and staged workspace changes covered by Git restore, so discardChanges must be true. The thread must be idle with no queued work, the provider must support conversation rollback, and the guarded workspace/index state must remain unchanged before the locked restore. Reuse the exact clientRequestId to read the original accepted command/effect status without repeating it. REQUESTED means accepted but pending/running or temporarily unobservable; PARTIAL means filesystem/provider state may have changed but the complete outcome was not recorded.",
   parameters: CheckpointMcpRestoreInput,
   success: CheckpointMcpRestoreResult,
   failure: CheckpointMcpFailure,

--- a/apps/server/src/mcp/toolkits/worktree/registration.test.ts
+++ b/apps/server/src/mcp/toolkits/worktree/registration.test.ts
@@ -114,6 +114,7 @@ it.effect("production mcp layer lists worktree tools over http", () =>
       expect(toolNames).toContain("t3_worktree_status");
       expect(toolNames).toContain("t3_checkpoint_list");
       expect(toolNames).toContain("t3_checkpoint_diff");
+      expect(toolNames).toContain("t3_checkpoint_restore");
       // The worktree registration merges alongside the other toolkits rather
       // than replacing them.
       expect(toolNames).toContain("preview_status");
@@ -131,10 +132,14 @@ it.effect("production mcp layer lists worktree tools over http", () =>
       expect(status?.annotations?.destructiveHint).toBe(false);
       const checkpointList = tools.find((tool) => tool.name === "t3_checkpoint_list");
       const checkpointDiff = tools.find((tool) => tool.name === "t3_checkpoint_diff");
+      const checkpointRestore = tools.find((tool) => tool.name === "t3_checkpoint_restore");
       expect(checkpointList?.annotations?.readOnlyHint).toBe(true);
       expect(checkpointList?.annotations?.destructiveHint).toBe(false);
       expect(checkpointDiff?.annotations?.readOnlyHint).toBe(true);
       expect(checkpointDiff?.annotations?.destructiveHint).toBe(false);
+      expect(checkpointRestore?.annotations?.readOnlyHint).toBe(false);
+      expect(checkpointRestore?.annotations?.destructiveHint).toBe(true);
+      expect(checkpointRestore?.annotations?.openWorldHint).toBe(true);
 
       // MCP requires every tool input schema to be a top-level object schema.
       // A non-object schema (e.g. the anyOf produced by an empty

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
@@ -169,6 +169,7 @@ it.effect("rejects a non-ready checkpoint before opening a session or restoring 
       .pipe(Effect.flip);
 
     assert.equal(error.reason, "rollback-target-invalid");
+    assert.equal(error._tag, "CheckpointRollbackRejectedError");
     assert.equal(
       error.message,
       `Rollback target ${checkpointId} for provider thread ${providerThreadId} on thread ${threadId} is incomplete or invalid.`,
@@ -426,6 +427,7 @@ it.effect("wraps underlying failures with an unexpected-failure reason and cause
       .pipe(Effect.flip);
 
     assert.equal(error.reason, "unexpected-failure");
+    assert.equal(error._tag, "CheckpointRollbackPreflightError");
     assert.equal(
       error.message,
       `Failed to execute rollback target ${checkpointId} on provider thread ${providerThreadId} for thread ${threadId}.`,
@@ -536,6 +538,7 @@ it.effect("reports an uncertain filesystem restore as partial before provider ro
       .pipe(Effect.flip);
 
     assert.equal(error.reason, "post-restore-finalization-failed");
+    assert.equal(error._tag, "CheckpointRollbackPartialError");
     assert.strictEqual(error.cause, restoreError);
     assert.equal(rollbackThread.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
@@ -1,26 +1,122 @@
 import { assert, it, vi } from "@effect/vitest";
 import {
   CheckpointId,
+  CheckpointRef,
   CheckpointScopeId,
+  MessageId,
+  NodeId,
   type OrchestrationV2ThreadProjection,
+  ProviderDriverKind,
   ProviderInstanceId,
   ProviderSessionId,
   ProviderThreadId,
+  RunId,
   ThreadId,
 } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { CheckpointServiceV2 } from "./CheckpointService.ts";
+import { CheckpointRestoreError, CheckpointServiceV2 } from "./CheckpointService.ts";
 import {
   CheckpointRollbackServiceV2,
   layer as checkpointRollbackServiceLayer,
 } from "./CheckpointRollbackService.ts";
-import { EventSinkV2 } from "./EventSink.ts";
+import { EventSinkV2, EventSinkWriteError } from "./EventSink.ts";
 import { layer as idAllocatorLayer } from "./IdAllocator.ts";
+import { threadDispatchLockLayer } from "./KeyedSerialExecutor.ts";
 import { ProjectionStoreReadError, ProjectionStoreV2 } from "./ProjectionStore.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
+
+const checkpointRollbackServiceTestLayer = checkpointRollbackServiceLayer.pipe(
+  Layer.provide(threadDispatchLockLayer),
+);
+
+function makeReadyRollbackProjection(input: {
+  readonly threadId: ThreadId;
+  readonly providerThreadId: ProviderThreadId;
+  readonly providerSessionId: ProviderSessionId;
+  readonly checkpointId: CheckpointId;
+  readonly scopeId: CheckpointScopeId;
+  readonly providerInstanceId: ProviderInstanceId;
+}): OrchestrationV2ThreadProjection {
+  const now = DateTime.makeUnsafe("2026-08-29T00:00:00.000Z");
+  const driver = ProviderDriverKind.make("codex");
+  const nodeId = NodeId.make(`node:${input.threadId}`);
+  return {
+    thread: {
+      id: input.threadId,
+      activeProviderThreadId: input.providerThreadId,
+      modelSelection: { instanceId: input.providerInstanceId, model: "test-model" },
+      archivedAt: null,
+      deletedAt: null,
+    },
+    providerThreads: [
+      {
+        id: input.providerThreadId,
+        providerSessionId: input.providerSessionId,
+        providerInstanceId: input.providerInstanceId,
+        driver,
+        lastRunOrdinal: 1,
+      },
+    ],
+    providerSessions: [{ id: input.providerSessionId }],
+    checkpoints: [
+      {
+        id: input.checkpointId,
+        threadId: input.threadId,
+        scopeId: input.scopeId,
+        runId: null,
+        nodeId,
+        parentCheckpointId: null,
+        ordinalWithinScope: 0,
+        appRunOrdinal: null,
+        ref: CheckpointRef.make(`refs/t3/${input.checkpointId}`),
+        status: "ready",
+        files: [],
+        capturedAt: now,
+      },
+    ],
+    checkpointScopes: [
+      {
+        id: input.scopeId,
+        threadId: input.threadId,
+        runId: null,
+        nodeId,
+        parentScopeId: null,
+        providerThreadId: input.providerThreadId,
+        kind: "root_run",
+        ordinalWithinParent: 0,
+        advancesAppRunCount: true,
+        cwd: "/repo",
+        createdAt: now,
+      },
+    ],
+    runs: [
+      {
+        id: RunId.make(`run:${input.threadId}`),
+        threadId: input.threadId,
+        ordinal: 1,
+        providerInstanceId: input.providerInstanceId,
+        modelSelection: { instanceId: input.providerInstanceId, model: "test-model" },
+        providerThreadId: input.providerThreadId,
+        userMessageId: MessageId.make(`message:${input.threadId}`),
+        rootNodeId: null,
+        activeAttemptId: null,
+        status: "completed",
+        requestedAt: now,
+        startedAt: now,
+        completedAt: now,
+        checkpointId: null,
+        contextHandoffId: null,
+      },
+    ],
+    nodes: [],
+    attempts: [],
+    providerTurns: [],
+  } as unknown as OrchestrationV2ThreadProjection;
+}
 
 it.effect("rejects a non-ready checkpoint before opening a session or restoring files", () => {
   const threadId = ThreadId.make("thread:rollback-non-ready");
@@ -41,14 +137,15 @@ it.effect("rejects a non-ready checkpoint before opening a session or restoring 
     checkpoints: [{ id: checkpointId, scopeId, status: "stale" }],
     checkpointScopes: [{ id: scopeId }],
   } as unknown as OrchestrationV2ThreadProjection;
-  const testLayer = checkpointRollbackServiceLayer.pipe(
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
     Layer.provide(
       Layer.mergeAll(
         Layer.mock(CheckpointServiceV2)({ restore }),
         Layer.mock(EventSinkV2)({}),
         idAllocatorLayer,
         Layer.mock(ProjectionStoreV2)({
-          getThreadProjection: () => Effect.succeed(projection),
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
         }),
         Layer.mock(ProviderSessionManagerV2)({ open }),
         Layer.mock(RuntimePolicyV2)({ resolve: resolveRuntimePolicy }),
@@ -111,14 +208,15 @@ it.effect("rejects a rollback when another provider thread became active", () =>
     checkpoints: [{ id: checkpointId, scopeId, status: "ready" }],
     checkpointScopes: [{ id: scopeId }],
   } as unknown as OrchestrationV2ThreadProjection;
-  const testLayer = checkpointRollbackServiceLayer.pipe(
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
     Layer.provide(
       Layer.mergeAll(
         Layer.mock(CheckpointServiceV2)({ restore }),
         Layer.mock(EventSinkV2)({}),
         idAllocatorLayer,
         Layer.mock(ProjectionStoreV2)({
-          getThreadProjection: () => Effect.succeed(projection),
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
         }),
         Layer.mock(ProviderSessionManagerV2)({ open }),
         Layer.mock(RuntimePolicyV2)({ resolve: resolveRuntimePolicy }),
@@ -183,14 +281,15 @@ it.effect("rejects a rollback when provider selection changed before execution",
     checkpoints: [{ id: checkpointId, scopeId, status: "ready" }],
     checkpointScopes: [{ id: scopeId }],
   } as unknown as OrchestrationV2ThreadProjection;
-  const testLayer = checkpointRollbackServiceLayer.pipe(
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
     Layer.provide(
       Layer.mergeAll(
         Layer.mock(CheckpointServiceV2)({ restore }),
         Layer.mock(EventSinkV2)({}),
         idAllocatorLayer,
         Layer.mock(ProjectionStoreV2)({
-          getThreadProjection: () => Effect.succeed(projection),
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
         }),
         Layer.mock(ProviderSessionManagerV2)({ open }),
         Layer.mock(RuntimePolicyV2)({ resolve: resolveRuntimePolicy }),
@@ -246,14 +345,15 @@ it.effect("reports a missing provider turn as a structured rollback failure", ()
     attempts: [],
     providerTurns: [],
   } as unknown as OrchestrationV2ThreadProjection;
-  const testLayer = checkpointRollbackServiceLayer.pipe(
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
     Layer.provide(
       Layer.mergeAll(
         Layer.mock(CheckpointServiceV2)({ restore }),
         Layer.mock(EventSinkV2)({}),
         idAllocatorLayer,
         Layer.mock(ProjectionStoreV2)({
-          getThreadProjection: () => Effect.succeed(projection),
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
         }),
         Layer.mock(ProviderSessionManagerV2)({
           open: () => Effect.succeed({} as never),
@@ -295,14 +395,14 @@ it.effect("wraps underlying failures with an unexpected-failure reason and cause
     threadId,
     cause: new Error("database read failed"),
   });
-  const testLayer = checkpointRollbackServiceLayer.pipe(
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
     Layer.provide(
       Layer.mergeAll(
         Layer.mock(CheckpointServiceV2)({}),
         Layer.mock(EventSinkV2)({}),
         idAllocatorLayer,
         Layer.mock(ProjectionStoreV2)({
-          getThreadProjection: () => Effect.fail(projectionError),
+          getThreadSnapshot: () => Effect.fail(projectionError),
         }),
         Layer.mock(ProviderSessionManagerV2)({}),
         Layer.mock(RuntimePolicyV2)({}),
@@ -327,5 +427,179 @@ it.effect("wraps underlying failures with an unexpected-failure reason and cause
       `Failed to execute rollback target ${checkpointId} on provider thread ${providerThreadId} for thread ${threadId}.`,
     );
     assert.strictEqual(error.cause, projectionError);
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("reports an uncertain filesystem restore as partial before provider rollback", () => {
+  const threadId = ThreadId.make("thread:rollback-filesystem-partial");
+  const providerThreadId = ProviderThreadId.make("provider-thread:rollback-filesystem-partial");
+  const providerSessionId = ProviderSessionId.make("provider-session:rollback-filesystem-partial");
+  const checkpointId = CheckpointId.make("checkpoint:rollback-filesystem-partial");
+  const scopeId = CheckpointScopeId.make("scope:rollback-filesystem-partial");
+  const providerInstanceId = ProviderInstanceId.make("provider_rollback_filesystem_partial");
+  const projection = makeReadyRollbackProjection({
+    threadId,
+    providerThreadId,
+    providerSessionId,
+    checkpointId,
+    scopeId,
+    providerInstanceId,
+  });
+  const rollbackThread = vi.fn(() => Effect.void);
+  const restoreError = new CheckpointRestoreError({
+    scopeId,
+    checkpointId,
+    reason: "restore-outcome-unknown",
+    cause: "Git restore failed after its first mutating command",
+  });
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.mock(CheckpointServiceV2)({ restore: () => Effect.fail(restoreError) }),
+        Layer.mock(EventSinkV2)({}),
+        idAllocatorLayer,
+        Layer.mock(ProjectionStoreV2)({
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
+        }),
+        Layer.mock(ProviderSessionManagerV2)({
+          open: () => Effect.succeed({ rollbackThread } as never),
+        }),
+        Layer.mock(RuntimePolicyV2)({ resolve: () => Effect.succeed({} as never) }),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const service = yield* CheckpointRollbackServiceV2;
+    const error = yield* service
+      .execute({
+        threadId,
+        providerThreadId,
+        checkpointId,
+        scopeId,
+        expectedIdle: true,
+        expectedWorkspaceFingerprint: "workspace-before",
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(error.reason, "post-restore-finalization-failed");
+    assert.strictEqual(error.cause, restoreError);
+    assert.equal(rollbackThread.mock.calls.length, 0);
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("rejects an ambiguous null-ordinal target inside the worker boundary", () => {
+  const threadId = ThreadId.make("thread:rollback-ambiguous-target");
+  const providerThreadId = ProviderThreadId.make("provider-thread:rollback-ambiguous-target");
+  const providerSessionId = ProviderSessionId.make("provider-session:rollback-ambiguous-target");
+  const checkpointId = CheckpointId.make("checkpoint:rollback-ambiguous-target");
+  const scopeId = CheckpointScopeId.make("scope:rollback-ambiguous-target");
+  const providerInstanceId = ProviderInstanceId.make("provider_rollback_ambiguous_target");
+  const ready = makeReadyRollbackProjection({
+    threadId,
+    providerThreadId,
+    providerSessionId,
+    checkpointId,
+    scopeId,
+    providerInstanceId,
+  });
+  const projection = {
+    ...ready,
+    checkpoints: ready.checkpoints.map((checkpoint) => ({
+      ...checkpoint,
+      ordinalWithinScope: 2,
+      appRunOrdinal: null,
+    })),
+  };
+  const restore = vi.fn(() => Effect.die("ambiguous restore must not touch files"));
+  const open = vi.fn(() => Effect.die("ambiguous restore must not open a provider session"));
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.mock(CheckpointServiceV2)({ restore }),
+        Layer.mock(EventSinkV2)({}),
+        idAllocatorLayer,
+        Layer.mock(ProjectionStoreV2)({
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
+        }),
+        Layer.mock(ProviderSessionManagerV2)({ open }),
+        Layer.mock(RuntimePolicyV2)({ resolve: () => Effect.succeed({} as never) }),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const service = yield* CheckpointRollbackServiceV2;
+    const error = yield* service
+      .execute({ threadId, providerThreadId, checkpointId, scopeId })
+      .pipe(Effect.flip);
+    assert.equal(error.reason, "rollback-target-ambiguous");
+    assert.equal(restore.mock.calls.length, 0);
+    assert.equal(open.mock.calls.length, 0);
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("reports persistence failure after provider rollback as partial", () => {
+  const threadId = ThreadId.make("thread:rollback-persistence-partial");
+  const providerThreadId = ProviderThreadId.make("provider-thread:rollback-persistence-partial");
+  const providerSessionId = ProviderSessionId.make("provider-session:rollback-persistence-partial");
+  const checkpointId = CheckpointId.make("checkpoint:rollback-persistence-partial");
+  const scopeId = CheckpointScopeId.make("scope:rollback-persistence-partial");
+  const providerInstanceId = ProviderInstanceId.make("provider_rollback_persistence_partial");
+  const projection = makeReadyRollbackProjection({
+    threadId,
+    providerThreadId,
+    providerSessionId,
+    checkpointId,
+    scopeId,
+    providerInstanceId,
+  });
+  const providerThread = projection.providerThreads[0]!;
+  const rollbackThread = vi.fn(() =>
+    Effect.succeed({ providerThread, providerTurns: [], messages: [], runtimeRequests: [] }),
+  );
+  const persistenceError = new EventSinkWriteError({
+    eventCount: 2,
+    cause: "simulated event persistence failure",
+  });
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.mock(CheckpointServiceV2)({
+          restore: () => Effect.void,
+          deleteStaleRefs: () => Effect.void,
+        }),
+        Layer.mock(EventSinkV2)({ write: () => Effect.fail(persistenceError) }),
+        idAllocatorLayer,
+        Layer.mock(ProjectionStoreV2)({
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
+        }),
+        Layer.mock(ProviderSessionManagerV2)({
+          open: () => Effect.succeed({ rollbackThread } as never),
+        }),
+        Layer.mock(RuntimePolicyV2)({ resolve: () => Effect.succeed({} as never) }),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const service = yield* CheckpointRollbackServiceV2;
+    const error = yield* service
+      .execute({
+        threadId,
+        providerThreadId,
+        checkpointId,
+        scopeId,
+        expectedIdle: true,
+        expectedWorkspaceFingerprint: "workspace-before",
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(error.reason, "post-restore-finalization-failed");
+    assert.strictEqual(error.cause, persistenceError);
+    assert.equal(rollbackThread.mock.calls.length, 1);
   }).pipe(Effect.provide(testLayer));
 });

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
@@ -17,7 +17,11 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { CheckpointRestoreError, CheckpointServiceV2 } from "./CheckpointService.ts";
+import {
+  CheckpointRestoreOutcomeUnknownError,
+  CheckpointRestorePreflightError,
+  CheckpointServiceV2,
+} from "./CheckpointService.ts";
 import {
   CheckpointRollbackServiceV2,
   layer as checkpointRollbackServiceLayer,
@@ -495,10 +499,9 @@ it.effect("reports an uncertain filesystem restore as partial before provider ro
     providerInstanceId,
   });
   const rollbackThread = vi.fn(() => Effect.void);
-  const restoreError = new CheckpointRestoreError({
+  const restoreError = new CheckpointRestoreOutcomeUnknownError({
     scopeId,
     checkpointId,
-    reason: "restore-outcome-unknown",
     cause: "Git restore failed after its first mutating command",
   });
   const testLayer = checkpointRollbackServiceTestLayer.pipe(
@@ -533,6 +536,64 @@ it.effect("reports an uncertain filesystem restore as partial before provider ro
       .pipe(Effect.flip);
 
     assert.equal(error.reason, "post-restore-finalization-failed");
+    assert.strictEqual(error.cause, restoreError);
+    assert.equal(rollbackThread.mock.calls.length, 0);
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("keeps a proven pre-restore failure retryable", () => {
+  const threadId = ThreadId.make("thread:rollback-restore-preflight");
+  const providerThreadId = ProviderThreadId.make("provider-thread:rollback-restore-preflight");
+  const providerSessionId = ProviderSessionId.make("provider-session:rollback-restore-preflight");
+  const checkpointId = CheckpointId.make("checkpoint:rollback-restore-preflight");
+  const scopeId = CheckpointScopeId.make("scope:rollback-restore-preflight");
+  const providerInstanceId = ProviderInstanceId.make("provider_rollback_restore_preflight");
+  const projection = makeReadyRollbackProjection({
+    threadId,
+    providerThreadId,
+    providerSessionId,
+    checkpointId,
+    scopeId,
+    providerInstanceId,
+  });
+  const rollbackThread = vi.fn(() => Effect.void);
+  const restoreError = new CheckpointRestorePreflightError({
+    scopeId,
+    checkpointId,
+    cause: "Unable to read the workspace fingerprint before restoring files",
+  });
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.mock(CheckpointServiceV2)({ restore: () => Effect.fail(restoreError) }),
+        Layer.mock(EventSinkV2)({}),
+        idAllocatorLayer,
+        Layer.mock(ProjectionStoreV2)({
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
+        }),
+        Layer.mock(ProviderSessionManagerV2)({
+          open: () => Effect.succeed({ rollbackThread } as never),
+        }),
+        Layer.mock(RuntimePolicyV2)({ resolve: () => Effect.succeed({} as never) }),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const service = yield* CheckpointRollbackServiceV2;
+    const error = yield* service
+      .execute({
+        threadId,
+        providerThreadId,
+        checkpointId,
+        scopeId,
+        expectedIdle: true,
+        expectedWorkspaceFingerprint: "workspace-before",
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(error.reason, "unexpected-failure");
     assert.strictEqual(error.cause, restoreError);
     assert.equal(rollbackThread.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
@@ -26,7 +26,7 @@ import { EventSinkV2, EventSinkWriteError } from "./EventSink.ts";
 import { layer as idAllocatorLayer } from "./IdAllocator.ts";
 import { threadDispatchLockLayer } from "./KeyedSerialExecutor.ts";
 import { ProjectionStoreReadError, ProjectionStoreV2 } from "./ProjectionStore.ts";
-import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
+import { ProviderSessionManagerV2, ProviderSessionOpenError } from "./ProviderSessionManager.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
 
 const checkpointRollbackServiceTestLayer = checkpointRollbackServiceLayer.pipe(
@@ -427,6 +427,55 @@ it.effect("wraps underlying failures with an unexpected-failure reason and cause
       `Failed to execute rollback target ${checkpointId} on provider thread ${providerThreadId} for thread ${threadId}.`,
     );
     assert.strictEqual(error.cause, projectionError);
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("opens the provider session before restoring files for legacy rollback", () => {
+  const threadId = ThreadId.make("thread:rollback-open-before-files");
+  const providerThreadId = ProviderThreadId.make("provider-thread:rollback-open-before-files");
+  const providerSessionId = ProviderSessionId.make("provider-session:rollback-open-before-files");
+  const checkpointId = CheckpointId.make("checkpoint:rollback-open-before-files");
+  const scopeId = CheckpointScopeId.make("scope:rollback-open-before-files");
+  const providerInstanceId = ProviderInstanceId.make("provider_rollback_open_before_files");
+  const projection = makeReadyRollbackProjection({
+    threadId,
+    providerThreadId,
+    providerSessionId,
+    checkpointId,
+    scopeId,
+    providerInstanceId,
+  });
+  const restore = vi.fn(() => Effect.die("session failure must preserve files"));
+  const openError = new ProviderSessionOpenError({
+    instanceId: providerInstanceId,
+    providerSessionId,
+    cause: "simulated transient provider open failure",
+  });
+  const testLayer = checkpointRollbackServiceTestLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.mock(CheckpointServiceV2)({ restore }),
+        Layer.mock(EventSinkV2)({}),
+        idAllocatorLayer,
+        Layer.mock(ProjectionStoreV2)({
+          getThreadSnapshot: () =>
+            Effect.succeed({ schemaVersion: 1, snapshotSequence: 1, projection }),
+        }),
+        Layer.mock(ProviderSessionManagerV2)({ open: () => Effect.fail(openError) }),
+        Layer.mock(RuntimePolicyV2)({ resolve: () => Effect.succeed({} as never) }),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const service = yield* CheckpointRollbackServiceV2;
+    const error = yield* service
+      .execute({ threadId, providerThreadId, checkpointId, scopeId })
+      .pipe(Effect.flip);
+
+    assert.equal(error.reason, "unexpected-failure");
+    assert.strictEqual(error.cause, openError);
+    assert.equal(restore.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));
 });
 

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
@@ -168,8 +168,8 @@ it.effect("rejects a non-ready checkpoint before opening a session or restoring 
       })
       .pipe(Effect.flip);
 
+    assert(error._tag === "CheckpointRollbackRejectedError");
     assert.equal(error.reason, "rollback-target-invalid");
-    assert.equal(error._tag, "CheckpointRollbackRejectedError");
     assert.equal(
       error.message,
       `Rollback target ${checkpointId} for provider thread ${providerThreadId} on thread ${threadId} is incomplete or invalid.`,
@@ -240,6 +240,7 @@ it.effect("rejects a rollback when another provider thread became active", () =>
       })
       .pipe(Effect.flip);
 
+    assert(error._tag === "CheckpointRollbackRejectedError");
     assert.equal(error.reason, "active-provider-changed");
     assert.equal(
       error.message,
@@ -313,6 +314,7 @@ it.effect("rejects a rollback when provider selection changed before execution",
       })
       .pipe(Effect.flip);
 
+    assert(error._tag === "CheckpointRollbackRejectedError");
     assert.equal(error.reason, "active-provider-changed");
     assert.equal(
       error.message,
@@ -381,6 +383,7 @@ it.effect("reports a missing provider turn as a structured rollback failure", ()
       })
       .pipe(Effect.flip);
 
+    assert(error._tag === "CheckpointRollbackRejectedError");
     assert.equal(error.reason, "provider-turn-unavailable");
     assert.equal(
       error.message,
@@ -391,7 +394,7 @@ it.effect("reports a missing provider turn as a structured rollback failure", ()
   }).pipe(Effect.provide(testLayer));
 });
 
-it.effect("wraps underlying failures with an unexpected-failure reason and cause", () => {
+it.effect("wraps underlying failures with a preflight tag and cause", () => {
   const threadId = ThreadId.make("thread:rollback-unexpected-failure");
   const providerThreadId = ProviderThreadId.make("provider-thread:rollback-unexpected-failure");
   const checkpointId = CheckpointId.make("checkpoint:rollback-unexpected-failure");
@@ -426,7 +429,6 @@ it.effect("wraps underlying failures with an unexpected-failure reason and cause
       })
       .pipe(Effect.flip);
 
-    assert.equal(error.reason, "unexpected-failure");
     assert.equal(error._tag, "CheckpointRollbackPreflightError");
     assert.equal(
       error.message,
@@ -479,7 +481,7 @@ it.effect("opens the provider session before restoring files for legacy rollback
       .execute({ threadId, providerThreadId, checkpointId, scopeId })
       .pipe(Effect.flip);
 
-    assert.equal(error.reason, "unexpected-failure");
+    assert.equal(error._tag, "CheckpointRollbackPreflightError");
     assert.strictEqual(error.cause, openError);
     assert.equal(restore.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));
@@ -537,8 +539,8 @@ it.effect("reports an uncertain filesystem restore as partial before provider ro
       })
       .pipe(Effect.flip);
 
+    assert(error._tag === "CheckpointRollbackPartialError");
     assert.equal(error.reason, "post-restore-finalization-failed");
-    assert.equal(error._tag, "CheckpointRollbackPartialError");
     assert.strictEqual(error.cause, restoreError);
     assert.equal(rollbackThread.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));
@@ -596,7 +598,7 @@ it.effect("keeps a proven pre-restore failure retryable", () => {
       })
       .pipe(Effect.flip);
 
-    assert.equal(error.reason, "unexpected-failure");
+    assert.equal(error._tag, "CheckpointRollbackPreflightError");
     assert.strictEqual(error.cause, restoreError);
     assert.equal(rollbackThread.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));
@@ -648,6 +650,7 @@ it.effect("rejects an ambiguous null-ordinal target inside the worker boundary",
     const error = yield* service
       .execute({ threadId, providerThreadId, checkpointId, scopeId })
       .pipe(Effect.flip);
+    assert(error._tag === "CheckpointRollbackRejectedError");
     assert.equal(error.reason, "rollback-target-ambiguous");
     assert.equal(restore.mock.calls.length, 0);
     assert.equal(open.mock.calls.length, 0);
@@ -711,6 +714,7 @@ it.effect("reports persistence failure after provider rollback as partial", () =
       })
       .pipe(Effect.flip);
 
+    assert(error._tag === "CheckpointRollbackPartialError");
     assert.equal(error.reason, "post-restore-finalization-failed");
     assert.strictEqual(error.cause, persistenceError);
     assert.equal(rollbackThread.mock.calls.length, 1);

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.test.ts
@@ -28,13 +28,13 @@ import {
 } from "./CheckpointRollbackService.ts";
 import { EventSinkV2, EventSinkWriteError } from "./EventSink.ts";
 import { layer as idAllocatorLayer } from "./IdAllocator.ts";
-import { threadDispatchLockLayer } from "./KeyedSerialExecutor.ts";
+import { layer as threadCommandExecutorLayer } from "./ThreadCommandExecutor.ts";
 import { ProjectionStoreReadError, ProjectionStoreV2 } from "./ProjectionStore.ts";
 import { ProviderSessionManagerV2, ProviderSessionOpenError } from "./ProviderSessionManager.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
 
 const checkpointRollbackServiceTestLayer = checkpointRollbackServiceLayer.pipe(
-  Layer.provide(threadDispatchLockLayer),
+  Layer.provide(threadCommandExecutorLayer),
 );
 
 function makeReadyRollbackProjection(input: {

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -1,4 +1,5 @@
 import {
+  checkpointRollbackAppRunOrdinal,
   CheckpointId,
   CheckpointScopeId,
   type OrchestrationV2DomainEvent,
@@ -14,6 +15,7 @@ import * as Schema from "effect/Schema";
 import { CheckpointRestoreError, CheckpointServiceV2 } from "./CheckpointService.ts";
 import { EventSinkV2 } from "./EventSink.ts";
 import { IdAllocatorV2 } from "./IdAllocator.ts";
+import { ThreadDispatchLockV2 } from "./KeyedSerialExecutor.ts";
 import { ProjectionStoreV2 } from "./ProjectionStore.ts";
 import type { ProviderAdapterV2RollbackTarget } from "./ProviderAdapter.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
@@ -24,10 +26,13 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
   {
     reason: Schema.Literals([
       "rollback-target-invalid",
+      "rollback-target-ambiguous",
       "active-provider-changed",
       "provider-turn-unavailable",
       "thread-not-idle",
+      "restore-precondition-changed",
       "provider-rollback-failed-after-restore",
+      "post-restore-finalization-failed",
       "unexpected-failure",
     ]),
     threadId: ThreadId,
@@ -40,14 +45,20 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
     switch (this.reason) {
       case "rollback-target-invalid":
         return `Rollback target ${this.checkpointId} for provider thread ${this.providerThreadId} on thread ${this.threadId} is incomplete or invalid.`;
+      case "rollback-target-ambiguous":
+        return `Rollback target ${this.checkpointId} does not identify a proven provider-history position.`;
       case "active-provider-changed":
         return `Active provider changed before rollback target ${this.checkpointId} could execute on thread ${this.threadId}.`;
       case "provider-turn-unavailable":
         return `Provider turn for rollback target ${this.checkpointId} is unavailable on provider thread ${this.providerThreadId}.`;
       case "thread-not-idle":
         return `Checkpoint rollback target ${this.checkpointId} requires an idle thread with no queued runs.`;
+      case "restore-precondition-changed":
+        return `Checkpoint rollback target ${this.checkpointId} changed before filesystem restoration began.`;
       case "provider-rollback-failed-after-restore":
         return `Provider conversation rollback failed after the filesystem checkpoint ${this.checkpointId} was restored; the result is partial.`;
+      case "post-restore-finalization-failed":
+        return `Checkpoint ${this.checkpointId} was restored, but rollback finalization failed; the result is partial.`;
       case "unexpected-failure":
         return `Failed to execute rollback target ${this.checkpointId} on provider thread ${this.providerThreadId} for thread ${this.threadId}.`;
     }
@@ -79,6 +90,7 @@ export const layer: Layer.Layer<
   | CheckpointServiceV2
   | EventSinkV2
   | IdAllocatorV2
+  | ThreadDispatchLockV2
   | ProjectionStoreV2
   | ProviderSessionManagerV2
   | RuntimePolicyV2
@@ -88,6 +100,7 @@ export const layer: Layer.Layer<
     const checkpoints = yield* CheckpointServiceV2;
     const eventSink = yield* EventSinkV2;
     const ids = yield* IdAllocatorV2;
+    const threadDispatch = yield* ThreadDispatchLockV2;
     const projections = yield* ProjectionStoreV2;
     const sessions = yield* ProviderSessionManagerV2;
     const runtimePolicy = yield* RuntimePolicyV2;
@@ -100,7 +113,8 @@ export const layer: Layer.Layer<
       readonly expectedIdle?: true;
       readonly expectedWorkspaceFingerprint?: string;
     }) {
-      const projection = yield* projections.getThreadProjection(input.threadId);
+      const initialSnapshot = yield* projections.getThreadSnapshot(input.threadId);
+      const projection = initialSnapshot.projection;
       const providerThread = projection.providerThreads.find(
         (candidate) => candidate.id === input.providerThreadId,
       );
@@ -123,6 +137,7 @@ export const layer: Layer.Layer<
           checkpointId: input.checkpointId,
         });
       }
+      const providerSessionId = providerThread.providerSessionId;
       if (
         providerThread.id !== projection.thread.activeProviderThreadId ||
         providerThread.providerInstanceId !== projection.thread.modelSelection.instanceId
@@ -148,23 +163,25 @@ export const layer: Layer.Layer<
         });
       }
 
+      const targetOrdinal = checkpointRollbackAppRunOrdinal(checkpoint, scope);
+      if (targetOrdinal === null) {
+        return yield* new CheckpointRollbackExecutionError({
+          reason: "rollback-target-ambiguous",
+          threadId: input.threadId,
+          providerThreadId: input.providerThreadId,
+          checkpointId: input.checkpointId,
+        });
+      }
+
       const modelSelection = projection.thread.modelSelection;
       const resolvedRuntimePolicy = yield* runtimePolicy.resolve({
         thread: projection.thread,
         modelSelection,
       });
       const existingSession = projection.providerSessions.find(
-        (candidate) => candidate.id === providerThread.providerSessionId,
+        (candidate) => candidate.id === providerSessionId,
       );
-      const session = yield* sessions.open({
-        threadId: input.threadId,
-        providerSessionId: providerThread.providerSessionId,
-        modelSelection,
-        runtimePolicy: resolvedRuntimePolicy,
-        ...(existingSession === undefined ? {} : { resumeFromSession: existingSession }),
-      });
 
-      const targetOrdinal = checkpoint.appRunOrdinal ?? 0;
       const runsToRollback = projection.runs.filter(
         (run) => run.ordinal > targetOrdinal && run.status === "completed",
       );
@@ -206,8 +223,9 @@ export const layer: Layer.Layer<
 
       const validateBeforeRestore =
         input.expectedIdle === true
-          ? projections.getThreadProjection(input.threadId).pipe(
-              Effect.flatMap((latest) => {
+          ? projections.getThreadSnapshot(input.threadId).pipe(
+              Effect.flatMap((latestSnapshot) => {
+                const latest = latestSnapshot.projection;
                 const latestCheckpoint = latest.checkpoints.find(
                   (candidate) => candidate.id === input.checkpointId,
                 );
@@ -215,6 +233,7 @@ export const layer: Layer.Layer<
                   ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
                 );
                 return remainsIdle &&
+                  latestSnapshot.snapshotSequence === initialSnapshot.snapshotSequence &&
                   latest.thread.archivedAt === null &&
                   latest.thread.deletedAt === null &&
                   latest.thread.activeProviderThreadId === input.providerThreadId &&
@@ -225,6 +244,7 @@ export const layer: Layer.Layer<
                       new CheckpointRestoreError({
                         scopeId: input.scopeId,
                         checkpointId: input.checkpointId,
+                        reason: "precondition-changed",
                         cause:
                           "Thread or rollback target changed after admission; current workspace files were preserved.",
                       }),
@@ -241,117 +261,155 @@ export const layer: Layer.Layer<
               ),
             )
           : undefined;
-      yield* checkpoints.restore({
-        scope,
-        checkpoint,
-        ...(input.expectedWorkspaceFingerprint === undefined
-          ? {}
-          : { expectedWorkspaceFingerprint: input.expectedWorkspaceFingerprint }),
-        ...(validateBeforeRestore === undefined ? {} : { validateBeforeRestore }),
-      });
-      const snapshot =
-        runsToRollback.length === 0
-          ? { providerThread }
-          : yield* session
-              .rollbackThread({
-                providerThread,
-                target: rollbackTarget,
-                providerThreadTurns,
-              })
-              .pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new CheckpointRollbackExecutionError({
-                      reason: "provider-rollback-failed-after-restore",
-                      threadId: input.threadId,
-                      providerThreadId: input.providerThreadId,
-                      checkpointId: input.checkpointId,
-                      cause,
-                    }),
-                ),
-              );
-      const staleCheckpoints = projection.checkpoints.filter(
-        (candidate) =>
-          candidate.scopeId === scope.id &&
-          candidate.appRunOrdinal !== null &&
-          candidate.appRunOrdinal > targetOrdinal &&
-          candidate.status === "ready",
-      );
-      if (staleCheckpoints.length > 0) {
-        yield* checkpoints.deleteStaleRefs({ scope, checkpoints: staleCheckpoints });
-      }
-
-      const now = yield* DateTime.now;
-      const makeEvent = <Event extends OrchestrationV2DomainEvent>(event: Omit<Event, "id">) =>
-        Effect.map(
-          ids.allocate.event({ threadId: event.threadId }),
-          (id) =>
-            ({
-              ...event,
-              id,
-            }) as Event,
+      yield* checkpoints
+        .restore({
+          scope,
+          checkpoint,
+          ...(input.expectedWorkspaceFingerprint === undefined
+            ? {}
+            : { expectedWorkspaceFingerprint: input.expectedWorkspaceFingerprint }),
+          ...(validateBeforeRestore === undefined ? {} : { validateBeforeRestore }),
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new CheckpointRollbackExecutionError({
+                reason:
+                  !isCheckpointRestoreError(cause) || cause.reason === "restore-outcome-unknown"
+                    ? "post-restore-finalization-failed"
+                    : "restore-precondition-changed",
+                threadId: input.threadId,
+                providerThreadId: input.providerThreadId,
+                checkpointId: input.checkpointId,
+                cause,
+              }),
+          ),
         );
-      const events: Array<OrchestrationV2DomainEvent> = [];
-      events.push(
-        yield* makeEvent({
-          type: "provider-thread.updated",
+      yield* Effect.gen(function* () {
+        const session = yield* sessions.open({
           threadId: input.threadId,
-          driver: providerThread.driver,
-          providerInstanceId: providerThread.providerInstanceId,
-          occurredAt: now,
-          payload: {
-            ...snapshot.providerThread,
-            lastRunOrdinal: targetOrdinal === 0 ? null : targetOrdinal,
-            updatedAt: now,
-          },
-        }),
-      );
-      for (const staleCheckpoint of staleCheckpoints) {
+          providerSessionId,
+          modelSelection,
+          runtimePolicy: resolvedRuntimePolicy,
+          ...(existingSession === undefined ? {} : { resumeFromSession: existingSession }),
+        });
+        const snapshot =
+          runsToRollback.length === 0
+            ? { providerThread }
+            : yield* session
+                .rollbackThread({
+                  providerThread,
+                  target: rollbackTarget,
+                  providerThreadTurns,
+                })
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new CheckpointRollbackExecutionError({
+                        reason: "provider-rollback-failed-after-restore",
+                        threadId: input.threadId,
+                        providerThreadId: input.providerThreadId,
+                        checkpointId: input.checkpointId,
+                        cause,
+                      }),
+                  ),
+                );
+        const staleCheckpoints = projection.checkpoints.filter(
+          (candidate) =>
+            candidate.scopeId === scope.id &&
+            candidate.appRunOrdinal !== null &&
+            candidate.appRunOrdinal > targetOrdinal &&
+            candidate.status === "ready",
+        );
+        if (staleCheckpoints.length > 0) {
+          yield* checkpoints.deleteStaleRefs({ scope, checkpoints: staleCheckpoints });
+        }
+
+        const now = yield* DateTime.now;
+        const makeEvent = <Event extends OrchestrationV2DomainEvent>(event: Omit<Event, "id">) =>
+          Effect.map(
+            ids.allocate.event({ threadId: event.threadId }),
+            (id) =>
+              ({
+                ...event,
+                id,
+              }) as Event,
+          );
+        const events: Array<OrchestrationV2DomainEvent> = [];
         events.push(
           yield* makeEvent({
-            type: "checkpoint.captured",
+            type: "provider-thread.updated",
             threadId: input.threadId,
-            ...(staleCheckpoint.runId === null ? {} : { runId: staleCheckpoint.runId }),
-            nodeId: staleCheckpoint.nodeId,
+            driver: providerThread.driver,
             providerInstanceId: providerThread.providerInstanceId,
             occurredAt: now,
-            payload: { ...staleCheckpoint, status: "stale" },
+            payload: {
+              ...snapshot.providerThread,
+              lastRunOrdinal: targetOrdinal === 0 ? null : targetOrdinal,
+              updatedAt: now,
+            },
           }),
         );
-      }
-      for (const run of runsToRollback) {
-        const rootNode = projection.nodes.find((candidate) => candidate.id === run.rootNodeId);
-        events.push(
-          yield* makeEvent({
-            type: "run.updated",
-            threadId: input.threadId,
-            runId: run.id,
-            ...(rootNode === undefined ? {} : { nodeId: rootNode.id }),
-            providerInstanceId: run.providerInstanceId,
-            occurredAt: now,
-            payload: { ...run, status: "rolled_back", completedAt: now },
-          }),
-        );
-        if (rootNode !== undefined) {
+        for (const staleCheckpoint of staleCheckpoints) {
           events.push(
             yield* makeEvent({
-              type: "node.updated",
+              type: "checkpoint.captured",
               threadId: input.threadId,
-              runId: run.id,
-              nodeId: rootNode.id,
-              providerInstanceId: run.providerInstanceId,
+              ...(staleCheckpoint.runId === null ? {} : { runId: staleCheckpoint.runId }),
+              nodeId: staleCheckpoint.nodeId,
+              providerInstanceId: providerThread.providerInstanceId,
               occurredAt: now,
-              payload: { ...rootNode, status: "rolled_back", completedAt: now },
+              payload: { ...staleCheckpoint, status: "stale" },
             }),
           );
         }
-      }
-      yield* eventSink.write({ events });
+        for (const run of runsToRollback) {
+          const rootNode = projection.nodes.find((candidate) => candidate.id === run.rootNodeId);
+          events.push(
+            yield* makeEvent({
+              type: "run.updated",
+              threadId: input.threadId,
+              runId: run.id,
+              ...(rootNode === undefined ? {} : { nodeId: rootNode.id }),
+              providerInstanceId: run.providerInstanceId,
+              occurredAt: now,
+              payload: { ...run, status: "rolled_back", completedAt: now },
+            }),
+          );
+          if (rootNode !== undefined) {
+            events.push(
+              yield* makeEvent({
+                type: "node.updated",
+                threadId: input.threadId,
+                runId: run.id,
+                nodeId: rootNode.id,
+                providerInstanceId: run.providerInstanceId,
+                occurredAt: now,
+                payload: { ...rootNode, status: "rolled_back", completedAt: now },
+              }),
+            );
+          }
+        }
+        yield* eventSink.write({ events });
+      }).pipe(
+        Effect.mapError((cause) =>
+          isCheckpointRollbackExecutionError(cause) &&
+          cause.reason === "provider-rollback-failed-after-restore"
+            ? cause
+            : new CheckpointRollbackExecutionError({
+                reason: "post-restore-finalization-failed",
+                threadId: input.threadId,
+                providerThreadId: input.providerThreadId,
+                checkpointId: input.checkpointId,
+                cause,
+              }),
+        ),
+      );
     });
 
     return CheckpointRollbackServiceV2.of({
       execute: (input) =>
-        execute(input).pipe(
+        threadDispatch.withLock(input.threadId, execute(input)).pipe(
           Effect.mapError((cause) =>
             isCheckpointRollbackExecutionError(cause)
               ? cause

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -85,7 +85,6 @@ export class CheckpointRollbackPartialError extends Schema.TaggedErrorClass<Chec
 export class CheckpointRollbackPreflightError extends Schema.TaggedErrorClass<CheckpointRollbackPreflightError>()(
   "CheckpointRollbackPreflightError",
   {
-    reason: Schema.Literal("unexpected-failure"),
     ...CheckpointRollbackErrorFields,
   },
 ) {
@@ -415,7 +414,6 @@ export const layer: Layer.Layer<
             }
             return new CheckpointRollbackPreflightError({
               ...fields,
-              reason: "unexpected-failure",
             });
           }),
         );
@@ -546,7 +544,6 @@ export const layer: Layer.Layer<
             isCheckpointRollbackExecutionError(cause)
               ? cause
               : new CheckpointRollbackPreflightError({
-                  reason: "unexpected-failure",
                   threadId: input.threadId,
                   providerThreadId: input.providerThreadId,
                   checkpointId: input.checkpointId,

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -181,31 +181,103 @@ export const layer: Layer.Layer<
       const existingSession = projection.providerSessions.find(
         (candidate) => candidate.id === providerSessionId,
       );
+      const session = yield* sessions.open({
+        threadId: input.threadId,
+        providerSessionId,
+        modelSelection,
+        runtimePolicy: resolvedRuntimePolicy,
+        ...(existingSession === undefined ? {} : { resumeFromSession: existingSession }),
+      });
 
-      const runsToRollback = projection.runs.filter(
+      const admittedSnapshot = yield* projections.getThreadSnapshot(input.threadId);
+      const admittedProjection = admittedSnapshot.projection;
+      const admittedProviderThread = admittedProjection.providerThreads.find(
+        (candidate) => candidate.id === input.providerThreadId,
+      );
+      const admittedCheckpoint = admittedProjection.checkpoints.find(
+        (candidate) => candidate.id === input.checkpointId,
+      );
+      const admittedScope = admittedProjection.checkpointScopes.find(
+        (candidate) => candidate.id === input.scopeId,
+      );
+      if (
+        admittedProviderThread === undefined ||
+        admittedProviderThread.providerSessionId !== providerSessionId ||
+        admittedCheckpoint === undefined ||
+        admittedScope === undefined ||
+        admittedCheckpoint.scopeId !== admittedScope.id ||
+        admittedCheckpoint.status !== "ready"
+      ) {
+        return yield* new CheckpointRollbackExecutionError({
+          reason: "rollback-target-invalid",
+          threadId: input.threadId,
+          providerThreadId: input.providerThreadId,
+          checkpointId: input.checkpointId,
+        });
+      }
+      if (
+        admittedProviderThread.id !== admittedProjection.thread.activeProviderThreadId ||
+        admittedProviderThread.providerInstanceId !==
+          admittedProjection.thread.modelSelection.instanceId
+      ) {
+        return yield* new CheckpointRollbackExecutionError({
+          reason: "active-provider-changed",
+          threadId: input.threadId,
+          providerThreadId: input.providerThreadId,
+          checkpointId: input.checkpointId,
+        });
+      }
+      if (
+        input.expectedIdle === true &&
+        admittedProjection.runs.some((run) =>
+          ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
+        )
+      ) {
+        return yield* new CheckpointRollbackExecutionError({
+          reason: "thread-not-idle",
+          threadId: input.threadId,
+          providerThreadId: input.providerThreadId,
+          checkpointId: input.checkpointId,
+        });
+      }
+      if (checkpointRollbackAppRunOrdinal(admittedCheckpoint, admittedScope) !== targetOrdinal) {
+        return yield* new CheckpointRollbackExecutionError({
+          reason: "rollback-target-invalid",
+          threadId: input.threadId,
+          providerThreadId: input.providerThreadId,
+          checkpointId: input.checkpointId,
+        });
+      }
+
+      const runsToRollback = admittedProjection.runs.filter(
         (run) => run.ordinal > targetOrdinal && run.status === "completed",
       );
-      const providerThreadTurns = projection.providerTurns.filter(
-        (turn) => turn.providerThreadId === providerThread.id,
+      const providerThreadTurns = admittedProjection.providerTurns.filter(
+        (turn) => turn.providerThreadId === admittedProviderThread.id,
       );
       const rollbackTarget: ProviderAdapterV2RollbackTarget =
         targetOrdinal === 0
           ? {
               type: "thread_start",
-              checkpointId: checkpoint.id,
+              checkpointId: admittedCheckpoint.id,
               appRunOrdinal: 0,
             }
           : yield* Effect.gen(function* () {
-              const targetRun = projection.runs.find((run) => run.ordinal === targetOrdinal);
-              const targetAttempt = projection.attempts.find(
+              const targetRun = admittedProjection.runs.find(
+                (run) => run.ordinal === targetOrdinal,
+              );
+              const targetAttempt = admittedProjection.attempts.find(
                 (attempt) => attempt.id === targetRun?.activeAttemptId,
               );
-              const targetTurn = projection.providerTurns.find(
+              const targetTurn = admittedProjection.providerTurns.find(
                 (turn) =>
                   turn.id === targetAttempt?.providerTurnId ||
                   turn.runAttemptId === targetAttempt?.id,
               );
-              if (targetTurn === undefined || targetTurn.providerThreadId !== providerThread.id) {
+              if (
+                targetTurn === undefined ||
+                targetTurn.providerThreadId !== admittedProviderThread.id
+              ) {
                 return yield* new CheckpointRollbackExecutionError({
                   reason: "provider-turn-unavailable",
                   threadId: input.threadId,
@@ -215,7 +287,7 @@ export const layer: Layer.Layer<
               }
               return {
                 type: "provider_turn" as const,
-                checkpointId: checkpoint.id,
+                checkpointId: admittedCheckpoint.id,
                 appRunOrdinal: targetOrdinal,
                 providerTurn: targetTurn,
               };
@@ -229,14 +301,20 @@ export const layer: Layer.Layer<
                 const latestCheckpoint = latest.checkpoints.find(
                   (candidate) => candidate.id === input.checkpointId,
                 );
+                const latestProviderThread = latest.providerThreads.find(
+                  (candidate) => candidate.id === input.providerThreadId,
+                );
                 const remainsIdle = !latest.runs.some((run) =>
                   ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
                 );
                 return remainsIdle &&
-                  latestSnapshot.snapshotSequence === initialSnapshot.snapshotSequence &&
+                  latestSnapshot.snapshotSequence === admittedSnapshot.snapshotSequence &&
                   latest.thread.archivedAt === null &&
                   latest.thread.deletedAt === null &&
                   latest.thread.activeProviderThreadId === input.providerThreadId &&
+                  latest.thread.modelSelection.instanceId ===
+                    admittedProviderThread.providerInstanceId &&
+                  latestProviderThread?.providerSessionId === providerSessionId &&
                   latestCheckpoint?.scopeId === input.scopeId &&
                   latestCheckpoint.status === "ready"
                   ? Effect.void
@@ -263,8 +341,8 @@ export const layer: Layer.Layer<
           : undefined;
       yield* checkpoints
         .restore({
-          scope,
-          checkpoint,
+          scope: admittedScope,
+          checkpoint: admittedCheckpoint,
           ...(input.expectedWorkspaceFingerprint === undefined
             ? {}
             : { expectedWorkspaceFingerprint: input.expectedWorkspaceFingerprint }),
@@ -286,19 +364,12 @@ export const layer: Layer.Layer<
           ),
         );
       yield* Effect.gen(function* () {
-        const session = yield* sessions.open({
-          threadId: input.threadId,
-          providerSessionId,
-          modelSelection,
-          runtimePolicy: resolvedRuntimePolicy,
-          ...(existingSession === undefined ? {} : { resumeFromSession: existingSession }),
-        });
         const snapshot =
           runsToRollback.length === 0
-            ? { providerThread }
+            ? { providerThread: admittedProviderThread }
             : yield* session
                 .rollbackThread({
-                  providerThread,
+                  providerThread: admittedProviderThread,
                   target: rollbackTarget,
                   providerThreadTurns,
                 })
@@ -314,15 +385,18 @@ export const layer: Layer.Layer<
                       }),
                   ),
                 );
-        const staleCheckpoints = projection.checkpoints.filter(
+        const staleCheckpoints = admittedProjection.checkpoints.filter(
           (candidate) =>
-            candidate.scopeId === scope.id &&
+            candidate.scopeId === admittedScope.id &&
             candidate.appRunOrdinal !== null &&
             candidate.appRunOrdinal > targetOrdinal &&
             candidate.status === "ready",
         );
         if (staleCheckpoints.length > 0) {
-          yield* checkpoints.deleteStaleRefs({ scope, checkpoints: staleCheckpoints });
+          yield* checkpoints.deleteStaleRefs({
+            scope: admittedScope,
+            checkpoints: staleCheckpoints,
+          });
         }
 
         const now = yield* DateTime.now;
@@ -340,8 +414,8 @@ export const layer: Layer.Layer<
           yield* makeEvent({
             type: "provider-thread.updated",
             threadId: input.threadId,
-            driver: providerThread.driver,
-            providerInstanceId: providerThread.providerInstanceId,
+            driver: admittedProviderThread.driver,
+            providerInstanceId: admittedProviderThread.providerInstanceId,
             occurredAt: now,
             payload: {
               ...snapshot.providerThread,
@@ -357,14 +431,16 @@ export const layer: Layer.Layer<
               threadId: input.threadId,
               ...(staleCheckpoint.runId === null ? {} : { runId: staleCheckpoint.runId }),
               nodeId: staleCheckpoint.nodeId,
-              providerInstanceId: providerThread.providerInstanceId,
+              providerInstanceId: admittedProviderThread.providerInstanceId,
               occurredAt: now,
               payload: { ...staleCheckpoint, status: "stale" },
             }),
           );
         }
         for (const run of runsToRollback) {
-          const rootNode = projection.nodes.find((candidate) => candidate.id === run.rootNodeId);
+          const rootNode = admittedProjection.nodes.find(
+            (candidate) => candidate.id === run.rootNodeId,
+          );
           events.push(
             yield* makeEvent({
               type: "run.updated",

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -11,7 +11,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 
-import { CheckpointServiceV2 } from "./CheckpointService.ts";
+import { CheckpointRestoreError, CheckpointServiceV2 } from "./CheckpointService.ts";
 import { EventSinkV2 } from "./EventSink.ts";
 import { IdAllocatorV2 } from "./IdAllocator.ts";
 import { ProjectionStoreV2 } from "./ProjectionStore.ts";
@@ -26,6 +26,8 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
       "rollback-target-invalid",
       "active-provider-changed",
       "provider-turn-unavailable",
+      "thread-not-idle",
+      "provider-rollback-failed-after-restore",
       "unexpected-failure",
     ]),
     threadId: ThreadId,
@@ -42,6 +44,10 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
         return `Active provider changed before rollback target ${this.checkpointId} could execute on thread ${this.threadId}.`;
       case "provider-turn-unavailable":
         return `Provider turn for rollback target ${this.checkpointId} is unavailable on provider thread ${this.providerThreadId}.`;
+      case "thread-not-idle":
+        return `Checkpoint rollback target ${this.checkpointId} requires an idle thread with no queued runs.`;
+      case "provider-rollback-failed-after-restore":
+        return `Provider conversation rollback failed after the filesystem checkpoint ${this.checkpointId} was restored; the result is partial.`;
       case "unexpected-failure":
         return `Failed to execute rollback target ${this.checkpointId} on provider thread ${this.providerThreadId} for thread ${this.threadId}.`;
     }
@@ -49,6 +55,7 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
 }
 
 const isCheckpointRollbackExecutionError = Schema.is(CheckpointRollbackExecutionError);
+const isCheckpointRestoreError = Schema.is(CheckpointRestoreError);
 
 export interface CheckpointRollbackServiceV2Shape {
   readonly execute: (input: {
@@ -56,6 +63,8 @@ export interface CheckpointRollbackServiceV2Shape {
     readonly providerThreadId: ProviderThreadId;
     readonly checkpointId: CheckpointId;
     readonly scopeId: CheckpointScopeId;
+    readonly expectedIdle?: true;
+    readonly expectedWorkspaceFingerprint?: string;
   }) => Effect.Effect<void, CheckpointRollbackExecutionError>;
 }
 
@@ -88,6 +97,8 @@ export const layer: Layer.Layer<
       readonly providerThreadId: ProviderThreadId;
       readonly checkpointId: CheckpointId;
       readonly scopeId: CheckpointScopeId;
+      readonly expectedIdle?: true;
+      readonly expectedWorkspaceFingerprint?: string;
     }) {
       const projection = yield* projections.getThreadProjection(input.threadId);
       const providerThread = projection.providerThreads.find(
@@ -118,6 +129,19 @@ export const layer: Layer.Layer<
       ) {
         return yield* new CheckpointRollbackExecutionError({
           reason: "active-provider-changed",
+          threadId: input.threadId,
+          providerThreadId: input.providerThreadId,
+          checkpointId: input.checkpointId,
+        });
+      }
+      if (
+        input.expectedIdle === true &&
+        projection.runs.some((run) =>
+          ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
+        )
+      ) {
+        return yield* new CheckpointRollbackExecutionError({
+          reason: "thread-not-idle",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
           checkpointId: input.checkpointId,
@@ -180,15 +204,72 @@ export const layer: Layer.Layer<
               };
             });
 
-      yield* checkpoints.restore({ scope, checkpoint });
+      const validateBeforeRestore =
+        input.expectedIdle === true
+          ? projections.getThreadProjection(input.threadId).pipe(
+              Effect.flatMap((latest) => {
+                const latestCheckpoint = latest.checkpoints.find(
+                  (candidate) => candidate.id === input.checkpointId,
+                );
+                const remainsIdle = !latest.runs.some((run) =>
+                  ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
+                );
+                return remainsIdle &&
+                  latest.thread.archivedAt === null &&
+                  latest.thread.deletedAt === null &&
+                  latest.thread.activeProviderThreadId === input.providerThreadId &&
+                  latestCheckpoint?.scopeId === input.scopeId &&
+                  latestCheckpoint.status === "ready"
+                  ? Effect.void
+                  : Effect.fail(
+                      new CheckpointRestoreError({
+                        scopeId: input.scopeId,
+                        checkpointId: input.checkpointId,
+                        cause:
+                          "Thread or rollback target changed after admission; current workspace files were preserved.",
+                      }),
+                    );
+              }),
+              Effect.mapError((cause) =>
+                isCheckpointRestoreError(cause)
+                  ? cause
+                  : new CheckpointRestoreError({
+                      scopeId: input.scopeId,
+                      checkpointId: input.checkpointId,
+                      cause,
+                    }),
+              ),
+            )
+          : undefined;
+      yield* checkpoints.restore({
+        scope,
+        checkpoint,
+        ...(input.expectedWorkspaceFingerprint === undefined
+          ? {}
+          : { expectedWorkspaceFingerprint: input.expectedWorkspaceFingerprint }),
+        ...(validateBeforeRestore === undefined ? {} : { validateBeforeRestore }),
+      });
       const snapshot =
         runsToRollback.length === 0
           ? { providerThread }
-          : yield* session.rollbackThread({
-              providerThread,
-              target: rollbackTarget,
-              providerThreadTurns,
-            });
+          : yield* session
+              .rollbackThread({
+                providerThread,
+                target: rollbackTarget,
+                providerThreadTurns,
+              })
+              .pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new CheckpointRollbackExecutionError({
+                      reason: "provider-rollback-failed-after-restore",
+                      threadId: input.threadId,
+                      providerThreadId: input.providerThreadId,
+                      checkpointId: input.checkpointId,
+                      cause,
+                    }),
+                ),
+              );
       const staleCheckpoints = projection.checkpoints.filter(
         (candidate) =>
           candidate.scopeId === scope.id &&

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -12,7 +12,12 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 
-import { CheckpointRestoreError, CheckpointServiceV2 } from "./CheckpointService.ts";
+import {
+  CheckpointRestoreOutcomeUnknownError,
+  CheckpointRestorePreflightError,
+  CheckpointRestorePreconditionError,
+  CheckpointServiceV2,
+} from "./CheckpointService.ts";
 import { EventSinkV2 } from "./EventSink.ts";
 import { IdAllocatorV2 } from "./IdAllocator.ts";
 import { ThreadDispatchLockV2 } from "./KeyedSerialExecutor.ts";
@@ -66,7 +71,9 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
 }
 
 const isCheckpointRollbackExecutionError = Schema.is(CheckpointRollbackExecutionError);
-const isCheckpointRestoreError = Schema.is(CheckpointRestoreError);
+const isCheckpointRestoreOutcomeUnknownError = Schema.is(CheckpointRestoreOutcomeUnknownError);
+const isCheckpointRestorePreflightError = Schema.is(CheckpointRestorePreflightError);
+const isCheckpointRestorePreconditionError = Schema.is(CheckpointRestorePreconditionError);
 
 export interface CheckpointRollbackServiceV2Shape {
   readonly execute: (input: {
@@ -319,7 +326,7 @@ export const layer: Layer.Layer<
                   latestCheckpoint.status === "ready"
                   ? Effect.void
                   : Effect.fail(
-                      new CheckpointRestoreError({
+                      new CheckpointRestorePreconditionError({
                         scopeId: input.scopeId,
                         checkpointId: input.checkpointId,
                         reason: "precondition-changed",
@@ -329,9 +336,10 @@ export const layer: Layer.Layer<
                     );
               }),
               Effect.mapError((cause) =>
-                isCheckpointRestoreError(cause)
+                isCheckpointRestorePreconditionError(cause) ||
+                isCheckpointRestorePreflightError(cause)
                   ? cause
-                  : new CheckpointRestoreError({
+                  : new CheckpointRestorePreflightError({
                       scopeId: input.scopeId,
                       checkpointId: input.checkpointId,
                       cause,
@@ -352,10 +360,11 @@ export const layer: Layer.Layer<
           Effect.mapError(
             (cause) =>
               new CheckpointRollbackExecutionError({
-                reason:
-                  !isCheckpointRestoreError(cause) || cause.reason === "restore-outcome-unknown"
-                    ? "post-restore-finalization-failed"
-                    : "restore-precondition-changed",
+                reason: isCheckpointRestoreOutcomeUnknownError(cause)
+                  ? "post-restore-finalization-failed"
+                  : isCheckpointRestorePreconditionError(cause)
+                    ? "restore-precondition-changed"
+                    : "unexpected-failure",
                 threadId: input.threadId,
                 providerThreadId: input.providerThreadId,
                 checkpointId: input.checkpointId,

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -93,20 +93,15 @@ export class CheckpointRollbackPreflightError extends Schema.TaggedErrorClass<Ch
   }
 }
 
-export type CheckpointRollbackExecutionError =
-  | CheckpointRollbackRejectedError
-  | CheckpointRollbackPartialError
-  | CheckpointRollbackPreflightError;
+export const CheckpointRollbackExecutionError = Schema.Union([
+  CheckpointRollbackRejectedError,
+  CheckpointRollbackPartialError,
+  CheckpointRollbackPreflightError,
+]);
+export type CheckpointRollbackExecutionError = typeof CheckpointRollbackExecutionError.Type;
 
-const isCheckpointRollbackRejectedError = Schema.is(CheckpointRollbackRejectedError);
 const isCheckpointRollbackPartialError = Schema.is(CheckpointRollbackPartialError);
-const isCheckpointRollbackPreflightError = Schema.is(CheckpointRollbackPreflightError);
-const isCheckpointRollbackExecutionError = (
-  value: unknown,
-): value is CheckpointRollbackExecutionError =>
-  isCheckpointRollbackRejectedError(value) ||
-  isCheckpointRollbackPartialError(value) ||
-  isCheckpointRollbackPreflightError(value);
+const isCheckpointRollbackExecutionError = Schema.is(CheckpointRollbackExecutionError);
 const isCheckpointRestoreOutcomeUnknownError = Schema.is(CheckpointRestoreOutcomeUnknownError);
 const isCheckpointRestorePreflightError = Schema.is(CheckpointRestorePreflightError);
 const isCheckpointRestorePreconditionError = Schema.is(CheckpointRestorePreconditionError);

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -26,8 +26,15 @@ import type { ProviderAdapterV2RollbackTarget } from "./ProviderAdapter.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
 
-export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<CheckpointRollbackExecutionError>()(
-  "CheckpointRollbackExecutionError",
+const CheckpointRollbackErrorFields = {
+  threadId: ThreadId,
+  providerThreadId: ProviderThreadId,
+  checkpointId: CheckpointId,
+  cause: Schema.optional(Schema.Defect()),
+};
+
+export class CheckpointRollbackRejectedError extends Schema.TaggedErrorClass<CheckpointRollbackRejectedError>()(
+  "CheckpointRollbackRejectedError",
   {
     reason: Schema.Literals([
       "rollback-target-invalid",
@@ -36,14 +43,8 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
       "provider-turn-unavailable",
       "thread-not-idle",
       "restore-precondition-changed",
-      "provider-rollback-failed-after-restore",
-      "post-restore-finalization-failed",
-      "unexpected-failure",
     ]),
-    threadId: ThreadId,
-    providerThreadId: ProviderThreadId,
-    checkpointId: CheckpointId,
-    cause: Schema.optional(Schema.Defect()),
+    ...CheckpointRollbackErrorFields,
   },
 ) {
   override get message(): string {
@@ -60,17 +61,53 @@ export class CheckpointRollbackExecutionError extends Schema.TaggedErrorClass<Ch
         return `Checkpoint rollback target ${this.checkpointId} requires an idle thread with no queued runs.`;
       case "restore-precondition-changed":
         return `Checkpoint rollback target ${this.checkpointId} changed before filesystem restoration began.`;
-      case "provider-rollback-failed-after-restore":
-        return `Provider conversation rollback failed after the filesystem checkpoint ${this.checkpointId} was restored; the result is partial.`;
-      case "post-restore-finalization-failed":
-        return `Checkpoint ${this.checkpointId} was restored, but rollback finalization failed; the result is partial.`;
-      case "unexpected-failure":
-        return `Failed to execute rollback target ${this.checkpointId} on provider thread ${this.providerThreadId} for thread ${this.threadId}.`;
     }
   }
 }
 
-const isCheckpointRollbackExecutionError = Schema.is(CheckpointRollbackExecutionError);
+export class CheckpointRollbackPartialError extends Schema.TaggedErrorClass<CheckpointRollbackPartialError>()(
+  "CheckpointRollbackPartialError",
+  {
+    reason: Schema.Literals([
+      "provider-rollback-failed-after-restore",
+      "post-restore-finalization-failed",
+    ]),
+    ...CheckpointRollbackErrorFields,
+  },
+) {
+  override get message(): string {
+    return this.reason === "provider-rollback-failed-after-restore"
+      ? `Provider conversation rollback failed after the filesystem checkpoint ${this.checkpointId} was restored; the result is partial.`
+      : `Checkpoint ${this.checkpointId} was restored, but rollback finalization failed; the result is partial.`;
+  }
+}
+
+export class CheckpointRollbackPreflightError extends Schema.TaggedErrorClass<CheckpointRollbackPreflightError>()(
+  "CheckpointRollbackPreflightError",
+  {
+    reason: Schema.Literal("unexpected-failure"),
+    ...CheckpointRollbackErrorFields,
+  },
+) {
+  override get message(): string {
+    return `Failed to execute rollback target ${this.checkpointId} on provider thread ${this.providerThreadId} for thread ${this.threadId}.`;
+  }
+}
+
+export type CheckpointRollbackExecutionError =
+  | CheckpointRollbackRejectedError
+  | CheckpointRollbackPartialError
+  | CheckpointRollbackPreflightError;
+
+const isCheckpointRollbackRejectedError = Schema.is(CheckpointRollbackRejectedError);
+const isCheckpointRollbackPartialError = Schema.is(CheckpointRollbackPartialError);
+const isCheckpointRollbackPreflightError = Schema.is(CheckpointRollbackPreflightError);
+const isCheckpointRollbackExecutionError = (
+  value: unknown,
+): value is CheckpointRollbackExecutionError =>
+  isCheckpointRollbackRejectedError(value) ||
+  isCheckpointRollbackPartialError(value) ||
+  isCheckpointRollbackPreflightError(value);
 const isCheckpointRestoreOutcomeUnknownError = Schema.is(CheckpointRestoreOutcomeUnknownError);
 const isCheckpointRestorePreflightError = Schema.is(CheckpointRestorePreflightError);
 const isCheckpointRestorePreconditionError = Schema.is(CheckpointRestorePreconditionError);
@@ -137,7 +174,7 @@ export const layer: Layer.Layer<
         checkpoint.scopeId !== scope.id ||
         checkpoint.status !== "ready"
       ) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "rollback-target-invalid",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -149,7 +186,7 @@ export const layer: Layer.Layer<
         providerThread.id !== projection.thread.activeProviderThreadId ||
         providerThread.providerInstanceId !== projection.thread.modelSelection.instanceId
       ) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "active-provider-changed",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -162,7 +199,7 @@ export const layer: Layer.Layer<
           ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
         )
       ) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "thread-not-idle",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -172,7 +209,7 @@ export const layer: Layer.Layer<
 
       const targetOrdinal = checkpointRollbackAppRunOrdinal(checkpoint, scope);
       if (targetOrdinal === null) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "rollback-target-ambiguous",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -215,7 +252,7 @@ export const layer: Layer.Layer<
         admittedCheckpoint.scopeId !== admittedScope.id ||
         admittedCheckpoint.status !== "ready"
       ) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "rollback-target-invalid",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -227,7 +264,7 @@ export const layer: Layer.Layer<
         admittedProviderThread.providerInstanceId !==
           admittedProjection.thread.modelSelection.instanceId
       ) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "active-provider-changed",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -240,7 +277,7 @@ export const layer: Layer.Layer<
           ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
         )
       ) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "thread-not-idle",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -248,7 +285,7 @@ export const layer: Layer.Layer<
         });
       }
       if (checkpointRollbackAppRunOrdinal(admittedCheckpoint, admittedScope) !== targetOrdinal) {
-        return yield* new CheckpointRollbackExecutionError({
+        return yield* new CheckpointRollbackRejectedError({
           reason: "rollback-target-invalid",
           threadId: input.threadId,
           providerThreadId: input.providerThreadId,
@@ -285,7 +322,7 @@ export const layer: Layer.Layer<
                 targetTurn === undefined ||
                 targetTurn.providerThreadId !== admittedProviderThread.id
               ) {
-                return yield* new CheckpointRollbackExecutionError({
+                return yield* new CheckpointRollbackRejectedError({
                   reason: "provider-turn-unavailable",
                   threadId: input.threadId,
                   providerThreadId: input.providerThreadId,
@@ -357,20 +394,30 @@ export const layer: Layer.Layer<
           ...(validateBeforeRestore === undefined ? {} : { validateBeforeRestore }),
         })
         .pipe(
-          Effect.mapError(
-            (cause) =>
-              new CheckpointRollbackExecutionError({
-                reason: isCheckpointRestoreOutcomeUnknownError(cause)
-                  ? "post-restore-finalization-failed"
-                  : isCheckpointRestorePreconditionError(cause)
-                    ? "restore-precondition-changed"
-                    : "unexpected-failure",
-                threadId: input.threadId,
-                providerThreadId: input.providerThreadId,
-                checkpointId: input.checkpointId,
-                cause,
-              }),
-          ),
+          Effect.mapError((cause): CheckpointRollbackExecutionError => {
+            const fields = {
+              threadId: input.threadId,
+              providerThreadId: input.providerThreadId,
+              checkpointId: input.checkpointId,
+              cause,
+            };
+            if (isCheckpointRestoreOutcomeUnknownError(cause)) {
+              return new CheckpointRollbackPartialError({
+                ...fields,
+                reason: "post-restore-finalization-failed",
+              });
+            }
+            if (isCheckpointRestorePreconditionError(cause)) {
+              return new CheckpointRollbackRejectedError({
+                ...fields,
+                reason: "restore-precondition-changed",
+              });
+            }
+            return new CheckpointRollbackPreflightError({
+              ...fields,
+              reason: "unexpected-failure",
+            });
+          }),
         );
       yield* Effect.gen(function* () {
         const snapshot =
@@ -385,7 +432,7 @@ export const layer: Layer.Layer<
                 .pipe(
                   Effect.mapError(
                     (cause) =>
-                      new CheckpointRollbackExecutionError({
+                      new CheckpointRollbackPartialError({
                         reason: "provider-rollback-failed-after-restore",
                         threadId: input.threadId,
                         providerThreadId: input.providerThreadId,
@@ -478,10 +525,10 @@ export const layer: Layer.Layer<
         yield* eventSink.write({ events });
       }).pipe(
         Effect.mapError((cause) =>
-          isCheckpointRollbackExecutionError(cause) &&
+          isCheckpointRollbackPartialError(cause) &&
           cause.reason === "provider-rollback-failed-after-restore"
             ? cause
-            : new CheckpointRollbackExecutionError({
+            : new CheckpointRollbackPartialError({
                 reason: "post-restore-finalization-failed",
                 threadId: input.threadId,
                 providerThreadId: input.providerThreadId,
@@ -498,7 +545,7 @@ export const layer: Layer.Layer<
           Effect.mapError((cause) =>
             isCheckpointRollbackExecutionError(cause)
               ? cause
-              : new CheckpointRollbackExecutionError({
+              : new CheckpointRollbackPreflightError({
                   reason: "unexpected-failure",
                   threadId: input.threadId,
                   providerThreadId: input.providerThreadId,

--- a/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointRollbackService.ts
@@ -20,11 +20,11 @@ import {
 } from "./CheckpointService.ts";
 import { EventSinkV2 } from "./EventSink.ts";
 import { IdAllocatorV2 } from "./IdAllocator.ts";
-import { ThreadDispatchLockV2 } from "./KeyedSerialExecutor.ts";
 import { ProjectionStoreV2 } from "./ProjectionStore.ts";
 import type { ProviderAdapterV2RollbackTarget } from "./ProviderAdapter.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
+import { ThreadCommandExecutor } from "./ThreadCommandExecutor.ts";
 
 const CheckpointRollbackErrorFields = {
   threadId: ThreadId,
@@ -128,7 +128,7 @@ export const layer: Layer.Layer<
   | CheckpointServiceV2
   | EventSinkV2
   | IdAllocatorV2
-  | ThreadDispatchLockV2
+  | ThreadCommandExecutor
   | ProjectionStoreV2
   | ProviderSessionManagerV2
   | RuntimePolicyV2
@@ -138,7 +138,7 @@ export const layer: Layer.Layer<
     const checkpoints = yield* CheckpointServiceV2;
     const eventSink = yield* EventSinkV2;
     const ids = yield* IdAllocatorV2;
-    const threadDispatch = yield* ThreadDispatchLockV2;
+    const threadDispatch = yield* ThreadCommandExecutor;
     const projections = yield* ProjectionStoreV2;
     const sessions = yield* ProviderSessionManagerV2;
     const runtimePolicy = yield* RuntimePolicyV2;

--- a/apps/server/src/orchestration-v2/CheckpointService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointService.test.ts
@@ -7,6 +7,7 @@ import {
   ProviderThreadId,
   RunId,
   ThreadId,
+  VcsProcessExitError,
   type OrchestrationV2CheckpointScope,
   type OrchestrationV2Checkpoint,
 } from "@t3tools/contracts";
@@ -125,7 +126,73 @@ it.effect("preserves concurrently changed files before locked restore", () => {
       })
       .pipe(Effect.flip);
 
-    assert.equal(error._tag, "CheckpointRestoreError");
+    assert.equal(error._tag, "CheckpointRestorePreconditionError");
+    assert.equal(restoreCheckpoint.mock.calls.length, 0);
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("classifies fingerprint read failures as retryable preflight failures", () => {
+  const scope: OrchestrationV2CheckpointScope = {
+    id: CheckpointScopeId.make("checkpoint-scope:fingerprint-read-failure"),
+    threadId: ThreadId.make("thread:fingerprint-read-failure"),
+    runId: null,
+    nodeId: NodeId.make("node:fingerprint-read-failure"),
+    parentScopeId: null,
+    providerThreadId: ProviderThreadId.make("provider-thread:fingerprint-read-failure"),
+    kind: "manual",
+    ordinalWithinParent: 0,
+    advancesAppRunCount: false,
+    cwd: "/repo",
+    createdAt: DateTime.makeUnsafe("2026-08-29T00:00:00.000Z"),
+  };
+  const checkpoint: OrchestrationV2Checkpoint = {
+    id: CheckpointId.make("checkpoint:fingerprint-read-failure"),
+    threadId: scope.threadId,
+    scopeId: scope.id,
+    runId: null,
+    nodeId: scope.nodeId,
+    parentCheckpointId: null,
+    ordinalWithinScope: 0,
+    appRunOrdinal: null,
+    ref: CheckpointRef.make("refs/t3/fingerprint-read-failure"),
+    status: "ready",
+    files: [],
+    capturedAt: scope.createdAt,
+  };
+  const fingerprintError = new VcsProcessExitError({
+    operation: "CheckpointStore.readWorkspaceFingerprint",
+    command: "git ls-files --stage",
+    cwd: scope.cwd,
+    exitCode: 0,
+    detail: "staged-state output was truncated",
+  });
+  const restoreCheckpoint = vi.fn(() => Effect.succeed(true));
+  const testLayer = checkpointServiceLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        idAllocatorLayer,
+        Layer.mock(CheckpointStore.CheckpointStore)({
+          readWorkspaceFingerprint: () => Effect.fail(fingerprintError),
+          restoreCheckpoint,
+        }),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const checkpoints = yield* CheckpointServiceV2;
+    const error = yield* checkpoints
+      .restore({
+        scope,
+        checkpoint,
+        expectedWorkspaceFingerprint: "tree:admitted",
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(error._tag, "CheckpointRestorePreflightError");
+    if (error._tag === "CheckpointRestorePreflightError") {
+      assert.strictEqual(error.cause, fingerprintError);
+    }
     assert.equal(restoreCheckpoint.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));
 });

--- a/apps/server/src/orchestration-v2/CheckpointService.test.ts
+++ b/apps/server/src/orchestration-v2/CheckpointService.test.ts
@@ -1,11 +1,14 @@
 import { assert, it, vi } from "@effect/vitest";
 import {
+  CheckpointId,
+  CheckpointRef,
   CheckpointScopeId,
   NodeId,
   ProviderThreadId,
   RunId,
   ThreadId,
   type OrchestrationV2CheckpointScope,
+  type OrchestrationV2Checkpoint,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -68,5 +71,61 @@ it.effect("materializes the captured baseline at the requested scope ordinal", (
       cwd: scope.cwd,
       checkpointRef: baseline.ref,
     });
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("preserves concurrently changed files before locked restore", () => {
+  const scope: OrchestrationV2CheckpointScope = {
+    id: CheckpointScopeId.make("checkpoint-scope:guarded-restore"),
+    threadId: ThreadId.make("thread:guarded-restore"),
+    runId: null,
+    nodeId: NodeId.make("node:guarded-restore"),
+    parentScopeId: null,
+    providerThreadId: ProviderThreadId.make("provider-thread:guarded-restore"),
+    kind: "manual",
+    ordinalWithinParent: 0,
+    advancesAppRunCount: false,
+    cwd: "/repo",
+    createdAt: DateTime.makeUnsafe("2026-08-29T00:00:00.000Z"),
+  };
+  const checkpoint: OrchestrationV2Checkpoint = {
+    id: CheckpointId.make("checkpoint:guarded-restore"),
+    threadId: scope.threadId,
+    scopeId: scope.id,
+    runId: null,
+    nodeId: scope.nodeId,
+    parentCheckpointId: null,
+    ordinalWithinScope: 0,
+    appRunOrdinal: null,
+    ref: CheckpointRef.make("refs/t3/guarded-restore"),
+    status: "ready",
+    files: [],
+    capturedAt: scope.createdAt,
+  };
+  const restoreCheckpoint = vi.fn(() => Effect.succeed(true));
+  const testLayer = checkpointServiceLayer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        idAllocatorLayer,
+        Layer.mock(CheckpointStore.CheckpointStore)({
+          readWorkspaceFingerprint: () => Effect.succeed("tree:changed"),
+          restoreCheckpoint,
+        }),
+      ),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const checkpoints = yield* CheckpointServiceV2;
+    const error = yield* checkpoints
+      .restore({
+        scope,
+        checkpoint,
+        expectedWorkspaceFingerprint: "tree:admitted",
+      })
+      .pipe(Effect.flip);
+
+    assert.equal(error._tag, "CheckpointRestoreError");
+    assert.equal(restoreCheckpoint.mock.calls.length, 0);
   }).pipe(Effect.provide(testLayer));
 });

--- a/apps/server/src/orchestration-v2/CheckpointService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointService.ts
@@ -77,19 +77,43 @@ export class CheckpointCaptureError extends Schema.TaggedErrorClass<CheckpointCa
   }
 }
 
-export class CheckpointRestoreError extends Schema.TaggedErrorClass<CheckpointRestoreError>()(
-  "CheckpointRestoreError",
+export class CheckpointRestorePreconditionError extends Schema.TaggedErrorClass<CheckpointRestorePreconditionError>()(
+  "CheckpointRestorePreconditionError",
   {
     scopeId: CheckpointScopeId,
     checkpointId: CheckpointId,
-    reason: Schema.optional(
-      Schema.Literals(["precondition-changed", "target-unavailable", "restore-outcome-unknown"]),
-    ),
+    reason: Schema.Literals(["precondition-changed", "target-unavailable"]),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to restore checkpoint ${this.checkpointId} for scope ${this.scopeId}.`;
+    return `Checkpoint ${this.checkpointId} for scope ${this.scopeId} no longer satisfies its restore preconditions.`;
+  }
+}
+
+export class CheckpointRestorePreflightError extends Schema.TaggedErrorClass<CheckpointRestorePreflightError>()(
+  "CheckpointRestorePreflightError",
+  {
+    scopeId: CheckpointScopeId,
+    checkpointId: CheckpointId,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to verify checkpoint ${this.checkpointId} for scope ${this.scopeId} before restoring files.`;
+  }
+}
+
+export class CheckpointRestoreOutcomeUnknownError extends Schema.TaggedErrorClass<CheckpointRestoreOutcomeUnknownError>()(
+  "CheckpointRestoreOutcomeUnknownError",
+  {
+    scopeId: CheckpointScopeId,
+    checkpointId: CheckpointId,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Checkpoint ${this.checkpointId} for scope ${this.scopeId} may have been partially restored.`;
   }
 }
 
@@ -111,12 +135,12 @@ export const CheckpointServiceV2Error = Schema.Union([
   CheckpointScopeEnsureError,
   CheckpointBaselineCaptureError,
   CheckpointCaptureError,
-  CheckpointRestoreError,
+  CheckpointRestorePreconditionError,
+  CheckpointRestorePreflightError,
+  CheckpointRestoreOutcomeUnknownError,
   CheckpointDeleteStaleRefsError,
 ]);
 export type CheckpointServiceV2Error = typeof CheckpointServiceV2Error.Type;
-
-const isCheckpointRestoreError = Schema.is(CheckpointRestoreError);
 
 export interface CheckpointServiceV2Shape {
   readonly prepareRootRunScope: (input: {
@@ -150,7 +174,10 @@ export interface CheckpointServiceV2Shape {
     readonly scope: OrchestrationV2CheckpointScope;
     readonly checkpoint: OrchestrationV2Checkpoint;
     readonly expectedWorkspaceFingerprint?: string;
-    readonly validateBeforeRestore?: Effect.Effect<void, CheckpointRestoreError>;
+    readonly validateBeforeRestore?: Effect.Effect<
+      void,
+      CheckpointRestorePreconditionError | CheckpointRestorePreflightError
+    >;
   }) => Effect.Effect<void, CheckpointServiceV2Error>;
   readonly deleteStaleRefs: (input: {
     readonly scope: OrchestrationV2CheckpointScope;
@@ -500,7 +527,7 @@ export const layer: Layer.Layer<
             yield* input.validateBeforeRestore;
           }
           if (input.checkpoint.status !== "ready") {
-            return yield* new CheckpointRestoreError({
+            return yield* new CheckpointRestorePreconditionError({
               scopeId: input.scope.id,
               checkpointId: input.checkpoint.id,
               reason: "target-unavailable",
@@ -509,11 +536,20 @@ export const layer: Layer.Layer<
           }
 
           if (input.expectedWorkspaceFingerprint !== undefined) {
-            const currentFingerprint = yield* checkpointStore.readWorkspaceFingerprint(
-              input.scope.cwd,
-            );
+            const currentFingerprint = yield* checkpointStore
+              .readWorkspaceFingerprint(input.scope.cwd)
+              .pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new CheckpointRestorePreflightError({
+                      scopeId: input.scope.id,
+                      checkpointId: input.checkpoint.id,
+                      cause,
+                    }),
+                ),
+              );
             if (currentFingerprint !== input.expectedWorkspaceFingerprint) {
-              return yield* new CheckpointRestoreError({
+              return yield* new CheckpointRestorePreconditionError({
                 scopeId: input.scope.id,
                 checkpointId: input.checkpoint.id,
                 reason: "precondition-changed",
@@ -531,16 +567,15 @@ export const layer: Layer.Layer<
             .pipe(
               Effect.mapError(
                 (cause) =>
-                  new CheckpointRestoreError({
+                  new CheckpointRestoreOutcomeUnknownError({
                     scopeId: input.scope.id,
                     checkpointId: input.checkpoint.id,
-                    reason: "restore-outcome-unknown",
                     cause,
                   }),
               ),
             );
           if (!restored) {
-            return yield* new CheckpointRestoreError({
+            return yield* new CheckpointRestorePreconditionError({
               scopeId: input.scope.id,
               checkpointId: input.checkpoint.id,
               reason: "target-unavailable",
@@ -548,16 +583,6 @@ export const layer: Layer.Layer<
             });
           }
         }),
-      ).pipe(
-        Effect.mapError((cause) =>
-          isCheckpointRestoreError(cause)
-            ? cause
-            : new CheckpointRestoreError({
-                scopeId: input.scope.id,
-                checkpointId: input.checkpoint.id,
-                cause,
-              }),
-        ),
       );
 
     const deleteStaleRefs: CheckpointServiceV2Shape["deleteStaleRefs"] = (input) =>

--- a/apps/server/src/orchestration-v2/CheckpointService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointService.ts
@@ -146,6 +146,8 @@ export interface CheckpointServiceV2Shape {
   readonly restore: (input: {
     readonly scope: OrchestrationV2CheckpointScope;
     readonly checkpoint: OrchestrationV2Checkpoint;
+    readonly expectedWorkspaceFingerprint?: string;
+    readonly validateBeforeRestore?: Effect.Effect<void, CheckpointRestoreError>;
   }) => Effect.Effect<void, CheckpointServiceV2Error>;
   readonly deleteStaleRefs: (input: {
     readonly scope: OrchestrationV2CheckpointScope;
@@ -491,12 +493,28 @@ export const layer: Layer.Layer<
       withWorkspaceLock(
         input.scope.cwd,
         Effect.gen(function* () {
+          if (input.validateBeforeRestore !== undefined) {
+            yield* input.validateBeforeRestore;
+          }
           if (input.checkpoint.status !== "ready") {
             return yield* new CheckpointRestoreError({
               scopeId: input.scope.id,
               checkpointId: input.checkpoint.id,
               cause: `Checkpoint status is ${input.checkpoint.status}.`,
             });
+          }
+
+          if (input.expectedWorkspaceFingerprint !== undefined) {
+            const currentFingerprint = yield* checkpointStore.readWorkspaceFingerprint(
+              input.scope.cwd,
+            );
+            if (currentFingerprint !== input.expectedWorkspaceFingerprint) {
+              return yield* new CheckpointRestoreError({
+                scopeId: input.scope.id,
+                checkpointId: input.checkpoint.id,
+                cause: "Workspace changed after rollback admission; current files were preserved.",
+              });
+            }
           }
 
           const restored = yield* checkpointStore.restoreCheckpoint({

--- a/apps/server/src/orchestration-v2/CheckpointService.ts
+++ b/apps/server/src/orchestration-v2/CheckpointService.ts
@@ -82,6 +82,9 @@ export class CheckpointRestoreError extends Schema.TaggedErrorClass<CheckpointRe
   {
     scopeId: CheckpointScopeId,
     checkpointId: CheckpointId,
+    reason: Schema.optional(
+      Schema.Literals(["precondition-changed", "target-unavailable", "restore-outcome-unknown"]),
+    ),
     cause: Schema.Defect(),
   },
 ) {
@@ -500,6 +503,7 @@ export const layer: Layer.Layer<
             return yield* new CheckpointRestoreError({
               scopeId: input.scope.id,
               checkpointId: input.checkpoint.id,
+              reason: "target-unavailable",
               cause: `Checkpoint status is ${input.checkpoint.status}.`,
             });
           }
@@ -512,20 +516,34 @@ export const layer: Layer.Layer<
               return yield* new CheckpointRestoreError({
                 scopeId: input.scope.id,
                 checkpointId: input.checkpoint.id,
+                reason: "precondition-changed",
                 cause: "Workspace changed after rollback admission; current files were preserved.",
               });
             }
           }
 
-          const restored = yield* checkpointStore.restoreCheckpoint({
-            cwd: input.scope.cwd,
-            checkpointRef: input.checkpoint.ref,
-            fallbackToHead: false,
-          });
+          const restored = yield* checkpointStore
+            .restoreCheckpoint({
+              cwd: input.scope.cwd,
+              checkpointRef: input.checkpoint.ref,
+              fallbackToHead: false,
+            })
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new CheckpointRestoreError({
+                    scopeId: input.scope.id,
+                    checkpointId: input.checkpoint.id,
+                    reason: "restore-outcome-unknown",
+                    cause,
+                  }),
+              ),
+            );
           if (!restored) {
             return yield* new CheckpointRestoreError({
               scopeId: input.scope.id,
               checkpointId: input.checkpoint.id,
+              reason: "target-unavailable",
               cause: "Checkpoint ref is unavailable.",
             });
           }

--- a/apps/server/src/orchestration-v2/EffectOutbox.ts
+++ b/apps/server/src/orchestration-v2/EffectOutbox.ts
@@ -81,6 +81,8 @@ export const OrchestrationEffectRequestV2 = Schema.Union([
     providerThreadId: ProviderThreadId,
     checkpointId: CheckpointId,
     scopeId: CheckpointScopeId,
+    expectedIdle: Schema.optional(Schema.Literal(true)),
+    expectedWorkspaceFingerprint: Schema.optional(Schema.String),
   }),
   Schema.Struct({
     type: Schema.Literal("checkpoint.capture"),

--- a/apps/server/src/orchestration-v2/EffectOutbox.ts
+++ b/apps/server/src/orchestration-v2/EffectOutbox.ts
@@ -490,7 +490,6 @@ export const layer: Layer.Layer<EffectOutboxV2, never, SqlClient.SqlClient> = La
           .filter(
             (effect) =>
               effect.request.type === "provider-thread.rollback" &&
-              effect.request.expectedIdle === true &&
               effect.request.expectedWorkspaceFingerprint !== undefined,
           )
           .map((effect) => effect.id);

--- a/apps/server/src/orchestration-v2/EffectOutbox.ts
+++ b/apps/server/src/orchestration-v2/EffectOutbox.ts
@@ -133,6 +133,12 @@ export const OrchestrationEffectStatusV2 = Schema.Literals([
 ]);
 export type OrchestrationEffectStatusV2 = typeof OrchestrationEffectStatusV2.Type;
 
+export const OrchestrationEffectFailureCodeV2 = Schema.Literals([
+  "checkpoint_restore_rejected",
+  "checkpoint_restore_partial",
+]);
+export type OrchestrationEffectFailureCodeV2 = typeof OrchestrationEffectFailureCodeV2.Type;
+
 export interface OrchestrationEffectV2 {
   readonly id: string;
   readonly commandId: CommandId;
@@ -147,6 +153,7 @@ export interface OrchestrationEffectV2 {
   readonly updatedAt: string;
   readonly completedAt: string | null;
   readonly lastError: string | null;
+  readonly failureCode?: OrchestrationEffectFailureCodeV2;
 }
 
 export interface PendingOrchestrationEffectV2 {
@@ -217,6 +224,7 @@ export interface EffectOutboxV2Shape {
     readonly effectId: string;
     readonly workerId: string;
     readonly error: string;
+    readonly failureCode?: OrchestrationEffectFailureCodeV2;
   }) => Effect.Effect<boolean, EffectOutboxError>;
 }
 
@@ -245,24 +253,57 @@ const encodeRequest = Schema.encodeSync(Schema.fromJsonString(OrchestrationEffec
 const decodeRequest = Schema.decodeUnknownEffect(
   Schema.fromJsonString(OrchestrationEffectRequestV2),
 );
+const StoredEffectFailure = Schema.Struct({
+  code: OrchestrationEffectFailureCodeV2,
+  message: Schema.String,
+});
+const encodeStoredEffectFailure = Schema.encodeSync(Schema.fromJsonString(StoredEffectFailure));
+const decodeStoredEffectFailure = Schema.decodeUnknownOption(
+  Schema.fromJsonString(StoredEffectFailure),
+);
+const STORED_EFFECT_FAILURE_PREFIX = "t3-effect-failure:";
+
+function decodeLastError(value: string | null): {
+  readonly lastError: string | null;
+  readonly failureCode?: OrchestrationEffectFailureCodeV2;
+} {
+  if (value === null || !value.startsWith(STORED_EFFECT_FAILURE_PREFIX)) {
+    return { lastError: value };
+  }
+  const decoded = decodeStoredEffectFailure(value.slice(STORED_EFFECT_FAILURE_PREFIX.length));
+  return Option.match(decoded, {
+    onNone: () => ({ lastError: value }),
+    onSome: (failure) => ({ lastError: failure.message, failureCode: failure.code }),
+  });
+}
+
+function encodeLastError(error: string, failureCode?: OrchestrationEffectFailureCodeV2): string {
+  return failureCode === undefined
+    ? error
+    : `${STORED_EFFECT_FAILURE_PREFIX}${encodeStoredEffectFailure({ code: failureCode, message: error })}`;
+}
 
 const rowToEffect = (row: EffectRow) =>
   decodeRequest(row.payload_json).pipe(
-    Effect.map((request): OrchestrationEffectV2 => ({
-      id: row.effect_id,
-      commandId: CommandId.make(row.command_id),
-      threadId: ThreadId.make(row.thread_id),
-      request,
-      status: row.status as OrchestrationEffectStatusV2,
-      attemptCount: row.attempt_count,
-      availableAt: row.available_at,
-      leaseOwner: row.lease_owner,
-      leaseExpiresAt: row.lease_expires_at,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-      completedAt: row.completed_at,
-      lastError: row.last_error,
-    })),
+    Effect.map((request): OrchestrationEffectV2 => {
+      const failure = decodeLastError(row.last_error);
+      return {
+        id: row.effect_id,
+        commandId: CommandId.make(row.command_id),
+        threadId: ThreadId.make(row.thread_id),
+        request,
+        status: row.status as OrchestrationEffectStatusV2,
+        attemptCount: row.attempt_count,
+        availableAt: row.available_at,
+        leaseOwner: row.lease_owner,
+        leaseExpiresAt: row.lease_expires_at,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+        completedAt: row.completed_at,
+        lastError: failure.lastError,
+        ...(failure.failureCode === undefined ? {} : { failureCode: failure.failureCode }),
+      };
+    }),
   );
 
 export const layer: Layer.Layer<EffectOutboxV2, never, SqlClient.SqlClient> = Layer.effect(
@@ -438,6 +479,39 @@ export const layer: Layer.Layer<EffectOutboxV2, never, SqlClient.SqlClient> = La
         }),
       reconcileAfterProcessLoss: Effect.gen(function* () {
         const now = DateTime.formatIso(yield* DateTime.now);
+        const rollbackRows = yield* sql<EffectRow>`
+          SELECT *
+          FROM orchestration_v2_effect_outbox
+          WHERE status = 'running'
+            AND effect_type = 'provider-thread.rollback'
+        `;
+        const rollbackEffects = yield* Effect.forEach(rollbackRows, rowToEffect);
+        const uncertainGuardedRollbackIds = rollbackEffects
+          .filter(
+            (effect) =>
+              effect.request.type === "provider-thread.rollback" &&
+              effect.request.expectedIdle === true &&
+              effect.request.expectedWorkspaceFingerprint !== undefined,
+          )
+          .map((effect) => effect.id);
+        if (uncertainGuardedRollbackIds.length > 0) {
+          const uncertainError = encodeLastError(
+            "The server process ended while a guarded checkpoint restore was running; its filesystem/provider outcome is uncertain and the restore was not repeated.",
+            "checkpoint_restore_partial",
+          );
+          yield* sql`
+            UPDATE orchestration_v2_effect_outbox
+            SET
+              status = 'failed',
+              lease_owner = NULL,
+              lease_expires_at = NULL,
+              completed_at = ${now},
+              updated_at = ${now},
+              last_error = ${uncertainError}
+            WHERE effect_id IN ${sql.in(uncertainGuardedRollbackIds)}
+              AND status = 'running'
+          `;
+        }
         const cancelledRows = yield* sql<{ readonly effect_id: string }>`
           UPDATE orchestration_v2_effect_outbox
           SET
@@ -587,9 +661,10 @@ export const layer: Layer.Layer<EffectOutboxV2, never, SqlClient.SqlClient> = La
             (cause) => new EffectOutboxError({ operation: "retry", effectId, cause }),
           ),
         ),
-      fail: ({ effectId, workerId, error }) =>
+      fail: ({ effectId, workerId, error, failureCode }) =>
         Effect.gen(function* () {
           const now = DateTime.formatIso(yield* DateTime.now);
+          const storedError = encodeLastError(error, failureCode);
           const rows = yield* sql<{ readonly effect_id: string }>`
             UPDATE orchestration_v2_effect_outbox
             SET
@@ -598,7 +673,7 @@ export const layer: Layer.Layer<EffectOutboxV2, never, SqlClient.SqlClient> = La
               lease_expires_at = NULL,
               completed_at = ${now},
               updated_at = ${now},
-              last_error = ${error}
+              last_error = ${storedError}
             WHERE effect_id = ${effectId}
               AND status = 'running'
               AND lease_owner = ${workerId}

--- a/apps/server/src/orchestration-v2/EffectWorker.test.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.test.ts
@@ -266,7 +266,10 @@ it.effect("retries legacy rollback failures while terminalizing guarded partial 
   Effect.gen(function* () {
     const now = yield* DateTime.now;
 
-    const runCase = (guarded: boolean) =>
+    const runCase = (
+      guarded: boolean,
+      failureCode?: "checkpoint_restore_rejected" | "checkpoint_restore_partial",
+    ) =>
       Effect.gen(function* () {
         const effect = rollbackEffect(now, guarded);
         const retries = yield* Ref.make(0);
@@ -288,7 +291,7 @@ it.effect("retries legacy rollback failures while terminalizing guarded partial 
                 new OrchestrationEffectExecutionError({
                   effectId: effect.id,
                   effectType: effect.request.type,
-                  ...(guarded ? { failureCode: "checkpoint_restore_partial" as const } : {}),
+                  ...(failureCode === undefined ? {} : { failureCode }),
                   cause: "simulated rollback failure",
                 }),
               ),
@@ -308,10 +311,112 @@ it.effect("retries legacy rollback failures while terminalizing guarded partial 
       });
 
     assert.deepEqual(yield* runCase(false), { retries: 1, failures: [] });
-    assert.deepEqual(yield* runCase(true), {
+    assert.deepEqual(yield* runCase(true), { retries: 1, failures: [] });
+    assert.deepEqual(yield* runCase(true, "checkpoint_restore_partial"), {
       retries: 0,
       failures: ["checkpoint_restore_partial"],
     });
+  }),
+);
+
+it.effect("retains guarded partial classification when the first fail settlement fails", () =>
+  Effect.gen(function* () {
+    const now = yield* DateTime.now;
+    const effect = rollbackEffect(now, true);
+    const failCodes = yield* Ref.make<ReadonlyArray<string | undefined>>([]);
+    const retries = yield* Ref.make(0);
+    const outboxLayer = Layer.mock(EffectOutboxV2)({
+      claimNext: () => Effect.succeed(Option.some(effect)),
+      get: () => Effect.succeed(Option.some(effect)),
+      awaitCancellation: () => Effect.never,
+      clearCancellation: () => Effect.void,
+      fail: ({ failureCode }) =>
+        Ref.updateAndGet(failCodes, (codes) => [...codes, failureCode]).pipe(
+          Effect.flatMap((codes) =>
+            codes.length === 1
+              ? Effect.fail(
+                  new EffectOutboxError({
+                    operation: "fail",
+                    effectId: effect.id,
+                    cause: "simulated first fail settlement failure",
+                  }),
+                )
+              : Effect.succeed(true),
+          ),
+        ),
+      retry: () => Ref.update(retries, (count) => count + 1).pipe(Effect.as(true)),
+    });
+    const executorLayer = Layer.succeed(
+      OrchestrationEffectExecutorV2,
+      OrchestrationEffectExecutorV2.of({
+        execute: () =>
+          Effect.fail(
+            new OrchestrationEffectExecutionError({
+              effectId: effect.id,
+              effectType: effect.request.type,
+              failureCode: "checkpoint_restore_partial",
+              cause: "simulated partial restore",
+            }),
+          ),
+      }),
+    );
+    const workerLayer = effectWorkerLayerWithOptions({ workerId: "test-worker" }).pipe(
+      Layer.provide(Layer.merge(outboxLayer, executorLayer)),
+    );
+
+    yield* OrchestrationEffectWorkerV2.pipe(
+      Effect.flatMap((worker) => worker.runOnce),
+      Effect.provide(workerLayer),
+      Effect.exit,
+    );
+
+    assert.deepEqual(yield* Ref.get(failCodes), [
+      "checkpoint_restore_partial",
+      "checkpoint_restore_partial",
+    ]);
+    assert.equal(yield* Ref.get(retries), 0);
+  }),
+);
+
+it.effect("terminalizes an unknown guarded restore defect as partial without replay", () =>
+  Effect.gen(function* () {
+    const now = yield* DateTime.now;
+    const effect = rollbackEffect(now, true);
+    const claims = yield* Ref.make(0);
+    const executions = yield* Ref.make(0);
+    const retries = yield* Ref.make(0);
+    const failCodes = yield* Ref.make<ReadonlyArray<string | undefined>>([]);
+    const outboxLayer = Layer.mock(EffectOutboxV2)({
+      claimNext: () =>
+        Ref.getAndUpdate(claims, (count) => count + 1).pipe(
+          Effect.map((count) => (count === 0 ? Option.some(effect) : Option.none())),
+        ),
+      get: () => Effect.succeed(Option.some(effect)),
+      awaitCancellation: () => Effect.never,
+      clearCancellation: () => Effect.void,
+      fail: ({ failureCode }) =>
+        Ref.update(failCodes, (codes) => [...codes, failureCode]).pipe(Effect.as(true)),
+      retry: () => Ref.update(retries, (count) => count + 1).pipe(Effect.as(true)),
+    });
+    const executorLayer = Layer.succeed(
+      OrchestrationEffectExecutorV2,
+      OrchestrationEffectExecutorV2.of({
+        execute: () =>
+          Ref.update(executions, (count) => count + 1).pipe(
+            Effect.andThen(Effect.die("simulated defect after filesystem mutation")),
+          ),
+      }),
+    );
+    const workerLayer = effectWorkerLayerWithOptions({ workerId: "test-worker" }).pipe(
+      Layer.provide(Layer.merge(outboxLayer, executorLayer)),
+    );
+
+    const worker = yield* OrchestrationEffectWorkerV2.pipe(Effect.provide(workerLayer));
+    assert.isTrue(yield* worker.runOnce);
+    assert.isFalse(yield* worker.runOnce);
+    assert.equal(yield* Ref.get(executions), 1);
+    assert.equal(yield* Ref.get(retries), 0);
+    assert.deepEqual(yield* Ref.get(failCodes), ["checkpoint_restore_partial"]);
   }),
 );
 

--- a/apps/server/src/orchestration-v2/EffectWorker.test.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.test.ts
@@ -275,6 +275,9 @@ it.effect("classifies retry-unsafe rollback failures only for guarded MCP reques
       Effect.flip,
     );
 
+    assert.instanceOf(legacy, OrchestrationEffectExecutionError);
+    assert.instanceOf(guarded, OrchestrationEffectExecutionError);
+    assert.instanceOf(fingerprintOnly, OrchestrationEffectExecutionError);
     assert.isUndefined(legacy.failureCode);
     assert.equal(guarded.failureCode, "checkpoint_restore_partial");
     assert.equal(fingerprintOnly.failureCode, "checkpoint_restore_partial");

--- a/apps/server/src/orchestration-v2/EffectWorker.test.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.test.ts
@@ -257,9 +257,27 @@ it.effect("classifies retry-unsafe rollback failures only for guarded MCP reques
       Effect.provide(layer),
       Effect.flip,
     );
+    const fingerprintOnlyEffect = rollbackEffect(now, false);
+    const fingerprintOnly = yield* OrchestrationEffectExecutorV2.pipe(
+      Effect.flatMap((executor) =>
+        executor.execute({
+          ...fingerprintOnlyEffect,
+          request: {
+            type: "provider-thread.rollback",
+            providerThreadId,
+            checkpointId: CheckpointId.make("checkpoint:effect-worker-rollback"),
+            scopeId: CheckpointScopeId.make("scope:effect-worker-rollback"),
+            expectedWorkspaceFingerprint: "workspace-before",
+          },
+        }),
+      ),
+      Effect.provide(layer),
+      Effect.flip,
+    );
 
     assert.isUndefined(legacy.failureCode);
     assert.equal(guarded.failureCode, "checkpoint_restore_partial");
+    assert.equal(fingerprintOnly.failureCode, "checkpoint_restore_partial");
   }),
 );
 

--- a/apps/server/src/orchestration-v2/EffectWorker.test.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.test.ts
@@ -1,5 +1,7 @@
 import { assert, it } from "@effect/vitest";
 import {
+  CheckpointId,
+  CheckpointScopeId,
   CommandId,
   MessageId,
   ProviderSessionId,
@@ -20,7 +22,10 @@ import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as TestClock from "effect/testing/TestClock";
 
-import { CheckpointRollbackServiceV2 } from "./CheckpointRollbackService.ts";
+import {
+  CheckpointRollbackExecutionError,
+  CheckpointRollbackServiceV2,
+} from "./CheckpointRollbackService.ts";
 import { EffectOutboxError, EffectOutboxV2, type OrchestrationEffectV2 } from "./EffectOutbox.ts";
 import {
   executorLayer,
@@ -86,9 +91,37 @@ function restartEffect(
   };
 }
 
+function rollbackEffect(now: DateTime.Utc, guarded: boolean): OrchestrationEffectV2 {
+  const timestamp = DateTime.formatIso(now);
+  return {
+    id: `effect:checkpoint-rollback:${guarded ? "guarded" : "legacy"}`,
+    commandId: CommandId.make(`command:checkpoint-rollback:${guarded ? "guarded" : "legacy"}`),
+    threadId,
+    request: {
+      type: "provider-thread.rollback",
+      providerThreadId,
+      checkpointId: CheckpointId.make("checkpoint:effect-worker-rollback"),
+      scopeId: CheckpointScopeId.make("scope:effect-worker-rollback"),
+      ...(guarded
+        ? { expectedIdle: true as const, expectedWorkspaceFingerprint: "workspace-before" }
+        : {}),
+    },
+    status: "running",
+    attemptCount: 1,
+    availableAt: timestamp,
+    leaseOwner: "test-worker",
+    leaseExpiresAt: timestamp,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    completedAt: null,
+    lastError: null,
+  };
+}
+
 function makeExecutorLayer(input: {
   readonly events: Ref.Ref<ReadonlyArray<string>>;
   readonly failFirstStart?: Ref.Ref<boolean>;
+  readonly rollbackError?: CheckpointRollbackExecutionError;
 }) {
   const record = (event: string) => Ref.update(input.events, (events) => [...events, event]);
   const dependencies = Layer.mergeAll(
@@ -140,7 +173,10 @@ function makeExecutorLayer(input: {
     ),
     Layer.succeed(
       CheckpointRollbackServiceV2,
-      CheckpointRollbackServiceV2.of({ execute: () => Effect.void }),
+      CheckpointRollbackServiceV2.of({
+        execute: () =>
+          input.rollbackError === undefined ? Effect.void : Effect.fail(input.rollbackError),
+      }),
     ),
     Layer.succeed(
       RuntimeRequestServiceV2,
@@ -197,6 +233,87 @@ it("does not retry pure interrupt races where the turn is already gone", () => {
     ),
   );
 });
+
+it.effect("classifies retry-unsafe rollback failures only for guarded MCP requests", () =>
+  Effect.gen(function* () {
+    const now = yield* DateTime.now;
+    const events = yield* Ref.make<ReadonlyArray<string>>([]);
+    const rollbackError = new CheckpointRollbackExecutionError({
+      reason: "provider-rollback-failed-after-restore",
+      threadId,
+      providerThreadId,
+      checkpointId: CheckpointId.make("checkpoint:effect-worker-rollback"),
+      cause: "simulated provider failure",
+    });
+    const layer = makeExecutorLayer({ events, rollbackError });
+    const legacy = yield* OrchestrationEffectExecutorV2.pipe(
+      Effect.flatMap((executor) => executor.execute(rollbackEffect(now, false))),
+      Effect.provide(layer),
+      Effect.flip,
+    );
+    const guarded = yield* OrchestrationEffectExecutorV2.pipe(
+      Effect.flatMap((executor) => executor.execute(rollbackEffect(now, true))),
+      Effect.provide(layer),
+      Effect.flip,
+    );
+
+    assert.isUndefined(legacy.failureCode);
+    assert.equal(guarded.failureCode, "checkpoint_restore_partial");
+  }),
+);
+
+it.effect("retries legacy rollback failures while terminalizing guarded partial outcomes", () =>
+  Effect.gen(function* () {
+    const now = yield* DateTime.now;
+
+    const runCase = (guarded: boolean) =>
+      Effect.gen(function* () {
+        const effect = rollbackEffect(now, guarded);
+        const retries = yield* Ref.make(0);
+        const failures = yield* Ref.make<ReadonlyArray<string | undefined>>([]);
+        const outboxLayer = Layer.mock(EffectOutboxV2)({
+          claimNext: () => Effect.succeed(Option.some(effect)),
+          get: () => Effect.succeed(Option.some(effect)),
+          awaitCancellation: () => Effect.never,
+          clearCancellation: () => Effect.void,
+          retry: () => Ref.update(retries, (count) => count + 1).pipe(Effect.as(true)),
+          fail: ({ failureCode }) =>
+            Ref.update(failures, (codes) => [...codes, failureCode]).pipe(Effect.as(true)),
+        });
+        const executorLayer = Layer.succeed(
+          OrchestrationEffectExecutorV2,
+          OrchestrationEffectExecutorV2.of({
+            execute: () =>
+              Effect.fail(
+                new OrchestrationEffectExecutionError({
+                  effectId: effect.id,
+                  effectType: effect.request.type,
+                  ...(guarded ? { failureCode: "checkpoint_restore_partial" as const } : {}),
+                  cause: "simulated rollback failure",
+                }),
+              ),
+          }),
+        );
+        const workerLayer = effectWorkerLayerWithOptions({ workerId: "test-worker" }).pipe(
+          Layer.provide(Layer.merge(outboxLayer, executorLayer)),
+        );
+
+        assert.isTrue(
+          yield* OrchestrationEffectWorkerV2.pipe(
+            Effect.flatMap((worker) => worker.runOnce),
+            Effect.provide(workerLayer),
+          ),
+        );
+        return { retries: yield* Ref.get(retries), failures: yield* Ref.get(failures) };
+      });
+
+    assert.deepEqual(yield* runCase(false), { retries: 1, failures: [] });
+    assert.deepEqual(yield* runCase(true), {
+      retries: 0,
+      failures: ["checkpoint_restore_partial"],
+    });
+  }),
+);
 
 it.effect("requeues a claim when a pre-execution worker check fails", () =>
   Effect.gen(function* () {

--- a/apps/server/src/orchestration-v2/EffectWorker.test.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.test.ts
@@ -23,7 +23,8 @@ import * as Ref from "effect/Ref";
 import * as TestClock from "effect/testing/TestClock";
 
 import {
-  CheckpointRollbackExecutionError,
+  type CheckpointRollbackExecutionError,
+  CheckpointRollbackPartialError,
   CheckpointRollbackServiceV2,
 } from "./CheckpointRollbackService.ts";
 import { EffectOutboxError, EffectOutboxV2, type OrchestrationEffectV2 } from "./EffectOutbox.ts";
@@ -238,7 +239,7 @@ it.effect("classifies retry-unsafe rollback failures only for guarded MCP reques
   Effect.gen(function* () {
     const now = yield* DateTime.now;
     const events = yield* Ref.make<ReadonlyArray<string>>([]);
-    const rollbackError = new CheckpointRollbackExecutionError({
+    const rollbackError = new CheckpointRollbackPartialError({
       reason: "provider-rollback-failed-after-restore",
       threadId,
       providerThreadId,

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -584,9 +584,15 @@ export const layerWithOptions = (
           const executionError = Cause.findErrorOption(exit.cause).pipe(
             Option.filter(isOrchestrationEffectExecutionError),
           );
-          const failureCode = Option.isSome(executionError)
-            ? executionError.value.failureCode
-            : undefined;
+          const uncertainGuardedFailure =
+            isGuardedCheckpointRestore(effect) &&
+            (Cause.hasDies(exit.cause) ||
+              (!Cause.hasInterruptsOnly(exit.cause) && Option.isNone(executionError)));
+          const failureCode = uncertainGuardedFailure
+            ? "checkpoint_restore_partial"
+            : Option.isSome(executionError)
+              ? executionError.value.failureCode
+              : undefined;
           const nonRetryable = isNonRetryableProviderTurnControlFailure(effect.request.type, error);
           const terminalRollbackFailure =
             effect.request.type === "provider-thread.rollback" && failureCode !== undefined;
@@ -607,7 +613,7 @@ export const layerWithOptions = (
                   error,
                   ...(failureCode === undefined ? {} : { failureCode }),
                 })
-                .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause)))
+                .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause, failureCode)))
             : nonRetryable
             ? yield* outbox
                 .succeed({ effectId: effect.id, workerId })

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -51,7 +51,6 @@ const isOrchestrationEffectExecutionError = Schema.is(OrchestrationEffectExecuti
 function isGuardedCheckpointRestore(effect: OrchestrationEffectV2): boolean {
   return (
     effect.request.type === "provider-thread.rollback" &&
-    effect.request.expectedIdle === true &&
     effect.request.expectedWorkspaceFingerprint !== undefined
   );
 }

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -19,6 +19,7 @@ import { RunFinalizationService } from "./RunFinalizationService.ts";
 import { ResourceCleanupService } from "./ResourceCleanupService.ts";
 import {
   EffectOutboxV2,
+  OrchestrationEffectFailureCodeV2,
   REPLAY_SAFE_EFFECT_TYPES_AFTER_PROCESS_LOSS,
   type OrchestrationEffectV2,
 } from "./EffectOutbox.ts";
@@ -37,9 +38,20 @@ export class OrchestrationEffectExecutionError extends Schema.TaggedErrorClass<O
   {
     effectId: Schema.String,
     effectType: Schema.String,
+    failureCode: Schema.optional(OrchestrationEffectFailureCodeV2),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {}
+
+const isOrchestrationEffectExecutionError = Schema.is(OrchestrationEffectExecutionError);
+
+function isGuardedCheckpointRestore(effect: OrchestrationEffectV2): boolean {
+  return (
+    effect.request.type === "provider-thread.rollback" &&
+    effect.request.expectedIdle === true &&
+    effect.request.expectedWorkspaceFingerprint !== undefined
+  );
+}
 
 /**
  * Pure interrupt races with hard process teardown or a dead session produce
@@ -259,7 +271,8 @@ export const executorLayer: Layer.Layer<
                     }),
                 ),
               );
-          case "provider-thread.rollback":
+          case "provider-thread.rollback": {
+            const guardedRestore = isGuardedCheckpointRestore(effect);
             return checkpointRollback
               .execute({
                 threadId: effect.threadId,
@@ -276,15 +289,24 @@ export const executorLayer: Layer.Layer<
                     }),
               })
               .pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new OrchestrationEffectExecutionError({
-                      effectId: effect.id,
-                      effectType: effect.request.type,
-                      cause,
-                    }),
-                ),
+                Effect.mapError((cause) => {
+                  const failureCode: OrchestrationEffectFailureCodeV2 | undefined = guardedRestore
+                    ? cause.reason === "provider-rollback-failed-after-restore" ||
+                      cause.reason === "post-restore-finalization-failed"
+                      ? "checkpoint_restore_partial"
+                      : cause.reason === "unexpected-failure"
+                        ? undefined
+                        : "checkpoint_restore_rejected"
+                    : undefined;
+                  return new OrchestrationEffectExecutionError({
+                    effectId: effect.id,
+                    effectType: effect.request.type,
+                    ...(failureCode === undefined ? {} : { failureCode }),
+                    cause,
+                  });
+                }),
               );
+          }
           case "checkpoint.capture":
             return runFinalization
               .finalize({
@@ -434,13 +456,18 @@ export const layerWithOptions = (
                   }),
                 ),
               );
-      const terminalizeClaim = (effect: OrchestrationEffectV2, cause: Cause.Cause<unknown>) => {
+      const terminalizeClaim = (
+        effect: OrchestrationEffectV2,
+        cause: Cause.Cause<unknown>,
+        failureCode?: OrchestrationEffectFailureCodeV2,
+      ) => {
         if (Cause.hasInterruptsOnly(cause)) return Effect.void;
         return outbox
           .fail({
             effectId: effect.id,
             workerId,
             error: `Worker failed to settle a process-bound effect after execution started: ${Cause.pretty(cause)}`,
+            ...(failureCode === undefined ? {} : { failureCode }),
           })
           .pipe(
             Effect.flatMap((failed) =>
@@ -473,11 +500,13 @@ export const layerWithOptions = (
         effect: OrchestrationEffectV2,
         cause: Cause.Cause<unknown>,
       ) =>
-        REPLAY_SAFE_EFFECT_TYPES_AFTER_PROCESS_LOSS.some(
-          (effectType) => effectType === effect.request.type,
-        )
-          ? requeueClaim(effect, cause)
-          : terminalizeClaim(effect, cause);
+        isGuardedCheckpointRestore(effect)
+          ? terminalizeClaim(effect, cause, "checkpoint_restore_partial")
+          : REPLAY_SAFE_EFFECT_TYPES_AFTER_PROCESS_LOSS.some(
+                (effectType) => effectType === effect.request.type,
+              )
+            ? requeueClaim(effect, cause)
+            : terminalizeClaim(effect, cause);
 
       const runOnce = (excludeRestartContinuations = false) =>
         Effect.gen(function* () {
@@ -552,8 +581,15 @@ export const layerWithOptions = (
           }
 
           const error = Cause.pretty(exit.cause);
+          const executionError = Cause.findErrorOption(exit.cause).pipe(
+            Option.filter(isOrchestrationEffectExecutionError),
+          );
+          const failureCode = Option.isSome(executionError)
+            ? executionError.value.failureCode
+            : undefined;
           const nonRetryable = isNonRetryableProviderTurnControlFailure(effect.request.type, error);
-          const terminalRollbackFailure = effect.request.type === "provider-thread.rollback";
+          const terminalRollbackFailure =
+            effect.request.type === "provider-thread.rollback" && failureCode !== undefined;
           yield* Effect.logWarning("Orchestration effect execution failed", {
             effectId: effect.id,
             effectType: effect.request.type,
@@ -565,7 +601,12 @@ export const layerWithOptions = (
           // keep a failed interrupt around; fail only when we must not retry.
           const updated = terminalRollbackFailure
             ? yield* outbox
-                .fail({ effectId: effect.id, workerId, error })
+                .fail({
+                  effectId: effect.id,
+                  workerId,
+                  error,
+                  ...(failureCode === undefined ? {} : { failureCode }),
+                })
                 .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause)))
             : nonRetryable
             ? yield* outbox

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -57,28 +57,22 @@ function isGuardedCheckpointRestore(effect: OrchestrationEffectV2): boolean {
 }
 
 function guardedCheckpointRestoreFailureCode(
-  reason: CheckpointRollbackExecutionError["reason"],
+  error: CheckpointRollbackExecutionError,
 ): OrchestrationEffectFailureCodeV2 | undefined {
-  switch (reason) {
-    case "provider-rollback-failed-after-restore":
-    case "post-restore-finalization-failed":
+  switch (error._tag) {
+    case "CheckpointRollbackPartialError":
       return "checkpoint_restore_partial";
-    case "unexpected-failure":
+    case "CheckpointRollbackPreflightError":
       return undefined;
-    case "rollback-target-invalid":
-    case "rollback-target-ambiguous":
-    case "active-provider-changed":
-    case "provider-turn-unavailable":
-    case "thread-not-idle":
-    case "restore-precondition-changed":
+    case "CheckpointRollbackRejectedError":
       return "checkpoint_restore_rejected";
   }
 
-  return assertUnhandledCheckpointRollbackReason(reason);
+  return assertUnhandledCheckpointRollbackError(error);
 }
 
-function assertUnhandledCheckpointRollbackReason(reason: never): never {
-  throw new Error(`Unhandled checkpoint rollback failure reason: ${String(reason)}`);
+function assertUnhandledCheckpointRollbackError(error: never): never {
+  throw new Error(`Unhandled checkpoint rollback failure: ${String(error)}`);
 }
 
 /**
@@ -319,7 +313,7 @@ export const executorLayer: Layer.Layer<
               .pipe(
                 Effect.mapError((cause) => {
                   const failureCode: OrchestrationEffectFailureCodeV2 | undefined = guardedRestore
-                    ? guardedCheckpointRestoreFailureCode(cause.reason)
+                    ? guardedCheckpointRestoreFailureCode(cause)
                     : undefined;
                   return new OrchestrationEffectExecutionError({
                     effectId: effect.id,

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -73,6 +73,12 @@ function guardedCheckpointRestoreFailureCode(
     case "restore-precondition-changed":
       return "checkpoint_restore_rejected";
   }
+
+  return assertUnhandledCheckpointRollbackReason(reason);
+}
+
+function assertUnhandledCheckpointRollbackReason(reason: never): never {
+  throw new Error(`Unhandled checkpoint rollback failure reason: ${String(reason)}`);
 }
 
 /**

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -23,7 +23,10 @@ import {
   REPLAY_SAFE_EFFECT_TYPES_AFTER_PROCESS_LOSS,
   type OrchestrationEffectV2,
 } from "./EffectOutbox.ts";
-import { CheckpointRollbackServiceV2 } from "./CheckpointRollbackService.ts";
+import {
+  type CheckpointRollbackExecutionError,
+  CheckpointRollbackServiceV2,
+} from "./CheckpointRollbackService.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { ProviderTurnControlServiceV2 } from "./ProviderTurnControlService.ts";
 import { ProviderTurnStartServiceV2 } from "./ProviderTurnStartService.ts";
@@ -51,6 +54,25 @@ function isGuardedCheckpointRestore(effect: OrchestrationEffectV2): boolean {
     effect.request.expectedIdle === true &&
     effect.request.expectedWorkspaceFingerprint !== undefined
   );
+}
+
+function guardedCheckpointRestoreFailureCode(
+  reason: CheckpointRollbackExecutionError["reason"],
+): OrchestrationEffectFailureCodeV2 | undefined {
+  switch (reason) {
+    case "provider-rollback-failed-after-restore":
+    case "post-restore-finalization-failed":
+      return "checkpoint_restore_partial";
+    case "unexpected-failure":
+      return undefined;
+    case "rollback-target-invalid":
+    case "rollback-target-ambiguous":
+    case "active-provider-changed":
+    case "provider-turn-unavailable":
+    case "thread-not-idle":
+    case "restore-precondition-changed":
+      return "checkpoint_restore_rejected";
+  }
 }
 
 /**
@@ -291,12 +313,7 @@ export const executorLayer: Layer.Layer<
               .pipe(
                 Effect.mapError((cause) => {
                   const failureCode: OrchestrationEffectFailureCodeV2 | undefined = guardedRestore
-                    ? cause.reason === "provider-rollback-failed-after-restore" ||
-                      cause.reason === "post-restore-finalization-failed"
-                      ? "checkpoint_restore_partial"
-                      : cause.reason === "unexpected-failure"
-                        ? undefined
-                        : "checkpoint_restore_rejected"
+                    ? guardedCheckpointRestoreFailureCode(cause.reason)
                     : undefined;
                   return new OrchestrationEffectExecutionError({
                     effectId: effect.id,

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -631,21 +631,21 @@ export const layerWithOptions = (
                 })
                 .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause, failureCode)))
             : nonRetryable
-            ? yield* outbox
-                .succeed({ effectId: effect.id, workerId })
-                .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause)))
-            : effect.attemptCount >= maxAttempts
               ? yield* outbox
-                  .fail({ effectId: effect.id, workerId, error })
+                  .succeed({ effectId: effect.id, workerId })
                   .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause)))
-              : yield* outbox
-                  .retry({
-                    effectId: effect.id,
-                    workerId,
-                    error,
-                    delayMs: Math.min(30_000, 100 * 2 ** Math.max(0, effect.attemptCount - 1)),
-                  })
-                  .pipe(Effect.onError((cause) => requeueClaim(effect, cause)));
+              : effect.attemptCount >= maxAttempts
+                ? yield* outbox
+                    .fail({ effectId: effect.id, workerId, error })
+                    .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause)))
+                : yield* outbox
+                    .retry({
+                      effectId: effect.id,
+                      workerId,
+                      error,
+                      delayMs: Math.min(30_000, 100 * 2 ** Math.max(0, effect.attemptCount - 1)),
+                    })
+                    .pipe(Effect.onError((cause) => requeueClaim(effect, cause)));
           if (!updated) {
             if (yield* wasCancelled(effect.id)) return true;
             return yield* new OrchestrationEffectWorkerError({

--- a/apps/server/src/orchestration-v2/EffectWorker.ts
+++ b/apps/server/src/orchestration-v2/EffectWorker.ts
@@ -266,6 +266,14 @@ export const executorLayer: Layer.Layer<
                 providerThreadId: effect.request.providerThreadId,
                 checkpointId: effect.request.checkpointId,
                 scopeId: effect.request.scopeId,
+                ...(effect.request.expectedIdle === undefined
+                  ? {}
+                  : { expectedIdle: effect.request.expectedIdle }),
+                ...(effect.request.expectedWorkspaceFingerprint === undefined
+                  ? {}
+                  : {
+                      expectedWorkspaceFingerprint: effect.request.expectedWorkspaceFingerprint,
+                    }),
               })
               .pipe(
                 Effect.mapError(
@@ -545,6 +553,7 @@ export const layerWithOptions = (
 
           const error = Cause.pretty(exit.cause);
           const nonRetryable = isNonRetryableProviderTurnControlFailure(effect.request.type, error);
+          const terminalRollbackFailure = effect.request.type === "provider-thread.rollback";
           yield* Effect.logWarning("Orchestration effect execution failed", {
             effectId: effect.id,
             effectType: effect.request.type,
@@ -554,7 +563,11 @@ export const layerWithOptions = (
           });
           // Prefer succeed for terminal interrupt races so the outbox does not
           // keep a failed interrupt around; fail only when we must not retry.
-          const updated = nonRetryable
+          const updated = terminalRollbackFailure
+            ? yield* outbox
+                .fail({ effectId: effect.id, workerId, error })
+                .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause)))
+            : nonRetryable
             ? yield* outbox
                 .succeed({ effectId: effect.id, workerId })
                 .pipe(Effect.onError((cause) => terminalizeClaim(effect, cause)))

--- a/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
+++ b/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
@@ -2348,6 +2348,7 @@ it.layer(TestLayer)("orchestration V2 foundation persistence", (it) => {
       assert.isTrue(Option.isSome(recovered));
       if (Option.isSome(recovered)) {
         assert.equal(recovered.value.id, "effect:b-foundation-legacy-rollback");
+        yield* outbox.succeed({ effectId: recovered.value.id, workerId: "recovery-worker" });
       }
     }),
   );

--- a/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
+++ b/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
@@ -2245,6 +2245,89 @@ it.layer(TestLayer)("orchestration V2 foundation persistence", (it) => {
     }),
   );
 
+  it.effect("does not repeat a guarded checkpoint restore after process loss", () =>
+    Effect.gen(function* () {
+      const outbox = yield* EffectOutboxV2;
+      const commandId = CommandId.make("command:foundation-rollback-process-loss");
+      const rollbackThreadId = ThreadId.make("thread:foundation-rollback-process-loss");
+      const rollbackProviderThreadId = ProviderThreadId.make(
+        "provider-thread:foundation-rollback-process-loss",
+      );
+      const checkpointId = CheckpointId.make("checkpoint:foundation-rollback-process-loss");
+      const scopeId = CheckpointScopeId.make("scope:foundation-rollback-process-loss");
+      yield* outbox.enqueue([
+        {
+          id: "effect:a-foundation-guarded-rollback",
+          commandId,
+          threadId: rollbackThreadId,
+          request: {
+            type: "provider-thread.rollback",
+            providerThreadId: rollbackProviderThreadId,
+            checkpointId,
+            scopeId,
+            expectedIdle: true,
+            expectedWorkspaceFingerprint: "workspace-before-restore",
+          },
+        },
+        {
+          id: "effect:b-foundation-legacy-rollback",
+          commandId,
+          threadId: ThreadId.make("thread:foundation-legacy-rollback-process-loss"),
+          request: {
+            type: "provider-thread.rollback",
+            providerThreadId: rollbackProviderThreadId,
+            checkpointId,
+            scopeId,
+          },
+        },
+      ]);
+      assert.isTrue(
+        Option.isSome(
+          yield* outbox.claimNext({ workerId: "crashed-worker", leaseDurationMs: 30_000 }),
+        ),
+      );
+      assert.isTrue(
+        Option.isSome(
+          yield* outbox.claimNext({ workerId: "crashed-worker", leaseDurationMs: 30_000 }),
+        ),
+      );
+
+      const runningGuarded = yield* outbox.get("effect:a-foundation-guarded-rollback");
+      assert.isTrue(Option.isSome(runningGuarded));
+      if (
+        Option.isSome(runningGuarded) &&
+        runningGuarded.value.request.type === "provider-thread.rollback"
+      ) {
+        assert.equal(runningGuarded.value.status, "running");
+        assert.isTrue(runningGuarded.value.request.expectedIdle);
+        assert.equal(
+          runningGuarded.value.request.expectedWorkspaceFingerprint,
+          "workspace-before-restore",
+        );
+      }
+
+      assert.deepEqual(yield* outbox.reconcileAfterProcessLoss, {
+        cancelled: 0,
+        requeued: 1,
+      });
+      const guarded = yield* outbox.get("effect:a-foundation-guarded-rollback");
+      assert.isTrue(Option.isSome(guarded));
+      if (Option.isSome(guarded)) {
+        assert.equal(guarded.value.status, "failed");
+        assert.equal(guarded.value.failureCode, "checkpoint_restore_partial");
+        assert.include(guarded.value.lastError ?? "", "outcome is uncertain");
+      }
+      const recovered = yield* outbox.claimNext({
+        workerId: "recovery-worker",
+        leaseDurationMs: 30_000,
+      });
+      assert.isTrue(Option.isSome(recovered));
+      if (Option.isSome(recovered)) {
+        assert.equal(recovered.value.id, "effect:b-foundation-legacy-rollback");
+      }
+    }),
+  );
+
   for (const replayRequest of [
     { type: "terminal.cleanup" },
     { type: "provider-runtime.continue", sourceRunId: RunId.make("run:restart-replay") },

--- a/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
+++ b/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
@@ -2280,7 +2280,24 @@ it.layer(TestLayer)("orchestration V2 foundation persistence", (it) => {
             scopeId,
           },
         },
+        {
+          id: "effect:c-foundation-fingerprint-rollback",
+          commandId,
+          threadId: ThreadId.make("thread:foundation-fingerprint-rollback-process-loss"),
+          request: {
+            type: "provider-thread.rollback",
+            providerThreadId: rollbackProviderThreadId,
+            checkpointId,
+            scopeId,
+            expectedWorkspaceFingerprint: "workspace-before-restore",
+          },
+        },
       ]);
+      assert.isTrue(
+        Option.isSome(
+          yield* outbox.claimNext({ workerId: "crashed-worker", leaseDurationMs: 30_000 }),
+        ),
+      );
       assert.isTrue(
         Option.isSome(
           yield* outbox.claimNext({ workerId: "crashed-worker", leaseDurationMs: 30_000 }),
@@ -2316,6 +2333,13 @@ it.layer(TestLayer)("orchestration V2 foundation persistence", (it) => {
         assert.equal(guarded.value.status, "failed");
         assert.equal(guarded.value.failureCode, "checkpoint_restore_partial");
         assert.include(guarded.value.lastError ?? "", "outcome is uncertain");
+      }
+      const fingerprintGuarded = yield* outbox.get("effect:c-foundation-fingerprint-rollback");
+      assert.isTrue(Option.isSome(fingerprintGuarded));
+      if (Option.isSome(fingerprintGuarded)) {
+        assert.equal(fingerprintGuarded.value.status, "failed");
+        assert.equal(fingerprintGuarded.value.failureCode, "checkpoint_restore_partial");
+        assert.include(fingerprintGuarded.value.lastError ?? "", "outcome is uncertain");
       }
       const recovered = yield* outbox.claimNext({
         workerId: "recovery-worker",

--- a/apps/server/src/orchestration-v2/KeyedSerialExecutor.ts
+++ b/apps/server/src/orchestration-v2/KeyedSerialExecutor.ts
@@ -1,4 +1,7 @@
+import { ThreadId } from "@t3tools/contracts";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import * as Semaphore from "effect/Semaphore";
 
@@ -53,3 +56,14 @@ export const makeKeyedSerialExecutor = <Key>(): Effect.Effect<KeyedSerialExecuto
         ),
     } satisfies KeyedSerialExecutor<Key>;
   });
+
+/** The single in-process admission boundary for commands targeting a V2 thread. */
+export class ThreadDispatchLockV2 extends Context.Service<
+  ThreadDispatchLockV2,
+  KeyedSerialExecutor<ThreadId>
+>()("t3/orchestration-v2/KeyedSerialExecutor/ThreadDispatchLockV2") {}
+
+export const threadDispatchLockLayer = Layer.effect(
+  ThreadDispatchLockV2,
+  makeKeyedSerialExecutor<ThreadId>(),
+);

--- a/apps/server/src/orchestration-v2/KeyedSerialExecutor.ts
+++ b/apps/server/src/orchestration-v2/KeyedSerialExecutor.ts
@@ -1,7 +1,4 @@
-import { ThreadId } from "@t3tools/contracts";
-import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import * as Semaphore from "effect/Semaphore";
 
@@ -56,14 +53,3 @@ export const makeKeyedSerialExecutor = <Key>(): Effect.Effect<KeyedSerialExecuto
         ),
     } satisfies KeyedSerialExecutor<Key>;
   });
-
-/** The single in-process admission boundary for commands targeting a V2 thread. */
-export class ThreadDispatchLockV2 extends Context.Service<
-  ThreadDispatchLockV2,
-  KeyedSerialExecutor<ThreadId>
->()("t3/orchestration-v2/KeyedSerialExecutor/ThreadDispatchLockV2") {}
-
-export const threadDispatchLockLayer = Layer.effect(
-  ThreadDispatchLockV2,
-  makeKeyedSerialExecutor<ThreadId>(),
-);

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -7473,7 +7473,6 @@ export const layer: Layer.Layer<
   | EventSinkV2
   | EffectOutboxV2
   | IdAllocatorV2
-  | ThreadDispatchLockV2
   | ProviderAdapterRegistryV2
   | ProviderSessionManagerV2
   | ProviderSwitchServiceV2

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -44,7 +44,11 @@ import { CommandPolicyV2 } from "./CommandPolicy.ts";
 import { CommandReceiptStoreV2 } from "./CommandReceiptStore.ts";
 import { ContextHandoffServiceV2 } from "./ContextHandoffService.ts";
 import { EventSinkV2 } from "./EventSink.ts";
-import type { OrchestrationEffectRequestV2, PendingOrchestrationEffectV2 } from "./EffectOutbox.ts";
+import {
+  EffectOutboxV2,
+  type OrchestrationEffectRequestV2,
+  type PendingOrchestrationEffectV2,
+} from "./EffectOutbox.ts";
 import { IdAllocatorV2 } from "./IdAllocator.ts";
 import {
   ThreadCommandExecutor,
@@ -215,6 +219,8 @@ export interface OrchestratorV2Shape {
   readonly getThreadEventSequence: (
     threadId: ThreadId,
   ) => Effect.Effect<number, OrchestratorV2Error>;
+  readonly getCommandReceipt: CommandReceiptStoreV2["Service"]["getByCommandId"];
+  readonly listCommandEffects: EffectOutboxV2["Service"]["listByCommandId"];
   readonly streamStoredEvents: Stream.Stream<OrchestrationV2StoredEvent, OrchestratorV2Error>;
   readonly streamStoredEventsFrom: (input?: {
     readonly threadId?: ThreadId;
@@ -543,6 +549,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
   const contextHandoffService = yield* ContextHandoffServiceV2;
   const eventSink = yield* EventSinkV2;
   const commandReceipts = yield* CommandReceiptStoreV2;
+  const effectOutbox = yield* EffectOutboxV2;
   const idAllocator = yield* IdAllocatorV2;
   const projectionStore = yield* ProjectionStoreV2;
   const providerAdapters = yield* ProviderAdapterRegistryV2;
@@ -6143,6 +6150,18 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
   ) =>
     Effect.gen(function* () {
       const projection = yield* loadProjectionForCommand(command);
+      if (
+        command.expectedIdle === true &&
+        projection.runs.some((run) =>
+          ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
+        )
+      ) {
+        return yield* new OrchestratorDispatchError({
+          commandId: command.commandId,
+          commandType: command.type,
+          cause: "Checkpoint rollback requires an idle thread with no queued runs.",
+        });
+      }
       const providerThread = projection.providerThreads.find(
         (candidate) => candidate.id === projection.thread.activeProviderThreadId,
       );
@@ -6256,6 +6275,10 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
             providerThreadId: providerThread.id,
             checkpointId: targetCheckpoint.id,
             scopeId: targetScope.id,
+            ...(command.expectedIdle === undefined ? {} : { expectedIdle: command.expectedIdle }),
+            ...(command.expectedWorkspaceFingerprint === undefined
+              ? {}
+              : { expectedWorkspaceFingerprint: command.expectedWorkspaceFingerprint }),
           },
         } satisfies PendingOrchestrationEffectV2,
       ]);
@@ -7366,6 +7389,8 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       eventSink
         .latestSequence({ threadId })
         .pipe(Effect.mapError((cause) => new OrchestratorProjectionError({ threadId, cause }))),
+    getCommandReceipt: commandReceipts.getByCommandId,
+    listCommandEffects: effectOutbox.listByCommandId,
     streamStoredEvents: eventSink.stream().pipe(
       Stream.mapError(
         (cause) =>
@@ -7411,6 +7436,7 @@ export const layer: Layer.Layer<
   | CommandReceiptStoreV2
   | ContextHandoffServiceV2
   | EventSinkV2
+  | EffectOutboxV2
   | IdAllocatorV2
   | ProviderAdapterRegistryV2
   | ProviderSessionManagerV2
@@ -7489,6 +7515,8 @@ export const layerUnavailable: Layer.Layer<OrchestratorV2> = Layer.succeed(
           cause: "Orchestration V2 live runtime is not configured.",
         }),
       ),
+    getCommandReceipt: () => Effect.succeed(Option.none()),
+    listCommandEffects: () => Effect.succeed([]),
     streamStoredEvents: Stream.fail(
       new OrchestratorDomainEventStreamError({
         cause: "Orchestration V2 live runtime is not configured.",

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -1,5 +1,7 @@
 import {
   type ChatAttachment,
+  checkpointRollbackAppRunOrdinal,
+  CheckpointId,
   CommandId,
   MessageId,
   type ModelSelection,
@@ -152,6 +154,31 @@ export class OrchestratorCommandIdConflictError extends Schema.TaggedErrorClass<
   }
 }
 
+export class OrchestratorCheckpointRollbackNotIdleError extends Schema.TaggedErrorClass<OrchestratorCheckpointRollbackNotIdleError>()(
+  "OrchestratorCheckpointRollbackNotIdleError",
+  {
+    commandId: CommandId,
+    threadId: ThreadId,
+  },
+) {
+  override get message(): string {
+    return `Checkpoint rollback ${this.commandId} requires idle thread ${this.threadId} with no queued runs.`;
+  }
+}
+
+export class OrchestratorCheckpointRollbackTargetUnsupportedError extends Schema.TaggedErrorClass<OrchestratorCheckpointRollbackTargetUnsupportedError>()(
+  "OrchestratorCheckpointRollbackTargetUnsupportedError",
+  {
+    commandId: CommandId,
+    threadId: ThreadId,
+    checkpointId: CheckpointId,
+  },
+) {
+  override get message(): string {
+    return `Checkpoint ${this.checkpointId} does not identify a proven provider-history target for thread ${this.threadId}.`;
+  }
+}
+
 /**
  * A command receipt only proves that this exact command already ran for the
  * thread it was recorded against. Replaying it for a command aimed at another
@@ -172,6 +199,8 @@ export const OrchestratorV2Error = Schema.Union([
   OrchestratorProviderAdapterError,
   OrchestratorCommandPreviouslyRejectedError,
   OrchestratorCommandIdConflictError,
+  OrchestratorCheckpointRollbackNotIdleError,
+  OrchestratorCheckpointRollbackTargetUnsupportedError,
 ]);
 export type OrchestratorV2Error = typeof OrchestratorV2Error.Type;
 
@@ -6156,10 +6185,9 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           ["preparing", "queued", "starting", "running", "waiting"].includes(run.status),
         )
       ) {
-        return yield* new OrchestratorDispatchError({
+        return yield* new OrchestratorCheckpointRollbackNotIdleError({
           commandId: command.commandId,
-          commandType: command.type,
-          cause: "Checkpoint rollback requires an idle thread with no queued runs.",
+          threadId: command.threadId,
         });
       }
       const providerThread = projection.providerThreads.find(
@@ -6228,7 +6256,14 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           cause: `Checkpoint ${command.checkpointId} belongs to scope ${targetScope.id}, not ${command.scopeId}.`,
         });
       }
-      const targetOrdinal = targetCheckpoint.appRunOrdinal ?? 0;
+      const targetOrdinal = checkpointRollbackAppRunOrdinal(targetCheckpoint, targetScope);
+      if (targetOrdinal === null) {
+        return yield* new OrchestratorCheckpointRollbackTargetUnsupportedError({
+          commandId: command.commandId,
+          threadId: command.threadId,
+          checkpointId: targetCheckpoint.id,
+        });
+      }
       if (targetOrdinal > 0) {
         const targetRun = projection.runs.find((run) => run.ordinal === targetOrdinal);
         const targetProviderTurn =
@@ -7438,6 +7473,7 @@ export const layer: Layer.Layer<
   | EventSinkV2
   | EffectOutboxV2
   | IdAllocatorV2
+  | ThreadDispatchLockV2
   | ProviderAdapterRegistryV2
   | ProviderSessionManagerV2
   | ProviderSwitchServiceV2

--- a/apps/server/src/orchestration-v2/ThreadManagementService.ts
+++ b/apps/server/src/orchestration-v2/ThreadManagementService.ts
@@ -299,6 +299,8 @@ export interface ThreadManagementServiceShape {
     input: ThreadManagementInterruptInput,
   ) => Effect.Effect<ThreadManagementInterruptResult, ThreadManagementFailure>;
   readonly getThreadEventSequence: OrchestratorV2["Service"]["getThreadEventSequence"];
+  readonly getCommandReceipt: OrchestratorV2["Service"]["getCommandReceipt"];
+  readonly listCommandEffects: OrchestratorV2["Service"]["listCommandEffects"];
   readonly streamStoredEvents: OrchestratorV2["Service"]["streamStoredEvents"];
   readonly streamStoredEventsFrom: OrchestratorV2["Service"]["streamStoredEventsFrom"];
   readonly streamDomainEvents: OrchestratorV2["Service"]["streamDomainEvents"];
@@ -671,6 +673,8 @@ const make = Effect.gen(function* () {
     waitForThread,
     interruptThread,
     getThreadEventSequence: orchestrator.getThreadEventSequence,
+    getCommandReceipt: orchestrator.getCommandReceipt,
+    listCommandEffects: orchestrator.listCommandEffects,
     streamStoredEvents: orchestrator.streamStoredEvents,
     streamStoredEventsFrom: orchestrator.streamStoredEventsFrom,
     streamDomainEvents: orchestrator.streamDomainEvents,

--- a/apps/server/src/orchestration-v2/runtimeLayer.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.ts
@@ -23,7 +23,6 @@ import { layerFromStores as eventSinkLayer } from "./EventSink.ts";
 import { layerFromOrchestrationEventStore as eventStoreLayer } from "./EventStore.ts";
 import { layer as idAllocatorLayer } from "./IdAllocator.ts";
 import { layer as legacyV1ThreadImporterLayer } from "./LegacyV1ThreadImporter.ts";
-import { threadDispatchLockLayer } from "./KeyedSerialExecutor.ts";
 import { layer as orchestratorLayer } from "./Orchestrator.ts";
 import { layer as projectionStoreLayer } from "./ProjectionStore.ts";
 import { layer as projectionMaintenanceLayer } from "./ProjectionMaintenance.ts";
@@ -31,6 +30,7 @@ import { layerFromProviderInstanceRegistry as providerAdapterRegistryLayerFromPr
 import { layer as providerContinuationRequestsLayer } from "./ProviderContinuationRequests.ts";
 import { workerLive as providerContinuationWorkerLive } from "./ProviderContinuationService.ts";
 import { layer as threadTitleRegenerationServiceLayer } from "./ThreadTitleRegenerationService.ts";
+import { layer as threadCommandExecutorLayer } from "./ThreadCommandExecutor.ts";
 import { layer as providerEventIngestorLayer } from "./ProviderEventIngestor.ts";
 import { layer as providerSessionManagerLayer } from "./ProviderSessionManager.ts";
 import { layer as providerRuntimeRecoveryLayer } from "./ProviderRuntimeRecoveryService.ts";
@@ -158,7 +158,7 @@ const checkpointRollbackServiceProvided = checkpointRollbackServiceLayer.pipe(
       projectionStoreLayer,
       providerSessionManagerProvided,
       runtimePolicyProvided,
-      threadDispatchLockLayer,
+      threadCommandExecutorLayer,
     ),
   ),
 );
@@ -196,7 +196,6 @@ const orchestratorProvided = orchestratorLayer.pipe(
       providerSwitchServiceProvided,
       runExecutionServiceProvided,
       threadForkServiceLayer,
-      threadDispatchLockLayer,
     ),
   ),
 );

--- a/apps/server/src/orchestration-v2/runtimeLayer.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.ts
@@ -23,6 +23,7 @@ import { layerFromStores as eventSinkLayer } from "./EventSink.ts";
 import { layerFromOrchestrationEventStore as eventStoreLayer } from "./EventStore.ts";
 import { layer as idAllocatorLayer } from "./IdAllocator.ts";
 import { layer as legacyV1ThreadImporterLayer } from "./LegacyV1ThreadImporter.ts";
+import { threadDispatchLockLayer } from "./KeyedSerialExecutor.ts";
 import { layer as orchestratorLayer } from "./Orchestrator.ts";
 import { layer as projectionStoreLayer } from "./ProjectionStore.ts";
 import { layer as projectionMaintenanceLayer } from "./ProjectionMaintenance.ts";
@@ -157,6 +158,7 @@ const checkpointRollbackServiceProvided = checkpointRollbackServiceLayer.pipe(
       projectionStoreLayer,
       providerSessionManagerProvided,
       runtimePolicyProvided,
+      threadDispatchLockLayer,
     ),
   ),
 );
@@ -194,6 +196,7 @@ const orchestratorProvided = orchestratorLayer.pipe(
       providerSwitchServiceProvided,
       runExecutionServiceProvided,
       threadForkServiceLayer,
+      threadDispatchLockLayer,
     ),
   ),
 );

--- a/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
+++ b/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
@@ -20,6 +20,7 @@ import * as VcsProcess from "../../vcs/VcsProcess.ts";
 import { layer as checkpointCaptureServiceLayer } from "../CheckpointCaptureService.ts";
 import { layer as checkpointServiceLayer } from "../CheckpointService.ts";
 import { layer as checkpointRollbackServiceLayer } from "../CheckpointRollbackService.ts";
+import { threadDispatchLockLayer } from "../KeyedSerialExecutor.ts";
 import { layer as commandPolicyLayer } from "../CommandPolicy.ts";
 import { layer as commandReceiptStoreLayer } from "../CommandReceiptStore.ts";
 import { layer as contextHandoffServiceLayer } from "../ContextHandoffService.ts";
@@ -347,6 +348,7 @@ export function makeOrchestratorV2ReplayLayerWithRegistry<Error>(
         storesLayer,
         providerSessionManagerProvided,
         runtimeLayer,
+        threadDispatchLockLayer,
       ),
     ),
   );
@@ -393,6 +395,7 @@ export function makeOrchestratorV2ReplayLayerWithRegistry<Error>(
         providerSwitchServiceProvided,
         runExecutionServiceProvided,
         threadForkServiceLayer,
+        threadDispatchLockLayer,
       ),
     ),
   );

--- a/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
+++ b/apps/server/src/orchestration-v2/testkit/ProviderReplayHarness.ts
@@ -20,7 +20,7 @@ import * as VcsProcess from "../../vcs/VcsProcess.ts";
 import { layer as checkpointCaptureServiceLayer } from "../CheckpointCaptureService.ts";
 import { layer as checkpointServiceLayer } from "../CheckpointService.ts";
 import { layer as checkpointRollbackServiceLayer } from "../CheckpointRollbackService.ts";
-import { threadDispatchLockLayer } from "../KeyedSerialExecutor.ts";
+import { layer as threadCommandExecutorLayer } from "../ThreadCommandExecutor.ts";
 import { layer as commandPolicyLayer } from "../CommandPolicy.ts";
 import { layer as commandReceiptStoreLayer } from "../CommandReceiptStore.ts";
 import { layer as contextHandoffServiceLayer } from "../ContextHandoffService.ts";
@@ -348,7 +348,7 @@ export function makeOrchestratorV2ReplayLayerWithRegistry<Error>(
         storesLayer,
         providerSessionManagerProvided,
         runtimeLayer,
-        threadDispatchLockLayer,
+        threadCommandExecutorLayer,
       ),
     ),
   );
@@ -395,7 +395,7 @@ export function makeOrchestratorV2ReplayLayerWithRegistry<Error>(
         providerSwitchServiceProvided,
         runExecutionServiceProvided,
         threadForkServiceLayer,
-        threadDispatchLockLayer,
+        threadCommandExecutorLayer,
       ),
     ),
   );

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -1,3 +1,5 @@
+import * as NodeCrypto from "node:crypto";
+
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -28,6 +30,7 @@ export interface ProcessRunInput {
   readonly maxOutputBytes?: number | undefined;
   readonly outputMode?: "error" | "truncate" | undefined;
   readonly truncatedMarker?: string | undefined;
+  readonly stdoutDigest?: "sha256" | undefined;
   /**
    * On timeout, return a synthetic timedOut result.
    * Partial stdout/stderr are not preserved.
@@ -44,6 +47,7 @@ export interface ProcessRunOutput {
   readonly stderrTruncated: boolean;
   readonly stdoutInvalidUtf8: boolean;
   readonly stderrInvalidUtf8: boolean;
+  readonly stdoutDigest?: string | undefined;
 }
 
 const ProcessInvocationFields = {
@@ -247,6 +251,35 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
   );
 });
 
+const digestStream = Effect.fn("processRunner.digestStream")(function* (input: {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string | undefined;
+  readonly spawnCwd?: string | undefined;
+  readonly stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>;
+}) {
+  const digest = NodeCrypto.createHash("sha256");
+  yield* input.stream.pipe(
+    Stream.mapError(
+      (cause) =>
+        new ProcessReadError({
+          command: input.command,
+          argumentCount: input.args.length,
+          cwd: input.cwd,
+          spawnCwd: input.spawnCwd,
+          stream: "stdout",
+          cause,
+        }),
+    ),
+    Stream.runForEach((chunk) =>
+      Effect.sync(() => {
+        digest.update(chunk);
+      }),
+    ),
+  );
+  return digest.digest("hex");
+});
+
 function finalizeRunProcess<R>(
   effect: Effect.Effect<ProcessRunOutput, ProcessRunError, R | Scope.Scope>,
   input: ProcessRunInput,
@@ -349,17 +382,32 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
 
   const [stdout, stderr] = yield* Effect.all(
     [
-      collectText({
-        command: input.command,
-        args: input.args,
-        cwd: input.cwd,
-        spawnCwd: input.spawnCwd,
-        streamName: "stdout",
-        stream: child.stdout,
-        maxOutputBytes,
-        outputMode,
-        truncatedMarker,
-      }),
+      input.stdoutDigest === "sha256"
+        ? digestStream({
+            command: input.command,
+            args: input.args,
+            cwd: input.cwd,
+            spawnCwd: input.spawnCwd,
+            stream: child.stdout,
+          }).pipe(
+            Effect.map((digest) => ({
+              text: "",
+              truncated: false,
+              invalidUtf8: false,
+              digest,
+            })),
+          )
+        : collectText({
+            command: input.command,
+            args: input.args,
+            cwd: input.cwd,
+            spawnCwd: input.spawnCwd,
+            streamName: "stdout",
+            stream: child.stdout,
+            maxOutputBytes,
+            outputMode,
+            truncatedMarker,
+          }),
       collectText({
         command: input.command,
         args: input.args,
@@ -399,6 +447,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
     stderrTruncated: stderr.truncated,
     stdoutInvalidUtf8: stdout.invalidUtf8,
     stderrInvalidUtf8: stderr.invalidUtf8,
+    ...("digest" in stdout ? { stdoutDigest: stdout.digest } : {}),
   } satisfies ProcessRunOutput;
 });
 

--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -130,6 +130,8 @@ const makeTestRelay = Effect.fnUntraced(function* (
     getCheckpointContext: unused,
     getThreadSnapshot: unused,
     getThreadSnapshotWindow: unused,
+    getCommandReceipt: unused,
+    listCommandEffects: unused,
     getProjectThread: unused,
     listProjectThreads: unused,
     sendToThread: unused,

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -113,18 +113,14 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
   );
 });
 
-it.effect("GitVcsDriver rejects a fingerprint built from truncated staged-state output", () =>
+it.effect("GitVcsDriver fingerprints staged state with bounded tree identities", () =>
   Effect.gen(function* () {
     const driver = yield* GitVcsDriver.makeVcsDriverShape();
     const checkpoints = driver.checkpoints;
     assert.ok(checkpoints);
 
-    const error = yield* checkpoints.readWorkspaceFingerprint("/repo").pipe(Effect.flip);
-
-    assert.equal(error._tag, "VcsProcessExitError");
-    if (error._tag === "VcsProcessExitError") {
-      assert.match(error.detail, /incomplete staged-state output/);
-    }
+    const fingerprint = yield* checkpoints.readWorkspaceFingerprint("/repo");
+    assert.isNotEmpty(fingerprint);
   }).pipe(
     Effect.provide(
       Layer.mergeAll(
@@ -132,15 +128,18 @@ it.effect("GitVcsDriver rejects a fingerprint built from truncated staged-state 
         Layer.mock(VcsProcess.VcsProcess)({
           run: (input) => {
             const args = input.args.join(" ");
+            assert.notInclude(args, "ls-files --stage");
             return Effect.succeed({
               exitCode: ChildProcessSpawner.ExitCode(0),
               stdout: args.includes("--git-common-dir")
                 ? ".git\n"
                 : args.includes("write-tree")
                   ? "tree-oid\n"
-                  : "",
+                  : args.includes("--show-prefix")
+                    ? "\n"
+                    : "",
               stderr: "",
-              stdoutTruncated: args.includes("ls-files --stage"),
+              stdoutTruncated: false,
               stderrTruncated: false,
             });
           },

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -112,39 +112,3 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
     ),
   );
 });
-
-it.effect("GitVcsDriver fingerprints staged state with bounded tree identities", () =>
-  Effect.gen(function* () {
-    const driver = yield* GitVcsDriver.makeVcsDriverShape();
-    const checkpoints = driver.checkpoints;
-    assert.ok(checkpoints);
-
-    const fingerprint = yield* checkpoints.readWorkspaceFingerprint("/repo");
-    assert.isNotEmpty(fingerprint);
-  }).pipe(
-    Effect.provide(
-      Layer.mergeAll(
-        NodeServices.layer,
-        Layer.mock(VcsProcess.VcsProcess)({
-          run: (input) => {
-            const args = input.args.join(" ");
-            assert.notInclude(args, "ls-files --stage");
-            return Effect.succeed({
-              exitCode: ChildProcessSpawner.ExitCode(0),
-              stdout: args.includes("--git-common-dir")
-                ? ".git\n"
-                : args.includes("write-tree")
-                  ? "tree-oid\n"
-                  : args.includes("--show-prefix")
-                    ? "\n"
-                    : "",
-              stderr: "",
-              stdoutTruncated: false,
-              stderrTruncated: false,
-            });
-          },
-        }),
-      ),
-    ),
-  ),
-);

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -112,3 +112,40 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
     ),
   );
 });
+
+it.effect("GitVcsDriver rejects a fingerprint built from truncated staged-state output", () =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    const checkpoints = driver.checkpoints;
+    assert.ok(checkpoints);
+
+    const error = yield* checkpoints.readWorkspaceFingerprint("/repo").pipe(Effect.flip);
+
+    assert.equal(error._tag, "VcsProcessExitError");
+    if (error._tag === "VcsProcessExitError") {
+      assert.match(error.detail, /incomplete staged-state output/);
+    }
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) => {
+            const args = input.args.join(" ");
+            return Effect.succeed({
+              exitCode: ChildProcessSpawner.ExitCode(0),
+              stdout: args.includes("--git-common-dir")
+                ? ".git\n"
+                : args.includes("write-tree")
+                  ? "tree-oid\n"
+                  : "",
+              stderr: "",
+              stdoutTruncated: args.includes("ls-files --stage"),
+              stderrTruncated: false,
+            });
+          },
+        }),
+      ),
+    ),
+  ),
+);

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -728,7 +728,41 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       return path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(cwd, gitCommonDir);
     });
 
+  const readWorkspaceFingerprint = Effect.fn("GitVcsDriver.checkpoints.readWorkspaceFingerprint")(
+    function* (cwd: string, operation = "GitVcsDriver.checkpoints.readWorkspaceFingerprint") {
+      const gitCommonDir = yield* resolveGitCommonDir(cwd);
+      const tempIndexPath = path.join(
+        gitCommonDir,
+        `t3-checkpoint-index-${NodeCrypto.randomUUID()}`,
+      );
+      const indexEnv: NodeJS.ProcessEnv = { ...process.env, GIT_INDEX_FILE: tempIndexPath };
+      const cleanupTempIndex = fileSystem
+        .remove(tempIndexPath, { force: true })
+        .pipe(Effect.ignore);
+
+      return yield* Effect.gen(function* () {
+        if (yield* hasHeadCommit(cwd)) {
+          yield* execute({ operation, cwd, args: ["read-tree", "HEAD"], env: indexEnv });
+        }
+        yield* execute({ operation, cwd, args: ["add", "-A", "--", "."], env: indexEnv });
+        const result = yield* execute({ operation, cwd, args: ["write-tree"], env: indexEnv });
+        const treeOid = result.stdout.trim();
+        if (treeOid.length === 0) {
+          return yield* new VcsProcessExitError({
+            operation,
+            command: "git write-tree",
+            cwd,
+            exitCode: 0,
+            detail: "git write-tree returned an empty tree oid.",
+          });
+        }
+        return treeOid;
+      }).pipe(Effect.ensuring(cleanupTempIndex));
+    },
+  );
+
   const checkpoints: VcsDriver.VcsCheckpointOps = {
+    readWorkspaceFingerprint: (cwd) => readWorkspaceFingerprint(cwd),
     captureCheckpoint: Effect.fn("GitVcsDriver.checkpoints.captureCheckpoint")(function* (input) {
       const operation = "GitVcsDriver.checkpoints.captureCheckpoint";
       const gitCommonDir = yield* resolveGitCommonDir(input.cwd);

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -450,6 +450,7 @@ const gitCommand = (
     readonly maxOutputBytes?: number;
     readonly outputMode?: VcsProcess.VcsProcessInput["outputMode"];
     readonly appendTruncationMarker?: boolean;
+    readonly stdoutDigest?: "sha256";
   },
 ) =>
   process.run({
@@ -469,6 +470,7 @@ const gitCommand = (
     ...(options?.appendTruncationMarker !== undefined
       ? { appendTruncationMarker: options.appendTruncationMarker }
       : {}),
+    ...(options?.stdoutDigest === undefined ? {} : { stdoutDigest: options.stdoutDigest }),
   });
 
 export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* () {
@@ -756,47 +758,27 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
             detail: "git write-tree returned an empty tree oid.",
           });
         }
-        const indexTreeResult = yield* execute({
+        const index = yield* gitCommand(
+          vcsProcess,
           operation,
           cwd,
-          args: ["write-tree"],
-        });
-        const indexTreeOid = indexTreeResult.stdout.trim();
-        if (indexTreeOid.length === 0) {
+          ["ls-files", "--stage", "-z", "--", "."],
+          { stdoutDigest: "sha256" },
+        );
+        if (index.stdoutDigest === undefined) {
           return yield* new VcsProcessExitError({
             operation,
-            command: "git write-tree",
+            command: "git ls-files --stage",
             cwd,
-            exitCode: 0,
-            detail: "git write-tree returned an empty index tree oid.",
+            exitCode: index.exitCode,
+            detail: "git ls-files did not return a staged-state digest.",
           });
         }
-        const prefixResult = yield* execute({
-          operation,
-          cwd,
-          args: ["rev-parse", "--show-prefix"],
-        });
-        const prefix = prefixResult.stdout.replace(/\r?\n$/, "").replace(/\/$/, "");
-        const indexWorkspaceOid =
-          prefix.length === 0
-            ? indexTreeOid
-            : yield* execute({
-                operation,
-                cwd,
-                args: ["rev-parse", "--verify", `${indexTreeOid}:${prefix}`],
-                allowNonZeroExit: true,
-              }).pipe(
-                Effect.flatMap((result) =>
-                  result.exitCode === 0
-                    ? Effect.succeed(result.stdout.trim())
-                    : Effect.succeed("empty"),
-                ),
-              );
         return NodeCrypto.createHash("sha256")
           .update("worktree\0")
           .update(treeOid)
           .update("\0index\0")
-          .update(indexWorkspaceOid)
+          .update(index.stdoutDigest)
           .digest("hex");
       }).pipe(Effect.ensuring(cleanupTempIndex));
     },

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -807,7 +807,10 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
             workspaceTreeIdentity = "absent";
           } else {
             const entries = subtreeResult.stdout.split("\0").filter((entry) => entry.length > 0);
-            const [metadata, entryPath] = entries[0]?.split("\t") ?? [];
+            const entry = entries[0];
+            const separator = entry?.indexOf("\t") ?? -1;
+            const metadata = separator < 0 ? undefined : entry?.slice(0, separator);
+            const entryPath = separator < 0 ? undefined : entry?.slice(separator + 1);
             const [, entryType, entryOid] = metadata?.split(" ") ?? [];
             if (
               entries.length !== 1 ||

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -758,6 +758,74 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
             detail: "git write-tree returned an empty tree oid.",
           });
         }
+        const prefixResult = yield* execute({
+          operation,
+          cwd,
+          args: ["rev-parse", "--show-prefix"],
+          maxOutputBytes: 16_384,
+        });
+        if (prefixResult.stdoutTruncated) {
+          return yield* new VcsProcessExitError({
+            operation,
+            command: "git rev-parse --show-prefix",
+            cwd,
+            exitCode: prefixResult.exitCode,
+            detail: "git rev-parse returned a truncated workspace prefix.",
+          });
+        }
+        const prefixWithTerminator = prefixResult.stdout.endsWith("\n")
+          ? prefixResult.stdout.slice(0, -1)
+          : prefixResult.stdout;
+        const workspacePrefix = prefixWithTerminator.endsWith("/")
+          ? prefixWithTerminator.slice(0, -1)
+          : prefixWithTerminator;
+        let workspaceTreeIdentity = treeOid;
+        if (workspacePrefix.length > 0) {
+          const subtreeResult = yield* execute({
+            operation,
+            cwd,
+            args: [
+              "ls-tree",
+              "-z",
+              "--full-tree",
+              treeOid,
+              "--",
+              `:(top,literal)${workspacePrefix}`,
+            ],
+            maxOutputBytes: 16_384,
+          });
+          if (subtreeResult.stdoutTruncated) {
+            return yield* new VcsProcessExitError({
+              operation,
+              command: "git ls-tree",
+              cwd,
+              exitCode: subtreeResult.exitCode,
+              detail: "git ls-tree returned a truncated workspace subtree entry.",
+            });
+          }
+          if (subtreeResult.stdout.length === 0) {
+            workspaceTreeIdentity = "absent";
+          } else {
+            const entries = subtreeResult.stdout.split("\0").filter((entry) => entry.length > 0);
+            const [metadata, entryPath] = entries[0]?.split("\t") ?? [];
+            const [, entryType, entryOid] = metadata?.split(" ") ?? [];
+            if (
+              entries.length !== 1 ||
+              entryType !== "tree" ||
+              entryOid === undefined ||
+              entryPath !== workspacePrefix
+            ) {
+              return yield* new VcsProcessExitError({
+                operation,
+                command: "git ls-tree",
+                cwd,
+                exitCode: subtreeResult.exitCode,
+                detail: "git ls-tree returned an invalid workspace subtree entry.",
+              });
+            }
+            workspaceTreeIdentity = entryOid;
+          }
+        }
         const index = yield* gitCommand(
           vcsProcess,
           operation,
@@ -776,7 +844,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         }
         return NodeCrypto.createHash("sha256")
           .update("worktree\0")
-          .update(treeOid)
+          .update(workspaceTreeIdentity)
           .update("\0index\0")
           .update(index.stdoutDigest)
           .digest("hex");

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -761,6 +761,15 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
           cwd,
           args: ["ls-files", "--stage", "-z", "--", "."],
         });
+        if (index.stdoutTruncated) {
+          return yield* new VcsProcessExitError({
+            operation,
+            command: "git ls-files --stage",
+            cwd,
+            exitCode: index.exitCode,
+            detail: "git ls-files returned incomplete staged-state output.",
+          });
+        }
         return NodeCrypto.createHash("sha256")
           .update("worktree\0")
           .update(treeOid)

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -756,25 +756,47 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
             detail: "git write-tree returned an empty tree oid.",
           });
         }
-        const index = yield* execute({
+        const indexTreeResult = yield* execute({
           operation,
           cwd,
-          args: ["ls-files", "--stage", "-z", "--", "."],
+          args: ["write-tree"],
         });
-        if (index.stdoutTruncated) {
+        const indexTreeOid = indexTreeResult.stdout.trim();
+        if (indexTreeOid.length === 0) {
           return yield* new VcsProcessExitError({
             operation,
-            command: "git ls-files --stage",
+            command: "git write-tree",
             cwd,
-            exitCode: index.exitCode,
-            detail: "git ls-files returned incomplete staged-state output.",
+            exitCode: 0,
+            detail: "git write-tree returned an empty index tree oid.",
           });
         }
+        const prefixResult = yield* execute({
+          operation,
+          cwd,
+          args: ["rev-parse", "--show-prefix"],
+        });
+        const prefix = prefixResult.stdout.replace(/\r?\n$/, "").replace(/\/$/, "");
+        const indexWorkspaceOid =
+          prefix.length === 0
+            ? indexTreeOid
+            : yield* execute({
+                operation,
+                cwd,
+                args: ["rev-parse", "--verify", `${indexTreeOid}:${prefix}`],
+                allowNonZeroExit: true,
+              }).pipe(
+                Effect.flatMap((result) =>
+                  result.exitCode === 0
+                    ? Effect.succeed(result.stdout.trim())
+                    : Effect.succeed("empty"),
+                ),
+              );
         return NodeCrypto.createHash("sha256")
           .update("worktree\0")
           .update(treeOid)
           .update("\0index\0")
-          .update(index.stdout)
+          .update(indexWorkspaceOid)
           .digest("hex");
       }).pipe(Effect.ensuring(cleanupTempIndex));
     },

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -756,7 +756,17 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
             detail: "git write-tree returned an empty tree oid.",
           });
         }
-        return treeOid;
+        const index = yield* execute({
+          operation,
+          cwd,
+          args: ["ls-files", "--stage", "-z", "--", "."],
+        });
+        return NodeCrypto.createHash("sha256")
+          .update("worktree\0")
+          .update(treeOid)
+          .update("\0index\0")
+          .update(index.stdout)
+          .digest("hex");
       }).pipe(Effect.ensuring(cleanupTempIndex));
     },
   );

--- a/apps/server/src/vcs/VcsDriver.ts
+++ b/apps/server/src/vcs/VcsDriver.ts
@@ -42,6 +42,8 @@ export interface VcsDeleteCheckpointRefsInput {
 }
 
 export interface VcsCheckpointOps {
+  /** Hash the workspace tree that checkpoint restore can overwrite. */
+  readonly readWorkspaceFingerprint: (cwd: string) => Effect.Effect<string, VcsError>;
   readonly captureCheckpoint: (input: VcsCaptureCheckpointInput) => Effect.Effect<void, VcsError>;
   readonly hasCheckpointRef: (
     input: Omit<VcsRestoreCheckpointInput, "fallbackToHead">,

--- a/apps/server/src/vcs/VcsDriver.ts
+++ b/apps/server/src/vcs/VcsDriver.ts
@@ -42,7 +42,7 @@ export interface VcsDeleteCheckpointRefsInput {
 }
 
 export interface VcsCheckpointOps {
-  /** Hash the workspace tree that checkpoint restore can overwrite. */
+  /** Hash the workspace tree and index entries that checkpoint restore can overwrite. */
   readonly readWorkspaceFingerprint: (cwd: string) => Effect.Effect<string, VcsError>;
   readonly captureCheckpoint: (input: VcsCaptureCheckpointInput) => Effect.Effect<void, VcsError>;
   readonly hasCheckpointRef: (

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -1,3 +1,5 @@
+import * as NodeCrypto from "node:crypto";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, expect, it } from "@effect/vitest";
 import { HostProcessWorkingDirectory } from "@t3tools/shared/hostProcess";
@@ -120,6 +122,25 @@ describe("VcsProcess.run", () => {
       expect(result.stderr).toBe("");
       expect(result.stdoutTruncated).toBe(false);
       expect(result.stderrTruncated).toBe(false);
+    }).pipe(provideLive),
+  );
+
+  it.effect("digests stdout incrementally without applying the capture limit", () =>
+    Effect.gen(function* () {
+      const result = yield* run({
+        operation: "test.stdout-digest",
+        command: "node",
+        args: ["-e", "process.stdout.write(Buffer.alloc(2_000_000, 0xab))"],
+        cwd: process.cwd(),
+        maxOutputBytes: 128,
+        stdoutDigest: "sha256",
+      });
+
+      expect(result.stdout).toBe("");
+      expect(result.stdoutTruncated).toBe(false);
+      expect(result.stdoutDigest).toBe(
+        NodeCrypto.createHash("sha256").update(Buffer.alloc(2_000_000, 0xab)).digest("hex"),
+      );
     }).pipe(provideLive),
   );
 

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -31,6 +31,7 @@ export interface VcsProcessInput {
   readonly maxOutputBytes?: number;
   readonly outputMode?: ProcessRunner.ProcessRunInput["outputMode"];
   readonly appendTruncationMarker?: boolean;
+  readonly stdoutDigest?: "sha256";
 }
 
 export interface VcsProcessOutput {
@@ -42,6 +43,7 @@ export interface VcsProcessOutput {
   /** Present on real process output; optional so narrow test doubles remain lightweight. */
   readonly stdoutInvalidUtf8?: boolean;
   readonly stderrInvalidUtf8?: boolean;
+  readonly stdoutDigest?: string;
 }
 
 export class VcsProcess extends Context.Service<
@@ -129,6 +131,7 @@ export const make = Effect.gen(function* () {
         outputMode: input.outputMode ?? "truncate",
         truncatedMarker: input.appendTruncationMarker ? OUTPUT_TRUNCATED_MARKER : "",
         timeoutBehavior: "error",
+        ...(input.stdoutDigest === undefined ? {} : { stdoutDigest: input.stdoutDigest }),
       })
       .pipe(
         Effect.mapError(
@@ -184,6 +187,7 @@ export const make = Effect.gen(function* () {
       stderrTruncated: result.stderrTruncated,
       stdoutInvalidUtf8: result.stdoutInvalidUtf8 ?? false,
       stderrInvalidUtf8: result.stderrInvalidUtf8 ?? false,
+      ...(result.stdoutDigest === undefined ? {} : { stdoutDigest: result.stdoutDigest }),
     } satisfies VcsProcessOutput;
   });
 

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -353,24 +353,30 @@ Admission requires an idle thread with no queued run, a ready checkpoint ref,
 the active provider thread/session, and provider conversation rollback with a
 returned snapshot. The command carries optional constraints understood by old
 servers as absent: `expectedIdle` is enforced inside the thread's serialized
-decision, while a workspace tree fingerprint is compared inside the existing
-per-workspace checkpoint lock. The worker re-reads idle, archive, provider,
-and checkpoint state from that locked boundary before touching files.
+decision. The worker acquires that same per-thread admission boundary, re-reads
+idle, archive, provider, checkpoint, and provider-history target state, then
+compares the workspace-and-index fingerprint inside the existing per-workspace
+checkpoint lock. New same-thread commands wait until guarded restore
+finalization releases the admission boundary. An unrelated external process
+can still write while Git is executing; T3 does not claim an OS-wide lock.
 
 The result includes the durable command receipt and current outbox status:
 
-- `REQUESTED`: accepted, but the rollback effect is still pending or running;
+- `REQUESTED`: accepted, but the rollback effect is pending, running, or its
+  current observation is temporarily unavailable;
 - `APPLIED`: filesystem and required provider rollback completed;
-- `FAILED`: no complete restore was recorded; the detail explains the guard
-  or execution failure; and
-- `PARTIAL`: filesystem restore completed, but provider conversation rollback
-  failed.
+- `FAILED`: a guard rejected the restore before mutation or an unguarded
+  request failed; and
+- `PARTIAL`: filesystem/provider state may have changed, but the complete
+  durable outcome could not be recorded.
 
 Reusing the exact key returns the original command/effect state. A key already
-accepted for another target is rejected. Rollback effect failures are
-terminalized after their first execution attempt so a normal MCP retry cannot
-repeat filesystem or provider side effects. Process-loss recovery remains the
-existing outbox responsibility.
+accepted for another target is rejected. Guarded MCP rollback failures become
+terminal after a retry-unsafe or uncertain phase, so a normal retry cannot
+repeat filesystem or provider side effects. If the process ends while such an
+effect is running, durable outbox recovery records `PARTIAL` instead of
+replaying it. Older unguarded rollback commands retain their existing retry
+behavior.
 
 ## Delegated Task Lifecycle
 

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -341,6 +341,37 @@ code-unit cursors and report total length, truncation, and the next cursor. A
 page can exceed its requested limit by one code unit to avoid splitting a
 surrogate pair. This makes pagination match MCP JSON string indexing.
 
+### `t3_checkpoint_restore`
+
+Requests the ordinary serialized V2 `checkpoint.rollback` command for one
+exact checkpoint/scope identity. The tool never runs Git restore directly.
+Because the restore discards current tracked and untracked workspace changes,
+the caller must pass `discardChanges: true` and a well-formed, exact
+`clientRequestId`.
+
+Admission requires an idle thread with no queued run, a ready checkpoint ref,
+the active provider thread/session, and provider conversation rollback with a
+returned snapshot. The command carries optional constraints understood by old
+servers as absent: `expectedIdle` is enforced inside the thread's serialized
+decision, while a workspace tree fingerprint is compared inside the existing
+per-workspace checkpoint lock. The worker re-reads idle, archive, provider,
+and checkpoint state from that locked boundary before touching files.
+
+The result includes the durable command receipt and current outbox status:
+
+- `REQUESTED`: accepted, but the rollback effect is still pending or running;
+- `APPLIED`: filesystem and required provider rollback completed;
+- `FAILED`: no complete restore was recorded; the detail explains the guard
+  or execution failure; and
+- `PARTIAL`: filesystem restore completed, but provider conversation rollback
+  failed.
+
+Reusing the exact key returns the original command/effect state. A key already
+accepted for another target is rejected. Rollback effect failures are
+terminalized after their first execution attempt so a normal MCP retry cannot
+repeat filesystem or provider side effects. Process-loss recovery remains the
+existing outbox responsibility.
+
 ## Delegated Task Lifecycle
 
 The MCP server is a command ingress into V2. It does not call provider adapters
@@ -387,6 +418,8 @@ falls back to a terminal-status message when no assistant text exists.
 - Checkpoint list and diff use the same current-project boundary. They never
   accept an environment, workspace path, or raw checkpoint ref from the
   caller.
+- Restore uses the same boundary and never expands privileges, substitutes a
+  different checkpoint, stashes files, or creates a backup workspace.
 - Provider instances must be enabled, installed, available, authenticated, and
   backed by a V2 adapter.
 - A requested model must be advertised by the selected provider when the

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -356,7 +356,11 @@ servers as absent: `expectedIdle` is enforced inside the thread's serialized
 decision. The worker acquires that same per-thread admission boundary, re-reads
 idle, archive, provider, checkpoint, and provider-history target state, then
 compares the workspace-and-index fingerprint inside the existing per-workspace
-checkpoint lock. New same-thread commands wait until guarded restore
+checkpoint lock. The thread-state comparison starts from this worker re-read,
+not from command acceptance. A run that starts and finishes before the worker
+acquires the boundary does not automatically reject the restore; the worker
+uses the current provider history when it validates and applies the requested
+rollback target. New same-thread commands wait until guarded restore
 finalization releases the admission boundary. An unrelated external process
 can still write while Git is executing; T3 does not claim an OS-wide lock.
 

--- a/docs/user/checkpoints.md
+++ b/docs/user/checkpoints.md
@@ -20,3 +20,19 @@ path, or another project's thread.
 
 Inspection is read-only. A checkpoint that is stale, missing, or unavailable
 is reported honestly rather than substituted with a different snapshot.
+
+## Restore safety
+
+`t3_checkpoint_restore` restores one exact checkpoint selected from the list.
+It is destructive: current tracked and untracked changes covered by the
+restore are discarded, so the agent must explicitly acknowledge that outcome.
+The thread must be idle with no queued work, and the provider must support
+rolling its conversation back to the same point.
+
+T3 verifies that the workspace has not changed between the request and the
+locked restore. If files or thread state change concurrently, the restore
+fails and preserves the newer state. The result distinguishes a request that
+is still running, a fully applied restore, a failure, and a partial result
+where files were restored but the provider conversation could not be rolled
+back. Retrying with the same idempotency key reads the original result instead
+of starting another restore.

--- a/docs/user/checkpoints.md
+++ b/docs/user/checkpoints.md
@@ -24,15 +24,17 @@ is reported honestly rather than substituted with a different snapshot.
 ## Restore safety
 
 `t3_checkpoint_restore` restores one exact checkpoint selected from the list.
-It is destructive: current tracked and untracked changes covered by the
+It is destructive: current tracked, untracked, and staged changes covered by the
 restore are discarded, so the agent must explicitly acknowledge that outcome.
 The thread must be idle with no queued work, and the provider must support
 rolling its conversation back to the same point.
 
-T3 verifies that the workspace has not changed between the request and the
-locked restore. If files or thread state change concurrently, the restore
-fails and preserves the newer state. The result distinguishes a request that
-is still running, a fully applied restore, a failure, and a partial result
-where files were restored but the provider conversation could not be rolled
-back. Retrying with the same idempotency key reads the original result instead
-of starting another restore.
+Before the locked restore begins, T3 verifies that the covered workspace files
+and thread state still match the accepted request. If either changed while the
+request was waiting, the restore fails and preserves the newer state. As with
+other filesystem commands, an unrelated process can still write while Git is
+executing. The result distinguishes a request that is still running, a fully
+applied restore, a failure, and a partial result where files were restored but
+the provider conversation or durable finalization could not be completed.
+Retrying with the same idempotency key reads the original result instead of
+starting another restore.

--- a/docs/user/checkpoints.md
+++ b/docs/user/checkpoints.md
@@ -30,11 +30,15 @@ The thread must be idle with no queued work, and the provider must support
 rolling its conversation back to the same point.
 
 Before the locked restore begins, T3 verifies that the covered workspace files
-and thread state still match the accepted request. If either changed while the
-request was waiting, the restore fails and preserves the newer state. As with
-other filesystem commands, an unrelated process can still write while Git is
-executing. The result distinguishes a request that is still running, a fully
-applied restore, a failure, and a partial result where files were restored but
-the provider conversation or durable finalization could not be completed.
+still match the accepted request. The worker then re-reads the thread under the
+same-thread admission boundary and rejects active or queued work and invalid
+rollback targets. Thread state must remain unchanged from that worker re-read
+through filesystem restoration. A run that starts and finishes before the
+worker acquires the boundary may be part of the provider history that the
+requested rollback removes; it is not an acceptance-time thread-state compare.
+As with other filesystem commands, an unrelated process can still write while
+Git is executing. The result distinguishes a request that is still running, a
+fully applied restore, a failure, and a partial result where files were restored
+but the provider conversation or durable finalization could not be completed.
 Retrying with the same idempotency key reads the original result instead of
 starting another restore.

--- a/packages/contracts/src/checkpointMcp.test.ts
+++ b/packages/contracts/src/checkpointMcp.test.ts
@@ -46,6 +46,11 @@ describe("checkpoint MCP contracts", () => {
       discardChanges: true,
     } as const;
     expect(() => decodeRestoreInput({ ...base, clientRequestId: "bad\ud800key" })).toThrow();
+    expect(() => decodeRestoreInput({ ...base, clientRequestId: "bad\ud800" })).toThrow();
+    expect(() => decodeRestoreInput({ ...base, clientRequestId: "bad\udc00key" })).toThrow();
+    expect(
+      decodeRestoreInput({ ...base, clientRequestId: "valid \ud83d\ude80" }).clientRequestId,
+    ).toBe("valid \ud83d\ude80");
     expect(decodeRestoreInput({ ...base, clientRequestId: " e\u0301 " }).clientRequestId).toBe(
       " e\u0301 ",
     );

--- a/packages/contracts/src/checkpointMcp.test.ts
+++ b/packages/contracts/src/checkpointMcp.test.ts
@@ -5,12 +5,14 @@ import {
   CheckpointId,
   CheckpointMcpDiffInput,
   CheckpointMcpListInput,
+  CheckpointMcpRestoreInput,
   CheckpointScopeId,
   ThreadId,
 } from "./index.ts";
 
 const decodeListInput = Schema.decodeUnknownSync(CheckpointMcpListInput);
 const decodeDiffInput = Schema.decodeUnknownSync(CheckpointMcpDiffInput);
+const decodeRestoreInput = Schema.decodeUnknownSync(CheckpointMcpRestoreInput);
 
 describe("checkpoint MCP contracts", () => {
   it("decodes bounded list and diff inputs from the old empty/default shape", () => {
@@ -35,5 +37,18 @@ describe("checkpoint MCP contracts", () => {
         limit: 100_001,
       }),
     ).toThrow();
+  });
+
+  it("rejects malformed UTF-16 idempotency keys without normalizing valid keys", () => {
+    const base = {
+      scopeId: CheckpointScopeId.make("scope:checkpoint-contract"),
+      checkpointId: CheckpointId.make("checkpoint:checkpoint-contract"),
+      discardChanges: true,
+    } as const;
+    expect(() => decodeRestoreInput({ ...base, clientRequestId: "bad\ud800key" })).toThrow();
+    expect(decodeRestoreInput({ ...base, clientRequestId: " e\u0301 " }).clientRequestId).toBe(
+      " e\u0301 ",
+    );
+    expect(decodeRestoreInput({ ...base, clientRequestId: " é " }).clientRequestId).toBe(" é ");
   });
 });

--- a/packages/contracts/src/checkpointMcp.ts
+++ b/packages/contracts/src/checkpointMcp.ts
@@ -148,10 +148,24 @@ export const CheckpointMcpDiffResult = Schema.Struct({
 });
 export type CheckpointMcpDiffResult = typeof CheckpointMcpDiffResult.Type;
 
+const isWellFormedUtf16 = (value: string) => {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = value.charCodeAt(index + 1);
+      if (!(nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff)) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+};
+
 export const CheckpointMcpClientRequestId = Schema.String.check(
   Schema.makeFilter(
     (value) =>
-      (value.length > 0 && value.length <= 256 && value.isWellFormed()) ||
+      (value.length > 0 && value.length <= 256 && isWellFormedUtf16(value)) ||
       new SchemaIssue.InvalidValue({
         message: "clientRequestId must contain 1-256 well-formed UTF-16 code units",
       }),

--- a/packages/contracts/src/checkpointMcp.ts
+++ b/packages/contracts/src/checkpointMcp.ts
@@ -176,7 +176,7 @@ export const CheckpointMcpRestoreInput = Schema.Struct({
   }),
   discardChanges: Schema.Literal(true).annotate({
     description:
-      "Required acknowledgement that applying the checkpoint discards current tracked and untracked workspace changes covered by the checkpoint restore.",
+      "Required acknowledgement that applying the checkpoint discards current tracked, untracked and staged workspace changes covered by the checkpoint restore.",
   }),
   clientRequestId: CheckpointMcpClientRequestId,
 });
@@ -201,7 +201,14 @@ export const CheckpointMcpRestoreResult = Schema.Struct({
     acceptedAt: IsoDateTime,
     sequence: NonNegativeInt,
   }),
-  effectStatus: Schema.Literals(["pending", "running", "succeeded", "failed", "cancelled"]),
+  effectStatus: Schema.Literals([
+    "pending",
+    "running",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "unavailable",
+  ]),
   detail: Schema.NullOr(Schema.String),
 });
 export type CheckpointMcpRestoreResult = typeof CheckpointMcpRestoreResult.Type;

--- a/packages/contracts/src/checkpointMcp.ts
+++ b/packages/contracts/src/checkpointMcp.ts
@@ -1,8 +1,10 @@
 import * as Schema from "effect/Schema";
+import * as SchemaIssue from "effect/SchemaIssue";
 
 import {
   CheckpointId,
   CheckpointScopeId,
+  CommandId,
   IsoDateTime,
   NodeId,
   NonNegativeInt,
@@ -146,6 +148,64 @@ export const CheckpointMcpDiffResult = Schema.Struct({
 });
 export type CheckpointMcpDiffResult = typeof CheckpointMcpDiffResult.Type;
 
+export const CheckpointMcpClientRequestId = Schema.String.check(
+  Schema.makeFilter(
+    (value) =>
+      (value.length > 0 && value.length <= 256 && value.isWellFormed()) ||
+      new SchemaIssue.InvalidValue({
+        message: "clientRequestId must contain 1-256 well-formed UTF-16 code units",
+      }),
+    { identifier: "CheckpointMcpClientRequestId" },
+  ),
+).annotate({
+  description:
+    "Exact idempotency key to reuse when retrying this restore. It is not trimmed or Unicode-normalized.",
+});
+export type CheckpointMcpClientRequestId = typeof CheckpointMcpClientRequestId.Type;
+
+export const CheckpointMcpRestoreInput = Schema.Struct({
+  threadId: Schema.optional(ThreadId).annotate({
+    description:
+      "Thread to restore. Defaults to the calling thread and must belong to its project.",
+  }),
+  scopeId: CheckpointScopeId.annotate({
+    description: "Exact durable checkpoint scope returned by t3_checkpoint_list.",
+  }),
+  checkpointId: CheckpointId.annotate({
+    description: "Exact durable checkpoint returned by t3_checkpoint_list.",
+  }),
+  discardChanges: Schema.Literal(true).annotate({
+    description:
+      "Required acknowledgement that applying the checkpoint discards current tracked and untracked workspace changes covered by the checkpoint restore.",
+  }),
+  clientRequestId: CheckpointMcpClientRequestId,
+});
+export type CheckpointMcpRestoreInput = typeof CheckpointMcpRestoreInput.Type;
+
+export const CheckpointMcpRestoreStatus = Schema.Literals([
+  "REQUESTED",
+  "APPLIED",
+  "FAILED",
+  "PARTIAL",
+]);
+export type CheckpointMcpRestoreStatus = typeof CheckpointMcpRestoreStatus.Type;
+
+export const CheckpointMcpRestoreResult = Schema.Struct({
+  commandId: CommandId,
+  threadId: ThreadId,
+  scopeId: CheckpointScopeId,
+  checkpointId: CheckpointId,
+  status: CheckpointMcpRestoreStatus,
+  receipt: Schema.Struct({
+    status: Schema.Literal("accepted"),
+    acceptedAt: IsoDateTime,
+    sequence: NonNegativeInt,
+  }),
+  effectStatus: Schema.Literals(["pending", "running", "succeeded", "failed", "cancelled"]),
+  detail: Schema.NullOr(Schema.String),
+});
+export type CheckpointMcpRestoreResult = typeof CheckpointMcpRestoreResult.Type;
+
 export class CheckpointMcpFailure extends Schema.TaggedErrorClass<CheckpointMcpFailure>()(
   "CheckpointMcpFailure",
   {
@@ -155,6 +215,8 @@ export class CheckpointMcpFailure extends Schema.TaggedErrorClass<CheckpointMcpF
       "scope_mismatch",
       "checkpoint_not_found",
       "checkpoint_unavailable",
+      "thread_active",
+      "idempotency_conflict",
       "invalid_request",
       "unsupported",
       "operation_failed",

--- a/packages/contracts/src/orchestrationV2.test.ts
+++ b/packages/contracts/src/orchestrationV2.test.ts
@@ -224,6 +224,23 @@ describe("orchestration V2 contracts", () => {
     expect(event.payload.id).toBe(RunId.make("run-1"));
   });
 
+  it("keeps checkpoint rollback commands from older clients decodable", () => {
+    const command = decodeOrchestrationV2Command({
+      type: "checkpoint.rollback",
+      commandId: "command-checkpoint-rollback-legacy",
+      threadId: "thread-1",
+      scopeId: "scope-1",
+      checkpointId: "checkpoint-1",
+    });
+
+    expect(command.type).toBe("checkpoint.rollback");
+    if (command.type !== "checkpoint.rollback") {
+      throw new Error("expected checkpoint.rollback");
+    }
+    expect(command.expectedIdle).toBeUndefined();
+    expect(command.expectedWorkspaceFingerprint).toBeUndefined();
+  });
+
   it("decodes app-owned delegated task commands", () => {
     const command = decodeOrchestrationV2Command({
       type: "delegated_task.request",

--- a/packages/contracts/src/orchestrationV2.ts
+++ b/packages/contracts/src/orchestrationV2.ts
@@ -2292,6 +2292,9 @@ export const OrchestrationV2Command = Schema.Union([
     threadId: ThreadId,
     scopeId: CheckpointScopeId,
     checkpointId: CheckpointId,
+    /** Optional MCP admission constraints. Older clients omit both fields. */
+    expectedIdle: Schema.optional(Schema.Literal(true)),
+    expectedWorkspaceFingerprint: Schema.optional(TrimmedNonEmptyString),
   }),
   Schema.Struct({
     type: Schema.Literal("thread.fork"),

--- a/packages/shared/src/t3McpToolPresentation.test.ts
+++ b/packages/shared/src/t3McpToolPresentation.test.ts
@@ -44,6 +44,10 @@ describe("resolveT3McpToolPresentation", () => {
       displayName: "Read a checkpoint diff",
       logo: "t3-code",
     });
+    expect(resolveT3McpToolPresentation("t3-code.t3_checkpoint_restore")).toEqual({
+      displayName: "Restore a thread checkpoint",
+      logo: "t3-code",
+    });
   });
 
   it("pretty prints preview T3 MCP tool names", () => {

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -53,6 +53,7 @@ const T3_MCP_TOOLS: Record<
   t3_thread_interrupt: { displayName: "Interrupt a T3 thread", summaryAction: "thread-interrupt" },
   t3_checkpoint_list: { displayName: "List thread checkpoints" },
   t3_checkpoint_diff: { displayName: "Read a checkpoint diff" },
+  t3_checkpoint_restore: { displayName: "Restore a thread checkpoint" },
   t3_worktree_handoff: { displayName: "Hand off thread to a git worktree" },
   t3_worktree_status: { displayName: "Get thread worktree status" },
   preview_status: { displayName: "Get preview browser status" },


### PR DESCRIPTION
Agents could identify durable checkpoints but had no safe MCP path to request the application's existing serialized rollback workflow or observe its durable outcome.

This adds explicit `t3_checkpoint_restore` over ordinary V2 `checkpoint.rollback`, including exact scope/checkpoint identity, an explicit discard acknowledgement, durable idempotency keys, accepted receipts, and truthful REQUESTED/APPLIED/FAILED/PARTIAL outcomes.

Behavior:

- rejects stale, foreign, unsupported, active, ambiguous, or concurrently changed restore targets
- preflights the provider session, refreshes the projection, then serializes restore with ordinary same-thread V2 admission through finalization
- guards tracked, untracked, and staged workspace state, rejecting incomplete Git index reads while retaining the unavoidable external-process writer window
- classifies precondition rejection, retryable preflight failure, and uncertain post-mutation outcomes with distinct typed errors
- classifies uncertain filesystem, execution-defect, process-loss, and post-restore failures as partial without replay
- preserves retry behavior for proven pre-mutation failures and legacy unguarded clients
- reports a committed request as REQUESTED with unavailable observation when post-acceptance receipt reads fail

Focused validation:

- 119 focused assertions across contracts, MCP schema/service, VCS, orchestration, outbox recovery, presentation, and provider exposure
- temporary real-Git coverage for tracked, untracked, staged-only, and nested-cwd fingerprints
- real V2 effect-worker and managed fake-provider coverage for admission ordering, applied restore, provider/finalization partial outcomes, process loss, and same-key replay
- targeted contracts/server/mobile typecheck, lint, and formatting

Dependency: upper layer of native stack #8713; requires #8702 for checkpoint discovery, identity, and MCP registration.

Implemented by GPT-5.6-Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Destructive Git restore plus provider rollback runs under new concurrency guards; misclassification or fingerprint gaps could leave workspaces or conversation state inconsistent, though the PR adds extensive guards and partial-failure handling.
> 
> **Overview**
> Adds **`t3_checkpoint_restore`**, an MCP entry point that validates scope/checkpoint identity, requires an idle thread, captures a **workspace fingerprint** guard, and dispatches V2 **`checkpoint.rollback`** with durable **`clientRequestId`** idempotency plus REQUESTED/APPLIED/FAILED/PARTIAL outcomes (including safe user-facing detail when observation fails after accept).
> 
> **`CheckpointStore.readWorkspaceFingerprint`** is exposed and heavily tested (tracked/untracked/staged, nested cwd, conflicts, large indexes). **`CheckpointService`** and **`CheckpointRollbackService`** now enforce fingerprint and admission checks under a **thread command lock**, restore Git state before provider rollback, use **`checkpointRollbackAppRunOrdinal`** for proven targets, and split failures into rejected / preflight / partial typed errors.
> 
> The effect outbox gains **`checkpoint_restore_*` failure codes**, guarded rollbacks **do not retry** on partial or process loss (reconcile marks uncertain running restores failed), while legacy unguarded rollbacks keep prior retry behavior. Orchestrator dispatch rejects non-idle guarded rollbacks and ambiguous rollback targets explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f00cfa2189938a23a45a912dfab9f1d78a5309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3_checkpoint_restore` MCP tool for durable checkpoint restoration
> - Adds the `t3_checkpoint_restore` MCP tool, which validates restore targets and preconditions, captures a workspace fingerprint guard, and dispatches `checkpoint.rollback` commands with expected-idle and expected-workspace constraints in [CheckpointMcpService.ts](https://github.com/pingdotgg/t3code/pull/8703/files#diff-9c19b92628871e4915c50199f003c2e2b4801622eb34b2de508426dfabe8d2cf).
> - `CheckpointRollbackServiceV2` and `CheckpointServiceV2` now run under a thread lock, restore filesystem state before provider-history rollback, and classify failures as rejected, partial, or preflight in [CheckpointRollbackService.ts](https://github.com/pingdotgg/t3code/pull/8703/files#diff-7e54d5fbf1d817b6cacbedda12cb882cbfe8c0c984c60b9cb1033125aa4a8959) and [CheckpointService.ts](https://github.com/pingdotgg/t3code/pull/8703/files#diff-1e55ccde2ca0b201e05b9a5d85c234113c0e8e412e2c947a9a946f076a5a1cc1).
> - `GitVcsDriver` implements `readWorkspaceFingerprint` using a temporary alternate index to hash the workspace tree and staged index entries in [GitVcsDriver.ts](https://github.com/pingdotgg/t3code/pull/8703/files#diff-51125f02a750f476d151ebf951da622dc9738e642dc72b99dc8bfccf689a1483). `VcsProcess` and `processRunner` support a `stdoutDigest` mode to compute SHA-256 digests without retaining stdout text.
> - `EffectWorkerV2` and `EffectOutboxV2` route guarded checkpoint restores interrupted by process loss to terminal `checkpoint_restore_partial` failure instead of retrying, and persist typed failure codes in the outbox's `last_error` column in [EffectWorker.ts](https://github.com/pingdotgg/t3code/pull/8703/files#diff-fb4accddc7a83684d32fb1be7b35e4a33389292a2b145038b376207f6faea78d) and [EffectOutbox.ts](https://github.com/pingdotgg/t3code/pull/8703/files#diff-decadd5c03f85ce30e4c22f8c0f9094c03d03f3f6765d7d27ae7c997f86dafb9).
> - Risk: Checkpoint rollback dispatch now rejects non-idle expected-idle commands and unsupported checkpoint targets via `OrchestratorCheckpointRollbackNotIdleError` and `OrchestratorCheckpointRollbackTargetUnsupportedError` in [Orchestrator.ts](https://github.com/pingdotgg/t3code/pull/8703/files#diff-8747d8bd671948fc866dd5d05e74fa07e196b1f397fa7895aa5095e3186cd570). Legacy rollbacks without workspace fingerprints remain unclassified and retryable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1f00cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->