### PR TITLE
chore: add Windows setup script to t3.json

### DIFF
--- a/t3.json
+++ b/t3.json
@@ -7,6 +7,12 @@
       "command": "vp i && ln -sf $T3CODE_PROJECT_ROOT/.env .env && ln -sf $T3CODE_PROJECT_ROOT/infra/relay/.env infra/relay/.env && node apps/web/scripts/warm-dep-cache.ts",
       "icon": "configure",
       "runOnWorktreeCreate": true
+    },
+    {
+      "name": "Setup Worktree (Windows)",
+      "command": "vp i && New-Item -ItemType SymbolicLink -Path .env -Target \"$env:T3CODE_PROJECT_ROOT\\.env\" -Force && New-Item -ItemType SymbolicLink -Path \"infra\\relay\\.env\" -Target \"$env:T3CODE_PROJECT_ROOT\\infra\\relay\\.env\" -Force && node apps\\web\\scripts\\warm-dep-cache.ts",
+      "icon": "configure",
+      "runOnWorktreeCreate": true
     }
   ]
 }


### PR DESCRIPTION
## What Changed

Add a second "Setup Worktree (Windows)" entry that creates the same `.env` symlinks with `New-Item -ItemType SymbolicLink` and uses pwsh env var syntax, so Windows worktrees get the same setup on worktree create.

## Why

A Windows user opening this repo in T3 Code couldn't run the automatic worktree setup. The checked-in setup script in t3.json only works on mac/linux. Its command is written verbatim to the platform default shell (bash/zsh there, pwsh on Windows), so the `ln -sf` lines fail on Windows. 

## UI Changes

No UI changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-environment T3 configuration only; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds a second T3 script, **Setup Worktree (Windows)**, alongside the existing Unix **Setup Worktree** entry so automatic worktree creation works on Windows.
> 
> The new command keeps the same flow (`vp i`, symlink root `.env` and `infra/relay/.env`, then `warm-dep-cache`) but uses PowerShell `New-Item -ItemType SymbolicLink` with `$env:T3CODE_PROJECT_ROOT` and Windows paths instead of `ln -sf`. It also sets `runOnWorktreeCreate: true` like the original.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fde1942edd6379723bc1a6c5a75ac716a6d1acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Windows worktree setup task to `t3.json`
> - Adds a "Setup Worktree (Windows)" task that runs automatically on worktree creation (`runOnWorktreeCreate: true`).
> - The task chains a PowerShell command: runs `vp i`, creates `.env` and `infra\relay\.env` symlinks pointing to `$env:T3CODE_PROJECT_ROOT`, and executes `node apps\web\scripts\warm-dep-cache.ts`.
> - Behavioral Change: Windows worktree creation now triggers dependency install, env symlink setup, and dependency cache warming automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fde194.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->