### PR TITLE
fix(client-runtime): count workflows between phases

### DIFF
--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -426,6 +426,38 @@ describe("deriveAgentPanelModel", () => {
     expect(model.liveCount).toBe(0);
   });
 
+  it("counts a running workflow coordinator between phases", () => {
+    const betweenPhases = fold([
+      activity("task.started", {
+        taskId: "wf-between-phases",
+        taskType: "local_workflow",
+        title: "review",
+      }),
+      activity("task.progress", {
+        taskId: "wf-between-phases:wf:0",
+        title: "review:a",
+        status: "completed",
+        parentAgentId: "wf-between-phases",
+        agentIndex: 0,
+        phaseIndex: 0,
+      }),
+      activity("task.completed", {
+        taskId: "wf-between-phases:wf:0",
+        status: "completed",
+        parentAgentId: "wf-between-phases",
+      }),
+    ]);
+
+    const model = deriveAgentPanelModel({ agents: betweenPhases });
+
+    expect(model.runningCount).toBe(1);
+    expect(model.settledCount).toBe(1);
+    expect(model.liveCount).toBe(1);
+    expect(model.runningCount + model.waitingCount + model.idleCount + model.settledCount).toBe(
+      betweenPhases.length,
+    );
+  });
+
   it("keeps direct spawns in first-seen order as their activity changes", () => {
     const directRoster = fold([
       activity("task.started", { taskId: "direct-a", title: "First" }, "2026-08-01T11:00:00.000Z"),

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -458,6 +458,30 @@ describe("deriveAgentPanelModel", () => {
     );
   });
 
+  it("does not count a workflow coordinator while a member is idle", () => {
+    const idleMember = fold([
+      activity("task.started", {
+        taskId: "wf-idle-member",
+        taskType: "local_workflow",
+        title: "review",
+      }),
+      activity("task.progress", {
+        taskId: "wf-idle-member:wf:0",
+        title: "review:a",
+        status: "idle",
+        parentAgentId: "wf-idle-member",
+        agentIndex: 0,
+        phaseIndex: 0,
+      }),
+    ]);
+
+    const model = deriveAgentPanelModel({ agents: idleMember });
+
+    expect(model.runningCount).toBe(0);
+    expect(model.idleCount).toBe(1);
+    expect(model.liveCount).toBe(0);
+  });
+
   it("keeps direct spawns in first-seen order as their activity changes", () => {
     const directRoster = fold([
       activity("task.started", { taskId: "direct-a", title: "First" }, "2026-08-01T11:00:00.000Z"),

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -826,16 +826,27 @@ export function deriveAgentPanelModel({
   let settledCount = 0;
   let totalTokens = 0;
   for (const agent of source) {
-    // A workflow coordinator with members is a container for those members, not
-    // work of its own: it reports running for the whole run and aggregates their
-    // usage upstream in some providers. Counting it would report one more agent
-    // working than there are, and double count tokens.
-    if (agent.kind === "workflow" && (members.get(agent.id) ?? []).length > 0) continue;
-    if (agent.status === "running" || agent.status === "pending") runningCount += 1;
-    else if (agent.status === "waiting") waitingCount += 1;
-    else if (agent.status === "idle") idleCount += 1;
-    else settledCount += 1;
-    totalTokens += agent.usage?.totalTokens ?? 0;
+    const workflowMembers = members.get(agent.id) ?? [];
+    const standsInForMembers =
+      agent.kind === "workflow" &&
+      workflowMembers.length > 0 &&
+      !(
+        isActiveSubagentStatus(agent.status) &&
+        !workflowMembers.some((member) => isActiveSubagentStatus(member.status))
+      );
+
+    if (!standsInForMembers) {
+      if (agent.status === "running" || agent.status === "pending") runningCount += 1;
+      else if (agent.status === "waiting") waitingCount += 1;
+      else if (agent.status === "idle") idleCount += 1;
+      else settledCount += 1;
+    }
+
+    // Workflow usage may aggregate member usage upstream, including while the
+    // coordinator is the only live unit between phases.
+    if (agent.kind !== "workflow" || workflowMembers.length === 0) {
+      totalTokens += agent.usage?.totalTokens ?? 0;
+    }
   }
 
   return {

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -832,7 +832,7 @@ export function deriveAgentPanelModel({
       workflowMembers.length > 0 &&
       !(
         isActiveSubagentStatus(agent.status) &&
-        !workflowMembers.some((member) => isActiveSubagentStatus(member.status))
+        workflowMembers.every((member) => isTerminalSubagentStatus(member.status))
       );
 
     if (!standsInForMembers) {


### PR DESCRIPTION
## What Changed

- Count a live workflow coordinator when all current phase members have settled.
- Keep workflow coordinator token usage excluded when members exist.
- Add coverage for the gap between workflow phases.

## Why

A workflow remains active while its coordinator prepares the next phase, but the shared rollup reported zero live agents during that gap.

Closes #8720

## Testing

- pnpm exec vp test run packages/client-runtime/src/state/subagentRuntime.test.ts
- pnpm exec vp run --filter @t3tools/client-runtime typecheck
- pnpm exec vp lint packages/client-runtime/src/state/subagentRuntime.ts packages/client-runtime/src/state/subagentRuntime.test.ts

## Checklist

- [x] One focused behavior change
- [x] Focused regression coverage
- [x] Formatting and lint pass

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to agent panel counting in client-runtime; callers of `deriveAgentPanelModel` may see different live/running counts during workflow phase transitions.
> 
> **Overview**
> Fixes the agent panel rollup so a **workflow coordinator** is counted as live when the current phase’s members are all settled but the workflow is still active (gap before the next phase). Previously, coordinators with members were always omitted from `runningCount` / `liveCount`, so the UI could show **zero** working agents while the coordinator was still running.
> 
> `deriveAgentPanelModel` now treats a coordinator as **standing in for** its members (and skips it in status buckets) only when members still need representation—**not** when the coordinator is active and every member is terminal. Token totals still **exclude** workflow rows that have members to avoid double-counting aggregated usage.
> 
> Regression tests cover the between-phases case and confirm the coordinator stays hidden when a phase member is **idle**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 770f5396e05d3c40d9b33866e025b5e976427181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `deriveAgentPanelModel` to count workflow coordinators between phases
> - Workflow coordinators with members are now counted as running/live when active and all members are terminal (e.g. between phases), and excluded when any member is non-terminal
> - `totalTokens` now excludes workflow coordinator usage whenever it has members, preventing double-counting; coordinators with no members still contribute their own usage
> - Adds tests in `deriveAgentPanelModel` suite asserting counting invariants for coordinators between phases and when members are idle
> - Behavioral Change: `runningCount`, `idleCount`, `settledCount`, and `liveCount` in [subagentRuntime.ts](https://github.com/pingdotgg/t3code/pull/8749/files#diff-b28278fe62e259afab164f07d2e56800ca49f60942f6b12da5f748e9415c8259) change semantics for coordinators with members; verify consumers of these tallies handle the between-phase inclusion
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 770f539.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->