### PR TITLE
feat(worktrees): add safe automatic cleanup

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -80,7 +80,7 @@ import * as WorkspaceEntries from "../src/workspace/WorkspaceEntries.ts";
 import * as WorkspacePaths from "../src/workspace/WorkspacePaths.ts";
 import * as VcsDriverRegistry from "../src/vcs/VcsDriverRegistry.ts";
 import { VcsStatusBroadcaster } from "../src/vcs/VcsStatusBroadcaster.ts";
-import { WorktreeLifecycleLock } from "../src/vcs/WorktreeLifecycleLock.ts";
+import * as WorktreeLifecycleLock from "../src/vcs/WorktreeLifecycleLock.ts";
 import { GitWorkflowService } from "../src/git/GitWorkflowService.ts";
 import * as VcsProcess from "../src/vcs/VcsProcess.ts";
 import * as AgentAwarenessRelay from "../src/relay/AgentAwarenessRelay.ts";

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -80,6 +80,7 @@ import * as WorkspaceEntries from "../src/workspace/WorkspaceEntries.ts";
 import * as WorkspacePaths from "../src/workspace/WorkspacePaths.ts";
 import * as VcsDriverRegistry from "../src/vcs/VcsDriverRegistry.ts";
 import { VcsStatusBroadcaster } from "../src/vcs/VcsStatusBroadcaster.ts";
+import { WorktreeLifecycleLock } from "../src/vcs/WorktreeLifecycleLock.ts";
 import { GitWorkflowService } from "../src/git/GitWorkflowService.ts";
 import * as VcsProcess from "../src/vcs/VcsProcess.ts";
 import * as AgentAwarenessRelay from "../src/relay/AgentAwarenessRelay.ts";
@@ -337,6 +338,7 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(gitWorkflowLayer),
       Layer.provideMerge(textGenerationLayer),
       Layer.provideMerge(serverSettingsLayer),
+      Layer.provideMerge(WorktreeLifecycleLock.layer),
     );
     const checkpointReactorLayer = CheckpointReactorLive.pipe(
       Layer.provideMerge(runtimeServicesLayer),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -62,6 +62,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Clock from "effect/Clock";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
+import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
 import * as GitWorkflowService from "../../git/GitWorkflowService.ts";
 
 const asProjectId = (value: string): ProjectId => ProjectId.make(value);
@@ -270,10 +271,21 @@ describe("ProviderCommandReactor", () => {
             : "renamed-branch",
       }),
     );
+    const worktreeLifecycleEvents: string[] = [];
+    const worktreeLifecycle = WorktreeLifecycleLock.of({
+      withLock: (effect) =>
+        Effect.sync(() => worktreeLifecycleEvents.push("lock")).pipe(
+          Effect.andThen(effect),
+          Effect.ensuring(Effect.sync(() => worktreeLifecycleEvents.push("unlock"))),
+        ),
+    });
     const pruneWorktrees = vi.fn((_: { readonly cwd: string }) => Effect.void);
     const createWorktree = vi.fn(
       (input: { readonly refName: string; readonly path: string | null }) =>
-        Effect.succeed({ worktree: { path: input.path ?? "", refName: input.refName } }),
+        Effect.sync(() => {
+          worktreeLifecycleEvents.push("create");
+          return { worktree: { path: input.path ?? "", refName: input.refName } };
+        }),
     );
     const refreshStatus = vi.fn((_: string) =>
       Effect.succeed({
@@ -427,6 +439,7 @@ describe("ProviderCommandReactor", () => {
         }),
       ),
       Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(Layer.succeed(WorktreeLifecycleLock, worktreeLifecycle)),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -515,6 +528,7 @@ describe("ProviderCommandReactor", () => {
       renameBranch,
       pruneWorktrees,
       createWorktree,
+      worktreeLifecycleEvents,
       refreshStatus,
       generateBranchName,
       generateThreadTitle,
@@ -1579,6 +1593,7 @@ describe("ProviderCommandReactor", () => {
       refName: "feature/restore",
       path: worktreePath,
     });
+    expect(harness.worktreeLifecycleEvents).toEqual(["lock", "create", "unlock"]);
     expect(harness.createWorktree.mock.invocationCallOrder[0]).toBeLessThan(
       harness.startSession.mock.invocationCallOrder[0]!,
     );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -62,7 +62,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Clock from "effect/Clock";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
-import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
+import * as WorktreeLifecycleLock from "../../vcs/WorktreeLifecycleLock.ts";
 import * as GitWorkflowService from "../../git/GitWorkflowService.ts";
 
 const asProjectId = (value: string): ProjectId => ProjectId.make(value);
@@ -272,7 +272,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
     const worktreeLifecycleEvents: string[] = [];
-    const worktreeLifecycle = WorktreeLifecycleLock.of({
+    const worktreeLifecycle = WorktreeLifecycleLock.WorktreeLifecycleLock.of({
       withLock: (effect) =>
         Effect.sync(() => worktreeLifecycleEvents.push("lock")).pipe(
           Effect.andThen(effect),
@@ -439,7 +439,9 @@ describe("ProviderCommandReactor", () => {
         }),
       ),
       Layer.provideMerge(ServerSettingsService.layerTest()),
-      Layer.provideMerge(Layer.succeed(WorktreeLifecycleLock, worktreeLifecycle)),
+      Layer.provideMerge(
+        Layer.succeed(WorktreeLifecycleLock.WorktreeLifecycleLock, worktreeLifecycle),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -47,6 +47,7 @@ import {
   ServerSettingsService,
 } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
+import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
@@ -309,6 +310,7 @@ const make = Effect.gen(function* () {
   const providerService = yield* ProviderService;
   const providerRegistry = yield* ProviderRegistry;
   const gitWorkflow = yield* GitWorkflowService;
+  const worktreeLifecycle = yield* WorktreeLifecycleLock;
   const fileSystem = yield* FileSystem.FileSystem;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;
@@ -1141,7 +1143,7 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    yield* ensureThreadWorktree(thread);
+    yield* worktreeLifecycle.withLock(ensureThreadWorktree(thread));
 
     const isFirstUserMessageTurn =
       thread.messages.filter((entry) => entry.role === "user").length === 1;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -47,7 +47,7 @@ import {
   ServerSettingsService,
 } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
-import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
+import * as WorktreeLifecycleLock from "../../vcs/WorktreeLifecycleLock.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
@@ -310,7 +310,7 @@ const make = Effect.gen(function* () {
   const providerService = yield* ProviderService;
   const providerRegistry = yield* ProviderRegistry;
   const gitWorkflow = yield* GitWorkflowService;
-  const worktreeLifecycle = yield* WorktreeLifecycleLock;
+  const worktreeLifecycle = yield* WorktreeLifecycleLock.WorktreeLifecycleLock;
   const fileSystem = yield* FileSystem.FileSystem;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;

--- a/apps/server/src/orchestration/Layers/WorktreeAutoDelete.test.ts
+++ b/apps/server/src/orchestration/Layers/WorktreeAutoDelete.test.ts
@@ -1,0 +1,269 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import {
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationThreadShell,
+  type ProviderSession,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+
+import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
+import { ThreadDeletionReactor } from "../Services/ThreadDeletionReactor.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProjectionProjectRepository,
+  type ProjectionProject,
+} from "../../persistence/Services/ProjectionProjects.ts";
+import {
+  ProjectionThreadRepository,
+  type ProjectionThread,
+} from "../../persistence/Services/ProjectionThreads.ts";
+import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import * as TerminalManager from "../../terminal/Manager.ts";
+import * as GitVcsDriver from "../../vcs/GitVcsDriver.ts";
+import { makeWorktreeAutoDelete } from "./WorktreeAutoDelete.ts";
+
+const projectId = ProjectId.make("worktree-cleanup-project");
+const branch = "feature/worktree-cleanup";
+const old = "2026-01-01T00:00:00.000Z";
+const recent = "2099-01-01T00:00:00.000Z";
+
+const makeThread = (
+  id: string,
+  worktreePath: string,
+  overrides: Partial<ProjectionThread> = {},
+): ProjectionThread => ({
+  threadId: ThreadId.make(id),
+  projectId,
+  title: id,
+  modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.6-sol" },
+  runtimeMode: DEFAULT_RUNTIME_MODE,
+  interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+  branch,
+  worktreePath,
+  latestTurnId: null,
+  createdAt: old,
+  updatedAt: old,
+  archivedAt: null,
+  settledOverride: "settled",
+  settledAt: old,
+  unsettledAt: null,
+  snoozedUntil: null,
+  snoozedAt: null,
+  pinnedAt: null,
+  latestUserMessageAt: null,
+  pendingApprovalCount: 0,
+  pendingUserInputCount: 0,
+  hasActionableProposedPlan: 0,
+  deletedAt: null,
+  ...overrides,
+});
+
+describe("worktree auto-delete", () => {
+  it.effect("only removes eligible clean managed worktrees", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let projects: ProjectionProject[] = [];
+        let threads: ProjectionThread[] = [];
+        const removed: Array<{ path: string; force: boolean | undefined }> = [];
+        const dirtyPaths = new Set<string>();
+        const activeThreadIds = new Set<ThreadId>();
+        const terminalPaths = new Set<string>();
+        let racePath = "";
+
+        const testLayer = Layer.mergeAll(
+          ServerConfig.layerTest(process.cwd(), { prefix: "t3-worktree-cleanup-test-" }).pipe(
+            Layer.provide(NodeServices.layer),
+          ),
+          ServerSettingsService.layerTest(),
+          Layer.mock(ProjectionProjectRepository)({
+            listAll: () => Effect.succeed(projects),
+          }),
+          Layer.mock(ProjectionThreadRepository)({
+            listByProjectId: () => Effect.succeed(threads),
+          }),
+          Layer.mock(ProjectionSnapshotQuery)({
+            getThreadShellById: (threadId) => {
+              const thread = threads.find(
+                (candidate) => candidate.threadId === threadId && candidate.deletedAt === null,
+              );
+              if (!thread) return Effect.succeed(Option.none<OrchestrationThreadShell>());
+              return Effect.succeed(
+                Option.some({
+                  id: thread.threadId,
+                  worktreePath: thread.worktreePath,
+                  branch: thread.branch,
+                  settledOverride: thread.settledOverride,
+                  settledAt: thread.settledAt,
+                  latestUserMessageAt: thread.latestUserMessageAt,
+                  latestTurn: null,
+                  session: null,
+                  hasPendingApprovals: thread.pendingApprovalCount > 0,
+                  hasPendingUserInput: thread.pendingUserInputCount > 0,
+                  backgroundLiveness: null,
+                } as unknown as OrchestrationThreadShell),
+              );
+            },
+          }),
+          Layer.mock(ProviderService)({
+            listSessions: () =>
+              Effect.succeed(
+                [...activeThreadIds].map((threadId) => ({ threadId }) as ProviderSession),
+              ),
+          }),
+          Layer.mock(TerminalManager.TerminalManager)({
+            subscribeMetadata: (listener) =>
+              listener({
+                type: "snapshot",
+                terminals: [...terminalPaths].map((cwd, index) => ({
+                  threadId: `other-${index}`,
+                  terminalId: `terminal-${index}`,
+                  cwd,
+                  worktreePath: null,
+                  status: "running" as const,
+                  pid: 1,
+                  exitCode: null,
+                  exitSignal: null,
+                  hasRunningSubprocess: false,
+                  label: "shell",
+                  updatedAt: old,
+                })),
+              }).pipe(Effect.as(() => undefined)),
+          }),
+          Layer.mock(GitVcsDriver.GitVcsDriver)({
+            statusDetailsLocal: (cwd) =>
+              Effect.sync(() => {
+                if (cwd === racePath) {
+                  threads = threads.map((thread) =>
+                    thread.worktreePath === racePath
+                      ? { ...thread, settledOverride: "active", settledAt: null }
+                      : thread,
+                  );
+                }
+                return {
+                  isRepo: true,
+                  hasOriginRemote: false,
+                  isDefaultBranch: false,
+                  branch,
+                  upstreamRef: null,
+                  hasWorkingTreeChanges: dirtyPaths.has(cwd),
+                  workingTree: { files: [], insertions: 0, deletions: 0 },
+                  hasUpstream: false,
+                  aheadCount: 0,
+                  behindCount: 0,
+                  aheadOfDefaultCount: 0,
+                };
+              }),
+            removeWorktree: (input) =>
+              Effect.sync(() => removed.push({ path: input.path, force: input.force })),
+          }),
+          Layer.mock(CheckpointReactor)({ drain: Effect.void }),
+          Layer.mock(ThreadDeletionReactor)({
+            start: () => Effect.void,
+            drainThrough: () => Effect.void,
+          }),
+          Layer.mock(OrchestrationEngineService)({
+            streamDomainEvents: Stream.empty,
+            latestSequence: Effect.succeed(0),
+          }),
+          NodeServices.layer,
+        );
+
+        yield* Effect.gen(function* () {
+          const config = yield* ServerConfig;
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const deletedPath = path.join(config.worktreesDir, "repo", "deleted");
+          const expiredPath = path.join(config.worktreesDir, "repo", "expired");
+          const recentPath = path.join(config.worktreesDir, "repo", "recent");
+          const sharedPath = path.join(config.worktreesDir, "repo", "shared");
+          const dirtyPath = path.join(config.worktreesDir, "repo", "dirty");
+          const sessionPath = path.join(config.worktreesDir, "repo", "session");
+          const terminalPath = path.join(config.worktreesDir, "repo", "terminal");
+          racePath = path.join(config.worktreesDir, "repo", "race");
+          const outsidePath = yield* fs.makeTempDirectoryScoped({ prefix: "outside-worktree-" });
+          const managedPaths = [
+            deletedPath,
+            expiredPath,
+            recentPath,
+            sharedPath,
+            dirtyPath,
+            sessionPath,
+            terminalPath,
+            racePath,
+          ];
+          yield* Effect.forEach(managedPaths, (candidate) =>
+            fs.makeDirectory(candidate, { recursive: true }),
+          );
+          const terminalChildPath = path.join(terminalPath, "packages", "app");
+          yield* fs.makeDirectory(terminalChildPath, { recursive: true });
+
+          projects = [
+            {
+              projectId,
+              title: "Project",
+              workspaceRoot: process.cwd(),
+              defaultModelSelection: null,
+              defaultThreadEnvMode: null,
+              scripts: [],
+              createdAt: old,
+              updatedAt: old,
+              deletedAt: null,
+            },
+          ];
+          threads = [
+            makeThread("deleted", deletedPath, {
+              settledOverride: null,
+              settledAt: null,
+              deletedAt: old,
+            }),
+            makeThread("expired", expiredPath),
+            makeThread("recent", recentPath, { settledAt: recent }),
+            makeThread("shared-settled", sharedPath),
+            makeThread("shared-active", sharedPath, {
+              settledOverride: null,
+              settledAt: null,
+            }),
+            makeThread("dirty", dirtyPath),
+            makeThread("outside", outsidePath),
+            makeThread("session", sessionPath),
+            makeThread("terminal", terminalPath),
+            makeThread("race", racePath),
+          ];
+          dirtyPaths.add(dirtyPath);
+          activeThreadIds.add(ThreadId.make("session"));
+          terminalPaths.add(terminalChildPath);
+
+          yield* TestClock.setTime(Date.parse("2026-08-30T00:00:00.000Z"));
+          const cleanup = yield* makeWorktreeAutoDelete;
+          const settings = yield* ServerSettingsService;
+
+          yield* cleanup.sweep;
+          assert.isEmpty(removed);
+
+          yield* settings.updateSettings({ worktreeAutoDeleteAfterDays: 3 });
+          yield* cleanup.sweep;
+
+          assert.deepStrictEqual(
+            removed.map(({ path: removedPath }) => removedPath).sort(),
+            [deletedPath, expiredPath].sort(),
+          );
+          assert.isTrue(removed.every(({ force }) => force !== true));
+        }).pipe(Effect.provide(testLayer));
+      }),
+    ),
+  );
+});

--- a/apps/server/src/orchestration/Layers/WorktreeAutoDelete.test.ts
+++ b/apps/server/src/orchestration/Layers/WorktreeAutoDelete.test.ts
@@ -9,7 +9,9 @@ import {
   type OrchestrationThreadShell,
   type ProviderSession,
 } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -73,7 +75,7 @@ const makeThread = (
 });
 
 describe("worktree auto-delete", () => {
-  it.effect("only removes eligible clean managed worktrees", () =>
+  it.effect("only removes eligible clean managed worktrees and preserves interrupts", () =>
     Effect.scoped(
       Effect.gen(function* () {
         let projects: ProjectionProject[] = [];
@@ -83,6 +85,7 @@ describe("worktree auto-delete", () => {
         const activeThreadIds = new Set<ThreadId>();
         const terminalPaths = new Set<string>();
         let racePath = "";
+        let interruptPath = "";
 
         const testLayer = Layer.mergeAll(
           ServerConfig.layerTest(process.cwd(), { prefix: "t3-worktree-cleanup-test-" }).pipe(
@@ -144,8 +147,9 @@ describe("worktree auto-delete", () => {
               }).pipe(Effect.as(() => undefined)),
           }),
           Layer.mock(GitVcsDriver.GitVcsDriver)({
-            statusDetailsLocal: (cwd) =>
-              Effect.sync(() => {
+            statusDetailsLocal: (cwd) => {
+              if (cwd === interruptPath) return Effect.interrupt;
+              return Effect.sync(() => {
                 if (cwd === racePath) {
                   threads = threads.map((thread) =>
                     thread.worktreePath === racePath
@@ -166,7 +170,8 @@ describe("worktree auto-delete", () => {
                   behindCount: 0,
                   aheadOfDefaultCount: 0,
                 };
-              }),
+              });
+            },
             removeWorktree: (input) =>
               Effect.sync(() => removed.push({ path: input.path, force: input.force })),
           }),
@@ -194,8 +199,10 @@ describe("worktree auto-delete", () => {
           const sessionPath = path.join(config.worktreesDir, "repo", "session");
           const terminalPath = path.join(config.worktreesDir, "repo", "terminal");
           racePath = path.join(config.worktreesDir, "repo", "race");
+          interruptPath = path.join(config.worktreesDir, "repo", "interrupt");
           const outsidePath = yield* fs.makeTempDirectoryScoped({ prefix: "outside-worktree-" });
           const managedPaths = [
+            interruptPath,
             deletedPath,
             expiredPath,
             recentPath,
@@ -225,6 +232,7 @@ describe("worktree auto-delete", () => {
             },
           ];
           threads = [
+            makeThread("interrupt", interruptPath, { settledAt: recent }),
             makeThread("deleted", deletedPath, {
               settledOverride: null,
               settledAt: null,
@@ -262,6 +270,13 @@ describe("worktree auto-delete", () => {
             [deletedPath, expiredPath].sort(),
           );
           assert.isTrue(removed.every(({ force }) => force !== true));
+
+          threads = threads.map((thread) =>
+            thread.threadId === ThreadId.make("interrupt") ? { ...thread, settledAt: old } : thread,
+          );
+          const exit = yield* Effect.exit(cleanup.sweep);
+          assert.isTrue(Exit.isFailure(exit));
+          if (Exit.isFailure(exit)) assert.isTrue(Cause.hasInterruptsOnly(exit.cause));
         }).pipe(Effect.provide(testLayer));
       }),
     ),

--- a/apps/server/src/orchestration/Layers/WorktreeAutoDelete.test.ts
+++ b/apps/server/src/orchestration/Layers/WorktreeAutoDelete.test.ts
@@ -36,6 +36,7 @@ import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import * as TerminalManager from "../../terminal/Manager.ts";
 import * as GitVcsDriver from "../../vcs/GitVcsDriver.ts";
+import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
 import { makeWorktreeAutoDelete } from "./WorktreeAutoDelete.ts";
 
 const projectId = ProjectId.make("worktree-cleanup-project");
@@ -86,6 +87,21 @@ describe("worktree auto-delete", () => {
         const terminalPaths = new Set<string>();
         let racePath = "";
         let interruptPath = "";
+        let bufferedTerminalPath = "";
+        let afterRemove: Effect.Effect<void> = Effect.void;
+        const terminalSummary = (cwd: string, id: string | number) => ({
+          threadId: `other-${id}`,
+          terminalId: `terminal-${id}`,
+          cwd,
+          worktreePath: null,
+          status: "running" as const,
+          pid: 1,
+          exitCode: null,
+          exitSignal: null,
+          hasRunningSubprocess: false,
+          label: "shell",
+          updatedAt: old,
+        });
 
         const testLayer = Layer.mergeAll(
           ServerConfig.layerTest(process.cwd(), { prefix: "t3-worktree-cleanup-test-" }).pipe(
@@ -129,22 +145,19 @@ describe("worktree auto-delete", () => {
           }),
           Layer.mock(TerminalManager.TerminalManager)({
             subscribeMetadata: (listener) =>
-              listener({
-                type: "snapshot",
-                terminals: [...terminalPaths].map((cwd, index) => ({
-                  threadId: `other-${index}`,
-                  terminalId: `terminal-${index}`,
-                  cwd,
-                  worktreePath: null,
-                  status: "running" as const,
-                  pid: 1,
-                  exitCode: null,
-                  exitSignal: null,
-                  hasRunningSubprocess: false,
-                  label: "shell",
-                  updatedAt: old,
-                })),
-              }).pipe(Effect.as(() => undefined)),
+              Effect.gen(function* () {
+                yield* listener({
+                  type: "snapshot",
+                  terminals: [...terminalPaths].map(terminalSummary),
+                });
+                if (bufferedTerminalPath) {
+                  yield* listener({
+                    type: "upsert",
+                    terminal: terminalSummary(bufferedTerminalPath, "buffered"),
+                  });
+                }
+                return () => undefined;
+              }),
           }),
           Layer.mock(GitVcsDriver.GitVcsDriver)({
             statusDetailsLocal: (cwd) => {
@@ -173,7 +186,9 @@ describe("worktree auto-delete", () => {
               });
             },
             removeWorktree: (input) =>
-              Effect.sync(() => removed.push({ path: input.path, force: input.force })),
+              Effect.sync(() => removed.push({ path: input.path, force: input.force })).pipe(
+                Effect.andThen(afterRemove),
+              ),
           }),
           Layer.mock(CheckpointReactor)({ drain: Effect.void }),
           Layer.mock(ThreadDeletionReactor)({
@@ -185,6 +200,7 @@ describe("worktree auto-delete", () => {
             latestSequence: Effect.succeed(0),
           }),
           NodeServices.layer,
+          WorktreeLifecycleLock.layer,
         );
 
         yield* Effect.gen(function* () {
@@ -198,6 +214,9 @@ describe("worktree auto-delete", () => {
           const dirtyPath = path.join(config.worktreesDir, "repo", "dirty");
           const sessionPath = path.join(config.worktreesDir, "repo", "session");
           const terminalPath = path.join(config.worktreesDir, "repo", "terminal");
+          const bufferedPath = path.join(config.worktreesDir, "repo", "buffered-terminal");
+          const disableFirstPath = path.join(config.worktreesDir, "repo", "disable-first");
+          const disableSecondPath = path.join(config.worktreesDir, "repo", "disable-second");
           racePath = path.join(config.worktreesDir, "repo", "race");
           interruptPath = path.join(config.worktreesDir, "repo", "interrupt");
           const outsidePath = yield* fs.makeTempDirectoryScoped({ prefix: "outside-worktree-" });
@@ -210,6 +229,9 @@ describe("worktree auto-delete", () => {
             dirtyPath,
             sessionPath,
             terminalPath,
+            bufferedPath,
+            disableFirstPath,
+            disableSecondPath,
             racePath,
           ];
           yield* Effect.forEach(managedPaths, (candidate) =>
@@ -218,6 +240,8 @@ describe("worktree auto-delete", () => {
           const terminalChildPath = path.join(terminalPath, "packages", "app");
           yield* fs.makeDirectory(terminalChildPath, { recursive: true });
 
+          const bufferedChildPath = path.join(bufferedPath, "packages", "app");
+          yield* fs.makeDirectory(bufferedChildPath, { recursive: true });
           projects = [
             {
               projectId,
@@ -277,6 +301,27 @@ describe("worktree auto-delete", () => {
           const exit = yield* Effect.exit(cleanup.sweep);
           assert.isTrue(Exit.isFailure(exit));
           if (Exit.isFailure(exit)) assert.isTrue(Cause.hasInterruptsOnly(exit.cause));
+
+          interruptPath = "";
+          removed.length = 0;
+          threads = [makeThread("buffered-terminal", bufferedPath)];
+          bufferedTerminalPath = bufferedChildPath;
+          yield* cleanup.sweep;
+          assert.isEmpty(removed);
+
+          bufferedTerminalPath = "";
+          threads = [
+            makeThread("disable-first", disableFirstPath),
+            makeThread("disable-second", disableSecondPath),
+          ];
+          afterRemove = settings
+            .updateSettings({ worktreeAutoDeleteAfterDays: null })
+            .pipe(Effect.orDie);
+          yield* cleanup.sweep;
+          assert.deepStrictEqual(
+            removed.map(({ path: removedPath }) => removedPath),
+            [disableFirstPath],
+          );
         }).pipe(Effect.provide(testLayer));
       }),
     ),

--- a/apps/server/src/orchestration/Layers/WorktreeAutoDelete.ts
+++ b/apps/server/src/orchestration/Layers/WorktreeAutoDelete.ts
@@ -210,10 +210,12 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
       if (candidate === null) continue;
       yield* removeCandidate(candidate, delay).pipe(
         Effect.catchCause((cause) =>
-          Effect.logDebug("worktree.auto-delete.skipped", {
-            path: candidate.path,
-            cause: Cause.pretty(cause),
-          }),
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.failCause(cause)
+            : Effect.logDebug("worktree.auto-delete.skipped", {
+                path: candidate.path,
+                cause: Cause.pretty(cause),
+              }),
         ),
       );
     }
@@ -221,7 +223,9 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
 
   const sweepSafely = sweep().pipe(
     Effect.catchCause((cause) =>
-      Effect.logWarning("worktree.auto-delete.sweep-failed", { cause: Cause.pretty(cause) }),
+      Cause.hasInterruptsOnly(cause)
+        ? Effect.failCause(cause)
+        : Effect.logWarning("worktree.auto-delete.sweep-failed", { cause: Cause.pretty(cause) }),
     ),
   );
   const worker = yield* makeDrainableWorker((_: void) => sweepSafely);

--- a/apps/server/src/orchestration/Layers/WorktreeAutoDelete.ts
+++ b/apps/server/src/orchestration/Layers/WorktreeAutoDelete.ts
@@ -25,6 +25,7 @@ import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import * as TerminalManager from "../../terminal/Manager.ts";
 import * as GitVcsDriver from "../../vcs/GitVcsDriver.ts";
+import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
 import { forkParked } from "../../serverActivation.ts";
 import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
@@ -73,6 +74,7 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
   const providerService = yield* ProviderService;
   const terminalManager = yield* TerminalManager.TerminalManager;
   const git = yield* GitVcsDriver.GitVcsDriver;
+  const worktreeLifecycle = yield* WorktreeLifecycleLock;
   const checkpointReactor = yield* CheckpointReactor;
   const deletionReactor = yield* ThreadDeletionReactor;
   const orchestrationEngine = yield* OrchestrationEngineService;
@@ -128,7 +130,23 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
   const readTerminals = Effect.fn("WorktreeAutoDelete.readTerminals")(function* () {
     const current = yield* Ref.make<ReadonlyArray<TerminalSummary>>([]);
     const unsubscribe = yield* terminalManager.subscribeMetadata((event) =>
-      event.type === "snapshot" ? Ref.set(current, event.terminals) : Effect.void,
+      Ref.update(current, (terminals) => {
+        if (event.type === "snapshot") return event.terminals;
+        if (event.type === "remove") {
+          return terminals.filter(
+            (terminal) =>
+              terminal.threadId !== event.threadId || terminal.terminalId !== event.terminalId,
+          );
+        }
+        return [
+          ...terminals.filter(
+            (terminal) =>
+              terminal.threadId !== event.terminal.threadId ||
+              terminal.terminalId !== event.terminal.terminalId,
+          ),
+          event.terminal,
+        ];
+      }),
     );
     yield* Effect.sync(unsubscribe);
     return yield* Ref.get(current);
@@ -177,7 +195,6 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
 
   const removeCandidate = Effect.fn("WorktreeAutoDelete.removeCandidate")(function* (
     initial: WorktreeCandidate,
-    delay: WorktreeAutoDeleteAfterDays,
   ) {
     if (!(yield* runtimeIsIdle(initial))) return;
     const status = yield* git.statusDetailsLocal(initial.path);
@@ -185,19 +202,26 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
       return;
     }
 
-    const freshGroups = yield* loadGroups(delay);
-    const fresh = toCandidate(initial.path, freshGroups.get(initial.path));
-    if (fresh === null || !(yield* runtimeIsIdle(fresh))) return;
+    yield* worktreeLifecycle.withLock(
+      Effect.gen(function* () {
+        const delay = (yield* serverSettings.getSettings).worktreeAutoDeleteAfterDays;
+        if (delay === null) return;
+        const freshGroups = yield* loadGroups(delay);
+        const fresh = toCandidate(initial.path, freshGroups.get(initial.path));
+        if (fresh === null || !(yield* runtimeIsIdle(fresh))) return;
+        if ((yield* serverSettings.getSettings).worktreeAutoDeleteAfterDays !== delay) return;
 
-    yield* git.removeWorktree({
-      cwd: fresh.references[0]!.workspaceRoot,
-      path: fresh.path,
-      force: false,
-    });
-    yield* Effect.logInfo("worktree.auto-delete.removed", {
-      path: fresh.path,
-      threadCount: fresh.references.length,
-    });
+        yield* git.removeWorktree({
+          cwd: fresh.references[0]!.workspaceRoot,
+          path: fresh.path,
+          force: false,
+        });
+        yield* Effect.logInfo("worktree.auto-delete.removed", {
+          path: fresh.path,
+          threadCount: fresh.references.length,
+        });
+      }),
+    );
   });
 
   const sweep = Effect.fn("WorktreeAutoDelete.sweep")(function* () {
@@ -208,7 +232,7 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
     for (const [candidatePath, references] of groups) {
       const candidate = toCandidate(candidatePath, references);
       if (candidate === null) continue;
-      yield* removeCandidate(candidate, delay).pipe(
+      yield* removeCandidate(candidate).pipe(
         Effect.catchCause((cause) =>
           Cause.hasInterruptsOnly(cause)
             ? Effect.failCause(cause)

--- a/apps/server/src/orchestration/Layers/WorktreeAutoDelete.ts
+++ b/apps/server/src/orchestration/Layers/WorktreeAutoDelete.ts
@@ -1,0 +1,257 @@
+import type {
+  OrchestrationEvent,
+  TerminalSummary,
+  WorktreeAutoDeleteAfterDays,
+} from "@t3tools/contracts";
+import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import * as Cause from "effect/Cause";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+
+import { ServerConfig } from "../../config.ts";
+import { ProjectionProjectRepository } from "../../persistence/Services/ProjectionProjects.ts";
+import {
+  ProjectionThreadRepository,
+  type ProjectionThread,
+} from "../../persistence/Services/ProjectionThreads.ts";
+import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import * as TerminalManager from "../../terminal/Manager.ts";
+import * as GitVcsDriver from "../../vcs/GitVcsDriver.ts";
+import { forkParked } from "../../serverActivation.ts";
+import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
+import { ThreadDeletionReactor } from "../Services/ThreadDeletionReactor.ts";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+type WorktreeReference = {
+  readonly thread: ProjectionThread;
+  readonly workspaceRoot: string;
+};
+
+type WorktreeCandidate = {
+  readonly path: string;
+  readonly branch: string;
+  readonly references: ReadonlyArray<WorktreeReference>;
+};
+
+const parsedMillis = (value: string): number | null => {
+  const parsed = DateTime.make(value);
+  return Option.isSome(parsed) ? DateTime.toEpochMillis(parsed.value) : null;
+};
+
+const threadIsReady = (
+  thread: ProjectionThread,
+  delay: WorktreeAutoDeleteAfterDays,
+  nowMs: number,
+): boolean => {
+  if (thread.deletedAt !== null) return true;
+  if (thread.settledOverride !== "settled" || thread.settledAt === null) return false;
+  const settledAt = parsedMillis(thread.settledAt);
+  if (settledAt === null || settledAt + delay * DAY_MS > nowMs) return false;
+  if (thread.latestUserMessageAt === null) return true;
+  const latestUserMessageAt = parsedMillis(thread.latestUserMessageAt);
+  return latestUserMessageAt !== null && latestUserMessageAt <= settledAt;
+};
+
+export const makeWorktreeAutoDelete = Effect.gen(function* () {
+  const config = yield* ServerConfig;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const projects = yield* ProjectionProjectRepository;
+  const threads = yield* ProjectionThreadRepository;
+  const snapshots = yield* ProjectionSnapshotQuery;
+  const providerService = yield* ProviderService;
+  const terminalManager = yield* TerminalManager.TerminalManager;
+  const git = yield* GitVcsDriver.GitVcsDriver;
+  const checkpointReactor = yield* CheckpointReactor;
+  const deletionReactor = yield* ThreadDeletionReactor;
+  const orchestrationEngine = yield* OrchestrationEngineService;
+  const serverSettings = yield* ServerSettingsService;
+  const isWithin = (parent: string, child: string) => {
+    const relative = path.relative(parent, child);
+    return (
+      relative === "" ||
+      (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+    );
+  };
+
+  const loadGroups = Effect.fn("WorktreeAutoDelete.loadGroups")(function* (
+    delay: WorktreeAutoDeleteAfterDays,
+  ) {
+    const root = yield* fileSystem.realPath(path.resolve(config.worktreesDir)).pipe(Effect.option);
+    if (Option.isNone(root)) return new Map<string, ReadonlyArray<WorktreeReference>>();
+
+    const nowMs = DateTime.toEpochMillis(yield* DateTime.now);
+    const groups = new Map<string, WorktreeReference[]>();
+    for (const project of yield* projects.listAll()) {
+      for (const thread of yield* threads.listByProjectId({ projectId: project.projectId })) {
+        if (thread.worktreePath === null) continue;
+        const realPath = yield* fileSystem
+          .realPath(path.resolve(thread.worktreePath))
+          .pipe(Effect.option);
+        if (Option.isNone(realPath)) continue;
+        if (realPath.value === root.value || !isWithin(root.value, realPath.value)) continue;
+        const references = groups.get(realPath.value) ?? [];
+        references.push({ thread, workspaceRoot: project.workspaceRoot });
+        groups.set(realPath.value, references);
+      }
+    }
+
+    return new Map(
+      [...groups].filter(([, references]) =>
+        references.every(({ thread }) => threadIsReady(thread, delay, nowMs)),
+      ),
+    );
+  });
+
+  const toCandidate = (
+    candidatePath: string,
+    references: ReadonlyArray<WorktreeReference> | undefined,
+  ): WorktreeCandidate | null => {
+    if (!references?.length) return null;
+    const branches = new Set(references.map(({ thread }) => thread.branch));
+    if (branches.size !== 1) return null;
+    const branch = references[0]?.thread.branch;
+    return branch ? { path: candidatePath, branch, references } : null;
+  };
+
+  const readTerminals = Effect.fn("WorktreeAutoDelete.readTerminals")(function* () {
+    const current = yield* Ref.make<ReadonlyArray<TerminalSummary>>([]);
+    const unsubscribe = yield* terminalManager.subscribeMetadata((event) =>
+      event.type === "snapshot" ? Ref.set(current, event.terminals) : Effect.void,
+    );
+    yield* Effect.sync(unsubscribe);
+    return yield* Ref.get(current);
+  });
+
+  const runtimeIsIdle = Effect.fn("WorktreeAutoDelete.runtimeIsIdle")(function* (
+    candidate: WorktreeCandidate,
+  ) {
+    const threadIds = new Set(candidate.references.map(({ thread }) => String(thread.threadId)));
+    const sessions = yield* providerService.listSessions();
+    if (sessions.some((session) => threadIds.has(String(session.threadId)))) return false;
+
+    for (const terminal of yield* readTerminals()) {
+      if (threadIds.has(terminal.threadId)) return false;
+      for (const terminalPath of [terminal.worktreePath, terminal.cwd]) {
+        if (terminalPath === null) continue;
+        const realPath = yield* fileSystem.realPath(path.resolve(terminalPath)).pipe(Effect.option);
+        if (Option.isSome(realPath) && isWithin(candidate.path, realPath.value)) return false;
+      }
+    }
+
+    for (const { thread } of candidate.references) {
+      if (thread.deletedAt !== null) continue;
+      const shell = yield* snapshots.getThreadShellById(thread.threadId);
+      if (Option.isNone(shell)) return false;
+      const current = shell.value;
+      if (
+        current.worktreePath === null ||
+        path.resolve(current.worktreePath) !== path.resolve(thread.worktreePath ?? "") ||
+        current.branch !== candidate.branch ||
+        current.settledOverride !== "settled" ||
+        current.settledAt !== thread.settledAt ||
+        current.hasPendingApprovals ||
+        current.hasPendingUserInput ||
+        current.backgroundLiveness !== null ||
+        current.latestTurn?.state === "running" ||
+        (current.session !== null &&
+          current.session.status !== "stopped" &&
+          current.session.status !== "error")
+      ) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  const removeCandidate = Effect.fn("WorktreeAutoDelete.removeCandidate")(function* (
+    initial: WorktreeCandidate,
+    delay: WorktreeAutoDeleteAfterDays,
+  ) {
+    if (!(yield* runtimeIsIdle(initial))) return;
+    const status = yield* git.statusDetailsLocal(initial.path);
+    if (!status.isRepo || status.branch !== initial.branch || status.hasWorkingTreeChanges) {
+      return;
+    }
+
+    const freshGroups = yield* loadGroups(delay);
+    const fresh = toCandidate(initial.path, freshGroups.get(initial.path));
+    if (fresh === null || !(yield* runtimeIsIdle(fresh))) return;
+
+    yield* git.removeWorktree({
+      cwd: fresh.references[0]!.workspaceRoot,
+      path: fresh.path,
+      force: false,
+    });
+    yield* Effect.logInfo("worktree.auto-delete.removed", {
+      path: fresh.path,
+      threadCount: fresh.references.length,
+    });
+  });
+
+  const sweep = Effect.fn("WorktreeAutoDelete.sweep")(function* () {
+    const delay = (yield* serverSettings.getSettings).worktreeAutoDeleteAfterDays;
+    if (delay === null) return;
+    yield* checkpointReactor.drain;
+    const groups = yield* loadGroups(delay);
+    for (const [candidatePath, references] of groups) {
+      const candidate = toCandidate(candidatePath, references);
+      if (candidate === null) continue;
+      yield* removeCandidate(candidate, delay).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logDebug("worktree.auto-delete.skipped", {
+            path: candidate.path,
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      );
+    }
+  });
+
+  const sweepSafely = sweep().pipe(
+    Effect.catchCause((cause) =>
+      Effect.logWarning("worktree.auto-delete.sweep-failed", { cause: Cause.pretty(cause) }),
+    ),
+  );
+  const worker = yield* makeDrainableWorker((_: void) => sweepSafely);
+
+  const onDomainEvent = (event: OrchestrationEvent) => {
+    if (event.type === "thread.deleted") {
+      return deletionReactor
+        .drainThrough(event.sequence)
+        .pipe(Effect.andThen(worker.enqueue(undefined)));
+    }
+    if (
+      event.type === "thread.settled" ||
+      (event.type === "thread.session-set" &&
+        (event.payload.session.status === "stopped" || event.payload.session.status === "error"))
+    ) {
+      return worker.enqueue(undefined);
+    }
+    return Effect.void;
+  };
+
+  const start = Effect.fn("WorktreeAutoDelete.start")(function* () {
+    const settingsChanges = yield* serverSettings.subscribeChanges;
+    yield* forkParked(Stream.runForEach(orchestrationEngine.streamDomainEvents, onDomainEvent));
+    yield* forkParked(Stream.runForEach(settingsChanges, () => worker.enqueue(undefined)));
+    yield* forkParked(worker.enqueue(undefined).pipe(Effect.repeat(Schedule.spaced("1 hour"))));
+  });
+
+  return { start, sweep: sweep() };
+});
+
+export const WorktreeAutoDeleteLive = Layer.effectDiscard(
+  makeWorktreeAutoDelete.pipe(Effect.flatMap(({ start }) => start())),
+);

--- a/apps/server/src/orchestration/WorktreeAutoDelete.test.ts
+++ b/apps/server/src/orchestration/WorktreeAutoDelete.test.ts
@@ -242,6 +242,9 @@ describe("worktree auto-delete", () => {
 
           const bufferedChildPath = path.join(bufferedPath, "packages", "app");
           yield* fs.makeDirectory(bufferedChildPath, { recursive: true });
+          assert.isTrue(yield* WorktreeAutoDelete.isManagedWorktreePath(deletedPath));
+          assert.isFalse(yield* WorktreeAutoDelete.isManagedWorktreePath(config.worktreesDir));
+          assert.isFalse(yield* WorktreeAutoDelete.isManagedWorktreePath(outsidePath));
           projects = [
             {
               projectId,

--- a/apps/server/src/orchestration/WorktreeAutoDelete.test.ts
+++ b/apps/server/src/orchestration/WorktreeAutoDelete.test.ts
@@ -19,25 +19,25 @@ import * as Path from "effect/Path";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 
-import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
-import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
-import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
-import { ThreadDeletionReactor } from "../Services/ThreadDeletionReactor.ts";
-import { ServerConfig } from "../../config.ts";
+import { CheckpointReactor } from "./Services/CheckpointReactor.ts";
+import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
+import { ThreadDeletionReactor } from "./Services/ThreadDeletionReactor.ts";
+import { ServerConfig } from "../config.ts";
 import {
   ProjectionProjectRepository,
   type ProjectionProject,
-} from "../../persistence/Services/ProjectionProjects.ts";
+} from "../persistence/Services/ProjectionProjects.ts";
 import {
   ProjectionThreadRepository,
   type ProjectionThread,
-} from "../../persistence/Services/ProjectionThreads.ts";
-import { ProviderService } from "../../provider/Services/ProviderService.ts";
-import { ServerSettingsService } from "../../serverSettings.ts";
-import * as TerminalManager from "../../terminal/Manager.ts";
-import * as GitVcsDriver from "../../vcs/GitVcsDriver.ts";
-import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
-import { makeWorktreeAutoDelete } from "./WorktreeAutoDelete.ts";
+} from "../persistence/Services/ProjectionThreads.ts";
+import { ProviderService } from "../provider/Services/ProviderService.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+import * as TerminalManager from "../terminal/Manager.ts";
+import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as WorktreeLifecycleLock from "../vcs/WorktreeLifecycleLock.ts";
+import * as WorktreeAutoDelete from "./WorktreeAutoDelete.ts";
 
 const projectId = ProjectId.make("worktree-cleanup-project");
 const branch = "feature/worktree-cleanup";
@@ -280,7 +280,7 @@ describe("worktree auto-delete", () => {
           terminalPaths.add(terminalChildPath);
 
           yield* TestClock.setTime(Date.parse("2026-08-30T00:00:00.000Z"));
-          const cleanup = yield* makeWorktreeAutoDelete;
+          const cleanup = yield* WorktreeAutoDelete.make;
           const settings = yield* ServerSettingsService;
 
           yield* cleanup.sweep;

--- a/apps/server/src/orchestration/WorktreeAutoDelete.ts
+++ b/apps/server/src/orchestration/WorktreeAutoDelete.ts
@@ -64,6 +64,32 @@ const threadIsReady = (
   return latestUserMessageAt !== null && latestUserMessageAt <= settledAt;
 };
 
+const isWithin = (path: Path.Path, parent: string, child: string) => {
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+};
+
+export const isManagedWorktreePath = Effect.fn("WorktreeAutoDelete.isManagedWorktreePath")(
+  function* (candidatePath: string) {
+    const config = yield* ServerConfig;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const [root, candidate] = yield* Effect.all([
+      fileSystem.realPath(path.resolve(config.worktreesDir)).pipe(Effect.option),
+      fileSystem.realPath(path.resolve(candidatePath)).pipe(Effect.option),
+    ]);
+    return (
+      Option.isSome(root) &&
+      Option.isSome(candidate) &&
+      root.value !== candidate.value &&
+      isWithin(path, root.value, candidate.value)
+    );
+  },
+);
+
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
@@ -79,13 +105,6 @@ export const make = Effect.gen(function* () {
   const deletionReactor = yield* ThreadDeletionReactor;
   const orchestrationEngine = yield* OrchestrationEngineService;
   const serverSettings = yield* ServerSettingsService;
-  const isWithin = (parent: string, child: string) => {
-    const relative = path.relative(parent, child);
-    return (
-      relative === "" ||
-      (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
-    );
-  };
 
   const loadGroups = Effect.fn("WorktreeAutoDelete.loadGroups")(function* (
     delay: WorktreeAutoDeleteAfterDays,
@@ -102,7 +121,7 @@ export const make = Effect.gen(function* () {
           .realPath(path.resolve(thread.worktreePath))
           .pipe(Effect.option);
         if (Option.isNone(realPath)) continue;
-        if (realPath.value === root.value || !isWithin(root.value, realPath.value)) continue;
+        if (realPath.value === root.value || !isWithin(path, root.value, realPath.value)) continue;
         const references = groups.get(realPath.value) ?? [];
         references.push({ thread, workspaceRoot: project.workspaceRoot });
         groups.set(realPath.value, references);
@@ -164,7 +183,7 @@ export const make = Effect.gen(function* () {
       for (const terminalPath of [terminal.worktreePath, terminal.cwd]) {
         if (terminalPath === null) continue;
         const realPath = yield* fileSystem.realPath(path.resolve(terminalPath)).pipe(Effect.option);
-        if (Option.isSome(realPath) && isWithin(candidate.path, realPath.value)) return false;
+        if (Option.isSome(realPath) && isWithin(path, candidate.path, realPath.value)) return false;
       }
     }
 

--- a/apps/server/src/orchestration/WorktreeAutoDelete.ts
+++ b/apps/server/src/orchestration/WorktreeAutoDelete.ts
@@ -15,22 +15,22 @@ import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 
-import { ServerConfig } from "../../config.ts";
-import { ProjectionProjectRepository } from "../../persistence/Services/ProjectionProjects.ts";
+import { ServerConfig } from "../config.ts";
+import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
 import {
   ProjectionThreadRepository,
   type ProjectionThread,
-} from "../../persistence/Services/ProjectionThreads.ts";
-import { ProviderService } from "../../provider/Services/ProviderService.ts";
-import { ServerSettingsService } from "../../serverSettings.ts";
-import * as TerminalManager from "../../terminal/Manager.ts";
-import * as GitVcsDriver from "../../vcs/GitVcsDriver.ts";
-import { WorktreeLifecycleLock } from "../../vcs/WorktreeLifecycleLock.ts";
-import { forkParked } from "../../serverActivation.ts";
-import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
-import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
-import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
-import { ThreadDeletionReactor } from "../Services/ThreadDeletionReactor.ts";
+} from "../persistence/Services/ProjectionThreads.ts";
+import { ProviderService } from "../provider/Services/ProviderService.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+import * as TerminalManager from "../terminal/Manager.ts";
+import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as WorktreeLifecycleLock from "../vcs/WorktreeLifecycleLock.ts";
+import { forkParked } from "../serverActivation.ts";
+import { CheckpointReactor } from "./Services/CheckpointReactor.ts";
+import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
+import { ThreadDeletionReactor } from "./Services/ThreadDeletionReactor.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
@@ -64,7 +64,7 @@ const threadIsReady = (
   return latestUserMessageAt !== null && latestUserMessageAt <= settledAt;
 };
 
-export const makeWorktreeAutoDelete = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -74,7 +74,7 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
   const providerService = yield* ProviderService;
   const terminalManager = yield* TerminalManager.TerminalManager;
   const git = yield* GitVcsDriver.GitVcsDriver;
-  const worktreeLifecycle = yield* WorktreeLifecycleLock;
+  const worktreeLifecycle = yield* WorktreeLifecycleLock.WorktreeLifecycleLock;
   const checkpointReactor = yield* CheckpointReactor;
   const deletionReactor = yield* ThreadDeletionReactor;
   const orchestrationEngine = yield* OrchestrationEngineService;
@@ -280,6 +280,4 @@ export const makeWorktreeAutoDelete = Effect.gen(function* () {
   return { start, sweep: sweep() };
 });
 
-export const WorktreeAutoDeleteLive = Layer.effectDiscard(
-  makeWorktreeAutoDelete.pipe(Effect.flatMap(({ start }) => start())),
-);
+export const layer = Layer.effectDiscard(make.pipe(Effect.flatMap(({ start }) => start())));

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6023,6 +6023,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
       assert.equal(refreshedStatus.isRepo, true);
+      assert.equal(refreshedStatus.isAutoDeleteManagedWorktree, false);
 
       const stackedEvents = yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -62,6 +62,7 @@ import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRun
 import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderCommandReactor.ts";
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
+import { WorktreeAutoDeleteLive } from "./orchestration/Layers/WorktreeAutoDelete.ts";
 import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
@@ -245,7 +246,7 @@ const PlatformServicesLive = Layer.unwrap(
   }),
 );
 
-const ReactorLayerLive = Layer.empty.pipe(
+const CoreReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(OrchestrationReactorLive),
   Layer.provideMerge(ProviderRuntimeIngestionLive),
   Layer.provideMerge(ProviderCommandReactorLive),
@@ -253,6 +254,11 @@ const ReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(ThreadDeletionReactorLive),
   Layer.provideMerge(AgentAwarenessRelay.layer.pipe(Layer.provide(ServerSecretStore.layer))),
   Layer.provideMerge(RuntimeReceiptBusLive),
+);
+
+const ReactorLayerLive = Layer.mergeAll(
+  CoreReactorLayerLive,
+  WorktreeAutoDeleteLive.pipe(Layer.provide(CoreReactorLayerLive)),
 );
 
 const ProviderSessionDirectoryLayerLive = ProviderSessionDirectoryLive.pipe(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -62,7 +62,7 @@ import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRun
 import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderCommandReactor.ts";
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
-import { WorktreeAutoDeleteLive } from "./orchestration/Layers/WorktreeAutoDelete.ts";
+import * as WorktreeAutoDelete from "./orchestration/WorktreeAutoDelete.ts";
 import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
@@ -74,7 +74,7 @@ import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
 import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
 import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
 import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
-import { WorktreeLifecycleLock } from "./vcs/WorktreeLifecycleLock.ts";
+import * as WorktreeLifecycleLock from "./vcs/WorktreeLifecycleLock.ts";
 import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProjectConfig from "./vcs/VcsProjectConfig.ts";
 import * as VcsProcess from "./vcs/VcsProcess.ts";
@@ -257,7 +257,7 @@ const CoreReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(RuntimeReceiptBusLive),
 );
 
-const ReactorLayerLive = WorktreeAutoDeleteLive.pipe(Layer.provideMerge(CoreReactorLayerLive));
+const ReactorLayerLive = WorktreeAutoDelete.layer.pipe(Layer.provideMerge(CoreReactorLayerLive));
 
 const ProviderSessionDirectoryLayerLive = ProviderSessionDirectoryLive.pipe(
   Layer.provide(ProviderSessionRuntime.layer),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -256,10 +256,7 @@ const CoreReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(RuntimeReceiptBusLive),
 );
 
-const ReactorLayerLive = Layer.mergeAll(
-  CoreReactorLayerLive,
-  WorktreeAutoDeleteLive.pipe(Layer.provide(CoreReactorLayerLive)),
-);
+const ReactorLayerLive = WorktreeAutoDeleteLive.pipe(Layer.provideMerge(CoreReactorLayerLive));
 
 const ProviderSessionDirectoryLayerLive = ProviderSessionDirectoryLive.pipe(
   Layer.provide(ProviderSessionRuntime.layer),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -74,6 +74,7 @@ import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
 import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
 import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
 import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
+import { WorktreeLifecycleLock } from "./vcs/WorktreeLifecycleLock.ts";
 import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProjectConfig from "./vcs/VcsProjectConfig.ts";
 import * as VcsProcess from "./vcs/VcsProcess.ts";
@@ -385,7 +386,11 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(GitLayerLive),
   Layer.provideMerge(VcsLayerLive),
   Layer.provideMerge(ProviderRuntimeLayerLive),
-  Layer.provideMerge(Layer.mergeAll(TerminalLayerLive, PreviewLayerLive)),
+  Layer.provideMerge(
+    Layer.mergeAll(TerminalLayerLive, PreviewLayerLive).pipe(
+      Layer.provideMerge(WorktreeLifecycleLock.layer),
+    ),
+  ),
   Layer.provideMerge(PersistenceLayerLive),
   // Both read a user-owned file out of the state directory and stream changes
   // to clients; neither depends on the other.

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -28,6 +28,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
+import { WorktreeLifecycleLock } from "../vcs/WorktreeLifecycleLock.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
@@ -230,7 +231,11 @@ const createManager = (
 ): Effect.Effect<
   ManagerFixture,
   PlatformError.PlatformError,
-  FileSystem.FileSystem | Path.Path | Scope.Scope | ProcessRunner.ProcessRunner
+  | FileSystem.FileSystem
+  | Path.Path
+  | Scope.Scope
+  | ProcessRunner.ProcessRunner
+  | WorktreeLifecycleLock
 > =>
   Effect.flatMap(Effect.service(FileSystem.FileSystem), (fs) =>
     Effect.gen(function* () {
@@ -277,7 +282,11 @@ const withHostPlatform = (platform: NodeJS.Platform) =>
   Layer.succeed(HostProcessPlatform, platform);
 
 it.layer(
-  Layer.merge(NodeServices.layer, ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer))),
+  Layer.mergeAll(
+    NodeServices.layer,
+    ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer)),
+    WorktreeLifecycleLock.layer,
+  ),
   { excludeTestServices: true },
 )("TerminalManager", (it) => {
   it.effect("spawns lazily and reuses running terminal per thread", () =>

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -28,7 +28,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
-import { WorktreeLifecycleLock } from "../vcs/WorktreeLifecycleLock.ts";
+import * as WorktreeLifecycleLock from "../vcs/WorktreeLifecycleLock.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
@@ -235,7 +235,7 @@ const createManager = (
   | Path.Path
   | Scope.Scope
   | ProcessRunner.ProcessRunner
-  | WorktreeLifecycleLock
+  | WorktreeLifecycleLock.WorktreeLifecycleLock
 > =>
   Effect.flatMap(Effect.service(FileSystem.FileSystem), (fs) =>
     Effect.gen(function* () {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -59,6 +59,7 @@ import {
 } from "../observability/Metrics.ts";
 import * as ProcessRunner from "../processRunner.ts";
 import * as PortScanner from "../preview/PortScanner.ts";
+import { WorktreeLifecycleLock } from "../vcs/WorktreeLifecycleLock.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
 export {
@@ -1146,6 +1147,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 ) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const worktreeLifecycle = yield* WorktreeLifecycleLock;
   const context = yield* Effect.context<never>();
   const runFork = Effect.runForkWith(context);
 
@@ -1246,6 +1248,9 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     effect: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E, R> =>
     Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+  const withWorktreeAndThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+    worktreeLifecycle.withLock(withThreadLock(threadId, effect));
 
   const clearKillFiber = Effect.fn("terminal.clearKillFiber")(function* (
     process: PtyAdapter.PtyProcess | null,
@@ -2266,10 +2271,10 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   });
 
   const open: TerminalManager["Service"]["open"] = (input) =>
-    withThreadLock(input.threadId, openLocked(input));
+    withWorktreeAndThreadLock(input.threadId, openLocked(input));
 
   const openOrAttachForStream = (input: TerminalAttachInput) =>
-    withThreadLock(
+    withWorktreeAndThreadLock(
       input.threadId,
       Effect.gen(function* () {
         const terminalId = input.terminalId;
@@ -2552,7 +2557,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     );
 
   const restart: TerminalManager["Service"]["restart"] = (input) =>
-    withThreadLock(
+    withWorktreeAndThreadLock(
       input.threadId,
       Effect.gen(function* () {
         yield* increment(terminalRestartsTotal, { scope: "thread" });

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -59,7 +59,7 @@ import {
 } from "../observability/Metrics.ts";
 import * as ProcessRunner from "../processRunner.ts";
 import * as PortScanner from "../preview/PortScanner.ts";
-import { WorktreeLifecycleLock } from "../vcs/WorktreeLifecycleLock.ts";
+import * as WorktreeLifecycleLock from "../vcs/WorktreeLifecycleLock.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
 
 export {
@@ -1147,7 +1147,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 ) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const worktreeLifecycle = yield* WorktreeLifecycleLock;
+  const worktreeLifecycle = yield* WorktreeLifecycleLock.WorktreeLifecycleLock;
   const context = yield* Effect.context<never>();
   const runFork = Effect.runForkWith(context);
 

--- a/apps/server/src/vcs/WorktreeLifecycleLock.ts
+++ b/apps/server/src/vcs/WorktreeLifecycleLock.ts
@@ -8,11 +8,10 @@ export class WorktreeLifecycleLock extends Context.Service<
   {
     readonly withLock: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>;
   }
->()("t3/vcs/WorktreeLifecycleLock") {
-  static readonly layer = Layer.effect(
-    WorktreeLifecycleLock,
-    Effect.map(Semaphore.make(1), (semaphore) =>
-      WorktreeLifecycleLock.of({ withLock: (effect) => semaphore.withPermit(effect) }),
-    ),
-  );
-}
+>()("t3/vcs/WorktreeLifecycleLock") {}
+
+export const make = Effect.map(Semaphore.make(1), (semaphore) =>
+  WorktreeLifecycleLock.of({ withLock: (effect) => semaphore.withPermit(effect) }),
+);
+
+export const layer = Layer.effect(WorktreeLifecycleLock, make);

--- a/apps/server/src/vcs/WorktreeLifecycleLock.ts
+++ b/apps/server/src/vcs/WorktreeLifecycleLock.ts
@@ -1,0 +1,18 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Semaphore from "effect/Semaphore";
+
+export class WorktreeLifecycleLock extends Context.Service<
+  WorktreeLifecycleLock,
+  {
+    readonly withLock: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>;
+  }
+>()("t3/vcs/WorktreeLifecycleLock") {
+  static readonly layer = Layer.effect(
+    WorktreeLifecycleLock,
+    Effect.map(Semaphore.make(1), (semaphore) =>
+      WorktreeLifecycleLock.of({ withLock: (effect) => semaphore.withPermit(effect) }),
+    ),
+  );
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -87,6 +87,7 @@ import {
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ThreadDeletionReactor } from "./orchestration/Services/ThreadDeletionReactor.ts";
+import * as WorktreeAutoDelete from "./orchestration/WorktreeAutoDelete.ts";
 import {
   observeRpcEffect as instrumentRpcEffect,
   observeRpcStream as instrumentRpcStream,
@@ -2141,7 +2142,15 @@ const makeWsRpcLayer = (
         [WS_METHODS.vcsRefreshStatus]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsRefreshStatus,
-            vcsStatusBroadcaster.refreshStatus(input.cwd),
+            Effect.all([
+              vcsStatusBroadcaster.refreshStatus(input.cwd),
+              WorktreeAutoDelete.isManagedWorktreePath(input.cwd),
+            ]).pipe(
+              Effect.map(([status, isAutoDeleteManagedWorktree]) => ({
+                ...status,
+                isAutoDeleteManagedWorktree,
+              })),
+            ),
             {
               "rpc.aggregate": "vcs",
             },

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -526,6 +526,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeAutoDeleteAfterDays !==
+      DEFAULT_UNIFIED_SETTINGS.worktreeAutoDeleteAfterDays
+        ? ["Auto-delete worktrees"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -563,6 +567,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
+      settings.worktreeAutoDeleteAfterDays,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
       settings.fontFamilyCode,
@@ -671,6 +676,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeAutoDeleteAfterDays: DEFAULT_UNIFIED_SETTINGS.worktreeAutoDeleteAfterDays,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2296,6 +2302,67 @@ export function GeneralSettingsPanel() {
             }
           />
         ) : null}
+
+        <SettingsRow
+          {...searchableSetting("worktree-auto-delete")}
+          description="Delete clean T3-managed worktrees for deleted threads, or after manually settled threads reach this age."
+          resetAction={
+            settings.worktreeAutoDeleteAfterDays !==
+            DEFAULT_UNIFIED_SETTINGS.worktreeAutoDeleteAfterDays ? (
+              <SettingResetButton
+                label="auto-delete worktrees"
+                onClick={() =>
+                  updateSettings({
+                    worktreeAutoDeleteAfterDays:
+                      DEFAULT_UNIFIED_SETTINGS.worktreeAutoDeleteAfterDays,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={
+                settings.worktreeAutoDeleteAfterDays === null
+                  ? "off"
+                  : String(settings.worktreeAutoDeleteAfterDays)
+              }
+              onValueChange={(value) => {
+                if (value === "off") {
+                  updateSettings({ worktreeAutoDeleteAfterDays: null });
+                } else if (value === "0" || value === "3" || value === "7") {
+                  updateSettings({
+                    worktreeAutoDeleteAfterDays: value === "0" ? 0 : value === "3" ? 3 : 7,
+                  });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-44" aria-label="Auto-delete worktrees">
+                <SelectValue>
+                  {settings.worktreeAutoDeleteAfterDays === null
+                    ? "Off"
+                    : settings.worktreeAutoDeleteAfterDays === 0
+                      ? "Instant"
+                      : `After ${settings.worktreeAutoDeleteAfterDays} days`}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="off">
+                  Off
+                </SelectItem>
+                <SelectItem hideIndicator value="0">
+                  Instant
+                </SelectItem>
+                <SelectItem hideIndicator value="3">
+                  After 3 days
+                </SelectItem>
+                <SelectItem hideIndicator value="7">
+                  After 7 days
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
 
         <SettingsRow
           {...searchableSetting("add-project-starts-in")}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -153,6 +153,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "new-threads",
   },
   {
+    id: "worktree-auto-delete",
+    title: "Auto-delete worktrees",
+    to: "/settings/general",
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -36,7 +36,11 @@ import {
 import { useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useUiStateStore } from "../uiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
-import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
+import {
+  canSkipWorktreeDeletePrompt,
+  formatWorktreePathForDisplay,
+  getOrphanedWorktreePathForThread,
+} from "../worktreeCleanup";
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { useClientSettings } from "./useSettings";
 import { useAtomCommand } from "../state/use-atom-command";
@@ -342,7 +346,16 @@ export function useThreadActions() {
       const canDeleteWorktree = orphanedWorktreePath !== null && threadProject !== null;
       const localApi = readLocalApi();
       let shouldDeleteWorktree = false;
-      if (canDeleteWorktree && worktreeAutoDeleteAfterDays === null && localApi) {
+      let skipWorktreeDeletePrompt = false;
+      if (canDeleteWorktree && worktreeAutoDeleteAfterDays !== null) {
+        const status = await refreshVcsStatus({
+          environmentId: threadRef.environmentId,
+          input: { cwd: orphanedWorktreePath },
+        });
+        skipWorktreeDeletePrompt =
+          status._tag === "Success" && canSkipWorktreeDeletePrompt(status.value, thread.branch);
+      }
+      if (canDeleteWorktree && !skipWorktreeDeletePrompt && localApi) {
         const confirmationResult = await settlePromise(() =>
           localApi.dialogs.confirm(
             [

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -18,6 +18,7 @@ import { useComposerDraftStore } from "../composerDraftStore";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
+import { environmentServerConfigsAtom } from "../state/server";
 import { useNewThreadHandler } from "./useHandleNewThread";
 import { refreshArchivedThreadsForEnvironment } from "../lib/archivedThreadsState";
 import { releaseComposerDraftUploads } from "../lib/composerDraftUploads";
@@ -39,6 +40,7 @@ import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { useClientSettings } from "./useSettings";
 import { useAtomCommand } from "../state/use-atom-command";
+import { appAtomRegistry } from "../rpc/atomRegistry";
 
 export class ThreadArchiveBlockedError extends Schema.TaggedErrorClass<ThreadArchiveBlockedError>()(
   "ThreadArchiveBlockedError",
@@ -334,10 +336,13 @@ export function useThreadActions() {
       const displayWorktreePath = orphanedWorktreePath
         ? formatWorktreePathForDisplay(orphanedWorktreePath)
         : null;
+      const worktreeAutoDeleteAfterDays =
+        appAtomRegistry.get(environmentServerConfigsAtom).get(threadRef.environmentId)?.settings
+          .worktreeAutoDeleteAfterDays ?? null;
       const canDeleteWorktree = orphanedWorktreePath !== null && threadProject !== null;
       const localApi = readLocalApi();
       let shouldDeleteWorktree = false;
-      if (canDeleteWorktree && localApi) {
+      if (canDeleteWorktree && worktreeAutoDeleteAfterDays === null && localApi) {
         const confirmationResult = await settlePromise(() =>
           localApi.dialogs.confirm(
             [

--- a/apps/web/src/worktreeCleanup.test.ts
+++ b/apps/web/src/worktreeCleanup.test.ts
@@ -2,9 +2,19 @@ import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools
 import { describe, expect, it } from "vite-plus/test";
 
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
-import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "./worktreeCleanup";
+import {
+  canSkipWorktreeDeletePrompt,
+  formatWorktreePathForDisplay,
+  getOrphanedWorktreePathForThread,
+} from "./worktreeCleanup";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+const autoDeleteStatus = {
+  isAutoDeleteManagedWorktree: true,
+  isRepo: true,
+  refName: "feature/demo",
+  hasWorkingTreeChanges: false,
+};
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
@@ -82,6 +92,35 @@ describe("getOrphanedWorktreePathForThread", () => {
     ];
     const result = getOrphanedWorktreePathForThread(threads, ThreadId.make("thread-1"));
     expect(result).toBe("/tmp/repo/worktrees/feature-a");
+  });
+});
+
+describe("canSkipWorktreeDeletePrompt", () => {
+  it("accepts a clean managed repository on the thread branch", () => {
+    expect(canSkipWorktreeDeletePrompt(autoDeleteStatus, "feature/demo")).toBe(true);
+  });
+
+  it.each([
+    [
+      "a missing managed flag",
+      {
+        isRepo: true,
+        refName: "feature/demo",
+        hasWorkingTreeChanges: false,
+      },
+      "feature/demo",
+    ],
+    [
+      "an unmanaged worktree",
+      { ...autoDeleteStatus, isAutoDeleteManagedWorktree: false },
+      "feature/demo",
+    ],
+    ["a dirty worktree", { ...autoDeleteStatus, hasWorkingTreeChanges: true }, "feature/demo"],
+    ["a non-repository", { ...autoDeleteStatus, isRepo: false }, "feature/demo"],
+    ["a branch mismatch", autoDeleteStatus, "feature/other"],
+    ["a branchless thread", { ...autoDeleteStatus, refName: null }, null],
+  ] as const)("rejects %s", (_case, status, branch) => {
+    expect(canSkipWorktreeDeletePrompt(status, branch)).toBe(false);
   });
 });
 

--- a/apps/web/src/worktreeCleanup.ts
+++ b/apps/web/src/worktreeCleanup.ts
@@ -1,4 +1,22 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+
 import type { ThreadShell } from "./types";
+
+export function canSkipWorktreeDeletePrompt(
+  status: Pick<
+    VcsStatusResult,
+    "hasWorkingTreeChanges" | "isAutoDeleteManagedWorktree" | "isRepo" | "refName"
+  >,
+  branch: string | null,
+): boolean {
+  return (
+    branch !== null &&
+    status.isAutoDeleteManagedWorktree === true &&
+    status.isRepo &&
+    !status.hasWorkingTreeChanges &&
+    status.refName === branch
+  );
+}
 
 function normalizeWorktreePath(path: string | null): string | null {
   const trimmed = path?.trim();

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -57,6 +57,16 @@ T3 Code works with the platforms your team already uses:
 - Works on GitHub, GitLab, and Bitbucket. Azure DevOps takes a new title and description; its
   comments stay read-only here, as they already were
 
+### Clean Up Worktrees Automatically
+
+In **Settings → General**, set **Auto-delete worktrees** to **Instant**, **After 3 days**, or
+**After 7 days**. It is off by default. When enabled, T3 Code removes worktrees as soon as their
+thread is deleted, or after a manually settled thread reaches the selected age.
+
+Only clean, idle worktrees managed by T3 Code are removed. Changed worktrees, worktrees shared
+with an active thread, active agent sessions, and open terminals are skipped and checked again
+later. The Git branch remains. A settled thread recreates its worktree when you use it again.
+
 ### Know Your Setup at a Glance
 
 The **Source Control settings** page shows you exactly what's connected:

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -244,6 +244,7 @@ export type VcsStatusRemoteResult = typeof VcsStatusRemoteResult.Type;
 export const VcsStatusResult = Schema.Struct({
   ...VcsStatusLocalShape,
   ...VcsStatusRemoteShape,
+  isAutoDeleteManagedWorktree: Schema.optional(Schema.Boolean),
 });
 export type VcsStatusResult = typeof VcsStatusResult.Type;
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -292,10 +292,28 @@ describe("ServerSettings worktree defaults", () => {
     expect(decodeServerSettings({}).newWorktreesStartFromOrigin).toBe(true);
   });
 
+  it("defaults automatic worktree deletion off for legacy configs", () => {
+    expect(decodeServerSettings({}).worktreeAutoDeleteAfterDays).toBeNull();
+  });
+
   it("accepts start-from-origin updates", () => {
     expect(
       decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
     ).toBe(false);
+  });
+
+  it.each([0, 3, 7] as const)("accepts a supported worktree deletion delay: %s", (value) => {
+    expect(
+      decodeServerSettings({ worktreeAutoDeleteAfterDays: value }).worktreeAutoDeleteAfterDays,
+    ).toBe(value);
+    expect(
+      decodeServerSettingsPatch({ worktreeAutoDeleteAfterDays: value }).worktreeAutoDeleteAfterDays,
+    ).toBe(value);
+  });
+
+  it.each([-1, 1, 14, "3"])("rejects an unsupported worktree deletion delay: %s", (value) => {
+    expect(() => decodeServerSettings({ worktreeAutoDeleteAfterDays: value })).toThrow();
+    expect(() => decodeServerSettingsPatch({ worktreeAutoDeleteAfterDays: value })).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -630,6 +630,9 @@ export const BackgroundActivitySettings = Schema.Struct({
 }).pipe(Schema.withDecodingDefault(Effect.succeed({})));
 export type BackgroundActivitySettings = typeof BackgroundActivitySettings.Type;
 
+export const WorktreeAutoDeleteAfterDays = Schema.Literals([0, 3, 7]);
+export type WorktreeAutoDeleteAfterDays = typeof WorktreeAutoDeleteAfterDays.Type;
+
 export const ServerSettings = Schema.Struct({
   // Legacy token-by-token assistant output. Deliberately a fresh key (was
   // `enableAssistantStreaming`): decoding drops the old key, so everyone,
@@ -682,6 +685,9 @@ export const ServerSettings = Schema.Struct({
   ),
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
+  worktreeAutoDeleteAfterDays: Schema.NullOr(WorktreeAutoDeleteAfterDays).pipe(
+    Schema.withDecodingDefault(Effect.succeed(null)),
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
@@ -888,6 +894,7 @@ export const ServerSettingsPatch = Schema.Struct({
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeAutoDeleteAfterDays: Schema.optionalKey(Schema.NullOr(WorktreeAutoDeleteAfterDays)),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(


### PR DESCRIPTION
## What Changed

Adds an opt-in environment setting to remove unused T3 worktrees:

- Off, Instant, After 3 days, or After 7 days
- deleted threads become eligible immediately when cleanup is enabled
- manually settled threads become eligible after the selected delay
- active sessions, open terminals, dirty worktrees, and worktrees shared with active threads are skipped
- branches are kept, so a missing worktree can be created again when a thread is used

The server owns cleanup, so the behavior is the same for local and remote clients. The desktop delete flow keeps its prompt when automatic cleanup is off, or when the server cannot safely claim a dirty, external, or incompatible worktree.

## Why

Finished threads can leave worktrees on disk until a desktop user removes them. This keeps cleanup off by default and lets the environment that owns the filesystem remove only worktrees that are safe to remove.

## Safety Boundary

Cleanup only considers canonical paths inside the configured T3 worktree directory. It uses non-forced Git worktree removal and retries skipped worktrees after later events or during the hourly scan. Before suppressing the desktop prompt, the client confirms that the server classifies the path as managed and Git reports a clean matching branch.

## UI Changes

**Default: Off**

![Auto-delete worktrees defaults to Off](https://github.com/user-attachments/assets/e6ef4a58-1851-4738-b949-8b940ab2a939)

**Delay choices**

![Auto-delete worktree delay choices](https://github.com/user-attachments/assets/ec7d1b23-c312-469d-ad45-b692ae718ffe)

**Configured for 3 days**

![Auto-delete worktrees configured for 3 days](https://github.com/user-attachments/assets/09862237-93f2-410f-9fb3-c43c5b7d2b29)

**Interaction**

https://github.com/user-attachments/assets/f1781785-2fb4-48f0-8101-2a79f066742c

## Verification

- focused settings, cleanup, lifecycle-race, prompt-fallback, and WebSocket RPC tests
- `pnpm --filter t3 typecheck`
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/contracts typecheck`
- targeted formatting and lint checks
- isolated server startup and Settings interaction

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with Codex (gpt-5.6-sol) in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automatic worktree cleanup with `WorktreeLifecycleLock` serialization
> - Introduces `WorktreeAutoDelete` service that periodically sweeps and removes clean, idle, T3-managed worktrees for deleted or settled threads, gated by a configurable `worktreeAutoDeleteAfterDays` setting (0, 3, 7, or off)
> - Adds `WorktreeLifecycleLock` — a process-wide semaphore(1) that serializes worktree lifecycle operations across `ProviderCommandReactor`, `TerminalManager`, and the auto-delete sweeper
> - Extends `vcsRefreshStatus` RPC with `isAutoDeleteManagedWorktree` and adds client-side `canSkipWorktreeDeletePrompt` so thread deletion skips the worktree-delete confirmation when it is safe and auto-delete is enabled
> - Wires the auto-delete worker into the server's live reactor layers and adds a General settings panel row with search support
> - Behavioral Change: terminal open/attach/restart and `ensureThreadWorktree` now run under the global `WorktreeLifecycleLock` in addition to their existing per-thread locks; check `WorktreeAutoDelete.make` and `TerminalManager.makeWithOptions` for contention if lifecycle operations are slow
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f278a34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
