### PR TITLE
fix(web): terminal input returns to bottom

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -697,6 +697,7 @@ export function TerminalViewport({
       const sendTerminalInput = async (data: string, fallbackError: string) => {
         const activeTerminal = terminalRef.current;
         if (!activeTerminal) return;
+        if (!activeTerminal.isAtBottom()) activeTerminal.scrollToBottom();
         const result = await writeTerminal(data);
         if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
           const error = squashAtomCommandFailure(result);
@@ -788,6 +789,8 @@ export function TerminalViewport({
       }
 
       function handleData(data: string): void {
+        const activeTerminal = terminalRef.current;
+        if (activeTerminal && !activeTerminal.isAtBottom()) activeTerminal.scrollToBottom();
         void (async () => {
           const result = await writeTerminal(data);
           if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -789,8 +789,6 @@ export function TerminalViewport({
       }
 
       function handleData(data: string): void {
-        const activeTerminal = terminalRef.current;
-        if (activeTerminal && !activeTerminal.isAtBottom()) activeTerminal.scrollToBottom();
         void (async () => {
           const result = await writeTerminal(data);
           if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -904,7 +904,7 @@ export class GhosttyTerminalSurface {
     this.pasteShortcutToken += 1;
     if (text.length === 0) return;
     const encoded = this.core.encodePaste(text);
-    if (encoded.length > 0) this.options.onData(encoded);
+    this.sendUserInput(encoded);
   }
 
   hasSelection(): boolean {
@@ -1078,7 +1078,7 @@ export class GhosttyTerminalSurface {
           (text) => {
             if (this.disposed || this.pasteShortcutToken !== token) return;
             this.pasteShortcutToken += 1;
-            if (text.length > 0) this.options.onData(this.core.encodePaste(text));
+            if (text.length > 0) this.sendUserInput(this.core.encodePaste(text));
           },
           () => {
             // Clipboard read denied; the native paste event remains the path.
@@ -1099,7 +1099,7 @@ export class GhosttyTerminalSurface {
     this.suppressedKeyCodes.delete(event.code);
     event.preventDefault();
     event.stopPropagation();
-    this.options.onData(data);
+    this.sendUserInput(data);
   };
 
   private readonly onKeyUp = (event: KeyboardEvent) => {
@@ -1114,7 +1114,7 @@ export class GhosttyTerminalSurface {
     if (data.length === 0) return;
     event.preventDefault();
     event.stopPropagation();
-    this.options.onData(data);
+    this.sendUserInput(data);
   };
 
   private readonly onFocus = () => {
@@ -1188,7 +1188,7 @@ export class GhosttyTerminalSurface {
     // The native paste won the race with actual text; a pending clipboard read
     // must not double. An empty native paste leaves the read as the only path.
     this.pasteShortcutToken += 1;
-    this.options.onData(this.core.encodePaste(data));
+    this.sendUserInput(this.core.encodePaste(data));
   };
 
   private readonly onCompositionStart = () => {
@@ -1200,7 +1200,7 @@ export class GhosttyTerminalSurface {
   private readonly onCompositionEnd = (event: CompositionEvent) => {
     this.composing = false;
     const data = this.input.value || event.data;
-    if (data.length > 0) this.options.onData(data);
+    this.sendUserInput(data);
     this.input.value = "";
     this.compositionInputToSuppress = data;
     this.compositionSuppressionTimer = window.setTimeout(() => {
@@ -1219,9 +1219,15 @@ export class GhosttyTerminalSurface {
       return;
     }
     this.clearCompositionInputSuppression();
-    if (data.length > 0) this.options.onData(data);
+    this.sendUserInput(data);
     this.input.value = "";
   };
+
+  private sendUserInput(data: string): void {
+    if (data.length === 0) return;
+    if (!this.isAtBottom()) this.scrollToBottom();
+    this.options.onData(data);
+  }
 
   private clearCompositionInputSuppression(): void {
     if (this.compositionSuppressionTimer !== null) {


### PR DESCRIPTION
When a user scrolled up in terminal history, typing or sending terminal input left the viewport behind the active prompt.

This returns the active terminal viewport to the bottom immediately before forwarding regular input or terminal shortcut input. The guard avoids extra redraws while the viewport is already active.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized terminal viewport behavior with an existing isAtBottom guard; no auth, data, or API changes.
> 
> **Overview**
> Fixes a UX bug where **scrolling up in scrollback** left the viewport on old output while the user typed or pasted, so the live prompt was off-screen.
> 
> **`GhosttyTerminalSurface`** now routes keyboard, paste, IME/composition, and clipboard-paste paths through a new **`sendUserInput`** helper that **scrolls to the bottom when the viewport is not already active** (`isAtBottom()` / `scrollToBottom()`), then forwards data via `onData`. Empty payloads are skipped in one place.
> 
> **`ThreadTerminalDrawer`** applies the same guard in **`sendTerminalInput`** (navigation/delete/clear shortcuts that write to the PTY without going through the surface input pipeline), so those actions also jump back to the latest output before sending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b141b72ea8d510644536e2daf88d0702af56935c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-scroll terminal to bottom on user input in `GhosttyTerminalSurface`
> - Adds `GhosttyTerminalSurface.sendUserInput(data)` helper that scrolls to bottom before forwarding data to `options.onData`, and routes all input paths (keyboard, paste, IME, generic) through it
> - Mirrors the same scroll-to-bottom behavior in `TerminalViewport.sendTerminalInput` before calling `writeTerminal`
> - Behavioral Change: all user-input events now force-scroll the terminal to the bottom before data is written; previously scrolled-back terminals would not jump to bottom on input
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b141b72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->