### PR TITLE
feat(pull-requests): link GitHub references in markdown

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -179,6 +179,7 @@ interface ChatMarkdownProps {
   onUseArtifactTemplate?: ((template: CodexArtifactTemplate) => void) | undefined;
   imageBaseDir?: string | undefined;
   onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
+  extraRemarkPlugins?: NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
 }
 
 export function canUseMarkdownFileShellActions(
@@ -211,6 +212,7 @@ export function shouldUseMarkdownFileBrowserPrimaryAction(input: {
 }
 
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const EMPTY_REMARK_PLUGINS: NonNullable<ReactMarkdownOptions["remarkPlugins"]> = [];
 
 const ARTIFACT_TEMPLATE_ICON_BY_KIND = {
   document: FileTextIcon,
@@ -360,6 +362,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
     blockquote: [...(defaultSchema.attributes?.blockquote ?? []), "dataAlert"],
     div: [...(defaultSchema.attributes?.div ?? []), ...CODEX_ARTIFACT_TEMPLATE_HAST_PROPERTIES],
+    a: [...(defaultSchema.attributes?.a ?? []), "dataPullRequestAutolink"],
     img: [...(defaultSchema.attributes?.img ?? []), "dataLocalSrc", "dataMarkdownTitle"],
   },
   protocols: {
@@ -1812,6 +1815,7 @@ function ChatMarkdown({
   onUseArtifactTemplate,
   imageBaseDir,
   onImageExpand,
+  extraRemarkPlugins = EMPTY_REMARK_PLUGINS,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
@@ -2208,6 +2212,16 @@ function ChatMarkdown({
           : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
+          const pullRequestAutolink = String(
+            (props as Record<string, unknown>)["data-pull-request-autolink"] ?? "",
+          );
+          const pullRequestCopy =
+            pullRequestAutolink === "commit"
+              ? /\/commit\/([0-9a-f]{40})$/iu.exec(href ?? "")?.[1]
+              : pullRequestAutolink === "reference"
+                ? plainHastText(node)
+                : undefined;
+          const isPullRequestAutolink = pullRequestCopy !== undefined;
           const isSameDocumentLink = href?.startsWith("#") ?? false;
           const onClick = props.onClick;
           const canOpenInPreview = Boolean(threadRef) && isPreviewSupportedInRuntime();
@@ -2215,6 +2229,8 @@ function ChatMarkdown({
           const link = (
             <a
               {...props}
+              className={cn(props.className, pullRequestAutolink === "commit" && "font-mono")}
+              data-markdown-copy={pullRequestCopy}
               href={href}
               target={isSameDocumentLink ? undefined : "_blank"}
               rel={isSameDocumentLink ? undefined : "noopener noreferrer"}
@@ -2286,7 +2302,7 @@ function ChatMarkdown({
                 });
               }}
             >
-              {faviconHost && hastHasText(node) ? (
+              {faviconHost && hastHasText(node) && !isPullRequestAutolink ? (
                 <MarkdownExternalLinkContent host={faviconHost} plainText={plainHastText(node)}>
                   {linkChildren}
                 </MarkdownExternalLinkContent>
@@ -2443,6 +2459,14 @@ function ChatMarkdown({
   ]);
   /* eslint-enable react/no-unstable-nested-components */
 
+  const remarkPlugins = useMemo(
+    () => [
+      ...(lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS),
+      ...extraRemarkPlugins,
+    ],
+    [extraRemarkPlugins, lineBreaks],
+  );
+
   // react-markdown converts unparsed HTML nodes to text when skipHtml is false.
   // Keep that behavior explicit because literal mode depends on escaping the
   // complete source token instead of dropping it from the rendered message.
@@ -2455,9 +2479,7 @@ function ChatMarkdown({
       onCopy={handleCopy}
     >
       <ReactMarkdown
-        remarkPlugins={
-          lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS
-        }
+        remarkPlugins={remarkPlugins}
         rehypePlugins={parseRawHtml ? CHAT_MARKDOWN_REHYPE_PLUGINS : undefined}
         skipHtml={false}
         components={markdownComponents}

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -96,6 +96,7 @@ import { DiffPanelLoadingState } from "../DiffPanelShell";
 import { PullRequestsUnavailableState } from "./PullRequestsUnavailableState";
 import type { PullRequestAgentSelectionInput } from "./PullRequestCodeTab";
 import { openOnHostLabel, showPullRequestLinkContextMenu } from "./pullRequestLinkContextMenu";
+import { PullRequestMarkdownContext } from "./PullRequestMarkdown";
 import { PullRequestSummaryTab } from "./PullRequestSummaryTab";
 import { PullRequestTimelineTab } from "./PullRequestTimelineTab";
 import {
@@ -1918,7 +1919,7 @@ export function PullRequestDetailPanel({
             {...(unavailableGitHubUrl ? { gitHubUrl: unavailableGitHubUrl } : {})}
           />
         ) : detail ? (
-          <>
+          <PullRequestMarkdownContext value={detail.provider === "github" ? repositoryUrl : null}>
             {mountedTabs.has("summary") ? (
               <div className={cn("absolute inset-0", tab !== "summary" && "invisible")}>
                 <PullRequestSummaryTab
@@ -1975,7 +1976,7 @@ export function PullRequestDetailPanel({
                 </Suspense>
               </div>
             ) : null}
-          </>
+          </PullRequestMarkdownContext>
         ) : null}
       </div>
 

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,10 +1,14 @@
 import { ExternalLinkIcon, PaperclipIcon, PlayIcon } from "lucide-react";
 import type { EnvironmentId } from "@t3tools/contracts";
+import { createContext, useContext, useMemo } from "react";
+import type { Options as ReactMarkdownOptions } from "react-markdown";
 
 import { cn } from "~/lib/utils";
 
 import ChatMarkdown from "../ChatMarkdown";
-import { splitPullRequestBody } from "./pullRequestMarkdown.logic";
+import { remarkPullRequestAutolinks, splitPullRequestBody } from "./pullRequestMarkdown.logic";
+
+export const PullRequestMarkdownContext = createContext<string | null>(null);
 
 /**
  * A pull request body, rendered with the app's markdown renderer plus a card for each upload
@@ -27,6 +31,11 @@ export function PullRequestMarkdown({
   className?: string;
 }) {
   const segments = splitPullRequestBody(text);
+  const repositoryUrl = useContext(PullRequestMarkdownContext);
+  const extraRemarkPlugins = useMemo<NonNullable<ReactMarkdownOptions["remarkPlugins"]>>(
+    () => (repositoryUrl ? [[remarkPullRequestAutolinks, { repositoryUrl }]] : []),
+    [repositoryUrl],
+  );
   return (
     <div className={cn("space-y-3", className)}>
       {segments.map((segment) => {
@@ -37,6 +46,7 @@ export function PullRequestMarkdown({
               text={segment.text}
               cwd={cwd}
               environmentId={environmentId}
+              extraRemarkPlugins={extraRemarkPlugins}
             />
           );
         }

--- a/apps/web/src/components/pullRequest/pullRequestMarkdown.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestMarkdown.logic.ts
@@ -1,3 +1,9 @@
+import {
+  findAndReplaceText,
+  type MarkdownNode,
+  type TextMatch,
+} from "~/vendor/mdast-find-and-replace";
+
 /** `id` is positional on purpose: the same attachment can be embedded twice in one body. */
 export type PullRequestBodySegment =
   | { readonly id: string; readonly kind: "markdown"; readonly text: string }
@@ -140,4 +146,47 @@ export function splitPullRequestBody(body: string): ReadonlyArray<PullRequestBod
 
   flushMarkdown();
   return segments;
+}
+
+const AUTOLINK_CANDIDATE_PATTERN = /#[1-9]\d*|[0-9a-f]{40}/giu;
+const AUTOLINK_WORD_CHARACTER_PATTERN = /[A-Za-z0-9_]/u;
+const AUTOLINK_COMMIT_PREFIX_PATTERN = /[\s([{]/u;
+const AUTOLINK_IGNORED_TYPES = new Set(["link", "linkReference"]);
+
+/** GitHub-style same-repository references for pull request prose, never code or authored links. */
+export function remarkPullRequestAutolinks(options: { readonly repositoryUrl: string }) {
+  const repositoryUrl = options.repositoryUrl.replace(/\/+$/u, "");
+  return (tree: MarkdownNode) => {
+    findAndReplaceText(
+      tree,
+      AUTOLINK_CANDIDATE_PATTERN,
+      (matched: string, match: TextMatch) => {
+        const reference = matched.startsWith("#");
+        const before = match.input[match.index - 1];
+        const after = match.input[match.index + matched.length];
+        if (
+          (before !== undefined &&
+            (reference
+              ? AUTOLINK_WORD_CHARACTER_PATTERN.test(before)
+              : !AUTOLINK_COMMIT_PREFIX_PATTERN.test(before))) ||
+          (after !== undefined && AUTOLINK_WORD_CHARACTER_PATTERN.test(after))
+        ) {
+          return false;
+        }
+        return {
+          type: "link",
+          url: reference
+            ? `${repositoryUrl}/issues/${matched.slice(1)}`
+            : `${repositoryUrl}/commit/${matched}`,
+          data: {
+            hProperties: {
+              dataPullRequestAutolink: reference ? "reference" : "commit",
+            },
+          },
+          children: [{ type: "text", value: reference ? matched : matched.slice(0, 7) }],
+        };
+      },
+      AUTOLINK_IGNORED_TYPES,
+    );
+  };
 }

--- a/apps/web/src/vendor/mdast-find-and-replace.ts
+++ b/apps/web/src/vendor/mdast-find-and-replace.ts
@@ -1,0 +1,90 @@
+/*
+ * Adapted from mdast-util-find-and-replace:
+ * https://github.com/syntax-tree/mdast-util-find-and-replace/blob/main/lib/index.js
+ *
+ * The MIT License
+ *
+ * Copyright (c) Titus Wormer <tituswormer@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export type MarkdownNode = {
+  type: string;
+  value?: string;
+  children?: MarkdownNode[];
+  url?: string;
+  data?: unknown;
+};
+
+export type TextMatch = {
+  index: number;
+  input: string;
+};
+
+/** The dependency-free subset of mdast-util-find-and-replace used by PR autolinks. */
+export function findAndReplaceText(
+  tree: MarkdownNode,
+  find: RegExp,
+  replace: (matched: string, match: TextMatch) => MarkdownNode | false,
+  ignoredTypes: ReadonlySet<string>,
+): void {
+  visit(tree);
+
+  function visit(node: MarkdownNode): void {
+    if (node.children === undefined) return;
+    for (let childIndex = 0; childIndex < node.children.length; childIndex += 1) {
+      const child = node.children[childIndex]!;
+      if (ignoredTypes.has(child.type)) continue;
+      if (child.type !== "text" || child.value === undefined) {
+        visit(child);
+        continue;
+      }
+
+      const replacements: MarkdownNode[] = [];
+      let start = 0;
+      let changed = false;
+      find.lastIndex = 0;
+      let match = find.exec(child.value);
+      while (match !== null) {
+        const position = match.index;
+        const replacement = replace(match[0], { index: position, input: match.input });
+        if (replacement === false) {
+          find.lastIndex = position + 1;
+        } else {
+          if (start < position) {
+            replacements.push({ type: "text", value: child.value.slice(start, position) });
+          }
+          replacements.push(replacement);
+          start = position + match[0].length;
+          changed = true;
+        }
+        if (!find.global) break;
+        match = find.exec(child.value);
+      }
+
+      if (!changed) continue;
+      if (start < child.value.length) {
+        replacements.push({ type: "text", value: child.value.slice(start) });
+      }
+      node.children.splice(childIndex, 1, ...replacements);
+      childIndex += replacements.length - 1;
+    }
+  }
+}


### PR DESCRIPTION
GitHub issue and pull request references plus full commit SHAs in pull request prose now link to the same repository. Full SHAs render as seven-character monospaced links, while authored links, code, and non-GitHub providers remain unchanged. Web typecheck, scoped lint, targeted formatting, and a real Markdown AST edge-case matrix pass. Built with GPT-5.6 through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown rendering change scoped to PR bodies when a GitHub repository URL is present; regex edge cases could mis-link rare prose but do not touch auth or data paths.
> 
> **Overview**
> **Pull request descriptions on GitHub** now autolink bare `#123` references and 40-character commit SHAs to the current repository, similar to GitHub’s prose behavior.
> 
> A new **`remarkPullRequestAutolinks`** remark plugin (with a small vendored **`findAndReplaceText`** helper) turns matching plain text into links while skipping existing links and link references. **`PullRequestMarkdownContext`** passes the repo URL from the detail panel for **GitHub-only** PRs; other providers get no autolinking.
> 
> **`ChatMarkdown`** accepts **`extraRemarkPlugins`** so PR markdown can plug in that plugin without forking the renderer. Autolinked anchors keep **`dataPullRequestAutolink`** through sanitization; the link renderer applies **monospace** and **`data-markdown-copy`** for commits (full SHA on copy) and **does not** add external-link favicons for these links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd9d66bbddfe8f956a26e17f598ae18ab55ea5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub autolinking for issue references and commit SHAs in PR markdown
> - Adds a new remark plugin `remarkPullRequestAutolinks` in [pullRequestMarkdown.logic.ts](https://github.com/pingdotgg/t3code/pull/8812/files#diff-ae56f29a80e09bbbe556d20612622485139d7323ce1142abd9f1ecfb55227a33) that converts `#123` issue references and 40-character hex commit SHAs in plain text into links to the host repository, with shortened 7-char display text for commits
> - Vendors a dependency-free `findAndReplaceText` utility in [mdast-find-and-replace.ts](https://github.com/pingdotgg/t3code/pull/8812/files#diff-d28743883e7ce3f624a8628fd9480b337ac44b56c0640eb4bc6ce084ee5163d2) to power the tree text scanning and replacement
> - Introduces `PullRequestMarkdownContext` to pass the repository URL down from [PullRequestDetailPanel.tsx](https://github.com/pingdotgg/t3code/pull/8812/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a) to [PullRequestMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8812/files#diff-e0ad675262612542e104a5b367f3f70bda7a32ec76b460e7e54367f33bdc434e), which enables the plugin only for GitHub providers
> - Extends [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8812/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) with an `extraRemarkPlugins` prop and updates the anchor renderer to style commit autolinks in monospace, set `data-markdown-copy`, and suppress the external-favicon wrapper for autolinked PR links
> - Risk: the sanitize schema now permits `dataPullRequestAutolink` on anchor tags in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8812/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05); autolinking is scoped to text nodes outside of existing links and linkReferences to avoid double-wrapping
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfd9d66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
