### PR TITLE
fix(android): prevent last thread line from clipping at bottom

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -2373,6 +2373,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             }
             contentContainerStyle={{
               paddingTop: 12,
+              paddingBottom: 12,
               paddingHorizontal: contentHorizontalPadding,
             }}
           />


### PR DESCRIPTION
Long assistant replies on Android could end with the last line half visible. The thread list had top padding but no bottom padding, so the final line sat right against the composer.

This adds 12pt bottom padding to the ThreadFeed content container. The last line now has room to render fully.

Note: #8220 fixes the same symptom on iOS with a native layout change. It does not affect Android.

Implemented with: muse-1.2-contributor in opencode with opencode go through t3 code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout padding tweak in the mobile thread list with no auth, data, or API impact.
> 
> **Overview**
> On Android, the last line of long assistant replies could sit flush against the composer and render partially clipped because the thread list only had top inset padding.
> 
> This adds **`paddingBottom: 12`** to the `KeyboardAwareLegendList` **`contentContainerStyle`** in `ThreadFeed`, mirroring the existing 12pt top padding so the final message line has space above the input area. iOS uses a separate native layout fix (#8220); this change targets Android only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34bf7ca215acefb0e9a3c54e2682bd7698822905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bottom padding to `ThreadFeed` list to prevent clipping
> Adds `paddingBottom: 12` to `contentContainerStyle` in [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/8800/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245). This stops the last thread line from being clipped at the bottom of the screen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34bf7ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->