### PR TITLE
fix(desktop): recover from obsolete catalog keys

### DIFF
--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
@@ -385,7 +385,7 @@ describe("DesktopConnectionCatalogStore", () => {
     ),
   );
 
-  it.effect("surfaces a catalog that can no longer be decrypted without deleting it", () =>
+  it.effect("treats a catalog encrypted with an obsolete key as empty until it is replaced", () =>
     Effect.gen(function* () {
       const path = yield* Path.Path;
       const fileSystem = yield* FileSystem.FileSystem;
@@ -399,25 +399,22 @@ describe("DesktopConnectionCatalogStore", () => {
       );
 
       assert.isTrue(yield* store.set('{"schemaVersion":1,"targets":[]}'));
+      const catalogPath = path.join(baseDir, "userdata", "connection-catalog.json");
+      const originalDocument = yield* fileSystem.readFileString(catalogPath);
       yield* Ref.set(failDecrypt, true);
-      const error = yield* store.get.pipe(Effect.flip);
-      assert.instanceOf(
-        error,
-        DesktopConnectionCatalogStore.DesktopConnectionCatalogStoreProtectionError,
-      );
-      assert.equal(error.operation, "decrypt-catalog");
-      assert.equal(error.catalogPath, path.join(baseDir, "userdata", "connection-catalog.json"));
-      assert.instanceOf(error.cause, ElectronSafeStorage.ElectronSafeStorageDecryptError);
-      const decryptError = error.cause as ElectronSafeStorage.ElectronSafeStorageDecryptError;
-      assert.instanceOf(decryptError.cause, Error);
-      assert.equal(decryptError.cause.message, "invalid encrypted catalog");
-      assert.equal(
-        error.message,
-        `Desktop connection catalog protection failed during decrypt-catalog at ${path.join(baseDir, "userdata", "connection-catalog.json")}.`,
-      );
-      assert.notEqual(error.message, decryptError.message);
+      assert.deepStrictEqual(yield* store.get, Option.none());
+      assert.equal(yield* fileSystem.readFileString(catalogPath), originalDocument);
+
       yield* Ref.set(failDecrypt, false);
       assert.deepStrictEqual(yield* store.get, Option.some('{"schemaVersion":1,"targets":[]}'));
+
+      yield* Ref.set(failDecrypt, true);
+      assert.isTrue(yield* store.set('{"schemaVersion":1,"targets":["replacement"]}'));
+      yield* Ref.set(failDecrypt, false);
+      assert.deepStrictEqual(
+        yield* store.get,
+        Option.some('{"schemaVersion":1,"targets":["replacement"]}'),
+      );
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
 });

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
@@ -408,13 +408,99 @@ describe("DesktopConnectionCatalogStore", () => {
       yield* Ref.set(failDecrypt, false);
       assert.deepStrictEqual(yield* store.get, Option.some('{"schemaVersion":1,"targets":[]}'));
 
-      yield* Ref.set(failDecrypt, true);
+      // The renderer retains the empty read even if decryption recovers. A
+      // backend credential refresh can then save that cached catalog at startup.
       assert.isTrue(yield* store.set('{"schemaVersion":1,"targets":["replacement"]}'));
-      yield* Ref.set(failDecrypt, false);
       assert.deepStrictEqual(
         yield* store.get,
         Option.some('{"schemaVersion":1,"targets":["replacement"]}'),
       );
+      const backupDirectories = (yield* fileSystem.readDirectory(path.dirname(catalogPath))).filter(
+        (name) => name.startsWith("connection-catalog.json.unreadable-"),
+      );
+      assert.lengthOf(backupDirectories, 1);
+      const backupPath = path.join(
+        path.dirname(catalogPath),
+        backupDirectories[0]!,
+        "connection-catalog.json",
+      );
+      assert.equal(yield* fileSystem.readFileString(backupPath), originalDocument);
+      assert.isTrue(yield* store.set('{"schemaVersion":1,"targets":["second"]}'));
+      assert.equal(yield* fileSystem.readFileString(backupPath), originalDocument);
+      assert.lengthOf(
+        (yield* fileSystem.readDirectory(path.dirname(catalogPath))).filter((name) =>
+          name.startsWith("connection-catalog.json.unreadable-"),
+        ),
+        1,
+      );
+
+      // A later unreadable document gets its own backup, including on clear.
+      const secondDocument = yield* fileSystem.readFileString(catalogPath);
+      yield* Ref.set(failDecrypt, true);
+      assert.deepStrictEqual(yield* store.get, Option.none());
+      yield* store.clear;
+      const allBackups = (yield* fileSystem.readDirectory(path.dirname(catalogPath))).filter(
+        (name) => name.startsWith("connection-catalog.json.unreadable-"),
+      );
+      assert.lengthOf(allBackups, 2);
+      const contents = yield* Effect.forEach(allBackups, (name) =>
+        fileSystem.readFileString(
+          path.join(path.dirname(catalogPath), name, "connection-catalog.json"),
+        ),
+      );
+      assert.sameMembers(contents, [originalDocument, secondDocument]);
+      assert.isFalse(yield* fileSystem.exists(catalogPath));
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+  it.effect("refuses automatic replacement when the encrypted backup cannot be written", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-catalog-backup-test-",
+      });
+      const failDecrypt = yield* Ref.make(false);
+      const failBackup = yield* Ref.make(true);
+      const backupError = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "copyFile",
+      });
+      const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore.pipe(
+        Effect.provide(
+          makeLayer(
+            baseDir,
+            true,
+            failDecrypt,
+            Layer.succeed(FileSystem.FileSystem, {
+              ...fileSystem,
+              copyFile: (from, to) =>
+                Effect.gen(function* () {
+                  if (yield* Ref.get(failBackup)) return yield* Effect.fail(backupError);
+                  yield* fileSystem.copyFile(from, to);
+                }),
+            }),
+          ),
+        ),
+      );
+      yield* store.set("original");
+      const catalogPath = path.join(baseDir, "userdata", "connection-catalog.json");
+      const original = yield* fileSystem.readFileString(catalogPath);
+      yield* Ref.set(failDecrypt, true);
+      assert.deepStrictEqual(yield* store.get, Option.none());
+      const error = yield* store.set("automatic replacement").pipe(Effect.flip);
+      assert.instanceOf(
+        error,
+        DesktopConnectionCatalogStore.DesktopConnectionCatalogStoreWriteError,
+      );
+      assert.equal(error.operation, "preserve-unreadable-catalog");
+      assert.equal(yield* fileSystem.readFileString(catalogPath), original);
+      yield* store.clear;
+      assert.equal(yield* fileSystem.readFileString(catalogPath), original);
+      yield* Ref.set(failBackup, false);
+      assert.isTrue(yield* store.set("automatic replacement"));
+      yield* Ref.set(failDecrypt, false);
+      assert.deepStrictEqual(yield* store.get, Option.some("automatic replacement"));
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
 });

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -52,6 +52,7 @@ const DesktopConnectionCatalogStoreWriteOperation = Schema.Literals([
   "create-directory",
   "write-temporary-file",
   "replace-catalog-file",
+  "preserve-unreadable-catalog",
 ]);
 
 const DesktopConnectionCatalogStoreMigrationOperation = Schema.Literals([
@@ -395,6 +396,41 @@ export const make = Effect.gen(function* () {
     ),
   );
 
+  let needsBackup = false;
+  const preserveUnreadableCatalog = Effect.fn(
+    "desktop.connectionCatalogStore.preserveUnreadableCatalog",
+  )(
+    function* () {
+      if (!needsBackup) {
+        return;
+      }
+      const backupDirectory = yield* fileSystem.makeTempDirectory({
+        directory: path.dirname(catalogPath),
+        prefix: "connection-catalog.json.unreadable-",
+      });
+      const backupPath = path.join(backupDirectory, "connection-catalog.json");
+      yield* fileSystem
+        .copyFile(catalogPath, backupPath)
+        .pipe(
+          Effect.onError(() =>
+            fileSystem.remove(backupDirectory, { recursive: true }).pipe(Effect.ignore),
+          ),
+        );
+      needsBackup = false;
+      yield* Effect.logWarning("Preserved an unreadable desktop connection catalog.", {
+        backupPath,
+      });
+    },
+    Effect.mapError(
+      (cause) =>
+        new DesktopConnectionCatalogStoreWriteError({
+          operation: "preserve-unreadable-catalog",
+          path: catalogPath,
+          cause,
+        }),
+    ),
+  );
+
   const writeCatalog = Effect.fn("desktop.connectionCatalogStore.writeCatalog")(function* (
     catalog: string,
   ) {
@@ -420,6 +456,7 @@ export const make = Effect.gen(function* () {
           }),
       ),
     )).replace(/-/g, "");
+    yield* preserveUnreadableCatalog();
     yield* writeDocument({
       fileSystem,
       path,
@@ -486,10 +523,16 @@ export const make = Effect.gen(function* () {
       return yield* safeStorage.decryptString(encryptedCatalog).pipe(
         Effect.map(Option.some),
         Effect.catch((error) =>
-          Effect.logWarning("Ignoring an unreadable desktop connection catalog.", {
-            catalogPath,
-            errorTag: error._tag,
-          }).pipe(Effect.as(Option.none<string>())),
+          Effect.gen(function* () {
+            // The renderer caches this empty read and may save automatically.
+            // Preserve the encrypted document before any subsequent replacement.
+            needsBackup = true;
+            yield* Effect.logWarning("Ignoring an unreadable desktop connection catalog.", {
+              catalogPath,
+              errorTag: error._tag,
+            });
+            return Option.none<string>();
+          }),
         ),
       );
     }).pipe(Effect.withSpan("desktop.connectionCatalogStore.get")),
@@ -500,7 +543,8 @@ export const make = Effect.gen(function* () {
       yield* writeCatalog(catalog);
       return true;
     }),
-    clear: fileSystem.remove(catalogPath, { force: true }).pipe(
+    clear: preserveUnreadableCatalog().pipe(
+      Effect.andThen(fileSystem.remove(catalogPath, { force: true })),
       Effect.catch((error) =>
         Effect.logWarning("Could not clear the desktop connection catalog.", {
           catalogPath,

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -479,21 +479,19 @@ export const make = Effect.gen(function* () {
       if (!(yield* encryptionAvailable)) {
         return Option.none<string>();
       }
-      const decrypted = yield* decodeSecretBytes(catalogPath, document.value.encryptedCatalog).pipe(
-        Effect.flatMap((encryptedCatalog) =>
-          safeStorage.decryptString(encryptedCatalog).pipe(
-            Effect.mapError(
-              (cause) =>
-                new DesktopConnectionCatalogStoreProtectionError({
-                  operation: "decrypt-catalog",
-                  catalogPath,
-                  cause,
-                }),
-            ),
-          ),
+      const encryptedCatalog = yield* decodeSecretBytes(
+        catalogPath,
+        document.value.encryptedCatalog,
+      );
+      return yield* safeStorage.decryptString(encryptedCatalog).pipe(
+        Effect.map(Option.some),
+        Effect.catch((error) =>
+          Effect.logWarning("Ignoring an unreadable desktop connection catalog.", {
+            catalogPath,
+            errorTag: error._tag,
+          }).pipe(Effect.as(Option.none<string>())),
         ),
       );
-      return Option.some(decrypted);
     }).pipe(Effect.withSpan("desktop.connectionCatalogStore.get")),
     set: Effect.fn("desktop.connectionCatalogStore.set")(function* (catalog) {
       if (!(yield* encryptionAvailable)) {


### PR DESCRIPTION
An unreadable encrypted desktop connection catalog currently prevents connection management from loading after a Safe Storage key change. Treat decryption failure as an empty catalog so the app can recover.

Keep the original encrypted file in place on read. Before a later replacement or clear, preserve its exact bytes in a unique connection-catalog.json.unreadable-* directory beside the catalog. This applies to automatic credential refreshes as well as user saves. If the backup fails, refuse replacement and retain the original. Later recovery incidents receive separate backups.

A direct store read can recover when decryption starts working again. The renderer caches its empty read and needs a reload to see that recovery; an intervening save writes a replacement while retaining the encrypted backup. This change does not add a recovery notice or an automatic backup-restore flow.

Validation: 10 focused desktop catalog tests pass. Two backup regressions fail before the fix. Coverage includes replacement after an empty read, repeated writes, unique backups, clear, and backup-failure retry. Rebased tests retain main's platform-aware paths. Scoped lint and desktop typecheck pass. Native macOS/Windows migration and the full WSL startup flow have not been exercised.

Closes #8341.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unreadable encrypted connection catalogs are now handled gracefully instead of causing a read failure.
  * Original unreadable catalog files are preserved in a backup before being replaced or removed.
  * Clear errors are reported if the unreadable catalog cannot be backed up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->