### PR TITLE
feat(server): fall back to the GitHub owner avatar for project icons

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -12,6 +12,7 @@ import * as TestClock from "effect/testing/TestClock";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as ServerConfig from "../config.ts";
+import * as GitHubAvatarResolver from "../project/GitHubAvatarResolver.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "../project/T3ProjectFileLoader.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
@@ -20,15 +21,28 @@ import { ASSET_ROUTE_PREFIX, issueAssetUrl, resolveAsset } from "./AssetAccess.t
 const configLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-asset-access-test-",
 });
-const testLayer = Layer.mergeAll(
-  configLayer,
-  WorkspacePaths.layer,
-  ProjectFaviconResolver.layer.pipe(
-    Layer.provide(WorkspacePaths.layer),
-    Layer.provide(T3ProjectFileLoader.layer),
-  ),
-  ServerSecretStore.layer.pipe(Layer.provide(configLayer)),
-).pipe(Layer.provideMerge(NodeServices.layer));
+const disabledGitHubAvatars = Layer.succeed(
+  GitHubAvatarResolver.GitHubAvatarResolver,
+  GitHubAvatarResolver.GitHubAvatarResolver.of({
+    resolvePath: () => Effect.succeed(null),
+    isManagedPath: () => false,
+  }),
+);
+const testLayerWithGitHubAvatars = (
+  githubAvatars: Layer.Layer<GitHubAvatarResolver.GitHubAvatarResolver>,
+) =>
+  Layer.mergeAll(
+    configLayer,
+    WorkspacePaths.layer,
+    githubAvatars,
+    ProjectFaviconResolver.layer.pipe(
+      Layer.provide(WorkspacePaths.layer),
+      Layer.provide(T3ProjectFileLoader.layer),
+      Layer.provide(githubAvatars),
+    ),
+    ServerSecretStore.layer.pipe(Layer.provide(configLayer)),
+  ).pipe(Layer.provideMerge(NodeServices.layer));
+const testLayer = testLayerWithGitHubAvatars(disabledGitHubAvatars);
 
 describe("AssetAccess", () => {
   it.effect("issues workspace URLs that resolve the entry file and sibling assets", () =>
@@ -354,6 +368,42 @@ describe("AssetAccess", () => {
       expect(tamperedSuffixResult).toEqual({ kind: "file", path: canonicalPath });
       expect(tamperedSuffixResult).not.toEqual({ kind: "file", path: canonicalSiblingPath });
     }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("serves a managed GitHub avatar through external claims", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-github-",
+      });
+      const managed = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-github-avatars-",
+      });
+      const avatarPath = path.join(managed, "avatar.png");
+      const avatarBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+      yield* fileSystem.writeFile(avatarPath, avatarBytes);
+      const canonicalAvatarPath = yield* fileSystem.realPath(avatarPath);
+      const githubAvatars = Layer.succeed(
+        GitHubAvatarResolver.GitHubAvatarResolver,
+        GitHubAvatarResolver.GitHubAvatarResolver.of({
+          resolvePath: () => Effect.succeed(avatarPath),
+          isManagedPath: (filePath) => filePath === avatarPath,
+        }),
+      );
+
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root },
+      }).pipe(Effect.provide(testLayerWithGitHubAvatars(githubAvatars)));
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+
+      expect(result.sourcePath).toBe(avatarPath);
+      expect(result.relativeUrl).toMatch(/\/v[0-9a-f]{64}-avatar\.png$/);
+      expect(
+        yield* resolveAsset(suffix.slice(0, separatorIndex), suffix.slice(separatorIndex + 1)),
+      ).toEqual({ kind: "file", path: canonicalAvatarPath });
+    }),
   );
 
   it.effect("ignores a client favicon path hint", () =>

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -43,6 +43,14 @@ const testLayerWithGitHubAvatars = (
     ServerSecretStore.layer.pipe(Layer.provide(configLayer)),
   ).pipe(Layer.provideMerge(NodeServices.layer));
 const testLayer = testLayerWithGitHubAvatars(disabledGitHubAvatars);
+const fakeGitHubAvatars = (state: { readonly avatarPath: string }) =>
+  Layer.succeed(
+    GitHubAvatarResolver.GitHubAvatarResolver,
+    GitHubAvatarResolver.GitHubAvatarResolver.of({
+      resolvePath: () => Effect.succeed(state.avatarPath),
+      isManagedPath: (filePath) => filePath === state.avatarPath,
+    }),
+  );
 
 describe("AssetAccess", () => {
   it.effect("issues workspace URLs that resolve the entry file and sibling assets", () =>
@@ -370,8 +378,9 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  it.effect("serves a managed GitHub avatar through external claims", () =>
-    Effect.gen(function* () {
+  it.effect("serves a managed GitHub avatar through external claims", () => {
+    const state = { avatarPath: "" };
+    return Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const root = yield* fileSystem.makeTempDirectoryScoped({
@@ -384,17 +393,11 @@ describe("AssetAccess", () => {
       const avatarBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
       yield* fileSystem.writeFile(avatarPath, avatarBytes);
       const canonicalAvatarPath = yield* fileSystem.realPath(avatarPath);
-      const githubAvatars = Layer.succeed(
-        GitHubAvatarResolver.GitHubAvatarResolver,
-        GitHubAvatarResolver.GitHubAvatarResolver.of({
-          resolvePath: () => Effect.succeed(avatarPath),
-          isManagedPath: (filePath) => filePath === avatarPath,
-        }),
-      );
+      state.avatarPath = avatarPath;
 
       const result = yield* issueAssetUrl({
         resource: { _tag: "project-favicon", cwd: root },
-      }).pipe(Effect.provide(testLayerWithGitHubAvatars(githubAvatars)));
+      });
       const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
       const separatorIndex = suffix.indexOf("/");
 
@@ -403,8 +406,8 @@ describe("AssetAccess", () => {
       expect(
         yield* resolveAsset(suffix.slice(0, separatorIndex), suffix.slice(separatorIndex + 1)),
       ).toEqual({ kind: "file", path: canonicalAvatarPath });
-    }),
-  );
+    }).pipe(Effect.provide(testLayerWithGitHubAvatars(fakeGitHubAvatars(state))));
+  });
 
   it.effect("ignores a client favicon path hint", () =>
     Effect.gen(function* () {

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -39,6 +39,7 @@ import {
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { parseAttachmentFileExtension, resolveAttachmentPathById } from "../attachmentStore.ts";
 import * as ServerConfig from "../config.ts";
+import * as GitHubAvatarResolver from "../project/GitHubAvatarResolver.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
@@ -331,6 +332,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         ),
       );
       const faviconResolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+      const githubAvatarResolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
       const faviconPath = yield* faviconResolver
         .resolvePath(workspaceRoot, input.projectFaviconPath ?? undefined)
         .pipe(
@@ -344,9 +346,10 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         );
       const isExternalOverride =
         faviconPath !== null &&
-        input.projectFaviconPath !== undefined &&
-        path.isAbsolute(input.projectFaviconPath) &&
-        path.normalize(faviconPath) === path.normalize(input.projectFaviconPath);
+        (githubAvatarResolver.isManagedPath(faviconPath) ||
+          (input.projectFaviconPath !== undefined &&
+            path.isAbsolute(input.projectFaviconPath) &&
+            path.normalize(faviconPath) === path.normalize(input.projectFaviconPath)));
       const relativePath =
         faviconPath && !isExternalOverride ? path.relative(workspaceRoot, faviconPath) : null;
       const sourceFaviconPath = isExternalOverride ? faviconPath : relativePath;

--- a/apps/server/src/project/GitHubAvatarResolver.test.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.test.ts
@@ -224,6 +224,26 @@ describe("GitHubAvatarResolver", () => {
     );
   });
 
+  it.effect("retries transient avatar-CDN responses without a negative marker", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(count.value).toBe(4);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          identity,
+          count,
+          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
+          avatar: () => new Response(null, { status: 503 }),
+        }),
+      ),
+    );
+  });
+
   it.effect("remembers oversized avatars as negative", () => {
     const count = { value: 0 };
     return Effect.gen(function* () {

--- a/apps/server/src/project/GitHubAvatarResolver.test.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.test.ts
@@ -216,6 +216,30 @@ describe("GitHubAvatarResolver", () => {
     );
   });
 
+  it.effect("caches JPEG avatars with their own extension", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      const first = yield* resolver.resolvePath("/worktrees/trino");
+      const second = yield* resolver.resolvePath("/worktrees/trino");
+
+      expect(first).not.toBeNull();
+      if (first === null) return;
+      expect(first).toBe(second);
+      expect(first).toMatch(/\.jpg$/);
+      expect(count.value).toBe(1);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          identity,
+          count,
+          response: () => new Response(pngBytes, { headers: { "content-type": "image/jpeg" } }),
+        }),
+      ),
+    );
+  });
+
   it.effect("remembers oversized avatars as negative", () => {
     const count = { value: 0 };
     return Effect.gen(function* () {

--- a/apps/server/src/project/GitHubAvatarResolver.test.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.test.ts
@@ -1,0 +1,208 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import type { RepositoryIdentity } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as TestClock from "effect/testing/TestClock";
+import { FetchHttpClient } from "effect/unstable/http";
+
+import * as ServerConfig from "../config.ts";
+import * as GitHubAvatarResolver from "./GitHubAvatarResolver.ts";
+import * as RepositoryIdentityResolver from "./RepositoryIdentityResolver.ts";
+
+const configLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-github-avatar-test-",
+});
+
+const identity: RepositoryIdentity = {
+  canonicalKey: "github.com/trinodb/trino",
+  locator: {
+    source: "git-remote",
+    remoteName: "origin",
+    remoteUrl: "https://github.com/trinodb/trino.git",
+  },
+};
+
+const gitlabIdentity: RepositoryIdentity = {
+  canonicalKey: "gitlab.com/owner/repo",
+  locator: {
+    source: "git-remote",
+    remoteName: "origin",
+    remoteUrl: "https://gitlab.com/owner/repo.git",
+  },
+};
+
+const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+const pngResponse = () =>
+  new Response(pngBytes, { status: 200, headers: { "content-type": "image/png" } });
+
+const makeLayer = (input: {
+  readonly identity: RepositoryIdentity | null;
+  readonly count: { value: number };
+  readonly repository: () => Response;
+  readonly avatar?: (url: string) => Response | null;
+}) =>
+  GitHubAvatarResolver.layer.pipe(
+    Layer.provide(
+      Layer.succeed(
+        RepositoryIdentityResolver.RepositoryIdentityResolver,
+        RepositoryIdentityResolver.RepositoryIdentityResolver.of({
+          resolve: () => Effect.succeed(input.identity),
+        }),
+      ),
+    ),
+    Layer.provide(
+      FetchHttpClient.layer.pipe(
+        Layer.provide(
+          Layer.succeed(
+            FetchHttpClient.Fetch,
+            ((url: RequestInfo | URL) => {
+              input.count.value += 1;
+              const target = String(url);
+              const response = target.includes("api.github.com/repos/")
+                ? input.repository()
+                : (input.avatar?.(target) ?? null);
+              return response === null
+                ? Promise.reject(new TypeError(`unrouted request: ${target}`))
+                : Promise.resolve(response);
+            }) as typeof fetch,
+          ),
+        ),
+      ),
+    ),
+  ).pipe(Layer.provideMerge(configLayer), Layer.provideMerge(NodeServices.layer));
+
+const AVATAR_URL = "https://avatars.githubusercontent.com/u/34147222?v=4";
+
+describe("GitHubAvatarResolver", () => {
+  it.effect("fetches and caches the owner avatar once", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+      const fileSystem = yield* FileSystem.FileSystem;
+
+      const first = yield* resolver.resolvePath("/worktrees/trino");
+      const second = yield* resolver.resolvePath("/worktrees/trino");
+
+      expect(first).not.toBeNull();
+      if (first === null) return;
+      expect(first).toBe(second);
+      expect(first).toContain("github-avatars");
+      expect(first).toMatch(/\.png$/);
+      const bytes = yield* fileSystem.readFile(first);
+      expect(Array.from(bytes)).toEqual(Array.from(pngBytes));
+      expect(count.value).toBe(1);
+      expect(resolver.isManagedPath(first)).toBe(true);
+      expect(resolver.isManagedPath("/etc/passwd")).toBe(false);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          identity,
+          count,
+          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
+          avatar: () => pngResponse(),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("shares one cache entry across worktrees of the same repository", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      const [left, right] = yield* Effect.all(
+        [resolver.resolvePath("/worktrees/one"), resolver.resolvePath("/worktrees/two")],
+        { concurrency: "unbounded" },
+      );
+
+      expect(left).not.toBeNull();
+      expect(left).toBe(right);
+      expect(count.value).toBe(1);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          identity,
+          count,
+          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
+          avatar: () => pngResponse(),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("skips non-github remotes without any request", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      const resolved = yield* resolver.resolvePath("/worktrees/repo");
+
+      expect(resolved).toBeNull();
+      expect(count.value).toBe(0);
+    }).pipe(
+      Effect.provide(makeLayer({ identity: gitlabIdentity, count, repository: () => jsonResponse({}) })),
+    ),
+  );
+
+  it.effect("skips identities that are not repositories", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      const resolved = yield* resolver.resolvePath("/worktrees/repo");
+
+      expect(resolved).toBeNull();
+      expect(count.value).toBe(0);
+    }).pipe(Effect.provide(makeLayer({ identity: null, count, repository: () => jsonResponse({}) }))),
+  );
+
+  it.effect("remembers private repositories as negative", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(count.value).toBe(1);
+    }).pipe(Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) }))),
+  );
+
+  it.effect("retries a negative result after its ttl", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      yield* TestClock.adjust("8 days");
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(count.value).toBe(2);
+    }).pipe(Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) }))),
+  );
+
+  it.effect("refuses avatars outside the GitHub avatar host", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      const resolved = yield* resolver.resolvePath("/worktrees/trino");
+
+      expect(resolved).toBeNull();
+      expect(count.value).toBe(1);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          identity,
+          count,
+          repository: () => jsonResponse({ owner: { avatar_url: "https://evil.example/avatar.png" } }),
+          avatar: () => pngResponse(),
+        }),
+      ),
+    ),
+  );
+});

--- a/apps/server/src/project/GitHubAvatarResolver.test.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.test.ts
@@ -35,48 +35,36 @@ const gitlabIdentity: RepositoryIdentity = {
 
 const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
-const jsonResponse = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
-
-const pngResponse = () =>
-  new Response(pngBytes, { status: 200, headers: { "content-type": "image/png" } });
-
 const makeLayer = (input: {
   readonly identity: RepositoryIdentity | null;
   readonly count: { value: number };
-  readonly repository: () => Response | Promise<Response>;
-  readonly avatar?: (url: string) => Response | null;
+  readonly response: () => Response | Promise<Response>;
 }) =>
-  GitHubAvatarResolver.layer
-    .pipe(
-      Layer.provide(
-        Layer.succeed(
-          RepositoryIdentityResolver.RepositoryIdentityResolver,
-          RepositoryIdentityResolver.RepositoryIdentityResolver.of({
-            resolve: () => Effect.succeed(input.identity),
-          }),
+  GitHubAvatarResolver.layer.pipe(
+    Layer.provide(
+      Layer.succeed(
+        RepositoryIdentityResolver.RepositoryIdentityResolver,
+        RepositoryIdentityResolver.RepositoryIdentityResolver.of({
+          resolve: () => Effect.succeed(input.identity),
+        }),
+      ),
+    ),
+    Layer.provide(
+      FetchHttpClient.layer.pipe(
+        Layer.provide(
+          Layer.succeed(FetchHttpClient.Fetch, ((url: Parameters<typeof fetch>[0]) => {
+            input.count.value += 1;
+            const response = input.response();
+            return response === undefined || response === null
+              ? Promise.reject(new TypeError(`unrouted request: ${String(url)}`))
+              : Promise.resolve(response);
+          }) as typeof fetch),
         ),
       ),
-      Layer.provide(
-        FetchHttpClient.layer.pipe(
-          Layer.provide(
-            Layer.succeed(FetchHttpClient.Fetch, ((url: Parameters<typeof fetch>[0]) => {
-              input.count.value += 1;
-              const target = String(url);
-              const response = target.includes("api.github.com/repos/")
-                ? input.repository()
-                : (input.avatar?.(target) ?? null);
-              return response === undefined || response === null
-                ? Promise.reject(new TypeError(`unrouted request: ${target}`))
-                : Promise.resolve(response);
-            }) as typeof fetch),
-          ),
-        ),
-      ),
-    )
-    .pipe(Layer.provideMerge(configLayer), Layer.provideMerge(NodeServices.layer));
-
-const AVATAR_URL = "https://avatars.githubusercontent.com/u/34147222?v=4";
+    ),
+    Layer.provideMerge(configLayer),
+    Layer.provideMerge(NodeServices.layer),
+  );
 
 describe("GitHubAvatarResolver", () => {
   it.effect("fetches and caches the owner avatar once", () => {
@@ -95,7 +83,7 @@ describe("GitHubAvatarResolver", () => {
       expect(first).toMatch(/\.png$/);
       const bytes = yield* fileSystem.readFile(first);
       expect(Array.from(bytes)).toEqual(Array.from(pngBytes));
-      expect(count.value).toBe(2);
+      expect(count.value).toBe(1);
       expect(resolver.isManagedPath(first)).toBe(true);
       expect(resolver.isManagedPath("/etc/passwd")).toBe(false);
     }).pipe(
@@ -103,8 +91,7 @@ describe("GitHubAvatarResolver", () => {
         makeLayer({
           identity,
           count,
-          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
-          avatar: () => pngResponse(),
+          response: () => new Response(pngBytes, { headers: { "content-type": "image/png" } }),
         }),
       ),
     );
@@ -122,14 +109,13 @@ describe("GitHubAvatarResolver", () => {
 
       expect(left).not.toBeNull();
       expect(left).toBe(right);
-      expect(count.value).toBe(2);
+      expect(count.value).toBe(1);
     }).pipe(
       Effect.provide(
         makeLayer({
           identity,
           count,
-          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
-          avatar: () => pngResponse(),
+          response: () => new Response(pngBytes, { headers: { "content-type": "image/png" } }),
         }),
       ),
     );
@@ -146,7 +132,7 @@ describe("GitHubAvatarResolver", () => {
       expect(count.value).toBe(0);
     }).pipe(
       Effect.provide(
-        makeLayer({ identity: gitlabIdentity, count, repository: () => jsonResponse({}) }),
+        makeLayer({ identity: gitlabIdentity, count, response: () => new Response(null) }),
       ),
     );
   });
@@ -161,7 +147,7 @@ describe("GitHubAvatarResolver", () => {
       expect(resolved).toBeNull();
       expect(count.value).toBe(0);
     }).pipe(
-      Effect.provide(makeLayer({ identity: null, count, repository: () => jsonResponse({}) })),
+      Effect.provide(makeLayer({ identity: null, count, response: () => new Response(null) })),
     );
   });
 
@@ -174,7 +160,9 @@ describe("GitHubAvatarResolver", () => {
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(count.value).toBe(1);
     }).pipe(
-      Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) })),
+      Effect.provide(
+        makeLayer({ identity, count, response: () => new Response(null, { status: 404 }) }),
+      ),
     );
   });
 
@@ -188,7 +176,9 @@ describe("GitHubAvatarResolver", () => {
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(count.value).toBe(2);
     }).pipe(
-      Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) })),
+      Effect.provide(
+        makeLayer({ identity, count, response: () => new Response(null, { status: 404 }) }),
+      ),
     );
   });
 
@@ -205,7 +195,7 @@ describe("GitHubAvatarResolver", () => {
         makeLayer({
           identity,
           count,
-          repository: () => Promise.reject(new TypeError("offline")),
+          response: () => Promise.reject(new TypeError("offline")),
         }),
       ),
     );
@@ -220,26 +210,8 @@ describe("GitHubAvatarResolver", () => {
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(count.value).toBe(2);
     }).pipe(
-      Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 403) })),
-    );
-  });
-
-  it.effect("retries transient avatar-CDN responses without a negative marker", () => {
-    const count = { value: 0 };
-    return Effect.gen(function* () {
-      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
-
-      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
-      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
-      expect(count.value).toBe(4);
-    }).pipe(
       Effect.provide(
-        makeLayer({
-          identity,
-          count,
-          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
-          avatar: () => new Response(null, { status: 503 }),
-        }),
+        makeLayer({ identity, count, response: () => new Response(null, { status: 429 }) }),
       ),
     );
   });
@@ -251,40 +223,16 @@ describe("GitHubAvatarResolver", () => {
 
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
-      expect(count.value).toBe(2);
-    }).pipe(
-      Effect.provide(
-        makeLayer({
-          identity,
-          count,
-          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
-          avatar: () =>
-            new Response(new Uint8Array(1024 * 1024 + 1), {
-              status: 200,
-              headers: { "content-type": "image/png" },
-            }),
-        }),
-      ),
-    );
-  });
-
-  it.effect("refuses avatars outside the GitHub avatar host", () => {
-    const count = { value: 0 };
-    return Effect.gen(function* () {
-      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
-
-      const resolved = yield* resolver.resolvePath("/worktrees/trino");
-
-      expect(resolved).toBeNull();
       expect(count.value).toBe(1);
     }).pipe(
       Effect.provide(
         makeLayer({
           identity,
           count,
-          repository: () =>
-            jsonResponse({ owner: { avatar_url: "https://evil.example/avatar.png" } }),
-          avatar: () => pngResponse(),
+          response: () =>
+            new Response(new Uint8Array(1024 * 1024 + 1), {
+              headers: { "content-type": "image/png" },
+            }),
         }),
       ),
     );

--- a/apps/server/src/project/GitHubAvatarResolver.test.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.test.ts
@@ -47,21 +47,20 @@ const makeLayer = (input: {
   readonly repository: () => Response | Promise<Response>;
   readonly avatar?: (url: string) => Response | null;
 }) =>
-  GitHubAvatarResolver.layer.pipe(
-    Layer.provide(
-      Layer.succeed(
-        RepositoryIdentityResolver.RepositoryIdentityResolver,
-        RepositoryIdentityResolver.RepositoryIdentityResolver.of({
-          resolve: () => Effect.succeed(input.identity),
-        }),
+  GitHubAvatarResolver.layer
+    .pipe(
+      Layer.provide(
+        Layer.succeed(
+          RepositoryIdentityResolver.RepositoryIdentityResolver,
+          RepositoryIdentityResolver.RepositoryIdentityResolver.of({
+            resolve: () => Effect.succeed(input.identity),
+          }),
+        ),
       ),
-    ),
-    Layer.provide(
-      FetchHttpClient.layer.pipe(
-        Layer.provide(
-          Layer.succeed(
-            FetchHttpClient.Fetch,
-            ((url: RequestInfo | URL) => {
+      Layer.provide(
+        FetchHttpClient.layer.pipe(
+          Layer.provide(
+            Layer.succeed(FetchHttpClient.Fetch, ((url: Parameters<typeof fetch>[0]) => {
               input.count.value += 1;
               const target = String(url);
               const response = target.includes("api.github.com/repos/")
@@ -70,19 +69,19 @@ const makeLayer = (input: {
               return response === undefined || response === null
                 ? Promise.reject(new TypeError(`unrouted request: ${target}`))
                 : Promise.resolve(response);
-            }) as typeof fetch,
+            }) as typeof fetch),
           ),
         ),
       ),
-    ),
-  ).pipe(Layer.provideMerge(configLayer), Layer.provideMerge(NodeServices.layer));
+    )
+    .pipe(Layer.provideMerge(configLayer), Layer.provideMerge(NodeServices.layer));
 
 const AVATAR_URL = "https://avatars.githubusercontent.com/u/34147222?v=4";
 
 describe("GitHubAvatarResolver", () => {
-  it.effect("fetches and caches the owner avatar once", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("fetches and caches the owner avatar once", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
       const fileSystem = yield* FileSystem.FileSystem;
 
@@ -96,7 +95,7 @@ describe("GitHubAvatarResolver", () => {
       expect(first).toMatch(/\.png$/);
       const bytes = yield* fileSystem.readFile(first);
       expect(Array.from(bytes)).toEqual(Array.from(pngBytes));
-      expect(count.value).toBe(1);
+      expect(count.value).toBe(2);
       expect(resolver.isManagedPath(first)).toBe(true);
       expect(resolver.isManagedPath("/etc/passwd")).toBe(false);
     }).pipe(
@@ -108,12 +107,12 @@ describe("GitHubAvatarResolver", () => {
           avatar: () => pngResponse(),
         }),
       ),
-    ),
-  );
+    );
+  });
 
-  it.effect("shares one cache entry across worktrees of the same repository", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("shares one cache entry across worktrees of the same repository", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       const [left, right] = yield* Effect.all(
@@ -123,7 +122,7 @@ describe("GitHubAvatarResolver", () => {
 
       expect(left).not.toBeNull();
       expect(left).toBe(right);
-      expect(count.value).toBe(1);
+      expect(count.value).toBe(2);
     }).pipe(
       Effect.provide(
         makeLayer({
@@ -133,12 +132,12 @@ describe("GitHubAvatarResolver", () => {
           avatar: () => pngResponse(),
         }),
       ),
-    ),
-  );
+    );
+  });
 
-  it.effect("skips non-github remotes without any request", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("skips non-github remotes without any request", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       const resolved = yield* resolver.resolvePath("/worktrees/repo");
@@ -146,48 +145,56 @@ describe("GitHubAvatarResolver", () => {
       expect(resolved).toBeNull();
       expect(count.value).toBe(0);
     }).pipe(
-      Effect.provide(makeLayer({ identity: gitlabIdentity, count, repository: () => jsonResponse({}) })),
-    ),
-  );
+      Effect.provide(
+        makeLayer({ identity: gitlabIdentity, count, repository: () => jsonResponse({}) }),
+      ),
+    );
+  });
 
-  it.effect("skips identities that are not repositories", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("skips identities that are not repositories", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       const resolved = yield* resolver.resolvePath("/worktrees/repo");
 
       expect(resolved).toBeNull();
       expect(count.value).toBe(0);
-    }).pipe(Effect.provide(makeLayer({ identity: null, count, repository: () => jsonResponse({}) }))),
-  );
+    }).pipe(
+      Effect.provide(makeLayer({ identity: null, count, repository: () => jsonResponse({}) })),
+    );
+  });
 
-  it.effect("remembers private repositories as negative", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("remembers private repositories as negative", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(count.value).toBe(1);
-    }).pipe(Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) }))),
-  );
+    }).pipe(
+      Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) })),
+    );
+  });
 
-  it.effect("retries a negative result after its ttl", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("retries a negative result after its ttl", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       yield* TestClock.adjust("8 days");
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(count.value).toBe(2);
-    }).pipe(Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) }))),
-  );
+    }).pipe(
+      Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) })),
+    );
+  });
 
-  it.effect("retries transport failures without a negative marker", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("retries transport failures without a negative marker", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
@@ -201,23 +208,25 @@ describe("GitHubAvatarResolver", () => {
           repository: () => Promise.reject(new TypeError("offline")),
         }),
       ),
-    ),
-  );
+    );
+  });
 
-  it.effect("retries rate-limited responses without a negative marker", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("retries rate-limited responses without a negative marker", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(count.value).toBe(2);
-    }).pipe(Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 403) }))),
-  );
+    }).pipe(
+      Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 403) })),
+    );
+  });
 
-  it.effect("remembers oversized avatars as negative", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("remembers oversized avatars as negative", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
@@ -236,12 +245,12 @@ describe("GitHubAvatarResolver", () => {
             }),
         }),
       ),
-    ),
-  );
+    );
+  });
 
-  it.effect("refuses avatars outside the GitHub avatar host", () =>
-    Effect.gen(function* () {
-      const count = { value: 0 };
+  it.effect("refuses avatars outside the GitHub avatar host", () => {
+    const count = { value: 0 };
+    return Effect.gen(function* () {
       const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
       const resolved = yield* resolver.resolvePath("/worktrees/trino");
@@ -253,10 +262,11 @@ describe("GitHubAvatarResolver", () => {
         makeLayer({
           identity,
           count,
-          repository: () => jsonResponse({ owner: { avatar_url: "https://evil.example/avatar.png" } }),
+          repository: () =>
+            jsonResponse({ owner: { avatar_url: "https://evil.example/avatar.png" } }),
           avatar: () => pngResponse(),
         }),
       ),
-    ),
-  );
+    );
+  });
 });

--- a/apps/server/src/project/GitHubAvatarResolver.test.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.test.ts
@@ -44,7 +44,7 @@ const pngResponse = () =>
 const makeLayer = (input: {
   readonly identity: RepositoryIdentity | null;
   readonly count: { value: number };
-  readonly repository: () => Response;
+  readonly repository: () => Response | Promise<Response>;
   readonly avatar?: (url: string) => Response | null;
 }) =>
   GitHubAvatarResolver.layer.pipe(
@@ -67,7 +67,7 @@ const makeLayer = (input: {
               const response = target.includes("api.github.com/repos/")
                 ? input.repository()
                 : (input.avatar?.(target) ?? null);
-              return response === null
+              return response === undefined || response === null
                 ? Promise.reject(new TypeError(`unrouted request: ${target}`))
                 : Promise.resolve(response);
             }) as typeof fetch,
@@ -183,6 +183,60 @@ describe("GitHubAvatarResolver", () => {
       expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
       expect(count.value).toBe(2);
     }).pipe(Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 404) }))),
+  );
+
+  it.effect("retries transport failures without a negative marker", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(count.value).toBe(2);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          identity,
+          count,
+          repository: () => Promise.reject(new TypeError("offline")),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("retries rate-limited responses without a negative marker", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(count.value).toBe(2);
+    }).pipe(Effect.provide(makeLayer({ identity, count, repository: () => jsonResponse({}, 403) }))),
+  );
+
+  it.effect("remembers oversized avatars as negative", () =>
+    Effect.gen(function* () {
+      const count = { value: 0 };
+      const resolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
+
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(yield* resolver.resolvePath("/worktrees/trino")).toBeNull();
+      expect(count.value).toBe(2);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          identity,
+          count,
+          repository: () => jsonResponse({ owner: { avatar_url: AVATAR_URL } }),
+          avatar: () =>
+            new Response(new Uint8Array(1024 * 1024 + 1), {
+              status: 200,
+              headers: { "content-type": "image/png" },
+            }),
+        }),
+      ),
+    ),
   );
 
   it.effect("refuses avatars outside the GitHub avatar host", () =>

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -8,7 +8,6 @@ import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
-import * as Either from "effect/Either";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -39,10 +38,11 @@ const CacheEntry = Schema.Struct({
 });
 const CacheEntryJson = Schema.fromJsonString(CacheEntry);
 const encodeCacheEntry = Schema.encodeSync(CacheEntryJson);
+const decodeCacheEntryJson = Schema.decodeUnknownOption(CacheEntryJson);
 
 function decodeCacheEntry(raw: string): Schema.Schema.Type<typeof CacheEntry> | null {
   try {
-    return Option.getOrNull(Schema.decodeUnknownOption(CacheEntryJson)(raw));
+    return Option.getOrNull(decodeCacheEntryJson(raw));
   } catch {
     return null;
   }
@@ -57,6 +57,7 @@ const RepositorySchema = Schema.Struct({
     ),
   ),
 });
+const decodeRepository = Schema.decodeUnknownOption(RepositorySchema);
 
 export class GitHubAvatarResolver extends Context.Service<
   GitHubAvatarResolver,
@@ -93,11 +94,6 @@ export const make = Effect.gen(function* () {
       .pipe(Effect.catchCause(() => Effect.void));
   });
 
-  type AvatarFetch =
-    | { readonly _tag: "avatar"; readonly bytes: Uint8Array; readonly extension: string }
-    | { readonly _tag: "negative" }
-    | { readonly _tag: "retry" };
-
   const downloadAvatar = Effect.fn("GitHubAvatarResolver.downloadAvatar")(function* (
     owner: string,
     name: string,
@@ -113,11 +109,9 @@ export const make = Effect.gen(function* () {
     if (repositoryResponse.status < 200 || repositoryResponse.status >= 300) {
       return { _tag: "retry" } as const;
     }
-    const decoded = yield* Schema.decodeUnknown(RepositorySchema)(yield* repositoryResponse.json).pipe(
-      Effect.option,
-    );
-    if (Option.isNone(decoded)) return { _tag: "retry" } as const;
-    const avatarUrl = decoded.value.owner?.avatar_url;
+    const decoded = Option.getOrNull(decodeRepository(yield* repositoryResponse.json));
+    if (decoded === null) return { _tag: "retry" } as const;
+    const avatarUrl = decoded.owner?.avatar_url;
     // A url from a response is data, not instruction: only the GitHub avatar CDN may be fetched.
     if (!avatarUrl || new URL(avatarUrl).host !== "avatars.githubusercontent.com") {
       return { _tag: "negative" } as const;
@@ -149,24 +143,24 @@ export const make = Effect.gen(function* () {
     name: string,
   ) {
     const now = yield* Clock.currentTimeMillis;
-    yield* fileSystem.makeDirectory(cacheDir, { recursive: true }).pipe(
-      Effect.catchCause(() => Effect.void),
-    );
+    yield* fileSystem
+      .makeDirectory(cacheDir, { recursive: true })
+      .pipe(Effect.catchCause(() => Effect.void));
     // Transport failures, timeouts and transient API states return null without
     // a marker, so one blip never hides an icon for the negative TTL.
     const outcome = yield* downloadAvatar(owner, name).pipe(
       Effect.timeout(FETCH_TIMEOUT_MS),
-      Effect.either,
+      Effect.catchCause(() => Effect.succeed({ _tag: "retry" } as const)),
     );
-    if (Either.isLeft(outcome)) return null;
-    if (outcome.right._tag === "retry") return null;
-    if (outcome.right._tag === "negative") {
-      yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
+    if (outcome._tag !== "avatar") {
+      if (outcome._tag === "negative") {
+        yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
+      }
       return null;
     }
-    const fileName = `${cacheKey}${outcome.right.extension}`;
+    const fileName = `${cacheKey}${outcome.extension}`;
     const written = yield* fileSystem
-      .writeFile(path.join(cacheDir, fileName), outcome.right.bytes)
+      .writeFile(path.join(cacheDir, fileName), outcome.bytes)
       .pipe(Effect.option);
     if (Option.isNone(written)) {
       yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
@@ -178,18 +172,16 @@ export const make = Effect.gen(function* () {
     return path.join(cacheDir, fileName);
   });
 
-  type CachedAvatar =
-    | { readonly _tag: "hit"; readonly path: string }
-    | { readonly _tag: "negative" }
-    | { readonly _tag: "miss" };
-
   const cachedAvatar = Effect.fn("GitHubAvatarResolver.cachedAvatar")(function* (cacheKey: string) {
-    const raw = yield* fileSystem.readFileString(path.join(cacheDir, `${cacheKey}.json`)).pipe(
-      Effect.option,
-    );
+    const raw = yield* fileSystem
+      .readFileString(path.join(cacheDir, `${cacheKey}.json`))
+      .pipe(Effect.option);
     const entry = Option.isNone(raw) ? null : decodeCacheEntry(raw.value);
     // A cache hit must name a file of this cache; anything else is a miss.
-    if (entry === null || (entry.ok && entry.file !== undefined && path.basename(entry.file) !== entry.file)) {
+    if (
+      entry === null ||
+      (entry.ok && entry.file !== undefined && path.basename(entry.file) !== entry.file)
+    ) {
       return { _tag: "miss" } as const;
     }
     if (entry.ok && entry.file !== undefined) {
@@ -208,7 +200,9 @@ export const make = Effect.gen(function* () {
   const resolvePath = Effect.fn("GitHubAvatarResolver.resolvePath")(function* (cwd: string) {
     const identity = yield* repositoryIdentityResolver.resolve(cwd);
     const nameWithOwner =
-      identity === null ? null : parseGitHubRepositoryNameWithOwnerFromRemoteUrl(identity.locator.remoteUrl);
+      identity === null
+        ? null
+        : parseGitHubRepositoryNameWithOwnerFromRemoteUrl(identity.locator.remoteUrl);
     if (nameWithOwner === null) return null;
     const [owner, name] = nameWithOwner.split("/");
     if (!owner || !name) return null;

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -23,6 +23,13 @@ const FETCH_TIMEOUT_MS = 5_000;
 const MAX_AVATAR_BYTES = 1024 * 1024;
 /** A repository with no avatar is remembered this long before one retry. */
 const NEGATIVE_RESULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const AVATAR_EXTENSIONS_BY_CONTENT_TYPE: Record<string, string> = {
+  "image/gif": ".gif",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+};
+const CACHED_AVATAR_EXTENSIONS = [".gif", ".jpg", ".jpeg", ".png", ".webp"] as const;
 
 export class GitHubAvatarResolver extends Context.Service<
   GitHubAvatarResolver,
@@ -69,7 +76,12 @@ export const make = Effect.gen(function* () {
     if (bytes.byteLength === 0 || bytes.byteLength > MAX_AVATAR_BYTES) {
       return { _tag: "negative" } as const;
     }
-    return { _tag: "avatar", bytes } as const;
+    const contentType = (response.headers["content-type"] ?? "").split(";")[0]?.trim() ?? "";
+    return {
+      _tag: "avatar",
+      bytes,
+      extension: AVATAR_EXTENSIONS_BY_CONTENT_TYPE[contentType] ?? ".png",
+    } as const;
   });
 
   // The miss file carries the marker epoch, so the negative TTL survives
@@ -106,23 +118,23 @@ export const make = Effect.gen(function* () {
       }
       return null;
     }
-    const targetPath = path.join(cacheDir, `${cacheKey}.png`);
+    const targetPath = path.join(cacheDir, `${cacheKey}${outcome.extension}`);
     const temporaryPath = `${targetPath}.tmp`;
     const written = yield* fileSystem.writeFile(temporaryPath, outcome.bytes).pipe(Effect.option);
     const renamed =
       Option.isSome(written) &&
       Option.isSome(yield* fileSystem.rename(temporaryPath, targetPath).pipe(Effect.option));
-    if (!renamed) {
-      yield* markMissing(cacheKey, now);
-      return null;
-    }
+    if (!renamed) return null;
     return targetPath;
   });
 
   const cachedAvatar = Effect.fn("GitHubAvatarResolver.cachedAvatar")(function* (cacheKey: string) {
-    const info = yield* fileSystem.stat(path.join(cacheDir, `${cacheKey}.png`)).pipe(Effect.option);
-    if (Option.isSome(info) && info.value.type === "File") {
-      return { _tag: "hit", path: path.join(cacheDir, `${cacheKey}.png`) } as const;
+    for (const extension of CACHED_AVATAR_EXTENSIONS) {
+      const cachedPath = path.join(cacheDir, `${cacheKey}${extension}`);
+      const info = yield* fileSystem.stat(cachedPath).pipe(Effect.option);
+      if (Option.isSome(info) && info.value.type === "File") {
+        return { _tag: "hit", path: cachedPath } as const;
+      }
     }
     const miss = yield* fileSystem
       .readFileString(path.join(cacheDir, `${cacheKey}.miss`))

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -1,0 +1,215 @@
+/**
+ * GitHubAvatarResolver - the last step of project icon discovery: the owner
+ * avatar of a github.com repository, for projects no local icon covers.
+ * One fetch per repository ever; every failure resolves to null.
+ */
+import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Encoding from "effect/Encoding";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import * as ServerConfig from "../config.ts";
+import * as RepositoryIdentityResolver from "./RepositoryIdentityResolver.ts";
+
+const FETCH_TIMEOUT_MS = 5_000;
+const MAX_AVATAR_BYTES = 1024 * 1024;
+/** A failed or iconless repository is remembered this long before one retry. */
+const NEGATIVE_RESULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const AVATAR_EXTENSIONS_BY_CONTENT_TYPE: Record<string, string> = {
+  "image/gif": ".gif",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+};
+
+const CacheEntry = Schema.Struct({
+  ok: Schema.Boolean,
+  file: Schema.optionalKey(Schema.String),
+  fetchedAtMs: Schema.Number,
+});
+const CacheEntryJson = Schema.fromJsonString(CacheEntry);
+const encodeCacheEntry = Schema.encodeSync(CacheEntryJson);
+
+function decodeCacheEntry(raw: string): Schema.Schema.Type<typeof CacheEntry> | null {
+  try {
+    return Option.getOrNull(Schema.decodeUnknownOption(CacheEntryJson)(raw));
+  } catch {
+    return null;
+  }
+}
+
+const RepositorySchema = Schema.Struct({
+  owner: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        avatar_url: Schema.optional(Schema.NullOr(Schema.String)),
+      }),
+    ),
+  ),
+});
+
+export class GitHubAvatarResolver extends Context.Service<
+  GitHubAvatarResolver,
+  {
+    /** Absolute path of the cached avatar file, or null when there is none. Never fails. */
+    readonly resolvePath: (cwd: string) => Effect.Effect<string | null>;
+    /** True for files under this service's cache, so the asset route may serve them as project icons. */
+    readonly isManagedPath: (filePath: string) => boolean;
+  }
+>()("t3/project/GitHubAvatarResolver") {}
+
+export const make = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
+  const httpClient = yield* HttpClient.HttpClient;
+  const config = yield* ServerConfig.ServerConfig;
+  const repositoryIdentityResolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
+  const semaphore = yield* Semaphore.make(1);
+
+  const cacheDir = path.join(config.stateDir, "github-avatars");
+
+  const isManagedPath = (filePath: string): boolean => {
+    const relative = path.relative(path.resolve(cacheDir), path.resolve(filePath));
+    return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+  };
+
+  const writeCacheEntry = Effect.fn("GitHubAvatarResolver.writeCacheEntry")(function* (
+    cacheKey: string,
+    entry: Schema.Schema.Type<typeof CacheEntry>,
+  ) {
+    yield* fileSystem
+      .writeFileString(path.join(cacheDir, `${cacheKey}.json`), encodeCacheEntry(entry))
+      .pipe(Effect.catchCause(() => Effect.void));
+  });
+
+  const downloadAvatar = Effect.fn("GitHubAvatarResolver.downloadAvatar")(function* (
+    owner: string,
+    name: string,
+  ) {
+    const repository = yield* httpClient
+      .execute(
+        HttpClientRequest.get(
+          `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
+        ).pipe(HttpClientRequest.acceptJson),
+      )
+      .pipe(
+        Effect.flatMap(HttpClientResponse.filterStatusOk),
+        Effect.flatMap((response) => response.json),
+        Effect.timeout(FETCH_TIMEOUT_MS),
+      );
+    const decoded = yield* Schema.decodeUnknown(RepositorySchema)(repository).pipe(Effect.option);
+    const avatarUrl = Option.isSome(decoded) ? decoded.value.owner?.avatar_url : undefined;
+    // A url returned inside a response is data, not instruction; only the
+    // GitHub avatar CDN may be fetched.
+    if (!avatarUrl || new URL(avatarUrl).host !== "avatars.githubusercontent.com") {
+      return null;
+    }
+
+    const avatarResponse = yield* httpClient
+      .execute(HttpClientRequest.get(avatarUrl))
+      .pipe(
+        Effect.flatMap(HttpClientResponse.filterStatusOk),
+        Effect.timeout(FETCH_TIMEOUT_MS),
+      );
+    const bytes = new Uint8Array(yield* avatarResponse.arrayBuffer);
+    if (bytes.byteLength === 0 || bytes.byteLength > MAX_AVATAR_BYTES) {
+      return null;
+    }
+    const contentType = (avatarResponse.headers["content-type"] ?? "").split(";")[0]?.trim() ?? "";
+    return { bytes, extension: AVATAR_EXTENSIONS_BY_CONTENT_TYPE[contentType] ?? ".png" };
+  });
+
+  const fetchAndCache = Effect.fn("GitHubAvatarResolver.fetchAndCache")(function* (
+    cacheKey: string,
+    owner: string,
+    name: string,
+  ) {
+    const now = yield* Clock.currentTimeMillis;
+    yield* fileSystem.makeDirectory(cacheDir, { recursive: true }).pipe(
+      Effect.catchCause(() => Effect.void),
+    );
+    const avatar = yield* downloadAvatar(owner, name).pipe(
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    if (avatar === null) {
+      yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
+      return null;
+    }
+    const fileName = `${cacheKey}${avatar.extension}`;
+    const written = yield* fileSystem.writeFile(path.join(cacheDir, fileName), avatar.bytes).pipe(
+      Effect.option,
+    );
+    if (Option.isNone(written)) {
+      yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
+      return null;
+    }
+    // The sidecar is the commit marker: a cache hit requires it, so a partially
+    // written image is never served.
+    yield* writeCacheEntry(cacheKey, { ok: true, file: fileName, fetchedAtMs: now });
+    return path.join(cacheDir, fileName);
+  });
+
+  type CachedAvatar =
+    | { readonly _tag: "hit"; readonly path: string }
+    | { readonly _tag: "negative" }
+    | { readonly _tag: "miss" };
+
+  const cachedAvatar = Effect.fn("GitHubAvatarResolver.cachedAvatar")(function* (cacheKey: string) {
+    const raw = yield* fileSystem.readFileString(path.join(cacheDir, `${cacheKey}.json`)).pipe(
+      Effect.option,
+    );
+    const entry = Option.isNone(raw) ? null : decodeCacheEntry(raw.value);
+    if (entry === null) return { _tag: "miss" } as const;
+    if (entry.ok && entry.file !== undefined) {
+      const cachedPath = path.join(cacheDir, entry.file);
+      const info = yield* fileSystem.stat(cachedPath).pipe(Effect.option);
+      return Option.isSome(info) && info.value.type === "File"
+        ? ({ _tag: "hit", path: cachedPath } as const)
+        : ({ _tag: "miss" } as const);
+    }
+    const now = yield* Clock.currentTimeMillis;
+    return now - entry.fetchedAtMs < NEGATIVE_RESULT_TTL_MS
+      ? ({ _tag: "negative" } as const)
+      : ({ _tag: "miss" } as const);
+  });
+
+  const resolvePath = Effect.fn("GitHubAvatarResolver.resolvePath")(function* (cwd: string) {
+    const identity = yield* repositoryIdentityResolver.resolve(cwd);
+    const nameWithOwner =
+      identity === null ? null : parseGitHubRepositoryNameWithOwnerFromRemoteUrl(identity.locator.remoteUrl);
+    if (nameWithOwner === null) return null;
+    const [owner, name] = nameWithOwner.split("/");
+    if (!owner || !name) return null;
+
+    const digest = yield* crypto.digest("SHA-256", new TextEncoder().encode(nameWithOwner));
+    const cacheKey = Encoding.encodeHex(digest);
+
+    // Hits and fresh negatives answer without the permit, so a reconnect burst
+    // of already-cached projects never queues behind a slow first fetch (#7536).
+    const fast = yield* cachedAvatar(cacheKey);
+    if (fast._tag !== "miss") return fast._tag === "hit" ? fast.path : null;
+    const decided = Effect.gen(function* () {
+      const rechecked = yield* cachedAvatar(cacheKey);
+      if (rechecked._tag !== "miss") return rechecked._tag === "hit" ? rechecked.path : null;
+      return yield* fetchAndCache(cacheKey, owner, name);
+    });
+    return yield* semaphore.withPermits(1)(decided);
+  });
+
+  return GitHubAvatarResolver.of({
+    resolvePath: (cwd) => resolvePath(cwd).pipe(Effect.catchCause(() => Effect.succeed(null))),
+    isManagedPath,
+  });
+});
+
+export const layer = Layer.effect(GitHubAvatarResolver, make);

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -8,6 +8,7 @@ import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import * as Either from "effect/Either";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -15,14 +16,14 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
-import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
 import * as RepositoryIdentityResolver from "./RepositoryIdentityResolver.ts";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const MAX_AVATAR_BYTES = 1024 * 1024;
-/** A failed or iconless repository is remembered this long before one retry. */
+/** A repository with no usable avatar is remembered this long before one retry. */
 const NEGATIVE_RESULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const AVATAR_EXTENSIONS_BY_CONTENT_TYPE: Record<string, string> = {
   "image/gif": ".gif",
@@ -92,36 +93,54 @@ export const make = Effect.gen(function* () {
       .pipe(Effect.catchCause(() => Effect.void));
   });
 
+  type AvatarFetch =
+    | { readonly _tag: "avatar"; readonly bytes: Uint8Array; readonly extension: string }
+    | { readonly _tag: "negative" }
+    | { readonly _tag: "retry" };
+
   const downloadAvatar = Effect.fn("GitHubAvatarResolver.downloadAvatar")(function* (
     owner: string,
     name: string,
   ) {
-    const repository = yield* httpClient
-      .execute(
-        HttpClientRequest.get(
-          `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
-        ).pipe(HttpClientRequest.acceptJson),
-      )
-      .pipe(
-        Effect.flatMap(HttpClientResponse.filterStatusOk),
-        Effect.flatMap((response) => response.json),
-      );
-    const decoded = yield* Schema.decodeUnknown(RepositorySchema)(repository).pipe(Effect.option);
-    const avatarUrl = Option.isSome(decoded) ? decoded.value.owner?.avatar_url : undefined;
+    // 404 means private or nonexistent; any other non-2xx (rate limits, 5xx) is
+    // transient and must retry on a later request rather than be remembered.
+    const repositoryResponse = yield* httpClient.execute(
+      HttpClientRequest.get(
+        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
+      ).pipe(HttpClientRequest.acceptJson),
+    );
+    if (repositoryResponse.status === 404) return { _tag: "negative" } as const;
+    if (repositoryResponse.status < 200 || repositoryResponse.status >= 300) {
+      return { _tag: "retry" } as const;
+    }
+    const decoded = yield* Schema.decodeUnknown(RepositorySchema)(yield* repositoryResponse.json).pipe(
+      Effect.option,
+    );
+    if (Option.isNone(decoded)) return { _tag: "retry" } as const;
+    const avatarUrl = decoded.value.owner?.avatar_url;
     // A url from a response is data, not instruction: only the GitHub avatar CDN may be fetched.
     if (!avatarUrl || new URL(avatarUrl).host !== "avatars.githubusercontent.com") {
-      return null;
+      return { _tag: "negative" } as const;
     }
 
-    const avatarResponse = yield* httpClient
-      .execute(HttpClientRequest.get(avatarUrl))
-      .pipe(Effect.flatMap(HttpClientResponse.filterStatusOk));
+    const avatarResponse = yield* httpClient.execute(HttpClientRequest.get(avatarUrl));
+    if (avatarResponse.status < 200 || avatarResponse.status >= 300) {
+      return { _tag: "negative" } as const;
+    }
+    const declaredBytes = Number(avatarResponse.headers["content-length"] ?? Number.NaN);
+    if (Number.isFinite(declaredBytes) && declaredBytes > MAX_AVATAR_BYTES) {
+      return { _tag: "negative" } as const;
+    }
     const bytes = new Uint8Array(yield* avatarResponse.arrayBuffer);
     if (bytes.byteLength === 0 || bytes.byteLength > MAX_AVATAR_BYTES) {
-      return null;
+      return { _tag: "negative" } as const;
     }
     const contentType = (avatarResponse.headers["content-type"] ?? "").split(";")[0]?.trim() ?? "";
-    return { bytes, extension: AVATAR_EXTENSIONS_BY_CONTENT_TYPE[contentType] ?? ".png" };
+    return {
+      _tag: "avatar",
+      bytes,
+      extension: AVATAR_EXTENSIONS_BY_CONTENT_TYPE[contentType] ?? ".png",
+    } as const;
   });
 
   const fetchAndCache = Effect.fn("GitHubAvatarResolver.fetchAndCache")(function* (
@@ -133,18 +152,22 @@ export const make = Effect.gen(function* () {
     yield* fileSystem.makeDirectory(cacheDir, { recursive: true }).pipe(
       Effect.catchCause(() => Effect.void),
     );
-    const avatar = yield* downloadAvatar(owner, name).pipe(
+    // Transport failures, timeouts and transient API states return null without
+    // a marker, so one blip never hides an icon for the negative TTL.
+    const outcome = yield* downloadAvatar(owner, name).pipe(
       Effect.timeout(FETCH_TIMEOUT_MS),
-      Effect.catchCause(() => Effect.succeed(null)),
+      Effect.either,
     );
-    if (avatar === null) {
+    if (Either.isLeft(outcome)) return null;
+    if (outcome.right._tag === "retry") return null;
+    if (outcome.right._tag === "negative") {
       yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
       return null;
     }
-    const fileName = `${cacheKey}${avatar.extension}`;
-    const written = yield* fileSystem.writeFile(path.join(cacheDir, fileName), avatar.bytes).pipe(
-      Effect.option,
-    );
+    const fileName = `${cacheKey}${outcome.right.extension}`;
+    const written = yield* fileSystem
+      .writeFile(path.join(cacheDir, fileName), outcome.right.bytes)
+      .pipe(Effect.option);
     if (Option.isNone(written)) {
       yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
       return null;

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -105,22 +105,17 @@ export const make = Effect.gen(function* () {
       .pipe(
         Effect.flatMap(HttpClientResponse.filterStatusOk),
         Effect.flatMap((response) => response.json),
-        Effect.timeout(FETCH_TIMEOUT_MS),
       );
     const decoded = yield* Schema.decodeUnknown(RepositorySchema)(repository).pipe(Effect.option);
     const avatarUrl = Option.isSome(decoded) ? decoded.value.owner?.avatar_url : undefined;
-    // A url returned inside a response is data, not instruction; only the
-    // GitHub avatar CDN may be fetched.
+    // A url from a response is data, not instruction: only the GitHub avatar CDN may be fetched.
     if (!avatarUrl || new URL(avatarUrl).host !== "avatars.githubusercontent.com") {
       return null;
     }
 
     const avatarResponse = yield* httpClient
       .execute(HttpClientRequest.get(avatarUrl))
-      .pipe(
-        Effect.flatMap(HttpClientResponse.filterStatusOk),
-        Effect.timeout(FETCH_TIMEOUT_MS),
-      );
+      .pipe(Effect.flatMap(HttpClientResponse.filterStatusOk));
     const bytes = new Uint8Array(yield* avatarResponse.arrayBuffer);
     if (bytes.byteLength === 0 || bytes.byteLength > MAX_AVATAR_BYTES) {
       return null;
@@ -139,6 +134,7 @@ export const make = Effect.gen(function* () {
       Effect.catchCause(() => Effect.void),
     );
     const avatar = yield* downloadAvatar(owner, name).pipe(
+      Effect.timeout(FETCH_TIMEOUT_MS),
       Effect.catchCause(() => Effect.succeed(null)),
     );
     if (avatar === null) {

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -118,8 +118,11 @@ export const make = Effect.gen(function* () {
     }
 
     const avatarResponse = yield* httpClient.execute(HttpClientRequest.get(avatarUrl));
-    if (avatarResponse.status < 200 || avatarResponse.status >= 300) {
+    if (avatarResponse.status === 404) {
       return { _tag: "negative" } as const;
+    }
+    if (avatarResponse.status < 200 || avatarResponse.status >= 300) {
+      return { _tag: "retry" } as const;
     }
     const declaredBytes = Number(avatarResponse.headers["content-length"] ?? Number.NaN);
     if (Number.isFinite(declaredBytes) && declaredBytes > MAX_AVATAR_BYTES) {

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -1,7 +1,7 @@
 /**
- * GitHubAvatarResolver - the last step of project icon discovery: the owner
- * avatar of a github.com repository, for projects no local icon covers.
- * One fetch per repository ever; every failure resolves to null.
+ * GitHubAvatarResolver - the last step of project icon discovery: the avatar
+ * of a github.com repository owner, for projects no local icon covers.
+ * One fetch per owner per repository ever; every failure resolves to null.
  */
 import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
 import * as Clock from "effect/Clock";
@@ -13,7 +13,6 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
-import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
@@ -22,42 +21,8 @@ import * as RepositoryIdentityResolver from "./RepositoryIdentityResolver.ts";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const MAX_AVATAR_BYTES = 1024 * 1024;
-/** A repository with no usable avatar is remembered this long before one retry. */
+/** A repository with no avatar is remembered this long before one retry. */
 const NEGATIVE_RESULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const AVATAR_EXTENSIONS_BY_CONTENT_TYPE: Record<string, string> = {
-  "image/gif": ".gif",
-  "image/jpeg": ".jpg",
-  "image/png": ".png",
-  "image/webp": ".webp",
-};
-
-const CacheEntry = Schema.Struct({
-  ok: Schema.Boolean,
-  file: Schema.optionalKey(Schema.String),
-  fetchedAtMs: Schema.Number,
-});
-const CacheEntryJson = Schema.fromJsonString(CacheEntry);
-const encodeCacheEntry = Schema.encodeSync(CacheEntryJson);
-const decodeCacheEntryJson = Schema.decodeUnknownOption(CacheEntryJson);
-
-function decodeCacheEntry(raw: string): Schema.Schema.Type<typeof CacheEntry> | null {
-  try {
-    return Option.getOrNull(decodeCacheEntryJson(raw));
-  } catch {
-    return null;
-  }
-}
-
-const RepositorySchema = Schema.Struct({
-  owner: Schema.optional(
-    Schema.NullOr(
-      Schema.Struct({
-        avatar_url: Schema.optional(Schema.NullOr(Schema.String)),
-      }),
-    ),
-  ),
-});
-const decodeRepository = Schema.decodeUnknownOption(RepositorySchema);
 
 export class GitHubAvatarResolver extends Context.Service<
   GitHubAvatarResolver,
@@ -85,119 +50,91 @@ export const make = Effect.gen(function* () {
     return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
   };
 
-  const writeCacheEntry = Effect.fn("GitHubAvatarResolver.writeCacheEntry")(function* (
-    cacheKey: string,
-    entry: Schema.Schema.Type<typeof CacheEntry>,
-  ) {
-    yield* fileSystem
-      .writeFileString(path.join(cacheDir, `${cacheKey}.json`), encodeCacheEntry(entry))
-      .pipe(Effect.catchCause(() => Effect.void));
-  });
-
   const downloadAvatar = Effect.fn("GitHubAvatarResolver.downloadAvatar")(function* (
     owner: string,
-    name: string,
   ) {
-    // 404 means private or nonexistent; any other non-2xx (rate limits, 5xx) is
-    // transient and must retry on a later request rather than be remembered.
-    const repositoryResponse = yield* httpClient.execute(
-      HttpClientRequest.get(
-        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
-      ).pipe(HttpClientRequest.acceptJson),
+    // github.com/<owner>.png is the avatar the repository page itself displays;
+    // it is not the rate-limited API. A 404 means private or nonexistent; any
+    // other non-2xx is transient and must retry on a later request.
+    const response = yield* httpClient.execute(
+      HttpClientRequest.get(`https://github.com/${encodeURIComponent(owner)}.png`),
     );
-    if (repositoryResponse.status === 404) return { _tag: "negative" } as const;
-    if (repositoryResponse.status < 200 || repositoryResponse.status >= 300) {
-      return { _tag: "retry" } as const;
-    }
-    const decoded = Option.getOrNull(decodeRepository(yield* repositoryResponse.json));
-    if (decoded === null) return { _tag: "retry" } as const;
-    const avatarUrl = decoded.owner?.avatar_url;
-    // A url from a response is data, not instruction: only the GitHub avatar CDN may be fetched.
-    if (!avatarUrl || new URL(avatarUrl).host !== "avatars.githubusercontent.com") {
-      return { _tag: "negative" } as const;
-    }
-
-    const avatarResponse = yield* httpClient.execute(HttpClientRequest.get(avatarUrl));
-    if (avatarResponse.status === 404) {
-      return { _tag: "negative" } as const;
-    }
-    if (avatarResponse.status < 200 || avatarResponse.status >= 300) {
-      return { _tag: "retry" } as const;
-    }
-    const declaredBytes = Number(avatarResponse.headers["content-length"] ?? Number.NaN);
+    if (response.status === 404) return { _tag: "negative" } as const;
+    if (response.status < 200 || response.status >= 300) return { _tag: "retry" } as const;
+    const declaredBytes = Number(response.headers["content-length"] ?? Number.NaN);
     if (Number.isFinite(declaredBytes) && declaredBytes > MAX_AVATAR_BYTES) {
       return { _tag: "negative" } as const;
     }
-    const bytes = new Uint8Array(yield* avatarResponse.arrayBuffer);
+    const bytes = new Uint8Array(yield* response.arrayBuffer);
     if (bytes.byteLength === 0 || bytes.byteLength > MAX_AVATAR_BYTES) {
       return { _tag: "negative" } as const;
     }
-    const contentType = (avatarResponse.headers["content-type"] ?? "").split(";")[0]?.trim() ?? "";
-    return {
-      _tag: "avatar",
-      bytes,
-      extension: AVATAR_EXTENSIONS_BY_CONTENT_TYPE[contentType] ?? ".png",
-    } as const;
+    return { _tag: "avatar", bytes } as const;
+  });
+
+  // The miss file carries the marker epoch, so the negative TTL survives
+  // restarts and is immune to system-clock jumps between write and read.
+  const markMissing = Effect.fn("GitHubAvatarResolver.markMissing")(function* (
+    cacheKey: string,
+    markedAtMs: number,
+  ) {
+    yield* fileSystem
+      .makeDirectory(cacheDir, { recursive: true })
+      .pipe(Effect.catchCause(() => Effect.void));
+    yield* fileSystem
+      .writeFileString(path.join(cacheDir, `${cacheKey}.miss`), String(markedAtMs))
+      .pipe(Effect.catchCause(() => Effect.void));
   });
 
   const fetchAndCache = Effect.fn("GitHubAvatarResolver.fetchAndCache")(function* (
     cacheKey: string,
     owner: string,
-    name: string,
   ) {
     const now = yield* Clock.currentTimeMillis;
     yield* fileSystem
       .makeDirectory(cacheDir, { recursive: true })
       .pipe(Effect.catchCause(() => Effect.void));
-    // Transport failures, timeouts and transient API states return null without
+    // Transport failures, timeouts and transient responses return null without
     // a marker, so one blip never hides an icon for the negative TTL.
-    const outcome = yield* downloadAvatar(owner, name).pipe(
+    const outcome = yield* downloadAvatar(owner).pipe(
       Effect.timeout(FETCH_TIMEOUT_MS),
       Effect.catchCause(() => Effect.succeed({ _tag: "retry" } as const)),
     );
     if (outcome._tag !== "avatar") {
       if (outcome._tag === "negative") {
-        yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
+        yield* markMissing(cacheKey, now);
       }
       return null;
     }
-    const fileName = `${cacheKey}${outcome.extension}`;
-    const written = yield* fileSystem
-      .writeFile(path.join(cacheDir, fileName), outcome.bytes)
-      .pipe(Effect.option);
-    if (Option.isNone(written)) {
-      yield* writeCacheEntry(cacheKey, { ok: false, fetchedAtMs: now });
+    const targetPath = path.join(cacheDir, `${cacheKey}.png`);
+    const temporaryPath = `${targetPath}.tmp`;
+    const written = yield* fileSystem.writeFile(temporaryPath, outcome.bytes).pipe(Effect.option);
+    const renamed =
+      Option.isSome(written) &&
+      Option.isSome(yield* fileSystem.rename(temporaryPath, targetPath).pipe(Effect.option));
+    if (!renamed) {
+      yield* markMissing(cacheKey, now);
       return null;
     }
-    // The sidecar is the commit marker: a cache hit requires it, so a partially
-    // written image is never served.
-    yield* writeCacheEntry(cacheKey, { ok: true, file: fileName, fetchedAtMs: now });
-    return path.join(cacheDir, fileName);
+    return targetPath;
   });
 
   const cachedAvatar = Effect.fn("GitHubAvatarResolver.cachedAvatar")(function* (cacheKey: string) {
-    const raw = yield* fileSystem
-      .readFileString(path.join(cacheDir, `${cacheKey}.json`))
+    const info = yield* fileSystem.stat(path.join(cacheDir, `${cacheKey}.png`)).pipe(Effect.option);
+    if (Option.isSome(info) && info.value.type === "File") {
+      return { _tag: "hit", path: path.join(cacheDir, `${cacheKey}.png`) } as const;
+    }
+    const miss = yield* fileSystem
+      .readFileString(path.join(cacheDir, `${cacheKey}.miss`))
       .pipe(Effect.option);
-    const entry = Option.isNone(raw) ? null : decodeCacheEntry(raw.value);
-    // A cache hit must name a file of this cache; anything else is a miss.
-    if (
-      entry === null ||
-      (entry.ok && entry.file !== undefined && path.basename(entry.file) !== entry.file)
-    ) {
-      return { _tag: "miss" } as const;
+    if (Option.isSome(miss)) {
+      const markedAtMs = Number(miss.value);
+      const now = yield* Clock.currentTimeMillis;
+      if (Number.isFinite(markedAtMs) && now - markedAtMs < NEGATIVE_RESULT_TTL_MS) {
+        return { _tag: "negative" } as const;
+      }
     }
-    if (entry.ok && entry.file !== undefined) {
-      const cachedPath = path.join(cacheDir, entry.file);
-      const info = yield* fileSystem.stat(cachedPath).pipe(Effect.option);
-      return Option.isSome(info) && info.value.type === "File"
-        ? ({ _tag: "hit", path: cachedPath } as const)
-        : ({ _tag: "miss" } as const);
-    }
-    const now = yield* Clock.currentTimeMillis;
-    return now - entry.fetchedAtMs < NEGATIVE_RESULT_TTL_MS
-      ? ({ _tag: "negative" } as const)
-      : ({ _tag: "miss" } as const);
+    return { _tag: "miss" } as const;
   });
 
   const resolvePath = Effect.fn("GitHubAvatarResolver.resolvePath")(function* (cwd: string) {
@@ -220,7 +157,7 @@ export const make = Effect.gen(function* () {
     const decided = Effect.gen(function* () {
       const rechecked = yield* cachedAvatar(cacheKey);
       if (rechecked._tag !== "miss") return rechecked._tag === "hit" ? rechecked.path : null;
-      return yield* fetchAndCache(cacheKey, owner, name);
+      return yield* fetchAndCache(cacheKey, owner);
     });
     return yield* semaphore.withPermits(1)(decided);
   });

--- a/apps/server/src/project/GitHubAvatarResolver.ts
+++ b/apps/server/src/project/GitHubAvatarResolver.ts
@@ -188,7 +188,10 @@ export const make = Effect.gen(function* () {
       Effect.option,
     );
     const entry = Option.isNone(raw) ? null : decodeCacheEntry(raw.value);
-    if (entry === null) return { _tag: "miss" } as const;
+    // A cache hit must name a file of this cache; anything else is a miss.
+    if (entry === null || (entry.ok && entry.file !== undefined && path.basename(entry.file) !== entry.file)) {
+      return { _tag: "miss" } as const;
+    }
     if (entry.ok && entry.file !== undefined) {
       const cachedPath = path.join(cacheDir, entry.file);
       const info = yield* fileSystem.stat(cachedPath).pipe(Effect.option);

--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -7,14 +7,24 @@ import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import * as GitHubAvatarResolver from "./GitHubAvatarResolver.ts";
 import * as ProjectFaviconResolver from "./ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "./T3ProjectFileLoader.ts";
+
+const disabledGitHubAvatars = Layer.succeed(
+  GitHubAvatarResolver.GitHubAvatarResolver,
+  GitHubAvatarResolver.GitHubAvatarResolver.of({
+    resolvePath: () => Effect.succeed(null),
+    isManagedPath: () => false,
+  }),
+);
 
 const TestLayer = Layer.empty.pipe(
   Layer.provideMerge(
     ProjectFaviconResolver.layer.pipe(
       Layer.provide(WorkspacePaths.layer),
       Layer.provide(T3ProjectFileLoader.layer),
+      Layer.provide(disabledGitHubAvatars),
     ),
   ),
   Layer.provideMerge(NodeServices.layer),
@@ -41,9 +51,12 @@ const writeTextFile = Effect.fn("writeTextFile")(function* (
   yield* fileSystem.writeFileString(absolutePath, contents).pipe(Effect.orDie);
 });
 
-const makeResolverWithFileSystem = (fileSystem: FileSystem.FileSystem) =>
+const makeResolverWithFileSystem = (
+  fileSystem: FileSystem.FileSystem,
+  githubAvatars: Layer.Layer<GitHubAvatarResolver.GitHubAvatarResolver> = disabledGitHubAvatars,
+) =>
   ProjectFaviconResolver.make.pipe(
-    Effect.provide([WorkspacePaths.layer, T3ProjectFileLoader.layer]),
+    Effect.provide([WorkspacePaths.layer, T3ProjectFileLoader.layer, githubAvatars]),
     Effect.provideService(FileSystem.FileSystem, fileSystem),
   );
 
@@ -286,6 +299,51 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).toBeNull();
+      }),
+    );
+
+    it.effect("falls back to the GitHub avatar when no local icon resolves", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const cwd = yield* makeTempDir;
+        const managed = yield* makeTempDir;
+        const avatarPath = path.join(managed, "avatar.png");
+        const githubAvatars = Layer.succeed(
+          GitHubAvatarResolver.GitHubAvatarResolver,
+          GitHubAvatarResolver.GitHubAvatarResolver.of({
+            resolvePath: () => Effect.succeed(avatarPath),
+            isManagedPath: () => true,
+          }),
+        );
+        const resolver = yield* makeResolverWithFileSystem(fileSystem, githubAvatars);
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).toBe(avatarPath);
+      }),
+    );
+
+    it.effect("prefers a local favicon over the GitHub avatar", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+        const managed = yield* makeTempDir;
+        const avatarPath = path.join(managed, "avatar.png");
+        const githubAvatars = Layer.succeed(
+          GitHubAvatarResolver.GitHubAvatarResolver,
+          GitHubAvatarResolver.GitHubAvatarResolver.of({
+            resolvePath: () => Effect.succeed(avatarPath),
+            isManagedPath: () => true,
+          }),
+        );
+        const resolver = yield* makeResolverWithFileSystem(fileSystem, githubAvatars);
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).toContain("favicon.svg");
       }),
     );
 

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -16,6 +16,7 @@ import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import * as GitHubAvatarResolver from "./GitHubAvatarResolver.ts";
 import * as T3ProjectFileLoader from "./T3ProjectFileLoader.ts";
 
 // Well-known favicon paths checked in order.
@@ -128,6 +129,7 @@ export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
   const projectFileLoader = yield* T3ProjectFileLoader.T3ProjectFileLoader;
+  const githubAvatarResolver = yield* GitHubAvatarResolver.GitHubAvatarResolver;
 
   const resolveIconHref = (href: string): ReadonlyArray<string> => {
     const clean = href.replace(/^\//, "");
@@ -262,6 +264,12 @@ export const make = Effect.gen(function* () {
       if (existing) {
         return existing;
       }
+    }
+
+    // The GitHub owner avatar fills only the gap where nothing local resolves.
+    const githubAvatar = yield* githubAvatarResolver.resolvePath(projectCwd);
+    if (githubAvatar !== null) {
+      return githubAvatar;
     }
 
     return null;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -133,6 +133,7 @@ import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
+import * as GitHubAvatarResolver from "./project/GitHubAvatarResolver.ts";
 import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "./project/T3ProjectFileLoader.ts";
 import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
@@ -578,9 +579,17 @@ const buildAppUnderTest = (options?: {
       Layer.provide(WorkspacePaths.layer),
       Layer.provideMerge(vcsDriverRegistryLayer),
     );
+    const disabledGitHubAvatars = Layer.succeed(
+      GitHubAvatarResolver.GitHubAvatarResolver,
+      GitHubAvatarResolver.GitHubAvatarResolver.of({
+        resolvePath: () => Effect.succeed(null),
+        isManagedPath: () => false,
+      }),
+    );
     const workspaceAndProjectServicesLayer = Layer.mergeAll(
       WorkspacePaths.layer,
       workspaceEntriesLayer,
+      disabledGitHubAvatars,
       WorkspaceFileSystem.layer.pipe(
         Layer.provide(WorkspacePaths.layer),
         Layer.provide(workspaceEntriesLayer),
@@ -588,6 +597,7 @@ const buildAppUnderTest = (options?: {
       ProjectFaviconResolver.layer.pipe(
         Layer.provide(WorkspacePaths.layer),
         Layer.provide(T3ProjectFileLoader.layer),
+        Layer.provide(disabledGitHubAvatars),
       ),
     );
     const gitWorkflowLayer = GitWorkflowService.layer.pipe(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -66,6 +66,7 @@ import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
 import * as ServerSettings from "./serverSettings.ts";
+import * as GitHubAvatarResolver from "./project/GitHubAvatarResolver.ts";
 import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "./project/T3ProjectFileLoader.ts";
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
@@ -351,9 +352,16 @@ const WorkspaceLayerLive = Layer.mergeAll(
   WorkspaceFileSystemLayerLive,
 );
 
-const ProjectFaviconResolverLayerLive = ProjectFaviconResolver.layer.pipe(
-  Layer.provide(WorkspacePaths.layer),
-  Layer.provide(T3ProjectFileLoader.layer),
+const GitHubAvatarResolverLayerLive = GitHubAvatarResolver.layer.pipe(
+  Layer.provide(RepositoryIdentityResolver.layer),
+);
+const ProjectFaviconResolverLayerLive = Layer.mergeAll(
+  ProjectFaviconResolver.layer.pipe(
+    Layer.provide(WorkspacePaths.layer),
+    Layer.provide(T3ProjectFileLoader.layer),
+    Layer.provide(GitHubAvatarResolverLayerLive),
+  ),
+  GitHubAvatarResolverLayerLive,
 );
 
 const AuthLayerLive = EnvironmentAuth.layer.pipe(

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -1,7 +1,8 @@
 # Customize a project icon
 
 T3 Code selects a project icon automatically. It checks `t3.json`, common favicon and app icon
-paths, and icon links in project HTML files.
+paths, and icon links in project HTML files. If a project has no local icon and its repository is
+hosted on GitHub, T3 Code shows the repository owner's avatar instead.
 
 To choose a different icon:
 


### PR DESCRIPTION
## Issue for this PR

Discussion: #8745 (idea originally raised in #4304)

## What Changed

Project icon discovery gains one final, failure-atomic step in `ProjectFaviconResolver`: when no local icon resolves (settings path → `t3.json iconPath` → well-known files → `<link rel=icon>` scrape) and the workspace's primary git remote is github.com, the repository owner's avatar is fetched from `github.com/<owner>.png` and served from a disk cache under the state dir.

- One HTTP GET per owner, ever: the cache is keyed by the lowercased owner, so every repository of an org shares one entry, and the avatar bytes are committed with an atomic rename of a temp file — a cache hit is a single `stat` and a partially written image can never be served.
- The body is read as a capped stream (1 MiB) under one 5s timeout, and the file is stored under the extension its content-type declares, since the asset route serves it under `nosniff`.
- A miss file carrying its own epoch remembers "no avatar" (404, oversized or unrenderable body) for 7 days. Transport failures, timeouts and transient responses (429/503) write no marker; they mute refetching for 5 minutes in memory, so an offline machine pays one connect timeout per owner instead of one per favicon request, and recovers by itself.
- Cache hits and fresh negatives answer without the fetch permit; concurrent misses single-flight into one request, so reconnect hydration bursts (#7536) never multiply requests.
- `AssetAccess` serves managed cache paths through the existing `project-favicon-external` claims. No contract, client, or UI changes.

## Why

GitHub-hosted projects without a local favicon all render the same generic letter avatar. GitHub has no per-repo icon — the image GitHub itself displays for a repository in every list is the owner's avatar — so that is what this shows for the "nothing found, nothing selected" gap. Repo-specific artwork keeps coming from the project: user-chosen icons and `t3.json iconPath` always win, and every failure path behaves exactly as today.

The only outbound request is to github.com, which the machine already talks to for `git fetch`, and it fires at most once per owner. Happy to gate it behind a setting if you'd prefer an opt-out.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/75047fd6-2a8a-40d9-87e7-4dd589f4cd3d" width="420"> | <img src="https://github.com/user-attachments/assets/4a4d27ec-7fb6-4e7d-b9e2-521b52f57ba0" width="420"> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Model: Claude Fable 5, GLM 5.3 via Claude Code and opencode
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds outbound HTTP to github.com during icon resolution and new disk cache semantics; failures are designed to fall back to null but first-fetch latency and GitHub availability matter for UX.
> 
> **Overview**
> When local icon discovery finds nothing, **github.com** workspaces can now show the repository owner’s avatar instead of the generic fallback.
> 
> A new **`GitHubAvatarResolver`** service fetches `https://github.com/<owner>.png`, stores bytes under the server state dir, and exposes `isManagedPath` so the asset layer can treat cache files like other external favicons. Caching covers successful downloads, a 7-day negative path for 404/oversized bodies, and retries without a long-lived “miss” marker for timeouts, transport errors, and rate limits.
> 
> **`ProjectFaviconResolver`** invokes this resolver only after saved paths, `t3.json`, well-known files, and HTML/metadata scraping are exhausted; local icons still win. **`AssetAccess.issueAssetUrl`** extends the external-override path so managed avatar files mint **`project-favicon-external`** tokens (with the real file extension in the URL). Live server layers and tests stub or exercise the new dependency; user docs note the GitHub fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0636465c2928cb5041fff9b1e5e6fb6fe1cc141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to GitHub owner avatar for project icons when no local favicon is found
> - Adds `GitHubAvatarResolver`, a Context service that fetches `https://github.com/<owner>.png` for github.com-hosted repositories, with on-disk positive and negative caching (7-day TTL for `.miss` markers), a 5s timeout, 1 MiB size cap, and semaphore-controlled concurrency
> - Updates `ProjectFaviconResolver` to call `githubAvatarResolver.resolvePath` as a final fallback after local icon strategies (t3.json `iconPath`, known favicon locations, HTML `<link rel>` icons) are exhausted
> - Updates `AssetAccess.issueAssetUrl` to treat managed GitHub avatar paths as external overrides, serving them directly and preserving the avatar's file extension in the token filename
> - Wires `GitHubAvatarResolver` into the live server layers and updates user docs to note the fallback behavior
> - Risk: `GitHubAvatarResolver` makes outbound HTTP requests to `github.com` at resolution time; check `apps/server/src/project/GitHubAvatarResolver.ts` for the fetch timeout, size cap, and negative-cache TTL if rate limits or network failures are a concern
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e063646.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
