### PR TITLE
fix(server): preserve user scope for Claude skills

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -66,6 +66,22 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
+  it.effect("keeps user scope when project and user skill roots match", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const workspace = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(workspace, ".claude");
+
+      yield* writeSkill(path.join(configDir, "skills"), "review", "---\nname: review\n---\n");
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+
+      assert.equal(skills.length, 1);
+      assert.equal(skills[0]?.scope, "user");
+    }),
+  );
+
   it.effect("discovers project skills from the workspace .agents directory", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -66,19 +66,26 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
-  it.effect("keeps user scope when project and user skill roots match", () =>
+  it.effect("keeps user scope when project and user skill roots name the same directory", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const workspace = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
       const configDir = path.join(workspace, ".claude");
+      const configLink = path.join(workspace, "claude-home");
 
       yield* writeSkill(path.join(configDir, "skills"), "review", "---\nname: review\n---\n");
+      yield* fs.symlink(configDir, configLink);
 
-      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+      const [directSkills, linkedSkills] = yield* Effect.all([
+        discoverClaudeSkills({ homePath: configDir }, workspace),
+        discoverClaudeSkills({ homePath: configLink }, workspace),
+      ]);
 
-      assert.equal(skills.length, 1);
-      assert.equal(skills[0]?.scope, "user");
+      for (const skills of [directSkills, linkedSkills]) {
+        assert.equal(skills.length, 1);
+        assert.equal(skills[0]?.scope, "user");
+      }
     }),
   );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -101,16 +101,26 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
   const path = yield* Path.Path;
   const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env, cwd);
   const userSkillsDirectory = path.join(configDirPath, "skills");
-  const resolvedUserSkillsDirectory = path.resolve(userSkillsDirectory);
+  const canonicalizeDirectory = (directory: string) => {
+    const resolved = path.resolve(directory);
+    return fileSystem.realPath(resolved).pipe(Effect.orElseSucceed(() => resolved));
+  };
+  const canonicalUserSkillsDirectory = yield* canonicalizeDirectory(userSkillsDirectory);
+  const projectRoots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = cwd
+    ? [
+        { directory: path.join(cwd, ".agents", "skills"), scope: "project" },
+        { directory: path.join(cwd, ".claude", "skills"), scope: "project" },
+      ]
+    : [];
+  const distinctProjectRoots = yield* Effect.filter(projectRoots, (root) =>
+    canonicalizeDirectory(root.directory).pipe(
+      Effect.map((directory) => directory !== canonicalUserSkillsDirectory),
+    ),
+  );
 
   const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
     { directory: userSkillsDirectory, scope: "user" },
-    ...(cwd
-      ? [
-          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
-          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
-        ].filter((root) => path.resolve(root.directory) !== resolvedUserSkillsDirectory)
-      : []),
+    ...distinctProjectRoots,
   ];
 
   const skillsByName = new Map<string, ServerProviderSkill>();

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -100,14 +100,16 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env, cwd);
+  const userSkillsDirectory = path.join(configDirPath, "skills");
+  const resolvedUserSkillsDirectory = path.resolve(userSkillsDirectory);
 
   const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
-    { directory: path.join(configDirPath, "skills"), scope: "user" },
+    { directory: userSkillsDirectory, scope: "user" },
     ...(cwd
       ? [
           { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
           { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
-        ]
+        ].filter((root) => path.resolve(root.directory) !== resolvedUserSkillsDirectory)
       : []),
   ];
 


### PR DESCRIPTION
## What Changed

- De-duplicate Claude skill discovery roots when the configured user skills directory and `<cwd>/.claude/skills` resolve to the same path.
- Preserve the original `user` scope instead of rescanning that directory as `project`.
- Add a regression test for the packaged desktop `$HOME` working-directory layout.

## Why

Packaged desktop starts the backend in `$HOME`. With the default Claude config, both discovery roots resolve to `$HOME/.claude/skills`; the later project scan overwrites every user skill's scope and the composer labels it "Project Skill."

Closes #8757

## Testing

- `vp test run apps/server/src/provider/Drivers/ClaudeSkills.test.ts` (10 tests)
- `vp run --filter t3 typecheck`
- `vp lint apps/server/src/provider/Drivers/ClaudeSkills.ts apps/server/src/provider/Drivers/ClaudeSkills.test.ts`
- `vp fmt --check apps/server/src/provider/Drivers/ClaudeSkills.ts apps/server/src/provider/Drivers/ClaudeSkills.test.ts`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI code changed; screenshots and video are not applicable

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to skill discovery and scope labeling in the Claude provider; no auth, data, or API surface changes.
> 
> **Overview**
> **`discoverClaudeSkills`** now canonicalizes skill root paths (via `realPath`) and drops workspace **`.agents/skills`** / **`.claude/skills`** entries when they resolve to the same directory as the user **`skills`** folder. That stops the second pass from relabeling those skills as **project** scope when the backend cwd overlaps the Claude config dir (e.g. packaged desktop with cwd `$HOME`).
> 
> A regression test covers the layout where **`homePath`** points at the workspace **`.claude`** directory (including a symlinked config path) and asserts discovered skills stay **`user`** scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d910e0d0f2aa478b30a612a86cb2590f5012e63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `discoverClaudeSkills` to preserve `user` scope for shared skill directories
> - [ClaudeSkills.ts](apps/server/src/provider/Drivers/ClaudeSkills.ts) canonicalizes the user skills directory and each project root via `path.resolve` and `fileSystem.realPath`, then excludes any project root whose canonical path matches the user skills directory.
> - When a project root (`.agents/skills` or `.claude/skills`) is the same directory as the user config `.claude/skills` — including via symlinks — skills from that directory are reported with scope `user` instead of `project`.
> - Adds test coverage in [ClaudeSkills.test.ts](apps/server/src/provider/Drivers/ClaudeSkills.test.ts) for both direct and symlinked `homePath` inputs.
> - Risk: `fileSystem.realPath` has a fallback when canonicalization fails, so a root that cannot be resolved may still appear as a distinct project root and shadow the user scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d910e0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->