### PR TITLE
fix(web): remove stale action keybindings

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -439,18 +439,23 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
-  it.effect("removes only the targeted custom keybinding", () =>
+  it.effect("removes semantically equivalent custom keybinding targets", () =>
     Effect.gen(function* () {
       const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
       yield* writeKeybindingsConfig(keybindingsConfigPath, [
-        { key: "mod+r", command: "script.run-tests.run" },
+        {
+          key: "option+r",
+          command: "script.run-tests.run",
+          when: "terminalFocus&&(!terminalOpen)",
+        },
         { key: "mod+shift+r", command: "script.run-tests.run" },
       ]);
       yield* Effect.gen(function* () {
         const keybindings = yield* Keybindings.Keybindings;
         return yield* keybindings.removeKeybindingRule({
-          key: "mod+r",
+          key: "alt+r",
           command: "script.run-tests.run",
+          when: "terminalFocus && !terminalOpen",
         });
       });
 

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -101,19 +101,19 @@ export const ResolvedKeybindingsFromConfig = Schema.Array(ResolvedKeybindingFrom
 );
 
 function isSameKeybindingRule(left: KeybindingRule, right: KeybindingRule): boolean {
-  return (
-    left.command === right.command &&
-    left.key === right.key &&
-    (left.when ?? undefined) === (right.when ?? undefined)
-  );
+  if (left.command !== right.command) return false;
+  const leftContext = keybindingShortcutContext(left);
+  const rightContext = keybindingShortcutContext(right);
+  return leftContext !== null && leftContext === rightContext;
 }
 
 function keybindingShortcutContext(rule: KeybindingRule): string | null {
-  const parsed = parseKeybindingShortcut(rule.key);
-  if (!parsed) return null;
-  const encoded = encodeShortcut(parsed);
+  const resolved = compileResolvedKeybindingRule(rule);
+  if (!resolved) return null;
+  const encoded = encodeShortcut(resolved.shortcut);
   if (!encoded) return null;
-  return `${encoded}\u0000${rule.when ?? ""}`;
+  const when = resolved.whenAst ? encodeWhenAst(resolved.whenAst) : "";
+  return `${encoded}\u0000${when}`;
 }
 
 function hasSameShortcutContext(left: KeybindingRule, right: KeybindingRule): boolean {

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -2,24 +2,22 @@ import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   useEffect,
-  useMemo,
   useState,
   useSyncExternalStore,
   type CSSProperties,
   type ReactNode,
 } from "react";
-import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
-import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useLocation, useNavigate } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
 import { getLocalStorageItem, removeLocalStorageItem } from "../hooks/useLocalStorage";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
-import { primaryServerKeybindingsAtom, serverEnvironment } from "../state/server";
-import { useComposerDraftStore } from "../composerDraftStore";
-import { mergeProjectScriptKeybindings } from "../lib/projectScriptKeybindings";
-import { hasChatSidebarShortcutClaim } from "../sidebarShortcutBus";
-import { resolveThreadRouteTarget } from "../threadRoutes";
+import { primaryServerKeybindingsAtom } from "../state/server";
+import {
+  readChatSidebarShortcutKeybindings,
+  subscribeChatSidebarShortcut,
+} from "../sidebarShortcutBus";
 import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
@@ -72,21 +70,12 @@ function readInitialThreadSidebarWidth(): number {
 
 function SidebarControl() {
   const primaryKeybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const routeTarget = useParams({ strict: false, select: resolveThreadRouteTarget });
-  const routeEnvironmentId = useComposerDraftStore((store) =>
-    routeTarget?.kind === "server"
-      ? routeTarget.threadRef.environmentId
-      : routeTarget?.kind === "draft"
-        ? (store.getDraftSession(routeTarget.draftId)?.environmentId ?? null)
-        : null,
+  const chatKeybindings = useSyncExternalStore(
+    subscribeChatSidebarShortcut,
+    readChatSidebarShortcutKeybindings,
+    () => null,
   );
-  const environmentKeybindings =
-    useAtomValue(serverEnvironment.configValueAtom(routeEnvironmentId))?.keybindings ??
-    DEFAULT_RESOLVED_KEYBINDINGS;
-  const keybindings = useMemo(
-    () => mergeProjectScriptKeybindings(primaryKeybindings, environmentKeybindings),
-    [environmentKeybindings, primaryKeybindings],
-  );
+  const keybindings = chatKeybindings ?? primaryKeybindings;
   const { toggleSidebar } = useSidebar();
   const isSidebarVisible = useSidebarVisibility();
   const environmentIdentificationMode = useEnvironmentIdentificationMode();
@@ -97,7 +86,7 @@ function SidebarControl() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (hasChatSidebarShortcutClaim() || event.defaultPrevented) return;
+      if (readChatSidebarShortcutKeybindings() !== null || event.defaultPrevented) return;
       if (
         event.target instanceof HTMLElement &&
         event.target.closest("[data-keybinding-capture]")

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -2,18 +2,23 @@ import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   useEffect,
+  useMemo,
   useState,
   useSyncExternalStore,
   type CSSProperties,
   type ReactNode,
 } from "react";
-import { useLocation, useNavigate } from "@tanstack/react-router";
+import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
 
 import { isElectron } from "../env";
 import { getLocalStorageItem, removeLocalStorageItem } from "../hooks/useLocalStorage";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { primaryServerKeybindingsAtom, serverEnvironment } from "../state/server";
+import { useComposerDraftStore } from "../composerDraftStore";
+import { mergeProjectScriptKeybindings } from "../lib/projectScriptKeybindings";
+import { resolveThreadRouteTarget } from "../threadRoutes";
 import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
@@ -65,7 +70,22 @@ function readInitialThreadSidebarWidth(): number {
 }
 
 function SidebarControl() {
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const primaryKeybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const routeTarget = useParams({ strict: false, select: resolveThreadRouteTarget });
+  const routeEnvironmentId = useComposerDraftStore((store) =>
+    routeTarget?.kind === "server"
+      ? routeTarget.threadRef.environmentId
+      : routeTarget?.kind === "draft"
+        ? (store.getDraftSession(routeTarget.draftId)?.environmentId ?? null)
+        : null,
+  );
+  const environmentKeybindings =
+    useAtomValue(serverEnvironment.configValueAtom(routeEnvironmentId))?.keybindings ??
+    DEFAULT_RESOLVED_KEYBINDINGS;
+  const keybindings = useMemo(
+    () => mergeProjectScriptKeybindings(primaryKeybindings, environmentKeybindings),
+    [environmentKeybindings, primaryKeybindings],
+  );
   const { toggleSidebar } = useSidebar();
   const isSidebarVisible = useSidebarVisibility();
   const environmentIdentificationMode = useEnvironmentIdentificationMode();

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -18,6 +18,7 @@ import { cn, isMacPlatform } from "../lib/utils";
 import { primaryServerKeybindingsAtom, serverEnvironment } from "../state/server";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { mergeProjectScriptKeybindings } from "../lib/projectScriptKeybindings";
+import { hasChatSidebarShortcutClaim } from "../sidebarShortcutBus";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
 import LegacyThreadSidebar from "./LegacySidebar";
@@ -86,7 +87,6 @@ function SidebarControl() {
     () => mergeProjectScriptKeybindings(primaryKeybindings, environmentKeybindings),
     [environmentKeybindings, primaryKeybindings],
   );
-  const chatHandlesSidebarShortcut = routeTarget !== null;
   const { toggleSidebar } = useSidebar();
   const isSidebarVisible = useSidebarVisibility();
   const environmentIdentificationMode = useEnvironmentIdentificationMode();
@@ -97,14 +97,14 @@ function SidebarControl() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (chatHandlesSidebarShortcut || event.defaultPrevented) return;
+      if (hasChatSidebarShortcutClaim() || event.defaultPrevented) return;
       if (
         event.target instanceof HTMLElement &&
         event.target.closest("[data-keybinding-capture]")
       ) {
         return;
       }
-      if (resolveShortcutCommand(event, keybindings) !== "sidebar.toggle") return;
+      if (resolveShortcutCommand(event, primaryKeybindings) !== "sidebar.toggle") return;
 
       event.preventDefault();
       event.stopPropagation();
@@ -114,7 +114,7 @@ function SidebarControl() {
     // Capture before focused editors consume commands such as Mod+B for rich-text formatting.
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [chatHandlesSidebarShortcut, keybindings, toggleSidebar]);
+  }, [primaryKeybindings, toggleSidebar]);
 
   return (
     // The right-side layout controls carry mr-px (border compensation inside

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -86,6 +86,7 @@ function SidebarControl() {
     () => mergeProjectScriptKeybindings(primaryKeybindings, environmentKeybindings),
     [environmentKeybindings, primaryKeybindings],
   );
+  const chatHandlesSidebarShortcut = routeTarget !== null;
   const { toggleSidebar } = useSidebar();
   const isSidebarVisible = useSidebarVisibility();
   const environmentIdentificationMode = useEnvironmentIdentificationMode();
@@ -96,7 +97,7 @@ function SidebarControl() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
+      if (chatHandlesSidebarShortcut || event.defaultPrevented) return;
       if (
         event.target instanceof HTMLElement &&
         event.target.closest("[data-keybinding-capture]")
@@ -113,7 +114,7 @@ function SidebarControl() {
     // Capture before focused editors consume commands such as Mod+B for rich-text formatting.
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [keybindings, toggleSidebar]);
+  }, [chatHandlesSidebarShortcut, keybindings, toggleSidebar]);
 
   return (
     // The right-side layout controls carry mr-px (border compensation inside

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5212,8 +5212,10 @@ function ChatViewContent(props: ChatViewProps) {
         terminalOpen: Boolean(terminalUiState.terminalOpen),
         modelPickerOpen: composerRef.current?.isModelPickerOpen() ?? false,
       };
+      const commandPaletteOpen = isCommandPaletteOpen();
 
       if (
+        !commandPaletteOpen &&
         !shortcutContext.terminalFocus &&
         !shortcutContext.modelPickerOpen &&
         shouldTypeToFocusComposer(event)
@@ -5236,7 +5238,7 @@ function ChatViewContent(props: ChatViewProps) {
         toggleSidebar();
         return;
       }
-      if (isCommandPaletteOpen()) return;
+      if (commandPaletteOpen) return;
 
       if (command === "thread.settle") {
         event.preventDefault();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5379,7 +5379,7 @@ function ChatViewContent(props: ChatViewProps) {
       event.stopPropagation();
       void runProjectScript(script);
     };
-    const releaseSidebarShortcut = activeThreadId ? claimChatSidebarShortcut() : null;
+    const releaseSidebarShortcut = activeThreadId ? claimChatSidebarShortcut(keybindings) : null;
     window.addEventListener("keydown", handler, true);
     return () => {
       releaseSidebarShortcut?.();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2833,6 +2833,15 @@ function ChatViewContent(props: ChatViewProps) {
   const environmentKeybindings =
     useAtomValue(serverEnvironment.configValueAtom(environmentId))?.keybindings ??
     DEFAULT_RESOLVED_KEYBINDINGS;
+  const chatKeybindings = useMemo(
+    () => [
+      ...keybindings.filter((binding) => projectScriptIdFromCommand(binding.command) === null),
+      ...environmentKeybindings.filter(
+        (binding) => projectScriptIdFromCommand(binding.command) !== null,
+      ),
+    ],
+    [environmentKeybindings, keybindings],
+  );
   const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
   // Prefer an instance-id match so a custom Codex instance (e.g.
   // `codex_personal`) surfaces its own status/message in the banner rather
@@ -5215,7 +5224,7 @@ function ChatViewContent(props: ChatViewProps) {
         }
       }
 
-      const command = resolveShortcutCommand(event, keybindings, {
+      const command = resolveShortcutCommand(event, chatKeybindings, {
         context: shortcutContext,
       });
       if (!command) return;
@@ -5380,6 +5389,7 @@ function ChatViewContent(props: ChatViewProps) {
     runProjectScript,
     splitTerminal,
     splitPanelTerminal,
+    chatKeybindings,
     keybindings,
     handleUnsettleActiveThread,
     isServerThread,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -53,6 +53,7 @@ import {
   resolvePromptInjectedEffort,
 } from "@t3tools/shared/model";
 import { CHAT_LIST_ANCHOR_OFFSET } from "@t3tools/shared/chatList";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
 import {
@@ -2829,6 +2830,9 @@ function ChatViewContent(props: ChatViewProps) {
         }),
   );
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const environmentKeybindings =
+    useAtomValue(serverEnvironment.configValueAtom(environmentId))?.keybindings ??
+    DEFAULT_RESOLVED_KEYBINDINGS;
   const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
   // Prefer an instance-id match so a custom Codex instance (e.g.
   // `codex_personal`) surfaces its own status/message in the banner rather
@@ -3353,7 +3357,7 @@ function ChatViewContent(props: ChatViewProps) {
       }
 
       const keybindingMutation = deriveProjectScriptKeybindingMutation({
-        keybindings,
+        keybindings: environmentKeybindings,
         keybinding: input.keybinding,
         command: input.keybindingCommand,
       });
@@ -3378,7 +3382,7 @@ function ChatViewContent(props: ChatViewProps) {
         () => undefined,
       );
     },
-    [environmentId, keybindings, removeKeybinding, updateProject, upsertKeybinding],
+    [environmentId, environmentKeybindings, removeKeybinding, updateProject, upsertKeybinding],
   );
   const saveProjectScript = useCallback(
     async (input: NewProjectScriptInput): Promise<AtomCommandResult<void, unknown>> => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -190,7 +190,7 @@ import {
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
 import { stackedThreadToast, toastManager } from "./ui/toast";
-import { deriveProjectScriptKeybindingMutation } from "~/lib/projectScriptKeybindings";
+import { deriveProjectScriptKeybindingMutations } from "~/lib/projectScriptKeybindings";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   buildProjectScript,
@@ -3356,31 +3356,28 @@ function ChatViewContent(props: ChatViewProps) {
         return updateResult;
       }
 
-      const keybindingMutation = deriveProjectScriptKeybindingMutation({
+      const keybindingMutations = deriveProjectScriptKeybindingMutations({
         keybindings: environmentKeybindings,
         keybinding: input.keybinding,
         command: input.keybindingCommand,
       });
 
-      if (!isElectron || !keybindingMutation) {
+      if (!isElectron) {
         return updateResult;
       }
-      if (keybindingMutation.type === "upsert") {
-        return mapAtomCommandResult(
-          await upsertKeybinding({
+      for (const mutation of keybindingMutations) {
+        const result = mapAtomCommandResult(
+          await (mutation.type === "upsert" ? upsertKeybinding : removeKeybinding)({
             environmentId,
-            input: keybindingMutation.input,
+            input: mutation.input,
           }),
           () => undefined,
         );
+        if (result._tag === "Failure") {
+          return result;
+        }
       }
-      return mapAtomCommandResult(
-        await removeKeybinding({
-          environmentId,
-          input: keybindingMutation.input,
-        }),
-        () => undefined,
-      );
+      return updateResult;
     },
     [environmentId, environmentKeybindings, removeKeybinding, updateProject, upsertKeybinding],
   );
@@ -7082,7 +7079,7 @@ function ChatViewContent(props: ChatViewProps) {
             preferredScriptId={
               activeProject ? (lastInvokedScriptByProjectId[activeProject.id] ?? null) : null
             }
-            keybindings={keybindings}
+            keybindings={environmentKeybindings}
             availableEditors={availableEditors}
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -190,6 +190,7 @@ import {
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
 import { stackedThreadToast, toastManager } from "./ui/toast";
+import { useSidebar } from "./ui/sidebar";
 import {
   deriveProjectScriptKeybindingMutations,
   mergeProjectScriptKeybindings,
@@ -1289,6 +1290,7 @@ function ChatViewContent(props: ChatViewProps) {
   const threadSyncPhase = routeKind === "server" ? (props.threadSyncPhase ?? null) : null;
   const threadDetailLoading = threadSyncPhase === "loading";
   const handleNewThread = useNewThreadHandler();
+  const { toggleSidebar } = useSidebar();
   const { settleThread, pinThread, confirmAndUnpinThread } = useThreadActions();
   const routeThreadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
@@ -2832,13 +2834,13 @@ function ChatViewContent(props: ChatViewProps) {
           input: { cwd: gitStatusCwd },
         }),
   );
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const primaryKeybindings = useAtomValue(primaryServerKeybindingsAtom);
   const environmentKeybindings =
     useAtomValue(serverEnvironment.configValueAtom(environmentId))?.keybindings ??
     DEFAULT_RESOLVED_KEYBINDINGS;
-  const chatKeybindings = useMemo(
-    () => mergeProjectScriptKeybindings(keybindings, environmentKeybindings),
-    [environmentKeybindings, keybindings],
+  const keybindings = useMemo(
+    () => mergeProjectScriptKeybindings(primaryKeybindings, environmentKeybindings),
+    [environmentKeybindings, primaryKeybindings],
   );
   const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
   // Prefer an instance-id match so a custom Codex instance (e.g.
@@ -5222,10 +5224,17 @@ function ChatViewContent(props: ChatViewProps) {
         }
       }
 
-      const command = resolveShortcutCommand(event, chatKeybindings, {
+      const command = resolveShortcutCommand(event, keybindings, {
         context: shortcutContext,
       });
       if (!command) return;
+
+      if (command === "sidebar.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleSidebar();
+        return;
+      }
 
       if (command === "thread.settle") {
         event.preventDefault();
@@ -5387,7 +5396,6 @@ function ChatViewContent(props: ChatViewProps) {
     runProjectScript,
     splitTerminal,
     splitPanelTerminal,
-    chatKeybindings,
     keybindings,
     handleUnsettleActiveThread,
     isServerThread,
@@ -5399,6 +5407,7 @@ function ChatViewContent(props: ChatViewProps) {
     confirmAndUnpinThread,
     toggleRightPanel,
     toggleRightPanelMaximized,
+    toggleSidebar,
     toggleTerminalVisibility,
     composerRef,
   ]);
@@ -7087,7 +7096,7 @@ function ChatViewContent(props: ChatViewProps) {
             preferredScriptId={
               activeProject ? (lastInvokedScriptByProjectId[activeProject.id] ?? null) : null
             }
-            keybindings={chatKeybindings}
+            keybindings={keybindings}
             availableEditors={availableEditors}
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7089,7 +7089,7 @@ function ChatViewContent(props: ChatViewProps) {
             preferredScriptId={
               activeProject ? (lastInvokedScriptByProjectId[activeProject.id] ?? null) : null
             }
-            keybindings={environmentKeybindings}
+            keybindings={chatKeybindings}
             availableEditors={availableEditors}
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -195,6 +195,7 @@ import {
   deriveProjectScriptKeybindingMutations,
   mergeProjectScriptKeybindings,
 } from "~/lib/projectScriptKeybindings";
+import { claimChatSidebarShortcut } from "~/sidebarShortcutBus";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   buildProjectScript,
@@ -5199,7 +5200,7 @@ function ChatViewContent(props: ChatViewProps) {
         event.stopPropagation();
         return;
       }
-      if (!activeThreadId || isCommandPaletteOpen()) {
+      if (!activeThreadId) {
         return;
       }
       const terminalFocusOwner = getTerminalFocusOwner();
@@ -5235,6 +5236,7 @@ function ChatViewContent(props: ChatViewProps) {
         toggleSidebar();
         return;
       }
+      if (isCommandPaletteOpen()) return;
 
       if (command === "thread.settle") {
         event.preventDefault();
@@ -5377,8 +5379,12 @@ function ChatViewContent(props: ChatViewProps) {
       event.stopPropagation();
       void runProjectScript(script);
     };
+    const releaseSidebarShortcut = activeThreadId ? claimChatSidebarShortcut() : null;
     window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
+    return () => {
+      releaseSidebarShortcut?.();
+      window.removeEventListener("keydown", handler, true);
+    };
   }, [
     activeProject,
     activeRightPanelSurface,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -190,7 +190,10 @@ import {
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
 import { stackedThreadToast, toastManager } from "./ui/toast";
-import { deriveProjectScriptKeybindingMutations } from "~/lib/projectScriptKeybindings";
+import {
+  deriveProjectScriptKeybindingMutations,
+  mergeProjectScriptKeybindings,
+} from "~/lib/projectScriptKeybindings";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   buildProjectScript,
@@ -2834,12 +2837,7 @@ function ChatViewContent(props: ChatViewProps) {
     useAtomValue(serverEnvironment.configValueAtom(environmentId))?.keybindings ??
     DEFAULT_RESOLVED_KEYBINDINGS;
   const chatKeybindings = useMemo(
-    () => [
-      ...keybindings.filter((binding) => projectScriptIdFromCommand(binding.command) === null),
-      ...environmentKeybindings.filter(
-        (binding) => projectScriptIdFromCommand(binding.command) !== null,
-      ),
-    ],
+    () => mergeProjectScriptKeybindings(keybindings, environmentKeybindings),
     [environmentKeybindings, keybindings],
   );
   const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -189,7 +189,7 @@ import {
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
 import { stackedThreadToast, toastManager } from "./ui/toast";
-import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
+import { deriveProjectScriptKeybindingMutation } from "~/lib/projectScriptKeybindings";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   buildProjectScript,
@@ -1293,6 +1293,9 @@ function ChatViewContent(props: ChatViewProps) {
   const routeThreadKey = useMemo(() => scopedThreadKey(routeThreadRef), [routeThreadRef]);
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
+    reportFailure: false,
+  });
+  const removeKeybinding = useAtomCommand(serverEnvironment.removeKeybinding, {
     reportFailure: false,
   });
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
@@ -3349,23 +3352,33 @@ function ChatViewContent(props: ChatViewProps) {
         return updateResult;
       }
 
-      const keybindingRule = decodeProjectScriptKeybindingRule({
+      const keybindingMutation = deriveProjectScriptKeybindingMutation({
+        keybindings,
         keybinding: input.keybinding,
         command: input.keybindingCommand,
       });
 
-      if (isElectron && keybindingRule) {
+      if (!isElectron || !keybindingMutation) {
+        return updateResult;
+      }
+      if (keybindingMutation.type === "upsert") {
         return mapAtomCommandResult(
           await upsertKeybinding({
             environmentId,
-            input: keybindingRule,
+            input: keybindingMutation.input,
           }),
           () => undefined,
         );
       }
-      return updateResult;
+      return mapAtomCommandResult(
+        await removeKeybinding({
+          environmentId,
+          input: keybindingMutation.input,
+        }),
+        () => undefined,
+      );
     },
-    [environmentId, updateProject, upsertKeybinding],
+    [environmentId, keybindings, removeKeybinding, updateProject, upsertKeybinding],
   );
   const saveProjectScript = useCallback(
     async (input: NewProjectScriptInput): Promise<AtomCommandResult<void, unknown>> => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -60,27 +60,17 @@ export function whenAstToExpression(node: KeybindingWhenNode | undefined): strin
     case "identifier":
       return node.name;
     case "not":
-      return `!${wrapWhenExpression(node.node, "not")}`;
+      return `!${wrapWhenExpression(node.node)}`;
     case "and":
-      return `${wrapWhenExpression(node.left, "and")} && ${wrapWhenExpression(node.right, "and", true)}`;
+      return `${wrapWhenExpression(node.left)} && ${wrapWhenExpression(node.right)}`;
     case "or":
-      return `${wrapWhenExpression(node.left, "or")} || ${wrapWhenExpression(node.right, "or", true)}`;
+      return `${wrapWhenExpression(node.left)} || ${wrapWhenExpression(node.right)}`;
   }
 }
 
-function wrapWhenExpression(
-  node: KeybindingWhenNode,
-  parent: "not" | "and" | "or",
-  right = false,
-): string {
-  const expression = whenAstToExpression(node);
-  const needsParentheses =
-    parent === "not"
-      ? node.type === "and" || node.type === "or"
-      : parent === "and"
-        ? node.type === "or" || (right && node.type === "and")
-        : right && node.type === "or";
-  return needsParentheses ? `(${expression})` : expression;
+function wrapWhenExpression(node: KeybindingWhenNode): string {
+  if (node.type === "identifier" || node.type === "not") return whenAstToExpression(node);
+  return `(${whenAstToExpression(node)})`;
 }
 
 export function parseWhenExpressionDraft(

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -60,17 +60,27 @@ export function whenAstToExpression(node: KeybindingWhenNode | undefined): strin
     case "identifier":
       return node.name;
     case "not":
-      return `!${wrapWhenExpression(node.node)}`;
+      return `!${wrapWhenExpression(node.node, "not")}`;
     case "and":
-      return `${wrapWhenExpression(node.left)} && ${wrapWhenExpression(node.right)}`;
+      return `${wrapWhenExpression(node.left, "and")} && ${wrapWhenExpression(node.right, "and", true)}`;
     case "or":
-      return `${wrapWhenExpression(node.left)} || ${wrapWhenExpression(node.right)}`;
+      return `${wrapWhenExpression(node.left, "or")} || ${wrapWhenExpression(node.right, "or", true)}`;
   }
 }
 
-function wrapWhenExpression(node: KeybindingWhenNode): string {
-  if (node.type === "identifier" || node.type === "not") return whenAstToExpression(node);
-  return `(${whenAstToExpression(node)})`;
+function wrapWhenExpression(
+  node: KeybindingWhenNode,
+  parent: "not" | "and" | "or",
+  right = false,
+): string {
+  const expression = whenAstToExpression(node);
+  const needsParentheses =
+    parent === "not"
+      ? node.type === "and" || node.type === "or"
+      : parent === "and"
+        ? node.type === "or" || (right && node.type === "and")
+        : right && node.type === "or";
+  return needsParentheses ? `(${expression})` : expression;
 }
 
 export function parseWhenExpressionDraft(

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -45,7 +45,7 @@ import {
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { useT3ProjectFileState } from "../../hooks/useT3ProjectFileScripts";
 import { shortcutLabelForCommand } from "../../keybindings";
-import { keybindingValueForCommand } from "../../lib/projectScriptKeybindings";
+import { deriveProjectScriptKeybindingMutations } from "../../lib/projectScriptKeybindings";
 import { releaseProjectDraftUploads } from "../../lib/composerDraftUploads";
 import { readLocalApi } from "../../localApi";
 import {
@@ -53,7 +53,6 @@ import {
   commandForProjectScript,
   nextProjectScriptId,
 } from "../../projectScripts";
-import { decodeProjectScriptKeybindingRule } from "../../lib/projectScriptKeybindings";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -518,9 +517,6 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       savingScriptsRef.current = true;
       setIsSavingScripts(true);
       try {
-        // Captured before the write so a cleared or deleted binding can be
-        // removed from the keybindings config afterwards.
-        const previousKeybinding = keybindingValueForCommand(keybindings, keybindingCommand);
         const updateResult = mapAtomCommandResult(
           await updateProject({
             environmentId: selectedCheckout.environmentId,
@@ -533,45 +529,28 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
           return updateResult;
         }
 
-        const keybindingRule = decodeProjectScriptKeybindingRule({
+        const keybindingMutations = deriveProjectScriptKeybindingMutations({
+          keybindings,
           keybinding,
           command: keybindingCommand,
         });
         if (!isElectron) return updateResult;
-        const environmentIds = [selectedCheckout.environmentId];
-        const previousTarget = previousKeybinding
-          ? decodeProjectScriptKeybindingRule({
-              keybinding: previousKeybinding,
-              command: keybindingCommand,
-            })
-          : null;
-        if (keybindingRule) {
-          // `replace` swaps the command's previous rule instead of appending a
-          // second one that would keep the old shortcut alive.
-          const input =
-            previousTarget && previousTarget.key !== keybindingRule.key
-              ? { ...keybindingRule, replace: previousTarget }
-              : keybindingRule;
-          for (const environmentId of environmentIds) {
-            const result = mapAtomCommandResult(
-              await upsertKeybinding({ environmentId, input }),
-              () => undefined,
+        for (const mutation of keybindingMutations) {
+          const result = mapAtomCommandResult(
+            await (mutation.type === "upsert" ? upsertKeybinding : removeKeybinding)({
+              environmentId: selectedCheckout.environmentId,
+              input: mutation.input,
+            }),
+            () => undefined,
+          );
+          if (result._tag === "Failure") {
+            reportFailure(
+              mutation.type === "upsert"
+                ? "Failed to save keybinding"
+                : "Failed to remove keybinding",
+              result,
             );
-            if (result._tag === "Failure") {
-              reportFailure("Failed to save keybinding", result);
-              return result;
-            }
-          }
-        } else if (previousTarget) {
-          for (const environmentId of environmentIds) {
-            const result = mapAtomCommandResult(
-              await removeKeybinding({ environmentId, input: previousTarget }),
-              () => undefined,
-            );
-            if (result._tag === "Failure") {
-              reportFailure("Failed to remove keybinding", result);
-              return result;
-            }
+            return result;
           }
         }
         return updateResult;

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -45,7 +45,7 @@ import {
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { useT3ProjectFileState } from "../../hooks/useT3ProjectFileScripts";
 import { shortcutLabelForCommand } from "../../keybindings";
-import { deriveProjectScriptKeybindingMutations } from "../../lib/projectScriptKeybindings";
+import { keybindingValueForCommand } from "../../lib/projectScriptKeybindings";
 import { releaseProjectDraftUploads } from "../../lib/composerDraftUploads";
 import { readLocalApi } from "../../localApi";
 import {
@@ -53,6 +53,7 @@ import {
   commandForProjectScript,
   nextProjectScriptId,
 } from "../../projectScripts";
+import { decodeProjectScriptKeybindingRule } from "../../lib/projectScriptKeybindings";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -517,6 +518,9 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       savingScriptsRef.current = true;
       setIsSavingScripts(true);
       try {
+        // Captured before the write so a cleared or deleted binding can be
+        // removed from the keybindings config afterwards.
+        const previousKeybinding = keybindingValueForCommand(keybindings, keybindingCommand);
         const updateResult = mapAtomCommandResult(
           await updateProject({
             environmentId: selectedCheckout.environmentId,
@@ -529,28 +533,45 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
           return updateResult;
         }
 
-        const keybindingMutations = deriveProjectScriptKeybindingMutations({
-          keybindings,
+        const keybindingRule = decodeProjectScriptKeybindingRule({
           keybinding,
           command: keybindingCommand,
         });
         if (!isElectron) return updateResult;
-        for (const mutation of keybindingMutations) {
-          const result = mapAtomCommandResult(
-            await (mutation.type === "upsert" ? upsertKeybinding : removeKeybinding)({
-              environmentId: selectedCheckout.environmentId,
-              input: mutation.input,
-            }),
-            () => undefined,
-          );
-          if (result._tag === "Failure") {
-            reportFailure(
-              mutation.type === "upsert"
-                ? "Failed to save keybinding"
-                : "Failed to remove keybinding",
-              result,
+        const environmentIds = [selectedCheckout.environmentId];
+        const previousTarget = previousKeybinding
+          ? decodeProjectScriptKeybindingRule({
+              keybinding: previousKeybinding,
+              command: keybindingCommand,
+            })
+          : null;
+        if (keybindingRule) {
+          // `replace` swaps the command's previous rule instead of appending a
+          // second one that would keep the old shortcut alive.
+          const input =
+            previousTarget && previousTarget.key !== keybindingRule.key
+              ? { ...keybindingRule, replace: previousTarget }
+              : keybindingRule;
+          for (const environmentId of environmentIds) {
+            const result = mapAtomCommandResult(
+              await upsertKeybinding({ environmentId, input }),
+              () => undefined,
             );
-            return result;
+            if (result._tag === "Failure") {
+              reportFailure("Failed to save keybinding", result);
+              return result;
+            }
+          }
+        } else if (previousTarget) {
+          for (const environmentId of environmentIds) {
+            const result = mapAtomCommandResult(
+              await removeKeybinding({ environmentId, input: previousTarget }),
+              () => undefined,
+            );
+            if (result._tag === "Failure") {
+              reportFailure("Failed to remove keybinding", result);
+              return result;
+            }
           }
         }
         return updateResult;

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -93,14 +93,14 @@ describe("projectScriptKeybindings", () => {
 
   it("removes every stale binding when changing or clearing a shortcut", () => {
     const command = commandForProjectScript("test");
-    const compactWhen = Array.from({ length: 38 }, (_, index) => `v${index}`).join("&&");
+    const when = Array.from({ length: 38 }, (_, index) => `v${index}`).join("&&");
     const keybindings = [
       resolvedBinding(command, "mod+r"),
-      resolvedBinding(command, "mod+alt+r", compactWhen),
+      resolvedBinding(command, "mod+alt+r", when),
     ];
     const targets = [
       { key: "mod+r", command },
-      { key: "mod+alt+r", command, when: compactWhen },
+      { key: "mod+alt+r", command, when },
     ];
     const derive = (keybinding: string | null) =>
       deriveProjectScriptKeybindingMutations({ keybindings, keybinding, command });

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -63,7 +63,30 @@ describe("projectScriptKeybindings", () => {
   it("reads latest matching keybinding value for a command", () => {
     const command = commandForProjectScript("test");
     const value = keybindingValueForCommand(
-      [resolvedBinding(command, "mod+esc"), resolvedBinding(command, "mod+shift+k")],
+      [
+        {
+          command,
+          shortcut: {
+            key: "escape",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: false,
+            modKey: true,
+          },
+        },
+        {
+          command,
+          shortcut: {
+            key: "k",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: true,
+            altKey: false,
+            modKey: true,
+          },
+        },
+      ],
       command,
     );
 

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { commandForProjectScript } from "../projectScripts";
 import {
   decodeProjectScriptKeybindingRule,
+  deriveProjectScriptKeybindingMutation,
   keybindingValueForCommand,
   PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE,
 } from "./projectScriptKeybindings";
@@ -79,5 +80,63 @@ describe("projectScriptKeybindings", () => {
     );
 
     expect(value).toBe("mod+shift+k");
+  });
+
+  it("replaces the previous keybinding when a script keybinding changes", () => {
+    const command = commandForProjectScript("test");
+
+    expect(
+      deriveProjectScriptKeybindingMutation({
+        keybindings: [
+          {
+            command,
+            shortcut: {
+              key: "r",
+              metaKey: false,
+              ctrlKey: false,
+              shiftKey: false,
+              altKey: false,
+              modKey: true,
+            },
+          },
+        ],
+        keybinding: "mod+shift+r",
+        command,
+      }),
+    ).toEqual({
+      type: "upsert",
+      input: {
+        key: "mod+shift+r",
+        command,
+        replace: { key: "mod+r", command },
+      },
+    });
+  });
+
+  it("removes the previous keybinding when a script keybinding is cleared", () => {
+    const command = commandForProjectScript("test");
+
+    expect(
+      deriveProjectScriptKeybindingMutation({
+        keybindings: [
+          {
+            command,
+            shortcut: {
+              key: "r",
+              metaKey: false,
+              ctrlKey: false,
+              shiftKey: false,
+              altKey: false,
+              modKey: true,
+            },
+          },
+        ],
+        keybinding: null,
+        command,
+      }),
+    ).toEqual({
+      type: "remove",
+      input: { key: "mod+r", command },
+    });
   });
 });

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -1,13 +1,24 @@
 import { MAX_KEYBINDING_VALUE_LENGTH, type KeybindingCommand } from "@t3tools/contracts";
+import { compileResolvedKeybindingRule } from "@t3tools/shared/keybindings";
 import { describe, expect, it } from "vite-plus/test";
 
 import { commandForProjectScript } from "../projectScripts";
 import {
   decodeProjectScriptKeybindingRule,
-  deriveProjectScriptKeybindingMutation,
+  deriveProjectScriptKeybindingMutations,
   keybindingValueForCommand,
   PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE,
 } from "./projectScriptKeybindings";
+
+function resolvedBinding(command: KeybindingCommand, keybinding: string, when?: string) {
+  const binding = compileResolvedKeybindingRule({
+    key: keybinding,
+    command,
+    ...(when ? { when } : {}),
+  });
+  if (!binding) throw new Error("Invalid test keybinding");
+  return binding;
+}
 
 describe("projectScriptKeybindings", () => {
   it("decodes and trims valid keybinding rules", () => {
@@ -52,30 +63,7 @@ describe("projectScriptKeybindings", () => {
   it("reads latest matching keybinding value for a command", () => {
     const command = commandForProjectScript("test");
     const value = keybindingValueForCommand(
-      [
-        {
-          command,
-          shortcut: {
-            key: "escape",
-            metaKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-            altKey: false,
-            modKey: true,
-          },
-        },
-        {
-          command,
-          shortcut: {
-            key: "k",
-            metaKey: false,
-            ctrlKey: false,
-            shiftKey: true,
-            altKey: false,
-            modKey: true,
-          },
-        },
-      ],
+      [resolvedBinding(command, "mod+esc"), resolvedBinding(command, "mod+shift+k")],
       command,
     );
 
@@ -86,57 +74,72 @@ describe("projectScriptKeybindings", () => {
     const command = commandForProjectScript("test");
 
     expect(
-      deriveProjectScriptKeybindingMutation({
+      deriveProjectScriptKeybindingMutations({
+        keybindings: [resolvedBinding(command, "mod+r")],
+        keybinding: "mod+shift+r",
+        command,
+      }),
+    ).toEqual([
+      {
+        type: "upsert",
+        input: {
+          key: "mod+shift+r",
+          command,
+          replace: { key: "mod+r", command },
+        },
+      },
+    ]);
+  });
+
+  it("removes every stale keybinding and preserves the latest condition when replacing", () => {
+    const command = commandForProjectScript("test");
+
+    expect(
+      deriveProjectScriptKeybindingMutations({
         keybindings: [
-          {
-            command,
-            shortcut: {
-              key: "r",
-              metaKey: false,
-              ctrlKey: false,
-              shiftKey: false,
-              altKey: false,
-              modKey: true,
-            },
-          },
+          resolvedBinding(command, "mod+r"),
+          resolvedBinding(command, "mod+alt+r", "terminalFocus"),
         ],
         keybinding: "mod+shift+r",
         command,
       }),
-    ).toEqual({
-      type: "upsert",
-      input: {
-        key: "mod+shift+r",
-        command,
-        replace: { key: "mod+r", command },
+    ).toEqual([
+      {
+        type: "remove",
+        input: { key: "mod+r", command },
       },
-    });
+      {
+        type: "upsert",
+        input: {
+          key: "mod+shift+r",
+          command,
+          replace: { key: "mod+alt+r", command, when: "terminalFocus" },
+        },
+      },
+    ]);
   });
 
-  it("removes the previous keybinding when a script keybinding is cleared", () => {
+  it("removes every stale keybinding when a script keybinding is cleared", () => {
     const command = commandForProjectScript("test");
 
     expect(
-      deriveProjectScriptKeybindingMutation({
+      deriveProjectScriptKeybindingMutations({
         keybindings: [
-          {
-            command,
-            shortcut: {
-              key: "r",
-              metaKey: false,
-              ctrlKey: false,
-              shiftKey: false,
-              altKey: false,
-              modKey: true,
-            },
-          },
+          resolvedBinding(command, "mod+r"),
+          resolvedBinding(command, "mod+shift+r", "terminalFocus"),
         ],
         keybinding: null,
         command,
       }),
-    ).toEqual({
-      type: "remove",
-      input: { key: "mod+r", command },
-    });
+    ).toEqual([
+      {
+        type: "remove",
+        input: { key: "mod+r", command },
+      },
+      {
+        type: "remove",
+        input: { key: "mod+shift+r", command, when: "terminalFocus" },
+      },
+    ]);
   });
 });

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -113,12 +113,14 @@ describe("projectScriptKeybindings", () => {
     expect(derive(null)).toEqual(targets.map((input) => ({ type: "remove", input })));
   });
 
-  it("lets routed script bindings override primary commands", () => {
+  it("preserves primary precedence and lets routed scripts override it", () => {
     const command = commandForProjectScript("test");
-    const keybindings = mergeProjectScriptKeybindings(
-      [resolvedBinding("sidebar.toggle", "mod+b"), resolvedBinding(command, "mod+r")],
-      [resolvedBinding(command, "mod+b", "terminalFocus")],
-    );
+    const action = resolvedBinding(command, "mod+b");
+    const primary = [action, resolvedBinding("sidebar.toggle", "mod+b")];
+    expect(mergeProjectScriptKeybindings(primary, primary)).toEqual(primary);
+    const keybindings = mergeProjectScriptKeybindings(primary, [
+      resolvedBinding(command, "mod+b", "terminalFocus"),
+    ]);
 
     expect(
       resolveShortcutCommand(

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -2,20 +2,18 @@ import { MAX_KEYBINDING_VALUE_LENGTH, type KeybindingCommand } from "@t3tools/co
 import { compileResolvedKeybindingRule } from "@t3tools/shared/keybindings";
 import { describe, expect, it } from "vite-plus/test";
 
+import { resolveShortcutCommand } from "../keybindings";
 import { commandForProjectScript } from "../projectScripts";
 import {
   decodeProjectScriptKeybindingRule,
   deriveProjectScriptKeybindingMutations,
   keybindingValueForCommand,
+  mergeProjectScriptKeybindings,
   PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE,
 } from "./projectScriptKeybindings";
 
-function resolvedBinding(command: KeybindingCommand, keybinding: string, when?: string) {
-  const binding = compileResolvedKeybindingRule({
-    key: keybinding,
-    command,
-    ...(when ? { when } : {}),
-  });
+function resolvedBinding(command: KeybindingCommand, key: string, when?: string) {
+  const binding = compileResolvedKeybindingRule({ key, command, ...(when ? { when } : {}) });
   if (!binding) throw new Error("Invalid test keybinding");
   return binding;
 }
@@ -93,76 +91,58 @@ describe("projectScriptKeybindings", () => {
     expect(value).toBe("mod+shift+k");
   });
 
-  it("replaces the previous keybinding when a script keybinding changes", () => {
+  it("removes every stale binding when changing or clearing a shortcut", () => {
     const command = commandForProjectScript("test");
+    const compactWhen = Array.from({ length: 38 }, (_, index) => `v${index}`).join("&&");
+    const keybindings = [
+      resolvedBinding(command, "mod+r"),
+      resolvedBinding(command, "mod+alt+r", compactWhen),
+    ];
+    const targets = [
+      { key: "mod+r", command },
+      { key: "mod+alt+r", command, when: compactWhen },
+    ];
 
     expect(
       deriveProjectScriptKeybindingMutations({
-        keybindings: [resolvedBinding(command, "mod+r")],
+        keybindings,
         keybinding: "mod+shift+r",
         command,
       }),
     ).toEqual([
+      { type: "remove", input: targets[0] },
       {
         type: "upsert",
         input: {
           key: "mod+shift+r",
           command,
-          replace: { key: "mod+r", command },
+          replace: targets[1],
         },
       },
     ]);
-  });
-
-  it("removes every stale keybinding and preserves the latest condition when replacing", () => {
-    const command = commandForProjectScript("test");
 
     expect(
       deriveProjectScriptKeybindingMutations({
-        keybindings: [
-          resolvedBinding(command, "mod+r"),
-          resolvedBinding(command, "mod+alt+r", "terminalFocus"),
-        ],
-        keybinding: "mod+shift+r",
-        command,
-      }),
-    ).toEqual([
-      {
-        type: "remove",
-        input: { key: "mod+r", command },
-      },
-      {
-        type: "upsert",
-        input: {
-          key: "mod+shift+r",
-          command,
-          replace: { key: "mod+alt+r", command, when: "terminalFocus" },
-        },
-      },
-    ]);
-  });
-
-  it("removes every stale keybinding when a script keybinding is cleared", () => {
-    const command = commandForProjectScript("test");
-
-    expect(
-      deriveProjectScriptKeybindingMutations({
-        keybindings: [
-          resolvedBinding(command, "mod+r"),
-          resolvedBinding(command, "mod+shift+r", "terminalFocus"),
-        ],
+        keybindings,
         keybinding: null,
         command,
       }),
-    ).toEqual([
-      {
-        type: "remove",
-        input: { key: "mod+r", command },
-      },
-      {
-        type: "remove",
-        input: { key: "mod+shift+r", command, when: "terminalFocus" },
-      },
-    ]);
+    ).toEqual(targets.map((input) => ({ type: "remove", input })));
+  });
+
+  it("lets routed script bindings override primary commands", () => {
+    const command = commandForProjectScript("test");
+    const keybindings = mergeProjectScriptKeybindings(
+      [resolvedBinding("sidebar.toggle", "mod+b"), resolvedBinding(command, "mod+r")],
+      [resolvedBinding(command, "mod+b")],
+    );
+
+    expect(
+      resolveShortcutCommand(
+        { key: "b", metaKey: false, ctrlKey: true, altKey: false, shiftKey: false },
+        keybindings,
+        { platform: "Linux" },
+      ),
+    ).toBe(command);
   });
 });

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -102,46 +102,29 @@ describe("projectScriptKeybindings", () => {
       { key: "mod+r", command },
       { key: "mod+alt+r", command, when: compactWhen },
     ];
+    const derive = (keybinding: string | null) =>
+      deriveProjectScriptKeybindingMutations({ keybindings, keybinding, command });
+    const next = { key: "mod+shift+r", command, replace: targets[1] };
 
-    expect(
-      deriveProjectScriptKeybindingMutations({
-        keybindings,
-        keybinding: "mod+shift+r",
-        command,
-      }),
-    ).toEqual([
+    expect(derive("mod+shift+r")).toEqual([
       { type: "remove", input: targets[0] },
-      {
-        type: "upsert",
-        input: {
-          key: "mod+shift+r",
-          command,
-          replace: targets[1],
-        },
-      },
+      { type: "upsert", input: next },
     ]);
-
-    expect(
-      deriveProjectScriptKeybindingMutations({
-        keybindings,
-        keybinding: null,
-        command,
-      }),
-    ).toEqual(targets.map((input) => ({ type: "remove", input })));
+    expect(derive(null)).toEqual(targets.map((input) => ({ type: "remove", input })));
   });
 
   it("lets routed script bindings override primary commands", () => {
     const command = commandForProjectScript("test");
     const keybindings = mergeProjectScriptKeybindings(
       [resolvedBinding("sidebar.toggle", "mod+b"), resolvedBinding(command, "mod+r")],
-      [resolvedBinding(command, "mod+b")],
+      [resolvedBinding(command, "mod+b", "terminalFocus")],
     );
 
     expect(
       resolveShortcutCommand(
         { key: "b", metaKey: false, ctrlKey: true, altKey: false, shiftKey: false },
         keybindings,
-        { platform: "Linux" },
+        { platform: "Linux", context: { terminalFocus: true } },
       ),
     ).toBe(command);
   });

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -12,6 +12,7 @@ import {
   shortcutToKeybindingInput,
   whenAstToExpression,
 } from "../components/settings/KeybindingsSettings.logic";
+import { projectScriptIdFromCommand } from "../projectScripts";
 
 export const PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE = "Invalid keybinding.";
 
@@ -48,9 +49,33 @@ export function keybindingValueForCommand(
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
     if (!binding || binding.command !== command) continue;
-    return shortcutToKeybindingInput(binding.shortcut);
+
+    const parts: string[] = [];
+    if (binding.shortcut.modKey) parts.push("mod");
+    if (binding.shortcut.ctrlKey) parts.push("ctrl");
+    if (binding.shortcut.metaKey) parts.push("meta");
+    if (binding.shortcut.altKey) parts.push("alt");
+    if (binding.shortcut.shiftKey) parts.push("shift");
+    const keyToken =
+      binding.shortcut.key === " "
+        ? "space"
+        : binding.shortcut.key === "escape"
+          ? "esc"
+          : binding.shortcut.key;
+    parts.push(keyToken);
+    return parts.join("+");
   }
   return null;
+}
+
+export function mergeProjectScriptKeybindings(
+  primary: ResolvedKeybindingsConfig,
+  environment: ResolvedKeybindingsConfig,
+): ResolvedKeybindingsConfig {
+  return [
+    ...primary.filter((binding) => projectScriptIdFromCommand(binding.command) === null),
+    ...environment.filter((binding) => projectScriptIdFromCommand(binding.command) !== null),
+  ];
 }
 
 type ProjectScriptKeybindingMutation =
@@ -66,7 +91,7 @@ export function deriveProjectScriptKeybindingMutations(input: {
   const targetsByKey = new Map<string, ServerRemoveKeybindingInput>();
   for (const binding of input.keybindings) {
     if (binding.command !== input.command) continue;
-    const when = whenAstToExpression(binding.whenAst);
+    const when = whenAstToExpression(binding.whenAst).replaceAll(" ", "");
     const target = {
       key: shortcutToKeybindingInput(binding.shortcut),
       command: binding.command,

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -2,16 +2,14 @@ import {
   KeybindingRule as KeybindingRuleSchema,
   type KeybindingCommand,
   type KeybindingRule,
+  type KeybindingWhenNode,
   type ResolvedKeybindingsConfig,
   type ServerRemoveKeybindingInput,
   type ServerUpsertKeybindingInput,
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
-import {
-  shortcutToKeybindingInput,
-  whenAstToExpression,
-} from "../components/settings/KeybindingsSettings.logic";
+import { shortcutToKeybindingInput } from "../components/settings/KeybindingsSettings.logic";
 import { projectScriptIdFromCommand } from "../projectScripts";
 
 export const PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE = "Invalid keybinding.";
@@ -23,6 +21,17 @@ function normalizeProjectScriptKeybindingInput(
 ): string | null {
   const trimmed = keybinding?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function compactWhen(node: KeybindingWhenNode | undefined, parent = 0, right = false): string {
+  if (!node) return "";
+  if (node.type === "identifier") return node.name;
+  const precedence = node.type === "or" ? 1 : node.type === "and" ? 2 : 3;
+  const expression =
+    node.type === "not"
+      ? `!${compactWhen(node.node, precedence)}`
+      : `${compactWhen(node.left, precedence)}${node.type === "and" ? "&&" : "||"}${compactWhen(node.right, precedence, true)}`;
+  return precedence < parent || (right && precedence === parent) ? `(${expression})` : expression;
 }
 
 export function decodeProjectScriptKeybindingRule(input: {
@@ -91,7 +100,7 @@ export function deriveProjectScriptKeybindingMutations(input: {
   const targetsByKey = new Map<string, ServerRemoveKeybindingInput>();
   for (const binding of input.keybindings) {
     if (binding.command !== input.command) continue;
-    const when = whenAstToExpression(binding.whenAst).replaceAll(" ", "");
+    const when = compactWhen(binding.whenAst);
     const target = {
       key: shortcutToKeybindingInput(binding.shortcut),
       command: binding.command,

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -81,6 +81,7 @@ export function mergeProjectScriptKeybindings(
   primary: ResolvedKeybindingsConfig,
   environment: ResolvedKeybindingsConfig,
 ): ResolvedKeybindingsConfig {
+  if (primary === environment) return primary;
   return [
     ...primary.filter((binding) => projectScriptIdFromCommand(binding.command) === null),
     ...environment.filter((binding) => projectScriptIdFromCommand(binding.command) !== null),

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -2,7 +2,6 @@ import {
   KeybindingRule as KeybindingRuleSchema,
   type KeybindingCommand,
   type KeybindingRule,
-  type ResolvedKeybindingRule,
   type ResolvedKeybindingsConfig,
   type ServerRemoveKeybindingInput,
   type ServerUpsertKeybindingInput,
@@ -58,42 +57,24 @@ type ProjectScriptKeybindingMutation =
   | { type: "upsert"; input: ServerUpsertKeybindingInput }
   | { type: "remove"; input: ServerRemoveKeybindingInput };
 
-function keybindingTargetForResolvedRule(
-  rule: ResolvedKeybindingRule,
-): ServerRemoveKeybindingInput {
-  const when = whenAstToExpression(rule.whenAst);
-  return {
-    key: shortcutToKeybindingInput(rule.shortcut),
-    command: rule.command,
-    ...(when.length > 0 ? { when } : {}),
-  };
-}
-
-function isSameKeybindingTarget(
-  left: ServerRemoveKeybindingInput,
-  right: ServerRemoveKeybindingInput,
-): boolean {
-  return (
-    left.key === right.key &&
-    left.command === right.command &&
-    (left.when ?? undefined) === (right.when ?? undefined)
-  );
-}
-
 export function deriveProjectScriptKeybindingMutations(input: {
   keybindings: ResolvedKeybindingsConfig;
   keybinding: string | null | undefined;
   command: KeybindingCommand;
 }): ReadonlyArray<ProjectScriptKeybindingMutation> {
   const nextRule = decodeProjectScriptKeybindingRule(input);
-  const previousTargets: ServerRemoveKeybindingInput[] = [];
+  const targetsByKey = new Map<string, ServerRemoveKeybindingInput>();
   for (const binding of input.keybindings) {
     if (binding.command !== input.command) continue;
-    const target = keybindingTargetForResolvedRule(binding);
-    if (!previousTargets.some((candidate) => isSameKeybindingTarget(candidate, target))) {
-      previousTargets.push(target);
-    }
+    const when = whenAstToExpression(binding.whenAst);
+    const target = {
+      key: shortcutToKeybindingInput(binding.shortcut),
+      command: binding.command,
+      ...(when.length > 0 ? { when } : {}),
+    };
+    targetsByKey.set(`${target.key}\u0000${when}`, target);
   }
+  const previousTargets = [...targetsByKey.values()];
 
   if (nextRule) {
     const replace = previousTargets.at(-1);

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -3,6 +3,8 @@ import {
   type KeybindingCommand,
   type KeybindingRule,
   type ResolvedKeybindingsConfig,
+  type ServerRemoveKeybindingInput,
+  type ServerUpsertKeybindingInput,
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
@@ -58,4 +60,35 @@ export function keybindingValueForCommand(
     return parts.join("+");
   }
   return null;
+}
+
+type ProjectScriptKeybindingMutation =
+  | { type: "upsert"; input: ServerUpsertKeybindingInput }
+  | { type: "remove"; input: ServerRemoveKeybindingInput }
+  | null;
+
+export function deriveProjectScriptKeybindingMutation(input: {
+  keybindings: ResolvedKeybindingsConfig;
+  keybinding: string | null | undefined;
+  command: KeybindingCommand;
+}): ProjectScriptKeybindingMutation {
+  const nextRule = decodeProjectScriptKeybindingRule(input);
+  const previousKeybinding = keybindingValueForCommand(input.keybindings, input.command);
+  const previousRule = previousKeybinding
+    ? decodeProjectScriptKeybindingRule({
+        keybinding: previousKeybinding,
+        command: input.command,
+      })
+    : null;
+
+  if (nextRule) {
+    return {
+      type: "upsert",
+      input:
+        previousRule && previousRule.key !== nextRule.key
+          ? { ...nextRule, replace: previousRule }
+          : nextRule,
+    };
+  }
+  return previousRule ? { type: "remove", input: previousRule } : null;
 }

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -2,11 +2,17 @@ import {
   KeybindingRule as KeybindingRuleSchema,
   type KeybindingCommand,
   type KeybindingRule,
+  type ResolvedKeybindingRule,
   type ResolvedKeybindingsConfig,
   type ServerRemoveKeybindingInput,
   type ServerUpsertKeybindingInput,
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
+
+import {
+  shortcutToKeybindingInput,
+  whenAstToExpression,
+} from "../components/settings/KeybindingsSettings.logic";
 
 export const PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE = "Invalid keybinding.";
 
@@ -43,52 +49,66 @@ export function keybindingValueForCommand(
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
     if (!binding || binding.command !== command) continue;
-
-    const parts: string[] = [];
-    if (binding.shortcut.modKey) parts.push("mod");
-    if (binding.shortcut.ctrlKey) parts.push("ctrl");
-    if (binding.shortcut.metaKey) parts.push("meta");
-    if (binding.shortcut.altKey) parts.push("alt");
-    if (binding.shortcut.shiftKey) parts.push("shift");
-    const keyToken =
-      binding.shortcut.key === " "
-        ? "space"
-        : binding.shortcut.key === "escape"
-          ? "esc"
-          : binding.shortcut.key;
-    parts.push(keyToken);
-    return parts.join("+");
+    return shortcutToKeybindingInput(binding.shortcut);
   }
   return null;
 }
 
 type ProjectScriptKeybindingMutation =
   | { type: "upsert"; input: ServerUpsertKeybindingInput }
-  | { type: "remove"; input: ServerRemoveKeybindingInput }
-  | null;
+  | { type: "remove"; input: ServerRemoveKeybindingInput };
 
-export function deriveProjectScriptKeybindingMutation(input: {
+function keybindingTargetForResolvedRule(
+  rule: ResolvedKeybindingRule,
+): ServerRemoveKeybindingInput {
+  const when = whenAstToExpression(rule.whenAst);
+  return {
+    key: shortcutToKeybindingInput(rule.shortcut),
+    command: rule.command,
+    ...(when.length > 0 ? { when } : {}),
+  };
+}
+
+function isSameKeybindingTarget(
+  left: ServerRemoveKeybindingInput,
+  right: ServerRemoveKeybindingInput,
+): boolean {
+  return (
+    left.key === right.key &&
+    left.command === right.command &&
+    (left.when ?? undefined) === (right.when ?? undefined)
+  );
+}
+
+export function deriveProjectScriptKeybindingMutations(input: {
   keybindings: ResolvedKeybindingsConfig;
   keybinding: string | null | undefined;
   command: KeybindingCommand;
-}): ProjectScriptKeybindingMutation {
+}): ReadonlyArray<ProjectScriptKeybindingMutation> {
   const nextRule = decodeProjectScriptKeybindingRule(input);
-  const previousKeybinding = keybindingValueForCommand(input.keybindings, input.command);
-  const previousRule = previousKeybinding
-    ? decodeProjectScriptKeybindingRule({
-        keybinding: previousKeybinding,
-        command: input.command,
-      })
-    : null;
+  const previousTargets: ServerRemoveKeybindingInput[] = [];
+  for (const binding of input.keybindings) {
+    if (binding.command !== input.command) continue;
+    const target = keybindingTargetForResolvedRule(binding);
+    if (!previousTargets.some((candidate) => isSameKeybindingTarget(candidate, target))) {
+      previousTargets.push(target);
+    }
+  }
 
   if (nextRule) {
-    return {
-      type: "upsert",
-      input:
-        previousRule && previousRule.key !== nextRule.key
-          ? { ...nextRule, replace: previousRule }
-          : nextRule,
-    };
+    const replace = previousTargets.at(-1);
+    return [
+      ...previousTargets.slice(0, -1).map(
+        (target): ProjectScriptKeybindingMutation => ({
+          type: "remove",
+          input: target,
+        }),
+      ),
+      {
+        type: "upsert",
+        input: replace ? { ...nextRule, replace } : nextRule,
+      },
+    ];
   }
-  return previousRule ? { type: "remove", input: previousRule } : null;
+  return previousTargets.map((target) => ({ type: "remove", input: target }));
 }

--- a/apps/web/src/sidebarShortcutBus.ts
+++ b/apps/web/src/sidebarShortcutBus.ts
@@ -1,8 +1,23 @@
-let chatSidebarShortcutClaims = 0;
+import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
 
-export function claimChatSidebarShortcut(): () => void {
-  chatSidebarShortcutClaims += 1;
-  return () => void (chatSidebarShortcutClaims -= 1);
+let chatSidebarShortcutKeybindings: ResolvedKeybindingsConfig | null = null;
+const listeners = new Set<() => void>();
+const notifyListeners = () => listeners.forEach((listener) => listener());
+
+export function claimChatSidebarShortcut(keybindings: ResolvedKeybindingsConfig): () => void {
+  chatSidebarShortcutKeybindings = keybindings;
+  notifyListeners();
+
+  return () => {
+    if (chatSidebarShortcutKeybindings !== keybindings) return;
+    chatSidebarShortcutKeybindings = null;
+    notifyListeners();
+  };
 }
 
-export const hasChatSidebarShortcutClaim = () => chatSidebarShortcutClaims > 0;
+export const readChatSidebarShortcutKeybindings = () => chatSidebarShortcutKeybindings;
+
+export function subscribeChatSidebarShortcut(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => void listeners.delete(listener);
+}

--- a/apps/web/src/sidebarShortcutBus.ts
+++ b/apps/web/src/sidebarShortcutBus.ts
@@ -1,0 +1,8 @@
+let chatSidebarShortcutClaims = 0;
+
+export function claimChatSidebarShortcut(): () => void {
+  chatSidebarShortcutClaims += 1;
+  return () => void (chatSidebarShortcutClaims -= 1);
+}
+
+export const hasChatSidebarShortcutClaim = () => chatSidebarShortcutClaims > 0;


### PR DESCRIPTION
## What Changed

Changing an action shortcut from either the chat header or Project Settings now removes every stale shortcut for that action before saving the new one. Clearing a shortcut or deleting the action removes all matching entries, including conditional rules and rules written with supported shortcut aliases.

Every ChatView consumer now uses one effective shortcut configuration: primary-environment non-action commands plus project actions from the routed environment. Primary-environment chats retain their original interleaved rule order. ChatView publishes its effective configuration while it owns sidebar shortcut handling, so the sidebar tooltip and active handler use the same rules; loading, missing, and non-chat routes consistently use the existing primary-keybinding fallback. The command palette continues to block type-to-focus while allowing its sidebar shortcut.

## Why

The chat-header action editor sent a bare upsert and never sent a removal. The server intentionally appends a bare same-command upsert, so changed, cleared, and deleted action shortcuts remained active. Project Settings also targeted only one prior rule, so it could not clean up duplicates accumulated by the affected path.

The fix derives ordered remove/upsert mutations from the current resolved rules, removes accumulated older targets first, and uses the existing `replace` input for the latest target. Both action editors use that helper. Server target matching compares parsed shortcut and condition semantics so reconstructed targets still match aliases and formatting from `keybindings.json`.

For routed chats, one composition keeps primary non-action commands and routed action commands in the intended precedence order; when both inputs are the primary configuration, the original order is preserved. ChatView uses the effective list for labels and dispatch and publishes it with its runtime sidebar ownership claim. While claimed, ChatView resolves with `terminalFocus`, `terminalOpen`, and `modelPickerOpen`; while unclaimed, the sidebar label and fallback both use primary keybindings. Compact condition serialization prevents the client from expanding a valid condition beyond the existing 256-character RPC limit.

Fixes #5687

## Verification

- `node_modules/.bin/vp test run apps/web/src/lib/projectScriptKeybindings.test.ts` — 7 tests passed. The stale-target, long-condition, and primary-precedence cases failed in their test-first runs before implementation; routed conflict coverage includes a conditional action.
- `node_modules/.bin/vp test run apps/web/src/components/settings/KeybindingsSettings.logic.test.ts` — 9 tests passed.
- `node_modules/.bin/vp test run apps/server/src/keybindings.test.ts -t "appends additional custom keybindings for the same command|replaces only the targeted custom keybinding|removes semantically equivalent custom keybinding targets"` — 3 tests passed, 19 skipped. The semantic-target case failed before the server fix.
- `node_modules/.bin/vp run --filter @t3tools/web --fail-if-no-match typecheck` — passed.
- `node_modules/.bin/vp run --filter ./apps/server --fail-if-no-match typecheck` — passed.
- `node_modules/.bin/vp lint --report-unused-disable-directives apps/web/src/components/AppSidebarLayout.tsx apps/web/src/components/ChatView.tsx apps/web/src/components/settings/ProjectSettingsPanel.tsx apps/web/src/lib/projectScriptKeybindings.ts apps/web/src/lib/projectScriptKeybindings.test.ts apps/web/src/sidebarShortcutBus.ts apps/server/src/keybindings.ts apps/server/src/keybindings.test.ts` — passed.
- `node_modules/.bin/vp fmt --check apps/web/src/components/AppSidebarLayout.tsx apps/web/src/components/ChatView.tsx apps/web/src/components/settings/ProjectSettingsPanel.tsx apps/web/src/lib/projectScriptKeybindings.ts apps/web/src/lib/projectScriptKeybindings.test.ts apps/web/src/sidebarShortcutBus.ts apps/server/src/keybindings.ts apps/server/src/keybindings.test.ts` — passed.
- `git diff --check` — passed.
- `node_modules/.bin/vp run dev` — integrated worktree client pass attempted with disposable state. The renderer started, but the server could not load `node-pty` because this environment could not download the Node headers required for its native build. No live T3 state was accessed, and both assigned ports were closed afterward.

## Scope

- Intentionally limited to the two existing action editors, routed shortcut composition/arbitration, compact reconstruction of existing action conditions, and semantic matching in the existing keybinding mutation service.
- Visual layout, text, motion, dependencies, documentation, defaults, migrations, providers, and wire contracts were not changed. UI evidence is not applicable.
- Web: action shortcut display, dispatch, and capture-phase arbitration use the routed environment; browser persistence remains unchanged because keybinding RPCs stay Electron-gated.
- Desktop: affected; editing, clearing, and deleting action shortcuts now persist the matching reverse operations from both existing editors.
- iOS and Android: not applicable.
- Server: affected only in how existing upsert/remove targets are compared; focused behavioral coverage verifies alias and condition normalization.
- Providers and contracts: unchanged.
- Local and remote connections: existing environment-scoped RPC routing is preserved.
- Relay and tunnel connections: transport behavior is unchanged.
- Multi-device behavior: unchanged.
- Multi-environment behavior: action editor state, labels, dispatch, persistence, and conflicting shortcut arbitration now agree on the routed environment.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included regression coverage
- [x] I included required UI evidence, or UI evidence is not applicable
- [x] I ran targeted checks only
- [x] I did not change unrelated behavior

Model: OpenAI GPT-5
Harness: Codex Work Mode in ChatGPT