### PR TITLE
fix(mobile): space project destination title

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -309,6 +309,9 @@ const NewTaskSheetStack = createNativeStackNavigator({
     AddProjectDestination: createNativeStackScreen({
       screen: AddProjectDestinationRoute,
       linking: "add-project/destination",
+      options: {
+        title: "Add Project Destination",
+      },
     }),
     AddProjectLocal: createNativeStackScreen({
       screen: AddProjectLocalRoute,


### PR DESCRIPTION
Fixes #8735

## What Changed

Adds an explicit `Add Project Destination` title to the mobile clone destination route.

## Why

Without a display title, React Navigation falls back to the internal `AddProjectDestination` route name. Android renders that fallback literally in the native header.

## Verification

- Built and launched the development app on an Android 16 (API 36) emulator
- Opened the project destination route and confirmed the native header reads `Add Project Destination`
- `vp run --filter @t3tools/mobile typecheck`
- `git diff --check`

## UI Changes

| Before | After |
| --- | --- |
| ![Android project destination header showing the unspaced route name](https://github.com/jetpham/t3code/releases/download/pr-evidence-android-project-destination-title/84eed400-fb82-4177-b85d-15e96611bf07-46502206-80c8-47e0-968f-4c09c174e277.png) | ![Android project destination header showing the readable title](https://github.com/jetpham/t3code/releases/download/pr-evidence-android-project-destination-title/after.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] This change does not involve animation or interaction
