### PR TITLE
fix(web): keep working status visible on hover

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
 import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
+  canSettle,
   canSnooze,
   changeRequestAutoSettles,
   effectiveSettled,
@@ -1090,10 +1091,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // While the snooze popover is open the pointer leaves the row, which
   // would fade the hover actions out from under the open menu; pin them.
   const [snoozeMenuOpenRaw, setSnoozeMenuOpen] = useState(false);
+  const actionNow = new Date().toISOString();
+  // The server rejects settling active work. Hide the affordance in the same
+  // states so a Working label never turns into an action that cannot succeed.
+  const showSettleButton = props.settlementSupported && canSettle(thread, { now: actionNow });
   // Snooze is offered only where it can succeed: capability-gated and never
   // on blocked-on-you work or queued turns (the server rejects both).
-  const showSnoozeButton =
-    props.snoozeSupported && canSnooze(thread, { now: new Date().toISOString() });
+  const showSnoozeButton = props.snoozeSupported && canSnooze(thread, { now: actionNow });
   // If the thread becomes blocked while the popover is open, the button
   // unmounts without firing onOpenChange(false). Deriving the flag keeps a
   // stale true from permanently hiding the status label / pinning the
@@ -1451,14 +1455,19 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                   the hidden state out of flow lets the project label reclaim
                   space without either state overlapping it. */}
               <span className="group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
-                {/* Read-only status labels yield to the hover actions. Woke is
-                    itself an action, so it stays pointer-enabled and visible
-                    while the other controls appear beside it. */}
+                {/* Read-only status labels yield to Settle when that action can
+                    succeed. A blocked status such as Working stays visible
+                    while any available secondary action appears beside it.
+                    Woke is itself an action, so it stays pointer-enabled. */}
                 <span
                   className={cn(
                     isWokeStatus
                       ? "pointer-events-auto"
-                      : "pointer-events-none group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
+                      : cn(
+                          "pointer-events-none",
+                          showSettleButton &&
+                            "group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
+                        ),
                     "flex items-center self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
                     snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
                   )}
@@ -1511,7 +1520,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     threadTimeLabel(thread)
                   )}
                 </span>
-                {props.settlementSupported || showSnoozeButton ? (
+                {showSettleButton || showSnoozeButton ? (
                   <span
                     className={cn(
                       // focus-visible, not focus-within: a mouse click leaves
@@ -1531,7 +1540,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                         timestampFormat={props.timestampFormat}
                       />
                     ) : null}
-                    {props.settlementSupported ? (
+                    {showSettleButton ? (
                       <Tooltip>
                         <TooltipTrigger
                           render={

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -18,11 +18,13 @@ import {
 import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
+  QUEUED_TURN_START_GRACE_MS,
   canSettle,
   canSnooze,
   changeRequestAutoSettles,
   effectiveSettled,
   effectiveSnoozed,
+  hasQueuedTurnStart,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
@@ -1091,7 +1093,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // While the snooze popover is open the pointer leaves the row, which
   // would fade the hover actions out from under the open menu; pin them.
   const [snoozeMenuOpenRaw, setSnoozeMenuOpen] = useState(false);
+  const [, refreshActionAvailability] = useState(0);
   const actionNow = new Date().toISOString();
+  const queuedTurnStartExpiresAt =
+    thread.latestUserMessageAt != null && hasQueuedTurnStart(thread, { now: actionNow })
+      ? Date.parse(thread.latestUserMessageAt) + QUEUED_TURN_START_GRACE_MS
+      : null;
+  useEffect(() => {
+    if (queuedTurnStartExpiresAt === null) return;
+    const timeoutId = window.setTimeout(
+      () => refreshActionAvailability((tick) => tick + 1),
+      Math.max(0, queuedTurnStartExpiresAt - Date.now()) + 1,
+    );
+    return () => window.clearTimeout(timeoutId);
+  }, [queuedTurnStartExpiresAt]);
   // The server rejects settling active work. Hide the affordance in the same
   // states so a Working label never turns into an action that cannot succeed.
   const showSettleButton = props.settlementSupported && canSettle(thread, { now: actionNow });
@@ -1469,7 +1484,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                             "group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
                         ),
                     "flex items-center self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
-                    snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
+                    showSettleButton &&
+                      snoozeMenuOpen &&
+                      "pointer-events-none absolute right-0 opacity-0",
                   )}
                 >
                   {topStatus ? (


### PR DESCRIPTION
Running threads replaced their Working status with a Settle action on hover, even though the shared lifecycle rules reject settlement while a session is starting or running.

The sidebar now gates that action with `canSettle`, the same rule used when settlement is dispatched. Blocked rows keep Working visible on hover, while Snooze still appears when it is allowed.

Before

![Before: a working thread shows Settle on hover](https://raw.githubusercontent.com/abcdmku/t3libre-paid/e56c0c23df8237734c4f5ee4524751187003a3eb/working-thread-hover-before.png)

After

![After: the thread keeps Working visible and does not show Settle](https://raw.githubusercontent.com/abcdmku/t3libre-paid/e56c0c23df8237734c4f5ee4524751187003a3eb/working-thread-hover-after.png)

Checks:

- `vp test run packages/client-runtime/src/state/threadSettled.test.ts apps/web/src/components/Sidebar.logic.test.ts` (301 tests)
- `vp run --filter @t3tools/web typecheck`
- `vp lint apps/web/src/components/Sidebar.tsx --report-unused-disable-directives`
- `vp fmt apps/web/src/components/Sidebar.tsx`

Generated with GPT-5.6 in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating in the sidebar using existing `canSettle` helpers; no server or settlement protocol changes.
> 
> **Overview**
> **Sidebar thread rows** no longer swap the **Working** status for **Settle** on hover when settlement would fail on the server.
> 
> **Settle** is shown only when `settlementSupported` and `canSettle(thread, { now })` both pass—the same rules used at dispatch time (running/starting sessions, queued turns, pending approval/input). The status label hides on hover only when **Settle** can actually appear; **Snooze** can still show beside a visible **Working** (or other blocked) label. A short timer re-evaluates affordances after the queued-turn grace window so buttons update without a full refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd0040eeaf77e80bbb8028df408f7c0746ef0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep working status visible on hover in `SidebarThreadRow` unless Settle is available
> - Replaces `settlementSupported` with `canSettle(thread, { now })` for gating the Settle button, so it only appears when the action can actually succeed
> - Adds a `refreshActionAvailability` timer that re-renders the row when the `QUEUED_TURN_START_GRACE_MS` window expires, letting the Settle button auto-appear or disappear without user interaction
> - Changes hover behavior so read-only status labels only fade out when Settle can succeed; blocked/working statuses stay visible, and Snooze alone no longer hides the label
> - Risk: the action controls container in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/8742/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) now renders only when Settle or Snooze can currently succeed — rows that previously showed actions on hover may show none until the grace window or thread state changes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bd0040.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->