### PR TITLE
fix(web,mobile): snooze menu no longer offers the same wake time twice

### DIFF
--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -436,8 +436,6 @@ export function resolveSnoozePresets(now: Date): ReadonlyArray<SnoozePreset> {
 
   const daysUntilMonday = (1 - now.getDay() + 7) % 7 || 7;
   const nextWeek = snoozeAtHour(addSnoozeDays(now, daysUntilMonday), MORNING_HOUR);
-  // On Sundays "Next week" is the same Monday 9:00 AM as "Tomorrow"; only
-  // offer it when it is actually a different wake time.
   if (nextWeek.getTime() !== tomorrow.getTime()) {
     presets.push({
       id: "next-week",

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -394,7 +394,9 @@ function addSnoozeDays(base: Date, days: number): Date {
 /**
  * Shared "snooze until" choices for every client. "This evening" only
  * appears while it is meaningfully before evening; after that the calendar
- * choices start at "Tomorrow".
+ * choices start at "Tomorrow". Calendar presets that land on the same
+ * instant collapse: on Sundays "Tomorrow" and "Next week" are both Monday
+ * morning, so only "Tomorrow" is offered.
  */
 export function resolveSnoozePresets(now: Date): ReadonlyArray<SnoozePreset> {
   const inAnHour = new Date(now.getTime() + HOUR_MS);
@@ -434,12 +436,16 @@ export function resolveSnoozePresets(now: Date): ReadonlyArray<SnoozePreset> {
 
   const daysUntilMonday = (1 - now.getDay() + 7) % 7 || 7;
   const nextWeek = snoozeAtHour(addSnoozeDays(now, daysUntilMonday), MORNING_HOUR);
-  presets.push({
-    id: "next-week",
-    label: "Next week",
-    whenLabel: `${nextWeek.toLocaleDateString(undefined, { weekday: "short" })} ${snoozeTimeOfDayLabel(nextWeek)}`,
-    snoozedUntil: nextWeek.toISOString(),
-  });
+  // On Sundays "Next week" is the same Monday 9:00 AM as "Tomorrow"; only
+  // offer it when it is actually a different wake time.
+  if (nextWeek.getTime() !== tomorrow.getTime()) {
+    presets.push({
+      id: "next-week",
+      label: "Next week",
+      whenLabel: `${nextWeek.toLocaleDateString(undefined, { weekday: "short" })} ${snoozeTimeOfDayLabel(nextWeek)}`,
+      snoozedUntil: nextWeek.toISOString(),
+    });
+  }
 
   return presets;
 }

--- a/packages/client-runtime/src/state/threadSnoozed.test.ts
+++ b/packages/client-runtime/src/state/threadSnoozed.test.ts
@@ -297,4 +297,17 @@ describe("resolveSnoozePresets", () => {
     expect(nextWeek.getDay()).toBe(1);
     expect(nextWeek.getDate()).toBe(13);
   });
+
+  it("drops next week on Sundays, when it lands on the same Monday as tomorrow", () => {
+    // Sunday 2026-08-30 07:01: "Tomorrow" and "Next week" are both Monday 9:00.
+    const presets = resolveSnoozePresets(localDate(2026, 8, 30, 7, 1));
+    expect(presets.map((preset) => preset.id)).toEqual([
+      "hour",
+      "three-hours",
+      "evening",
+      "tomorrow",
+    ]);
+    const tomorrow = new Date(presets.find((preset) => preset.id === "tomorrow")!.snoozedUntil);
+    expect(tomorrow.getDay()).toBe(1);
+  });
 });


### PR DESCRIPTION
Found on a Sunday, fixed on a Sunday — for the ones who work on Sundays only!

Fixes #8740

## What Changed

- `resolveSnoozePresets` (the shared snooze-preset builder in `packages/client-runtime`) now only offers "Next week" when it lands on a **different instant** than "Tomorrow".
- On Sundays both resolve to Monday 9:00 AM, so the menu collapses to four options and never shows the same wake time twice.
- One new unit test pinning Sunday 2026-08-30 (the repro date) in `threadSnoozed.test.ts`.

## Why

"Next week" is next Monday 9:00 AM — and on a Sunday, tomorrow *is* Monday. Every client (web sidebar popover, web context menus, chat-header menu, mobile native snooze menus) renders the same shared preset list, so the menu offered two rows with identical wake targets one day a week. The guard lives in the one shared builder, so no per-client duplication and every surface inherits the fix.

## UI Changes

**Before (Sunday):** five options — "Tomorrow 9:00 AM" and "Next week Mon 9:00 AM" are the same instant:

![before: snooze menu shows Tomorrow and Next week pointing at the same Monday 9:00 AM](https://github.com/user-attachments/assets/eec89dbc-6fda-4265-9ef2-29efd56f929a)

**After (Sunday):** four options, duplicate gone:

![after: four snooze options, no duplicate wake time](https://github.com/user-attachments/assets/f267bb4c-89bc-4703-a9a3-604efedab0e3)

No motion or timing changes, so no video.

## Testing

- `vp test run packages/client-runtime/src/state/threadSnoozed.test.ts` — new Sunday test asserts the four-option list and that what remains lands on Monday.
- Reproduced in a live dev environment on Sunday 2026-08-30: before the fix the popover showed the duplicate; after the fix it shows four options (screenshots above are from that run).
- Targeted typecheck, lint, and format on the touched files are clean.

## Checklist

- [x] Small and focused: 2 files, +26/−7, one concern
- [x] Explained what changed and why
- [x] Before/after screenshots attached
- [x] No video needed (no motion/interaction change)

---
Created with z-ai/glm-5.3-flash via the opencode harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small calendar-edge guard in shared snooze preset generation with no auth, data, or server contract changes.
> 
> **Overview**
> **Fixes duplicate snooze options on Sundays** by tightening the shared `resolveSnoozePresets` builder in client-runtime.
> 
> The **"Next week"** preset is only added when its wake instant differs from **"Tomorrow"**. On Sundays both resolve to Monday morning (9:00), so the menu drops the redundant row and every surface that uses this list (web and mobile snooze menus) shows four choices instead of two identical wake times.
> 
> A unit test locks Sunday 2026-08-30 to assert `next-week` is omitted while **Tomorrow** still targets Monday.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4776f840eb38e4d4cdcc8027d5414cc913b4e5cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveSnoozePresets` duplicating the same wake time on Sundays
> On Sundays, the "Tomorrow" and "Next week" snooze presets both resolve to Monday morning, causing the menu to show the same wake time twice. `resolveSnoozePresets` now compares the computed "next-week" Date against "tomorrow" and omits "next-week" when they are equal. A test in [threadSnoozed.test.ts](https://github.com/pingdotgg/t3code/pull/8741/files#diff-fa4d12536a51233379d8384adf25ef7888341a96b51aa8383e08cd7adf6145f6) verifies the Sunday edge case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4776f84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->