### PR TITLE
fix(web): prevent pull request metadata overlap

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -72,7 +72,7 @@ function PullRequestRowImpl({
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <span className="flex min-w-0 items-center gap-1 rounded-full border border-border/60 px-1 text-[10px]" />
+                  <span className="flex min-w-0 items-center gap-1 overflow-hidden rounded-full border border-border/60 px-1 text-[10px]" />
                 }
               >
                 <span className="sr-only">matched in the description</span>

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -72,7 +72,7 @@ function PullRequestRowImpl({
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <span className="flex min-w-0 items-center gap-1 overflow-hidden rounded-full border border-border/60 px-1 text-[10px]" />
+                  <span className="flex min-w-6 items-center gap-1 overflow-hidden rounded-full border border-border/60 px-1 text-[10px]" />
                 }
               >
                 <span className="sr-only">matched in the description</span>

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -61,7 +61,7 @@ function PullRequestRowImpl({
       />
       <span className="min-w-0">
         <span className="block truncate text-sm font-medium text-foreground">{entry.title}</span>
-        <PullRequestMetaLine className="mt-0.5 text-xs text-muted-foreground/70">
+        <PullRequestMetaLine className="mt-0.5 overflow-hidden text-xs text-muted-foreground/70">
           <span className="flex shrink-0 items-center gap-1">
             {showProvider ? (
               <Tooltip>
@@ -91,7 +91,7 @@ function PullRequestRowImpl({
           {environmentLabel ? (
             <span className="max-w-32 shrink-0 truncate">{environmentLabel}</span>
           ) : null}
-          <PullRequestActorLabel actor={entry.author} className="max-w-40 shrink-0" />
+          <PullRequestActorLabel actor={entry.author} className="max-w-40" />
           {/* Only a verdict somebody has actually given: "review required" is the absence of
               one, and saying so on every unreviewed row would say nothing. */}
           {entry.reviewDecision === "approved" || entry.reviewDecision === "changes-requested" ? (

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -60,7 +60,7 @@ function PullRequestRowImpl({
         mergeability={entry.mergeability}
         baseBranch={entry.baseBranch}
       />
-      <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-3 gap-y-0.5">
+      <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-0.5">
         <span className="col-start-1 row-start-1 block truncate text-sm font-medium text-foreground">
           {entry.title}
         </span>

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -113,7 +113,11 @@ function PullRequestRowImpl({
           {environmentLabel ? (
             <span className="min-w-0 max-w-32 truncate">{environmentLabel}</span>
           ) : null}
-          <PullRequestActorLabel actor={entry.author} className="min-w-4 max-w-40" />
+          <PullRequestActorLabel
+            actor={entry.author}
+            className="min-w-4 max-w-40"
+            labelClassName="sr-only @xs/pr-row-meta:not-sr-only @xs/pr-row-meta:truncate"
+          />
           {/* Only a verdict somebody has actually given: "review required" is the absence of
               one, and saying so on every unreviewed row would say nothing. */}
           {entry.reviewDecision === "approved" || entry.reviewDecision === "changes-requested" ? (

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -46,7 +46,7 @@ function PullRequestRowImpl({
       aria-current={selected ? "true" : undefined}
       onClick={() => onSelect(entry)}
       className={cn(
-        "grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         // Offscreen rows are skipped for style, layout and paint: a long list costs what the
         // viewport shows, not what the pages have loaded. The intrinsic size keeps the
         // scrollbar honest while a row is skipped.
@@ -60,19 +60,24 @@ function PullRequestRowImpl({
         mergeability={entry.mergeability}
         baseBranch={entry.baseBranch}
       />
-      <span className="@container/pr-row-meta min-w-0 overflow-hidden">
-        <span className="block truncate text-sm font-medium text-foreground">{entry.title}</span>
-        <PullRequestMetaLine className="mt-0.5 overflow-hidden text-xs text-muted-foreground/70">
+      <span className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-3 gap-y-0.5">
+        <span className="col-start-1 row-start-1 block truncate text-sm font-medium text-foreground">
+          {entry.title}
+        </span>
+        <span className="col-start-2 row-start-1 justify-self-end whitespace-nowrap text-xs text-muted-foreground/70 tabular-nums">
+          {formatRelativeTimeLabel(entry.updatedAt)}
+        </span>
+        <PullRequestMetaLine className="@container/pr-row-meta col-start-1 row-start-2 overflow-hidden text-xs text-muted-foreground/70">
           {matchedElsewhere ? (
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <span className="flex shrink-0 items-center gap-1 rounded-full border border-border/60 px-1 text-[10px]" />
+                  <span className="flex min-w-0 items-center gap-1 rounded-full border border-border/60 px-1 text-[10px]" />
                 }
               >
                 <span className="sr-only">matched in the description</span>
                 <SearchIcon aria-hidden className="size-3 shrink-0" />
-                <span aria-hidden className="hidden @xs/pr-row-meta:inline">
+                <span aria-hidden className="hidden truncate @xs/pr-row-meta:block">
                   matched in the description
                 </span>
               </TooltipTrigger>
@@ -135,10 +140,11 @@ function PullRequestRowImpl({
             />
           )}
         </PullRequestMetaLine>
-      </span>
-      <span className="flex shrink-0 flex-col items-end gap-0.5 text-xs text-muted-foreground/70 tabular-nums">
-        <span>{formatRelativeTimeLabel(entry.updatedAt)}</span>
-        <PullRequestDiffStat additions={entry.additions} deletions={entry.deletions} />
+        <PullRequestDiffStat
+          additions={entry.additions}
+          deletions={entry.deletions}
+          className="col-start-2 row-start-2 justify-self-end text-xs"
+        />
       </span>
     </button>
   );

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -126,6 +126,7 @@ function PullRequestRowImpl({
           {entry.checksState === undefined ? null : (
             <PullRequestChecksPopover
               checksState={entry.checksState}
+              className="hidden @xs/pr-row-meta:inline-flex"
               environmentId={entry.environmentId}
               reference={{
                 projectId: entry.projectId,

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -1,3 +1,4 @@
+import { SearchIcon } from "lucide-react";
 import { memo } from "react";
 
 import { cn } from "~/lib/utils";
@@ -59,9 +60,25 @@ function PullRequestRowImpl({
         mergeability={entry.mergeability}
         baseBranch={entry.baseBranch}
       />
-      <span className="min-w-0">
+      <span className="@container/pr-row-meta min-w-0 overflow-hidden">
         <span className="block truncate text-sm font-medium text-foreground">{entry.title}</span>
-        <PullRequestMetaLine className="mt-0.5 text-xs text-muted-foreground/70">
+        <PullRequestMetaLine className="mt-0.5 overflow-hidden text-xs text-muted-foreground/70">
+          {matchedElsewhere ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span className="flex shrink-0 items-center gap-1 rounded-full border border-border/60 px-1 text-[10px]" />
+                }
+              >
+                <span className="sr-only">matched in the description</span>
+                <SearchIcon aria-hidden className="size-3 shrink-0" />
+                <span aria-hidden className="hidden @xs/pr-row-meta:inline">
+                  matched in the description
+                </span>
+              </TooltipTrigger>
+              <TooltipPopup side="top">Matched in the description</TooltipPopup>
+            </Tooltip>
+          ) : null}
           <span className="flex shrink-0 items-center gap-1">
             {showProvider ? (
               <Tooltip>
@@ -89,7 +106,7 @@ function PullRequestRowImpl({
           </span>
           {showProjectTitle ? <span className="truncate">{entry.repository}</span> : null}
           {environmentLabel ? (
-            <span className="max-w-32 shrink-0 truncate">{environmentLabel}</span>
+            <span className="min-w-0 max-w-32 truncate">{environmentLabel}</span>
           ) : null}
           <PullRequestActorLabel actor={entry.author} className="max-w-40" />
           {/* Only a verdict somebody has actually given: "review required" is the absence of
@@ -97,7 +114,7 @@ function PullRequestRowImpl({
           {entry.reviewDecision === "approved" || entry.reviewDecision === "changes-requested" ? (
             <span
               className={cn(
-                "shrink-0",
+                "min-w-0 truncate",
                 entry.reviewDecision === "approved"
                   ? "text-emerald-600/90 dark:text-emerald-400/80"
                   : "text-amber-600/90 dark:text-amber-400/80",
@@ -117,11 +134,6 @@ function PullRequestRowImpl({
               }}
             />
           )}
-          {matchedElsewhere ? (
-            <span className="shrink-0 rounded-full border border-border/60 px-1.5 text-[10px]">
-              matched in the description
-            </span>
-          ) : null}
         </PullRequestMetaLine>
       </span>
       <span className="flex shrink-0 flex-col items-end gap-0.5 text-xs text-muted-foreground/70 tabular-nums">

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -126,7 +126,6 @@ function PullRequestRowImpl({
           {entry.checksState === undefined ? null : (
             <PullRequestChecksPopover
               checksState={entry.checksState}
-              className="hidden @xs/pr-row-meta:inline-flex"
               environmentId={entry.environmentId}
               reference={{
                 projectId: entry.projectId,

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -108,7 +108,7 @@ function PullRequestRowImpl({
           {environmentLabel ? (
             <span className="min-w-0 max-w-32 truncate">{environmentLabel}</span>
           ) : null}
-          <PullRequestActorLabel actor={entry.author} className="max-w-40" />
+          <PullRequestActorLabel actor={entry.author} className="min-w-4 max-w-40" />
           {/* Only a verdict somebody has actually given: "review required" is the absence of
               one, and saying so on every unreviewed row would say nothing. */}
           {entry.reviewDecision === "approved" || entry.reviewDecision === "changes-requested" ? (

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -61,7 +61,7 @@ function PullRequestRowImpl({
       />
       <span className="min-w-0">
         <span className="block truncate text-sm font-medium text-foreground">{entry.title}</span>
-        <PullRequestMetaLine className="mt-0.5 overflow-hidden text-xs text-muted-foreground/70">
+        <PullRequestMetaLine className="mt-0.5 text-xs text-muted-foreground/70">
           <span className="flex shrink-0 items-center gap-1">
             {showProvider ? (
               <Tooltip>

--- a/apps/web/src/components/pullRequest/pullRequestPresentation.tsx
+++ b/apps/web/src/components/pullRequest/pullRequestPresentation.tsx
@@ -339,17 +339,19 @@ export function PullRequestActorAvatar({
 export function PullRequestActorLabel({
   actor,
   className,
+  labelClassName,
   tooltip = true,
 }: {
   actor: PullRequestActor | null;
   className?: string;
+  labelClassName?: string;
   tooltip?: boolean;
 }) {
   const login = actor?.login ?? "ghost";
   const label = (
     <>
       <PullRequestActorAvatar actor={actor} />
-      <span className="truncate">{login}</span>
+      <span className={cn("truncate", labelClassName)}>{login}</span>
     </>
   );
   if (!tooltip) {

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1864,7 +1864,7 @@ function PullRequestsColumn({
             {/* The page name remains the foreground anchor in both states; the live filters are
                 its compact scope, grouped as the second crumb rather than pretending each menu
                 is a separate page in the hierarchy. */}
-            <WorkspaceBreadcrumbItem current className="shrink-0">
+            <WorkspaceBreadcrumbItem current>
               <h1 className="truncate">Pull Requests</h1>
             </WorkspaceBreadcrumbItem>
             <WorkspaceBreadcrumbSeparator />

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1867,17 +1867,13 @@ function PullRequestsColumn({
         {titlebarControls}
         {condensed ? (
           <WorkspaceBreadcrumb ariaLabel="Pull request scope" className="overflow-hidden">
-            {/* An expanded search owns the scarce horizontal space. The page title returns when
-                it folds, while the live filters remain available in both states. */}
-            {searchExpanded ? null : (
-              <>
-                <WorkspaceBreadcrumbItem current>
-                  <h1 className="truncate">Pull Requests</h1>
-                </WorkspaceBreadcrumbItem>
-                <WorkspaceBreadcrumbSeparator />
-              </>
-            )}
-            <WorkspaceBreadcrumbItem className="shrink gap-1.5">
+            {/* An expanded search owns the scarce horizontal space. The page title stays
+                available to readers while the live filters remain available in both states. */}
+            <WorkspaceBreadcrumbItem current className={cn(searchExpanded && "sr-only")}>
+              <h1 className="truncate">Pull Requests</h1>
+            </WorkspaceBreadcrumbItem>
+            {searchExpanded ? null : <WorkspaceBreadcrumbSeparator />}
+            <WorkspaceBreadcrumbItem className="shrink-0 gap-1.5">
               <CompactFilterMenu
                 label="Filter by state"
                 value={state}
@@ -1910,7 +1906,7 @@ function PullRequestsColumn({
         )}
         <div className="min-w-0 flex-1" />
         {condensed ? (
-          <div className="flex min-w-[8.125rem] shrink items-center gap-1.5">
+          <div className="flex shrink items-center gap-1.5">
             <ExpandableSearch
               searchInput={searchInput}
               searchValue={searchValue}

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1877,7 +1877,7 @@ function PullRequestsColumn({
                 <WorkspaceBreadcrumbSeparator />
               </>
             )}
-            <WorkspaceBreadcrumbItem className="shrink gap-1.5 overflow-hidden">
+            <WorkspaceBreadcrumbItem className="shrink gap-1.5">
               <CompactFilterMenu
                 label="Filter by state"
                 value={state}

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1628,11 +1628,13 @@ function CompactFilterMenu<Value extends string>({
   value,
   options,
   onChange,
+  className,
 }: {
   label: string;
   value: Value;
   options: ReadonlyArray<PullRequestFilterOption<Value>>;
   onChange: (value: Value) => void;
+  className?: string;
 }) {
   const current = options.find((option) => option.value === value) ?? options[0];
   if (!current) return null;
@@ -1640,10 +1642,13 @@ function CompactFilterMenu<Value extends string>({
     <Menu>
       <MenuTrigger
         aria-label={label}
-        className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+        className={cn(
+          "inline-flex h-7 min-w-0 items-center gap-1 rounded-md px-1.5 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground",
+          className,
+        )}
       >
-        {current.label}
-        <ChevronDownIcon aria-hidden className="size-3 text-muted-foreground/70" />
+        <span className="truncate">{current.label}</span>
+        <ChevronDownIcon aria-hidden className="size-3 shrink-0 text-muted-foreground/70" />
       </MenuTrigger>
       <MenuPopup align="start" side="bottom" className="min-w-40">
         <MenuRadioGroup value={value} onValueChange={(next) => onChange(next as Value)}>
@@ -1808,6 +1813,7 @@ function PullRequestsColumn({
   const inFlowSearchRef = useRef<HTMLDivElement | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const searchExpanded = searchOpen || searchValue.length > 0;
   // Mod+F belongs to this page's own search: the desktop shell binds no find-in-page, so the
   // shortcut would otherwise do nothing. Condensed, it unfolds the topbar search; at the top,
   // it focuses the in-flow bar and selects the query the way a find field would.
@@ -1861,19 +1867,23 @@ function PullRequestsColumn({
         {titlebarControls}
         {condensed ? (
           <WorkspaceBreadcrumb ariaLabel="Pull request scope" className="overflow-hidden">
-            {/* The page name remains the foreground anchor in both states; the live filters are
-                its compact scope, grouped as the second crumb rather than pretending each menu
-                is a separate page in the hierarchy. */}
-            <WorkspaceBreadcrumbItem current>
-              <h1 className="truncate">Pull Requests</h1>
-            </WorkspaceBreadcrumbItem>
-            <WorkspaceBreadcrumbSeparator />
+            {/* An expanded search owns the scarce horizontal space. The page title returns when
+                it folds, while the live filters remain available in both states. */}
+            {searchExpanded ? null : (
+              <>
+                <WorkspaceBreadcrumbItem current>
+                  <h1 className="truncate">Pull Requests</h1>
+                </WorkspaceBreadcrumbItem>
+                <WorkspaceBreadcrumbSeparator />
+              </>
+            )}
             <WorkspaceBreadcrumbItem className="shrink gap-1.5 overflow-hidden">
               <CompactFilterMenu
                 label="Filter by state"
                 value={state}
                 options={STATE_TABS}
                 onChange={onState}
+                className="shrink-0"
               />
               <CompactFilterMenu
                 label="Filter by involvement"
@@ -1900,7 +1910,7 @@ function PullRequestsColumn({
         )}
         <div className="min-w-0 flex-1" />
         {condensed ? (
-          <div className="flex min-w-0 items-center gap-1.5">
+          <div className="flex min-w-[8.125rem] shrink items-center gap-1.5">
             <ExpandableSearch
               searchInput={searchInput}
               searchValue={searchValue}

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1721,7 +1721,7 @@ function ExpandableSearch({
     return (
       <div
         ref={containerRef}
-        className="w-56 shrink-0"
+        className="w-56 min-w-24 shrink"
         onFocus={() => onFocusWithin?.(true)}
         onBlur={() => {
           onFocusWithin?.(false);
@@ -1860,15 +1860,15 @@ function PullRequestsColumn({
       >
         {titlebarControls}
         {condensed ? (
-          <WorkspaceBreadcrumb ariaLabel="Pull request scope">
+          <WorkspaceBreadcrumb ariaLabel="Pull request scope" className="overflow-hidden">
             {/* The page name remains the foreground anchor in both states; the live filters are
                 its compact scope, grouped as the second crumb rather than pretending each menu
                 is a separate page in the hierarchy. */}
-            <WorkspaceBreadcrumbItem current>
+            <WorkspaceBreadcrumbItem current className="shrink-0">
               <h1 className="truncate">Pull Requests</h1>
             </WorkspaceBreadcrumbItem>
             <WorkspaceBreadcrumbSeparator />
-            <WorkspaceBreadcrumbItem className="gap-1.5 overflow-hidden">
+            <WorkspaceBreadcrumbItem className="shrink gap-1.5 overflow-hidden">
               <CompactFilterMenu
                 label="Filter by state"
                 value={state}
@@ -1900,7 +1900,7 @@ function PullRequestsColumn({
         )}
         <div className="min-w-0 flex-1" />
         {condensed ? (
-          <div className="flex shrink-0 items-center gap-1.5">
+          <div className="flex min-w-0 items-center gap-1.5">
             <ExpandableSearch
               searchInput={searchInput}
               searchValue={searchValue}

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1873,7 +1873,7 @@ function PullRequestsColumn({
               <h1 className="truncate">Pull Requests</h1>
             </WorkspaceBreadcrumbItem>
             {searchExpanded ? null : <WorkspaceBreadcrumbSeparator />}
-            <WorkspaceBreadcrumbItem className="shrink-0 gap-1.5">
+            <WorkspaceBreadcrumbItem className="shrink gap-1.5">
               <CompactFilterMenu
                 label="Filter by state"
                 value={state}


### PR DESCRIPTION
![Pull request list before and after: overlapping metadata at branch start and the corrected responsive layout](<https://github.com/user-attachments/assets/0cced697-4e18-4d32-8864-ee4493405a8f>)

_Branch point 8f525af5a → current e90e9c7ab_

## Problem

Opening a pull request detail panel narrows the list. Row metadata, including the “matched in the description” hint, could paint underneath the fixed timestamp and diff-stat column. In the condensed header, an active search could also squeeze the breadcrumb until the Open filter painted underneath the search field.

## Fix

Keep each row in a two-line grid: the title and timestamp share the first row, while metadata and reported diff stats share the second. Timestamp and diff stats own a non-shrinking right column. Title, repository, environment, review decision, and description-match text truncate on the left; at narrow row widths the author login folds into its avatar, with the full login retained in the tooltip and accessible text.

In the condensed header, reserve a usable floor for search and refresh, let filter labels truncate without clipping their focusable controls, and visually hide the page title while preserving its heading semantics when an active search owns the limited width. The Open filter remains fully readable in both panel states.

## UI changes

### Condensed header with search expanded

Before — the involvement filter and search activity collide:

![Before condensed header: filter controls overlap the expanded search](https://github.com/user-attachments/assets/8ba2c86a-efac-4589-a176-113f2b329ece)

After — filter controls remain separate and reachable, the search keeps a usable width, and refresh stays clear:

![After condensed header: filters, expanded search, and refresh remain separated](https://github.com/user-attachments/assets/edc7165d-63de-4644-9d58-ab727ef40c2f)

### Narrow rows with the detail panel open

Before — metadata and the description-match label paint under the fixed timestamp and diff stats:

![Before narrow rows: metadata overlaps the timestamp and diff-stat column](https://github.com/user-attachments/assets/a3565669-ad1d-4b87-ac8a-6aa4384965a2)

After — the timestamp aligns with the title, reported diff stats stay on the metadata row, and lower-priority text truncates without displacing either fixed field or clipping the checks control:

![After narrow rows: truncated metadata and compact match badge remain inside their column](https://github.com/user-attachments/assets/9a5f18ab-29e6-4895-b72b-8970b42539ad)

### Wide rows with the detail panel closed

Before — the row has room, but this is the unfixed baseline behavior:

![Before wide rows: full description-match label in the baseline layout](https://github.com/user-attachments/assets/0e09c598-2075-4e42-89cc-4195367a5416)

After — the full description-match label returns when space is available and all metadata remains separated:

![After wide rows: full description-match label and metadata remain separated](https://github.com/user-attachments/assets/56a6e451-e8ec-431b-bc4e-26ad9a4d5d26)

## Verification

- `bun run fmt --check apps/web/src/components/pullRequest/PullRequestRow.tsx apps/web/src/routes/_chat.pull-requests.tsx`
- `bun run lint apps/web/src/components/pullRequest/PullRequestRow.tsx apps/web/src/routes/_chat.pull-requests.tsx`
- `bun run --cwd apps/web typecheck`
- `git diff --check`
- Browser-verified with matched before/after captures for the condensed header, narrow rows with the detail panel open, and wide rows with it closed.

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and layout changes in the pull-requests list and header; no API, auth, or data-flow changes.
> 
> **Overview**
> Fixes layout overlap when the PR list is narrow (detail panel open) or the condensed header search is expanded.
> 
> **List rows** move from a three-column shell to a two-column grid with an inner two-row grid: **updated time** sits on the title row (right), and **diff stats** sit on the metadata row (right) so they no longer stack in a fixed column that metadata could paint under. Metadata chips get stronger **truncation** and **min-width** rules; the author login can collapse to avatar-only at small widths via a new **`labelClassName`** on `PullRequestActorLabel` and `@container/pr-row-meta`. The **“matched in the description”** hint becomes a compact **search icon + tooltip** badge with responsive label text instead of a full inline string.
> 
> **Condensed header** tracks **`searchExpanded`** to **visually hide** the “Pull Requests” title (still in the DOM for accessibility) while search is open, drops the breadcrumb separator in that state, and lets filters/search **shrink** with truncated filter menu labels and a flexible expanded search width (`min-w-24 shrink` vs fixed `shrink-0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92bfd4ed9ffa30e4d3076311e37c0f35c5bbeeb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pull request metadata overlap in `PullRequestRowImpl` and pull-requests header layout
> - Reworks the row layout in `PullRequestRowImpl` from a 3-column to a 2-column grid, placing the `updatedAt` label inline with the title on the first row and the diff stat right-aligned on the second row
> - Replaces the plain `matchedElsewhere` text badge with an icon-and-tooltip chip using `SearchIcon`, with an accessible sr-only label and a responsive text span
> - Updates truncation and min-width classes across `environmentLabel`, `PullRequestActorLabel`, and `reviewDecision` to prevent overflow; `PullRequestActorLabel` gains an optional `labelClassName` prop for independent truncation control
> - In the pull-requests route header, the condensed breadcrumb hides the title when search is expanded, filter menu triggers accept external `className` and truncate long labels, and `ExpandableSearch` shrinks with a smaller minimum width instead of using `shrink-0`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92bfd4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->





