### PR TITLE
fix(server): bound OpenCode version probes

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -3,8 +3,10 @@ import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
 
 import { OpenCodeSettings } from "@t3tools/contracts";
@@ -34,6 +36,7 @@ const DEFAULT_VERSION_STDOUT = "opencode 1.14.19\n";
 const runtimeMock = {
   state: {
     runVersionError: null as Error | null,
+    runVersionPending: false,
     versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
     connectionError: null as Error | null,
@@ -52,6 +55,7 @@ const runtimeMock = {
   },
   reset() {
     this.state.runVersionError = null;
+    this.state.runVersionPending = false;
     this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
     this.state.connectionError = null;
@@ -114,15 +118,17 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       };
     }),
   runOpenCodeCommand: () =>
-    runtimeMock.state.runVersionError
-      ? Effect.fail(
-          new OpenCodeRuntimeError({
-            operation: "runOpenCodeCommand",
-            detail: runtimeMock.state.runVersionError.message,
-            cause: runtimeMock.state.runVersionError,
-          }),
-        )
-      : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
+    runtimeMock.state.runVersionPending
+      ? Effect.never
+      : runtimeMock.state.runVersionError
+        ? Effect.fail(
+            new OpenCodeRuntimeError({
+              operation: "runOpenCodeCommand",
+              detail: runtimeMock.state.runVersionError.message,
+              cause: runtimeMock.state.runVersionError,
+            }),
+          )
+        : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
   createOpenCodeSdkClient: (input) => {
     runtimeMock.state.sdkClientInputs.push(input);
     return {} as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>;
@@ -214,6 +220,24 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       NodeAssert.equal(snapshot.installed, true);
       NodeAssert.equal(snapshot.message, "Failed to execute OpenCode CLI health check.");
     }),
+  );
+
+  it.effect("times out a hanging local CLI version probe", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.runVersionPending = true;
+      const probeFiber = yield* checkProvider(makeOpenCodeSettings()).pipe(Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("4 seconds");
+      const snapshot = yield* Fiber.join(probeFiber);
+
+      NodeAssert.equal(snapshot.status, "error");
+      NodeAssert.equal(snapshot.installed, true);
+      NodeAssert.equal(
+        snapshot.message,
+        "Failed to execute OpenCode CLI health check: OpenCode CLI version probe timed out after 4 seconds.",
+      );
+    }).pipe(Effect.provide(TestClock.layer())),
   );
 
   it.effect("emits OpenCode variant defaults so trait picker can resolve a visible selection", () =>

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -31,6 +31,7 @@ const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
   showInteractionModeToggle: false,
 } as const;
+const OPENCODE_VERSION_PROBE_TIMEOUT = "4 seconds";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
   readonly cause: unknown;
@@ -399,6 +400,16 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
           Effect.mapError(
             (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
           ),
+          Effect.timeoutOrElse({
+            duration: OPENCODE_VERSION_PROBE_TIMEOUT,
+            orElse: () =>
+              Effect.fail(
+                new OpenCodeProbeError({
+                  cause: new Error("OpenCode CLI version probe timed out."),
+                  detail: "OpenCode CLI version probe timed out after 4 seconds.",
+                }),
+              ),
+          }),
         ),
     );
     if (versionExit._tag === "Failure") {

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -34,7 +34,7 @@ const OPENCODE_PRESENTATION = {
 const OPENCODE_VERSION_PROBE_TIMEOUT = "4 seconds";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
-  readonly cause: unknown;
+  readonly cause?: unknown;
   readonly detail: string;
 }> {}
 
@@ -405,8 +405,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
             orElse: () =>
               Effect.fail(
                 new OpenCodeProbeError({
-                  cause: new Error("OpenCode CLI version probe timed out."),
-                  detail: "OpenCode CLI version probe timed out after 4 seconds.",
+                  detail: `OpenCode CLI version probe timed out after ${OPENCODE_VERSION_PROBE_TIMEOUT}.`,
                 }),
               ),
           }),

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -555,11 +555,23 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const spawnCommand = yield* resolveCommand(input.binaryPath, input.args, input.environment);
       const child = yield* spawner.spawn(
         ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+          detached: hostPlatform !== "win32",
           shell: spawnCommand.shell,
           ...(input.cwd ? { cwd: input.cwd } : {}),
           ...(input.environment ? { env: input.environment } : { extendEnv: true }),
         }),
       );
+      const terminateCommandGroup =
+        hostPlatform === "win32"
+          ? child.kill({ killSignal: "SIGKILL" }).pipe(Effect.asVoid)
+          : Effect.sync(() => {
+              try {
+                process.kill(-Number(child.pid), "SIGKILL");
+              } catch {
+                // The command and its process group may already have exited.
+              }
+            });
+      yield* Effect.addFinalizer(() => terminateCommandGroup.pipe(Effect.ignore));
       const collectOptions =
         input.maxOutputBytes === undefined ? undefined : { maxBytes: input.maxOutputBytes };
       const [stdout, stderr, code] = yield* Effect.all(


### PR DESCRIPTION
## What Changed

- Stop local OpenCode version probes after four seconds.
- Spawn probe commands in a process group on POSIX hosts.
- Kill the full probe group when its scope closes.
- Add coverage for a version command that never returns.

## Why

A hanging OpenCode wrapper could leave provider discovery running indefinitely and retain CPU-heavy descendants.

Closes #8681

## Testing

- pnpm exec vp test run apps/server/src/provider/Layers/OpenCodeProvider.test.ts apps/server/src/provider/opencodeRuntime.inventory.test.ts
- pnpm exec vp run --filter t3 typecheck
- pnpm exec vp lint apps/server/src/provider/opencodeRuntime.ts apps/server/src/provider/Layers/OpenCodeProvider.ts apps/server/src/provider/Layers/OpenCodeProvider.test.ts

## Checklist

- [x] One focused behavior change
- [x] Focused regression coverage
- [x] Formatting and lint pass

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process spawn/teardown and provider health checks; mis-kill logic could affect unrelated processes on POSIX, but scope is limited to OpenCode CLI invocations.
> 
> **Overview**
> **OpenCode provider discovery** no longer blocks forever when the local `opencode --version` health check hangs. The version probe is capped at **4 seconds**; on timeout the check returns an error snapshot with a clear timeout message.
> 
> To avoid orphaned CLI processes when the probe is cancelled or times out, **local command spawns** on POSIX use a detached process group and a scope finalizer that **SIGKILLs the whole group** (Windows still kills the child directly). Tests add a hanging-CLI mock and a **TestClock** case that asserts the timeout path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600c95ce766fc13f227a6676c188a4667fe9e605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound OpenCode CLI version probe with 4-second timeout and force-terminate spawned process
> - Wraps `runOpenCodeCommand(--version)` in `checkOpenCodeProviderStatus` with `Effect.timeoutOrElse` using the new `OPENCODE_VERSION_PROBE_TIMEOUT` constant (4 seconds), failing with a timeout-specific `OpenCodeProbeError` when the probe hangs
> - Makes `OpenCodeProbeError.cause` optional so timeout errors can be constructed without an underlying throwable
> - Adds a finalizer to `makeOpenCodeRuntime.runOpenCodeCommand` that sends `SIGKILL` to the child (Windows) or the negative child PID (non-Windows, process group) when the effect scope ends, ignoring errors if the process already exited
> - Risk: `runOpenCodeCommand` now sets `detached=true` on non-Windows platforms; out-of-tree callers relying on the child sharing the parent process group may see different process-group behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 600c95c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->