### PR TITLE
fix(web): remove projects with archived threads

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -1458,13 +1458,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   );
 
   const removeProject = useCallback(
-    async (member: SidebarProjectGroupMember, options: { force?: boolean } = {}) => {
+    async (member: SidebarProjectGroupMember) => {
       const memberProjectRef = scopeProjectRef(member.environmentId, member.id);
       const result = await deleteProject({
         environmentId: member.environmentId,
         input: {
           projectId: member.id,
-          ...(options.force === true ? { force: true } : {}),
+          force: true,
         },
       });
       if (result._tag === "Failure") {
@@ -1532,7 +1532,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                           ...(member.environmentLabel
                             ? [`Environment: ${member.environmentLabel}`]
                             : []),
-                          "This permanently clears conversation history for those threads.",
+                          "This permanently clears conversation history for those threads and any archived threads.",
                           "This removes only this project entry.",
                           "This action cannot be undone.",
                         ].join("\n")
@@ -1542,6 +1542,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                           ...(member.environmentLabel
                             ? [`Environment: ${member.environmentLabel}`]
                             : []),
+                          "This permanently clears any archived conversation history.",
                           "This removes only this project entry.",
                         ].join("\n"),
                     { variant: "destructive" },
@@ -1550,7 +1551,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                     return;
                   }
 
-                  const result = await removeProject(member, { force: true });
+                  const result = await removeProject(member);
                   if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
                     const error = squashAtomCommandFailure(result);
                     toastManager.add(
@@ -1591,6 +1592,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         `Remove project "${member.title}"?`,
         `Path: ${member.workspaceRoot}`,
         ...(member.environmentLabel ? [`Environment: ${member.environmentLabel}`] : []),
+        "This permanently clears any archived conversation history.",
         "This removes only this project entry.",
       ].join("\n");
       const confirmed = await api.dialogs.confirm(message, { variant: "destructive" });

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -700,8 +700,10 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                 ]
               : [`This removes ${members.length} grouped project entries.`]),
             ...(projectThreads.length > 0
-              ? ["This permanently clears conversation history for those threads."]
-              : []),
+              ? [
+                  "This permanently clears conversation history for those threads and any archived threads.",
+                ]
+              : ["This permanently clears any archived conversation history."]),
             isWholeGroup
               ? "This removes only the project entries, not the files on disk."
               : "Other entries in this grouped project are unaffected.",
@@ -723,7 +725,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
             environmentId: member.environmentId,
             input: {
               projectId: member.id,
-              ...(memberThreads.length > 0 ? { force: true } : {}),
+              force: true,
             },
           }),
           () => undefined,


### PR DESCRIPTION
## What Changed

Project removal now warns when archived conversation history will be cleared and sends `force` after confirmation.

This applies to both the legacy sidebar and Project Settings.

## Why

Projects with no active threads can still contain archived threads. They appear empty, so the client previously omitted `force` and the server rejected their removal.

Sending `force` only after destructive confirmation keeps the server safeguard intact.

Fixes #2866.

## UI Changes

### Project Settings

| Before | After |
| --- | --- |
| ![Remove Project modal in Project Settings before the fix](https://github-pr-attachments.none23.workers.dev/a/375018fd-7235-42c4-af08-1d2dd9557986/before-settings-remove-project-modal.png) | ![Remove Project modal in Project Settings after the fix](https://github-pr-attachments.none23.workers.dev/a/735b7905-8355-4785-a92d-c0e1b045fed8/after-settings-remove-project-modal.png) |

### Legacy sidebar

| Before | After |
| --- | --- |
| ![Remove Project modal in the legacy sidebar before the fix](https://github-pr-attachments.none23.workers.dev/a/33ca86a0-7752-444c-9916-0730264cb977/before-sidebar-remove-project-modal.png) | ![Remove Project modal in the legacy sidebar after the fix](https://github-pr-attachments.none23.workers.dev/a/34d557b4-3b90-44e6-8415-e3950314ce99/after-sidebar-remove-project-modal.png) |


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with Claude (Fable 5) in Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permanent data-deletion behavior for confirmed project removal by always forcing delete, but only after explicit destructive confirmation in both entry points.
> 
> **Overview**
> Fixes project removal when a checkout looks empty in the sidebar but still has **archived** threads—the client used to skip `force` unless visible threads existed, so the server could reject the delete.
> 
> **Legacy sidebar** and **Project Settings** now always call `deleteProject` with `force: true` after the user confirms, instead of conditionally omitting it. `removeProject` no longer takes a `force` option; confirmation is the gate for the server safeguard.
> 
> Destructive confirm copy now states that removal clears conversation history for listed threads **and any archived threads**, including the “no active threads” path where archived history is still wiped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de578a3f058b8ab5cf47627fdb5d83b17820c15e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force project deletion to include archived threads in web UI
> - Updates `SidebarProjectItem` and `ProjectDetail` components to always pass `force: true` to `deleteProject` instead of conditionally checking for active threads.
> - Changes confirmation dialogs in both the sidebar and settings panel to explicitly state that active and archived threads will be permanently cleared.
> - Behavioral Change: Project removal from the web UI now always uses forced deletion, clearing archived conversation history even when no active threads are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de578a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->