### PR TITLE
fix(web): keep right panel synced with agent edits

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -118,6 +118,10 @@ import {
 } from "../pendingUserInput";
 import { useUiStateStore } from "../uiStateStore";
 import {
+  latestWorkspaceMutationId,
+  useWorkspaceMutationRefresh,
+} from "../hooks/useWorkspaceMutationRefresh";
+import {
   buildPlanImplementationThreadTitle,
   buildPlanImplementationPrompt,
   resolvePlanFollowUpSubmission,
@@ -2343,6 +2347,13 @@ function ChatViewContent(props: ChatViewProps) {
   const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
   const phase = derivePhase(activeThread?.session ?? null);
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const latestCheckpointCompletedAt = activeThread?.checkpoints.at(-1)?.completedAt ?? null;
+  const workspaceMutationId = useMemo(() => {
+    const activityId = latestWorkspaceMutationId(threadActivities);
+    return activityId === null && latestCheckpointCompletedAt === null
+      ? null
+      : JSON.stringify([activityId, latestCheckpointCompletedAt]);
+  }, [latestCheckpointCompletedAt, threadActivities]);
   const activeContextWindow = useMemo(
     () => deriveLatestContextWindowSnapshot(threadActivities),
     [threadActivities],
@@ -2896,6 +2907,12 @@ function ChatViewContent(props: ChatViewProps) {
           input: { cwd: gitStatusCwd },
         }),
   );
+  useWorkspaceMutationRefresh({
+    enabled: gitStatusCwd !== null,
+    mutationId: workspaceMutationId,
+    refresh: gitStatusQuery.refresh,
+    resourceKey: `git-status:${activeThreadKey ?? ""}:${gitStatusCwd ?? ""}`,
+  });
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
   // Prefer an instance-id match so a custom Codex instance (e.g.
@@ -7027,6 +7044,7 @@ function ChatViewContent(props: ChatViewProps) {
           mode="embedded"
           composerDraftTarget={composerDraftTarget}
           initialGitScope={initialDiffPanelGitScope}
+          workspaceMutationId={workspaceMutationId}
         />
       </Suspense>
     ) : activeRightPanelSurface?.kind === "pull-request" && !pullRequestsCapabilityKnown ? (
@@ -7095,6 +7113,10 @@ function ChatViewContent(props: ChatViewProps) {
           revealRequestId={activeFileSurface?.revealRequestId ?? 0}
           onOpenFile={openFileSurface}
           onPendingChange={handleFilePendingChange}
+          selectedFilePending={
+            activeFileSurface !== null && pendingFileSurfaceIds.has(activeFileSurface.id)
+          }
+          workspaceMutationId={workspaceMutationId}
         />
       </Suspense>
     ) : null

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -39,6 +39,7 @@ import {
 } from "../lib/diffRendering";
 import { areAllDiffFilesCollapsed, toggleAllDiffFiles } from "../lib/diffCollapse";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
+import { useWorkspaceMutationRefresh } from "../hooks/useWorkspaceMutationRefresh";
 import { useProject, useThread } from "../state/entities";
 import { resolveThreadRouteRef } from "../threadRoutes";
 import { useClientSettings } from "../hooks/useSettings";
@@ -90,6 +91,7 @@ interface DiffPanelProps {
   mode?: DiffPanelMode;
   composerDraftTarget: ScopedThreadRef | DraftId;
   initialGitScope: "branch" | "unstaged";
+  workspaceMutationId: string | null;
 }
 
 export { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
@@ -98,6 +100,7 @@ export default function DiffPanel({
   mode = "inline",
   composerDraftTarget,
   initialGitScope: initialGitScopeProp,
+  workspaceMutationId,
 }: DiffPanelProps) {
   const { resolvedTheme } = useTheme();
   const settings = useClientSettings();
@@ -113,10 +116,6 @@ export default function DiffPanel({
   }));
   const [codeViewRevision, setCodeViewRevision] = useState(0);
   const codeViewRef = useRef<AnnotatableCodeViewHandle>(null);
-  const lastCompletedTurnRefreshRef = useRef<{
-    readonly threadKey: string | null;
-    readonly turnId: TurnId | null;
-  } | null>(null);
 
   const routeThreadRef = useParams({
     strict: false,
@@ -290,23 +289,12 @@ export default function DiffPanel({
     return () => window.removeEventListener("focus", refreshOnFocus);
   }, [canRefreshGitDiff, refreshBranchDiffPreview]);
 
-  useEffect(() => {
-    const current = {
-      threadKey: activeThreadRefreshKey,
-      turnId: latestTurn?.turnId ?? null,
-    };
-    const previous = lastCompletedTurnRefreshRef.current;
-    if (!canRefreshGitDiff) {
-      return;
-    }
-    if (previous === null || previous.threadKey !== current.threadKey) {
-      lastCompletedTurnRefreshRef.current = current;
-      return;
-    }
-    if (previous.turnId === current.turnId) return;
-    refreshBranchDiffPreview();
-    lastCompletedTurnRefreshRef.current = current;
-  }, [activeThreadRefreshKey, canRefreshGitDiff, latestTurn?.turnId, refreshBranchDiffPreview]);
+  useWorkspaceMutationRefresh({
+    enabled: canRefreshGitDiff,
+    mutationId: workspaceMutationId,
+    refresh: refreshBranchDiffPreview,
+    resourceKey: `diff:${activeThreadRefreshKey ?? ""}`,
+  });
 
   const selectedGitSource = branchDiffPreview.data?.sources.find(
     (source) => source.kind === (selectedGitScope === "unstaged" ? "working-tree" : "branch-range"),

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -15,6 +15,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useComposerHandleContext } from "~/composerHandleContext";
 import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { useTheme } from "~/hooks/useTheme";
+import { useWorkspaceMutationRefresh } from "~/hooks/useWorkspaceMutationRefresh";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import { T3_PIERRE_ICONS } from "~/pierre-icons";
@@ -32,6 +33,7 @@ interface FileBrowserPanelProps {
   selectedPathRevealId: number;
   onOpenFile: (relativePath: string) => void;
   onRefreshSelectedFile?: () => void;
+  workspaceMutationId: string | null;
 }
 
 const TREE_UNSAFE_CSS = `
@@ -107,6 +109,7 @@ export default function FileBrowserPanel({
   selectedPathRevealId,
   onOpenFile,
   onRefreshSelectedFile,
+  workspaceMutationId,
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
   const composerRef = useComposerHandleContext();
@@ -260,6 +263,11 @@ export default function FileBrowserPanel({
     entriesQuery.refresh();
     onRefreshSelectedFile?.();
   };
+  useWorkspaceMutationRefresh({
+    mutationId: workspaceMutationId,
+    refresh: entriesQuery.refresh,
+    resourceKey: `files:${environmentId}:${cwd}`,
+  });
 
   useEffect(() => {
     if (previousTreePathsRef.current === treePaths) return;

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -23,6 +23,7 @@ import { useRemoteOpenState } from "~/remoteOpen";
 import { useClientSettings } from "~/hooks/useSettings";
 import { useTheme } from "~/hooks/useTheme";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "~/hooks/useLocalStorage";
+import { useWorkspaceMutationRefresh } from "~/hooks/useWorkspaceMutationRefresh";
 import { DIFF_SURFACE_THEME_UNSAFE_CSS, resolveDiffThemeName } from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
@@ -78,6 +79,8 @@ interface FilePreviewPanelProps {
   revealRequestId: number;
   onOpenFile: (relativePath: string) => void;
   onPendingChange: (relativePath: string, pending: boolean) => void;
+  selectedFilePending: boolean;
+  workspaceMutationId: string | null;
 }
 
 const FILE_EXPLORER_STORAGE_KEY = "t3code.fileExplorerOpen";
@@ -133,6 +136,7 @@ function WorkspaceImagePreview(props: {
   readonly threadRef: ScopedThreadRef;
   readonly absolutePath: string;
   readonly alt: string;
+  readonly workspaceMutationId: string | null;
 }) {
   const assetUrl = useAssetUrlState(props.environmentId, {
     _tag: "workspace-file",
@@ -140,8 +144,13 @@ function WorkspaceImagePreview(props: {
     path: props.absolutePath,
   });
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const revisionSuffix =
+    props.workspaceMutationId === null
+      ? ""
+      : `${assetUrl._tag === "Success" && assetUrl.url.includes("?") ? "&" : "?"}workspace-revision=${encodeURIComponent(props.workspaceMutationId)}`;
+  const imageUrl = assetUrl._tag === "Success" ? `${assetUrl.url}${revisionSuffix}` : null;
 
-  if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
+  if (assetUrl._tag === "Failure" || (imageUrl !== null && failedUrl === imageUrl)) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
         Unable to load workspace image.
@@ -149,13 +158,13 @@ function WorkspaceImagePreview(props: {
     );
   }
 
-  return assetUrl._tag === "Success" ? (
+  return assetUrl._tag === "Success" && imageUrl !== null ? (
     <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
       <img
         className="max-h-full max-w-full object-contain"
-        src={assetUrl.url}
+        src={imageUrl}
         alt={props.alt}
-        onError={() => setFailedUrl(assetUrl.url)}
+        onError={() => setFailedUrl(imageUrl)}
       />
     </div>
   ) : (
@@ -768,6 +777,8 @@ export default function FilePreviewPanel({
   revealRequestId,
   onOpenFile,
   onPendingChange,
+  selectedFilePending,
+  workspaceMutationId,
 }: FilePreviewPanelProps) {
   const { resolvedTheme } = useTheme();
   const wordWrap = useClientSettings((settings) => settings.wordWrap);
@@ -812,6 +823,12 @@ export default function FilePreviewPanel({
     [projectName, relativePath],
   );
   const onFilePostRender = useFileLineReveal(relativePath, revealLine, revealRequestId);
+  useWorkspaceMutationRefresh({
+    enabled: relativePath !== null && !isImage && !selectedFilePending,
+    mutationId: workspaceMutationId,
+    refresh: file.refresh,
+    resourceKey: `file:${environmentId}:${cwd}:${relativePath ?? ""}`,
+  });
 
   useEffect(() => {
     const currentCrumb = breadcrumbRef.current?.querySelector<HTMLElement>(
@@ -1001,6 +1018,7 @@ export default function FilePreviewPanel({
               threadRef={threadRef}
               absolutePath={absolutePath}
               alt={relativePath}
+              workspaceMutationId={workspaceMutationId}
             />
           ) : relativePath && file.error && file.data === null ? (
             <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
@@ -1080,6 +1098,7 @@ export default function FilePreviewPanel({
               selectedPath={relativePath}
               selectedPathRevealId={revealRequestId}
               onOpenFile={onOpenFile}
+              workspaceMutationId={workspaceMutationId}
               {...(relativePath && !isImage ? { onRefreshSelectedFile: file.refresh } : {})}
             />
           </aside>

--- a/apps/web/src/components/files/projectFilesQueryState.test.tsx
+++ b/apps/web/src/components/files/projectFilesQueryState.test.tsx
@@ -1,0 +1,193 @@
+import { EnvironmentId, type ProjectReadFileResult } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import { Atom, AtomRegistry } from "effect/unstable/reactivity";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const projectMocks = vi.hoisted(() => ({
+  listEntries: vi.fn(),
+  optimisticFile: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+const atomHooks = vi.hoisted(() => ({
+  registry: null as {
+    get(atom: object): unknown;
+    refresh(atom: object): void;
+  } | null,
+}));
+
+const reactHooks = vi.hoisted(() => {
+  let cursor = 0;
+  let refs: Array<{ current: unknown }> = [];
+  const nextIndex = () => cursor++;
+
+  return {
+    beginRender() {
+      cursor = 0;
+    },
+    reset() {
+      cursor = 0;
+      refs = [];
+    },
+    useCallback<A>(callback: A): A {
+      nextIndex();
+      return callback;
+    },
+    useEffect(effect: () => void): void {
+      nextIndex();
+      effect();
+    },
+    useRef<A>(initialValue: A): { current: A } {
+      const index = nextIndex();
+      refs[index] ??= { current: initialValue };
+      return refs[index] as { current: A };
+    },
+  };
+});
+
+vi.mock("@effect/atom-react", () => ({
+  useAtomRefresh: (atom: object) => () => {
+    atomHooks.registry?.refresh(atom);
+  },
+  useAtomValue: (atom: object) => atomHooks.registry?.get(atom),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useCallback: reactHooks.useCallback,
+    useEffect: reactHooks.useEffect,
+    useRef: reactHooks.useRef,
+  };
+});
+
+vi.mock("~/state/projects", () => ({
+  projectEnvironment: projectMocks,
+}));
+
+vi.mock("~/state/queries", () => ({
+  useProjectPathSearch: vi.fn(),
+}));
+
+import { useWorkspaceMutationRefresh } from "~/hooks/useWorkspaceMutationRefresh";
+import { useProjectFileQuery } from "./projectFilesQueryState";
+
+const environmentId = EnvironmentId.make("environment-1");
+
+function deferred<A>() {
+  let resolve!: (value: A) => void;
+  const promise = new Promise<A>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function file(contents: string): ProjectReadFileResult {
+  return {
+    relativePath: "src/preview.ts",
+    contents,
+    byteLength: contents.length,
+    truncated: false,
+  };
+}
+
+async function flushEffects(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("project file query refresh", () => {
+  beforeEach(() => {
+    projectMocks.listEntries.mockReset();
+    projectMocks.optimisticFile.mockReset();
+    projectMocks.readFile.mockReset();
+    reactHooks.reset();
+  });
+
+  it("replaces an in-flight initial read when a workspace mutation arrives", async () => {
+    const requests: Array<ReturnType<typeof deferred<ProjectReadFileResult>>> = [];
+    const readAtom = Atom.make(
+      Effect.promise(() => {
+        const request = deferred<ProjectReadFileResult>();
+        requests.push(request);
+        return request.promise;
+      }),
+    ).pipe(Atom.swr({ staleTime: 30_000, revalidateOnMount: true }));
+    const registry = AtomRegistry.make();
+    const unmount = registry.mount(readAtom);
+    projectMocks.readFile.mockReturnValue(readAtom);
+    projectMocks.optimisticFile.mockReturnValue(Atom.make(null));
+    atomHooks.registry = registry;
+    let renderedContents: string | null = null;
+
+    const render = (mutationId: string | null) => {
+      reactHooks.beginRender();
+      const query = useProjectFileQuery(environmentId, "/repo", "src/preview.ts");
+      renderedContents = query.data?.contents ?? null;
+      useWorkspaceMutationRefresh({
+        mutationId,
+        refresh: query.refresh,
+        resourceKey: "file:environment-1:/repo:src/preview.ts",
+      });
+    };
+
+    try {
+      render(null);
+      await flushEffects();
+      expect(requests).toHaveLength(1);
+
+      render("mutation-1");
+      await flushEffects();
+      expect(requests).toHaveLength(2);
+
+      requests[1]!.resolve(file("fresh"));
+      await flushEffects();
+      render("mutation-1");
+      expect(renderedContents).toBe("fresh");
+
+      requests[0]!.resolve(file("stale"));
+      await flushEffects();
+      render("mutation-1");
+      expect(renderedContents).toBe("fresh");
+    } finally {
+      unmount();
+      registry.dispose();
+      atomHooks.registry = null;
+    }
+  });
+
+  it("does not issue a file read for a disabled image preview", async () => {
+    const requests: Array<ReturnType<typeof deferred<ProjectReadFileResult>>> = [];
+    const readAtom = Atom.make(
+      Effect.promise(() => {
+        const request = deferred<ProjectReadFileResult>();
+        requests.push(request);
+        return request.promise;
+      }),
+    );
+    const registry = AtomRegistry.make();
+    projectMocks.readFile.mockReturnValue(readAtom);
+    projectMocks.optimisticFile.mockReturnValue(Atom.make(null));
+    atomHooks.registry = registry;
+
+    try {
+      reactHooks.beginRender();
+      const query = useProjectFileQuery(environmentId, "/repo", "preview.png", false);
+      useWorkspaceMutationRefresh({
+        enabled: false,
+        mutationId: "mutation-1",
+        refresh: query.refresh,
+        resourceKey: "file:environment-1:/repo:preview.png",
+      });
+      await flushEffects();
+
+      expect(projectMocks.readFile).not.toHaveBeenCalled();
+      expect(requests).toHaveLength(0);
+    } finally {
+      registry.dispose();
+      atomHooks.registry = null;
+    }
+  });
+});

--- a/apps/web/src/hooks/useWorkspaceMutationRefresh.test.ts
+++ b/apps/web/src/hooks/useWorkspaceMutationRefresh.test.ts
@@ -1,0 +1,61 @@
+import { EventId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  latestWorkspaceMutationId,
+  workspaceMutationRefreshToken,
+} from "./useWorkspaceMutationRefresh";
+
+function activity(
+  id: string,
+  kind: string,
+  itemType: string,
+  status?: string,
+): OrchestrationThreadActivity {
+  return {
+    id: EventId.make(id),
+    kind,
+    tone: "tool",
+    summary: "Tool activity",
+    payload: { itemType, ...(status ? { status } : {}) },
+    turnId: null,
+    createdAt: "2026-08-30T00:00:00.000Z",
+  };
+}
+
+describe("workspace mutation refresh", () => {
+  it("tracks the latest completed file change or command", () => {
+    expect(
+      latestWorkspaceMutationId([
+        activity("file-started", "tool.started", "file_change"),
+        activity("search-completed", "tool.completed", "web_search"),
+        activity("file-completed", "tool.completed", "file_change"),
+        activity("command-completed", "tool.completed", "command_execution"),
+      ]),
+    ).toBe("command-completed");
+  });
+
+  it("ignores read-only and in-progress tools", () => {
+    expect(
+      latestWorkspaceMutationId([
+        activity("command-updated", "tool.updated", "command_execution", "inProgress"),
+        activity("image-completed", "tool.completed", "image_view"),
+      ]),
+    ).toBeNull();
+  });
+
+  it("accepts providers that report terminal state on an update", () => {
+    expect(
+      latestWorkspaceMutationId([
+        activity("file-updated", "tool.updated", "file_change", "completed"),
+      ]),
+    ).toBe("file-updated");
+  });
+
+  it("scopes the same mutation to each preview resource", () => {
+    expect(workspaceMutationRefreshToken("file:/repo/README.md", "event-1")).not.toBe(
+      workspaceMutationRefreshToken("diff:/repo", "event-1"),
+    );
+    expect(workspaceMutationRefreshToken("file:/repo/README.md", null)).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/useWorkspaceMutationRefresh.test.ts
+++ b/apps/web/src/hooks/useWorkspaceMutationRefresh.test.ts
@@ -39,6 +39,7 @@ describe("workspace mutation refresh", () => {
     expect(
       latestWorkspaceMutationId([
         activity("command-updated", "tool.updated", "command_execution", "inProgress"),
+        activity("legacy-command-updated", "tool.updated", "command_execution", "in_progress"),
         activity("image-completed", "tool.completed", "image_view"),
       ]),
     ).toBeNull();

--- a/apps/web/src/hooks/useWorkspaceMutationRefresh.ts
+++ b/apps/web/src/hooks/useWorkspaceMutationRefresh.ts
@@ -24,7 +24,8 @@ export function latestWorkspaceMutationId(
     const terminalUpdate =
       activity.kind === "tool.updated" &&
       typeof payload?.status === "string" &&
-      payload.status !== "inProgress";
+      payload.status !== "inProgress" &&
+      payload.status !== "in_progress";
     if (activity.kind !== "tool.completed" && !terminalUpdate) continue;
     const itemType = payload?.itemType;
     if (typeof itemType === "string" && WORKSPACE_MUTATION_ITEM_TYPES.has(itemType)) {

--- a/apps/web/src/hooks/useWorkspaceMutationRefresh.ts
+++ b/apps/web/src/hooks/useWorkspaceMutationRefresh.ts
@@ -1,0 +1,64 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+import { useEffect, useRef } from "react";
+
+const WORKSPACE_MUTATION_ITEM_TYPES = new Set(["command_execution", "file_change"]);
+
+function activityPayload(activity: OrchestrationThreadActivity): Record<string, unknown> | null {
+  return activity.payload !== null && typeof activity.payload === "object"
+    ? (activity.payload as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * The latest provider event after which files on disk may have changed.
+ * File tools are explicit; completed commands are included because a shell
+ * command can mutate the workspace without reporting the paths it touched.
+ */
+export function latestWorkspaceMutationId(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): string | null {
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (!activity) continue;
+    const payload = activityPayload(activity);
+    const terminalUpdate =
+      activity.kind === "tool.updated" &&
+      typeof payload?.status === "string" &&
+      payload.status !== "inProgress";
+    if (activity.kind !== "tool.completed" && !terminalUpdate) continue;
+    const itemType = payload?.itemType;
+    if (typeof itemType === "string" && WORKSPACE_MUTATION_ITEM_TYPES.has(itemType)) {
+      return activity.id;
+    }
+  }
+  return null;
+}
+
+export function workspaceMutationRefreshToken(
+  resourceKey: string,
+  mutationId: string | null,
+): string | null {
+  return mutationId === null ? null : `${resourceKey}\u0000${mutationId}`;
+}
+
+/**
+ * Refreshes once per mutation and resource. Disabled mutations stay pending,
+ * which lets an editable file catch up after its local save finishes.
+ */
+export function useWorkspaceMutationRefresh(input: {
+  readonly enabled?: boolean;
+  readonly mutationId: string | null;
+  readonly refresh: () => void;
+  readonly resourceKey: string;
+}): void {
+  const { enabled = true, mutationId, refresh, resourceKey } = input;
+  const handledTokenRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const token = workspaceMutationRefreshToken(resourceKey, mutationId);
+    if (token === null || token === handledTokenRef.current) return;
+    handledTokenRef.current = token;
+    refresh();
+  }, [enabled, mutationId, refresh, resourceKey]);
+}


### PR DESCRIPTION
Completed provider commands and file changes now refresh the open file, file tree, diff, and git status while the turn is still running. Unsaved local edits remain untouched until they are saved, and image previews use the workspace revision to avoid stale browser caches. Verified with the web typecheck, focused lint and formatting checks, and a real Codex turn in the dark-mode web app.

[dark-mode demo](https://uploads-production-47e4.up.railway.app/files/f58f6edb-a2dd-4883-b2f4-d55e8f4141b6/live-right-panel-refresh-dark.webm)

## related

closes #5779

addresses #5866
addresses #6524

supersedes #7627

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refresh behavior only; main caveat is mutation detection depends on provider activity shapes (`tool.updated` with status).
> 
> **Overview**
> **Keeps the diff, file tree, open file, git status, and image previews in sync while an agent turn is still running**, instead of waiting for turn completion or window focus.
> 
> Introduces `useWorkspaceMutationRefresh` and `latestWorkspaceMutationId`, which derive a refresh signal from the latest completed `file_change` or `command_execution` activity (including terminal `tool.updated` events). `ChatView` builds a `workspaceMutationId` from that activity id plus the latest checkpoint `completedAt`, then passes it into the right-panel surfaces.
> 
> `DiffPanel` drops its turn-id-based auto-refresh in favor of this hook. **File preview refresh is disabled while the open file has unsaved local edits** (`selectedFilePending`). Workspace images append a `workspace-revision` query param for cache busting. Tests cover mutation detection, per-resource tokens, and in-flight read replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5e0dcfc7fae8d8858ce836221bfe8e3aa1906d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep right panel synced with agent workspace edits via `useWorkspaceMutationRefresh`
> - Adds `useWorkspaceMutationRefresh` hook and helpers `latestWorkspaceMutationId` and `workspaceMutationRefreshToken` to trigger one refresh per unique workspace mutation event per resource
> - Wires the hook into [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8803/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/8803/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3), [FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/8803/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea), and [FileBrowserPanel.tsx](https://github.com/pingdotgg/t3code/pull/8803/files#diff-aeb8bbbac738f422eace5ad6cee4745362f7559fdd5668df4eb1be558f4b5fb3) so diffs, file contents, file tree, and image previews reload after agent edits
> - Replaces the old branch-diff refresh-on-turn-id-change effect in `DiffPanel` with mutation-driven refresh
> - File preview skips auto-refresh while the selected file has pending local edits; image previews use a cache-busting query parameter
> - Risk: `latestWorkspaceMutationId` only scans `command_execution` and `file_change` activity types and excludes in-progress statuses — other tool types that mutate the workspace will not trigger refresh
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf5e0dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->