### PR TITLE
fix(codex): keep live collab children from false watchdog interrupts

### DIFF
--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -65,7 +65,10 @@ function collabWaitCompletion(input: {
   } as const;
 }
 
-function agentMessageCompletion(id: string) {
+function agentMessageCompletion(
+  id: string,
+  input: { readonly threadId?: string; readonly turnId?: string } = {},
+) {
   return {
     method: "item/completed",
     params: {
@@ -74,8 +77,8 @@ function agentMessageCompletion(id: string) {
         id,
         text: "Still working.",
       },
-      threadId: ROOT,
-      turnId: wireFixture.responses.turnStart.turn.id,
+      threadId: input.threadId ?? ROOT,
+      turnId: input.turnId ?? wireFixture.responses.turnStart.turn.id,
       completedAtMs: 1_785_898_349_931,
     },
   } as const;
@@ -809,6 +812,76 @@ describe("CodexSessionRuntime collab integration", () => {
 
       yield* runtime.start();
       yield* runtime.sendTurn({ input: "ignore foreign waits, then stop the root loop" });
+      const guardEvents = yield* Fiber.join(guardEventFiber).pipe(Effect.timeout("2 seconds"));
+      assert.lengthOf(Array.from(guardEvents), 1);
+
+      const interrupted = NodeFS.readFileSync(interruptsPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as { threadId?: string; turnId?: string });
+      assert.deepEqual(interrupted, [
+        {
+          threadId: ROOT,
+          turnId: wireFixture.responses.turnStart.turn.id,
+        },
+      ]);
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("does not let unregistered foreign progress reset root empty waits", () =>
+    Effect.gen(function* () {
+      const foreignTurnId = "unregistered-foreign-turn";
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        notifications: [
+          collabWaitCompletion({ id: "root-empty-wait-interleaved-1" }),
+          agentMessageCompletion("foreign-progress-1", {
+            threadId: CHILD_A,
+            turnId: foreignTurnId,
+          }),
+          collabWaitCompletion({ id: "root-empty-wait-interleaved-2" }),
+          agentMessageCompletion("foreign-progress-2", {
+            threadId: CHILD_A,
+            turnId: foreignTurnId,
+          }),
+          collabWaitCompletion({ id: "root-empty-wait-interleaved-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-root-empty-waits-with-foreign-progress"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const guardEventFiber = yield* runtime.events.pipe(
+        Stream.filter(
+          (event) =>
+            event.method === "process/stderr" &&
+            event.message?.includes("three completed collaboration waits") === true,
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "ignore foreign progress while counting root waits" });
       const guardEvents = yield* Fiber.join(guardEventFiber).pipe(Effect.timeout("2 seconds"));
       assert.lengthOf(Array.from(guardEvents), 1);
 

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -36,6 +36,51 @@ const decodeMcpElicitationResponse = Schema.decodeUnknownEffect(
   ),
 );
 
+function collabWaitCompletion(input: {
+  readonly id: string;
+  readonly receiverThreadIds?: ReadonlyArray<string>;
+  readonly threadId?: string;
+  readonly turnId?: string;
+}) {
+  const threadId = input.threadId ?? ROOT;
+  return {
+    method: "item/completed",
+    params: {
+      item: {
+        type: "collabAgentToolCall",
+        id: input.id,
+        tool: "wait",
+        status: "completed",
+        senderThreadId: threadId,
+        receiverThreadIds: input.receiverThreadIds ?? [],
+        prompt: null,
+        model: null,
+        reasoningEffort: null,
+        agentsStates: {},
+      },
+      threadId,
+      turnId: input.turnId ?? wireFixture.responses.turnStart.turn.id,
+      completedAtMs: 1_785_898_349_931,
+    },
+  } as const;
+}
+
+function agentMessageCompletion(id: string) {
+  return {
+    method: "item/completed",
+    params: {
+      item: {
+        type: "agentMessage",
+        id,
+        text: "Still working.",
+      },
+      threadId: ROOT,
+      turnId: wireFixture.responses.turnStart.turn.id,
+      completedAtMs: 1_785_898_349_931,
+    },
+  } as const;
+}
+
 /**
  * The captured sequence, extended with the shapes the live capture didn't
  * include: a collabAgentToolCall with receiverThreadIds (feeds the legacy
@@ -648,6 +693,506 @@ describe("CodexSessionRuntime collab integration", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
+  it.live("interrupts a turn after three empty collaboration waits", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        notifications: [
+          collabWaitCompletion({ id: "empty-wait-1" }),
+          collabWaitCompletion({ id: "empty-wait-2" }),
+          collabWaitCompletion({ id: "empty-wait-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-collab-wait"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const guardEventFiber = yield* runtime.events.pipe(
+        Stream.filter(
+          (event) =>
+            event.method === "process/stderr" &&
+            event.message?.includes("three completed collaboration waits") === true,
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait without workers" });
+      const guardEvents = yield* Fiber.join(guardEventFiber).pipe(Effect.timeout("2 seconds"));
+      assert.lengthOf(Array.from(guardEvents), 1);
+
+      const interrupted = NodeFS.readFileSync(interruptsPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as { threadId?: string });
+      assert.deepEqual(
+        interrupted.map((entry) => entry.threadId),
+        [ROOT],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("ignores empty collaboration waits from an unregistered foreign child", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        notifications: [
+          collabWaitCompletion({
+            id: "foreign-empty-wait-1",
+            threadId: CHILD_A,
+            turnId: "foreign-turn-1",
+          }),
+          collabWaitCompletion({
+            id: "foreign-empty-wait-2",
+            threadId: CHILD_A,
+            turnId: "foreign-turn-1",
+          }),
+          collabWaitCompletion({
+            id: "foreign-empty-wait-3",
+            threadId: CHILD_A,
+            turnId: "foreign-turn-1",
+          }),
+          collabWaitCompletion({ id: "root-empty-wait-1" }),
+          collabWaitCompletion({ id: "root-empty-wait-2" }),
+          collabWaitCompletion({ id: "root-empty-wait-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-collab-wait-foreign-child"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const guardEventFiber = yield* runtime.events.pipe(
+        Stream.filter(
+          (event) =>
+            event.method === "process/stderr" &&
+            event.message?.includes("three completed collaboration waits") === true,
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "ignore foreign waits, then stop the root loop" });
+      const guardEvents = yield* Fiber.join(guardEventFiber).pipe(Effect.timeout("2 seconds"));
+      assert.lengthOf(Array.from(guardEvents), 1);
+
+      const interrupted = NodeFS.readFileSync(interruptsPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as { threadId?: string; turnId?: string });
+      assert.deepEqual(interrupted, [
+        {
+          threadId: ROOT,
+          turnId: wireFixture.responses.turnStart.turn.id,
+        },
+      ]);
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("does not accumulate empty waits across completed assistant messages", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [
+          collabWaitCompletion({ id: "empty-wait-1" }),
+          agentMessageCompletion("assistant-progress-1"),
+          collabWaitCompletion({ id: "empty-wait-2" }),
+          agentMessageCompletion("assistant-progress-2"),
+          collabWaitCompletion({ id: "empty-wait-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-wait-with-progress"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const completedFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "turn/completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait while reporting progress" });
+      yield* Fiber.join(completedFiber).pipe(Effect.timeout("2 seconds"));
+      assert.isFalse(NodeFS.existsSync(interruptsPath));
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("does not interrupt empty waits while a registered child turn is live", () =>
+    Effect.gen(function* () {
+      const captured = wireFixture.notifications;
+      const isTurnStarted = (entry: (typeof captured)[number], child: string) =>
+        entry.method === "turn/started" &&
+        (entry.params as { threadId?: string }).threadId === child;
+      const isRegistration = (entry: (typeof captured)[number], child: string) => {
+        const item = (entry.params as { item?: { type?: string; agentThreadId?: string } }).item;
+        return item?.type === "subAgentActivity" && item.agentThreadId === child;
+      };
+      const registeredChildTurn = captured.find((entry) => isTurnStarted(entry, CHILD_B));
+      const registeredChildActivity = captured.find((entry) => isRegistration(entry, CHILD_B));
+      assert.isDefined(registeredChildTurn);
+      assert.isDefined(registeredChildActivity);
+      if (registeredChildTurn === undefined || registeredChildActivity === undefined) {
+        return yield* Effect.die(
+          new Error("captured collaboration lifecycle fixture is incomplete"),
+        );
+      }
+
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [
+          registeredChildActivity,
+          registeredChildTurn,
+          collabWaitCompletion({ id: "empty-wait-with-live-child-1" }),
+          collabWaitCompletion({ id: "empty-wait-with-live-child-2" }),
+          collabWaitCompletion({ id: "empty-wait-with-live-child-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-wait-with-live-child"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const completedFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "turn/completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait while a registered child is still working" });
+      yield* Fiber.join(completedFiber).pipe(Effect.timeout("2 seconds"));
+      assert.isFalse(NodeFS.existsSync(interruptsPath));
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("does not interrupt when a live child registers after its turn starts", () =>
+    Effect.gen(function* () {
+      const captured = wireFixture.notifications;
+      const childTurnStarted = captured.find(
+        (entry) =>
+          entry.method === "turn/started" &&
+          (entry.params as { threadId?: string }).threadId === CHILD_A,
+      );
+      const childRegistration = captured.find((entry) => {
+        const item = (entry.params as { item?: { type?: string; agentThreadId?: string } }).item;
+        return item?.type === "subAgentActivity" && item.agentThreadId === CHILD_A;
+      });
+      assert.isDefined(childTurnStarted);
+      assert.isDefined(childRegistration);
+      if (childTurnStarted === undefined || childRegistration === undefined) {
+        return yield* Effect.die(
+          new Error("captured collaboration lifecycle fixture is incomplete"),
+        );
+      }
+
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [
+          childTurnStarted,
+          childRegistration,
+          collabWaitCompletion({ id: "empty-wait-after-late-registration-1" }),
+          collabWaitCompletion({ id: "empty-wait-after-late-registration-2" }),
+          collabWaitCompletion({ id: "empty-wait-after-late-registration-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-wait-after-late-child-registration"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const completedFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "turn/completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait after the live child registers late" });
+      yield* Fiber.join(completedFiber).pipe(Effect.timeout("2 seconds"));
+      assert.isFalse(NodeFS.existsSync(interruptsPath));
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("does not interrupt empty waits after a live child retryable error", () =>
+    Effect.gen(function* () {
+      const captured = wireFixture.notifications;
+      const childTurnStarted = captured.find(
+        (entry) =>
+          entry.method === "turn/started" &&
+          (entry.params as { threadId?: string }).threadId === CHILD_B,
+      );
+      const childRegistration = captured.find((entry) => {
+        const item = (entry.params as { item?: { type?: string; agentThreadId?: string } }).item;
+        return item?.type === "subAgentActivity" && item.agentThreadId === CHILD_B;
+      });
+      assert.isDefined(childTurnStarted);
+      assert.isDefined(childRegistration);
+      if (childTurnStarted === undefined || childRegistration === undefined) {
+        return yield* Effect.die(
+          new Error("captured collaboration lifecycle fixture is incomplete"),
+        );
+      }
+      const childTurnId = (childTurnStarted.params as { turn: { id: string } }).turn.id;
+
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [
+          childRegistration,
+          childTurnStarted,
+          {
+            method: "error",
+            params: {
+              threadId: CHILD_B,
+              turnId: childTurnId,
+              error: { message: "Reconnecting... 2/5" },
+              willRetry: true,
+            },
+          },
+          collabWaitCompletion({ id: "empty-wait-after-retryable-child-error-1" }),
+          collabWaitCompletion({ id: "empty-wait-after-retryable-child-error-2" }),
+          collabWaitCompletion({ id: "empty-wait-after-retryable-child-error-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-wait-after-retryable-child-error"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const completedFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "turn/completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait while the live child reconnects" });
+      yield* Fiber.join(completedFiber).pipe(Effect.timeout("2 seconds"));
+      assert.isFalse(NodeFS.existsSync(interruptsPath));
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("recovers when Stop bookkeeping only contains an unregistered stale child turn", () =>
+    Effect.gen(function* () {
+      const unregisteredChildTurn = wireFixture.notifications.find(
+        (entry) =>
+          entry.method === "turn/started" &&
+          (entry.params as { threadId?: string }).threadId === CHILD_A,
+      );
+      assert.isDefined(unregisteredChildTurn);
+      if (unregisteredChildTurn === undefined) {
+        return yield* Effect.die(
+          new Error("captured collaboration lifecycle fixture is incomplete"),
+        );
+      }
+
+      const script = {
+        rootThreadId: ROOT,
+        holdTurnOpen: true,
+        notifications: [
+          unregisteredChildTurn,
+          collabWaitCompletion({ id: "empty-wait-after-stale-child-1" }),
+          collabWaitCompletion({ id: "empty-wait-after-stale-child-2" }),
+          collabWaitCompletion({ id: "empty-wait-after-stale-child-3" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-wait-with-unregistered-stale-child"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const guardEventFiber = yield* runtime.events.pipe(
+        Stream.filter(
+          (event) =>
+            event.method === "process/stderr" &&
+            event.message?.includes("three completed collaboration waits") === true,
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait after unregistered stale child lifecycle" });
+      const guardEvents = yield* Fiber.join(guardEventFiber).pipe(Effect.timeout("2 seconds"));
+      assert.lengthOf(Array.from(guardEvents), 1);
+
+      const interrupted = NodeFS.readFileSync(interruptsPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as { threadId?: string });
+      assert.deepEqual(
+        interrupted.map((entry) => entry.threadId),
+        [ROOT],
+      );
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("resets empty collaboration waits when a receiver appears", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [
+          collabWaitCompletion({ id: "empty-wait-1" }),
+          collabWaitCompletion({ id: "empty-wait-2" }),
+          collabWaitCompletion({ id: "receiver-wait", receiverThreadIds: [CHILD_A] }),
+          collabWaitCompletion({ id: "empty-wait-3" }),
+          collabWaitCompletion({ id: "empty-wait-4" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-collab-wait-reset"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const completedFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "turn/completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "wait for a real receiver" });
+      yield* Fiber.join(completedFiber).pipe(Effect.timeout("2 seconds"));
+      assert.isFalse(NodeFS.existsSync(interruptsPath));
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
   const elicitationCases = [
     {
       decision: "accept",

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -874,6 +874,52 @@ describe("CodexSessionRuntime collab integration", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
+  it.live("restarts empty-wait counting after root child activity", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [
+          collabWaitCompletion({ id: "empty-wait-before-child-activity-1" }),
+          collabWaitCompletion({ id: "empty-wait-before-child-activity-2" }),
+          capturedStartedActivity(),
+          collabWaitCompletion({ id: "empty-wait-after-child-activity-1" }),
+          collabWaitCompletion({ id: "empty-wait-after-child-activity-2" }),
+        ],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      const interruptsPath = `${scriptPath}.interrupts`;
+      NodeFS.rmSync(interruptsPath, { force: true });
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+          NodeFS.rmSync(interruptsPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-empty-wait-reset-by-child-activity"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const completedFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "turn/completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      yield* runtime.sendTurn({ input: "reset empty waits after child activity" });
+      yield* Fiber.join(completedFiber).pipe(Effect.timeout("2 seconds"));
+      assert.isFalse(NodeFS.existsSync(interruptsPath));
+
+      yield* runtime.close;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.live("does not interrupt empty waits while a registered child turn is live", () =>
     Effect.gen(function* () {
       const captured = wireFixture.notifications;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -1935,10 +1935,11 @@ export const makeCodexSessionRuntime = (
             }
           }
         } else if (
-          completedEmptyCollabWait ||
-          notification.method === "turn/started" ||
-          notification.method === "turn/completed" ||
-          isMeaningfulItemCompletion(notification)
+          rootConversation &&
+          (completedEmptyCollabWait ||
+            notification.method === "turn/started" ||
+            notification.method === "turn/completed" ||
+            isMeaningfulItemCompletion(notification))
         ) {
           yield* Ref.set(emptyCollabWaitGuardRef, {
             turnId: activeTurnId,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -1788,6 +1788,23 @@ export const makeCodexSessionRuntime = (
         // become synthetic collabAgent events (review finding). The
         // suppressor still covers UNREGISTERED children.
         if (yield* interceptCollabChildNotification(notification)) {
+          // A root-side subAgentActivity completion is meaningful parent-turn
+          // progress, but interception consumes it before the general guard
+          // reset below. Reset here so waits completed before a child activity
+          // cannot contribute to the next empty-wait sequence. Keep foreign
+          // child activity isolated from the root watchdog.
+          const interceptedSession = yield* Ref.get(sessionRef);
+          const interceptedProviderThreadId = currentProviderThreadId(interceptedSession);
+          const interceptedRootConversation =
+            notificationProviderThreadId === undefined ||
+            notificationProviderThreadId === interceptedProviderThreadId;
+          if (interceptedRootConversation && isMeaningfulItemCompletion(notification)) {
+            yield* Ref.set(emptyCollabWaitGuardRef, {
+              turnId: route.turnId ?? interceptedSession.activeTurnId ?? null,
+              completedWaits: 0,
+              interruptRequested: false,
+            });
+          }
           yield* Ref.set(collabReceiverTurnsRef, collabReceiverTurns);
           return;
         }

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -53,6 +53,14 @@ const BENIGN_ERROR_LOG_SNIPPETS = [
   "state db record_discrepancy: find_thread_path_by_id_str_in_subdir, falling_back",
 ];
 const CODEX_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
+// A child can settle while a wait request is in flight. Two consecutive empty
+// completions absorb that race; a third provider-confirmed empty result is a
+// liveness failure only when no registered child still has a live turn. The
+// live-turn map also contains unregistered foreign threads for Stop safety, so
+// intersect it with the registered-child map before using it as a liveness
+// signal.
+const EMPTY_COLLAB_WAIT_INTERRUPT_THRESHOLD = 3;
+const EMPTY_COLLAB_WAIT_INTERRUPT_TIMEOUT = "5 seconds" as const;
 const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "not found",
   "missing thread",
@@ -468,6 +476,37 @@ function makeCodexServerNotification<M extends CodexRpc.ServerNotificationMethod
   params: CodexRpc.ServerNotificationParamsByMethod[M],
 ): CodexServerNotification {
   return { method, params } as CodexServerNotification;
+}
+
+interface EmptyCollabWaitGuardState {
+  readonly turnId: TurnId | null;
+  readonly completedWaits: number;
+  readonly interruptRequested: boolean;
+}
+
+function isCompletedEmptyCollabWait(notification: CodexServerNotification): boolean {
+  if (notification.method !== "item/completed") {
+    return false;
+  }
+  const item = notification.params.item;
+  return (
+    item.type === "collabAgentToolCall" &&
+    item.tool === "wait" &&
+    item.status === "completed" &&
+    item.receiverThreadIds.length === 0 &&
+    Object.keys(item.agentsStates).length === 0
+  );
+}
+
+function isMeaningfulItemCompletion(notification: CodexServerNotification): boolean {
+  if (notification.method !== "item/completed") {
+    return false;
+  }
+  const item = notification.params.item;
+  if (item.type === "reasoning") {
+    return false;
+  }
+  return !isCompletedEmptyCollabWait(notification);
 }
 
 function normalizeCodexModelSlug(
@@ -1241,6 +1280,11 @@ export const makeCodexSessionRuntime = (
       updatedAt: sessionCreatedAt,
     } satisfies ProviderSession;
     const sessionRef = yield* Ref.make<ProviderSession>(initialSession);
+    const emptyCollabWaitGuardRef = yield* Ref.make<EmptyCollabWaitGuardState>({
+      turnId: null,
+      completedWaits: 0,
+      interruptRequested: false,
+    });
     const offerEvent = (event: ProviderEvent) => Queue.offer(events, event).pipe(Effect.asVoid);
 
     const emitEvent = (event: Omit<ProviderEvent, "id" | "provider" | "createdAt">) =>
@@ -1730,10 +1774,10 @@ export const makeCodexSessionRuntime = (
         const payload = notification.params;
         const route = readRouteFields(notification);
         const collabReceiverTurns = yield* Ref.get(collabReceiverTurnsRef);
+        const notificationProviderThreadId = readNotificationThreadId(notification);
         const childParentTurnId = (() => {
-          const providerConversationId = readNotificationThreadId(notification);
-          return providerConversationId
-            ? collabReceiverTurns.get(providerConversationId)
+          return notificationProviderThreadId
+            ? collabReceiverTurns.get(notificationProviderThreadId)
             : undefined;
         })();
 
@@ -1757,11 +1801,10 @@ export const makeCodexSessionRuntime = (
         // root's own early notifications flowing during session open.
         const suppressRootId = currentProviderThreadId(yield* Ref.get(sessionRef));
         const foreignConversation = (() => {
-          const providerConversationId = readNotificationThreadId(notification);
           return (
-            providerConversationId !== undefined &&
+            notificationProviderThreadId !== undefined &&
             suppressRootId !== undefined &&
-            providerConversationId !== suppressRootId
+            notificationProviderThreadId !== suppressRootId
           );
         })();
         if (
@@ -1775,7 +1818,7 @@ export const makeCodexSessionRuntime = (
           // Stop (review finding). Track live turns for ANY foreign
           // conversation; interrupts are best-effort per child, so a
           // false-positive entry costs one ignored RPC at worst.
-          const foreignThreadId = readNotificationThreadId(notification);
+          const foreignThreadId = notificationProviderThreadId;
           if (foreignThreadId !== undefined) {
             if (notification.method === "turn/started") {
               const foreignTurnId =
@@ -1806,6 +1849,85 @@ export const makeCodexSessionRuntime = (
 
         if (isMemoryConsolidationNotification) {
           return;
+        }
+
+        const session = yield* Ref.get(sessionRef);
+        const activeTurnId = childParentTurnId ?? route.turnId ?? session.activeTurnId ?? null;
+        const providerThreadId = currentProviderThreadId(session);
+        const completedEmptyCollabWait = isCompletedEmptyCollabWait(notification);
+        let hasRegisteredLiveCollabChild = false;
+        if (completedEmptyCollabWait) {
+          const liveChildTurns = yield* Ref.get(collabChildLiveTurnsRef);
+          const registeredChildren = yield* Ref.get(collabChildAgentsRef);
+          hasRegisteredLiveCollabChild = Array.from(liveChildTurns.keys()).some((threadId) =>
+            registeredChildren.has(threadId),
+          );
+        }
+        const rootConversation =
+          notificationProviderThreadId === undefined ||
+          notificationProviderThreadId === providerThreadId;
+        if (
+          completedEmptyCollabWait &&
+          !hasRegisteredLiveCollabChild &&
+          rootConversation &&
+          activeTurnId !== null &&
+          providerThreadId !== undefined
+        ) {
+          const shouldInterrupt = yield* Ref.modify(emptyCollabWaitGuardRef, (current) => {
+            if (current.turnId === activeTurnId && current.interruptRequested) {
+              return [false, current] as const;
+            }
+            const completedWaits = current.turnId === activeTurnId ? current.completedWaits + 1 : 1;
+            const interruptRequested = completedWaits >= EMPTY_COLLAB_WAIT_INTERRUPT_THRESHOLD;
+            return [
+              interruptRequested,
+              {
+                turnId: activeTurnId,
+                completedWaits,
+                interruptRequested,
+              },
+            ] as const;
+          });
+          if (shouldInterrupt) {
+            const interruptExit = yield* client
+              .request("turn/interrupt", {
+                threadId: providerThreadId,
+                turnId: activeTurnId,
+              })
+              .pipe(Effect.timeout(EMPTY_COLLAB_WAIT_INTERRUPT_TIMEOUT), Effect.exit);
+            if (Exit.isFailure(interruptExit)) {
+              yield* Ref.set(emptyCollabWaitGuardRef, {
+                turnId: activeTurnId,
+                completedWaits: 0,
+                interruptRequested: false,
+              });
+              yield* Effect.logWarning("Failed to interrupt an empty collaboration-wait loop.", {
+                threadId: options.threadId,
+                turnId: activeTurnId,
+                cause: interruptExit.cause,
+              });
+            } else {
+              yield* emitEvent({
+                kind: "notification",
+                threadId: options.threadId,
+                turnId: activeTurnId,
+                method: "process/stderr",
+                message:
+                  "Interrupted a stalled Codex turn after three completed collaboration waits reported no active agents.",
+              });
+            }
+          }
+        } else if (
+          completedEmptyCollabWait ||
+          notification.method === "turn/started" ||
+          notification.method === "turn/completed" ||
+          isMeaningfulItemCompletion(notification)
+        ) {
+          yield* Ref.set(emptyCollabWaitGuardRef, {
+            turnId: activeTurnId,
+            completedWaits: 0,
+            interruptRequested: false,
+          });
         }
 
         let requestId: ApprovalRequestId | undefined;


### PR DESCRIPTION
## Summary

Prevent false watchdog interrupts while Codex collaboration children are still live.

- interrupt only after three provider-confirmed empty collaboration waits
- scope the guard to the root turn and the current provider thread
- protect registered live child turns, including late registration and retryable-error races
- reset the guard on meaningful progress, receiver activity, and turn boundaries
- keep Stop bookkeeping for foreign child turns without treating stale/unregistered turns as live work

## Validation

- focused Codex collaboration integration tests: 19/19 passed
- server typecheck: passed
- scoped formatter and lint checks: passed
- git diff --check: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Codex root turns are forcibly interrupted during multi-agent collaboration; incorrect liveness detection could interrupt active work or leave a stalled turn running if `turn/interrupt` times out.
> 
> **Overview**
> Adds an **empty collaboration-wait watchdog** in `CodexSessionRuntime` so root turns that keep completing `collabAgentToolCall` **wait** with no receivers and no agent state can be stopped instead of spinning forever.
> 
> The runtime counts **three consecutive** provider-confirmed empty waits on the **root thread and active turn**, then issues **`turn/interrupt`** (5s timeout) and emits a **`process/stderr`** notice. Interrupts are **skipped** when any **registered** child still has a live turn in the live-turn map (including late registration and retryable child errors). **Unregistered foreign** child waits and progress do not reset or satisfy the root counter.
> 
> The guard **resets** on meaningful root completions (e.g. agent messages), turn start/complete, receiver-bearing waits, and root-side child activity handled during interception. Integration tests script these sequences via new `collabWaitCompletion` / `agentMessageCompletion` helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49eb874eaba36cc4c803eec3e828e9e79e788f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Interrupt root turns after `3` consecutive empty collab waits in `CodexSessionRuntime`
> - Adds an empty-collab-wait guard to `makeCodexSessionRuntime` that counts consecutive completed `collabAgentToolCall` wait notifications with empty `receiverThreadIds` and no `agentsStates` during an active root turn
> - After `EMPTY_COLLAB_WAIT_INTERRUPT_THRESHOLD` (3) such waits with no registered live collab child, sends `turn/interrupt` (5s timeout) and emits a `process/stderr` event describing the interruption
> - Meaningful progress (assistant messages, child activity, turn boundaries, or waits with receivers) resets the counter; foreign/unregistered child activity is ignored for the root guard
> - Adds extensive integration tests in `CodexCollabRuntime.integration.test.ts` covering interrupt, reset, and no-interrupt scenarios
> - Behavioral Change: `handleRawNotification` now intercepts and may interrupt root turns that previously ran indefinitely on repeated empty waits; check `EMPTY_COLLAB_WAIT_INTERRUPT_THRESHOLD` and the `emptyCollabWaitGuardRef` reset logic in [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/8768/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49eb874.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->