### PR TITLE
fix(server): stop overpricing cached Claude tokens

### DIFF
--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { lookupRate, normalizeModelName, parseRateTable } from "./usagePricing.ts";
+
+const rate = (input: number, cacheRead?: number) => ({
+  input_cost_per_token: input,
+  output_cost_per_token: input * 5,
+  ...(cacheRead === undefined ? {} : { cache_read_input_token_cost: cacheRead }),
+});
+
+describe("usage pricing", () => {
+  it("keeps the existing model-name normalization contract", () => {
+    expect(normalizeModelName(" Anthropic/Claude-Opus-5 ")).toBe("claude-opus-5");
+  });
+
+  it("keeps the canonical Fable rate separate from DeepInfra in either order", () => {
+    const canonical = ["claude-fable-5", rate(1e-5, 1e-6)] as const;
+    const deepInfra = ["deepinfra/anthropic/claude-fable-5", rate(1e-5)] as const;
+
+    for (const entries of [
+      [canonical, deepInfra],
+      [deepInfra, canonical],
+    ]) {
+      const table = parseRateTable(Object.fromEntries(entries));
+
+      expect(lookupRate(table, "claude-fable-5")?.cacheReadCostPerToken).toBe(1e-6);
+      expect(lookupRate(table, "deepinfra/anthropic/claude-fable-5")?.cacheReadCostPerToken).toBe(
+        1e-5,
+      );
+      expect(lookupRate(table, "other/claude-fable-5")).toBeNull();
+    }
+  });
+
+  it("adds a bare alias when every qualified entry has the same rate", () => {
+    const table = parseRateTable({
+      "provider-a/example-model": rate(1),
+      "provider-b/example-model": rate(1),
+    });
+
+    expect(lookupRate(table, "example-model")).toEqual(
+      lookupRate(table, "provider-a/example-model"),
+    );
+  });
+
+  it("leaves an ambiguous bare name unpriced", () => {
+    const table = parseRateTable({
+      "provider-a/example-model": rate(1),
+      "provider-b/example-model": rate(3),
+    });
+
+    expect(lookupRate(table, "provider-a/example-model")?.inputCostPerToken).toBe(1);
+    expect(lookupRate(table, "provider-b/example-model")?.inputCostPerToken).toBe(3);
+    expect(lookupRate(table, "example-model")).toBeNull();
+  });
+});

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -44,6 +44,9 @@ function finiteNumber(value: unknown): number | null {
  * Entries without both an input and an output rate are dropped: a half-priced
  * model would silently under-report cost, which is worse than reporting the
  * model as unpriced.
+ *
+ * Entries keep their full normalized key; a bare name is aliased only when no
+ * canonical entry exists and every qualified entry has the same rate.
  */
 export function parseRateTable(document: unknown): RateTable {
   const table = new Map<string, ModelRate>();
@@ -56,7 +59,9 @@ export function parseRateTable(document: unknown): RateTable {
     const output = finiteNumber(entry.output_cost_per_token);
     if (input === null || output === null) continue;
 
-    table.set(normalizeModelName(name), {
+    const key = normalizeRateKey(name);
+    if (key.length === 0) continue;
+    table.set(key, {
       inputCostPerToken: input,
       outputCostPerToken: output,
       // Anthropic bills cache reads at a discount and cache writes at a
@@ -66,20 +71,52 @@ export function parseRateTable(document: unknown): RateTable {
       cacheCreationCostPerToken: finiteNumber(entry.cache_creation_input_token_cost) ?? input,
     });
   }
+
+  // `null` marks a bare name claimed at conflicting rates: no alias for it.
+  const aliasCandidates = new Map<string, ModelRate | null>();
+  for (const [key, rate] of table) {
+    const alias = bareModelName(key);
+    if (alias.length === 0 || alias === key || table.has(alias)) continue;
+    const held = aliasCandidates.get(alias);
+    if (held === undefined) {
+      aliasCandidates.set(alias, rate);
+    } else if (held !== null && !sameRate(held, rate)) {
+      aliasCandidates.set(alias, null);
+    }
+  }
+  for (const [alias, rate] of aliasCandidates) {
+    if (rate !== null) table.set(alias, rate);
+  }
+
   return table;
+}
+
+function sameRate(a: ModelRate, b: ModelRate): boolean {
+  return (
+    a.inputCostPerToken === b.inputCostPerToken &&
+    a.outputCostPerToken === b.outputCostPerToken &&
+    a.cacheReadCostPerToken === b.cacheReadCostPerToken &&
+    a.cacheCreationCostPerToken === b.cacheCreationCostPerToken
+  );
+}
+
+function normalizeRateKey(model: string): string {
+  return model.trim().toLowerCase();
 }
 
 /**
  * Canonicalises a model name for lookup.
  *
- * Strips a `provider/` prefix (LiteLLM publishes both `claude-opus-5` and
- * `anthropic/claude-opus-5`) and lowercases, since transcripts are inconsistent
- * about casing.
+ * Strips a `provider/` prefix and lowercases, since transcripts are
+ * inconsistent about casing.
  */
 export function normalizeModelName(model: string): string {
-  const trimmed = model.trim().toLowerCase();
-  const slash = trimmed.lastIndexOf("/");
-  return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+  return bareModelName(normalizeRateKey(model));
+}
+
+function bareModelName(key: string): string {
+  const slash = key.lastIndexOf("/");
+  return slash === -1 ? key : key.slice(slash + 1);
 }
 
 /**
@@ -99,9 +136,10 @@ const UNPRICEABLE_MODELS = new Set([
 ]);
 
 export function lookupRate(table: RateTable, model: string): ModelRate | null {
-  const normalized = normalizeModelName(model);
-  if (normalized.length === 0 || UNPRICEABLE_MODELS.has(normalized)) return null;
-  return table.get(normalized) ?? null;
+  const key = normalizeRateKey(model);
+  const bareName = bareModelName(key);
+  if (bareName.length === 0 || UNPRICEABLE_MODELS.has(bareName)) return null;
+  return table.get(key) ?? null;
 }
 
 export interface PricedUsage {

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -88,7 +88,7 @@ describe("scan cache round trip", () => {
 
   it("rejects the whole cache when an intern table holds a non-string", () => {
     // models: [1] would pass the undefined guard, put a number in a record's
-    // model, and crash normalizeModelName at aggregate time.
+    // model, and crash lookupRate at aggregate time.
     const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
     const poisoned = { ...encoded, models: [1] };
 

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -124,7 +124,7 @@ export function decodeScanCache(document: unknown): ScanCache {
 
   // The intern tables must be all strings: a numeric entry would pass the
   // undefined guard below, land in a record's model, and crash the aggregate
-  // at normalizeModelName. A corrupt table rejects the whole cache.
+  // at lookupRate. A corrupt table rejects the whole cache.
   if (!root.models.every((value) => typeof value === "string")) return cache;
   if (!root.sessions.every((value) => typeof value === "string")) return cache;
   const models = root.models as readonly string[];


### PR DESCRIPTION
The Usage page can overprice cached Claude tokens when LiteLLM publishes canonical and provider-qualified entries with the same bare model name. The parser stripped provider prefixes before inserting rates, so a later entry without the Anthropic cache discount could overwrite the canonical rate and price cache reads as ordinary input.

This builds on the exact-key approach in #8529 by @none23. @mackinleysmith identified one important edge case during that review: multiple qualified entries are safe to alias when their effective rates are identical. Treating those entries as ambiguous leaves models such as Claude Opus 4.6 and Claude Haiku 4.5 unpriced.

## What changed

- Preserve each LiteLLM rate under its full normalized key.
- Keep canonical bare entries authoritative.
- Add a bare alias when every qualified entry has the same effective rate.
- Leave genuinely conflicting bare names unpriced instead of guessing.

## Verification

- `vp test run apps/server/src/usage/usagePricing.test.ts apps/server/src/usage/usageAggregation.test.ts apps/server/src/usage/usageScanCache.test.ts`
- `vp lint apps/server/src/usage/usagePricing.ts apps/server/src/usage/usagePricing.test.ts apps/server/src/usage/usageScanCache.ts apps/server/src/usage/usageScanCache.test.ts`
- `vp run --filter t3 typecheck`
- Replayed the parser against the current LiteLLM table and confirmed Claude Opus 5, Claude Fable 5, Claude Opus 4.6, Claude Haiku 4.5, and GPT-5.2 Chat all retain prices.

Closes #5797.

Built with GPT-5.6 Sol in the Codex harness via T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cached Claude token overpricing by preserving provider-qualified keys in `lookupRate`
> - Changes `normalizeRateKey` to trim and lowercase keys without stripping provider prefixes, so `parseRateTable` stores full qualified keys like `anthropic/claude-3.5-sonnet`
> - `lookupRate` now matches the exact normalized key; it no longer falls back to the bare model name automatically, which previously caused a cheaper cache entry to match a more expensive non-cache rate
> - Adds bare-name aliases (e.g. `claude-3.5-sonnet`) only when no canonical bare entry exists and all provider-qualified entries for that name share the same rate; conflicting rates leave the bare name unpriced
> - Adds `sameRate` and `bareModelName` helpers; refactors `normalizeModelName` to delegate to `normalizeRateKey` then `bareModelName`
> - Risk: any rate table relying on bare-name fallback for a model with provider-specific rates will now return unpriced instead of guessing; check rate table configs in `apps/server/src/usage/usagePricing.ts` and any callers of `lookupRate` that expect bare-name matching
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63bf1f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how usage costs are computed for models with multiple LiteLLM keys; incorrect aliasing could misprice or leave models unpriced, but behavior is covered by new tests and avoids silent overwrites.
> 
> **Overview**
> Fixes **cached Claude token overpricing** when LiteLLM publishes both a canonical bare model entry (with cache-read discounts) and provider-qualified entries that share the same trailing name. Rates are no longer collapsed to bare names at insert time, so a later DeepInfra-style row cannot overwrite the canonical cache-read rate.
> 
> **`parseRateTable`** now stores each entry under its full normalized key (`trim` + lowercase). It may add a **bare-name alias** only when no canonical bare key exists and every qualified variant agrees on input, output, and cache rates; conflicting bare names stay **unpriced** (`lookupRate` returns `null`).
> 
> **`lookupRate`** matches the normalized transcript model string against the table directly (still blocking ambiguous family names like `opus`/`sonnet`). **`normalizeModelName`** keeps the same bare-name contract for callers that strip provider prefixes.
> 
> Adds **`usagePricing.test.ts`** for normalization, Fable vs DeepInfra ordering, unanimous aliasing, and ambiguous bare names. Scan-cache comments were updated to reference `lookupRate` instead of `normalizeModelName`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63bf1f86ac251765f50bafd1c508f9a64cf639d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->