### PR TITLE
feat(mcp): list and close preview tabs

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -11,6 +11,7 @@ import { HttpBody, HttpClient, HttpRouter, HttpServerResponse } from "effect/uns
 import * as McpHttpServer from "./McpHttpServer.ts";
 import * as McpInvocationContext from "./McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
+import * as PreviewManager from "../preview/Manager.ts";
 
 const environmentId = EnvironmentId.make("environment-mcp-test");
 const threadId = ThreadId.make("thread-mcp-test");
@@ -37,6 +38,7 @@ const client = McpSchema.McpServerClient.of({
 const TestLayer = McpHttpServer.PreviewToolkitRegistrationLive.pipe(
   Layer.provideMerge(McpServer.McpServer.layer),
   Layer.provideMerge(PreviewAutomationBroker.layer.pipe(Layer.provide(NodeServices.layer))),
+  Layer.provideMerge(PreviewManager.layer),
 );
 
 it("normalizes empty successful notification responses to accepted", () => {
@@ -156,6 +158,7 @@ it.effect("registers annotated tools and preserves authenticated request context
     Effect.gen(function* () {
       const server = yield* McpServer.McpServer;
       const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+      const previewManager = yield* PreviewManager.PreviewManager;
       const routedRequests: Array<{
         readonly operation: string;
         readonly tabId?: string | undefined;
@@ -228,6 +231,27 @@ it.effect("registers annotated tools and preserves authenticated request context
       const navigateTool = server.tools.find(({ tool }) => tool.name === "preview_navigate");
       expect(navigateTool?.tool.annotations?.destructiveHint).toBe(false);
       expect(navigateTool?.tool.annotations?.openWorldHint).toBe(true);
+
+      const opened = yield* previewManager.open({ threadId });
+      const listed = yield* server
+        .callTool({ name: "preview_list", arguments: { limit: 1 } })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+      expect(listed.isError).toBe(false);
+      expect(listed.structuredContent).toMatchObject({
+        sessions: [{ threadId, tabId: opened.tabId }],
+      });
+      const closed = yield* server
+        .callTool({ name: "preview_close", arguments: { tabId: opened.tabId } })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+      expect(closed.isError).toBe(false);
+      expect(closed.structuredContent).toEqual({ tabId: opened.tabId, closed: true });
+      expect((yield* previewManager.list({ threadId })).sessions).toHaveLength(0);
 
       const status = yield* server
         .callTool({ name: "preview_status", arguments: {} })

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -15,6 +15,7 @@ import * as OrchestratorMcpService from "./OrchestratorMcpService.ts";
 import * as ThreadMetadataMcpService from "./ThreadMetadataMcpService.ts";
 import * as McpSessionRegistry from "./McpSessionRegistry.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
+import * as PreviewMcpService from "./PreviewMcpService.ts";
 import { OrchestratorToolkitHandlersLive } from "./toolkits/orchestrator/handlers.ts";
 import { OrchestratorToolkit } from "./toolkits/orchestrator/tools.ts";
 import {
@@ -211,6 +212,7 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
 
 const PreviewStandardToolkitRegistrationLive = McpServer.toolkit(PreviewStandardToolkit).pipe(
   Layer.provide(PreviewStandardToolkitHandlersLive),
+  Layer.provide(PreviewMcpService.layer),
 );
 
 const PreviewSnapshotRegistrationLive = Layer.effectDiscard(registerPreviewSnapshot()).pipe(

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -173,6 +173,57 @@ it.effect("does not let an older response replace a newer explicit tab target", 
   ),
 );
 
+it.effect("blocks a closed in-flight tab without discarding another selected tab", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const selectedTabId = PreviewTabId.make("tab-selected-b");
+      const closingTabId = PreviewTabId.make("tab-closing-a");
+      const connected = yield* Deferred.make<void>();
+      const closingRequest = yield* Deferred.make<void>();
+      const releaseClosingResponse = yield* Deferred.make<void>();
+      const routedRequests: RoutedRequest[] = [];
+      const events = yield* broker.connect(makeHost());
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
+        const request = { ...event.request, connectionId: event.connectionId };
+        routedRequests.push(request);
+        return Effect.gen(function* () {
+          if (request.tabId === closingTabId) {
+            yield* Deferred.succeed(closingRequest, undefined);
+            yield* Deferred.await(releaseClosingResponse);
+          }
+          yield* broker.respond({
+            clientId: "client-1",
+            connectionId: request.connectionId,
+            requestId: request.requestId,
+            ok: true,
+            result:
+              request.operation === "open"
+                ? { available: true, tabId: selectedTabId }
+                : request.tabId === closingTabId
+                  ? { available: true, tabId: closingTabId }
+                  : { url: "http://localhost:3200" },
+          });
+        }).pipe(Effect.forkScoped, Effect.asVoid);
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
+
+      yield* broker.invoke({ scope, operation: "open", input: {} });
+      const delayed = yield* broker
+        .invoke({ scope, operation: "status", input: {}, tabId: closingTabId })
+        .pipe(Effect.forkScoped);
+      yield* Deferred.await(closingRequest);
+      yield* broker.forgetClosedTab(scope, closingTabId);
+      yield* Deferred.succeed(releaseClosingResponse, undefined);
+      yield* Fiber.join(delayed);
+      yield* broker.invoke({ scope, operation: "snapshot", input: {} });
+
+      expect(routedRequests.at(-1)?.tabId).toBe(selectedTabId);
+    }),
+  ),
+);
+
 it.effect("tracks the tab returned by a targeted recording stop", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -7,6 +7,7 @@ import {
   PreviewAutomationMalformedResponseError,
   PreviewAutomationNoAvailableHostError,
   PreviewAutomationTargetNotEditableError,
+  PreviewAutomationTimeoutError,
   PreviewTabId,
   ProviderInstanceId,
   ThreadId,
@@ -19,6 +20,7 @@ import * as Deferred from "effect/Deferred";
 import * as Fiber from "effect/Fiber";
 import * as Result from "effect/Result";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
 
@@ -224,7 +226,115 @@ it.effect("blocks a closed in-flight tab without discarding another selected tab
   ),
 );
 
-it.effect("commits a response tab before delivery so a following close cannot be undone", () =>
+it.effect("allows an older response for another tab after closing the selected tab", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const selectedTabId = PreviewTabId.make("tab-selected-before-close");
+      const otherTabId = PreviewTabId.make("tab-other-in-flight");
+      const connected = yield* Deferred.make<void>();
+      const otherRequestRouted = yield* Deferred.make<void>();
+      const releaseOtherResponse = yield* Deferred.make<void>();
+      const routedRequests: RoutedRequest[] = [];
+      const events = yield* broker.connect(makeHost());
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
+        const request = { ...event.request, connectionId: event.connectionId };
+        routedRequests.push(request);
+        return Effect.gen(function* () {
+          if (request.tabId === otherTabId) {
+            yield* Deferred.succeed(otherRequestRouted, undefined);
+            yield* Deferred.await(releaseOtherResponse);
+          }
+          yield* broker.respond({
+            clientId: "client-1",
+            connectionId: request.connectionId,
+            requestId: request.requestId,
+            ok: true,
+            result:
+              request.operation === "open"
+                ? { available: true, tabId: selectedTabId }
+                : request.tabId === otherTabId
+                  ? { available: true, tabId: otherTabId }
+                  : { url: "http://localhost:3200" },
+          });
+        }).pipe(Effect.forkScoped, Effect.asVoid);
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
+
+      yield* broker.invoke({ scope, operation: "open", input: {} });
+      const other = yield* broker
+        .invoke({ scope, operation: "status", input: {}, tabId: otherTabId })
+        .pipe(Effect.forkScoped);
+      yield* Deferred.await(otherRequestRouted);
+      yield* broker.forgetClosedTab(scope, selectedTabId);
+      yield* Deferred.succeed(releaseOtherResponse, undefined);
+      yield* Fiber.join(other);
+      yield* broker.invoke({ scope, operation: "snapshot", input: {} });
+
+      expect(routedRequests.at(-1)?.tabId).toBe(otherTabId);
+    }),
+  ),
+);
+
+it.effect("does not install a host response after the caller has timed out", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const lateTabId = PreviewTabId.make("tab-after-timeout");
+      const connected = yield* Deferred.make<void>();
+      const requestRouted = yield* Deferred.make<void>();
+      const releaseResponse = yield* Deferred.make<void>();
+      const responseHandled = yield* Deferred.make<void>();
+      const routedRequests: RoutedRequest[] = [];
+      const events = yield* broker.connect(makeHost());
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
+        const request = { ...event.request, connectionId: event.connectionId };
+        routedRequests.push(request);
+        return Effect.gen(function* () {
+          if (request.operation === "status") {
+            yield* Deferred.succeed(requestRouted, undefined);
+            yield* Deferred.await(releaseResponse);
+          }
+          yield* broker.respond({
+            clientId: "client-1",
+            connectionId: request.connectionId,
+            requestId: request.requestId,
+            ok: true,
+            result:
+              request.operation === "status"
+                ? { available: true, tabId: lateTabId }
+                : { url: "http://localhost:3200" },
+          });
+          if (request.operation === "status") {
+            yield* Deferred.succeed(responseHandled, undefined);
+          }
+        }).pipe(Effect.forkScoped, Effect.asVoid);
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
+
+      const timedOut = yield* broker
+        .invoke<{ readonly available: boolean }>({
+          scope,
+          operation: "status",
+          input: {},
+          timeoutMs: 1_000,
+        })
+        .pipe(Effect.flip, Effect.forkScoped);
+      yield* Deferred.await(requestRouted);
+      yield* TestClock.adjust("1 second");
+      expect(yield* Fiber.join(timedOut)).toBeInstanceOf(PreviewAutomationTimeoutError);
+      yield* Deferred.succeed(releaseResponse, undefined);
+      yield* Deferred.await(responseHandled);
+      yield* broker.invoke({ scope, operation: "snapshot", input: {} });
+
+      expect(routedRequests.at(-1)?.tabId).toBeUndefined();
+    }),
+  ),
+);
+
+it.effect("keeps a response pending until close can reject its returned tab", () =>
   Effect.scoped(
     Effect.gen(function* () {
       const broker = yield* makeBroker;

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -224,6 +224,134 @@ it.effect("blocks a closed in-flight tab without discarding another selected tab
   ),
 );
 
+it.effect("commits a response tab before delivery so a following close cannot be undone", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const closingTabId = PreviewTabId.make("tab-response-before-close");
+      const connected = yield* Deferred.make<void>();
+      const responseDelivered = yield* Deferred.make<void>();
+      const routedRequests: RoutedRequest[] = [];
+      const events = yield* broker.connect(makeHost());
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
+        const request = { ...event.request, connectionId: event.connectionId };
+        routedRequests.push(request);
+        return Effect.gen(function* () {
+          yield* broker.respond({
+            clientId: "client-1",
+            connectionId: request.connectionId,
+            requestId: request.requestId,
+            ok: true,
+            result:
+              request.operation === "status"
+                ? { available: true, tabId: closingTabId }
+                : { url: "http://localhost:3200" },
+          });
+          if (request.operation === "status") {
+            yield* Deferred.succeed(responseDelivered, undefined);
+          }
+        });
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
+
+      const response = yield* broker
+        .invoke({ scope, operation: "status", input: {}, tabId: closingTabId })
+        .pipe(Effect.forkScoped);
+      yield* Deferred.await(responseDelivered);
+      yield* broker.forgetClosedTab(scope, closingTabId);
+      yield* Fiber.join(response);
+      yield* broker.invoke({ scope, operation: "snapshot", input: {} });
+
+      expect(routedRequests.at(-1)?.tabId).toBeUndefined();
+    }),
+  ),
+);
+
+it.effect("retires close barriers after failed and interrupted invocations", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const closingTabId = PreviewTabId.make("tab-finalized-barrier");
+      const connected = yield* Deferred.make<void>();
+      const failedRequestRouted = yield* Deferred.make<void>();
+      const interruptedRequestRouted = yield* Deferred.make<void>();
+      const releaseFailure = yield* Deferred.make<void>();
+      const routedRequests: RoutedRequest[] = [];
+      const events = yield* broker.connect(makeHost());
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
+        const request = { ...event.request, connectionId: event.connectionId };
+        routedRequests.push(request);
+        const marker =
+          typeof request.input === "object" && request.input !== null && "marker" in request.input
+            ? request.input.marker
+            : undefined;
+        return Effect.gen(function* () {
+          if (marker === "fail") {
+            yield* Deferred.succeed(failedRequestRouted, undefined);
+            yield* Deferred.await(releaseFailure);
+            yield* broker.respond({
+              clientId: "client-1",
+              connectionId: request.connectionId,
+              requestId: request.requestId,
+              ok: false,
+              error: {
+                _tag: "PreviewAutomationUnavailableError",
+                message: "host failed",
+              },
+            });
+            return;
+          }
+          if (marker === "interrupt") {
+            yield* Deferred.succeed(interruptedRequestRouted, undefined);
+            return yield* Effect.never;
+          }
+          yield* broker.respond({
+            clientId: "client-1",
+            connectionId: request.connectionId,
+            requestId: request.requestId,
+            ok: true,
+            result:
+              marker === "fresh"
+                ? { available: true, tabId: closingTabId }
+                : { url: "http://localhost:3200" },
+          });
+        }).pipe(Effect.forkScoped, Effect.asVoid);
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
+
+      const failed = yield* broker
+        .invoke({ scope, operation: "status", input: { marker: "fail" }, tabId: closingTabId })
+        .pipe(Effect.flip, Effect.forkScoped);
+      const interrupted = yield* broker
+        .invoke({
+          scope,
+          operation: "status",
+          input: { marker: "interrupt" },
+          tabId: closingTabId,
+        })
+        .pipe(Effect.forkScoped);
+      yield* Deferred.await(failedRequestRouted);
+      yield* Deferred.await(interruptedRequestRouted);
+      yield* broker.forgetClosedTab(scope, closingTabId);
+      yield* Deferred.succeed(releaseFailure, undefined);
+      yield* Fiber.await(failed);
+      yield* Fiber.interrupt(interrupted);
+
+      yield* broker.invoke({
+        scope,
+        operation: "status",
+        input: { marker: "fresh" },
+        tabId: closingTabId,
+      });
+      yield* broker.invoke({ scope, operation: "snapshot", input: {} });
+
+      expect(routedRequests.at(-1)?.tabId).toBe(closingTabId);
+    }),
+  ),
+);
+
 it.effect("tracks the tab returned by a targeted recording stop", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -430,21 +430,42 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
   const respond: PreviewAutomationBroker["Service"]["respond"] = Effect.fn(
     "PreviewAutomationBroker.respond",
   )(function* (response) {
-    const pending = yield* SynchronizedRef.modify(state, (current) => {
-      const entry = current.pending.get(response.requestId);
-      if (
-        !entry ||
-        entry.context.clientId !== response.clientId ||
-        entry.context.connectionId !== response.connectionId
-      ) {
-        return [undefined, current] as const;
-      }
-      const nextPending = new Map(current.pending);
-      nextPending.delete(response.requestId);
-      let assignments: ReadonlyMap<string, HostAssignment> = current.assignments;
-      if (response.ok) {
+    const pending = yield* SynchronizedRef.get(state).pipe(
+      Effect.map((current) => {
+        const entry = current.pending.get(response.requestId);
+        if (
+          !entry ||
+          entry.context.clientId !== response.clientId ||
+          entry.context.connectionId !== response.connectionId
+        ) {
+          return undefined;
+        }
+        return entry;
+      }),
+    );
+    if (!pending) return;
+    if (response.ok) {
+      yield* Deferred.succeed(pending.deferred, response.result);
+    } else {
+      yield* Deferred.fail(
+        pending.deferred,
+        response.error
+          ? classifyResponseError(pending.context, response.error)
+          : new PreviewAutomationMalformedResponseError(pending.context),
+      );
+    }
+  });
+
+  const commitSuccessfulResponse = Effect.fn("PreviewAutomationBroker.commitSuccessfulResponse")(
+    function* (requestId: string, result: unknown) {
+      yield* SynchronizedRef.update(state, (current) => {
+        const entry = current.pending.get(requestId);
+        if (entry === undefined) return current;
+        const pending = new Map(current.pending);
+        pending.delete(requestId);
+        let assignments: ReadonlyMap<string, HostAssignment> = current.assignments;
         const assignment = assignments.get(entry.assignmentKey);
-        const responseTabId = readResultTabId(response.result);
+        const responseTabId = readResultTabId(result);
         const resultTabId =
           responseTabId === undefined && entry.tabIdExplicit ? entry.context.tabId : responseTabId;
         if (
@@ -473,22 +494,11 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
           }
           assignments = nextAssignments;
         }
-      }
-      assignments = pruneClosedTabBarriers(assignments, nextPending, entry.assignmentKey);
-      return [entry, { ...current, assignments, pending: nextPending }] as const;
-    });
-    if (!pending) return;
-    if (response.ok) {
-      yield* Deferred.succeed(pending.deferred, response.result);
-    } else {
-      yield* Deferred.fail(
-        pending.deferred,
-        response.error
-          ? classifyResponseError(pending.context, response.error)
-          : new PreviewAutomationMalformedResponseError(pending.context),
-      );
-    }
-  });
+        assignments = pruneClosedTabBarriers(assignments, pending, entry.assignmentKey);
+        return { ...current, assignments, pending };
+      });
+    },
+  );
 
   const forgetClosedTab: PreviewAutomationBroker["Service"]["forgetClosedTab"] = Effect.fn(
     "PreviewAutomationBroker.forgetClosedTab",
@@ -513,7 +523,6 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         const { tabId: _tabId, ...withoutTabId } = assignment;
         assignments.set(assignmentKey, {
           ...withoutTabId,
-          tabSequence: current.requestSequence,
           ...(closedTabSequences.size === 0 ? {} : { closedTabSequences }),
         });
       } else {
@@ -673,7 +682,10 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         onSome: (value) => Effect.succeed(value as A),
       });
     });
-    const result = yield* awaitResponse().pipe(Effect.ensuring(removePending));
+    const result = yield* awaitResponse().pipe(
+      Effect.tap((response) => commitSuccessfulResponse(requestId, response)),
+      Effect.ensuring(removePending),
+    );
     return result;
   });
 

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -76,6 +76,8 @@ interface PendingRequest {
   readonly queue: ClientConnection["queue"];
   readonly deferred: Deferred.Deferred<unknown, PreviewAutomationError>;
   readonly context: PreviewAutomationRequestErrorContext;
+  readonly assignmentKey: string;
+  readonly requestSequence: number;
 }
 
 /**
@@ -92,6 +94,7 @@ interface HostAssignment {
   readonly queue: ClientConnection["queue"];
   readonly tabId?: PreviewTabId;
   readonly tabSequence?: number;
+  readonly closedTabSequences?: ReadonlyMap<PreviewTabId, number>;
 }
 
 interface PreviewAutomationRequestErrorContext {
@@ -433,13 +436,20 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
     yield* SynchronizedRef.update(state, (current) => {
       const assignmentKey = hostAssignmentKey(scope);
       const assignment = current.assignments.get(assignmentKey);
-      if (assignment?.tabId !== tabId) return current;
+      if (assignment === undefined) return current;
       const assignments = new Map(current.assignments);
-      const { tabId: _tabId, ...withoutTabId } = assignment;
-      assignments.set(assignmentKey, {
-        ...withoutTabId,
-        tabSequence: current.requestSequence,
-      });
+      const closedTabSequences = new Map(assignment.closedTabSequences);
+      closedTabSequences.set(tabId, current.requestSequence);
+      if (assignment.tabId === tabId) {
+        const { tabId: _tabId, ...withoutTabId } = assignment;
+        assignments.set(assignmentKey, {
+          ...withoutTabId,
+          tabSequence: current.requestSequence,
+          closedTabSequences,
+        });
+      } else {
+        assignments.set(assignmentKey, { ...assignment, closedTabSequences });
+      }
       return {
         ...current,
         assignments,
@@ -506,6 +516,9 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         ...(canReuseAssignedTab && assigned.tabSequence !== undefined
           ? { tabSequence: assigned.tabSequence }
           : {}),
+        ...(canReuseAssignedTab && assigned.closedTabSequences !== undefined
+          ? { closedTabSequences: assigned.closedTabSequences }
+          : {}),
       });
 
       const requestSequence = current.requestSequence;
@@ -526,7 +539,13 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         ...selectorDiagnostics,
       };
       const pending = new Map(current.pending);
-      pending.set(requestId, { queue: connection.queue, deferred, context });
+      pending.set(requestId, {
+        queue: connection.queue,
+        deferred,
+        context,
+        assignmentKey,
+        requestSequence,
+      });
       return [
         { connection, requestId, requestContext: context, requestSequence },
         { ...current, assignments, pending, requestSequence: current.requestSequence + 1 },
@@ -591,15 +610,37 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         return current;
       }
       const assignments = new Map(current.assignments);
+      const closedAt =
+        resultTabId === null ? undefined : assignment.closedTabSequences?.get(resultTabId);
+      const responsePredatesClose = closedAt !== undefined && requestSequence < closedAt;
       if (resultTabId === null) {
         const { tabId: _tabId, ...withoutTabId } = assignment;
         assignments.set(assignmentKey, { ...withoutTabId, tabSequence: requestSequence });
-      } else {
+      } else if (!responsePredatesClose) {
         assignments.set(assignmentKey, {
           ...assignment,
           ...(resultTabId === undefined ? {} : { tabId: resultTabId }),
           tabSequence: requestSequence,
         });
+      }
+      const nextAssignment = assignments.get(assignmentKey);
+      if (nextAssignment?.closedTabSequences !== undefined) {
+        const closedTabSequences = new Map(nextAssignment.closedTabSequences);
+        for (const [closedTabId, barrier] of closedTabSequences) {
+          const olderRequestPending = Array.from(current.pending.values()).some(
+            (pending) =>
+              pending.assignmentKey === assignmentKey && pending.requestSequence < barrier,
+          );
+          if (!olderRequestPending) closedTabSequences.delete(closedTabId);
+        }
+        const { closedTabSequences: _closedTabSequences, ...withoutClosedTabSequences } =
+          nextAssignment;
+        assignments.set(
+          assignmentKey,
+          closedTabSequences.size === 0
+            ? withoutClosedTabSequences
+            : { ...withoutClosedTabSequences, closedTabSequences },
+        );
       }
       return { ...current, assignments };
     });

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -52,6 +52,10 @@ export class PreviewAutomationBroker extends Context.Service<
     readonly respond: (
       response: PreviewAutomationResponse,
     ) => Effect.Effect<void, PreviewAutomationError>;
+    readonly forgetClosedTab: (
+      scope: McpInvocationContext.McpInvocationScope,
+      tabId: PreviewTabId,
+    ) => Effect.Effect<void>;
     readonly invoke: <A = unknown>(
       request: PreviewAutomationInvokeInput,
     ) => Effect.Effect<A, PreviewAutomationError>;
@@ -423,6 +427,27 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
     }
   });
 
+  const forgetClosedTab: PreviewAutomationBroker["Service"]["forgetClosedTab"] = Effect.fn(
+    "PreviewAutomationBroker.forgetClosedTab",
+  )(function* (scope, tabId) {
+    yield* SynchronizedRef.update(state, (current) => {
+      const assignmentKey = hostAssignmentKey(scope);
+      const assignment = current.assignments.get(assignmentKey);
+      if (assignment?.tabId !== tabId) return current;
+      const assignments = new Map(current.assignments);
+      const { tabId: _tabId, ...withoutTabId } = assignment;
+      assignments.set(assignmentKey, {
+        ...withoutTabId,
+        tabSequence: current.requestSequence,
+      });
+      return {
+        ...current,
+        assignments,
+        requestSequence: current.requestSequence + 1,
+      };
+    });
+  });
+
   const invoke = Effect.fn("PreviewAutomationBroker.invoke")(function* <A = unknown>(
     input: Parameters<PreviewAutomationBroker["Service"]["invoke"]>[0],
   ): Effect.fn.Return<A, PreviewAutomationError> {
@@ -581,7 +606,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
     return result;
   });
 
-  return PreviewAutomationBroker.of({ connect, focusHost, respond, invoke });
+  return PreviewAutomationBroker.of({ connect, focusHost, respond, forgetClosedTab, invoke });
 }).pipe(Effect.withSpan("PreviewAutomationBroker.make"));
 
 export const layer = Layer.effect(PreviewAutomationBroker, make);

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -78,6 +78,7 @@ interface PendingRequest {
   readonly context: PreviewAutomationRequestErrorContext;
   readonly assignmentKey: string;
   readonly requestSequence: number;
+  readonly tabIdExplicit: boolean;
 }
 
 /**
@@ -119,6 +120,31 @@ interface BrokerState {
   readonly requestSequence: number;
   readonly focusSequence: number;
 }
+
+const pruneClosedTabBarriers = (
+  assignments: ReadonlyMap<string, HostAssignment>,
+  pending: ReadonlyMap<string, PendingRequest>,
+  assignmentKey: string,
+): ReadonlyMap<string, HostAssignment> => {
+  const assignment = assignments.get(assignmentKey);
+  if (assignment?.closedTabSequences === undefined) return assignments;
+  const closedTabSequences = new Map(assignment.closedTabSequences);
+  for (const [closedTabId, barrier] of closedTabSequences) {
+    const olderInvocationCanCommit = Array.from(pending.values()).some(
+      (request) => request.assignmentKey === assignmentKey && request.requestSequence < barrier,
+    );
+    if (!olderInvocationCanCommit) closedTabSequences.delete(closedTabId);
+  }
+  const next = new Map(assignments);
+  const { closedTabSequences: _closedTabSequences, ...withoutClosedTabSequences } = assignment;
+  next.set(
+    assignmentKey,
+    closedTabSequences.size === 0
+      ? withoutClosedTabSequences
+      : { ...withoutClosedTabSequences, closedTabSequences },
+  );
+  return next;
+};
 
 const removeConnectionFromState = (
   current: BrokerState,
@@ -413,9 +439,43 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
       ) {
         return [undefined, current] as const;
       }
-      const next = new Map(current.pending);
-      next.delete(response.requestId);
-      return [entry, { ...current, pending: next }] as const;
+      const nextPending = new Map(current.pending);
+      nextPending.delete(response.requestId);
+      let assignments: ReadonlyMap<string, HostAssignment> = current.assignments;
+      if (response.ok) {
+        const assignment = assignments.get(entry.assignmentKey);
+        const responseTabId = readResultTabId(response.result);
+        const resultTabId =
+          responseTabId === undefined && entry.tabIdExplicit ? entry.context.tabId : responseTabId;
+        if (
+          resultTabId !== undefined &&
+          assignment !== undefined &&
+          assignment.connectionId === entry.context.connectionId &&
+          assignment.queue === entry.queue &&
+          (assignment.tabSequence ?? -1) <= entry.requestSequence
+        ) {
+          const nextAssignments = new Map(assignments);
+          const closedAt =
+            resultTabId === null ? undefined : assignment.closedTabSequences?.get(resultTabId);
+          const responsePredatesClose = closedAt !== undefined && entry.requestSequence < closedAt;
+          if (resultTabId === null) {
+            const { tabId: _tabId, ...withoutTabId } = assignment;
+            nextAssignments.set(entry.assignmentKey, {
+              ...withoutTabId,
+              tabSequence: entry.requestSequence,
+            });
+          } else if (!responsePredatesClose) {
+            nextAssignments.set(entry.assignmentKey, {
+              ...assignment,
+              tabId: resultTabId,
+              tabSequence: entry.requestSequence,
+            });
+          }
+          assignments = nextAssignments;
+        }
+      }
+      assignments = pruneClosedTabBarriers(assignments, nextPending, entry.assignmentKey);
+      return [entry, { ...current, assignments, pending: nextPending }] as const;
     });
     if (!pending) return;
     if (response.ok) {
@@ -435,20 +495,36 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
   )(function* (scope, tabId) {
     yield* SynchronizedRef.update(state, (current) => {
       const assignmentKey = hostAssignmentKey(scope);
-      const assignment = current.assignments.get(assignmentKey);
+      const prunedAssignments = pruneClosedTabBarriers(
+        current.assignments,
+        current.pending,
+        assignmentKey,
+      );
+      const assignment = prunedAssignments.get(assignmentKey);
       if (assignment === undefined) return current;
-      const assignments = new Map(current.assignments);
+      const assignments = new Map(prunedAssignments);
       const closedTabSequences = new Map(assignment.closedTabSequences);
-      closedTabSequences.set(tabId, current.requestSequence);
+      const olderInvocationCanCommit = Array.from(current.pending.values()).some(
+        (request) => request.assignmentKey === assignmentKey,
+      );
+      if (olderInvocationCanCommit) closedTabSequences.set(tabId, current.requestSequence);
+      else closedTabSequences.delete(tabId);
       if (assignment.tabId === tabId) {
         const { tabId: _tabId, ...withoutTabId } = assignment;
         assignments.set(assignmentKey, {
           ...withoutTabId,
           tabSequence: current.requestSequence,
-          closedTabSequences,
+          ...(closedTabSequences.size === 0 ? {} : { closedTabSequences }),
         });
       } else {
-        assignments.set(assignmentKey, { ...assignment, closedTabSequences });
+        const { closedTabSequences: _closedTabSequences, ...withoutClosedTabSequences } =
+          assignment;
+        assignments.set(
+          assignmentKey,
+          closedTabSequences.size === 0
+            ? withoutClosedTabSequences
+            : { ...withoutClosedTabSequences, closedTabSequences },
+        );
       }
       return {
         ...current,
@@ -545,6 +621,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         context,
         assignmentKey,
         requestSequence,
+        tabIdExplicit: input.tabId !== undefined,
       });
       return [
         { connection, requestId, requestContext: context, requestSequence },
@@ -560,12 +637,14 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         providerInstanceId: input.scope.providerInstanceId,
       });
     }
-    const { connection, requestId, requestContext, requestSequence } = route;
+    const { connection, requestId, requestContext } = route;
     const removePending = SynchronizedRef.update(state, (next) => {
-      if (!next.pending.has(requestId)) return next;
+      const entry = next.pending.get(requestId);
+      if (entry === undefined) return next;
       const pending = new Map(next.pending);
       pending.delete(requestId);
-      return { ...next, pending };
+      const assignments = pruneClosedTabBarriers(next.assignments, pending, entry.assignmentKey);
+      return { ...next, assignments, pending };
     });
     const awaitResponse = Effect.fn("PreviewAutomationBroker.awaitResponse")(function* () {
       const offered = yield* Queue.offer(connection.queue, {
@@ -595,55 +674,6 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
       });
     });
     const result = yield* awaitResponse().pipe(Effect.ensuring(removePending));
-    const responseTabId = readResultTabId(result);
-    const resultTabId = responseTabId === undefined ? input.tabId : responseTabId;
-    if (resultTabId === undefined) return result;
-    const assignmentKey = hostAssignmentKey(input.scope);
-    yield* SynchronizedRef.update(state, (current) => {
-      const assignment = current.assignments.get(assignmentKey);
-      if (
-        !assignment ||
-        assignment.connectionId !== connection.connectionId ||
-        assignment.queue !== connection.queue ||
-        (assignment.tabSequence ?? -1) > requestSequence
-      ) {
-        return current;
-      }
-      const assignments = new Map(current.assignments);
-      const closedAt =
-        resultTabId === null ? undefined : assignment.closedTabSequences?.get(resultTabId);
-      const responsePredatesClose = closedAt !== undefined && requestSequence < closedAt;
-      if (resultTabId === null) {
-        const { tabId: _tabId, ...withoutTabId } = assignment;
-        assignments.set(assignmentKey, { ...withoutTabId, tabSequence: requestSequence });
-      } else if (!responsePredatesClose) {
-        assignments.set(assignmentKey, {
-          ...assignment,
-          ...(resultTabId === undefined ? {} : { tabId: resultTabId }),
-          tabSequence: requestSequence,
-        });
-      }
-      const nextAssignment = assignments.get(assignmentKey);
-      if (nextAssignment?.closedTabSequences !== undefined) {
-        const closedTabSequences = new Map(nextAssignment.closedTabSequences);
-        for (const [closedTabId, barrier] of closedTabSequences) {
-          const olderRequestPending = Array.from(current.pending.values()).some(
-            (pending) =>
-              pending.assignmentKey === assignmentKey && pending.requestSequence < barrier,
-          );
-          if (!olderRequestPending) closedTabSequences.delete(closedTabId);
-        }
-        const { closedTabSequences: _closedTabSequences, ...withoutClosedTabSequences } =
-          nextAssignment;
-        assignments.set(
-          assignmentKey,
-          closedTabSequences.size === 0
-            ? withoutClosedTabSequences
-            : { ...withoutClosedTabSequences, closedTabSequences },
-        );
-      }
-      return { ...current, assignments };
-    });
     return result;
   });
 

--- a/apps/server/src/mcp/PreviewMcpService.test.ts
+++ b/apps/server/src/mcp/PreviewMcpService.test.ts
@@ -252,9 +252,9 @@ it.effect("finishes broker cleanup when close is interrupted after manager remov
       yield* Deferred.await(cleanupEntered);
       expect((yield* manager.list({ threadId })).sessions).toHaveLength(0);
 
-      const interruption = yield* Fiber.interrupt(closeFiber).pipe(Effect.forkScoped);
+      closeFiber.interruptUnsafe();
       yield* Deferred.succeed(releaseCleanup, undefined);
-      yield* Fiber.join(interruption);
+      yield* Fiber.await(closeFiber);
       expect(yield* Ref.get(cleanupCompleted)).toBe(true);
       const repeated = yield* service.close(scope, { tabId: opened.tabId }).pipe(Effect.flip);
       expect(repeated._tag).toBe("PreviewSessionLookupError");

--- a/apps/server/src/mcp/PreviewMcpService.test.ts
+++ b/apps/server/src/mcp/PreviewMcpService.test.ts
@@ -1,0 +1,156 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  EnvironmentId,
+  ProviderInstanceId,
+  ThreadId,
+  type PreviewAutomationRequest,
+} from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as PubSub from "effect/PubSub";
+import * as Result from "effect/Result";
+import * as Stream from "effect/Stream";
+
+import * as PreviewManager from "../preview/Manager.ts";
+import * as McpInvocationContext from "./McpInvocationContext.ts";
+import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
+import * as PreviewMcpService from "./PreviewMcpService.ts";
+
+const environmentId = EnvironmentId.make("environment-preview-mcp");
+const scopeFor = (
+  threadId: ThreadId,
+  capabilities: McpInvocationContext.McpInvocationScope["capabilities"] = new Set(["preview"]),
+): McpInvocationContext.McpInvocationScope => ({
+  environmentId,
+  threadId,
+  providerSessionId: `provider-session-${threadId}`,
+  providerInstanceId: ProviderInstanceId.make("codex"),
+  capabilities,
+  issuedAt: 1,
+});
+
+const TestLayer = PreviewMcpService.layer.pipe(
+  Layer.provideMerge(PreviewManager.layer),
+  Layer.provideMerge(PreviewAutomationBroker.layer.pipe(Layer.provide(NodeServices.layer))),
+);
+
+it.layer(TestLayer)("PreviewMcpService", (it) => {
+  it.effect("uses a stable thread-bound cursor when an earlier tab closes", () =>
+    Effect.gen(function* () {
+      const manager = yield* PreviewManager.PreviewManager;
+      const service = yield* PreviewMcpService.PreviewMcpService;
+      const currentThreadId = ThreadId.make("thread-preview-paging");
+      const foreignThreadId = ThreadId.make("thread-preview-paging-foreign");
+      const scope = scopeFor(currentThreadId);
+      const opened = yield* Effect.all([
+        manager.open({ threadId: currentThreadId }),
+        manager.open({ threadId: currentThreadId }),
+        manager.open({ threadId: currentThreadId }),
+      ]);
+      yield* manager.open({ threadId: foreignThreadId });
+      const sortedIds = opened.map((session) => session.tabId).toSorted();
+
+      const first = yield* service.list(scope, { limit: 1 });
+      expect(first.sessions.map((session) => session.tabId)).toEqual([sortedIds[0]]);
+      expect(first.nextCursor).not.toBeNull();
+
+      yield* service.close(scope, { tabId: sortedIds[0]! });
+      const second = yield* service.list(scope, {
+        limit: 1,
+        cursor: first.nextCursor ?? undefined,
+      });
+      expect(second.sessions.map((session) => session.tabId)).toEqual([sortedIds[1]]);
+      expect(second.sessions.every((session) => session.threadId === currentThreadId)).toBe(true);
+
+      const foreignCursorError = yield* service
+        .list(scopeFor(foreignThreadId), { cursor: first.nextCursor! })
+        .pipe(Effect.flip);
+      expect(foreignCursorError._tag).toBe("PreviewMcpInvalidCursorError");
+    }),
+  );
+
+  it.effect("closes through manager events and clears the broker's current-tab lease", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const manager = yield* PreviewManager.PreviewManager;
+        const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+        const service = yield* PreviewMcpService.PreviewMcpService;
+        const currentThreadId = ThreadId.make("thread-preview-close");
+        const scope = scopeFor(currentThreadId);
+        const opened = yield* manager.open({ threadId: currentThreadId });
+        const events = yield* manager.subscribeEvents;
+        const requests: PreviewAutomationRequest[] = [];
+        const hostEvents = yield* broker.connect({ clientId: "preview-host", environmentId });
+        const requestEvents = hostEvents.pipe(
+          Stream.filterMap((event) =>
+            event.type === "request"
+              ? Result.succeed({ ...event.request, connectionId: event.connectionId })
+              : Result.failVoid,
+          ),
+        );
+        yield* Stream.runForEach(requestEvents, (request) => {
+          requests.push(request);
+          return broker.respond({
+            clientId: "preview-host",
+            connectionId: request.connectionId,
+            requestId: request.requestId,
+            ok: true,
+            result: {
+              available: true,
+              visible: false,
+              tabId: request.tabId ?? null,
+              url: null,
+              title: null,
+              loading: false,
+            },
+          });
+        }).pipe(Effect.forkScoped);
+        yield* Effect.yieldNow;
+
+        yield* broker.invoke({ scope, operation: "status", input: {}, tabId: opened.tabId });
+        expect(requests.at(-1)?.tabId).toBe(opened.tabId);
+
+        expect(yield* service.close(scope, { tabId: opened.tabId })).toEqual({
+          tabId: opened.tabId,
+          closed: true,
+        });
+        const closedEvent = yield* PubSub.take(events);
+        expect(closedEvent).toMatchObject({
+          type: "closed",
+          threadId: currentThreadId,
+          tabId: opened.tabId,
+        });
+
+        yield* broker.invoke({ scope, operation: "status", input: {} });
+        expect(requests.at(-1)?.tabId).toBeUndefined();
+        const repeated = yield* service.close(scope, { tabId: opened.tabId }).pipe(Effect.flip);
+        expect(repeated._tag).toBe("PreviewSessionLookupError");
+      }),
+    ),
+  );
+
+  it.effect("rejects foreign tabs and credentials without preview access", () =>
+    Effect.gen(function* () {
+      const manager = yield* PreviewManager.PreviewManager;
+      const service = yield* PreviewMcpService.PreviewMcpService;
+      const currentThreadId = ThreadId.make("thread-preview-authority");
+      const foreignThreadId = ThreadId.make("thread-preview-authority-foreign");
+      const scope = scopeFor(currentThreadId);
+      const foreign = yield* manager.open({ threadId: foreignThreadId });
+
+      const foreignError = yield* service.close(scope, { tabId: foreign.tabId }).pipe(Effect.flip);
+      expect(foreignError._tag).toBe("PreviewSessionLookupError");
+      expect((yield* manager.list({ threadId: foreignThreadId })).sessions).toHaveLength(1);
+
+      const deniedScope = scopeFor(currentThreadId, new Set());
+      const deniedList = yield* service.list(deniedScope, {}).pipe(Effect.flip);
+      expect(deniedList._tag).toBe("PreviewAutomationUnavailableError");
+      const deniedClose = yield* service
+        .close(deniedScope, { tabId: foreign.tabId })
+        .pipe(Effect.flip);
+      expect(deniedClose._tag).toBe("PreviewAutomationUnavailableError");
+      expect((yield* manager.list({ threadId: foreignThreadId })).sessions).toHaveLength(1);
+    }),
+  );
+});

--- a/apps/server/src/mcp/PreviewMcpService.test.ts
+++ b/apps/server/src/mcp/PreviewMcpService.test.ts
@@ -1,15 +1,20 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   EnvironmentId,
+  PREVIEW_MCP_NAV_DIAGNOSTIC_MAX_LENGTH,
+  PreviewMcpListResult,
   ProviderInstanceId,
   ThreadId,
   type PreviewAutomationRequest,
 } from "@t3tools/contracts";
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as PubSub from "effect/PubSub";
-import * as Result from "effect/Result";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 
 import * as PreviewManager from "../preview/Manager.ts";
@@ -18,6 +23,7 @@ import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
 import * as PreviewMcpService from "./PreviewMcpService.ts";
 
 const environmentId = EnvironmentId.make("environment-preview-mcp");
+const decodePreviewMcpListResult = Schema.decodeUnknownSync(PreviewMcpListResult);
 const scopeFor = (
   threadId: ThreadId,
   capabilities: McpInvocationContext.McpInvocationScope["capabilities"] = new Set(["preview"]),
@@ -70,6 +76,56 @@ it.layer(TestLayer)("PreviewMcpService", (it) => {
     }),
   );
 
+  it.effect("keeps long thread ids out of cursors and bounds failed-navigation diagnostics", () =>
+    Effect.gen(function* () {
+      const manager = yield* PreviewManager.PreviewManager;
+      const service = yield* PreviewMcpService.PreviewMcpService;
+      const currentThreadId = ThreadId.make(`thread-preview-long-${"x".repeat(4_000)}`);
+      const scope = scopeFor(currentThreadId);
+      const opened = yield* Effect.all([
+        manager.open({ threadId: currentThreadId }),
+        manager.open({ threadId: currentThreadId }),
+      ]);
+      const failed = opened[0]!;
+      yield* manager.reportStatus({
+        threadId: currentThreadId,
+        tabId: failed.tabId,
+        navStatus: {
+          _tag: "LoadFailed",
+          url: "http://localhost:3000",
+          title: "Failed preview",
+          code: -2,
+          description: "diagnostic".repeat(1_000),
+        },
+        canGoBack: false,
+        canGoForward: false,
+      });
+
+      const first = yield* service.list(scope, { limit: 1 });
+      expect(first.nextCursor?.length).toBeLessThanOrEqual(512);
+      const second = yield* service.list(scope, { limit: 1, cursor: first.nextCursor! });
+      expect([...first.sessions, ...second.sessions]).toHaveLength(2);
+      const failedResult = [...first.sessions, ...second.sessions].find(
+        (session) => session.tabId === failed.tabId,
+      );
+      expect(failedResult?.navStatus._tag).toBe("LoadFailed");
+      if (failedResult?.navStatus._tag === "LoadFailed") {
+        expect(failedResult.navStatus.description).toHaveLength(
+          PREVIEW_MCP_NAV_DIAGNOSTIC_MAX_LENGTH,
+        );
+        expect(failedResult.navStatus.descriptionTruncated).toBe(true);
+      }
+      expect(() => decodePreviewMcpListResult(first)).not.toThrow();
+      expect(() => decodePreviewMcpListResult(second)).not.toThrow();
+
+      const foreignLongThreadId = ThreadId.make(`thread-preview-other-${"x".repeat(4_000)}`);
+      const foreign = yield* service
+        .list(scopeFor(foreignLongThreadId), { cursor: first.nextCursor! })
+        .pipe(Effect.flip);
+      expect(foreign._tag).toBe("PreviewMcpInvalidCursorError");
+    }),
+  );
+
   it.effect("closes through manager events and clears the broker's current-tab lease", () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -81,34 +137,41 @@ it.layer(TestLayer)("PreviewMcpService", (it) => {
         const opened = yield* manager.open({ threadId: currentThreadId });
         const events = yield* manager.subscribeEvents;
         const requests: PreviewAutomationRequest[] = [];
+        const connected = yield* Deferred.make<void>();
+        const targetedRequest = yield* Deferred.make<void>();
+        const releaseTargetedResponse = yield* Deferred.make<void>();
         const hostEvents = yield* broker.connect({ clientId: "preview-host", environmentId });
-        const requestEvents = hostEvents.pipe(
-          Stream.filterMap((event) =>
-            event.type === "request"
-              ? Result.succeed({ ...event.request, connectionId: event.connectionId })
-              : Result.failVoid,
-          ),
-        );
-        yield* Stream.runForEach(requestEvents, (request) => {
+        yield* Stream.runForEach(hostEvents, (event) => {
+          if (event.type === "connected") return Deferred.succeed(connected, undefined);
+          const request = { ...event.request, connectionId: event.connectionId };
           requests.push(request);
-          return broker.respond({
-            clientId: "preview-host",
-            connectionId: request.connectionId,
-            requestId: request.requestId,
-            ok: true,
-            result: {
-              available: true,
-              visible: false,
-              tabId: request.tabId ?? null,
-              url: null,
-              title: null,
-              loading: false,
-            },
-          });
+          return Effect.gen(function* () {
+            if (request.tabId === opened.tabId) {
+              yield* Deferred.succeed(targetedRequest, undefined);
+              yield* Deferred.await(releaseTargetedResponse);
+            }
+            yield* broker.respond({
+              clientId: "preview-host",
+              connectionId: request.connectionId,
+              requestId: request.requestId,
+              ok: true,
+              result: {
+                available: true,
+                visible: false,
+                tabId: request.tabId ?? null,
+                url: null,
+                title: null,
+                loading: false,
+              },
+            });
+          }).pipe(Effect.forkScoped, Effect.asVoid);
         }).pipe(Effect.forkScoped);
-        yield* Effect.yieldNow;
+        yield* Deferred.await(connected);
 
-        yield* broker.invoke({ scope, operation: "status", input: {}, tabId: opened.tabId });
+        const delayedStatus = yield* broker
+          .invoke({ scope, operation: "status", input: {}, tabId: opened.tabId })
+          .pipe(Effect.forkScoped);
+        yield* Deferred.await(targetedRequest);
         expect(requests.at(-1)?.tabId).toBe(opened.tabId);
 
         expect(yield* service.close(scope, { tabId: opened.tabId })).toEqual({
@@ -121,6 +184,9 @@ it.layer(TestLayer)("PreviewMcpService", (it) => {
           threadId: currentThreadId,
           tabId: opened.tabId,
         });
+
+        yield* Deferred.succeed(releaseTargetedResponse, undefined);
+        yield* Fiber.join(delayedStatus);
 
         yield* broker.invoke({ scope, operation: "status", input: {} });
         expect(requests.at(-1)?.tabId).toBeUndefined();
@@ -154,3 +220,44 @@ it.layer(TestLayer)("PreviewMcpService", (it) => {
     }),
   );
 });
+
+it.effect("finishes broker cleanup when close is interrupted after manager removal", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const cleanupEntered = yield* Deferred.make<void>();
+      const releaseCleanup = yield* Deferred.make<void>();
+      const cleanupCompleted = yield* Ref.make(false);
+      const manager = yield* PreviewManager.make;
+      const broker = PreviewAutomationBroker.PreviewAutomationBroker.of({
+        connect: () => Effect.die("unused"),
+        focusHost: () => Effect.die("unused"),
+        respond: () => Effect.die("unused"),
+        invoke: () => Effect.die("unused"),
+        forgetClosedTab: () =>
+          Deferred.succeed(cleanupEntered, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseCleanup)),
+            Effect.andThen(Ref.set(cleanupCompleted, true)),
+          ),
+      });
+      const service = yield* PreviewMcpService.make.pipe(
+        Effect.provideService(PreviewManager.PreviewManager, manager),
+        Effect.provideService(PreviewAutomationBroker.PreviewAutomationBroker, broker),
+      );
+      const threadId = ThreadId.make("thread-preview-interrupted-close");
+      const scope = scopeFor(threadId);
+      const opened = yield* manager.open({ threadId });
+      const closeFiber = yield* service
+        .close(scope, { tabId: opened.tabId })
+        .pipe(Effect.forkScoped);
+      yield* Deferred.await(cleanupEntered);
+      expect((yield* manager.list({ threadId })).sessions).toHaveLength(0);
+
+      const interruption = yield* Fiber.interrupt(closeFiber).pipe(Effect.forkScoped);
+      yield* Deferred.succeed(releaseCleanup, undefined);
+      yield* Fiber.join(interruption);
+      expect(yield* Ref.get(cleanupCompleted)).toBe(true);
+      const repeated = yield* service.close(scope, { tabId: opened.tabId }).pipe(Effect.flip);
+      expect(repeated._tag).toBe("PreviewSessionLookupError");
+    }),
+  ),
+);

--- a/apps/server/src/mcp/PreviewMcpService.ts
+++ b/apps/server/src/mcp/PreviewMcpService.ts
@@ -1,4 +1,5 @@
 import {
+  PREVIEW_MCP_NAV_DIAGNOSTIC_MAX_LENGTH,
   PREVIEW_MCP_LIST_DEFAULT_LIMIT,
   PreviewAutomationUnavailableError,
   PreviewMcpInvalidCursorError,
@@ -9,8 +10,11 @@ import {
   type PreviewMcpError,
   type PreviewMcpListInput,
   type PreviewMcpListResult,
+  type PreviewMcpSessionSnapshot,
+  type PreviewSessionSnapshot,
   type ThreadId,
 } from "@t3tools/contracts";
+import * as NodeCrypto from "node:crypto";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -20,8 +24,14 @@ import * as PreviewManager from "../preview/Manager.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
 
+const cursorThreadScope = (threadId: ThreadId): string =>
+  NodeCrypto.createHash("sha256").update(threadId).digest("base64url");
+
 const encodeCursor = (threadId: ThreadId, tabId: PreviewTabId): string =>
-  Buffer.from(`${threadId}\u0000${tabId}`, "utf8").toString("base64url");
+  Buffer.from(`v1\u0000${cursorThreadScope(threadId)}\u0000${tabId}`, "utf8").toString("base64url");
+
+const compareTabIds = (left: PreviewTabId, right: PreviewTabId): number =>
+  left < right ? -1 : left > right ? 1 : 0;
 
 const isPreviewTabId = Schema.is(PreviewTabId);
 
@@ -30,12 +40,11 @@ const decodeCursor = Effect.fn("PreviewMcpService.decodeCursor")(function* (
   cursor: string,
 ) {
   const decoded = Buffer.from(cursor, "base64url").toString("utf8");
-  const separator = decoded.indexOf("\u0000");
-  const cursorThreadId = decoded.slice(0, separator);
-  const tabId = decoded.slice(separator + 1);
+  const [version, scopeHash, tabId, ...rest] = decoded.split("\u0000");
   if (
-    separator <= 0 ||
-    cursorThreadId !== threadId ||
+    version !== "v1" ||
+    scopeHash !== cursorThreadScope(threadId) ||
+    rest.length > 0 ||
     !isPreviewTabId(tabId) ||
     encodeCursor(threadId, tabId) !== cursor
   ) {
@@ -43,6 +52,24 @@ const decodeCursor = Effect.fn("PreviewMcpService.decodeCursor")(function* (
   }
   return tabId;
 });
+
+const projectSession = (session: PreviewSessionSnapshot): PreviewMcpSessionSnapshot => {
+  if (session.navStatus._tag !== "LoadFailed") {
+    return { ...session, navStatus: session.navStatus };
+  }
+  const descriptionTruncated =
+    session.navStatus.description.length > PREVIEW_MCP_NAV_DIAGNOSTIC_MAX_LENGTH;
+  return {
+    ...session,
+    navStatus: {
+      ...session.navStatus,
+      description: descriptionTruncated
+        ? session.navStatus.description.slice(0, PREVIEW_MCP_NAV_DIAGNOSTIC_MAX_LENGTH)
+        : session.navStatus.description,
+      descriptionTruncated,
+    },
+  };
+};
 
 export class PreviewMcpService extends Context.Service<
   PreviewMcpService,
@@ -84,10 +111,10 @@ export const make = Effect.gen(function* PreviewMcpServiceMake() {
       const limit = input.limit ?? PREVIEW_MCP_LIST_DEFAULT_LIMIT;
       const state = yield* manager.list({ threadId: scope.threadId });
       const candidates = state.sessions
-        .toSorted((left, right) => left.tabId.localeCompare(right.tabId))
-        .filter((session) => boundary === undefined || session.tabId > boundary)
+        .toSorted((left, right) => compareTabIds(left.tabId, right.tabId))
+        .filter((session) => boundary === undefined || compareTabIds(session.tabId, boundary) > 0)
         .slice(0, limit + 1);
-      const sessions = candidates.slice(0, limit);
+      const sessions = candidates.slice(0, limit).map(projectSession);
       const hasMore = candidates.length > limit;
       const last = sessions.at(-1);
       return {
@@ -102,15 +129,22 @@ export const make = Effect.gen(function* PreviewMcpServiceMake() {
   const close: PreviewMcpService["Service"]["close"] = Effect.fn("PreviewMcpService.close")(
     function* (inputScope, input) {
       const scope = yield* requirePreviewScope(inputScope);
-      const closed = yield* manager.closeExact({ threadId: scope.threadId, tabId: input.tabId });
-      if (!closed) {
-        return yield* new PreviewSessionLookupError({
-          threadId: scope.threadId,
-          tabId: input.tabId,
-        });
-      }
-      yield* broker.forgetClosedTab(scope, input.tabId);
-      return { tabId: input.tabId, closed: true };
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const closed = yield* manager.closeExact({
+            threadId: scope.threadId,
+            tabId: input.tabId,
+          });
+          if (!closed) {
+            return yield* new PreviewSessionLookupError({
+              threadId: scope.threadId,
+              tabId: input.tabId,
+            });
+          }
+          yield* broker.forgetClosedTab(scope, input.tabId);
+          return { tabId: input.tabId, closed: true } as const;
+        }),
+      );
     },
   );
 

--- a/apps/server/src/mcp/PreviewMcpService.ts
+++ b/apps/server/src/mcp/PreviewMcpService.ts
@@ -1,0 +1,120 @@
+import {
+  PREVIEW_MCP_LIST_DEFAULT_LIMIT,
+  PreviewAutomationUnavailableError,
+  PreviewMcpInvalidCursorError,
+  PreviewSessionLookupError,
+  PreviewTabId,
+  type PreviewMcpCloseInput,
+  type PreviewMcpCloseResult,
+  type PreviewMcpError,
+  type PreviewMcpListInput,
+  type PreviewMcpListResult,
+  type ThreadId,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as PreviewManager from "../preview/Manager.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
+
+const encodeCursor = (threadId: ThreadId, tabId: PreviewTabId): string =>
+  Buffer.from(`${threadId}\u0000${tabId}`, "utf8").toString("base64url");
+
+const isPreviewTabId = Schema.is(PreviewTabId);
+
+const decodeCursor = Effect.fn("PreviewMcpService.decodeCursor")(function* (
+  threadId: ThreadId,
+  cursor: string,
+) {
+  const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+  const separator = decoded.indexOf("\u0000");
+  const cursorThreadId = decoded.slice(0, separator);
+  const tabId = decoded.slice(separator + 1);
+  if (
+    separator <= 0 ||
+    cursorThreadId !== threadId ||
+    !isPreviewTabId(tabId) ||
+    encodeCursor(threadId, tabId) !== cursor
+  ) {
+    return yield* new PreviewMcpInvalidCursorError({ cursorLength: cursor.length });
+  }
+  return tabId;
+});
+
+export class PreviewMcpService extends Context.Service<
+  PreviewMcpService,
+  {
+    readonly list: (
+      scope: McpInvocationScope,
+      input: PreviewMcpListInput,
+    ) => Effect.Effect<PreviewMcpListResult, PreviewMcpError>;
+    readonly close: (
+      scope: McpInvocationScope,
+      input: PreviewMcpCloseInput,
+    ) => Effect.Effect<PreviewMcpCloseResult, PreviewMcpError>;
+  }
+>()("t3/mcp/PreviewMcpService") {}
+
+export const make = Effect.gen(function* PreviewMcpServiceMake() {
+  const manager = yield* PreviewManager.PreviewManager;
+  const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+
+  const requirePreviewScope = Effect.fn("PreviewMcpService.requirePreviewScope")(function* (
+    scope: McpInvocationScope,
+  ) {
+    if (!scope.capabilities.has("preview")) {
+      return yield* new PreviewAutomationUnavailableError({
+        capability: "preview",
+        environmentId: scope.environmentId,
+        threadId: scope.threadId,
+        providerSessionId: scope.providerSessionId,
+        providerInstanceId: scope.providerInstanceId,
+      });
+    }
+    return scope;
+  });
+
+  const list: PreviewMcpService["Service"]["list"] = Effect.fn("PreviewMcpService.list")(
+    function* (inputScope, input) {
+      const scope = yield* requirePreviewScope(inputScope);
+      const boundary = input.cursor ? yield* decodeCursor(scope.threadId, input.cursor) : undefined;
+      const limit = input.limit ?? PREVIEW_MCP_LIST_DEFAULT_LIMIT;
+      const state = yield* manager.list({ threadId: scope.threadId });
+      const candidates = state.sessions
+        .toSorted((left, right) => left.tabId.localeCompare(right.tabId))
+        .filter((session) => boundary === undefined || session.tabId > boundary)
+        .slice(0, limit + 1);
+      const sessions = candidates.slice(0, limit);
+      const hasMore = candidates.length > limit;
+      const last = sessions.at(-1);
+      return {
+        sessions,
+        nextCursor: hasMore && last ? encodeCursor(scope.threadId, last.tabId) : null,
+        serverEpoch: state.serverEpoch,
+        revision: state.revision,
+      };
+    },
+  );
+
+  const close: PreviewMcpService["Service"]["close"] = Effect.fn("PreviewMcpService.close")(
+    function* (inputScope, input) {
+      const scope = yield* requirePreviewScope(inputScope);
+      const closed = yield* manager.closeExact({ threadId: scope.threadId, tabId: input.tabId });
+      if (!closed) {
+        return yield* new PreviewSessionLookupError({
+          threadId: scope.threadId,
+          tabId: input.tabId,
+        });
+      }
+      yield* broker.forgetClosedTab(scope, input.tabId);
+      return { tabId: input.tabId, closed: true };
+    },
+  );
+
+  return PreviewMcpService.of({ list, close });
+}).pipe(Effect.withSpan("PreviewMcpService.make"));
+
+export const layer = Layer.effect(PreviewMcpService, make);

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -13,6 +13,7 @@ import type {
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
+import * as PreviewMcpService from "../../PreviewMcpService.ts";
 import { PreviewSnapshotToolkit, PreviewStandardToolkit, PreviewToolkit } from "./tools.ts";
 
 /**
@@ -69,6 +70,18 @@ const invokeTargeted = <A>(
 
 const handlers = {
   preview_status: (input) => invokeTargeted<PreviewAutomationStatus>("status", input ?? {}),
+  preview_list: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext.McpInvocationContext;
+      const service = yield* PreviewMcpService.PreviewMcpService;
+      return yield* service.list(scope, input ?? {});
+    }),
+  preview_close: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext.McpInvocationContext;
+      const service = yield* PreviewMcpService.PreviewMcpService;
+      return yield* service.close(scope, input);
+    }),
   preview_open: (input) =>
     invokeTargeted<PreviewAutomationStatus>("open", normalizePreviewOpenInput(input)),
   preview_navigate: (input) =>

--- a/apps/server/src/mcp/toolkits/preview/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.test.ts
@@ -43,10 +43,12 @@ it("exports provider-compatible object schemas with described parameters", () =>
     if (tool.name === "preview_navigate") {
       expect(schemaHasMultipleAllOfDescriptions(schema)).toBe(false);
     }
-    expect(
-      schema.properties?.tabId,
-      `${tool.name} must allow an explicit collaborative browser tab target`,
-    ).toBeDefined();
+    if (tool.name !== "preview_list") {
+      expect(
+        schema.properties?.tabId,
+        `${tool.name} must allow an explicit collaborative browser tab target`,
+      ).toBeDefined();
+    }
     for (const [field, fieldSchema] of Object.entries(schema.properties ?? {})) {
       expect(
         schemaHasDescription(fieldSchema),

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -17,16 +17,27 @@ import {
   PreviewAutomationTabTargetInput,
   PreviewAutomationTypeInput,
   PreviewAutomationWaitForInput,
+  PreviewMcpCloseInput,
+  PreviewMcpCloseResult,
+  PreviewMcpError,
+  PreviewMcpListInput,
+  PreviewMcpListResult,
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 import { Tool, Toolkit } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
+import * as PreviewMcpService from "../../PreviewMcpService.ts";
 
 const dependencies = [
   McpInvocationContext.McpInvocationContext,
   PreviewAutomationBroker.PreviewAutomationBroker,
+];
+
+const previewMcpDependencies = [
+  McpInvocationContext.McpInvocationContext,
+  PreviewMcpService.PreviewMcpService,
 ];
 
 const PreviewActionResult = Schema.Record(Schema.String, Schema.Never).annotate({
@@ -56,6 +67,32 @@ export const PreviewStatusTool = Tool.make("preview_status", {
   .annotate(Tool.Title, "Get preview status")
   .annotate(Tool.Readonly, true)
   .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, true);
+
+export const PreviewListTool = Tool.make("preview_list", {
+  description:
+    "List a bounded page of collaborative browser tabs owned by the calling thread. This only reads server-tracked sessions and never opens, attaches, navigates, or launches a browser.",
+  parameters: PreviewMcpListInput,
+  success: PreviewMcpListResult,
+  failure: PreviewMcpError,
+  dependencies: previewMcpDependencies,
+})
+  .annotate(Tool.Title, "List preview tabs")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, true);
+
+export const PreviewCloseTool = Tool.make("preview_close", {
+  description:
+    "Close one exact collaborative browser tab owned by the calling thread. tabId is required; this never closes every tab or a tab from another thread.",
+  parameters: PreviewMcpCloseInput,
+  success: PreviewMcpCloseResult,
+  failure: PreviewMcpError,
+  dependencies: previewMcpDependencies,
+})
+  .annotate(Tool.Title, "Close preview tab")
+  .annotate(Tool.Readonly, false)
+  .annotate(Tool.Destructive, true)
   .annotate(Tool.Idempotent, true);
 
 export const PreviewOpenTool = browserTool(
@@ -209,6 +246,8 @@ export const PreviewRecordingStopTool = safeBrowserTool(
 
 export const PreviewToolkit = Toolkit.make(
   PreviewStatusTool,
+  PreviewListTool,
+  PreviewCloseTool,
   PreviewOpenTool,
   PreviewNavigateTool,
   PreviewResizeTool,
@@ -226,6 +265,8 @@ export const PreviewToolkit = Toolkit.make(
 
 export const PreviewStandardToolkit = Toolkit.make(
   PreviewStatusTool,
+  PreviewListTool,
+  PreviewCloseTool,
   PreviewOpenTool,
   PreviewNavigateTool,
   PreviewResizeTool,

--- a/apps/server/src/mcp/toolkits/worktree/registration.test.ts
+++ b/apps/server/src/mcp/toolkits/worktree/registration.test.ts
@@ -19,6 +19,7 @@ import { VcsStatusBroadcaster } from "../../../vcs/VcsStatusBroadcaster.ts";
 import * as McpHttpServer from "../../McpHttpServer.ts";
 import * as McpSessionRegistry from "../../McpSessionRegistry.ts";
 import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
+import * as PreviewManager from "../../../preview/Manager.ts";
 
 const StubServicesLive = Layer.mergeAll(
   Layer.mock(ThreadManagementService)({}),
@@ -37,7 +38,11 @@ const ToolsListPayload = Schema.fromJsonString(
       tools: Schema.Array(
         Schema.Struct({
           name: Schema.String,
-          inputSchema: Schema.Struct({ type: Schema.optional(Schema.String) }),
+          inputSchema: Schema.Struct({
+            type: Schema.optional(Schema.String),
+            properties: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+            required: Schema.optional(Schema.Array(Schema.String)),
+          }),
           annotations: Schema.optional(
             Schema.Struct({
               readOnlyHint: Schema.optional(Schema.Boolean),
@@ -66,6 +71,7 @@ it.effect("production mcp layer lists worktree tools over http", () =>
           }),
         ),
         Layer.provide(PreviewAutomationBroker.layer),
+        Layer.provide(PreviewManager.layer),
         Layer.provide(StubServicesLive),
         Layer.build,
       );
@@ -113,6 +119,8 @@ it.effect("production mcp layer lists worktree tools over http", () =>
       // The worktree registration merges alongside the other toolkits rather
       // than replacing them.
       expect(toolNames).toContain("preview_status");
+      expect(toolNames).toContain("preview_list");
+      expect(toolNames).toContain("preview_close");
       expect(toolNames).toContain("delegate_task");
 
       // The handoff tool mutates thread state, reaches the network (origin
@@ -125,6 +133,15 @@ it.effect("production mcp layer lists worktree tools over http", () =>
       const status = tools.find((tool) => tool.name === "t3_worktree_status");
       expect(status?.annotations?.readOnlyHint).toBe(true);
       expect(status?.annotations?.destructiveHint).toBe(false);
+      const previewList = tools.find((tool) => tool.name === "preview_list");
+      expect(previewList?.annotations?.readOnlyHint).toBe(true);
+      expect(previewList?.annotations?.destructiveHint).toBe(false);
+      expect(previewList?.inputSchema.properties).toHaveProperty("cursor");
+      expect(previewList?.inputSchema.properties).toHaveProperty("limit");
+      const previewClose = tools.find((tool) => tool.name === "preview_close");
+      expect(previewClose?.annotations?.readOnlyHint).toBe(false);
+      expect(previewClose?.annotations?.destructiveHint).toBe(true);
+      expect(previewClose?.inputSchema.required).toContain("tabId");
 
       // MCP requires every tool input schema to be a top-level object schema.
       // A non-object schema (e.g. the anyOf produced by an empty

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
@@ -46,6 +46,7 @@ import { formatClaudeResumeCompactionQuestion } from "@t3tools/shared/claudeComp
 import { attachmentRelativePath } from "../../attachmentStore.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { OrchestratorToolkit } from "../../mcp/toolkits/orchestrator/tools.ts";
+import { PreviewToolkit } from "../../mcp/toolkits/preview/tools.ts";
 import type { EventNdjsonLogger } from "../../provider/Layers/EventNdjsonLogger.ts";
 import {
   ProviderAdapterV2RuntimePolicy,
@@ -580,7 +581,10 @@ describe("ClaudeAdapterV2 MCP query overrides", () => {
   });
 
   it("matches the read-only allowlist to the orchestrator toolkit annotations", () => {
-    const readOnlyToolNames = Object.values(OrchestratorToolkit.tools)
+    const readOnlyToolNames = [
+      ...Object.values(OrchestratorToolkit.tools),
+      ...Object.values(PreviewToolkit.tools),
+    ]
       .filter((tool) => Context.get(tool.annotations, Tool.Readonly))
       .map((tool) => `mcp__t3-code__${tool.name}`)
       .sort();

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -801,13 +801,17 @@ export function makeClaudeQueryOptions(input: {
 
 export const CLAUDE_T3_MCP_TOOL_WILDCARD = "mcp__t3-code__*";
 
-// Must stay in sync with the Tool.Readonly annotations on OrchestratorToolkit;
-// ClaudeAdapterV2.test.ts cross-checks this list against the toolkit.
+// Must stay in sync with the Tool.Readonly annotations on the orchestration and
+// preview toolkits; ClaudeAdapterV2.test.ts cross-checks this list.
 export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
   "mcp__t3-code__orchestrator_capabilities",
   "mcp__t3-code__list_scheduled_tasks",
   "mcp__t3-code__t3_thread_list",
   "mcp__t3-code__t3_thread_wait",
+  "mcp__t3-code__preview_status",
+  "mcp__t3-code__preview_list",
+  "mcp__t3-code__preview_snapshot",
+  "mcp__t3-code__preview_wait_for",
 ];
 
 // The SDK's `allowedTools` only pre-approves tool calls; availability is the

--- a/apps/server/src/preview/Manager.ts
+++ b/apps/server/src/preview/Manager.ts
@@ -24,6 +24,7 @@ import {
   FILL_PREVIEW_VIEWPORT,
   PreviewSessionLookupError,
   type PreviewSessionSnapshot,
+  type PreviewTabId,
   type PreviewViewportSetting,
 } from "@t3tools/contracts";
 import {
@@ -54,6 +55,10 @@ export class PreviewManager extends Context.Service<
     ) => Effect.Effect<PreviewSessionSnapshot, PreviewError>;
     readonly refresh: (input: PreviewRefreshInput) => Effect.Effect<void, PreviewError>;
     readonly close: (input: PreviewCloseInput) => Effect.Effect<void, PreviewError>;
+    readonly closeExact: (input: {
+      readonly threadId: PreviewCloseInput["threadId"];
+      readonly tabId: PreviewTabId;
+    }) => Effect.Effect<boolean>;
     readonly list: (input: PreviewListInput) => Effect.Effect<PreviewListResult>;
     readonly events: Stream.Stream<PreviewEvent>;
     readonly subscribeEvents: Effect.Effect<PubSub.Subscription<PreviewEvent>, never, Scope.Scope>;
@@ -393,42 +398,54 @@ export const make = Effect.gen(function* PreviewManagerMake() {
     },
   );
 
+  const closeSessions = Effect.fn("PreviewManager.closeSessions")(function* (
+    input: PreviewCloseInput,
+  ) {
+    const createdAt = yield* currentIsoTimestamp;
+    return yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+      const eventsToEmit: PreviewEvent[] = [];
+      const sessions = new Map(state.sessions);
+      const targets = input.tabId
+        ? [state.sessions.get(compositeKey(input.threadId, input.tabId))].filter(
+            (entry): entry is PreviewSessionState => entry !== undefined,
+          )
+        : sessionsForThread(state, input.threadId);
+      let revision = state.revision;
+      for (const target of targets) {
+        revision += 1;
+        sessions.delete(compositeKey(target.threadId, target.tabId));
+        eventsToEmit.push({
+          type: "closed",
+          threadId: target.threadId,
+          tabId: target.tabId,
+          createdAt,
+          serverEpoch,
+          revision,
+        });
+      }
+      if (eventsToEmit.length === 0) {
+        return Effect.succeed([0, state] as const);
+      }
+      return Effect.as(
+        Effect.forEach(eventsToEmit, (event) => PubSub.publish(eventsPubSub, event), {
+          discard: true,
+        }),
+        [eventsToEmit.length, { sessions, revision }] as const,
+      );
+    });
+  });
+
   const close: PreviewManager["Service"]["close"] = Effect.fn("PreviewManager.close")(
     function* (input) {
-      const createdAt = yield* currentIsoTimestamp;
-      yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-        const eventsToEmit: PreviewEvent[] = [];
-        const sessions = new Map(state.sessions);
-        const targets = input.tabId
-          ? [state.sessions.get(compositeKey(input.threadId, input.tabId))].filter(
-              (entry): entry is PreviewSessionState => entry !== undefined,
-            )
-          : sessionsForThread(state, input.threadId);
-        let revision = state.revision;
-        for (const target of targets) {
-          revision += 1;
-          sessions.delete(compositeKey(target.threadId, target.tabId));
-          eventsToEmit.push({
-            type: "closed",
-            threadId: target.threadId,
-            tabId: target.tabId,
-            createdAt,
-            serverEpoch,
-            revision,
-          });
-        }
-        if (eventsToEmit.length === 0) {
-          return Effect.succeed([undefined, state] as const);
-        }
-        return Effect.as(
-          Effect.forEach(eventsToEmit, (event) => PubSub.publish(eventsPubSub, event), {
-            discard: true,
-          }),
-          [undefined, { sessions, revision }] as const,
-        );
-      });
+      yield* closeSessions(input);
     },
   );
+
+  const closeExact: PreviewManager["Service"]["closeExact"] = Effect.fn(
+    "PreviewManager.closeExact",
+  )(function* (input) {
+    return (yield* closeSessions(input)) === 1;
+  });
 
   const list: PreviewManager["Service"]["list"] = Effect.fn("PreviewManager.list")(
     function* (input) {
@@ -451,6 +468,7 @@ export const make = Effect.gen(function* PreviewManagerMake() {
     resize,
     refresh,
     close,
+    closeExact,
     list,
     events,
     subscribeEvents: PubSub.subscribe(eventsPubSub),

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 - [Usage and limits](./user/usage.md)
 - [Product usage data](./user/telemetry.md)
 - [Remote access](./user/remote-access.md)
+- [Agent browser controls](./user/agent-browser.md)
 - [Running in the background](./user/background-service.md)
 - [Updating T3 Code](./user/updating.md)
 - Provider guides: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md) · [OpenCode](./user/providers-opencode.md) · [Antigravity](./user/providers-antigravity.md)

--- a/docs/orchestration-v2/orchestrator-mcp-server.md
+++ b/docs/orchestration-v2/orchestrator-mcp-server.md
@@ -143,6 +143,17 @@ selection model-visible without allowing a request that cannot run.
 
 The server exposes eleven orchestration tools.
 
+The same authenticated endpoint also exposes thread-scoped preview tools when the provider session
+has the `preview` capability. `preview_list` returns a bounded keyset page from the server's preview
+session manager. Its opaque cursor is bound to the calling thread, and closing an earlier tab does
+not shift the next page. `preview_close` requires an exact tab ID and uses the manager's ordinary
+closed event, which lets connected clients release the matching desktop tab. Missing, foreign, and
+already-closed tabs return `PreviewSessionLookupError`.
+
+Neither operation enables browser access. The server omits the preview capability from credentials
+created while `enableAgentBrowserAccess` is off. Listing does not select an automation host or
+create browser state.
+
 ### `orchestrator_capabilities`
 
 Returns:

--- a/docs/user/agent-browser.md
+++ b/docs/user/agent-browser.md
@@ -1,0 +1,13 @@
+# Agent browser controls
+
+When agent browser access is enabled, a coding agent can use the collaborative preview browser for
+the current thread. Browser tools never grant access by themselves. Turn access on or off in
+Settings under Integrations.
+
+Agents can list the current thread's preview tabs before choosing a target. Lists are paginated and
+do not open a window, attach a host, or navigate a page. An agent can close one tab by its exact tab
+ID. It cannot omit the ID to close every tab, and it cannot list or close another thread's tabs.
+
+Closing a tab updates the server-owned preview session. Connected desktop clients remove the
+matching webview through the normal preview event stream. Repeating the close reports that the tab
+no longer exists instead of claiming that another tab was closed.

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -26,6 +26,7 @@ const OptionalTimeoutMs = Schema.optional(
 
 export const PREVIEW_MCP_LIST_DEFAULT_LIMIT = 20;
 export const PREVIEW_MCP_LIST_MAX_LIMIT = 100;
+export const PREVIEW_MCP_NAV_DIAGNOSTIC_MAX_LENGTH = 2_000;
 
 export const PreviewMcpCursor = TrimmedNonEmptyString.check(Schema.isMaxLength(512));
 export type PreviewMcpCursor = typeof PreviewMcpCursor.Type;
@@ -50,8 +51,30 @@ export const PreviewMcpListInput = Schema.Struct({
 });
 export type PreviewMcpListInput = typeof PreviewMcpListInput.Type;
 
+const PreviewMcpUrl = TrimmedNonEmptyString.check(Schema.isMaxLength(2048));
+const PreviewMcpTitle = Schema.String.check(Schema.isMaxLength(512));
+export const PreviewMcpNavStatus = Schema.Union([
+  Schema.TaggedStruct("Idle", {}),
+  Schema.TaggedStruct("Loading", { url: PreviewMcpUrl, title: PreviewMcpTitle }),
+  Schema.TaggedStruct("Success", { url: PreviewMcpUrl, title: PreviewMcpTitle }),
+  Schema.TaggedStruct("LoadFailed", {
+    url: PreviewMcpUrl,
+    title: PreviewMcpTitle,
+    code: Schema.Int,
+    description: Schema.String.check(Schema.isMaxLength(PREVIEW_MCP_NAV_DIAGNOSTIC_MAX_LENGTH)),
+    descriptionTruncated: Schema.Boolean,
+  }),
+]);
+export type PreviewMcpNavStatus = typeof PreviewMcpNavStatus.Type;
+
+export const PreviewMcpSessionSnapshot = Schema.Struct({
+  ...PreviewSessionSnapshot.fields,
+  navStatus: PreviewMcpNavStatus,
+});
+export type PreviewMcpSessionSnapshot = typeof PreviewMcpSessionSnapshot.Type;
+
 export const PreviewMcpListResult = Schema.Struct({
-  sessions: Schema.Array(PreviewSessionSnapshot).check(
+  sessions: Schema.Array(PreviewMcpSessionSnapshot).check(
     Schema.isMaxLength(PREVIEW_MCP_LIST_MAX_LIMIT),
   ),
   nextCursor: Schema.NullOr(PreviewMcpCursor),

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -4,6 +4,8 @@ import { EnvironmentId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts
 import {
   PREVIEW_VIEWPORT_MAX_AREA,
   PreviewRenderedViewportSize,
+  PreviewSessionLookupError,
+  PreviewSessionSnapshot,
   PreviewTabId,
   PreviewViewportPresetId,
   PreviewViewportSetting,
@@ -21,6 +23,58 @@ const OptionalTimeoutMs = Schema.optional(
     .check(Schema.isLessThanOrEqualTo(60_000))
     .annotate({ description: "Maximum wait in milliseconds. Defaults to 15000; maximum 60000." }),
 ).annotate({ description: "Maximum wait in milliseconds. Defaults to 15000; maximum 60000." });
+
+export const PREVIEW_MCP_LIST_DEFAULT_LIMIT = 20;
+export const PREVIEW_MCP_LIST_MAX_LIMIT = 100;
+
+export const PreviewMcpCursor = TrimmedNonEmptyString.check(Schema.isMaxLength(512));
+export type PreviewMcpCursor = typeof PreviewMcpCursor.Type;
+
+export const PreviewMcpListInput = Schema.Struct({
+  cursor: Schema.optional(
+    PreviewMcpCursor.annotate({
+      description: "Opaque continuation cursor returned by a previous preview_list call.",
+    }),
+  ).annotate({
+    description: "Opaque continuation cursor returned by a previous preview_list call.",
+  }),
+  limit: Schema.optional(
+    Schema.Int.check(
+      Schema.isBetween({ minimum: 1, maximum: PREVIEW_MCP_LIST_MAX_LIMIT }),
+    ).annotate({
+      description: `Maximum tabs to return. Defaults to ${PREVIEW_MCP_LIST_DEFAULT_LIMIT}; maximum ${PREVIEW_MCP_LIST_MAX_LIMIT}.`,
+    }),
+  ).annotate({
+    description: `Maximum tabs to return. Defaults to ${PREVIEW_MCP_LIST_DEFAULT_LIMIT}; maximum ${PREVIEW_MCP_LIST_MAX_LIMIT}.`,
+  }),
+});
+export type PreviewMcpListInput = typeof PreviewMcpListInput.Type;
+
+export const PreviewMcpListResult = Schema.Struct({
+  sessions: Schema.Array(PreviewSessionSnapshot).check(
+    Schema.isMaxLength(PREVIEW_MCP_LIST_MAX_LIMIT),
+  ),
+  nextCursor: Schema.NullOr(PreviewMcpCursor),
+  serverEpoch: TrimmedNonEmptyString,
+  revision: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+});
+export type PreviewMcpListResult = typeof PreviewMcpListResult.Type;
+
+export const PreviewMcpCloseInput = Schema.Struct({
+  tabId: Schema.String.check(Schema.isTrimmed())
+    .check(Schema.isNonEmpty())
+    .check(Schema.isMaxLength(128))
+    .annotate({
+      description: "Exact collaborative browser tab to close in the calling thread.",
+    }),
+});
+export type PreviewMcpCloseInput = typeof PreviewMcpCloseInput.Type;
+
+export const PreviewMcpCloseResult = Schema.Struct({
+  tabId: PreviewTabId,
+  closed: Schema.Literal(true),
+});
+export type PreviewMcpCloseResult = typeof PreviewMcpCloseResult.Type;
 
 /** Operations understood by desktop hosts predating viewport resizing. */
 export const PREVIEW_AUTOMATION_V1_OPERATIONS = [
@@ -873,6 +927,24 @@ export const PreviewAutomationError = Schema.Union([
   PreviewAutomationMalformedResponseError,
 ]);
 export type PreviewAutomationError = typeof PreviewAutomationError.Type;
+
+export class PreviewMcpInvalidCursorError extends Schema.TaggedErrorClass<PreviewMcpInvalidCursorError>()(
+  "PreviewMcpInvalidCursorError",
+  {
+    cursorLength: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  },
+) {
+  override get message(): string {
+    return "The preview list cursor is invalid or belongs to a different thread.";
+  }
+}
+
+export const PreviewMcpError = Schema.Union([
+  PreviewAutomationUnavailableError,
+  PreviewSessionLookupError,
+  PreviewMcpInvalidCursorError,
+]);
+export type PreviewMcpError = typeof PreviewMcpError.Type;
 
 export const PreviewUrlResolution = Schema.Struct({
   requestedUrl: Schema.String,

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -55,6 +55,8 @@ const T3_MCP_TOOLS: Record<
   t3_worktree_handoff: { displayName: "Hand off thread to a git worktree" },
   t3_worktree_status: { displayName: "Get thread worktree status" },
   preview_status: { displayName: "Get preview browser status" },
+  preview_list: { displayName: "List preview browser tabs" },
+  preview_close: { displayName: "Close a preview browser tab" },
   preview_open: { displayName: "Open a page in the preview browser" },
   preview_navigate: { displayName: "Navigate the preview browser" },
   preview_snapshot: { displayName: "Snapshot the preview page" },


### PR DESCRIPTION
Agents could open and control collaborative browser tabs through MCP, but they could not discover every tab owned by the current thread or close one exact tab without using a client UI.

This adds bounded `preview_list` and explicit-tab `preview_close` tools. Listing reads only the server preview manager with a thread-bound keyset cursor. Closing uses the manager's existing close event, preserves foreign tabs, and clears the provider session's implicit broker tab behind a sequence barrier so an older automation response cannot restore the closed target.

Behavior:

- browser access remains gated by the credential's existing preview capability;
- list never selects a host, opens a browser, or navigates;
- close requires `tabId`, returns the exact closed ID, and reports missing, foreign, or repeated closes as `PreviewSessionLookupError`;
- connected clients receive the normal server-owned closed event and release the matching desktop webview;
- read-only Claude sessions can use the preview tools whose annotations are read-only.

Focused validation:

- 123 focused server/shared tests, including production HTTP `tools/list`, manager events, broker lease clearing, stable pagination, authority denial, and repeated close;
- contracts, shared, and server typechecks;
- targeted lint and formatting checks.

Dependency: standalone sibling based on `agents/mcp-controls/base-490318a` at `490318afa505d3d033295eca12d7e62b4b922725`. It does not depend on the project or queue/input stacks.

Implemented by GPT-5.6-Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent preview automation broker tab-leasing and close races; incorrect barriers could mis-route automation or leave stale tab targets, though behavior is heavily test-covered.
> 
> **Overview**
> Agents can **discover** and **tear down** collaborative preview tabs for the current thread via new MCP tools **`preview_list`** and **`preview_close`**, without opening or attaching a browser host for listing.
> 
> **`preview_list`** reads server-tracked sessions only: thread-scoped keyset pagination (`cursor` / `limit`), stable cursors (hashed thread binding, size-capped), truncated load-failure diagnostics, and rejection of foreign-thread cursors. Access still requires the credential **`preview`** capability.
> 
> **`preview_close`** requires an exact **`tabId`**, closes through **`PreviewManager.closeExact`** (normal closed events for desktop clients), and calls **`PreviewAutomationBroker.forgetClosedTab`** so the provider session’s implicit “current tab” lease is cleared. The broker now commits tab assignments only after successful responses and uses **close sequence barriers** so in-flight or late host responses cannot resurrect a closed tab or steal routing from another tab; barriers retire on timeout, failure, or interrupt.
> 
> Wiring includes **`PreviewMcpService`**, contract schemas/errors, toolkit handlers and registration, Claude read-only allowlist updates for annotated read-only preview tools, UI presentation strings, and user/docs notes on agent browser controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66853cebe52d658b7fa3a2b1fb3b76ccbd142550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Orchestration V2 system with MCP toolkits for preview, orchestrator, and worktree operations
> - Introduces a full Orchestration V2 backend: event store, projection store, provider adapters (Claude, Codex, Cursor, OpenCode, Grok, ACP Registry), checkpoint capture/rollback services, effect outbox, thread launch/lifecycle management, scheduled tasks, and legacy V1 importer. Backed by migrations 044–052 creating the V2 persistence schema.
> - Adds three MCP service toolkits registered on the HTTP server: `PreviewMcpService` (list/close preview tabs with cursor pagination), `OrchestratorMcpService` (thread/task lifecycle, delegation, scheduling), and `WorktreeMcpService` (git worktree handoff and status). Each enforces capability-scoped access via `McpInvocationContext`.
> - Migrates web and mobile clients to V2 types: shell/thread projections, bounded snapshot loading with progressive history paging, queue workflow controls, thread relationships panel, scheduled tasks settings, legacy migration toast, and composer UI refactors using `ComposerBanner` primitives.
> - Includes extensive provider replay testkit infrastructure with deterministic runtime fixtures across all built-in providers and scenarios (interrupts, forks, subagents, rollbacks, web search, queued turns, steering).
> - Behavioral Change: `OrchestrationCommandReceipt` schema now requires a `commandType` string field; `ProviderInstance.adapter` renamed to `orchestrationAdapter` with type `ProviderAdapterV2Shape`; `LatestTurnTiming`/`SessionActivityState` renamed to `LatestRunTiming`/`RuntimeActivityState` with `turnId`→`runId` and `activeTurnId`→`activeRunId`; WebSocket RPC methods switched from `ORCHESTRATION_WS_METHODS` to `ORCHESTRATION_V2_WS_METHODS`; `requireMcpCapability` signature narrowed to only accept `'preview'`; cache schema version bumped to 3 and old V1 entries are auto-discarded on decode failure; `ModelSelection` encoding now emits instance-based canonical form instead of legacy provider-based form.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe4579d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->