### PR TITLE
fix(terminal): mitigate limited Ghostty scrollback

### DIFF
--- a/apps/mobile/modules/t3-terminal/android/src/main/cpp/t3_terminal_jni.cpp
+++ b/apps/mobile/modules/t3-terminal/android/src/main/cpp/t3_terminal_jni.cpp
@@ -12,7 +12,7 @@ namespace {
 
 constexpr uint32_t kSnapshotMagic = 0x54563354;  // "T3VT" in little endian.
 constexpr uint16_t kSnapshotVersion = 1;
-constexpr size_t kMaxScrollbackRows = 10000;
+constexpr size_t kMaxScrollbackBytes = 32 * 1024 * 1024;
 
 enum CellFlag : uint16_t {
   kBold = 1 << 0,
@@ -205,7 +205,7 @@ Java_expo_modules_t3terminal_GhosttyBridge_nativeCreate(
   GhosttyTerminalOptions options = {
       .cols = static_cast<uint16_t>(std::clamp(cols, 1, 65535)),
       .rows = static_cast<uint16_t>(std::clamp(rows, 1, 65535)),
-      .max_scrollback = kMaxScrollbackRows,
+      .max_scrollback = kMaxScrollbackBytes,
   };
   if (ghostty_terminal_new(nullptr, &session->terminal, options) != GHOSTTY_SUCCESS ||
       ghostty_render_state_new(nullptr, &session->render_state) != GHOSTTY_SUCCESS ||

--- a/apps/web/src/terminal/ghostty/core.integration.test.ts
+++ b/apps/web/src/terminal/ghostty/core.integration.test.ts
@@ -1,0 +1,55 @@
+// @effect-diagnostics nodeBuiltinImport:off -- exercises the checked-in WASM artifacts.
+import * as NodeFS from "node:fs";
+import * as NodeURL from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { GhosttyTerminalCore, type GhosttyTheme } from "./core";
+
+vi.mock("./vendor/ghostty-vt.wasm?url", () => ({ default: "test://ghostty-vt.wasm" }));
+vi.mock("./vendor/ghostty-write-pty.wasm?url&no-inline", () => ({
+  default: "test://ghostty-write-pty.wasm",
+}));
+
+const testTheme: GhosttyTheme = {
+  foreground: { r: 255, g: 255, b: 255 },
+  background: { r: 0, g: 0, b: 0 },
+  cursor: { r: 255, g: 255, b: 255 },
+};
+
+const wasmPaths = {
+  "ghostty-vt.wasm": NodeURL.fileURLToPath(new URL("./vendor/ghostty-vt.wasm", import.meta.url)),
+  "ghostty-write-pty.wasm": NodeURL.fileURLToPath(
+    new URL("./vendor/ghostty-write-pty.wasm", import.meta.url),
+  ),
+} as const;
+
+async function serveVendoredWasm(input: string | URL | Request): Promise<Response> {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  const filename = Object.keys(wasmPaths).find((candidate) => url.includes(candidate));
+  if (!filename) return new Response(null, { status: 404 });
+
+  const bytes = NodeFS.readFileSync(wasmPaths[filename as keyof typeof wasmPaths]);
+  return new Response(Uint8Array.from(bytes).buffer);
+}
+
+describe("GhosttyTerminalCore", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("retains history through the app's configured scrollback budget", async () => {
+    vi.stubGlobal("fetch", serveVendoredWasm);
+    const core = await GhosttyTerminalCore.create(80, 10, 8, 16, testTheme, () => {});
+
+    try {
+      core.write(Array.from({ length: 1_200 }, (_, index) => `${index + 1}\r\n`).join(""));
+      const scrollbar = core.scrollbarState();
+      if (!scrollbar) throw new Error("libghostty-vt did not return scrollbar state");
+
+      // This scenario retained only 602 rows with the previous 10,000-byte
+      // configuration. The byte budget does not promise an exact row count.
+      expect(scrollbar.total - scrollbar.len).toBeGreaterThan(1_000);
+    } finally {
+      core.dispose();
+    }
+  });
+});

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -9,7 +9,7 @@ import { GhosttyRuntime, loadGhosttyRuntime } from "./runtime";
 
 const GHOSTTY_SUCCESS = 0;
 const GHOSTTY_OUT_OF_SPACE = -3;
-const MAX_SCROLLBACK_ROWS = 10_000;
+const MAX_SCROLLBACK_BYTES = 32 * 1024 * 1024;
 // wasm32 C ABI layout for GhosttyTerminalSelectionFormatOptions at the
 // libghostty-vt revision pinned alongside this module.
 const SELECTION_FORMAT_OPTIONS_SIZE = 16;
@@ -249,7 +249,12 @@ export class GhosttyTerminalCore {
     const options = this.runtime.alloc(optionsSize);
     this.runtime.setField(options, "GhosttyTerminalOptions", "cols", cols);
     this.runtime.setField(options, "GhosttyTerminalOptions", "rows", rows);
-    this.runtime.setField(options, "GhosttyTerminalOptions", "max_scrollback", MAX_SCROLLBACK_ROWS);
+    this.runtime.setField(
+      options,
+      "GhosttyTerminalOptions",
+      "max_scrollback",
+      MAX_SCROLLBACK_BYTES,
+    );
     this.terminalSlot = this.runtime.allocOpaque();
     const terminalResult = this.runtime.call("ghostty_terminal_new", 0, this.terminalSlot, options);
     this.runtime.free(options, optionsSize);

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -219,8 +219,9 @@ describe("vendored libghostty-vt WebAssembly", () => {
     const optionsView = new DataView(memory.buffer, options, 8);
     optionsView.setUint16(0, 80, true);
     optionsView.setUint16(2, 10, true);
-    // This is the value currently passed to the pinned ABI as max_scrollback.
-    optionsView.setUint32(4, 10_000, true);
+    // The pinned Ghostty generation interprets max_scrollback as bytes. Use
+    // the uncompressed per-terminal budget shared by T3's embedded surfaces.
+    optionsView.setUint32(4, 32 * 1024 * 1024, true);
 
     const terminalSlot = call("ghostty_wasm_alloc_opaque");
     expect(call("ghostty_terminal_new", 0, terminalSlot, options)).toBe(0);

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -204,6 +204,51 @@ describe("vendored libghostty-vt WebAssembly", () => {
     call("ghostty_wasm_free_u8_array", options, 8);
   });
 
+  it("retains substantial history without collapsing to Ghostty's minimum allocation", async () => {
+    const result = await WebAssembly.instantiate(
+      decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,
+      { env: { log: () => {} } },
+    );
+    const instance = result instanceof WebAssembly.Instance ? result : result.instance;
+    const memory = instance.exports.memory as WebAssembly.Memory;
+    const call = (name: string, ...args: number[]) =>
+      (instance.exports[name] as WasmFunction)(...args);
+    const alloc = (size: number) => call("ghostty_wasm_alloc_u8_array", size);
+
+    const options = alloc(8);
+    const optionsView = new DataView(memory.buffer, options, 8);
+    optionsView.setUint16(0, 80, true);
+    optionsView.setUint16(2, 10, true);
+    // This is the value currently passed to the pinned ABI as max_scrollback.
+    optionsView.setUint32(4, 10_000, true);
+
+    const terminalSlot = call("ghostty_wasm_alloc_opaque");
+    expect(call("ghostty_terminal_new", 0, terminalSlot, options)).toBe(0);
+    const terminal = new DataView(memory.buffer).getUint32(terminalSlot, true);
+    const input = new TextEncoder().encode(
+      Array.from({ length: 12_000 }, (_, index) => `${index + 1}\r\n`).join(""),
+    );
+    const inputPointer = alloc(input.length);
+    new Uint8Array(memory.buffer, inputPointer, input.length).set(input);
+    call("ghostty_terminal_vt_write", terminal, inputPointer, input.length);
+
+    const scrollbar = alloc(24);
+    expect(call("ghostty_terminal_get", terminal, 9, scrollbar)).toBe(0);
+    const retainedRows =
+      Number(new DataView(memory.buffer, scrollbar, 24).getBigUint64(0, true)) - 10;
+
+    call("ghostty_wasm_free_u8_array", scrollbar, 24);
+    call("ghostty_wasm_free_u8_array", inputPointer, input.length);
+    call("ghostty_terminal_free", terminal);
+    call("ghostty_wasm_free_opaque", terminalSlot);
+    call("ghostty_wasm_free_u8_array", options, 8);
+
+    // This representative width previously retained only 800 rows. The byte
+    // budget is not a promise of an exact row count, but it must avoid that
+    // minimum allocation and preserve substantially more useful history.
+    expect(retainedRows).toBeGreaterThan(8_000);
+  });
+
   it("routes terminal-generated replies through the shared callback table", async () => {
     const mainResult = await WebAssembly.instantiate(
       decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -1,11 +1,20 @@
+// @effect-diagnostics nodeBuiltinImport:off -- exercises the checked-in WASM artifacts.
+import * as NodeFS from "node:fs";
+import * as NodeURL from "node:url";
+
 import { describe, expect, it } from "vite-plus/test";
 
-import wasmDataUrl from "./vendor/ghostty-vt.wasm?inline";
-import writePtyWasmDataUrl from "./vendor/ghostty-write-pty.wasm?inline";
 import pinnedVersion from "../../../../../native/libghostty-vt/VERSION?raw";
 import { ghosttyKeyForCode } from "./keyCodes";
 
 type WasmFunction = (...args: number[]) => number;
+
+const wasmDataUrl = `data:application/wasm;base64,${NodeFS.readFileSync(
+  NodeURL.fileURLToPath(new URL("./vendor/ghostty-vt.wasm", import.meta.url)),
+).toString("base64")}`;
+const writePtyWasmDataUrl = `data:application/wasm;base64,${NodeFS.readFileSync(
+  NodeURL.fileURLToPath(new URL("./vendor/ghostty-write-pty.wasm", import.meta.url)),
+).toString("base64")}`;
 
 function decodeWasmDataUrl(dataUrl: string): Uint8Array {
   const encoded = dataUrl.split(",", 2)[1];


### PR DESCRIPTION
> A separate PR will provide the durable fix for #8701 by upgrading libghostty-vt and configuring independent line and byte limits. This smaller hotfix is intended to remove the immediate user impact while that larger change is reviewed.

Refs #8701

## Summary

T3 currently passes `10,000` as Ghostty's maximum scrollback value, treating it as a row count. The currently pinned Ghostty ABI interprets that value as bytes, causing terminals to retain very little history.

This hotfix works around the issue without changing the Ghostty ABI:

- Renames the web and Android constants to accurately describe bytes.
- Uses a 32 MiB (`33,554,432` byte) per-terminal budget for T3's uncompressed embedded paths.
- Applies the same value to web and Android.
- Keeps direct vendored-WASM regression coverage and adds a production-constructor regression through `GhosttyTerminalCore`.
- Verifies that an 80-column terminal retains substantially more history and no longer collapses to Ghostty's minimum allocation.

This is intentionally not a complete fix for #8701. A byte budget cannot guarantee exactly 10,000 retained rows because row memory usage varies with terminal width and content. The durable fix requires the newer Ghostty ABI with independent byte and line limits.

The 32 MiB cap did not undercut the intended history in the verified regression scenarios while preserving a deliberate per-terminal memory bound. It does not turn the byte-based ABI into a line guarantee.

This PR does not:

- Upgrade libghostty-vt.
- Rebuild vendored Ghostty artifacts.
- Add client/server scrollback configurability.
- Change application protocols or persisted settings.

## Verification

- The direct vendored-WASM regression confirms that an 80-column terminal retains substantially more than Ghostty's minimum allocation.
- The production-constructor regression exercises the app's configured budget through `GhosttyTerminalCore.create`, `write`, and `scrollbarState`; reverting only the production value to 10,000 bytes makes it fail with 602 retained rows.
- Both focused Ghostty test files pass: 11 tests in 301 ms of test execution.
- Targeted formatting, linting, web typechecking, and the web build pass.
- Desktop build and smoke test pass.
- Android typechecking, x86_64 native compilation, and the Android app build pass.
- The Android native fingerprint includes the changed JNI source.

The following 12,000-line scenario was exercised in real web, desktop, and Android terminals:

```sh
printf '\033c'; cols=$(tput cols 2>/dev/null || printf '?'); i=1; while [ "$i" -le 12000 ]; do printf 'T3-SCROLLBACK-%05d\n' "$i"; i=$((i+1)); done; printf 'T3-END cols=%s\n' "$cols"
```

Observed oldest retained lines:

| Surface | Width | Oldest line |
|---|---:|---|
| Web | 129 columns | `T3-SCROLLBACK-00001` |
| Desktop | 106 columns | `T3-SCROLLBACK-00001` |
| Android | 80 columns | `T3-SCROLLBACK-00001` |

These results demonstrate improved retention, not an exact row-count guarantee.

Model: GPT-5.6 Codex  
Harness: T3 Code
