### PR TITLE
fix(web): open agent images in expanded preview

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -35,6 +35,7 @@ import React, {
   Suspense,
   type CSSProperties,
   type ClipboardEvent as ReactClipboardEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   isValidElement,
   use,
@@ -55,6 +56,7 @@ import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { remarkGithubAlerts } from "../markdown-github-alerts";
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
+import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 import {
@@ -155,6 +157,7 @@ interface ChatMarkdownProps {
   /** Parse sanitized raw HTML instead of displaying its source text. */
   parseRawHtml?: boolean;
   imageBaseDir?: string | undefined;
+  onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }
 
 export function canUseMarkdownFileShellActions(
@@ -1089,6 +1092,31 @@ const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
   CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
   "rounded-lg border border-border/40",
 );
+const MarkdownLinkContext = React.createContext(false);
+
+function expandableMarkdownImageProps(
+  onImageExpand: ((preview: ExpandedImagePreview) => void) | undefined,
+  src: string,
+  alt: string,
+) {
+  if (!onImageExpand) return {};
+  const previewName = alt.trim() || "image";
+  const expand = (event: ReactMouseEvent | ReactKeyboardEvent) => {
+    if (event.currentTarget.closest("a")) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onImageExpand({ images: [{ src, name: previewName }], index: 0 });
+  };
+  return {
+    role: "button" as const,
+    tabIndex: 0,
+    "aria-label": `Preview ${previewName}`,
+    onClick: expand,
+    onKeyDown: (event: ReactKeyboardEvent) => {
+      if (event.key === "Enter" || event.key === " ") expand(event);
+    },
+  };
+}
 
 function ChatMarkdownImageFallback(props: {
   readonly alt: string;
@@ -1118,6 +1146,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   readonly copyMarkdown: string;
   readonly srcFragment: string;
   readonly style?: CSSProperties | undefined;
+  readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
   const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
     _tag: "workspace-file",
@@ -1144,15 +1173,20 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
       />
     );
   }
+  const src = assetUrl.url + props.srcFragment;
   return (
     <img
-      src={assetUrl.url + props.srcFragment}
+      src={src}
       alt={props.alt}
       data-markdown-copy={props.copyMarkdown}
       loading="lazy"
       draggable={false}
-      className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
+      className={cn(
+        CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME,
+        props.onImageExpand && "cursor-zoom-in",
+      )}
       style={props.style}
+      {...expandableMarkdownImageProps(props.onImageExpand, src, props.alt)}
       onError={() => setFailedUrl(assetUrl.url)}
     />
   );
@@ -1694,6 +1728,7 @@ function ChatMarkdown({
   lineBreaks = false,
   parseRawHtml = true,
   imageBaseDir,
+  onImageExpand,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
@@ -2084,6 +2119,7 @@ function ChatMarkdown({
           const isSameDocumentLink = href?.startsWith("#") ?? false;
           const onClick = props.onClick;
           const canOpenInPreview = Boolean(threadRef) && isPreviewSupportedInRuntime();
+          const linkChildren = <MarkdownLinkContext value>{children}</MarkdownLinkContext>;
           const link = (
             <a
               {...props}
@@ -2160,10 +2196,10 @@ function ChatMarkdown({
             >
               {faviconHost && hastHasText(node) ? (
                 <MarkdownExternalLinkContent host={faviconHost} plainText={plainHastText(node)}>
-                  {children}
+                  {linkChildren}
                 </MarkdownExternalLinkContent>
               ) : (
-                children
+                linkChildren
               )}
             </a>
           );
@@ -2205,7 +2241,8 @@ function ChatMarkdown({
           </code>
         );
       },
-      img({ node, title, src, alt, ...props }) {
+      img: function MarkdownImage({ node, title, src, alt, ...props }) {
+        const imageExpand = use(MarkdownLinkContext) ? undefined : onImageExpand;
         const localSrc = node?.properties?.dataLocalSrc;
         const markdownTitle = node?.properties?.dataMarkdownTitle;
         const authoredSrc = typeof localSrc === "string" ? localSrc : src;
@@ -2225,8 +2262,13 @@ function ChatMarkdown({
               src={imageSource.uri}
               alt={altText}
               loading="lazy"
-              className={cn(props.className, CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME)}
+              className={cn(
+                props.className,
+                CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
+                imageExpand && "cursor-zoom-in",
+              )}
               style={authoredSizeStyle}
+              {...expandableMarkdownImageProps(imageExpand, imageSource.uri, altText)}
             />
           );
         }
@@ -2239,6 +2281,7 @@ function ChatMarkdown({
               copyMarkdown={copyMarkdown}
               srcFragment={markdownImageSourceFragment(classifiedSrc)}
               style={authoredSizeStyle}
+              onImageExpand={imageExpand}
             />
           );
         }
@@ -2289,6 +2332,7 @@ function ChatMarkdown({
     isStreaming,
     markdownFileLinkMetaByHref,
     onTaskListChange,
+    onImageExpand,
     openFileInPanel,
     openInPreferredEditor,
     openChangeRequestLink,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1251,6 +1251,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           isStreaming={Boolean(row.message.streaming)}
           lineBreaks={shouldPreserveAssistantLineBreaks(messageText)}
           skills={ctx.skills}
+          onImageExpand={ctx.onImageExpand}
         />
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}


### PR DESCRIPTION
Agent-authored markdown images were inert while user attachments already opened the expanded preview. This routes both direct and signed workspace image sources through the same dialog, with mouse and keyboard activation. Verified with 62 focused web tests, targeted lint and typecheck, plus real-client checks at desktop and narrow viewport sizes. Built with gpt-5.6-sol through the Codex harness.

Before:

![Agent images in the message](https://uploads-production-47e4.up.railway.app/files/9a5b2fb5-9245-49f1-836f-a40f53c89638/t3code-agent-image-before.png)

After:

![Agent workspace image in the expanded preview](https://uploads-production-47e4.up.railway.app/files/ce6bae05-108a-48e8-b262-cf5fc72d6e0f/t3code-agent-image-after.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only interaction wiring behind an optional callback; link-wrapped images are explicitly excluded to avoid breaking navigation.
> 
> **Overview**
> **Agent-authored markdown images** can now open the same expanded image preview as user attachments, instead of staying non-interactive in assistant messages.
> 
> `ChatMarkdown` gains an optional **`onImageExpand`** callback. A shared **`expandableMarkdownImageProps`** helper wires click, Enter, and Space with button semantics (`cursor-zoom-in`, ARIA label) for both **direct URL** images and **workspace file** images loaded via signed asset URLs in `ChatMarkdownWorkspaceImage`.
> 
> **`MarkdownLinkContext`** marks link descendants so images inside anchors do not steal the link’s navigation—expand is disabled when an image is nested in a link. If `onImageExpand` is omitted, image rendering is unchanged.
> 
> The messages timeline passes **`ctx.onImageExpand`** into assistant `ChatMarkdown` so agent message images use the existing preview dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b033f377d372b8297a549553bbf883376e718cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add expanded image preview support for `ChatMarkdown` images
> - Adds an `onImageExpand` callback to `ChatMarkdown` and `ChatMarkdownWorkspaceImage` to trigger an expanded preview for markdown images.
> - Images become interactive via click or Enter/Space keypress using the new `expandableMarkdownImageProps` utility, adding `cursor-zoom-in` styling.
> - Uses a new `MarkdownLinkContext` to disable expansion for images nested inside markdown links.
> - Threads the expansion handler from `MessagesTimeline` through `AssistantTimelineRow`.
> - Behavioral Change: Images with an `onImageExpand` handler now render with `role=button` and `tabIndex=0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b033f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->