### PR TITLE
fix(server): back off relay client restarts after rapid exits

### DIFF
--- a/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { vi } from "vite-plus/test";
 import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
@@ -8,6 +9,7 @@ import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as RelayClient from "@t3tools/shared/relayClient";
 
@@ -281,6 +283,126 @@ describe("CloudManagedEndpointRuntime", () => {
       expect(spawned).toEqual([400, 401]);
       expect(killed).toEqual([400]);
     }),
+  );
+
+  const makeCrashLoopSpawner = (basePid: number, slots: number) =>
+    Effect.gen(function* () {
+      const spawned: Array<number> = [];
+      const exits: Array<Deferred.Deferred<ChildProcessSpawner.ExitCode>> = [];
+      const spawnSignals: Array<Deferred.Deferred<void>> = [];
+      for (let index = 0; index < slots; index += 1) {
+        exits.push(yield* Deferred.make<ChildProcessSpawner.ExitCode>());
+        spawnSignals.push(yield* Deferred.make<void>());
+      }
+      const spawner = ChildProcessSpawner.make(() =>
+        Effect.gen(function* () {
+          const index = spawned.length;
+          spawned.push(basePid + index);
+          yield* Deferred.succeed(spawnSignals[index]!, undefined);
+          const handle = makeHandle({
+            pid: basePid + index,
+            exitCode: Deferred.await(exits[index]!),
+            onKill: () => {},
+          });
+          yield* Effect.addFinalizer(() => handle.kill().pipe(Effect.ignore));
+          return handle;
+        }),
+      );
+      return { spawner, spawned, exits, spawnSignals };
+    });
+
+  it.effect("backs off restarts while the connector crash-loops", () =>
+    Effect.gen(function* () {
+      const { spawner, spawned, exits, spawnSignals } = yield* makeCrashLoopSpawner(600, 4);
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
+
+      yield* runtime.applyConfig({
+        providerKind: "cloudflare_tunnel",
+        connectorToken: "token",
+        tunnelId: "tunnel-1",
+      });
+      expect(spawned).toEqual([600]);
+
+      // The first crash restarts immediately.
+      yield* Deferred.succeed(exits[0]!, ChildProcessSpawner.ExitCode(1));
+      yield* Deferred.await(spawnSignals[1]!);
+      expect(spawned).toEqual([600, 601]);
+
+      // The second rapid crash waits out the base delay before restarting.
+      yield* Deferred.succeed(exits[1]!, ChildProcessSpawner.ExitCode(1));
+      yield* TestClock.adjust(Duration.millis(999));
+      expect(spawned).toEqual([600, 601]);
+      yield* TestClock.adjust(Duration.millis(1));
+      yield* Deferred.await(spawnSignals[2]!);
+      expect(spawned).toEqual([600, 601, 602]);
+
+      // The third rapid crash doubles the delay.
+      yield* Deferred.succeed(exits[2]!, ChildProcessSpawner.ExitCode(1));
+      yield* TestClock.adjust(Duration.millis(1999));
+      expect(spawned).toEqual([600, 601, 602]);
+      yield* TestClock.adjust(Duration.millis(1));
+      yield* Deferred.await(spawnSignals[3]!);
+      expect(spawned).toEqual([600, 601, 602, 603]);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("resets the backoff after the connector runs stably", () =>
+    Effect.gen(function* () {
+      const { spawner, spawned, exits, spawnSignals } = yield* makeCrashLoopSpawner(700, 5);
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
+
+      yield* runtime.applyConfig({
+        providerKind: "cloudflare_tunnel",
+        connectorToken: "token",
+      });
+
+      // One rapid crash arms the backoff.
+      yield* Deferred.succeed(exits[0]!, ChildProcessSpawner.ExitCode(1));
+      yield* Deferred.await(spawnSignals[1]!);
+
+      // The replacement stays up past the stable-uptime window, so its exit
+      // restarts immediately and the backoff starts over.
+      yield* TestClock.adjust(Duration.millis(30_000));
+      yield* Deferred.succeed(exits[1]!, ChildProcessSpawner.ExitCode(1));
+      yield* Deferred.await(spawnSignals[2]!);
+      yield* Deferred.succeed(exits[2]!, ChildProcessSpawner.ExitCode(1));
+      yield* Deferred.await(spawnSignals[3]!);
+
+      // The next rapid crash waits the base delay again, not a doubled one.
+      yield* Deferred.succeed(exits[3]!, ChildProcessSpawner.ExitCode(1));
+      yield* TestClock.adjust(Duration.millis(999));
+      expect(spawned).toEqual([700, 701, 702, 703]);
+      yield* TestClock.adjust(Duration.millis(1));
+      yield* Deferred.await(spawnSignals[4]!);
+      expect(spawned).toEqual([700, 701, 702, 703, 704]);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("an explicit config change clears the backoff and preempts a delayed restart", () =>
+    Effect.gen(function* () {
+      const { spawner, spawned, exits, spawnSignals } = yield* makeCrashLoopSpawner(800, 3);
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
+
+      yield* runtime.applyConfig({
+        providerKind: "cloudflare_tunnel",
+        connectorToken: "token-1",
+      });
+      yield* Deferred.succeed(exits[0]!, ChildProcessSpawner.ExitCode(1));
+      yield* Deferred.await(spawnSignals[1]!);
+
+      // Leave the supervisor sleeping on the base delay, then change config.
+      yield* Deferred.succeed(exits[1]!, ChildProcessSpawner.ExitCode(1));
+      const status = yield* runtime.applyConfig({
+        providerKind: "cloudflare_tunnel",
+        connectorToken: "token-2",
+      });
+      expect(status).toMatchObject({ status: "running", pid: 802 });
+      expect(spawned).toEqual([800, 801, 802]);
+
+      // The preempted supervisor wakes later and must not spawn a duplicate.
+      yield* TestClock.adjust(Duration.millis(60_000));
+      expect(spawned).toEqual([800, 801, 802]);
+    }).pipe(Effect.provide(TestClock.layer())),
   );
 
   it.effect("serializes concurrent connector config changes", () =>

--- a/apps/server/src/cloud/ManagedEndpointRuntime.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.ts
@@ -1,6 +1,8 @@
 import type { RelayManagedEndpointRuntimeConfig } from "@t3tools/contracts/relay";
 import * as RelayClient from "@t3tools/shared/relayClient";
+import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
@@ -66,7 +68,17 @@ interface ActiveConnector {
   readonly scope: Scope.Closeable;
   readonly configKey: string;
   readonly config: RelayManagedEndpointRuntimeConfig;
+  readonly startedAtMillis: number;
 }
+
+// A connector that exits before running this long is treated as part of a
+// crash loop; one that stays up at least this long earns an immediate restart
+// again. Without the backoff below, a relay client that fails instantly (a
+// stale version-manager shim, a bad binary) respawns ~100 times per second
+// until the accumulated tracing exhausts the V8 heap.
+const RELAY_RESTART_STABLE_UPTIME_MS = 30_000;
+const RELAY_RESTART_BACKOFF_BASE_MS = 1_000;
+const RELAY_RESTART_BACKOFF_MAX_MS = 60_000;
 
 export function classifyRelayClientOutput(line: string): "connected" | "warning" | "debug" {
   if (/\bRegistered tunnel connection\b/iu.test(line)) {
@@ -105,6 +117,7 @@ export const make = Effect.gen(function* () {
   const activeRef = yield* Ref.make<ActiveConnector | null>(null);
   const desiredConfigRef = yield* Ref.make<RelayManagedEndpointRuntimeConfig | null>(null);
   const reconcileSemaphore = yield* Semaphore.make(1);
+  const restartDelayRef = yield* Ref.make(0);
   let reconcileConfig: CloudManagedEndpointRuntime["Service"]["applyConfig"];
 
   const stopActive = Effect.gen(function* () {
@@ -115,6 +128,39 @@ export const make = Effect.gen(function* () {
   const superviseConnector = (connector: ActiveConnector) =>
     Effect.gen(function* () {
       const result = yield* Effect.result(connector.child.exitCode);
+      const activeAtExit = yield* Ref.get(activeRef);
+      if (
+        activeAtExit?.child.pid !== connector.child.pid ||
+        activeAtExit.configKey !== connector.configKey
+      ) {
+        return;
+      }
+      const uptimeMillis = (yield* Clock.currentTimeMillis) - connector.startedAtMillis;
+      // The first crash restarts immediately; every further crash inside the
+      // stable-uptime window doubles the wait, up to the cap. The delay runs
+      // before the semaphore so a user config change is never blocked behind
+      // it, and reconcileConfig re-checks the desired config afterwards.
+      const restartDelayMillis = yield* Ref.modify(restartDelayRef, (current) => {
+        if (uptimeMillis >= RELAY_RESTART_STABLE_UPTIME_MS) {
+          return [0, 0];
+        }
+        return [
+          current,
+          current === 0
+            ? RELAY_RESTART_BACKOFF_BASE_MS
+            : Math.min(current * 2, RELAY_RESTART_BACKOFF_MAX_MS),
+        ];
+      });
+      if (restartDelayMillis > 0) {
+        yield* Effect.logWarning("Relay client is crash-looping; delaying restart", {
+          pid: Number(connector.child.pid),
+          uptimeMillis,
+          restartDelayMillis,
+          tunnelId: connector.config.tunnelId,
+          tunnelName: connector.config.tunnelName,
+        });
+        yield* Effect.sleep(Duration.millis(restartDelayMillis));
+      }
       yield* reconcileSemaphore.withPermits(1)(
         Effect.gen(function* () {
           const active = yield* Ref.get(activeRef);
@@ -274,6 +320,7 @@ export const make = Effect.gen(function* () {
         scope: connectorScope,
         configKey: nextConfigKey,
         config,
+        startedAtMillis: yield* Clock.currentTimeMillis,
       } satisfies ActiveConnector;
       yield* Ref.set(activeRef, connector);
       yield* Effect.forkIn(observeConnectorOutput(connector), connectorScope);
@@ -299,7 +346,11 @@ export const make = Effect.gen(function* () {
   const applyConfig = Effect.fn("CloudManagedEndpointRuntime.applyConfig")(
     (config: RelayManagedEndpointRuntimeConfig | null) =>
       reconcileSemaphore.withPermits(1)(
-        Ref.set(desiredConfigRef, config).pipe(Effect.andThen(reconcileConfig(config))),
+        // An explicit config change starts over with a fresh backoff.
+        Ref.set(restartDelayRef, 0).pipe(
+          Effect.andThen(Ref.set(desiredConfigRef, config)),
+          Effect.andThen(reconcileConfig(config)),
+        ),
       ),
   );
 


### PR DESCRIPTION
A relay client that exits immediately (a stale version-manager shim, a broken binary) is respawned by `superviseConnector` with no delay - roughly 90-100 processes per second - until the accumulated tracing exhausts the V8 heap and the backend aborts about once an hour.

The supervisor now tracks connector uptime. The first crash still restarts immediately; each further crash inside a 30-second stable-uptime window doubles the restart delay, from 1 second up to a 60-second cap. A connector that stays up past the stable window, or an explicit config change, resets the backoff. The delay runs before the reconcile semaphore so a user config change is never blocked behind it, and a supervisor preempted by a config change cannot spawn a duplicate connector.

Fixes #8760

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connector supervision and restart timing for cloud managed endpoints; behavior is well-tested but affects process lifecycle under failure modes that previously could take down the server.
> 
> **Overview**
> When the Cloudflare relay client exits immediately on startup, the connector supervisor used to respawn it with no delay (~100 times per second), which could exhaust the V8 heap from accumulated tracing.
> 
> **Backoff on crash-loops:** The supervisor now records connector start time and applies exponential backoff on rapid exits: the first crash still restarts immediately; further crashes within a **30s** stable-uptime window wait **1s**, then double up to a **60s** cap, with a warning log. A run that lasts at least 30s resets backoff to immediate restart on the next exit.
> 
> **Config changes:** `applyConfig` clears backoff and the sleep runs *before* the reconcile lock so user config updates are not blocked; stale supervisors that wake after a config change bail out via PID/configKey checks so they do not spawn duplicate connectors.
> 
> New tests use `TestClock` to verify backoff timing, stable-uptime reset, and config preempting a delayed restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b84654d77b328db80001ed28bd270bca5aecbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add exponential backoff to relay client restarts after rapid crashes
> - Connector restarts now delay with exponential backoff when the process crashes within 30s of starting: first restart is immediate, then 1s, 2s, doubling up to a 60s cap (`RELAY_RESTART_BACKOFF_MAX_MS`).
> - Backoff resets to zero after a connector runs stably for 30s (`RELAY_RESTART_STABLE_UPTIME_MS`), tracked via `startedAtMillis` on `ActiveConnector`.
> - `applyConfig` clears `restartDelayRef` before reconciling, so explicit config changes preempt any in-flight delayed restart and trigger an immediate respawn.
> - Warning logs are emitted before each delayed restart with pid, uptime, delay, and tunnel identifiers.
> - Adds tests in [ManagedEndpointRuntime.test.ts](https://github.com/pingdotgg/t3code/pull/8788/files#diff-e2d9ec3b87e32bb2026d5a763444ad67e2966b0d75e3d3807deb8e889742e28b) covering crash-loop backoff, reset after stable uptime, and config-change preemption using `TestClock`.
> - Behavioral Change: the `superviseConnector` helper in [ManagedEndpointRuntime.ts](https://github.com/pingdotgg/t3code/pull/8788/files#diff-7e51d782034aeae3187abebda413ecbd44a5d6b4f7caf5ede93d4e38a474ec53) now re-checks `activeRef` after the backoff sleep and before acquiring the reconcile semaphore; stale exits are ignored, and a prior delayed supervisor will not spawn a duplicate if a config change already promoted a new connector.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76b8465.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->