### PR TITLE
fix(cursor): populate $ picker from filesystem skills

### DIFF
--- a/apps/server/src/provider/Drivers/CursorSkills.test.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.test.ts
@@ -1,0 +1,191 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverCursorSkills } from "./CursorSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  directoryName: string,
+  contents: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDir = path.join(skillsDir, directoryName);
+  yield* fs.makeDirectory(skillDir, { recursive: true });
+  yield* fs.writeFileString(path.join(skillDir, "SKILL.md"), contents);
+});
+
+it.layer(NodeServices.layer)("discoverCursorSkills", (it) => {
+  it.effect("discovers user skills with frontmatter metadata", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const homeDir = path.join(tempDir, "home");
+
+      yield* writeSkill(
+        path.join(homeDir, ".cursor", "skills"),
+        "codex-review",
+        [
+          "---",
+          "name: codex-review",
+          "description: Ask Codex for a review.",
+          "---",
+          "",
+          "# Body",
+        ].join("\n"),
+      );
+
+      const skills = yield* discoverCursorSkills({ homeDir });
+
+      assert.deepEqual(skills, [
+        {
+          name: "codex-review",
+          path: path.join(homeDir, ".cursor", "skills", "codex-review", "SKILL.md"),
+          enabled: true,
+          scope: "user",
+          description: "Ask Codex for a review.",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("discovers project skills from workspace .cursor and .agents directories", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const homeDir = path.join(tempDir, "home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(workspace, ".cursor", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Deploy the app.", "---", "", "# Deploy"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "review",
+        ["---", "name: review", "description: Review the changes.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverCursorSkills({ homeDir, cwd: workspace });
+
+      assert.deepEqual(skills, [
+        {
+          name: "deploy",
+          path: path.join(workspace, ".cursor", "skills", "deploy", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Deploy the app.",
+        },
+        {
+          name: "review",
+          path: path.join(workspace, ".agents", "skills", "review", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Review the changes.",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("prefers later roots on name collisions across user and project scopes", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const homeDir = path.join(tempDir, "home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(homeDir, ".claude", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Claude home deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(homeDir, ".omp", "agent", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: OMP deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(homeDir, ".agents", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Agents home deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(homeDir, ".cursor", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Cursor home deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".agents", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Agents project deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".cursor", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Cursor project deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".claude", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Claude project deploy.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverCursorSkills({ homeDir, cwd: workspace });
+
+      assert.deepEqual(skills, [
+        {
+          name: "deploy",
+          path: path.join(workspace, ".claude", "skills", "deploy", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Claude project deploy.",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("falls back to the directory name and skips malformed frontmatter", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const homeDir = path.join(tempDir, "home");
+      const skillsDir = path.join(homeDir, ".cursor", "skills");
+
+      yield* writeSkill(skillsDir, "no-frontmatter", "# Just a heading\n");
+      yield* writeSkill(skillsDir, "broken-yaml", "---\nname: [unclosed\n---\n");
+      yield* fs.makeDirectory(skillsDir, { recursive: true });
+      yield* fs.writeFileString(path.join(skillsDir, "README.md"), "not a skill");
+
+      const skills = yield* discoverCursorSkills({ homeDir });
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["no-frontmatter"],
+      );
+      assert.equal(skills[0]?.description, undefined);
+    }),
+  );
+
+  it.effect("returns an empty list when no skill roots exist", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+
+      const skills = yield* discoverCursorSkills({
+        homeDir: path.join(tempDir, "missing-home"),
+        cwd: path.join(tempDir, "missing-workspace"),
+      });
+
+      assert.deepEqual(skills, []);
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -1,0 +1,121 @@
+/**
+ * CursorSkills — filesystem discovery of Cursor agent skills for the `$` picker.
+ *
+ * Cursor loads skills from the same on-disk locations as Claude Code and related
+ * harnesses: user-scope roots under the home directory, then project-scope roots
+ * under the workspace cwd. Each skill is one directory with a `SKILL.md` file
+ * carrying YAML frontmatter. Later roots win on name collisions.
+ *
+ * @module provider/Drivers/CursorSkills
+ */
+import * as NodeOS from "node:os";
+
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { parse as parseYamlDocument } from "yaml";
+
+type CursorSkillScope = "user" | "project";
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+type SkillFrontmatter =
+  | { readonly kind: "missing" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "parsed"; readonly name?: string; readonly description?: string };
+
+function parseSkillFrontmatter(contents: string): SkillFrontmatter {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  if (!match) {
+    return { kind: "missing" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYamlDocument(match[1] ?? "");
+  } catch {
+    return { kind: "malformed" };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { kind: "malformed" };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  const description = typeof record.description === "string" ? record.description.trim() : "";
+  return {
+    kind: "parsed",
+    ...(name ? { name } : {}),
+    ...(description ? { description } : {}),
+  };
+}
+
+/**
+ * Enumerate Cursor skills from user and project skill roots. Discovery is
+ * best-effort: unreadable roots and malformed skill entries are skipped so a
+ * broken skill never degrades the provider snapshot. On name collisions, later
+ * roots win.
+ */
+export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* (options?: {
+  readonly homeDir?: string;
+  readonly cwd?: string;
+}): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const homeDir = options?.homeDir ?? NodeOS.homedir();
+  const cwd = options?.cwd;
+
+  const roots: ReadonlyArray<{ directory: string; scope: CursorSkillScope }> = [
+    { directory: path.join(homeDir, ".claude", "skills"), scope: "user" },
+    { directory: path.join(homeDir, ".omp", "agent", "skills"), scope: "user" },
+    { directory: path.join(homeDir, ".agents", "skills"), scope: "user" },
+    { directory: path.join(homeDir, ".cursor", "skills"), scope: "user" },
+    ...(cwd
+      ? [
+          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".cursor", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
+        ]
+      : []),
+  ];
+
+  const skillsByName = new Map<string, ServerProviderSkill>();
+  for (const root of roots) {
+    const entries = yield* fileSystem
+      .readDirectory(root.directory)
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+    for (const entry of [...entries].sort()) {
+      const skillPath = path.join(root.directory, entry, "SKILL.md");
+      const contents = yield* fileSystem
+        .readFileString(skillPath)
+        .pipe(Effect.orElseSucceed(() => undefined));
+      if (contents === undefined) {
+        continue;
+      }
+
+      const frontmatter = parseSkillFrontmatter(contents);
+      if (frontmatter.kind === "malformed") {
+        continue;
+      }
+
+      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
+      if (!name) {
+        continue;
+      }
+
+      skillsByName.set(name, {
+        name,
+        path: skillPath,
+        enabled: true,
+        scope: root.scope,
+        ...(frontmatter.kind === "parsed" && frontmatter.description
+          ? { description: frontmatter.description }
+          : {}),
+      });
+    }
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+});

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -369,6 +369,39 @@ describe("buildCursorProviderSnapshot", () => {
       ],
     });
   });
+
+  it("forwards a provided skills array onto the snapshot", () => {
+    expect(
+      buildCursorProviderSnapshot({
+        checkedAt: "2026-01-01T00:00:00.000Z",
+        cursorSettings: baseCursorSettings,
+        parsed: {
+          version: "2026.04.09-f2b0fcd",
+          status: "ready",
+          auth: { status: "authenticated", email: "cursor@example.com" },
+        },
+        skills: [
+          {
+            name: "review",
+            path: "/tmp/skills/review/SKILL.md",
+            enabled: true,
+            scope: "user",
+            description: "Review the changes.",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      skills: [
+        {
+          name: "review",
+          path: "/tmp/skills/review/SKILL.md",
+          enabled: true,
+          scope: "user",
+          description: "Review the changes.",
+        },
+      ],
+    });
+  });
 });
 
 describe("buildCursorCapabilitiesFromConfigOptions", () => {

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -6,6 +6,7 @@ import type {
   ServerProvider,
   ServerProviderAuth,
   ServerProviderModel,
+  ServerProviderSkill,
   ServerProviderState,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
@@ -46,6 +47,7 @@ import {
 } from "../providerMaintenance.ts";
 import * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import { CursorListAvailableModelsResponse } from "../acp/CursorAcpExtension.ts";
+import { discoverCursorSkills } from "../Drivers/CursorSkills.ts";
 
 const decodeCursorListAvailableModelsResponse = Schema.decodeUnknownEffect(
   CursorListAvailableModelsResponse,
@@ -628,6 +630,7 @@ export function buildCursorProviderSnapshot(input: {
   readonly parsed: CursorAboutResult;
   readonly discoveredModels?: ReadonlyArray<ServerProviderModel>;
   readonly discoveryWarning?: string;
+  readonly skills?: ReadonlyArray<ServerProviderSkill>;
 }): ServerProviderDraft {
   const message = joinProviderMessages(input.parsed.message, input.discoveryWarning);
   return buildServerProvider({
@@ -639,6 +642,7 @@ export function buildCursorProviderSnapshot(input: {
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
     ),
+    skills: input.skills ?? [],
     probe: {
       installed: true,
       version: input.parsed.version,
@@ -1001,6 +1005,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: false,
       checkedAt,
       models: fallbackModels,
+      skills: [],
       probe: {
         installed: false,
         version: null,
@@ -1010,6 +1015,8 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       },
     });
   }
+
+  const skills = yield* discoverCursorSkills({ cwd: process.cwd() });
 
   // Single `agent about` probe: returns version + auth status in one call.
   const aboutProbe = yield* runCursorAboutCommand(cursorSettings, environment).pipe(
@@ -1027,6 +1034,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: !isCommandMissingCause(error),
         version: null,
@@ -1045,6 +1053,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version: null,
@@ -1068,6 +1077,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version: parsed.version,
@@ -1109,6 +1119,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       Option.filter(discoveredModels, (models) => models.length > 0),
       () => [] as const,
     ),
+    skills,
     ...(discoveryWarning ? { discoveryWarning } : {}),
   });
 });


### PR DESCRIPTION
## What Changed

Cursor provider snapshots now scan on-disk skill roots and put the result on `skills`, so the composer `$` picker is no longer empty for `driver: cursor`.

New `discoverCursorSkills` (same shape as `discoverClaudeSkills`):

- User: `~/.claude/skills`, `~/.omp/agent/skills`, `~/.agents/skills`, `~/.cursor/skills`
- Project (when cwd is set): `.agents/skills`, `.cursor/skills`, `.claude/skills`
- Flat `SKILL.md` + YAML frontmatter; later roots win on name; missing/malformed skipped

`checkCursorProviderStatus` attaches that list on ready, timeout, and error paths. Disabled stays `[]`.

Custom Cursor-driver instances (for example an omp ACP shim) get the same snapshot, because they share this driver.

## Why

Claude, Grok, and OpenCode already fill `$`. Cursor does not: `cursor-agent` has no inspect/catalog API T3 reads, and `CursorProvider` never scanned the filesystem.

That is pingdotgg/t3code#2736 for Cursor. Grok/OpenCode were covered later (`grok inspect`, OpenCode SDK). This is the Cursor half, using the same filesystem approach as Claude.

Missing directories are a no-op, so extra roots (including `~/.omp/agent/skills`) do not affect a default Cursor install.

Fixes #2736

## UI Changes

The existing `$` picker renders `provider.skills`. No new chrome, layout, or animation. I did not attach a screenshot; the picker UI is unchanged and only its data source is filled.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a — picker UI unchanged)
- [x] I included a video for animation/interaction changes (n/a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only filesystem discovery added to provider snapshots; no auth, payment, or session logic changes.
> 
> **Overview**
> Cursor provider snapshots now **include discovered skills** so the composer `$` picker is populated for the Cursor driver, matching other providers that already expose on-disk skills.
> 
> A new **`discoverCursorSkills`** module scans user and project skill roots (`.cursor`, `.agents`, `.claude`, and `~/.omp/agent/skills`), reads each folder’s `SKILL.md` with YAML frontmatter, and merges results with **later roots winning** on name collisions. Malformed or missing entries are skipped without failing the snapshot.
> 
> **`checkCursorProviderStatus`** and **`buildCursorProviderSnapshot`** attach that list on every enabled path (ready, CLI errors, timeouts); disabled Cursor still reports `skills: []`. Vitests cover discovery behavior and snapshot forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e5f186bbfabbdecf2f901c70d879cc587f742c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Populate `$ picker` with filesystem-discovered Cursor skills
> - Adds `discoverCursorSkills` effect that scans predefined user roots (`~/.cursor/skills`, `~/.claude/skills`, `~/.agents/skills`, `~/.omp/agent/skills`) and project roots (`.cursor/skills`, `.claude/skills`, `.agents/skills` under cwd) for `SKILL.md` files
> - Adds `parseSkillFrontmatter` util to extract `name` and `description` from YAML frontmatter; falls back to directory name when frontmatter is missing or malformed
> - Skills are keyed by name in a `Map` so later roots override earlier collisions; results are sorted by name with `enabled=true` and scope set per root
> - Threads the discovered skills array into `buildCursorProviderSnapshot` and all branches of `checkCursorProviderStatus` (disabled provider returns `skills: []`)
> - Risk: `checkCursorProviderStatus` now performs filesystem reads on every status check; unreadable directories or malformed frontmatter are silently skipped, so a corrupt `SKILL.md` will not surface as an error
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12e5f18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->