### PR TITLE
feat(web): filter sidebar from thread menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3992,10 +3992,24 @@ export default function Sidebar() {
         const isPinned = thread.pinnedAt != null;
         // Presets resolve at menu-open time (same as the popover).
         const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
+        const threadProjectGroup =
+          projectGroupsRef.current.find((project) =>
+            project.memberProjectRefs.some(
+              (projectRef) =>
+                projectRef.environmentId === thread.environmentId &&
+                projectRef.projectId === thread.projectId,
+            ),
+          ) ?? null;
         const clicked = await settlePromise(() =>
           api.contextMenu.show(
             buildThreadActionMenuItems({
               branch: thread.branch ?? null,
+              projectFilter: threadProjectGroup
+                ? {
+                    label: threadProjectGroup.displayName,
+                    isActive: projectScopeKey === threadProjectGroup.projectKey,
+                  }
+                : null,
               isPinned,
               isSettled,
               isSnoozed,
@@ -4023,17 +4037,20 @@ export default function Sidebar() {
           return;
         }
         switch (clicked.value) {
-          case "project-settings": {
-            const projectGroup = projectGroupsRef.current.find((group) =>
-              group.memberProjectRefs.some(
-                (projectRef) =>
-                  projectRef.environmentId === thread.environmentId &&
-                  projectRef.projectId === thread.projectId,
-              ),
-            );
-            if (projectGroup) openProjectSettings(projectGroup);
+          case "filter-by-project":
+            // This item is the only scope control here, so picking the
+            // already-scoped project again is the way back to all projects.
+            if (threadProjectGroup) {
+              setProjectScopeKey(
+                projectScopeKey === threadProjectGroup.projectKey
+                  ? null
+                  : threadProjectGroup.projectKey,
+              );
+            }
             return;
-          }
+          case "project-settings":
+            if (threadProjectGroup) openProjectSettings(threadProjectGroup);
+            return;
           case "new-thread-on-branch": {
             // Explicit branch carry-over: reuse the thread's worktree when it
             // has one, otherwise its branch on the local checkout.
@@ -4194,8 +4211,10 @@ export default function Sidebar() {
       handleMultiSelectContextMenu,
       markThreadUnread,
       openProjectSettings,
+      projectScopeKey,
       projectByKey,
       serverConfigs,
+      setProjectScopeKey,
       startThreadRename,
       updateThreadMetadata,
       timestampFormat,

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -4,6 +4,7 @@ import { buildThreadActionMenuItems, type ThreadActionMenuState } from "./thread
 
 const baseState: ThreadActionMenuState = {
   branch: null,
+  projectFilter: null,
   isPinned: false,
   isSettled: false,
   isSnoozed: false,
@@ -45,6 +46,38 @@ describe("buildThreadActionMenuItems", () => {
       icon: "settings",
     });
     expect(items[copyIndex + 2]?.id).toBe("archive");
+  });
+
+  it("offers project filtering only for surfaces with a scoped thread list", () => {
+    expect(ids(baseState)).not.toContain("filter-by-project");
+    expect(
+      buildThreadActionMenuItems({
+        ...baseState,
+        projectFilter: { label: "Beta Project", isActive: false },
+      }).find((item) => item.id === "filter-by-project"),
+    ).toMatchObject({ label: "Filter by Beta Project", icon: "folder-tree" });
+  });
+
+  it("offers the way back to all projects once the list is scoped", () => {
+    const items = buildThreadActionMenuItems({
+      ...baseState,
+      projectFilter: { label: "Beta Project", isActive: true },
+    });
+    const item = items.find((candidate) => candidate.id === "filter-by-project");
+    expect(item).toMatchObject({ label: "Show all projects" });
+    expect(items.map((candidate) => candidate.id)).toEqual([
+      "pin",
+      "settle",
+      "snooze",
+      "rename",
+      "regenerate-title",
+      "mark-unread",
+      "filter-by-project",
+      "copy",
+      "project-settings",
+      "archive",
+      "delete",
+    ]);
   });
 
   it("includes branch items only for threads with a branch", () => {

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -63,21 +63,10 @@ describe("buildThreadActionMenuItems", () => {
       ...baseState,
       projectFilter: { label: "Beta Project", isActive: true },
     });
-    const item = items.find((candidate) => candidate.id === "filter-by-project");
-    expect(item).toMatchObject({ label: "Show all projects" });
-    expect(items.map((candidate) => candidate.id)).toEqual([
-      "pin",
-      "settle",
-      "snooze",
-      "rename",
-      "regenerate-title",
-      "mark-unread",
-      "filter-by-project",
-      "copy",
-      "project-settings",
-      "archive",
-      "delete",
-    ]);
+    const filterIndex = items.findIndex((candidate) => candidate.id === "filter-by-project");
+    expect(items[filterIndex]).toMatchObject({ label: "Show all projects", icon: "folder-tree" });
+    expect(items[filterIndex - 1]?.id).toBe("mark-unread");
+    expect(items[filterIndex + 1]?.id).toBe("copy");
   });
 
   it("includes branch items only for threads with a branch", () => {

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -56,8 +56,8 @@ export interface ThreadActionMenuState {
 
 /**
  * Single source for the per-thread action menu: the sidebar row's right-click
- * menu and the chat header menu both render exactly this list, so labels,
- * ordering, and capability gating cannot drift between the two surfaces.
+ * menu and the chat header menu share labels, ordering, and capability gating.
+ * Each surface supplies state for the actions it supports.
  */
 export function buildThreadActionMenuItems(
   state: ThreadActionMenuState,

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -8,6 +8,7 @@ import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled"
  */
 export type ThreadActionMenuId =
   | "new-thread-on-branch"
+  | "filter-by-project"
   | "project-settings"
   | "pin"
   | "unpin"
@@ -28,6 +29,15 @@ export type ThreadActionMenuId =
 
 export interface ThreadActionMenuState {
   readonly branch: string | null;
+  /**
+   * Project scoping for the thread list. Null on surfaces with no scoped
+   * list behind the menu (the chat header), where the item must not show.
+   */
+  readonly projectFilter: {
+    readonly label: string;
+    /** True when the list is already scoped to this thread's project. */
+    readonly isActive: boolean;
+  } | null;
   readonly isPinned: boolean;
   readonly isSettled: boolean;
   readonly isSnoozed: boolean;
@@ -107,6 +117,17 @@ export function buildThreadActionMenuItems(
         ]
       : []),
     { id: "mark-unread", label: "Mark unread", icon: "mail-open" },
+    ...(state.projectFilter
+      ? [
+          {
+            id: "filter-by-project" as const,
+            label: state.projectFilter.isActive
+              ? "Show all projects"
+              : `Filter by ${state.projectFilter.label}`,
+            icon: "folder-tree",
+          },
+        ]
+      : []),
     {
       id: "copy",
       label: "Copy",

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -139,6 +139,9 @@ export function useThreadActionMenu(input: {
         const snoozePresets = resolveSnoozePresets(now, timestampFormat);
         const items = buildThreadActionMenuItems({
           branch: thread.branch ?? null,
+          // The chat header has no project-scoped thread list behind the
+          // menu, so the "Filter by project" affordance is sidebar-only.
+          projectFilter: null,
           isPinned: thread.pinnedAt != null,
           isSettled: supports.settlement && thread.settledOverride === "settled",
           isSnoozed: supports.snooze && effectiveSnoozed(thread, { now: now.toISOString() }),


### PR DESCRIPTION
Filtering to a thread’s project currently requires opening the project picker in the sidebar header. This adds “Filter by <project>” to the sidebar thread’s context menu, changing to “Show all projects” when that project is already selected.

The action reuses the existing persisted project scope and resolves projects by environment and project ID. It leaves the open thread in place and shares the project-group lookup with “Project settings”. The chat-header menu omits this sidebar-only action.

Rebased onto `main` at `c542b781c6`. Upstream project-scope persistence (#9416), thread-menu project settings (#8925), and the compact sidebar header (#11315) are retained; none supplies this shortcut. No new store, wire contract, or server behavior is needed.

## Verification

- `vp test run apps/web/src/components/threadActionMenu.logic.test.ts apps/web/src/components/Sidebar.logic.test.ts`: 169 passed.
- `vp run typecheck` in `apps/web`: passed after refreshing local dependencies with `vp i`.
- `vp lint` and `vp fmt --check` on the four changed files: passed; existing Sidebar lint warnings remain.
- Independent read-only Claude Fable 5 high review: two minor comment/test findings fixed, then no actionable findings on the final patch; process exit 0. The 12 menu tests and web typecheck passed again after those fixes.

Web and desktop share this menu. Native mobile uses a separate thread list and is unchanged. Desktop shell and remote/relay connections were not exercised; project matching includes the environment ID. The existing project picker remains another way to set or clear the same scope.

## Before and after

These are earlier full-web-client recordings, using five threads across Harbor and cedar, light theme, at 1280×800. The GIFs focus on the sidebar. They show the same menu labels, icon, filter/reset actions and retained open thread as this patch. Upstream has since folded the project picker into the search row (#11315), so the surrounding header is older; these are not fresh captures of the rebased head. Both GIFs and linked MP4s were downloaded and decoded successfully during this update.

**Before:** the thread menu has no project-filter action.

![Before: no project-filter action in the thread menu](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8719-before.gif)

**After:** “Filter by Harbor” hides the cedar thread; “Show all projects” restores it. The open Harbor thread stays selected.

![After: filter to Harbor and restore all projects](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8719-after.gif)

[Before recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8719-before-clean.mp4) · [After recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8719-after-clean.mp4)

Coordination trace: T3 thread aaade76d-4ec0-4717-96ed-490d10a783a9

Updated with GPT-6 in the Codex harness (T3 Code). Independent review: Claude Fable 5 high via direct Claude Code CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project filtering to thread context menus.
  * Users can filter the sidebar by a thread’s project or return to viewing all projects.
  * Menu labels and availability now reflect the currently active project scope.
  * Project filtering is available when a thread belongs to a recognized project.

* **Tests**
  * Added coverage for project-filter menu visibility, labels, icons, and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->