### PR TITLE
fix(server): stop reading every provider binding on each session list

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -531,6 +531,84 @@ it.effect(
     }).pipe(Effect.provide(NodeServices.layer)),
 );
 
+it.effect("ProviderServiceLive reads persisted bindings only for live sessions", () =>
+  Effect.gen(function* () {
+    const codex = makeFakeCodexAdapter();
+    const registry = makeAdapterRegistryMock({
+      [ProviderDriverKind.make("codex")]: codex.adapter,
+    });
+    const providerAdapterLayer = Layer.succeed(
+      ProviderAdapterRegistry.ProviderAdapterRegistry,
+      registry,
+    );
+    // Records every per-thread runtime read so the test can assert that listing
+    // sessions does not query threads without a live session.
+    const readThreadIds: Array<ThreadId> = [];
+    const runtimeRepositoryLayer = Layer.effect(
+      ProviderSessionRuntime.ProviderSessionRuntimeRepository,
+      Effect.gen(function* () {
+        const inner = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        return {
+          ...inner,
+          getByThreadId: (input: { readonly threadId: ThreadId }) => {
+            readThreadIds.push(input.threadId);
+            return inner.getByThreadId(input);
+          },
+        };
+      }),
+    ).pipe(
+      Layer.provide(ProviderSessionRuntime.layer.pipe(Layer.provide(SqlitePersistenceMemory))),
+    );
+    const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+    const providerLayer = makeProviderServiceLive().pipe(
+      Layer.provide(providerAdapterLayer),
+      Layer.provide(directoryLayer),
+      Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(serverConfigTestLayer),
+      Layer.provide(AnalyticsService.layerTest),
+      Layer.provide(
+        Layer.succeed(
+          ProviderEventLoggers.ProviderEventLoggers,
+          ProviderEventLoggers.NoOpProviderEventLoggers,
+        ),
+      ),
+    );
+
+    yield* Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const activeThreadId = asThreadId("thread-live-binding");
+
+      // Threads that ran an agent in the past keep their runtime binding.
+      for (let index = 0; index < 25; index += 1) {
+        yield* directory.upsert({
+          threadId: asThreadId(`thread-stopped-binding-${index}`),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          status: "stopped",
+        });
+      }
+
+      yield* provider.startSession(activeThreadId, {
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId: activeThreadId,
+        cwd: "/tmp/project-live-binding",
+        runtimeMode: "full-access",
+      });
+
+      readThreadIds.length = 0;
+      const sessions = yield* provider.listSessions();
+
+      assert.deepEqual(
+        sessions.map((session) => session.threadId),
+        [activeThreadId],
+      );
+      assert.deepEqual(readThreadIds, [activeThreadId]);
+    }).pipe(Effect.provide(Layer.mergeAll(providerLayer, directoryLayer)));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
 it.effect("ProviderServiceLive rejects new sessions for disabled custom instances", () =>
   Effect.gen(function* () {
     const instanceId = ProviderInstanceId.make("codex_personal");

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -996,24 +996,22 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         ),
       );
       const activeSessions = sessionsByProvider.flatMap((sessions) => sessions);
-      const persistedBindings = yield* directory.listThreadIds().pipe(
-        Effect.flatMap((threadIds) =>
-          Effect.forEach(
-            threadIds,
-            (threadId) =>
-              directory
-                .getBinding(threadId)
-                .pipe(
-                  Effect.orElseSucceed(() =>
-                    Option.none<ProviderSessionDirectory.ProviderRuntimeBinding>(),
-                  ),
-                ),
-            { concurrency: "unbounded" },
-          ),
-        ),
-        Effect.orElseSucceed(
-          () => [] as Array<Option.Option<ProviderSessionDirectory.ProviderRuntimeBinding>>,
-        ),
+      // Only threads with a live adapter session can be decorated below. The
+      // runtime table keeps one row per thread that has ever run an agent, so
+      // reading every binding here costs one query per historical thread on
+      // each call, and listSessions runs several times per turn start.
+      const activeThreadIds = [...new Set(activeSessions.map((session) => session.threadId))];
+      const persistedBindings = yield* Effect.forEach(
+        activeThreadIds,
+        (threadId) =>
+          directory
+            .getBinding(threadId)
+            .pipe(
+              Effect.orElseSucceed(() =>
+                Option.none<ProviderSessionDirectory.ProviderRuntimeBinding>(),
+              ),
+            ),
+        { concurrency: "unbounded" },
       );
       const bindingsByThreadId = new Map<
         ThreadId,


### PR DESCRIPTION
Fixes #8794.

## Problem

`ProviderService.listSessions` asked the session directory for every persisted thread id, then issued one binding lookup per thread. The provider runtime table keeps a row for every thread that has ever run an agent, so on an install with 886 rows every call ran 886 single-row queries at unbounded concurrency. `listSessions` runs several times per turn start, so a turn start issued roughly 3,500 queries and saturated the event loop. Unrelated RPCs queued behind it, including `server.getConfig`, which gates connection setup, so clients timed out and reconnected.

`directory.listThreadIds()` already reads the whole table, so the per-thread lookups re-read rows that were just read.

## Fix

Only threads with a live adapter session are used after the lookup, so look up those bindings instead of all of them. On the install above that is 9 reads instead of 886, and the cost no longer grows with thread history.

The added test seeds 25 stopped bindings, starts one session, and asserts that listing sessions reads only the live thread's row. It fails on `main` with 26 reads.

## Verification

- `vp test run apps/server/src/provider/Layers/ProviderService.test.ts` — 39 passed
- `tsgo --noEmit -p apps/server/tsconfig.json` — clean
- `vp lint` on the changed files — clean

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path session listing behavior; scope is narrow and aligned with how bindings are actually consumed, with a targeted regression test.
> 
> **Overview**
> **`listSessions`** no longer loads persisted runtime bindings for every thread that ever ran an agent. It now collects thread IDs from **live adapter sessions** only and runs **`getBinding`** for those threads when decorating session metadata.
> 
> That cuts per-call DB work from scaling with full thread history to scaling with active sessions—important because **`listSessions`** runs multiple times per turn start and the old path could issue hundreds of concurrent single-row reads and stall the event loop.
> 
> A regression test seeds many **stopped** bindings plus one active session and asserts **`listSessions`** triggers a single runtime read for the live thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27585b01ab897c6a19ef2baf622f5156596f8e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop reading persisted bindings for stopped sessions in `ProviderService.listSessions`
> - `listSessions` previously fetched a persisted binding for every threadId in the directory, including stopped sessions. It now derives `activeThreadIds` from currently active adapter sessions and loads bindings only for those.
> - Added an integration test in [ProviderService.test.ts](https://github.com/pingdotgg/t3code/pull/8795/files#diff-cbac8cf0b9c33ddbfff2137001d4b9ef6d645a0b205efcf6c714b12efab70f14) that seeds many stopped sessions, starts one live session, and asserts only the live threadId is read from the `ProviderSessionRuntimeRepository`.
> - Risk: stopped sessions no longer have their persisted bindings loaded during `listSessions`; any consumer relying on binding data for non-active threads will not receive it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27585b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->