### PR TITLE
feat(web): mod+alt+o opens the system folder picker to add or open a project

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -91,6 +91,11 @@ describe("reduceCommandPaletteUiState", () => {
       mode: "command",
       openIntent: { kind: "new-thread-in" },
     });
+    expect(reduceCommandPaletteUiState(filesOpen, { _tag: "OpenFolderPicker" })).toEqual({
+      open: true,
+      mode: "command",
+      openIntent: { kind: "open-folder" },
+    });
   });
 
   it("preserves the mode on close and resets it on open", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -38,7 +38,7 @@ export function browseInputEndPaddingClass(input: {
 export type SearchOverlayMode = "command" | "files" | "content";
 
 export interface CommandPaletteOpenIntent {
-  readonly kind: "add-project" | "new-thread-in";
+  readonly kind: "add-project" | "new-thread-in" | "open-folder";
 }
 
 export interface CommandPaletteUiState {
@@ -52,6 +52,7 @@ export type CommandPaletteUiAction =
   | { readonly _tag: "ToggleMode"; readonly mode: SearchOverlayMode }
   | { readonly _tag: "OpenAddProject" }
   | { readonly _tag: "OpenNewThreadIn" }
+  | { readonly _tag: "OpenFolderPicker" }
   | { readonly _tag: "ClearOpenIntent" };
 
 export function reduceCommandPaletteUiState(
@@ -71,6 +72,8 @@ export function reduceCommandPaletteUiState(
       return { open: true, mode: "command", openIntent: { kind: "add-project" } };
     case "OpenNewThreadIn":
       return { open: true, mode: "command", openIntent: { kind: "new-thread-in" } };
+    case "OpenFolderPicker":
+      return { open: true, mode: "command", openIntent: { kind: "open-folder" } };
     case "ClearOpenIntent":
       return state.openIntent ? { ...state, openIntent: null } : state;
   }

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2144,10 +2144,8 @@ function OpenCommandPaletteDialog(props: {
       return undefined;
     }
 
-    // The `project.openFolder` hotkey opens the picker before a browse view
-    // exists, so there is no query to derive a directory from. Start at the
-    // environment's configured add-project directory instead; the desktop
-    // expands a leading `~` against the target's home, including over WSL.
+    // The desktop expands the leading `~` against the target's home, including
+    // over WSL.
     if (!isBrowsing) {
       return getAddProjectInitialQueryForEnvironment(browseEnvironmentId);
     }
@@ -2358,11 +2356,8 @@ function OpenCommandPaletteDialog(props: {
     primaryEnvironmentId,
   ]);
 
-  // `project.openFolder` routes here: jump straight to the native folder
-  // picker against the environment browsing would target, opening the
-  // add-project browse view behind it so cancelling lands somewhere useful.
-  // Falls back to the regular add-project flow when the picker can't run (web
-  // client, WSL instance not yet resolved) or environment selection is needed.
+  // The native picker needs the desktop bridge and one unambiguous
+  // environment; without both, `project.openFolder` can only open the flow.
   useLayoutEffect(() => {
     if (openIntent?.kind !== "open-folder") {
       return;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2140,8 +2140,16 @@ function OpenCommandPaletteDialog(props: {
     window.desktopBridge !== undefined;
   const canOpenProjectFromFileManager = isBrowsing && canPickProjectFolder;
   const fileManagerInitialPath = useMemo(() => {
-    if (!canOpenProjectFromFileManager) {
+    if (!canPickProjectFolder) {
       return undefined;
+    }
+
+    // The `project.openFolder` hotkey opens the picker before a browse view
+    // exists, so there is no query to derive a directory from. Start at the
+    // environment's configured add-project directory instead; the desktop
+    // expands a leading `~` against the target's home, including over WSL.
+    if (!isBrowsing) {
+      return getAddProjectInitialQueryForEnvironment(browseEnvironmentId);
     }
 
     const trimmedQuery = query.trim();
@@ -2157,9 +2165,12 @@ function OpenCommandPaletteDialog(props: {
     return resolvedPath.length > 0 ? resolvedPath : undefined;
   }, [
     browseDirectoryPath,
+    browseEnvironmentId,
     browseResult?.parentPath,
-    canOpenProjectFromFileManager,
+    canPickProjectFolder,
     currentProjectCwdForBrowse,
+    getAddProjectInitialQueryForEnvironment,
+    isBrowsing,
     query,
   ]);
 
@@ -2347,36 +2358,28 @@ function OpenCommandPaletteDialog(props: {
     primaryEnvironmentId,
   ]);
 
-  const openFolderBrowseStartedRef = useRef(false);
-  // `project.openFolder` routes here: open the add-project browse view for the
-  // environment browsing would target, then hand off to the native picker once
-  // that view has committed so the picker starts at the environment's
-  // configured add-project directory. Falls back to the regular add-project
-  // flow when the picker can't run (web client, WSL instance not yet resolved)
-  // or environment selection is needed first.
+  // `project.openFolder` routes here: jump straight to the native folder
+  // picker against the environment browsing would target, opening the
+  // add-project browse view behind it so cancelling lands somewhere useful.
+  // Falls back to the regular add-project flow when the picker can't run (web
+  // client, WSL instance not yet resolved) or environment selection is needed.
   useLayoutEffect(() => {
     if (openIntent?.kind !== "open-folder") {
-      openFolderBrowseStartedRef.current = false;
-      return;
-    }
-    if (
-      browseEnvironmentId === null ||
-      !canPickProjectFolder ||
-      addProjectEnvironmentOptions.length > 1
-    ) {
-      clearOpenIntent();
-      openAddProjectFlow();
-      return;
-    }
-    if (!isBrowsing) {
-      if (!openFolderBrowseStartedRef.current) {
-        openFolderBrowseStartedRef.current = true;
-        void startAddProjectBrowse(browseEnvironmentId);
-      }
       return;
     }
     clearOpenIntent();
-    void handleOpenProjectFromFileManager();
+    if (
+      browseEnvironmentId !== null &&
+      canPickProjectFolder &&
+      addProjectEnvironmentOptions.length <= 1
+    ) {
+      if (!isBrowsing) {
+        void startAddProjectBrowse(browseEnvironmentId);
+      }
+      void handleOpenProjectFromFileManager();
+      return;
+    }
+    openAddProjectFlow();
   }, [
     addProjectEnvironmentOptions.length,
     browseEnvironmentId,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -403,6 +403,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
   );
   const openAddProject = useCallback(() => dispatch({ _tag: "OpenAddProject" }), []);
   const openNewThreadIn = useCallback(() => dispatch({ _tag: "OpenNewThreadIn" }), []);
+  const openFolderPicker = useCallback(() => dispatch({ _tag: "OpenFolderPicker" }), []);
   const clearOpenIntent = useCallback(() => dispatch({ _tag: "ClearOpenIntent" }), []);
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const { theme, themeHalves, resolvedTheme } = useTheme();
@@ -458,6 +459,12 @@ export function CommandPalette({ children }: { children: ReactNode }) {
         });
         return;
       }
+      if (command === "project.openFolder") {
+        event.preventDefault();
+        event.stopPropagation();
+        openFolderPicker();
+        return;
+      }
       const mode = overlayModeForCommand(command);
       if (mode === null) {
         return;
@@ -468,7 +475,16 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keybindings, previewOpen, resolvedTheme, terminalOpen, theme, themeHalves, toggleMode]);
+  }, [
+    keybindings,
+    openFolderPicker,
+    previewOpen,
+    resolvedTheme,
+    terminalOpen,
+    theme,
+    themeHalves,
+    toggleMode,
+  ]);
 
   useEffect(
     () =>
@@ -2111,8 +2127,7 @@ function OpenCommandPaletteDialog(props: {
     canCreateProjectInEnvironment(browseEnvironment?.connection.phase) &&
     !isRemoteProjectPending;
   const fileManagerName = getLocalFileManagerName(navigator.platform);
-  const canOpenProjectFromFileManager =
-    isBrowsing &&
+  const canPickProjectFolder =
     browseEnvironmentId !== null &&
     // For a desktop-local (WSL) env, only offer the picker once we have resolved
     // its desktop pool instance id. Without it pickFolder can't be routed to the
@@ -2123,6 +2138,7 @@ function OpenCommandPaletteDialog(props: {
       (browseEnvironmentIsDesktopLocal && browseDesktopInstanceId !== null)) &&
     typeof window !== "undefined" &&
     window.desktopBridge !== undefined;
+  const canOpenProjectFromFileManager = isBrowsing && canPickProjectFolder;
   const fileManagerInitialPath = useMemo(() => {
     if (!canOpenProjectFromFileManager) {
       return undefined;
@@ -2221,7 +2237,7 @@ function OpenCommandPaletteDialog(props: {
   }
 
   const handleOpenProjectFromFileManager = useCallback(async () => {
-    if (!canOpenProjectFromFileManager || isPickingProjectFolder) {
+    if (!canPickProjectFolder || isPickingProjectFolder) {
       return;
     }
     const api = readLocalApi();
@@ -2321,7 +2337,7 @@ function OpenCommandPaletteDialog(props: {
     browseDesktopInstanceId,
     browseEnvironmentId,
     browseEnvironmentPlatform,
-    canOpenProjectFromFileManager,
+    canPickProjectFolder,
     desktopLocalBootstraps,
     environments,
     fileManagerInitialPath,
@@ -2329,6 +2345,39 @@ function OpenCommandPaletteDialog(props: {
     handleAddProjectForEnvironment,
     isPickingProjectFolder,
     primaryEnvironmentId,
+  ]);
+
+  // `project.openFolder` routes here: jump straight to the native folder
+  // picker against the environment browsing would target, falling back to the
+  // regular add-project flow when the picker can't run (web client, WSL
+  // instance not yet resolved) or environment selection is needed first.
+  useLayoutEffect(() => {
+    if (openIntent?.kind !== "open-folder") {
+      return;
+    }
+    clearOpenIntent();
+    if (
+      browseEnvironmentId !== null &&
+      canPickProjectFolder &&
+      addProjectEnvironmentOptions.length <= 1
+    ) {
+      if (!isBrowsing) {
+        void startAddProjectBrowse(browseEnvironmentId);
+      }
+      void handleOpenProjectFromFileManager();
+      return;
+    }
+    openAddProjectFlow();
+  }, [
+    addProjectEnvironmentOptions.length,
+    browseEnvironmentId,
+    canPickProjectFolder,
+    clearOpenIntent,
+    handleOpenProjectFromFileManager,
+    isBrowsing,
+    openAddProjectFlow,
+    openIntent,
+    startAddProjectBrowse,
   ]);
 
   const inputAccessory =

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2347,27 +2347,36 @@ function OpenCommandPaletteDialog(props: {
     primaryEnvironmentId,
   ]);
 
-  // `project.openFolder` routes here: jump straight to the native folder
-  // picker against the environment browsing would target, falling back to the
-  // regular add-project flow when the picker can't run (web client, WSL
-  // instance not yet resolved) or environment selection is needed first.
+  const openFolderBrowseStartedRef = useRef(false);
+  // `project.openFolder` routes here: open the add-project browse view for the
+  // environment browsing would target, then hand off to the native picker once
+  // that view has committed so the picker starts at the environment's
+  // configured add-project directory. Falls back to the regular add-project
+  // flow when the picker can't run (web client, WSL instance not yet resolved)
+  // or environment selection is needed first.
   useLayoutEffect(() => {
     if (openIntent?.kind !== "open-folder") {
+      openFolderBrowseStartedRef.current = false;
+      return;
+    }
+    if (
+      browseEnvironmentId === null ||
+      !canPickProjectFolder ||
+      addProjectEnvironmentOptions.length > 1
+    ) {
+      clearOpenIntent();
+      openAddProjectFlow();
+      return;
+    }
+    if (!isBrowsing) {
+      if (!openFolderBrowseStartedRef.current) {
+        openFolderBrowseStartedRef.current = true;
+        void startAddProjectBrowse(browseEnvironmentId);
+      }
       return;
     }
     clearOpenIntent();
-    if (
-      browseEnvironmentId !== null &&
-      canPickProjectFolder &&
-      addProjectEnvironmentOptions.length <= 1
-    ) {
-      if (!isBrowsing) {
-        void startAddProjectBrowse(browseEnvironmentId);
-      }
-      void handleOpenProjectFromFileManager();
-      return;
-    }
-    openAddProjectFlow();
+    void handleOpenProjectFromFileManager();
   }, [
     addProjectEnvironmentOptions.length,
     browseEnvironmentId,

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -37,6 +37,10 @@ Examples: `mod+j`, `mod+shift+d`, `ctrl+l`, `cmd+k`.
 Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refresh`, and
 `chat.new`. Project scripts are addressable as `script.{id}.run`, for example `script.test.run`.
 
+`project.openFolder` opens the system folder picker and adds the chosen folder as a project, or
+jumps to the existing project for that folder. Its default shortcut is `mod+alt+o`. The native
+picker needs the desktop app; elsewhere the shortcut opens the add-project flow instead.
+
 `filePicker.toggle` opens file search for the active project and defaults to `mod+p`.
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -73,6 +73,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "chat.new",
   "chat.newLocal",
   "editor.openFavorite",
+  "project.openFolder",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,
 ] as const;

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -44,6 +44,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  { key: "mod+alt+o", command: "project.openFolder" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
   { key: "mod+shift+s", command: "thread.settle", when: "!terminalFocus" },


### PR DESCRIPTION
Adding a project takes four steps through the command palette: open it, pick "Add project", pick "Browse local", then type a path or click "Open in Finder". The Codex desktop app binds a hotkey to its system folder picker, and that shortcut is the fastest way to add or switch projects there. T3 Code has no equivalent.

This adds a `project.openFolder` keybinding command, bound to `mod+alt+o` by default since `mod+o` already belongs to `editor.openFavorite`. It opens the native folder picker in one step. Picking a folder that is already a project navigates to that project's latest thread. A new folder gets added as a project and a thread starts, same as the existing footer button.

The hotkey dispatches a new `open-folder` palette intent, and the palette then calls the same `handleOpenProjectFromFileManager` that the "Open in Finder" footer button uses, so WSL path routing and the existing-project dedup are untouched. The only refactor is splitting `canOpenProjectFromFileManager` into "picker available" and "browse view showing", because the handler now runs before the browse view opens. On the web client, or when several environments are connected, the shortcut falls back to the regular add-project flow instead.

No existing default binding changed. The server's startup reconciliation merges the new default into existing user configs. Includes a reducer test case and a docs entry in `docs/user/keybindings.md`.

The keybindings and palette logic test files pass, and typecheck is clean on contracts, shared, web, mobile, client-runtime, and server. The only visible change is the OS folder picker opening over the palette; I can attach a short recording if that helps review.

Written by Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project creation and desktop/WSL picker routing, though behavior reuses the existing file-manager handler; fallback paths when several environments are connected need to behave correctly.
> 
> **Overview**
> Adds **`project.openFolder`** (default **`mod+alt+o`**) so users can open the OS folder picker in one step instead of walking through Add project → Browse local.
> 
> The shortcut is registered in contracts/shared keybindings and handled in the command palette global key listener (separate from overlay toggles). It sets a new **`open-folder`** palette intent; a layout effect then either calls the existing **`handleOpenProjectFromFileManager`** when the desktop bridge is available and the target environment is unambiguous, or falls back to the normal add-project flow (web or multiple connected environments).
> 
> **`canPickProjectFolder`** is split out from the browse-only “Open in Finder” footer gate so the picker can run before the browse view opens; initial picker path can use the environment’s add-project base directory when not browsing. Reducer coverage and **`docs/user/keybindings.md`** document the command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ee7187452c5c618ad9bbb57cd505841cc5da74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mod+alt+o` shortcut to open system folder picker
> - Introduces the `project.openFolder` command and binds it to the `mod+alt+o` default keybinding.
> - Dispatching the command opens the command palette with an `open-folder` intent.
> - The `OpenCommandPaletteDialog` component handles this intent by triggering the native folder picker when the desktop bridge and a single environment are available; otherwise, it opens the standard add-project flow.
> - Behavioral Change: Gating logic in `OpenCommandPaletteDialog` refactored to use `canPickProjectFolder`, changing how `fileManagerInitialPath` and `handleOpenProjectFromFileManager` execute in non-browsing scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4ee718.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->