### PR TITLE
feat(mcp): expose thread search

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -29,6 +29,7 @@ import {
 import { WorktreeToolkitHandlersLive } from "./toolkits/worktree/handlers.ts";
 import { WorktreeToolkit } from "./toolkits/worktree/tools.ts";
 import * as WorktreeMcpService from "./WorktreeMcpService.ts";
+import * as ThreadSearchMcpService from "./ThreadSearchMcpService.ts";
 
 const unauthorized = HttpServerResponse.jsonUnsafe(
   {
@@ -226,6 +227,7 @@ export const OrchestratorToolkitRegistrationLive = McpServer.toolkit(Orchestrato
   Layer.provide(OrchestratorToolkitHandlersLive),
   Layer.provide(OrchestratorMcpService.layer),
   Layer.provide(ThreadMetadataMcpService.layer),
+  Layer.provide(ThreadSearchMcpService.layer),
 );
 
 export const WorktreeToolkitRegistrationLive = McpServer.toolkit(WorktreeToolkit).pipe(

--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -1175,6 +1175,7 @@ const make = Effect.gen(function* () {
             batchThreadCreation: true,
             threadManagement: true,
             incrementalThreadRead: true,
+            threadSearch: true,
             scheduledTasks: true,
             maxBatchThreads: 20,
           },
@@ -1575,7 +1576,23 @@ const make = Effect.gen(function* () {
       Effect.gen(function* () {
         const { parent, target } = yield* loadScopedThread(scope, input.threadId);
         const view = input.view ?? "messages";
-        const afterPosition = input.afterPosition ?? -1;
+        const anchorRow =
+          input.anchor === undefined
+            ? undefined
+            : target.visibleTurnItems.find(
+                (row) =>
+                  row.sourceThreadId === input.anchor?.sourceThreadId &&
+                  (row.item.type === "user_message" || row.item.type === "assistant_message") &&
+                  row.item.messageId === input.anchor.messageId,
+              );
+        if (input.anchor !== undefined && anchorRow === undefined) {
+          return yield* failure(
+            "invalid_request",
+            `Message ${input.anchor.messageId} is not visible in thread ${input.threadId}.`,
+          );
+        }
+        const afterPosition =
+          anchorRow === undefined ? (input.afterPosition ?? -1) : anchorRow.position - 1;
         const limit = input.limit ?? DEFAULT_THREAD_READ_LIMIT;
         const maxChars = input.maxCharsPerItem ?? DEFAULT_THREAD_ITEM_MAX_CHARS;
         const matching = target.visibleTurnItems

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -81,6 +81,7 @@ import { makeProviderRegistryLayer } from "../provider/testUtils/providerRegistr
 import * as ThreadBackgroundLiveness from "../orchestration/ThreadBackgroundLiveness.ts";
 import * as ThreadPlanProgress from "../orchestration/ThreadPlanProgress.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "../orchestration/Layers/ProjectionSnapshotQuery.ts";
+import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ScheduledTaskService } from "../scheduledTasks/ScheduledTaskService.ts";
 import * as McpHttpServer from "./McpHttpServer.ts";
 import * as McpInvocationContext from "./McpInvocationContext.ts";
@@ -3049,6 +3050,7 @@ describe("orchestrator MCP toolkit", () => {
         const testLayer = McpHttpServer.OrchestratorToolkitRegistrationLive.pipe(
           Layer.provideMerge(McpServer.McpServer.layer),
           Layer.provideMerge(orchestrationLayer),
+          Layer.provide(Layer.mock(ProjectionSnapshotQuery)({})),
           Layer.provide(providerRegistryLayer),
           Layer.provide(unusedScheduledTaskStubLayer),
           Layer.provide(NodeServices.layer),

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -17,6 +17,7 @@ import {
   OrchestratorMcpThreadInterruptResult,
   OrchestratorMcpThreadListResult,
   OrchestratorMcpThreadReadResult,
+  OrchestratorMcpThreadSearchResult,
   OrchestratorMcpThreadSendResult,
   OrchestratorMcpThreadWaitResult,
   ProjectId,
@@ -44,7 +45,9 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { McpSchema, McpServer } from "effect/unstable/ai";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
 
+import { ServerConfig } from "../config.ts";
 import { ClaudeProviderCapabilitiesV2 } from "../orchestration-v2/Adapters/ClaudeAdapterV2.ts";
 import { CodexProviderCapabilitiesV2 } from "../orchestration-v2/Adapters/CodexAdapterV2.ts";
 import { CodexOrchestratorReplayHarness } from "../orchestration-v2/Adapters/CodexAdapterV2.testkit.ts";
@@ -70,7 +73,14 @@ import {
   decodeProviderReplayNdjson,
   materializeReplayTranscriptWorkspace,
 } from "../orchestration-v2/testkit/ReplayTranscriptNdjson.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import * as ProjectEnrichment from "../project/ProjectEnrichmentService.ts";
+import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
+import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
 import { makeProviderRegistryLayer } from "../provider/testUtils/providerRegistryMock.ts";
+import * as ThreadBackgroundLiveness from "../orchestration/ThreadBackgroundLiveness.ts";
+import * as ThreadPlanProgress from "../orchestration/ThreadPlanProgress.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "../orchestration/Layers/ProjectionSnapshotQuery.ts";
 import { ScheduledTaskService } from "../scheduledTasks/ScheduledTaskService.ts";
 import * as McpHttpServer from "./McpHttpServer.ts";
 import * as McpInvocationContext from "./McpInvocationContext.ts";
@@ -86,7 +96,8 @@ const parentPrompt = "Keep this parent turn active while orchestration tools are
 const delegatedPrompt = "Inspect the delegated API boundary and return the result.";
 const delegatedResult = "Delegated API boundary inspected.";
 const cancellationPrompt = "Remain active until the parent cancels this delegated task.";
-const createdThreadPrompt = "Complete the newly created ordinary thread.";
+const createdThreadPrompt = `${"😀".repeat(600)} needle newly created ordinary thread`;
+const createdThreadResponse = "Created ordinary thread completed.";
 const queuedFollowupPrompt = "Complete the queued follow-up and return the final result.";
 const queuedFollowupResult = "Queued delegated follow-up completed.";
 
@@ -99,6 +110,7 @@ const decodeThreadInterruptResult = Schema.decodeUnknownEffect(
 );
 const decodeThreadListResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadListResult);
 const decodeThreadReadResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadReadResult);
+const decodeThreadSearchResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadSearchResult);
 const decodeThreadSendResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadSendResult);
 const decodeThreadWaitResult = Schema.decodeUnknownEffect(OrchestratorMcpThreadWaitResult);
 const decodeThreadUpdateResult = Schema.decodeUnknownEffect(ThreadMetadataMcpUpdateResult);
@@ -501,10 +513,13 @@ describe("orchestrator MCP toolkit", () => {
                 turn.message.text.startsWith("Delegated tasks")
                   ? deliveryTerminalGates.get(turn.threadId)
                   : parentTerminalGates.get(turn.threadId),
-              response: (turn) =>
-                turn.message.text === delegatedPrompt
-                  ? delegatedResult
-                  : `Claude completed: ${turn.message.text}`,
+              response: (turn) => {
+                if (turn.message.text === delegatedPrompt) return delegatedResult;
+                if (turn.message.text === createdThreadPrompt) {
+                  return createdThreadResponse;
+                }
+                return `Claude completed: ${turn.message.text}`;
+              },
             }),
           ]);
           // Captures parent-wake offers made when a delegated child
@@ -539,6 +554,7 @@ describe("orchestrator MCP toolkit", () => {
                 expect(yield* Ref.get(continuationOffers)).toHaveLength(count);
               }
             });
+          const databaseLayer = SqlitePersistenceMemory;
           const orchestratorLayer = makeOrchestratorV2ReplayLayerWithRegistry(
             {
               name: "orchestrator-mcp-toolkit",
@@ -553,6 +569,7 @@ describe("orchestrator MCP toolkit", () => {
               },
             },
             registryLayer,
+            { databaseLayer },
           ).pipe(Layer.provide(continuationProbeLayer));
           const orchestrationLayer = Layer.merge(
             orchestratorLayer,
@@ -613,9 +630,39 @@ describe("orchestrator MCP toolkit", () => {
               runNow: () => Effect.die("ScheduledTaskService.runNow is unused in this test"),
             }),
           );
+          const projectionMetadataLayer = Layer.merge(
+            Layer.succeed(RepositoryIdentityResolver.RepositoryIdentityResolver, {
+              resolve: (workspaceRoot) =>
+                Effect.succeed({
+                  canonicalKey: `test:${workspaceRoot}`,
+                  locator: {
+                    source: "git-remote" as const,
+                    remoteName: "origin",
+                    remoteUrl: "https://example.test/search.git",
+                  },
+                  rootPath: workspaceRoot,
+                }),
+            }),
+            Layer.succeed(ProjectFaviconResolver.ProjectFaviconResolver, {
+              resolvePath: () => Effect.succeed(null),
+            }),
+          );
+          const projectionQueryLayer = OrchestrationProjectionSnapshotQueryLive.pipe(
+            Layer.provideMerge(ThreadBackgroundLiveness.layer),
+            Layer.provideMerge(ThreadPlanProgress.layer),
+            Layer.provideMerge(ProjectEnrichment.layer),
+            Layer.provideMerge(projectionMetadataLayer),
+            Layer.provideMerge(databaseLayer),
+            Layer.provide(
+              ServerConfig.layerTest(process.cwd(), { prefix: "mcp-thread-search-test-" }),
+            ),
+            Layer.provide(NodeServices.layer),
+          );
           const testLayer = McpHttpServer.OrchestratorToolkitRegistrationLive.pipe(
             Layer.provideMerge(McpServer.McpServer.layer),
             Layer.provideMerge(orchestrationLayer),
+            Layer.provideMerge(databaseLayer),
+            Layer.provide(projectionQueryLayer),
             Layer.provide(providerRegistryLayer),
             Layer.provide(scheduledTaskStubLayer),
             Layer.provide(NodeServices.layer),
@@ -624,6 +671,18 @@ describe("orchestrator MCP toolkit", () => {
           yield* Effect.gen(function* () {
             const orchestrator = yield* OrchestratorV2;
             const server = yield* McpServer.McpServer;
+            const sql = yield* SqlClient.SqlClient;
+            // Projects remain environment-owned projection records; every
+            // thread/message/run/item searched below is written by V2.
+            yield* sql`
+              INSERT INTO projection_projects (
+                project_id, title, workspace_root, default_model_selection_json, scripts_json,
+                created_at, updated_at, deleted_at
+              ) VALUES (
+                ${projectId}, 'MCP orchestrator', ${cwd}, NULL, '[]',
+                '2026-06-17T00:00:00.000Z', '2026-06-17T00:00:00.000Z', NULL
+              )
+            `;
             yield* orchestrator.dispatch({
               type: "thread.create",
               createdBy: "user",
@@ -1939,6 +1998,78 @@ describe("orchestrator MCP toolkit", () => {
               creationSource: "mcp",
             });
             expect(promptedRead.hasMore).toBe(true);
+            const searchMessage = promptedRead.items[0]!;
+            expect(searchMessage.messageId).not.toBeNull();
+            const searchCall = yield* invoke("t3_thread_search", {
+              query: "needle",
+              threadId: promptedThread.threadId,
+              snippetChars: 1_000,
+            });
+            const searchResult = yield* decodeThreadSearchResult(searchCall.structuredContent).pipe(
+              Effect.orDie,
+            );
+            expect(searchResult).toMatchObject({
+              projectId,
+              hasMore: false,
+              nextCursor: null,
+              traversalTruncated: false,
+              consistency: "live",
+            });
+            expect(searchResult.hits[0]?.readAnchor).toEqual({
+              sourceThreadId: promptedThread.threadId,
+              messageId: searchMessage.messageId,
+            });
+            expect(Array.from(searchResult.hits[0]?.snippet ?? "").length).toBeLessThanOrEqual(
+              1_000,
+            );
+            expect((searchResult.hits[0]?.snippet ?? "").length).toBeGreaterThan(1_000);
+            const anchoredReadCall = yield* invoke("t3_thread_read", {
+              threadId: promptedThread.threadId,
+              anchor: searchResult.hits[0]?.readAnchor,
+              limit: 1,
+            });
+            const anchoredRead = yield* decodeThreadReadResult(
+              anchoredReadCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(anchoredRead.items[0]?.messageId).toBe(searchMessage.messageId);
+            expect(anchoredRead.items[0]?.position).toBe(searchMessage.position);
+            const staleAnchorReadCall = yield* invoke("t3_thread_read", {
+              threadId: promptedThread.threadId,
+              anchor: {
+                sourceThreadId: promptedThread.threadId,
+                messageId: "message:missing-search-anchor",
+              },
+              limit: 1,
+            });
+            expect(staleAnchorReadCall.structuredContent).toMatchObject({
+              _tag: "OrchestratorMcpFailure",
+              code: "invalid_request",
+            });
+            const nulSearchCall = yield* invoke("t3_thread_search", {
+              query: "unrelated\0needle",
+              threadId: promptedThread.threadId,
+            });
+            expect(nulSearchCall.structuredContent).toMatchObject({
+              _tag: "OrchestratorMcpFailure",
+              code: "invalid_request",
+            });
+
+            yield* sql`
+              ALTER TABLE projection_projects
+              RENAME TO projection_projects_search_failure
+            `;
+            const unavailableSearchCall = yield* invoke("t3_thread_search", {
+              query: "malformed-search-boundary",
+            });
+            expect(unavailableSearchCall.structuredContent).toEqual({
+              _tag: "OrchestratorMcpFailure",
+              code: "orchestration_error",
+              message: `Unable to search thread content in project ${projectId}.`,
+            });
+            yield* sql`
+              ALTER TABLE projection_projects_search_failure
+              RENAME TO projection_projects
+            `;
             const promptedReadNextCall = yield* invoke("t3_thread_read", {
               threadId: promptedThread.threadId,
               afterPosition: promptedRead.nextPosition,
@@ -1948,9 +2079,7 @@ describe("orchestrator MCP toolkit", () => {
               promptedReadNextCall.structuredContent,
             ).pipe(Effect.orDie);
             expect(promptedReadNext.items.map((item) => item.type)).toEqual(["assistant_message"]);
-            expect(promptedReadNext.items[0]?.text).toBe(
-              `Claude completed: ${createdThreadPrompt}`,
-            );
+            expect(promptedReadNext.items[0]?.text).toBe(createdThreadResponse);
 
             const forkedThreadId = ThreadId.make("thread:mcp-orchestrator-inherited-read");
             yield* orchestrator.dispatch({
@@ -2139,6 +2268,14 @@ describe("orchestrator MCP toolkit", () => {
               title: "Should stay foreign",
             });
             expect(foreignUpdateCall.structuredContent).toMatchObject({
+              _tag: "OrchestratorMcpFailure",
+              code: "thread_not_found",
+            });
+            const foreignSearchCall = yield* invoke("t3_thread_search", {
+              query: "foreign",
+              threadId: foreignThreadId,
+            });
+            expect(foreignSearchCall.structuredContent).toMatchObject({
               _tag: "OrchestratorMcpFailure",
               code: "thread_not_found",
             });

--- a/apps/server/src/mcp/ThreadSearchMcpService.ts
+++ b/apps/server/src/mcp/ThreadSearchMcpService.ts
@@ -1,0 +1,127 @@
+import {
+  OrchestratorMcpFailure,
+  type OrchestratorMcpThreadSearchInput,
+  type OrchestratorMcpThreadSearchResult,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { ThreadManagementService } from "../orchestration-v2/ThreadManagementService.ts";
+import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+
+const DEFAULT_LIMIT = 20;
+const DEFAULT_SNIPPET_CHARS = 240;
+
+export class ThreadSearchMcpService extends Context.Service<
+  ThreadSearchMcpService,
+  {
+    readonly search: (
+      scope: McpInvocationScope,
+      input: OrchestratorMcpThreadSearchInput,
+    ) => Effect.Effect<OrchestratorMcpThreadSearchResult, OrchestratorMcpFailure>;
+  }
+>()("t3/mcp/ThreadSearchMcpService") {}
+
+function failure(code: OrchestratorMcpFailure["code"], message: string): OrchestratorMcpFailure {
+  return new OrchestratorMcpFailure({ code, message });
+}
+
+const make = Effect.gen(function* () {
+  const threadManagement = yield* ThreadManagementService;
+  const projectionQuery = yield* ProjectionSnapshotQuery;
+
+  const loadShell = (threadId: McpInvocationScope["threadId"]) =>
+    threadManagement.getThreadShell(threadId).pipe(
+      Effect.mapError(() => failure("orchestration_error", `Unable to read thread ${threadId}.`)),
+      Effect.flatMap((shell) =>
+        shell === null
+          ? Effect.fail(failure("thread_not_found", `Thread ${threadId} was not found.`))
+          : Effect.succeed(shell),
+      ),
+    );
+
+  return {
+    search: (scope, input) =>
+      Effect.gen(function* () {
+        if (!scope.capabilities.has("orchestration")) {
+          return yield* failure(
+            "capability_denied",
+            "This MCP credential does not grant orchestration capabilities.",
+          );
+        }
+
+        const caller = yield* loadShell(scope.threadId);
+        if (input.threadId !== undefined) {
+          const target = yield* loadShell(input.threadId);
+          if (target.projectId !== caller.projectId) {
+            return yield* failure(
+              "thread_not_found",
+              `Thread ${input.threadId} was not found in this project.`,
+            );
+          }
+        }
+
+        const page = yield* projectionQuery
+          .searchThreadContent({
+            projectId: caller.projectId,
+            ...(input.threadId === undefined ? {} : { threadId: input.threadId }),
+            query: input.query,
+            includeArchived: input.includeArchived === true,
+            offset: input.cursor ?? 0,
+            limit: input.limit ?? DEFAULT_LIMIT,
+            snippetChars: input.snippetChars ?? DEFAULT_SNIPPET_CHARS,
+          })
+          .pipe(
+            Effect.catchTags({
+              ProjectionThreadContentSearchInputError: (error) =>
+                Effect.fail(failure("invalid_request", error.message)),
+              PersistenceSqlError: () =>
+                Effect.fail(
+                  failure(
+                    "orchestration_error",
+                    `Unable to search thread content in project ${caller.projectId}.`,
+                  ),
+                ),
+              PersistenceDecodeError: () =>
+                Effect.fail(
+                  failure(
+                    "orchestration_error",
+                    `Unable to search thread content in project ${caller.projectId}.`,
+                  ),
+                ),
+            }),
+          );
+
+        return {
+          projectId: caller.projectId,
+          hits: page.hits.map((hit) => ({
+            threadId: hit.threadId,
+            projectId: hit.projectId,
+            threadTitle: hit.threadTitle,
+            threadTitleTruncated: hit.threadTitleTruncated,
+            archived: hit.archived,
+            source: hit.source,
+            origin: hit.origin,
+            snippet: hit.snippet,
+            snippetTruncated: hit.snippetTruncated,
+            matchedAt: hit.matchedAt,
+            messageId: hit.messageId,
+            runId: hit.runId,
+            itemId: hit.itemId,
+            readAnchor:
+              hit.sourceThreadId === null || hit.messageId === null
+                ? null
+                : { sourceThreadId: hit.sourceThreadId, messageId: hit.messageId },
+          })),
+          nextCursor: page.nextOffset,
+          hasMore: page.hasMore,
+          traversalTruncated: page.hasMore && page.nextOffset === null,
+          consistency: "live",
+        } satisfies OrchestratorMcpThreadSearchResult;
+      }),
+  } satisfies ThreadSearchMcpService["Service"];
+});
+
+export const layer = Layer.effect(ThreadSearchMcpService, make);

--- a/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/handlers.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import { McpInvocationContext } from "../../McpInvocationContext.ts";
 import { OrchestratorMcpService } from "../../OrchestratorMcpService.ts";
 import { ThreadMetadataMcpService } from "../../ThreadMetadataMcpService.ts";
+import { ThreadSearchMcpService } from "../../ThreadSearchMcpService.ts";
 
 const handlers = {
   orchestrator_capabilities: () =>
@@ -97,6 +98,12 @@ const handlers = {
       const scope = yield* McpInvocationContext;
       const service = yield* ThreadMetadataMcpService;
       return yield* service.update(scope, input);
+    }),
+  t3_thread_search: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* ThreadSearchMcpService;
+      return yield* service.search(scope, input);
     }),
   t3_thread_send: (input) =>
     Effect.gen(function* () {

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.ts
@@ -21,6 +21,8 @@ import {
   OrchestratorMcpThreadListResult,
   OrchestratorMcpThreadReadInput,
   OrchestratorMcpThreadReadResult,
+  OrchestratorMcpThreadSearchInput,
+  OrchestratorMcpThreadSearchResult,
   OrchestratorMcpThreadSendInput,
   OrchestratorMcpThreadSendResult,
   OrchestratorMcpThreadStartInput,
@@ -34,6 +36,7 @@ import { Tool, Toolkit } from "effect/unstable/ai";
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import { OrchestratorMcpService } from "../../OrchestratorMcpService.ts";
 import { ThreadMetadataMcpService } from "../../ThreadMetadataMcpService.ts";
+import { ThreadSearchMcpService } from "../../ThreadSearchMcpService.ts";
 
 const dependencies = [McpInvocationContext.McpInvocationContext, OrchestratorMcpService];
 const threadMetadataDependencies = [
@@ -210,6 +213,20 @@ export const ThreadUpdateTool = Tool.make("t3_thread_update", {
   .annotate(Tool.Destructive, true)
   .annotate(Tool.Idempotent, false);
 
+export const ThreadSearchTool = Tool.make("t3_thread_search", {
+  description:
+    "Search durable thread titles and visible user/assistant messages in the calling project. Archived threads are excluded unless includeArchived=true; deleted threads and other projects are never searched. Results and snippets are bounded. Pagination reads live projection state, so concurrent updates can shift later pages. A non-null readAnchor can be passed to t3_thread_read.anchor to open the visible hit.",
+  parameters: OrchestratorMcpThreadSearchInput,
+  success: OrchestratorMcpThreadSearchResult,
+  failure: OrchestratorMcpFailure,
+  failureMode: "return",
+  dependencies: [McpInvocationContext.McpInvocationContext, ThreadSearchMcpService],
+})
+  .annotate(Tool.Title, "Search T3 threads")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, true);
+
 export const ThreadSendTool = Tool.make("t3_thread_send", {
   description:
     "Send a message to a T3 thread in the calling project. mode='auto' starts an idle thread, steers a fully active turn, or queues behind a turn that is not yet steerable. Use queue for a separate follow-up turn, steer for an in-flight update, or restart to interrupt-and-restart the active turn. clientRequestId makes retries idempotent.",
@@ -263,6 +280,7 @@ export const OrchestratorToolkit = Toolkit.make(
   ThreadListTool,
   ThreadReadTool,
   ThreadUpdateTool,
+  ThreadSearchTool,
   ThreadSendTool,
   ThreadWaitTool,
   ThreadInterruptTool,

--- a/apps/server/src/mcp/toolkits/worktree/registration.test.ts
+++ b/apps/server/src/mcp/toolkits/worktree/registration.test.ts
@@ -10,6 +10,7 @@ import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
 import * as ServerEnvironment from "../../../environment/ServerEnvironment.ts";
 import * as GitWorkflowService from "../../../git/GitWorkflowService.ts";
 import { ThreadManagementService } from "../../../orchestration-v2/ThreadManagementService.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as ProjectService from "../../../project/ProjectService.ts";
 import * as ProjectSetupScriptRunner from "../../../project/ProjectSetupScriptRunner.ts";
 import { ProviderRegistry } from "../../../provider/Services/ProviderRegistry.ts";
@@ -22,6 +23,7 @@ import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
 
 const StubServicesLive = Layer.mergeAll(
   Layer.mock(ThreadManagementService)({}),
+  Layer.mock(ProjectionSnapshotQuery)({}),
   Layer.mock(ProviderRegistry)({}),
   Layer.mock(ScheduledTaskService)({}),
   Layer.mock(ProjectService.ProjectService)({}),
@@ -114,6 +116,10 @@ it.effect("production mcp layer lists worktree tools over http", () =>
       // than replacing them.
       expect(toolNames).toContain("preview_status");
       expect(toolNames).toContain("delegate_task");
+      const search = tools.find((tool) => tool.name === "t3_thread_search");
+      expect(search?.inputSchema.type).toBe("object");
+      expect(search?.annotations?.readOnlyHint).toBe(true);
+      expect(search?.annotations?.destructiveHint).toBe(false);
 
       // The handoff tool mutates thread state, reaches the network (origin
       // fetch), and runs project setup scripts, so its MCP hints must not

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -807,6 +807,7 @@ export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
   "mcp__t3-code__orchestrator_capabilities",
   "mcp__t3-code__list_scheduled_tasks",
   "mcp__t3-code__t3_thread_list",
+  "mcp__t3-code__t3_thread_search",
   "mcp__t3-code__t3_thread_wait",
 ];
 

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -141,7 +141,7 @@ selection model-visible without allowing a request that cannot run.
 
 ## Tool Surface
 
-The server exposes eleven orchestration tools.
+The server exposes the following orchestration tools.
 
 ### `orchestrator_capabilities`
 
@@ -151,7 +151,8 @@ Returns:
 - the parent runtime and interaction modes;
 - registered provider instances and advertised models;
 - whether each provider can run a child task; and
-- feature flags for polling, cancellation, and batch thread creation.
+- feature flags for polling, cancellation, batch thread creation, incremental
+  reads, and thread search.
 
 Unavailable providers include model-visible constraints such as missing V2
 adapter support, disabled state, missing executable, or missing authentication.
@@ -276,7 +277,11 @@ timeline. The default `messages` view returns user messages, assistant
 messages, and proposed plans. The `activity` view also returns summarized tool,
 reasoning, checkpoint, handoff, and runtime-request items. Large item text is
 bounded and reports whether it was truncated. `afterPosition` and
-`nextPosition` support incremental reads.
+`nextPosition` support incremental reads. A search hit with a non-null
+`readAnchor` can instead be passed as `anchor`; the read starts inclusively at
+that currently visible source message. `anchor` and `afterPosition` are
+mutually exclusive, and an anchor that is no longer visible fails rather than
+falling back to a raw stored ordinal.
 
 Thread and message results include required `createdBy` and `creationSource`
 provenance. MCP-created threads and user-role messages use `createdBy: "agent"`
@@ -297,6 +302,29 @@ resultant title, title-regeneration marker, and linked pull request. Reusing a
 `clientRequestId` for the same action and thread replays the same command
 receipt. Thread list and read results expose the linked pull request, and thread
 detail also exposes an in-flight title regeneration.
+
+### `t3_thread_search`
+
+Searches durable thread titles and locally stored visible user and assistant
+messages in the calling thread's project. Archived threads are excluded by
+default and can be included explicitly; deleted threads, deleted projects, and
+threads from other projects are always excluded. Streaming messages,
+rolled-back runs, cancelled queued messages, and inherited-only fork content
+are not search candidates. This avoids duplicating source text under every
+fork and keeps the result aligned with canonical durable history.
+
+The literal query is 2–200 Unicode code points, display titles are bounded to
+500 code points, and `snippetChars` accepts 64–1,000 code points. Bounds never
+split a valid surrogate pair. Literal `%`, `_`, and `!` characters are escaped
+rather than treated as SQL wildcard syntax; NUL is rejected because SQLite
+cannot apply literal `LIKE` matching to it reliably. Pages and traversal
+cursors are bounded. Results report source kind, storage origin, stable V2
+identities when available, and whether the bounded display title or snippet
+was truncated. Legacy matches keep nullable anchors instead of inventing V2
+item IDs. `nextCursor` continues a live query, not a snapshot: concurrent
+projection updates can shift later pages. When the bounded traversal ceiling
+is reached, `hasMore` remains true, `traversalTruncated` is true, and no further
+cursor is returned.
 
 ### `t3_thread_send`
 

--- a/packages/contracts/src/orchestratorMcp.test.ts
+++ b/packages/contracts/src/orchestratorMcp.test.ts
@@ -8,6 +8,7 @@ import {
   OrchestratorMcpThreadInterruptInput,
   OrchestratorMcpThreadListInput,
   OrchestratorMcpThreadReadInput,
+  OrchestratorMcpThreadSearchInput,
   OrchestratorMcpThreadSendInput,
   OrchestratorMcpThreadStartInput,
   OrchestratorMcpThreadWaitInput,
@@ -19,6 +20,7 @@ const decodeDelegateTaskResult = Schema.decodeUnknownSync(OrchestratorMcpDelegat
 const decodeThreadInterruptInput = Schema.decodeUnknownSync(OrchestratorMcpThreadInterruptInput);
 const decodeThreadListInput = Schema.decodeUnknownSync(OrchestratorMcpThreadListInput);
 const decodeThreadReadInput = Schema.decodeUnknownSync(OrchestratorMcpThreadReadInput);
+const decodeThreadSearchInput = Schema.decodeUnknownSync(OrchestratorMcpThreadSearchInput);
 const decodeThreadSendInput = Schema.decodeUnknownSync(OrchestratorMcpThreadSendInput);
 const decodeThreadStartInput = Schema.decodeUnknownSync(OrchestratorMcpThreadStartInput);
 const decodeThreadWaitInput = Schema.decodeUnknownSync(OrchestratorMcpThreadWaitInput);
@@ -149,6 +151,14 @@ describe("orchestrator MCP contracts", () => {
       }).afterPosition,
     ).toBe(10);
     expect(
+      decodeThreadSearchInput({
+        query: "  durable result  ",
+        includeArchived: true,
+        limit: 25,
+        snippetChars: 300,
+      }).query,
+    ).toBe("durable result");
+    expect(
       decodeThreadSendInput({
         threadId: "thread-loop-1",
         message: "Continue with the next iteration.",
@@ -169,5 +179,13 @@ describe("orchestrator MCP contracts", () => {
         reason: "Loop converged.",
       }).reason,
     ).toBe("Loop converged.");
+
+    expect(() =>
+      decodeThreadReadInput({
+        threadId: "thread-loop-1",
+        afterPosition: 10,
+        anchor: { sourceThreadId: "thread-loop-1", messageId: "message-loop-1" },
+      }),
+    ).toThrow(/anchor and afterPosition/);
   });
 });

--- a/packages/contracts/src/orchestratorMcp.ts
+++ b/packages/contracts/src/orchestratorMcp.ts
@@ -13,6 +13,7 @@ import {
   RunId,
   ScheduledTaskId,
   ThreadId,
+  TrimmedString,
   TrimmedNonEmptyString,
   TurnItemId,
 } from "./baseSchemas.ts";
@@ -45,6 +46,18 @@ const OrchestratorMcpTitle = TrimmedNonEmptyString.check(Schema.isMaxLength(512)
 const OrchestratorMcpClientRequestId = TrimmedNonEmptyString.check(
   Schema.isMaxLength(256),
 ).annotate({ description: "Stable idempotency key to reuse when retrying this mutation." });
+
+const unicodeCodePointLength = (minimum: number, maximum: number) =>
+  Schema.makeFilter((input: string) => {
+    if (input.length > maximum * 2) {
+      return `Expected between ${minimum} and ${maximum} Unicode code points.`;
+    }
+    const length = Array.from(input).length;
+    return (
+      (length >= minimum && length <= maximum) ||
+      `Expected between ${minimum} and ${maximum} Unicode code points.`
+    );
+  });
 
 /**
  * OpenCode 1.15 has been observed serializing nested MCP union objects as JSON
@@ -328,14 +341,87 @@ export const OrchestratorMcpThreadListResult = Schema.Struct({
 });
 export type OrchestratorMcpThreadListResult = typeof OrchestratorMcpThreadListResult.Type;
 
+export const OrchestratorMcpThreadSearchInput = Schema.Struct({
+  query: TrimmedString.check(unicodeCodePointLength(2, 200)).annotate({
+    description:
+      "Literal text to find, from 2 to 200 Unicode code points; %, _, and ! are ordinary characters.",
+  }),
+  threadId: Schema.optional(
+    ThreadId.annotate({ description: "Optional thread in the calling project to search." }),
+  ),
+  includeArchived: Schema.optional(
+    Schema.Boolean.annotate({
+      description: "Include archived threads. Defaults to false; deleted threads stay excluded.",
+    }),
+  ),
+  cursor: Schema.optional(
+    NonNegativeInt.check(Schema.isLessThanOrEqualTo(10_000)).annotate({
+      description: "Live-query continuation cursor returned by the previous page.",
+    }),
+  ),
+  limit: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(50))),
+  snippetChars: Schema.optional(
+    PositiveInt.check(Schema.isBetween({ minimum: 64, maximum: 1_000 })).annotate({
+      description: "Maximum Unicode code points in each returned snippet. Defaults to 240.",
+    }),
+  ),
+});
+export type OrchestratorMcpThreadSearchInput = typeof OrchestratorMcpThreadSearchInput.Type;
+
+export const OrchestratorMcpThreadReadAnchor = Schema.Struct({
+  sourceThreadId: ThreadId,
+  messageId: MessageId,
+});
+export type OrchestratorMcpThreadReadAnchor = typeof OrchestratorMcpThreadReadAnchor.Type;
+
+export const OrchestratorMcpThreadSearchHit = Schema.Struct({
+  threadId: ThreadId,
+  projectId: ProjectId,
+  threadTitle: Schema.String.check(unicodeCodePointLength(0, 500)),
+  threadTitleTruncated: Schema.Boolean,
+  archived: Schema.Boolean,
+  source: Schema.Literals(["title", "user", "assistant"]),
+  origin: Schema.Literals(["legacy", "v2"]),
+  snippet: Schema.String.check(unicodeCodePointLength(0, 1_000)),
+  snippetTruncated: Schema.Boolean,
+  matchedAt: IsoDateTime,
+  messageId: Schema.NullOr(MessageId),
+  runId: Schema.NullOr(RunId),
+  itemId: Schema.NullOr(TurnItemId),
+  readAnchor: Schema.NullOr(OrchestratorMcpThreadReadAnchor),
+});
+export type OrchestratorMcpThreadSearchHit = typeof OrchestratorMcpThreadSearchHit.Type;
+
+export const OrchestratorMcpThreadSearchResult = Schema.Struct({
+  projectId: ProjectId,
+  hits: Schema.Array(OrchestratorMcpThreadSearchHit),
+  nextCursor: Schema.NullOr(NonNegativeInt),
+  hasMore: Schema.Boolean,
+  traversalTruncated: Schema.Boolean,
+  consistency: Schema.Literal("live"),
+});
+export type OrchestratorMcpThreadSearchResult = typeof OrchestratorMcpThreadSearchResult.Type;
+
 export const OrchestratorMcpThreadReadInput = Schema.Struct({
   threadId: ThreadId,
   view: Schema.optional(Schema.Literals(["messages", "activity"])),
   afterPosition: Schema.optional(NonNegativeInt),
+  anchor: Schema.optional(
+    OrchestratorMcpThreadReadAnchor.annotate({
+      description:
+        "Start inclusively at a visible source message returned by t3_thread_search. Cannot be combined with afterPosition.",
+    }),
+  ),
   limit: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(100))),
   runLimit: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(50))),
   maxCharsPerItem: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(50_000))),
-});
+}).check(
+  Schema.makeFilter(
+    (input) =>
+      !(input.anchor !== undefined && input.afterPosition !== undefined) ||
+      "anchor and afterPosition cannot be specified together",
+  ),
+);
 export type OrchestratorMcpThreadReadInput = typeof OrchestratorMcpThreadReadInput.Type;
 
 export const OrchestratorMcpThreadDetail = Schema.Struct({
@@ -488,6 +574,7 @@ export const OrchestratorMcpCapabilitiesResult = Schema.Struct({
     batchThreadCreation: Schema.Boolean,
     threadManagement: Schema.Boolean,
     incrementalThreadRead: Schema.Boolean,
+    threadSearch: Schema.optional(Schema.Boolean),
     scheduledTasks: Schema.Boolean,
     maxBatchThreads: Schema.Number,
   }),

--- a/packages/shared/src/t3McpToolPresentation.test.ts
+++ b/packages/shared/src/t3McpToolPresentation.test.ts
@@ -8,6 +8,10 @@ describe("resolveT3McpToolPresentation", () => {
       displayName: "Read a T3 thread",
       logo: "t3-code",
     });
+    expect(resolveT3McpToolPresentation("mcp__t3-code__t3_thread_search")).toEqual({
+      displayName: "Search T3 threads",
+      logo: "t3-code",
+    });
   });
 
   it("pretty prints Codex T3 MCP tool names", () => {

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -49,6 +49,7 @@ const T3_MCP_TOOLS: Record<
   t3_thread_list: { displayName: "List T3 threads", summaryAction: "thread-list" },
   t3_thread_read: { displayName: "Read a T3 thread", summaryAction: "thread-read" },
   t3_thread_update: { displayName: "Update T3 thread metadata" },
+  t3_thread_search: { displayName: "Search T3 threads" },
   t3_thread_send: { displayName: "Send to a T3 thread", summaryAction: "thread-send" },
   t3_thread_wait: { displayName: "Wait for a T3 thread", summaryAction: "thread-wait" },
   t3_thread_interrupt: { displayName: "Interrupt a T3 thread", summaryAction: "thread-interrupt" },


### PR DESCRIPTION
## Problem

Agents can read known threads but cannot search durable thread content and then navigate directly to a matching visible message.

## Change

Expose `t3_thread_search` as a read-only MCP tool over the bounded projection query from [#8721](https://github.com/pingdotgg/t3code/pull/8721). The tool:

- defaults to the calling thread and current project scope
- supports an optional same-project thread filter and archived opt-in
- returns bounded snippets, source and storage origin, live pagination state, and nullable V2 read anchors
- lets `t3_thread_read.anchor` start inclusively at the matching visible source/message identity
- maps typed input errors to `invalid_request` and persistence failures to fixed structural errors without exposing SQL details
- remains available to every provider, including Claude's read-only allowlist
- keeps the merged `t3_thread_update` registration and metadata behavior intact

## Behavior

Search is read-only and never imports transcripts, acknowledges child delivery, or returns full messages. An anchor that is foreign, stale, rolled back, or no longer visible fails instead of falling back to a raw ordinal.

## Validation

- `vp test run apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts apps/server/src/mcp/toolkits/worktree/registration.test.ts packages/contracts/src/orchestratorMcp.test.ts packages/shared/src/t3McpToolPresentation.test.ts` (15/15)
- production MCP registration with a real SQLite/V2 search hit to anchored-read round trip
- root-object tool schemas, current-project rejection, bounded astral-Unicode result encoding, and provider presentation/allowlist coverage
- scoped `t3`, `@t3tools/contracts`, and `@t3tools/shared` typechecks
- targeted lint, format, and `git diff --check`

## Dependency

Upper member of native stack #8785. Depends on [#8721](https://github.com/pingdotgg/t3code/pull/8721).

Implemented by GPT-5.6-Sol via Codex in T3 Code.
