### PR TITLE
fix(web): keep image preview above sidebar control

### DIFF
--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -66,7 +66,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
   const videoDownloadFailed = downloadFailedVideoSrc === item.src;
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 px-4 py-6 [-webkit-app-region:no-drag]"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 px-4 py-6 [-webkit-app-region:no-drag]"
       role="dialog"
       aria-modal="true"
       aria-label={`Expanded ${mediaLabel} preview`}


### PR DESCRIPTION
The expanded image backdrop shared z-50 with the global sidebar control, which renders later and stayed undimmed above the overlay. This moves the preview to z-[60], above app chrome and below toast and popover layers. Full CI is green; visual after evidence is pending browser approval. Built with gpt-5.6-sol through the Codex harness.

Before:

![sidebar control above image backdrop](https://uploads-production-47e4.up.railway.app/files/44380e18-f28c-44c1-821f-d0477b7a76bd/bc34c073-396a-4ca7-84e9-8b6e8aae43b7-61ca6d75-2d9f-48d4-af2a-95214f45f01a.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single z-index tweak in a presentation component with no auth, data, or business-logic impact.
> 
> **Overview**
> Fixes expanded chat **image/video preview** appearing **under** the global sidebar/workspace chrome because both used **`z-50`**.
> 
> Raises the `ExpandedImageDialog` backdrop from **`z-50`** to **`z-[60]`** so the dimmed full-screen overlay and preview sit above those fixed controls while staying below higher UI layers (e.g. composer at `z-[70]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57676f3315c3d032744e428e701eb0268aed28f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `ExpandedImageDialog` overlay z-index from `z-50` to `z-[60]`
> Changes the top-level dialog div in [ExpandedImageDialog.tsx](https://github.com/pingdotgg/t3code/pull/8811/files#diff-63ec07b58fe78d5e3d0566500664dd08cb5f6f2f8fe10371b4752b49757d8049) so the image preview renders above the sidebar control. The overlay now sits at stacking order 60.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57676f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->