### PR TITLE
fix(web): prevent connection rows from wrapping during removal

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1437,10 +1437,12 @@ function SavedBackendListRow({
                   : null
               }
             />
-            <h3 className="text-sm font-medium text-foreground">{environment.label}</h3>
+            <h3 className="min-w-0 truncate text-sm font-medium text-foreground">
+              {environment.label}
+            </h3>
           </div>
           {metadataBits.length > 0 ? (
-            <p className="text-xs text-muted-foreground">{metadataBits.join(" · ")}</p>
+            <p className="truncate text-xs text-muted-foreground">{metadataBits.join(" · ")}</p>
           ) : null}
           {serverUpdateState.status !== "idle" ? (
             <div className="max-w-md">


### PR DESCRIPTION
## What Changed

- Constrain saved-environment names to the available flex width and truncate overflow with an ellipsis.
- Apply the same single-line truncation to connection metadata, including long Windows SSH paths.

## Why

When a connection removal starts, the action label grows from `Remove` or `Disconnect` to `Removing…` or `Disconnecting…`. That temporarily reduces the text column's available width. The connection name and metadata previously had no overflow constraint, so they could wrap and increase the row height—especially with Windows font metrics and long Windows paths.

`min-w-0` lets the title participate correctly in flex shrinking, while `truncate` keeps both fields on one line and preserves the full text in the DOM. The action controls remain fixed-width and readable.

## UI Changes

The evidence uses a 480px-wide desktop row, a Windows-style environment name/path, and the wider pending-removal controls.

Before:

![Connection text wrapping before the fix](https://gist.githubusercontent.com/MatthewFeroz/ed506438ba6faf423c40c7127efa549e/raw/before.png)

After:

![Connection text truncating after the fix](https://gist.githubusercontent.com/MatthewFeroz/ed506438ba6faf423c40c7127efa549e/raw/after.png)

## Scope and conventions

- This is a six-line, presentation-only web change with no contract, persistence, or connection-lifecycle changes.
- Desktop receives the fix because it renders the shared web settings component.
- Mobile uses its separate React Native connections screen and is unaffected.
- Below the existing `sm` breakpoint, the row already stacks its controls; this change preserves that responsive behavior.
- No documentation change is needed because user-facing behavior and terminology are unchanged.

## Verification

- `vp run --filter @t3tools/web typecheck`
- `vp lint apps/web/src/components/settings/ConnectionsSettings.tsx --report-unused-disable-directives`
- `vp fmt --check apps/web/src/components/settings/ConnectionsSettings.tsx`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No video is needed because there is no animation or timing change

Created with GPT-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind class changes in the web settings UI; no connection logic, APIs, or persistence.
> 
> **Overview**
> **Saved connection rows** in Connections settings no longer jump in height when Remove/Disconnect switches to the longer pending labels (`Removing…`, `Disconnecting…`).
> 
> In `SavedBackendListRow`, the environment **title** gets `min-w-0` (so it can shrink inside the flex row) plus `truncate`, and the **metadata** line (SSH path, T3 Connect, etc.) gets `truncate` so both stay on one line with ellipsis instead of wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af5247f1412f98bae6995df387c3c2d6510d351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix connection rows wrapping by truncating labels and metadata in `SavedBackendListRow`
> Adds `min-w-0 truncate` to the environment label `<h3>` and `truncate` to the metadata `<p>` in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/8706/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9). This stops long text from overflowing and breaking the row layout during removal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7af5247.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->