### PR TITLE
feat(web): continue handoffs in a new thread

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -381,6 +381,7 @@ import {
   startAttachmentUpload,
 } from "../lib/attachmentUploadQueue";
 import { sanitizeThreadErrorMessage } from "~/rpc/transportError";
+import { buildSessionHandoffPrompt, parseSessionHandoff } from "../lib/sessionHandoff";
 import { RightPanelSheet } from "./RightPanelSheet";
 import { previewEnvironment } from "../state/preview";
 import { clampFileAttachmentUploadBytes } from "@t3tools/client-runtime/state/attachments";
@@ -6702,6 +6703,150 @@ function ChatViewContent(props: ChatViewProps) {
     composerRef,
   ]);
 
+  const onContinueInNewThread = useCallback(
+    async (handoffText: string) => {
+      const handoff = parseSessionHandoff(handoffText);
+      if (
+        handoff === null ||
+        !activeThread ||
+        !activeProject ||
+        !activeThreadRef ||
+        !isServerThread ||
+        isSendBusy ||
+        isConnecting ||
+        activeEnvironmentUnavailable ||
+        sendInFlightRef.current
+      ) {
+        return;
+      }
+
+      const sendCtx = composerRef.current?.getSendContext();
+      if (!sendCtx?.providerAvailable) return;
+
+      const prompt = buildSessionHandoffPrompt({
+        handoff,
+        sourceEnvironmentId: activeThread.environmentId,
+        sourceThreadId: activeThread.id,
+      });
+      const outgoingPrompt = formatOutgoingPrompt({
+        provider: sendCtx.selectedProvider,
+        model: sendCtx.selectedModel,
+        models: sendCtx.selectedProviderModels,
+        effort: sendCtx.selectedPromptEffort,
+        text: prompt,
+      });
+      if (composerRef.current?.validateProviderInput(outgoingPrompt) === false) return;
+
+      const createdAt = new Date().toISOString();
+      const nextThreadId = newThreadId();
+      const nextThreadRef = scopeThreadRef(activeThread.environmentId, nextThreadId);
+      const modelSelection = sendCtx.selectedModelSelection;
+      const interactionMode = activeThread.interactionMode;
+
+      sendInFlightRef.current = true;
+      beginLocalDispatch({ preparingWorktree: false });
+      const finish = () => {
+        sendInFlightRef.current = false;
+        resetLocalDispatch();
+      };
+
+      const startResult = await startThreadTurn({
+        environmentId,
+        input: {
+          threadId: nextThreadId,
+          message: {
+            messageId: newMessageId(),
+            role: "user",
+            text: outgoingPrompt,
+            attachments: [],
+          },
+          modelSelection,
+          titleSeed: handoff.title,
+          runtimeMode,
+          interactionMode,
+          bootstrap: {
+            createThread: {
+              projectId: activeProject.id,
+              title: handoff.title,
+              modelSelection,
+              runtimeMode,
+              interactionMode,
+              branch: activeThreadBranch,
+              worktreePath: activeThread.worktreePath,
+              createdAt,
+            },
+          },
+          createdAt,
+        },
+      });
+      let failure: AtomCommandResult<unknown, unknown> | null =
+        startResult._tag === "Failure" ? startResult : null;
+
+      if (failure === null) {
+        const startedResult = await settlePromise(() => waitForStartedServerThread(nextThreadRef));
+        failure = startedResult._tag === "Failure" ? startedResult : null;
+      }
+
+      if (failure === null && supportsSettlement) {
+        const settledResult = await settleThread(activeThreadRef);
+        if (settledResult._tag === "Failure" && !isAtomCommandInterrupted(settledResult)) {
+          const error = squashAtomCommandFailure(settledResult);
+          toastManager.add(
+            stackedThreadToast({
+              type: "warning",
+              title: "New thread started; previous thread was not settled",
+              description: chatActionErrorMessage(error),
+            }),
+          );
+        }
+      }
+
+      if (failure === null) {
+        const navigateResult = await settlePromise(() =>
+          navigate({
+            to: "/$environmentId/$threadId",
+            params: {
+              environmentId: activeThread.environmentId,
+              threadId: nextThreadId,
+            },
+          }),
+        );
+        failure = navigateResult._tag === "Failure" ? navigateResult : null;
+      }
+
+      if (failure !== null && !isAtomCommandInterrupted(failure)) {
+        const error = squashAtomCommandFailure(failure);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not continue in a new thread",
+            description: chatActionErrorMessage(error),
+          }),
+        );
+      }
+      finish();
+    },
+    [
+      activeEnvironmentUnavailable,
+      activeProject,
+      activeThread,
+      activeThreadBranch,
+      activeThreadRef,
+      beginLocalDispatch,
+      composerRef,
+      environmentId,
+      isConnecting,
+      isSendBusy,
+      isServerThread,
+      navigate,
+      resetLocalDispatch,
+      runtimeMode,
+      settleThread,
+      startThreadTurn,
+      supportsSettlement,
+    ],
+  );
+
   const getModelDisabledReason = useCallback(
     (instanceId: ProviderInstanceId, model: string): string | null => {
       if (!activeThread) {
@@ -7123,6 +7268,7 @@ function ChatViewContent(props: ChatViewProps) {
               <MessagesTimeline
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
+                onContinueInNewThread={onContinueInNewThread}
                 key={activeThread.id}
                 isWorking={isWorking}
                 workingStepLabel={workingStepLabel}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -237,6 +237,40 @@ function buildAssistantTimelineEntry(text: string) {
 }
 
 describe("MessagesTimeline", () => {
+  it("offers a new-thread action for a completed handoff packet", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        onContinueInNewThread={async () => {}}
+        timelineEntries={[
+          buildAssistantTimelineEntry(`<!-- t3-handoff:1 -->
+# Handoff
+
+## Outcome
+Done.
+
+## Next task
+Start the next task.
+<!-- /t3-handoff -->`),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Continue in new thread"');
+  });
+
+  it("keeps the new-thread action hidden on ordinary assistant responses", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        onContinueInNewThread={async () => {}}
+        timelineEntries={[buildAssistantTimelineEntry("Done.")]}
+      />,
+    );
+
+    expect(markup).not.toContain('aria-label="Continue in new thread"');
+  });
+
   it("renders a feedback command and its pending response as normal thread messages", () => {
     const submission = {
       id: MessageId.make("feedback-command"),

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -61,6 +61,7 @@ import {
   DownloadIcon,
   EyeIcon,
   FileIcon,
+  ForwardIcon,
   GlobeIcon,
   HammerIcon,
   MessageCircleIcon,
@@ -119,6 +120,7 @@ import { cn } from "~/lib/utils";
 import { useUiStateStore } from "~/uiStateStore";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { formatChatTimestampTooltip, formatDayAwareTimestamp } from "../../timestampFormat";
+import { parseSessionHandoff } from "../../lib/sessionHandoff";
 
 import {
   buildInlineTerminalContextText,
@@ -158,6 +160,7 @@ interface TimelineRowSharedState {
   onToggleWorkGroup: (groupId: string, anchorKey: string) => void;
   agentPanelModel: AgentPanelModel;
   onOpenAgents: () => void;
+  onContinueInNewThread: ((handoffText: string) => Promise<void>) | null;
 }
 
 interface TimelineRowActivityState {
@@ -217,6 +220,7 @@ const TIMELINE_MAINTAIN_SCROLL_AT_END = {
 interface MessagesTimelineProps {
   agentPanelModel?: AgentPanelModel;
   onOpenAgents?: () => void;
+  onContinueInNewThread?: (handoffText: string) => Promise<void>;
   isWorking: boolean;
   workingStepLabel?: string | null;
   activeTurnStartedAt: string | null;
@@ -266,6 +270,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   activeTurnStartedAt,
   agentPanelModel = EMPTY_AGENT_PANEL_MODEL,
   onOpenAgents = NOOP_OPEN_AGENTS,
+  onContinueInNewThread = null,
   listRef,
   timelineEntries,
   latestTurn,
@@ -542,6 +547,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onToggleWorkGroup,
       agentPanelModel,
       onOpenAgents,
+      onContinueInNewThread,
     }),
     [
       timestampFormat,
@@ -559,6 +565,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onToggleWorkGroup,
       agentPanelModel,
       onOpenAgents,
+      onContinueInNewThread,
     ],
   );
   const activityState = useMemo<TimelineRowActivityState>(
@@ -1242,6 +1249,8 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
 }
 
 function AssistantCopyButton({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
+  const ctx = use(TimelineRowCtx);
+  const [continuing, setContinuing] = useState(false);
   const assistantCopyState = resolveAssistantMessageCopyState({
     text: row.message.text ?? null,
     showCopyButton: row.showAssistantCopyButton,
@@ -1252,7 +1261,39 @@ function AssistantCopyButton({ row }: { row: Extract<TimelineRow, { kind: "messa
     return null;
   }
 
-  return <MessageCopyButton text={assistantCopyState.text ?? ""} variant="ghost" />;
+  const text = assistantCopyState.text ?? "";
+  const canContinue = ctx.onContinueInNewThread !== null && parseSessionHandoff(text) !== null;
+
+  return (
+    <>
+      <MessageCopyButton text={text} variant="ghost" />
+      {canContinue ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label="Continue in new thread"
+                disabled={continuing}
+                onClick={() => {
+                  setContinuing(true);
+                  void ctx.onContinueInNewThread!(text).finally(() => setContinuing(false));
+                }}
+                type="button"
+                size="xs"
+                variant="ghost"
+                className="text-muted-foreground hover:text-foreground"
+              />
+            }
+          >
+            <ForwardIcon className="size-3" />
+          </TooltipTrigger>
+          <TooltipPopup>
+            <p>{continuing ? "Starting new thread…" : "Continue in new thread"}</p>
+          </TooltipPopup>
+        </Tooltip>
+      ) : null}
+    </>
+  );
 }
 
 function ProposedPlanTimelineRow({

--- a/apps/web/src/lib/sessionHandoff.test.ts
+++ b/apps/web/src/lib/sessionHandoff.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildSessionHandoffPrompt, parseSessionHandoff } from "./sessionHandoff";
+
+const packet = `Before
+<!-- t3-handoff:1 -->
+# Handoff
+
+## Outcome
+The first task is complete.
+
+## Next task
+Implement the follow-up and verify it in the app.
+
+## References
+apps/web/src/App.tsx
+<!-- /t3-handoff -->
+After`;
+
+describe("parseSessionHandoff", () => {
+  it("extracts the packet and next task from a marked assistant response", () => {
+    expect(parseSessionHandoff(packet)).toEqual({
+      packet: `# Handoff
+
+## Outcome
+The first task is complete.
+
+## Next task
+Implement the follow-up and verify it in the app.
+
+## References
+apps/web/src/App.tsx`,
+      nextTask: "Implement the follow-up and verify it in the app.",
+      title: "Implement the follow-up and verify it in the app.",
+    });
+  });
+
+  it("rejects incomplete or unmarked responses", () => {
+    expect(parseSessionHandoff("## Next task\nDo the thing.")).toBeNull();
+    expect(parseSessionHandoff("<!-- t3-handoff:1 -->\n# Handoff")).toBeNull();
+    expect(
+      parseSessionHandoff("<!-- t3-handoff:1 -->\n# Handoff\n<!-- /t3-handoff -->"),
+    ).toBeNull();
+  });
+});
+
+describe("buildSessionHandoffPrompt", () => {
+  it("adds a source-thread link and the transfer instruction", () => {
+    const handoff = parseSessionHandoff(packet)!;
+    expect(
+      buildSessionHandoffPrompt({
+        handoff,
+        sourceEnvironmentId: "local env",
+        sourceThreadId: "thread/1",
+      }),
+    ).toContain("[previous thread](/local%20env/thread%2F1)");
+  });
+});

--- a/apps/web/src/lib/sessionHandoff.ts
+++ b/apps/web/src/lib/sessionHandoff.ts
@@ -1,0 +1,49 @@
+const HANDOFF_OPEN = "<!-- t3-handoff:1 -->";
+const HANDOFF_CLOSE = "<!-- /t3-handoff -->";
+
+export interface SessionHandoff {
+  readonly packet: string;
+  readonly nextTask: string;
+  readonly title: string;
+}
+
+function titleFromNextTask(nextTask: string): string {
+  const firstLine = nextTask
+    .split("\n")
+    .map((line) => line.trim().replace(/^[-*]\s+/, ""))
+    .find((line) => line.length > 0);
+  const title = firstLine ?? "Continue previous task";
+  return title.length <= 72 ? title : `${title.slice(0, 69).trimEnd()}...`;
+}
+
+export function parseSessionHandoff(text: string | null): SessionHandoff | null {
+  if (text === null) return null;
+  const openAt = text.indexOf(HANDOFF_OPEN);
+  if (openAt < 0) return null;
+  const packetStart = openAt + HANDOFF_OPEN.length;
+  const closeAt = text.indexOf(HANDOFF_CLOSE, packetStart);
+  if (closeAt < 0) return null;
+
+  const packet = text.slice(packetStart, closeAt).trim();
+  const nextTaskMatch = packet.match(
+    /(?:^|\n)## Next task\s*\n([\s\S]*?)(?=\n## [^\n]+\s*(?:\n|$)|$)/,
+  );
+  const nextTask = nextTaskMatch?.[1]?.trim() ?? "";
+  if (packet.length === 0 || nextTask.length === 0) return null;
+
+  return { packet, nextTask, title: titleFromNextTask(nextTask) };
+}
+
+export function buildSessionHandoffPrompt(input: {
+  readonly handoff: SessionHandoff;
+  readonly sourceEnvironmentId: string;
+  readonly sourceThreadId: string;
+}): string {
+  const sourcePath = `/${encodeURIComponent(input.sourceEnvironmentId)}/${encodeURIComponent(input.sourceThreadId)}`;
+  return [
+    `Continue this work from the [previous thread](${sourcePath}).`,
+    "Treat the handoff as task context, then complete its Next task.",
+    "",
+    input.handoff.packet,
+  ].join("\n");
+}

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -46,6 +46,11 @@ same `$name` skill token to your message. The original skill name remains search
 also reports that skill as a native slash command, T3 Code hides the duplicate native entry and keeps
 the `/skill:Skill Name` label.
 
+On web and desktop, when an agent returns a marked session handoff, use **Continue in new thread**
+beside the response. T3 Code starts a thread in the same project and checkout, sends the handoff as
+its first message, links back to the previous thread, and settles the previous thread when the
+server supports it.
+
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the
 thread that started. The new thread keeps the selected workspace mode and base branch. If **New


### PR DESCRIPTION
A completed task can leave a compact handoff for the next task, but today the user has to create the next thread and paste that context manually. This adds an explicit action for versioned handoff packets.

When a terminal assistant response contains a `t3-handoff:1` packet, web and desktop show **Continue in new thread** beside Copy. The action atomically creates and starts a thread in the same project and checkout, sends the packet with a backlink to the source thread, then settles the source thread when supported. Ordinary assistant responses are unchanged.

Discussed first in #8754.

Checks:
- parser smoke test with Node type stripping
- Bun syntax build for the changed TypeScript and TSX
- targeted oxlint
- oxfmt check
- `git diff --check`

The focused Vite+ tests could not run locally because Corepack could not reach the npm registry while installing pnpm. CI is the first full type and test pass.

Implemented with OpenAI Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The flow creates threads, sends turns, navigates routes, and optionally settles the prior thread, but it is gated on server-thread/send-busy state and treats settlement errors as non-fatal.
> 
> **Overview**
> Adds **Continue in new thread** for assistant messages that include a versioned `t3-handoff:1` packet. A new `sessionHandoff` helper parses the marked block (requiring a **Next task** section), derives a thread title, and builds the first user message with a link back to the source thread.
> 
> **ChatView** wires the action: it reuses the current composer provider/model, bootstraps a new thread in the same project, branch, and worktree, starts the turn with the handoff prompt, navigates to the new route, and attempts to **settle** the previous thread when supported (settlement failures surface as a warning toast only). The timeline shows the control next to copy only when parsing succeeds; ordinary replies are unchanged.
> 
> User docs in `composer.md` describe the flow; unit tests cover parsing/prompt building and timeline visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ce8d6fa1356808f93663929d96087c7a654bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Continue in new thread" action for session handoffs in `ChatView`
> - Adds `parseSessionHandoff` and `buildSessionHandoffPrompt` in [sessionHandoff.ts](https://github.com/pingdotgg/t3code/pull/8755/files#diff-7530ac69f6403dc5fb5a2fedb06f316b05f8b01f284e0bbff15e05c9080dc058) to detect handoff packets in assistant text and build a prompt linking back to the source thread
> - Wires `onContinueInNewThread` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8755/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e): it validates runtime preconditions, creates a new thread in the same project/checkout, sends the handoff prompt as the first message, optionally settles the previous thread, and navigates to the new thread
> - Renders a `ForwardIcon` button in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/8755/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) on assistant messages that contain a valid handoff packet, disabled while the async continuation is in flight
> - Behavioral Change: previous thread settlement is best-effort; settlement failures show a warning toast but do not block navigation to the new thread
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 35ce8d6. 4 files reviewed, 4 issues evaluated, 1 issue filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/lib/sessionHandoff.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 16](https://github.com/pingdotgg/t3code/blob/35ce8d6fa1356808f93663929d96087c7a654bfc/apps/web/src/lib/sessionHandoff.ts#L16): `titleFromNextTask` truncates with UTF-16 code-unit `length`/`slice`, so a Next task whose 69th code unit is the first half of an astral character (for example, 68 ASCII characters followed by an emoji) produces a title containing an unpaired surrogate followed by `...`. The new thread then displays/stores a replacement character rather than the task text at the truncation boundary. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Status update

Closing this after finding the prior work I should have checked before opening it. Discussion #8433 tracks agent-controlled T3 threads. PRs #7487, #8452, and #8492 already explored agent-requested or fresh-thread handoffs. In particular, #8452 was closed on August 28, 2026 with an explicit decision not to add a separate Continue in new thread action.

The implementation remains available on the branch, but this PR should not compete with that existing history.