### PR TITLE
feat(mcp): expose current environment diagnostics

### DIFF
--- a/apps/server/src/mcp/EnvironmentMcpService.test.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  DEFAULT_SERVER_SETTINGS,
+  ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS,
+  ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS,
+  EnvironmentId,
+  EnvironmentMcpReadResult,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
+import { ProviderRegistry } from "../provider/Services/ProviderRegistry.ts";
+import { makeProviderRegistryLayer } from "../provider/testUtils/providerRegistryMock.ts";
+import * as ServerSettings from "../serverSettings.ts";
+import { EnvironmentMcpService, layer } from "./EnvironmentMcpService.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+
+const encodeEnvironmentMcpReadResult = Schema.encodeUnknownEffect(EnvironmentMcpReadResult);
+const environmentId = EnvironmentId.make("environment-test");
+const scope: McpInvocationScope = {
+  environmentId,
+  threadId: ThreadId.make("thread-test"),
+  providerSessionId: "provider-session-test",
+  providerInstanceId: ProviderInstanceId.make("codex"),
+  capabilities: new Set(["orchestration"]),
+  issuedAt: 0,
+};
+
+const provider = (input: {
+  readonly instanceId: string;
+  readonly displayName?: string;
+  readonly version?: string | null;
+  readonly status?: ServerProvider["status"];
+  readonly availability?: ServerProvider["availability"];
+  readonly enabled?: boolean;
+  readonly installed?: boolean;
+  readonly modelCount?: number;
+}): ServerProvider => ({
+  instanceId: ProviderInstanceId.make(input.instanceId),
+  driver: ProviderDriverKind.make("codex"),
+  ...(input.displayName === undefined ? {} : { displayName: input.displayName }),
+  enabled: input.enabled ?? true,
+  installed: input.installed ?? true,
+  version: input.version ?? "1.0.0",
+  status: input.status ?? "ready",
+  auth: { status: "authenticated" },
+  checkedAt: "2026-08-29T00:00:00.000Z",
+  ...(input.availability === undefined ? {} : { availability: input.availability }),
+  models: Array.from({ length: input.modelCount ?? 0 }, (_, index) => ({
+    slug: `model-${index}`,
+    name: `Sensitive model name ${index}`,
+    isCustom: false,
+  })),
+  slashCommands: [],
+  skills: [],
+  message: "SENTINEL_PROVIDER_RAW_DIAGNOSTIC",
+});
+
+const environmentLayer = (label: string, serverVersion: string) =>
+  Layer.succeed(
+    ServerEnvironment.ServerEnvironment,
+    ServerEnvironment.ServerEnvironment.of({
+      getEnvironmentId: Effect.succeed(environmentId),
+      getDescriptor: Effect.succeed({
+        environmentId,
+        label,
+        platform: { os: "darwin", arch: "arm64" },
+        serverVersion,
+        capabilities: {
+          repositoryIdentity: true,
+          attachmentUploads: true,
+          fileAttachments: { maxUploadBytes: 1234 },
+          serverSelfUpdate: "boot-service",
+          agentActivityPublishing: true,
+        },
+      }),
+    }),
+  );
+
+const serviceLayer = (input: {
+  readonly providers?: ReadonlyArray<ServerProvider>;
+  readonly label?: string;
+  readonly serverVersion?: string;
+  readonly customInstructions?: string;
+}) =>
+  layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        environmentLayer(input.label ?? "Test environment", input.serverVersion ?? "1.2.3"),
+        makeProviderRegistryLayer(input.providers ?? []),
+        ServerSettings.layerTest({
+          enableAgentBrowserAccess: true,
+          addProjectBaseDirectory: "/SENTINEL_PRIVATE_PATH",
+          observability: {
+            otlpTracesUrl: "https://SENTINEL_PRIVATE_OBSERVABILITY",
+          },
+          providers: {
+            codex: {
+              environment: {
+                SENTINEL_SECRET_ENVIRONMENT: "SENTINEL_SECRET_VALUE",
+              },
+            },
+          },
+          sourceControlWritingStyle: {
+            mode: "custom",
+            customInstructions: input.customInstructions ?? "Keep commit messages concise.",
+            followChangeRequestTemplates: true,
+          },
+        }),
+      ),
+    ),
+  );
+
+describe("EnvironmentMcpService", () => {
+  it.effect("returns only bounded allowlisted environment and provider diagnostics", () =>
+    Effect.gen(function* () {
+      const service = yield* EnvironmentMcpService;
+      const result = yield* service.read(scope, { providerLimit: 1 });
+      const encoded = yield* encodeEnvironmentMcpReadResult(result);
+
+      expect(result.identity.label).toEqual({
+        text: "😀".repeat(ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS),
+        characters: ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS + 3,
+        maximumCharacters: ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS,
+        truncated: true,
+      });
+      expect(result.identity.serverVersion).toEqual(result.identity.label);
+      expect(result.providers.map((item) => item.instanceId)).toEqual([
+        ProviderInstanceId.make("a-provider"),
+      ]);
+      expect(result.providerNextCursor).toBe(1);
+      expect(result.providerTotal).toBe(2);
+      expect(result.providerHealth).toMatchObject({
+        status: "degraded",
+        total: 2,
+        ready: 1,
+        warning: 1,
+        unavailable: 1,
+        usable: 1,
+      });
+      expect(result.preferences.sourceControlWritingStyle.customInstructions).toEqual({
+        text: "🧪".repeat(ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS),
+        characters: ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS + 2,
+        maximumCharacters: ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS,
+        truncated: true,
+      });
+
+      const serialized = JSON.stringify(encoded);
+      expect(serialized).not.toContain("SENTINEL_");
+      expect(serialized).not.toContain("Sensitive model name");
+      expect(serialized).not.toContain("serverSelfUpdate");
+      expect(serialized).not.toContain("agentActivityPublishing");
+    }).pipe(
+      Effect.provide(
+        serviceLayer({
+          providers: [
+            provider({
+              instanceId: "z-provider",
+              displayName: "😀".repeat(ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS + 3),
+              version: "😀".repeat(ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS + 3),
+              modelCount: 2,
+            }),
+            provider({
+              instanceId: "a-provider",
+              status: "warning",
+              availability: "unavailable",
+              enabled: false,
+              installed: false,
+            }),
+          ],
+          label: "😀".repeat(ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS + 3),
+          serverVersion: "😀".repeat(ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS + 3),
+          customInstructions: "🧪".repeat(ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS + 2),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("denies credentials without orchestration capability before reading services", () => {
+    let providerReads = 0;
+    const providerLayer = Layer.succeed(ProviderRegistry, {
+      getProviders: Effect.sync(() => {
+        providerReads += 1;
+        return [];
+      }),
+    } as never);
+    return Effect.gen(function* () {
+      const service = yield* EnvironmentMcpService;
+      const error = yield* Effect.flip(service.read({ ...scope, capabilities: new Set() }, {}));
+      expect(error.code).toBe("capability_denied");
+      expect(providerReads).toBe(0);
+    }).pipe(
+      Effect.provide(
+        layer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              environmentLayer("Test", "1.0.0"),
+              providerLayer,
+              ServerSettings.layerTest({}),
+            ),
+          ),
+        ),
+      ),
+    );
+  });
+
+  it.effect("distinguishes an unavailable provider registry from a healthy empty result", () => {
+    const unavailableRegistry = Layer.succeed(ProviderRegistry, {
+      getProviders: Effect.die("SENTINEL_PROVIDER_FAILURE"),
+    } as never);
+    return Effect.gen(function* () {
+      const service = yield* EnvironmentMcpService;
+      const error = yield* Effect.flip(service.read(scope, {}));
+      expect(error.code).toBe("provider_registry_unavailable");
+      expect(error.message).not.toContain("SENTINEL_PROVIDER_FAILURE");
+    }).pipe(
+      Effect.provide(
+        layer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              environmentLayer("Test", "1.0.0"),
+              unavailableRegistry,
+              ServerSettings.layerTest(DEFAULT_SERVER_SETTINGS),
+            ),
+          ),
+        ),
+      ),
+    );
+  });
+});

--- a/apps/server/src/mcp/EnvironmentMcpService.test.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.test.ts
@@ -22,6 +22,7 @@ import { EnvironmentMcpService, layer } from "./EnvironmentMcpService.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
 
 const encodeEnvironmentMcpReadResult = Schema.encodeUnknownEffect(EnvironmentMcpReadResult);
+const encodeUnknownJsonString = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
 const environmentId = EnvironmentId.make("environment-test");
 const scope: McpInvocationScope = {
   environmentId,
@@ -56,6 +57,7 @@ const provider = (input: {
     slug: `model-${index}`,
     name: `Sensitive model name ${index}`,
     isCustom: false,
+    capabilities: null,
   })),
   slashCommands: [],
   skills: [],
@@ -100,11 +102,17 @@ const serviceLayer = (input: {
           observability: {
             otlpTracesUrl: "https://SENTINEL_PRIVATE_OBSERVABILITY",
           },
-          providers: {
-            codex: {
-              environment: {
-                SENTINEL_SECRET_ENVIRONMENT: "SENTINEL_SECRET_VALUE",
-              },
+          providerInstances: {
+            [ProviderInstanceId.make("sentinel")]: {
+              driver: ProviderDriverKind.make("codex"),
+              config: {},
+              environment: [
+                {
+                  name: "SENTINEL_SECRET_ENVIRONMENT",
+                  value: "SENTINEL_SECRET_VALUE",
+                  sensitive: true,
+                },
+              ],
             },
           },
           sourceControlWritingStyle: {
@@ -151,7 +159,7 @@ describe("EnvironmentMcpService", () => {
         truncated: true,
       });
 
-      const serialized = JSON.stringify(encoded);
+      const serialized = encodeUnknownJsonString(encoded);
       expect(serialized).not.toContain("SENTINEL_");
       expect(serialized).not.toContain("Sensitive model name");
       expect(serialized).not.toContain("serverSelfUpdate");
@@ -233,4 +241,15 @@ describe("EnvironmentMcpService", () => {
       ),
     );
   });
+
+  it.effect("distinguishes a credential environment mismatch from service unavailability", () =>
+    Effect.gen(function* () {
+      const service = yield* EnvironmentMcpService;
+      const error = yield* Effect.flip(
+        service.read({ ...scope, environmentId: EnvironmentId.make("environment-other") }, {}),
+      );
+      expect(error.code).toBe("environment_mismatch");
+      expect(error.message).toBe("The MCP credential does not belong to the running environment.");
+    }).pipe(Effect.provide(serviceLayer({}))),
+  );
 });

--- a/apps/server/src/mcp/EnvironmentMcpService.test.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.test.ts
@@ -242,14 +242,38 @@ describe("EnvironmentMcpService", () => {
     );
   });
 
-  it.effect("distinguishes a credential environment mismatch from service unavailability", () =>
-    Effect.gen(function* () {
+  it.effect("rejects an environment mismatch before reading scoped dependencies", () => {
+    let providerReads = 0;
+    let settingsReads = 0;
+    const providerLayer = Layer.succeed(ProviderRegistry, {
+      getProviders: Effect.sync(() => {
+        providerReads += 1;
+        return [];
+      }),
+    } as never);
+    const settingsLayer = Layer.succeed(ServerSettings.ServerSettingsService, {
+      getSettings: Effect.sync(() => {
+        settingsReads += 1;
+        return DEFAULT_SERVER_SETTINGS;
+      }),
+    } as never);
+    return Effect.gen(function* () {
       const service = yield* EnvironmentMcpService;
       const error = yield* Effect.flip(
         service.read({ ...scope, environmentId: EnvironmentId.make("environment-other") }, {}),
       );
       expect(error.code).toBe("environment_mismatch");
       expect(error.message).toBe("The MCP credential does not belong to the running environment.");
-    }).pipe(Effect.provide(serviceLayer({}))),
-  );
+      expect(providerReads).toBe(0);
+      expect(settingsReads).toBe(0);
+    }).pipe(
+      Effect.provide(
+        layer.pipe(
+          Layer.provide(
+            Layer.mergeAll(environmentLayer("Test", "1.0.0"), providerLayer, settingsLayer),
+          ),
+        ),
+      ),
+    );
+  });
 });

--- a/apps/server/src/mcp/EnvironmentMcpService.test.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.test.ts
@@ -245,18 +245,18 @@ describe("EnvironmentMcpService", () => {
   it.effect("rejects an environment mismatch before reading scoped dependencies", () => {
     let providerReads = 0;
     let settingsReads = 0;
-    const providerLayer = Layer.succeed(ProviderRegistry, {
+    const providerLayer = Layer.mock(ProviderRegistry)({
       getProviders: Effect.sync(() => {
         providerReads += 1;
         return [];
       }),
-    } as never);
-    const settingsLayer = Layer.succeed(ServerSettings.ServerSettingsService, {
+    });
+    const settingsLayer = Layer.mock(ServerSettings.ServerSettingsService)({
       getSettings: Effect.sync(() => {
         settingsReads += 1;
         return DEFAULT_SERVER_SETTINGS;
       }),
-    } as never);
+    });
     return Effect.gen(function* () {
       const service = yield* EnvironmentMcpService;
       const error = yield* Effect.flip(

--- a/apps/server/src/mcp/EnvironmentMcpService.test.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.test.ts
@@ -15,10 +15,10 @@ import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 
 import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
-import { ProviderRegistry } from "../provider/Services/ProviderRegistry.ts";
+import * as ProviderRegistryModule from "../provider/Services/ProviderRegistry.ts";
 import { makeProviderRegistryLayer } from "../provider/testUtils/providerRegistryMock.ts";
 import * as ServerSettings from "../serverSettings.ts";
-import { EnvironmentMcpService, layer } from "./EnvironmentMcpService.ts";
+import * as EnvironmentMcp from "./EnvironmentMcpService.ts";
 import type { McpInvocationScope } from "./McpInvocationContext.ts";
 
 const encodeEnvironmentMcpReadResult = Schema.encodeUnknownEffect(EnvironmentMcpReadResult);
@@ -91,7 +91,7 @@ const serviceLayer = (input: {
   readonly serverVersion?: string;
   readonly customInstructions?: string;
 }) =>
-  layer.pipe(
+  EnvironmentMcp.layer.pipe(
     Layer.provide(
       Layer.mergeAll(
         environmentLayer(input.label ?? "Test environment", input.serverVersion ?? "1.2.3"),
@@ -128,7 +128,7 @@ const serviceLayer = (input: {
 describe("EnvironmentMcpService", () => {
   it.effect("returns only bounded allowlisted environment and provider diagnostics", () =>
     Effect.gen(function* () {
-      const service = yield* EnvironmentMcpService;
+      const service = yield* EnvironmentMcp.EnvironmentMcpService;
       const result = yield* service.read(scope, { providerLimit: 1 });
       const encoded = yield* encodeEnvironmentMcpReadResult(result);
 
@@ -192,20 +192,20 @@ describe("EnvironmentMcpService", () => {
 
   it.effect("denies credentials without orchestration capability before reading services", () => {
     let providerReads = 0;
-    const providerLayer = Layer.succeed(ProviderRegistry, {
+    const providerLayer = Layer.mock(ProviderRegistryModule.ProviderRegistry)({
       getProviders: Effect.sync(() => {
         providerReads += 1;
         return [];
       }),
-    } as never);
+    });
     return Effect.gen(function* () {
-      const service = yield* EnvironmentMcpService;
+      const service = yield* EnvironmentMcp.EnvironmentMcpService;
       const error = yield* Effect.flip(service.read({ ...scope, capabilities: new Set() }, {}));
       expect(error.code).toBe("capability_denied");
       expect(providerReads).toBe(0);
     }).pipe(
       Effect.provide(
-        layer.pipe(
+        EnvironmentMcp.layer.pipe(
           Layer.provide(
             Layer.mergeAll(
               environmentLayer("Test", "1.0.0"),
@@ -219,17 +219,17 @@ describe("EnvironmentMcpService", () => {
   });
 
   it.effect("distinguishes an unavailable provider registry from a healthy empty result", () => {
-    const unavailableRegistry = Layer.succeed(ProviderRegistry, {
+    const unavailableRegistry = Layer.mock(ProviderRegistryModule.ProviderRegistry)({
       getProviders: Effect.die("SENTINEL_PROVIDER_FAILURE"),
-    } as never);
+    });
     return Effect.gen(function* () {
-      const service = yield* EnvironmentMcpService;
+      const service = yield* EnvironmentMcp.EnvironmentMcpService;
       const error = yield* Effect.flip(service.read(scope, {}));
       expect(error.code).toBe("provider_registry_unavailable");
       expect(error.message).not.toContain("SENTINEL_PROVIDER_FAILURE");
     }).pipe(
       Effect.provide(
-        layer.pipe(
+        EnvironmentMcp.layer.pipe(
           Layer.provide(
             Layer.mergeAll(
               environmentLayer("Test", "1.0.0"),
@@ -245,7 +245,7 @@ describe("EnvironmentMcpService", () => {
   it.effect("rejects an environment mismatch before reading scoped dependencies", () => {
     let providerReads = 0;
     let settingsReads = 0;
-    const providerLayer = Layer.mock(ProviderRegistry)({
+    const providerLayer = Layer.mock(ProviderRegistryModule.ProviderRegistry)({
       getProviders: Effect.sync(() => {
         providerReads += 1;
         return [];
@@ -258,7 +258,7 @@ describe("EnvironmentMcpService", () => {
       }),
     });
     return Effect.gen(function* () {
-      const service = yield* EnvironmentMcpService;
+      const service = yield* EnvironmentMcp.EnvironmentMcpService;
       const error = yield* Effect.flip(
         service.read({ ...scope, environmentId: EnvironmentId.make("environment-other") }, {}),
       );
@@ -268,7 +268,7 @@ describe("EnvironmentMcpService", () => {
       expect(settingsReads).toBe(0);
     }).pipe(
       Effect.provide(
-        layer.pipe(
+        EnvironmentMcp.layer.pipe(
           Layer.provide(
             Layer.mergeAll(environmentLayer("Test", "1.0.0"), providerLayer, settingsLayer),
           ),

--- a/apps/server/src/mcp/EnvironmentMcpService.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.ts
@@ -29,19 +29,16 @@ export class EnvironmentMcpService extends Context.Service<
   }
 >()("t3/mcp/EnvironmentMcpService") {}
 
-const failure = (code: EnvironmentMcpFailure["code"], message: string) =>
-  new EnvironmentMcpFailure({ code, message });
-
-const unavailable = <A>(
-  effect: Effect.Effect<A, unknown>,
+const unavailable = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
   code: EnvironmentMcpFailure["code"],
-  message: string,
-): Effect.Effect<A, EnvironmentMcpFailure> =>
+): Effect.Effect<A, EnvironmentMcpFailure, R> =>
   effect.pipe(
-    Effect.catchCause((cause) =>
-      Cause.hasInterrupts(cause)
-        ? Effect.failCause(cause).pipe(Effect.orDie)
-        : Effect.fail(failure(code, message)),
+    Effect.catchCause(
+      (cause): Effect.Effect<never, EnvironmentMcpFailure> =>
+        Cause.hasInterrupts(cause)
+          ? Effect.failCause(cause).pipe(Effect.orDie)
+          : Effect.fail(new EnvironmentMcpFailure({ code })),
     ),
   );
 
@@ -122,33 +119,15 @@ const make = Effect.gen(function* () {
     read: (scope, input) =>
       Effect.gen(function* () {
         if (!scope.capabilities.has("orchestration")) {
-          return yield* failure(
-            "capability_denied",
-            "This MCP credential does not grant environment read capabilities.",
-          );
+          return yield* new EnvironmentMcpFailure({ code: "capability_denied" });
         }
         const [descriptor, providers, settings] = yield* Effect.all([
-          unavailable(
-            environment.getDescriptor,
-            "environment_unavailable",
-            "The current environment descriptor is unavailable.",
-          ),
-          unavailable(
-            providerRegistry.getProviders,
-            "provider_registry_unavailable",
-            "The provider registry is unavailable.",
-          ),
-          unavailable(
-            settingsService.getSettings,
-            "settings_unavailable",
-            "Server-owned preferences are unavailable.",
-          ),
+          unavailable(environment.getDescriptor, "environment_unavailable"),
+          unavailable(providerRegistry.getProviders, "provider_registry_unavailable"),
+          unavailable(settingsService.getSettings, "settings_unavailable"),
         ]);
         if (descriptor.environmentId !== scope.environmentId) {
-          return yield* failure(
-            "environment_unavailable",
-            "The MCP credential does not belong to the running environment.",
-          );
+          return yield* new EnvironmentMcpFailure({ code: "environment_mismatch" });
         }
 
         const ordered = [...providers].sort((left, right) =>

--- a/apps/server/src/mcp/EnvironmentMcpService.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.ts
@@ -1,0 +1,217 @@
+import {
+  ENVIRONMENT_MCP_DEFAULT_PROVIDER_LIMIT,
+  ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS,
+  ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS,
+  EnvironmentMcpFailure,
+  type EnvironmentMcpPreferences,
+  type EnvironmentMcpReadInput,
+  type EnvironmentMcpReadResult,
+  type ServerProvider,
+  type ServerSettings,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as ServerEnvironment from "../environment/ServerEnvironment.ts";
+import { ProviderRegistry } from "../provider/Services/ProviderRegistry.ts";
+import * as ServerSettingsModule from "../serverSettings.ts";
+import type { McpInvocationScope } from "./McpInvocationContext.ts";
+
+export class EnvironmentMcpService extends Context.Service<
+  EnvironmentMcpService,
+  {
+    readonly read: (
+      scope: McpInvocationScope,
+      input: EnvironmentMcpReadInput,
+    ) => Effect.Effect<EnvironmentMcpReadResult, EnvironmentMcpFailure>;
+  }
+>()("t3/mcp/EnvironmentMcpService") {}
+
+const failure = (code: EnvironmentMcpFailure["code"], message: string) =>
+  new EnvironmentMcpFailure({ code, message });
+
+const unavailable = <A>(
+  effect: Effect.Effect<A, unknown>,
+  code: EnvironmentMcpFailure["code"],
+  message: string,
+): Effect.Effect<A, EnvironmentMcpFailure> =>
+  effect.pipe(
+    Effect.catchCause((cause) =>
+      Cause.hasInterrupts(cause)
+        ? Effect.failCause(cause).pipe(Effect.orDie)
+        : Effect.fail(failure(code, message)),
+    ),
+  );
+
+const textWindow = (value: string, maximumCharacters: number) => {
+  const characters = Array.from(value);
+  return {
+    text: characters.slice(0, maximumCharacters).join(""),
+    characters: characters.length,
+    maximumCharacters,
+    truncated: characters.length > maximumCharacters,
+  } as const;
+};
+
+export const presentEnvironmentPreferences = (
+  settings: ServerSettings,
+): EnvironmentMcpPreferences => ({
+  defaultThreadEnvMode: settings.defaultThreadEnvMode,
+  newWorktreesStartFromOrigin: settings.newWorktreesStartFromOrigin,
+  enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+  backgroundActivity: {
+    profile: settings.backgroundActivity.profile,
+    baseProfile: settings.backgroundActivity.baseProfile ?? null,
+  },
+  sourceControlWritingStyle: {
+    mode: settings.sourceControlWritingStyle.mode,
+    customInstructions: textWindow(
+      settings.sourceControlWritingStyle.customInstructions,
+      ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS,
+    ),
+    followChangeRequestTemplates: settings.sourceControlWritingStyle.followChangeRequestTemplates,
+  },
+});
+
+const providerHealth = (providers: ReadonlyArray<ServerProvider>) => {
+  const count = (state: ServerProvider["status"]) =>
+    providers.filter((provider) => provider.status === state).length;
+  const unavailableCount = providers.filter(
+    (provider) => provider.availability === "unavailable",
+  ).length;
+  const usable = providers.filter(
+    (provider) =>
+      provider.availability !== "unavailable" &&
+      provider.enabled &&
+      provider.installed &&
+      (provider.status === "ready" || provider.status === "warning"),
+  ).length;
+  const status =
+    providers.length === 0
+      ? "empty"
+      : usable === 0
+        ? "unavailable"
+        : providers.some(
+              (provider) =>
+                provider.status === "warning" ||
+                provider.status === "error" ||
+                provider.availability === "unavailable",
+            )
+          ? "degraded"
+          : "healthy";
+  return {
+    status,
+    total: providers.length,
+    ready: count("ready"),
+    warning: count("warning"),
+    error: count("error"),
+    disabled: count("disabled"),
+    unavailable: unavailableCount,
+    usable,
+  } as const;
+};
+
+const make = Effect.gen(function* () {
+  const environment = yield* ServerEnvironment.ServerEnvironment;
+  const providerRegistry = yield* ProviderRegistry;
+  const settingsService = yield* ServerSettingsModule.ServerSettingsService;
+
+  return EnvironmentMcpService.of({
+    read: (scope, input) =>
+      Effect.gen(function* () {
+        if (!scope.capabilities.has("orchestration")) {
+          return yield* failure(
+            "capability_denied",
+            "This MCP credential does not grant environment read capabilities.",
+          );
+        }
+        const [descriptor, providers, settings] = yield* Effect.all([
+          unavailable(
+            environment.getDescriptor,
+            "environment_unavailable",
+            "The current environment descriptor is unavailable.",
+          ),
+          unavailable(
+            providerRegistry.getProviders,
+            "provider_registry_unavailable",
+            "The provider registry is unavailable.",
+          ),
+          unavailable(
+            settingsService.getSettings,
+            "settings_unavailable",
+            "Server-owned preferences are unavailable.",
+          ),
+        ]);
+        if (descriptor.environmentId !== scope.environmentId) {
+          return yield* failure(
+            "environment_unavailable",
+            "The MCP credential does not belong to the running environment.",
+          );
+        }
+
+        const ordered = [...providers].sort((left, right) =>
+          left.instanceId < right.instanceId ? -1 : left.instanceId > right.instanceId ? 1 : 0,
+        );
+        const cursor = input.providerCursor ?? 0;
+        const limit = input.providerLimit ?? ENVIRONMENT_MCP_DEFAULT_PROVIDER_LIMIT;
+        const page = ordered.slice(cursor, cursor + limit);
+        const capabilities = descriptor.capabilities;
+        return {
+          identity: {
+            environmentId: descriptor.environmentId,
+            label: textWindow(descriptor.label, ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS),
+            platform: descriptor.platform,
+            serverVersion: textWindow(
+              descriptor.serverVersion,
+              ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS,
+            ),
+          },
+          capabilities: {
+            repositoryIdentity: capabilities.repositoryIdentity,
+            connectionProbe: capabilities.connectionProbe ?? false,
+            attachmentUploads: capabilities.attachmentUploads ?? false,
+            fileAttachmentMaxUploadBytes: capabilities.fileAttachments?.maxUploadBytes ?? null,
+            pullRequests: capabilities.pullRequests ?? false,
+            threadSettlement: capabilities.threadSettlement ?? false,
+            threadSnooze: capabilities.threadSnooze ?? false,
+            environmentThemes: capabilities.environmentThemes ?? false,
+            threadPinning: capabilities.threadPinning ?? false,
+            threadPinReorder: capabilities.threadPinReorder ?? false,
+            threadTitleRegeneration: capabilities.threadTitleRegeneration ?? false,
+            threadVisitedTracking: capabilities.threadVisitedTracking ?? false,
+            threadPullRequestLinking: capabilities.threadPullRequestLinking ?? false,
+          },
+          providerHealth: providerHealth(ordered),
+          providers: page.map((provider) => ({
+            instanceId: provider.instanceId,
+            driver: provider.driver,
+            displayName:
+              provider.displayName === undefined
+                ? null
+                : textWindow(provider.displayName, ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS),
+            availability: provider.availability ?? "available",
+            enabled: provider.enabled,
+            installed: provider.installed,
+            state: provider.status,
+            authStatus: provider.auth.status,
+            version:
+              provider.version === null
+                ? null
+                : textWindow(provider.version, ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS),
+            checkedAt: provider.checkedAt,
+            modelCount: provider.models.length,
+            supportsInteractionMode: provider.showInteractionModeToggle ?? false,
+            requiresNewThreadForModelChange: provider.requiresNewThreadForModelChange ?? false,
+          })),
+          providerNextCursor: cursor + page.length < ordered.length ? cursor + page.length : null,
+          providerTotal: ordered.length,
+          preferences: presentEnvironmentPreferences(settings),
+          preferenceScope: "server_owned",
+        };
+      }),
+  });
+});
+
+export const layer = Layer.effect(EnvironmentMcpService, make);

--- a/apps/server/src/mcp/EnvironmentMcpService.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.ts
@@ -121,14 +121,14 @@ const make = Effect.gen(function* () {
         if (!scope.capabilities.has("orchestration")) {
           return yield* new EnvironmentMcpFailure({ code: "capability_denied" });
         }
-        const [descriptor, providers, settings] = yield* Effect.all([
-          unavailable(environment.getDescriptor, "environment_unavailable"),
-          unavailable(providerRegistry.getProviders, "provider_registry_unavailable"),
-          unavailable(settingsService.getSettings, "settings_unavailable"),
-        ]);
+        const descriptor = yield* unavailable(environment.getDescriptor, "environment_unavailable");
         if (descriptor.environmentId !== scope.environmentId) {
           return yield* new EnvironmentMcpFailure({ code: "environment_mismatch" });
         }
+        const [providers, settings] = yield* Effect.all([
+          unavailable(providerRegistry.getProviders, "provider_registry_unavailable"),
+          unavailable(settingsService.getSettings, "settings_unavailable"),
+        ]);
 
         const ordered = [...providers].sort((left, right) =>
           left.instanceId < right.instanceId ? -1 : left.instanceId > right.instanceId ? 1 : 0,

--- a/apps/server/src/mcp/EnvironmentMcpService.ts
+++ b/apps/server/src/mcp/EnvironmentMcpService.ts
@@ -34,11 +34,10 @@ const unavailable = <A, E, R>(
   code: EnvironmentMcpFailure["code"],
 ): Effect.Effect<A, EnvironmentMcpFailure, R> =>
   effect.pipe(
-    Effect.catchCause(
-      (cause): Effect.Effect<never, EnvironmentMcpFailure> =>
-        Cause.hasInterrupts(cause)
-          ? Effect.failCause(cause).pipe(Effect.orDie)
-          : Effect.fail(new EnvironmentMcpFailure({ code })),
+    Effect.catchCause((cause): Effect.Effect<never, EnvironmentMcpFailure> =>
+      Cause.hasInterrupts(cause)
+        ? Effect.failCause(cause).pipe(Effect.orDie)
+        : Effect.fail(new EnvironmentMcpFailure({ code })),
     ),
   );
 

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -15,6 +15,9 @@ import * as OrchestratorMcpService from "./OrchestratorMcpService.ts";
 import * as ThreadMetadataMcpService from "./ThreadMetadataMcpService.ts";
 import * as McpSessionRegistry from "./McpSessionRegistry.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
+import * as EnvironmentMcpService from "./EnvironmentMcpService.ts";
+import { EnvironmentToolkitHandlersLive } from "./toolkits/environment/handlers.ts";
+import { EnvironmentToolkit } from "./toolkits/environment/tools.ts";
 import { OrchestratorToolkitHandlersLive } from "./toolkits/orchestrator/handlers.ts";
 import { OrchestratorToolkit } from "./toolkits/orchestrator/tools.ts";
 import {
@@ -233,6 +236,11 @@ export const WorktreeToolkitRegistrationLive = McpServer.toolkit(WorktreeToolkit
   Layer.provide(WorktreeMcpService.layer),
 );
 
+export const EnvironmentToolkitRegistrationLive = McpServer.toolkit(EnvironmentToolkit).pipe(
+  Layer.provide(EnvironmentToolkitHandlersLive),
+  Layer.provide(EnvironmentMcpService.layer),
+);
+
 const McpTransportLive = McpServer.layerHttp({
   name: "T3 Code",
   version: packageJson.version,
@@ -244,4 +252,5 @@ export const layer = Layer.mergeAll(
   PreviewToolkitRegistrationLive,
   OrchestratorToolkitRegistrationLive,
   WorktreeToolkitRegistrationLive,
+  EnvironmentToolkitRegistrationLive,
 ).pipe(Layer.provideMerge(McpTransportLive));

--- a/apps/server/src/mcp/toolkits/environment/handlers.ts
+++ b/apps/server/src/mcp/toolkits/environment/handlers.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+
+import { EnvironmentMcpService } from "../../EnvironmentMcpService.ts";
+import { McpInvocationContext } from "../../McpInvocationContext.ts";
+import { EnvironmentToolkit } from "./tools.ts";
+
+const handlers = {
+  t3_environment_read: (input) =>
+    Effect.gen(function* () {
+      const scope = yield* McpInvocationContext;
+      const service = yield* EnvironmentMcpService;
+      return yield* service.read(scope, input);
+    }),
+} satisfies Parameters<typeof EnvironmentToolkit.toLayer>[0];
+
+export const EnvironmentToolkitHandlersLive = EnvironmentToolkit.toLayer(handlers);

--- a/apps/server/src/mcp/toolkits/environment/registration.test.ts
+++ b/apps/server/src/mcp/toolkits/environment/registration.test.ts
@@ -1,0 +1,138 @@
+import { expect, it } from "@effect/vitest";
+import { NodeHttpServer } from "@effect/platform-node";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { EnvironmentId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
+
+import * as ServerEnvironment from "../../../environment/ServerEnvironment.ts";
+import * as GitWorkflowService from "../../../git/GitWorkflowService.ts";
+import { ThreadManagementService } from "../../../orchestration-v2/ThreadManagementService.ts";
+import * as ProjectService from "../../../project/ProjectService.ts";
+import * as ProjectSetupScriptRunner from "../../../project/ProjectSetupScriptRunner.ts";
+import { ProviderRegistry } from "../../../provider/Services/ProviderRegistry.ts";
+import { ScheduledTaskService } from "../../../scheduledTasks/ScheduledTaskService.ts";
+import * as ServerSettings from "../../../serverSettings.ts";
+import { VcsStatusBroadcaster } from "../../../vcs/VcsStatusBroadcaster.ts";
+import * as McpHttpServer from "../../McpHttpServer.ts";
+import * as McpSessionRegistry from "../../McpSessionRegistry.ts";
+import * as PreviewAutomationBroker from "../../PreviewAutomationBroker.ts";
+
+const environmentId = EnvironmentId.make("environment-scratch");
+const StubServicesLive = Layer.mergeAll(
+  Layer.mock(ThreadManagementService)({}),
+  Layer.mock(ProviderRegistry)({ getProviders: Effect.succeed([]) }),
+  Layer.mock(ScheduledTaskService)({}),
+  Layer.mock(ProjectService.ProjectService)({}),
+  ServerSettings.layerTest({}),
+  Layer.mock(GitWorkflowService.GitWorkflowService)({}),
+  Layer.mock(ProjectSetupScriptRunner.ProjectSetupScriptRunner)({}),
+  Layer.mock(VcsStatusBroadcaster)({}),
+);
+
+const ToolsListPayload = Schema.fromJsonString(
+  Schema.Struct({
+    result: Schema.Struct({
+      tools: Schema.Array(
+        Schema.Struct({
+          name: Schema.String,
+          inputSchema: Schema.Struct({
+            type: Schema.optional(Schema.String),
+            properties: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+          }),
+          annotations: Schema.optional(
+            Schema.Struct({
+              readOnlyHint: Schema.optional(Schema.Boolean),
+              destructiveHint: Schema.optional(Schema.Boolean),
+              openWorldHint: Schema.optional(Schema.Boolean),
+            }),
+          ),
+        }),
+      ),
+    }),
+  }),
+);
+const decodeToolsListPayload = Schema.decodeUnknownEffect(ToolsListPayload);
+
+it.effect("production MCP lists the bounded current-environment read tool", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const routes = McpHttpServer.layer.pipe(Layer.provide(McpSessionRegistry.layer));
+      yield* HttpRouter.serve(routes, {
+        disableListenLog: true,
+        disableLogger: true,
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(
+            ServerEnvironment.ServerEnvironment,
+            ServerEnvironment.ServerEnvironment.of({
+              getEnvironmentId: Effect.succeed(environmentId),
+              getDescriptor: Effect.succeed({
+                environmentId,
+                label: "Scratch",
+                platform: { os: "darwin", arch: "arm64" },
+                serverVersion: "1.0.0",
+                capabilities: { repositoryIdentity: true },
+              }),
+            }),
+          ),
+        ),
+        Layer.provide(PreviewAutomationBroker.layer),
+        Layer.provide(StubServicesLive),
+        Layer.build,
+      );
+
+      const credential = yield* McpSessionRegistry.issueActiveMcpCredential({
+        threadId: ThreadId.make("thread-scratch"),
+        providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+      });
+      expect(credential).toBeDefined();
+
+      const httpClient = yield* HttpClient.HttpClient;
+      const authorization = credential!.config.authorizationHeader;
+      const initializeResponse = yield* httpClient.post("/mcp", {
+        headers: {
+          accept: "application/json, text/event-stream",
+          authorization,
+        },
+        body: HttpBody.text(
+          `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"scratch","version":"1.0.0"}}}`,
+          "application/json",
+        ),
+      });
+      expect(initializeResponse.status).toBe(200);
+      const sessionId = initializeResponse.headers["mcp-session-id"];
+
+      const listResponse = yield* httpClient.post("/mcp", {
+        headers: {
+          accept: "application/json, text/event-stream",
+          authorization,
+          "mcp-protocol-version": "2025-06-18",
+          ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+        },
+        body: HttpBody.text(
+          `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+          "application/json",
+        ),
+      });
+      const bodyText = yield* listResponse.text;
+      const payload = yield* decodeToolsListPayload(bodyText.match(/\{.*\}/s)![0]);
+      const environmentRead = payload.result.tools.find(
+        (tool) => tool.name === "t3_environment_read",
+      );
+      expect(environmentRead).toBeDefined();
+      expect(environmentRead?.inputSchema.type).toBe("object");
+      expect(Object.keys(environmentRead?.inputSchema.properties ?? {}).sort()).toEqual([
+        "providerCursor",
+        "providerLimit",
+      ]);
+      expect(environmentRead?.annotations).toMatchObject({
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      });
+    }),
+  ).pipe(Effect.provide(Layer.mergeAll(NodeHttpServer.layerTest, NodeServices.layer))),
+);

--- a/apps/server/src/mcp/toolkits/environment/tools.ts
+++ b/apps/server/src/mcp/toolkits/environment/tools.ts
@@ -1,0 +1,28 @@
+import {
+  EnvironmentMcpFailure,
+  EnvironmentMcpReadInput,
+  EnvironmentMcpReadResult,
+} from "@t3tools/contracts";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { EnvironmentMcpService } from "../../EnvironmentMcpService.ts";
+
+const dependencies = [McpInvocationContext.McpInvocationContext, EnvironmentMcpService];
+
+export const EnvironmentReadTool = Tool.make("t3_environment_read", {
+  description:
+    "Read the current authenticated T3 environment identity, platform, server version, safe feature capabilities, bounded provider availability/auth summaries, and the explicit server-owned preference allowlist. This never refreshes providers and never returns credentials, provider configuration, filesystem paths, raw diagnostics, model inventories, client-local preferences, or admin settings. Use providerCursor/providerLimit to page configured provider instances.",
+  parameters: EnvironmentMcpReadInput,
+  success: EnvironmentMcpReadResult,
+  failure: EnvironmentMcpFailure,
+  failureMode: "return",
+  dependencies,
+})
+  .annotate(Tool.Title, "Read current T3 environment")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, true)
+  .annotate(Tool.OpenWorld, false);
+
+export const EnvironmentToolkit = Toolkit.make(EnvironmentReadTool);

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
@@ -46,6 +46,7 @@ import { formatClaudeResumeCompactionQuestion } from "@t3tools/shared/claudeComp
 import { attachmentRelativePath } from "../../attachmentStore.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { OrchestratorToolkit } from "../../mcp/toolkits/orchestrator/tools.ts";
+import { EnvironmentToolkit } from "../../mcp/toolkits/environment/tools.ts";
 import type { EventNdjsonLogger } from "../../provider/Layers/EventNdjsonLogger.ts";
 import {
   ProviderAdapterV2RuntimePolicy,
@@ -580,7 +581,10 @@ describe("ClaudeAdapterV2 MCP query overrides", () => {
   });
 
   it("matches the read-only allowlist to the orchestrator toolkit annotations", () => {
-    const readOnlyToolNames = Object.values(OrchestratorToolkit.tools)
+    const readOnlyToolNames = [
+      ...Object.values(OrchestratorToolkit.tools),
+      ...Object.values(EnvironmentToolkit.tools),
+    ]
       .filter((tool) => Context.get(tool.annotations, Tool.Readonly))
       .map((tool) => `mcp__t3-code__${tool.name}`)
       .sort();

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -801,9 +801,10 @@ export function makeClaudeQueryOptions(input: {
 
 export const CLAUDE_T3_MCP_TOOL_WILDCARD = "mcp__t3-code__*";
 
-// Must stay in sync with the Tool.Readonly annotations on OrchestratorToolkit;
-// ClaudeAdapterV2.test.ts cross-checks this list against the toolkit.
+// Must stay in sync with the Tool.Readonly annotations on every toolkit
+// available to provider sessions; ClaudeAdapterV2.test.ts cross-checks them.
 export const CLAUDE_READ_ONLY_T3_MCP_ALLOWED_TOOLS: ReadonlyArray<string> = [
+  "mcp__t3-code__t3_environment_read",
   "mcp__t3-code__orchestrator_capabilities",
   "mcp__t3-code__list_scheduled_tasks",
   "mcp__t3-code__t3_thread_list",

--- a/docs/internals/environment-mcp.md
+++ b/docs/internals/environment-mcp.md
@@ -1,0 +1,24 @@
+# Environment MCP boundary
+
+The environment MCP family exposes the running `ServerEnvironment`, cached
+`ProviderRegistry`, and `ServerSettingsService` through explicit contracts. It
+does not instantiate another environment service and has no environment target
+selector: the MCP credential's environment must match the running descriptor.
+
+`t3_environment_read` is a closed-world, read-only tool. Its provider page is
+sorted by opaque provider instance ID and contains normalized status,
+capability, authentication, version, and model-count fields only. Raw provider
+messages, model inventories, account data, settings records, paths, environment
+variables, and self-update or relay administration are outside the contract.
+Service failures are returned distinctly from a healthy empty provider list.
+
+Display text is bounded by Unicode code points before result encoding. The wire
+schema deliberately does not use `Schema.isMaxLength` for those fields because
+that validator counts UTF-16 code units and would reject an in-bound astral
+character value. Each text window carries the original character count, limit,
+and truncation state.
+
+The preference projection is a literal allowlist. It must be extended field by
+field; never spread a server settings or provider configuration object into an
+MCP result. Environment reads use cached provider state and do not call provider
+refresh or the usage service.

--- a/docs/user/environment-mcp.md
+++ b/docs/user/environment-mcp.md
@@ -1,0 +1,22 @@
+# Environment MCP tools
+
+Agents can inspect the T3 Code environment that issued their MCP credential with
+`t3_environment_read`. The tool reports the current environment identity,
+platform, server version, supported T3 features, provider availability and
+authentication status, and a small set of server-owned preferences.
+
+Provider results are ordered by their opaque instance ID and paged. The read
+uses the provider registry's existing cached state; it does not install,
+refresh, authenticate, or reconfigure a provider. Provider model inventories,
+credentials, configuration, environment variables, filesystem paths, raw
+diagnostics, and account identities are not returned.
+
+Human-readable labels and versions are capped at 256 Unicode characters. Source
+control writing instructions are capped at 4,000 Unicode characters. Each such
+value reports its original character count, the applied limit, and whether it
+was truncated. Opaque environment and provider IDs are never shortened.
+
+The preference snapshot is server-owned and applies across web, desktop, and
+mobile clients connected to this environment. Client-local appearance and
+desktop preferences are not available through this tool. Reading the
+environment does not scan usage transcripts or trigger provider maintenance.

--- a/packages/contracts/src/environmentMcp.ts
+++ b/packages/contracts/src/environmentMcp.ts
@@ -141,10 +141,27 @@ export class EnvironmentMcpFailure extends Schema.TaggedErrorClass<EnvironmentMc
     code: Schema.Literals([
       "capability_denied",
       "environment_unavailable",
+      "environment_mismatch",
       "provider_registry_unavailable",
       "settings_unavailable",
       "operation_failed",
     ]),
-    message: Schema.String,
   },
-) {}
+) {
+  override get message(): string {
+    switch (this.code) {
+      case "capability_denied":
+        return "This MCP credential does not grant environment read capabilities.";
+      case "environment_unavailable":
+        return "The current environment descriptor is unavailable.";
+      case "environment_mismatch":
+        return "The MCP credential does not belong to the running environment.";
+      case "provider_registry_unavailable":
+        return "The provider registry is unavailable.";
+      case "settings_unavailable":
+        return "Server-owned preferences are unavailable.";
+      case "operation_failed":
+        return "The environment operation failed.";
+    }
+  }
+}

--- a/packages/contracts/src/environmentMcp.ts
+++ b/packages/contracts/src/environmentMcp.ts
@@ -1,0 +1,150 @@
+import * as Schema from "effect/Schema";
+
+import { EnvironmentId, IsoDateTime, NonNegativeInt } from "./baseSchemas.ts";
+import { ExecutionEnvironmentPlatform, ThreadEnvMode } from "./environment.ts";
+import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
+import {
+  BackgroundActivityProfile,
+  BackgroundActivityProfileSelection,
+  SourceControlWritingStyleMode,
+} from "./settings.ts";
+import {
+  ServerProviderAuthStatus,
+  ServerProviderAvailability,
+  ServerProviderState,
+} from "./server.ts";
+
+export const ENVIRONMENT_MCP_DEFAULT_PROVIDER_LIMIT = 20;
+export const ENVIRONMENT_MCP_MAX_PROVIDER_LIMIT = 32;
+export const ENVIRONMENT_MCP_MAX_DIAGNOSTIC_CHARACTERS = 256;
+export const ENVIRONMENT_MCP_MAX_WRITING_INSTRUCTIONS = 4_000;
+
+export const EnvironmentMcpReadInput = Schema.Struct({
+  providerCursor: Schema.optional(
+    Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)).annotate({
+      description: "Zero-based provider page offset. Defaults to 0.",
+    }),
+  ),
+  providerLimit: Schema.optional(
+    Schema.Int.check(
+      Schema.isGreaterThanOrEqualTo(1),
+      Schema.isLessThanOrEqualTo(ENVIRONMENT_MCP_MAX_PROVIDER_LIMIT),
+    ).annotate({
+      description: `Provider page size. Defaults to ${ENVIRONMENT_MCP_DEFAULT_PROVIDER_LIMIT}; maximum ${ENVIRONMENT_MCP_MAX_PROVIDER_LIMIT}.`,
+    }),
+  ),
+});
+export type EnvironmentMcpReadInput = typeof EnvironmentMcpReadInput.Type;
+
+export const EnvironmentMcpSafeCapabilities = Schema.Struct({
+  repositoryIdentity: Schema.Boolean,
+  connectionProbe: Schema.Boolean,
+  attachmentUploads: Schema.Boolean,
+  fileAttachmentMaxUploadBytes: Schema.NullOr(Schema.Int),
+  pullRequests: Schema.Boolean,
+  threadSettlement: Schema.Boolean,
+  threadSnooze: Schema.Boolean,
+  environmentThemes: Schema.Boolean,
+  threadPinning: Schema.Boolean,
+  threadPinReorder: Schema.Boolean,
+  threadTitleRegeneration: Schema.Boolean,
+  threadVisitedTracking: Schema.Boolean,
+  threadPullRequestLinking: Schema.Boolean,
+});
+
+export const EnvironmentMcpProviderSummary = Schema.Struct({
+  instanceId: ProviderInstanceId,
+  driver: ProviderDriverKind,
+  displayName: Schema.NullOr(
+    Schema.Struct({
+      text: Schema.String,
+      characters: NonNegativeInt,
+      maximumCharacters: NonNegativeInt,
+      truncated: Schema.Boolean,
+    }),
+  ),
+  availability: ServerProviderAvailability,
+  enabled: Schema.Boolean,
+  installed: Schema.Boolean,
+  state: ServerProviderState,
+  authStatus: ServerProviderAuthStatus,
+  version: Schema.NullOr(
+    Schema.Struct({
+      text: Schema.String,
+      characters: NonNegativeInt,
+      maximumCharacters: NonNegativeInt,
+      truncated: Schema.Boolean,
+    }),
+  ),
+  checkedAt: IsoDateTime,
+  modelCount: NonNegativeInt,
+  supportsInteractionMode: Schema.Boolean,
+  requiresNewThreadForModelChange: Schema.Boolean,
+});
+
+export const EnvironmentMcpProviderHealth = Schema.Struct({
+  status: Schema.Literals(["empty", "healthy", "degraded", "unavailable"]),
+  total: NonNegativeInt,
+  ready: NonNegativeInt,
+  warning: NonNegativeInt,
+  error: NonNegativeInt,
+  disabled: NonNegativeInt,
+  unavailable: NonNegativeInt,
+  usable: NonNegativeInt,
+});
+
+export const EnvironmentMcpTextWindow = Schema.Struct({
+  // Service producers bound this by Unicode code points. A UTF-16 length
+  // check here would reject valid astral characters within that limit.
+  text: Schema.String,
+  characters: NonNegativeInt,
+  maximumCharacters: NonNegativeInt,
+  truncated: Schema.Boolean,
+});
+
+export const EnvironmentMcpPreferences = Schema.Struct({
+  defaultThreadEnvMode: ThreadEnvMode,
+  newWorktreesStartFromOrigin: Schema.Boolean,
+  enableProviderUpdateChecks: Schema.Boolean,
+  backgroundActivity: Schema.Struct({
+    profile: BackgroundActivityProfileSelection,
+    baseProfile: Schema.NullOr(BackgroundActivityProfile),
+  }),
+  sourceControlWritingStyle: Schema.Struct({
+    mode: SourceControlWritingStyleMode,
+    customInstructions: EnvironmentMcpTextWindow,
+    followChangeRequestTemplates: Schema.Boolean,
+  }),
+});
+export type EnvironmentMcpPreferences = typeof EnvironmentMcpPreferences.Type;
+
+export const EnvironmentMcpReadResult = Schema.Struct({
+  identity: Schema.Struct({
+    environmentId: EnvironmentId,
+    label: EnvironmentMcpTextWindow,
+    platform: ExecutionEnvironmentPlatform,
+    serverVersion: EnvironmentMcpTextWindow,
+  }),
+  capabilities: EnvironmentMcpSafeCapabilities,
+  providerHealth: EnvironmentMcpProviderHealth,
+  providers: Schema.Array(EnvironmentMcpProviderSummary),
+  providerNextCursor: Schema.NullOr(NonNegativeInt),
+  providerTotal: NonNegativeInt,
+  preferences: EnvironmentMcpPreferences,
+  preferenceScope: Schema.Literal("server_owned"),
+});
+export type EnvironmentMcpReadResult = typeof EnvironmentMcpReadResult.Type;
+
+export class EnvironmentMcpFailure extends Schema.TaggedErrorClass<EnvironmentMcpFailure>()(
+  "EnvironmentMcpFailure",
+  {
+    code: Schema.Literals([
+      "capability_denied",
+      "environment_unavailable",
+      "provider_registry_unavailable",
+      "settings_unavailable",
+      "operation_failed",
+    ]),
+    message: Schema.String,
+  },
+) {}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,7 @@ export * from "./assistantCitations.ts";
 export * from "./background.ts";
 export * from "./auth.ts";
 export * from "./environment.ts";
+export * from "./environmentMcp.ts";
 export * from "./environmentHttp.ts";
 export * from "./relayClient.ts";
 export * from "./desktopBootstrap.ts";

--- a/packages/shared/src/t3McpToolPresentation.test.ts
+++ b/packages/shared/src/t3McpToolPresentation.test.ts
@@ -53,6 +53,13 @@ describe("resolveT3McpToolPresentation", () => {
     });
   });
 
+  it("pretty prints environment T3 MCP tool names", () => {
+    expect(resolveT3McpToolPresentation("mcp__t3-code__t3_environment_read")).toEqual({
+      displayName: "Read current T3 environment",
+      logo: "t3-code",
+    });
+  });
+
   it("keeps unknown MCP tools on the generic renderer path", () => {
     expect(resolveT3McpToolPresentation("mcp__github__search_issues")).toBeNull();
   });

--- a/packages/shared/src/t3McpToolPresentation.ts
+++ b/packages/shared/src/t3McpToolPresentation.ts
@@ -54,6 +54,7 @@ const T3_MCP_TOOLS: Record<
   t3_thread_interrupt: { displayName: "Interrupt a T3 thread", summaryAction: "thread-interrupt" },
   t3_worktree_handoff: { displayName: "Hand off thread to a git worktree" },
   t3_worktree_status: { displayName: "Get thread worktree status" },
+  t3_environment_read: { displayName: "Read current T3 environment" },
   preview_status: { displayName: "Get preview browser status" },
   preview_open: { displayName: "Open a page in the preview browser" },
   preview_navigate: { displayName: "Navigate the preview browser" },


### PR DESCRIPTION
## Problem

Agents could not inspect the identity or safe operational state of the T3 environment backing their current conversation without relying on unrelated settings payloads.

## Change

Add `t3_environment_read`, backed by the existing environment, provider registry, and settings services. It returns a paged provider-health summary, explicit safe capabilities, and a narrow server-owned preference projection.

## Behavior

The tool is current-environment only, read-only, and closed-world. It reads cached provider state without refreshing, installing, or authenticating providers. Human-readable diagnostics are Unicode-safe and bounded; credentials, provider configuration, model inventories, paths, raw diagnostics, and administrative fields never enter the result. Environment mismatch is checked before provider/settings reads, and finite public failure codes do not expose internal causes.

## Focused validation

- allowlisted service projection, capability/mismatch denial, unavailable-service, and Unicode-bound tests
- production HTTP `tools/list` root-object and annotation coverage
- Claude read-only allowlist and shared presentation coverage
- 6 focused files / 18 tests passed across the complete native stack
- server and contracts scoped typechecks, targeted formatting, and `git diff --check`

## Dependency

Bottom layer of native stack 8782, based on `t3code/codex-turn-mapping` at the pinned rollout target. [#8728](https://github.com/pingdotgg/t3code/pull/8728) adds the dependent preference mutation.

Implemented by GPT-5.6-Sol via Codex in T3 Code.
