### PR TITLE
fix(web): preserve file attachments after input reset

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -87,6 +87,7 @@ import {
   fileAttachmentCapabilityBlockReason,
   fileAttachmentStagingLimit,
   normalizeComposerImageFileMimeType,
+  snapshotComposerFilesBeforeInputReset,
   shouldHandleComposerAttachmentPaste,
 } from "./composerAttachmentFiles";
 import {
@@ -4053,10 +4054,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                         multiple
                         className="hidden"
                         onChange={(event) => {
-                          const files = Array.from(event.currentTarget.files ?? []);
-                          event.currentTarget.value = "";
-                          void addComposerAttachments(files);
-                          focusComposer();
+                          const input = event.currentTarget;
+                          void snapshotComposerFilesBeforeInputReset(
+                            Array.from(input.files ?? []),
+                            () => {
+                              input.value = "";
+                            },
+                          ).then((files) => {
+                            void addComposerAttachments(files);
+                            focusComposer();
+                          });
                         }}
                       />
                       <Tooltip>

--- a/apps/web/src/components/chat/composerAttachmentFiles.test.ts
+++ b/apps/web/src/components/chat/composerAttachmentFiles.test.ts
@@ -9,6 +9,7 @@ import {
   fileAttachmentStagingLimit,
   inferImageMimeTypeFromName,
   normalizeComposerImageFileMimeType,
+  snapshotComposerFilesBeforeInputReset,
   shouldHandleComposerAttachmentPaste,
 } from "./composerAttachmentFiles";
 
@@ -111,6 +112,37 @@ describe("composer attachment files", () => {
     expect(normalizeComposerImageFileMimeType(binary)).toBe(binary);
     expect(normalizeComposerImageFileMimeType(document)).toBe(document);
     expect(normalizeComposerImageFileMimeType(explicitImage)).toBe(explicitImage);
+  });
+
+  it("snapshots a generic input file before reset preserves its upload bytes", async () => {
+    const bytes = new Uint8Array([80, 75, 3, 4, 10, 20, 30]);
+    const file = new File([bytes], "seo-by-rank-math-pro (5).zip", {
+      type: "application/zip",
+      lastModified: 1_725_000_000_000,
+    });
+    let inputOwnsFile = true;
+    let readWhileInputOwned = false;
+    Object.defineProperty(file, "arrayBuffer", {
+      value: async () => {
+        readWhileInputOwned = inputOwnsFile;
+        return bytes.buffer.slice(0);
+      },
+    });
+
+    const [snapshot] = await snapshotComposerFilesBeforeInputReset([file], () => {
+      inputOwnsFile = false;
+    });
+
+    expect(readWhileInputOwned).toBe(true);
+    expect(inputOwnsFile).toBe(false);
+    expect(snapshot).not.toBe(file);
+    expect(snapshot).toMatchObject({
+      name: file.name,
+      type: file.type,
+      lastModified: file.lastModified,
+      size: file.size,
+    });
+    expect(new Uint8Array(await snapshot!.arrayBuffer())).toEqual(bytes);
   });
 
   it("uses the hard local limit while server config is unknown", () => {

--- a/apps/web/src/components/chat/composerAttachmentFiles.ts
+++ b/apps/web/src/components/chat/composerAttachmentFiles.ts
@@ -75,6 +75,38 @@ export function classifyComposerAttachmentFile(
   return isProviderSendTurnSupportedImageMimeType(file.type) ? "image" : "unsupported-image";
 }
 
+/**
+ * Detach generic files from a file input before clearing it. Electron on
+ * macOS can invalidate the input-owned `File` when its value is reset, so the
+ * upload queue must retain an in-memory snapshot instead of that native
+ * handle. Keep image files on their existing compression path.
+ */
+export async function snapshotComposerFilesBeforeInputReset(
+  files: ReadonlyArray<File>,
+  resetInput: () => void,
+): Promise<File[]> {
+  try {
+    return await Promise.all(
+      files.map(async (file) => {
+        if (classifyComposerAttachmentFile(file) !== "file") {
+          return file;
+        }
+        try {
+          const bytes = await file.arrayBuffer();
+          return new File([bytes], file.name, {
+            type: file.type,
+            lastModified: file.lastModified,
+          });
+        } catch {
+          return file;
+        }
+      }),
+    );
+  } finally {
+    resetInput();
+  }
+}
+
 /** Byte limit for adding a generic file to the local composer draft. */
 export function fileAttachmentStagingLimit(input: FileAttachmentCapabilityState): number | null {
   if (!input.attachmentUploadsCapabilityKnown) {


### PR DESCRIPTION
Focused upstream fix for native file attachment bytes being cleared before preservation.

This branch is based on upstream/main at 2daff8c25adf701fddd062ae93b94cc57d420ec2 and contains only the attachment helper, its tests, and ChatComposer wiring. Local validation passed: 18 attachment assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only composer attachment handling with a targeted workaround; large files are still bounded by existing staging limits, with extra in-memory copies only for generic attachments at pick time.
> 
> **Overview**
> Fixes **generic file attachments** in the chat composer losing their bytes on **Electron/macOS** when the hidden file input is cleared immediately after selection.
> 
> Adds `snapshotComposerFilesBeforeInputReset`, which **copies generic files into in-memory `File` objects** via `arrayBuffer()` before the input value is reset, while **leaving images unchanged** so they still go through the existing compression path. `ChatComposer`’s file `onChange` now awaits that snapshot, then passes the result to `addComposerAttachments`. A unit test asserts bytes are read before reset and the snapshot matches name, type, and content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a83a7123bf0f4c64249b85109eaed6bc6fe003b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve file attachments after input reset in `ChatComposer`
> - Adds `snapshotComposerFilesBeforeInputReset` to read generic files into new `File` objects detached from the input element before it is cleared, fixing attachment loss on Electron/macOS where input reset invalidates `File` handles
> - Updates the `ChatComposer` `onChange` handler to call this snapshot utility asynchronously before clearing `input.value`; image files continue on their existing unmodified path
> - The `resetInput` callback runs in a `finally` block so the input clears even if snapshotting fails
> - Risk: generic files are now fully read into memory via `arrayBuffer` before the input resets; very large files may consume more memory during the snapshot step
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a83a712. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->