### PR TITLE
fix(server): respect disabled text generation providers

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -368,34 +368,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
-  it.effect("prefers enabled provider instances for text generation fallbacks", () =>
-    Effect.gen(function* () {
-      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
-      const claudeInstanceId = ProviderInstanceId.make("claude_work");
-
-      const instanceFallback = yield* serverSettings.updateSettings({
-        providerInstances: {
-          [ProviderInstanceId.make("codex")]: {
-            driver: ProviderDriverKind.make("codex"),
-            enabled: false,
-            config: {},
-          },
-          [claudeInstanceId]: {
-            driver: ProviderDriverKind.make("claudeAgent"),
-            enabled: true,
-            config: {},
-          },
-        },
-      });
-
-      assert.deepEqual(instanceFallback.textGenerationModelSelection, {
-        instanceId: claudeInstanceId,
-        model: "claude-haiku-4-5",
-      });
-    }).pipe(Effect.provide(makeServerSettingsLayer())),
-  );
-
-  it.effect("skips disabled instance drivers when falling back to legacy providers", () =>
+  it.effect("skips a legacy fallback when its explicit default instance is disabled", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
 
@@ -404,6 +377,11 @@ it.layer(NodeServices.layer)("server settings", (it) => {
           [ProviderInstanceId.make("codex")]: {
             driver: ProviderDriverKind.make("codex"),
             enabled: false,
+            config: {},
+          },
+          [ProviderInstanceId.make("unavailable_custom")]: {
+            driver: ProviderDriverKind.make("unknown"),
+            enabled: true,
             config: {},
           },
         },

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -368,6 +368,54 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("prefers enabled provider instances for text generation fallbacks", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const claudeInstanceId = ProviderInstanceId.make("claude_work");
+
+      const instanceFallback = yield* serverSettings.updateSettings({
+        providerInstances: {
+          [ProviderInstanceId.make("codex")]: {
+            driver: ProviderDriverKind.make("codex"),
+            enabled: false,
+            config: {},
+          },
+          [claudeInstanceId]: {
+            driver: ProviderDriverKind.make("claudeAgent"),
+            enabled: true,
+            config: {},
+          },
+        },
+      });
+
+      assert.deepEqual(instanceFallback.textGenerationModelSelection, {
+        instanceId: claudeInstanceId,
+        model: "claude-haiku-4-5",
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("skips disabled instance drivers when falling back to legacy providers", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+
+      const legacyFallback = yield* serverSettings.updateSettings({
+        providerInstances: {
+          [ProviderInstanceId.make("codex")]: {
+            driver: ProviderDriverKind.make("codex"),
+            enabled: false,
+            config: {},
+          },
+        },
+      });
+
+      assert.deepEqual(legacyFallback.textGenerationModelSelection, {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: "claude-haiku-4-5",
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("preserves enabled text generation selections for non-built-in drivers", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -300,34 +300,22 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
 }
 
 function fallbackTextGenerationProvider(settings: ServerSettings): ServerSettings {
-  const providerInstanceEntries = Object.entries(settings.providerInstances);
-  const enabledInstance = providerInstanceEntries.find(([, instance]) =>
-    resolveProviderInstanceEnabled(instance),
-  );
-  const configuredDrivers = new Set(providerInstanceEntries.map(([, instance]) => instance.driver));
-  const enabledLegacyProvider = Object.entries(settings.providers).find(
-    ([driver, provider]) =>
-      provider.enabled && !configuredDrivers.has(ProviderDriverKind.make(driver)),
-  );
-  const fallbackDriver =
-    enabledInstance?.[1].driver ??
-    (enabledLegacyProvider ? ProviderDriverKind.make(enabledLegacyProvider[0]) : undefined);
-  const fallbackInstanceId = enabledInstance
-    ? ProviderInstanceId.make(enabledInstance[0])
-    : fallbackDriver
-      ? ProviderInstanceId.make(fallbackDriver)
-      : undefined;
-  if (!fallbackDriver || !fallbackInstanceId) {
+  const fallbackEntry = Object.entries(settings.providers).find(([driver, provider]) => {
+    const instance = settings.providerInstances[ProviderInstanceId.make(driver)];
+    return provider.enabled && (instance === undefined || resolveProviderInstanceEnabled(instance));
+  });
+  const fallback = fallbackEntry ? ProviderDriverKind.make(fallbackEntry[0]) : undefined;
+  if (!fallback) {
     return settings;
   }
 
   return {
     ...settings,
     textGenerationModelSelection: {
-      instanceId: fallbackInstanceId,
+      instanceId: ProviderInstanceId.make(fallback),
       model:
-        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallbackDriver] ??
-        DEFAULT_MODEL_BY_PROVIDER[fallbackDriver] ??
+        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallback] ??
+        DEFAULT_MODEL_BY_PROVIDER[fallback] ??
         DEFAULT_TEXT_GENERATION_MODEL,
     } satisfies ModelSelection,
   };

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -20,6 +20,7 @@ import {
   type ProviderInstanceEnvironmentVariable,
   ProviderDriverKind,
   ProviderInstanceId,
+  resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsError,
   type ServerSettingsPatch,
@@ -299,19 +300,34 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
 }
 
 function fallbackTextGenerationProvider(settings: ServerSettings): ServerSettings {
-  const fallbackEntry = Object.entries(settings.providers).find(([, provider]) => provider.enabled);
-  const fallback = fallbackEntry ? ProviderDriverKind.make(fallbackEntry[0]) : undefined;
-  if (!fallback) {
+  const providerInstanceEntries = Object.entries(settings.providerInstances);
+  const enabledInstance = providerInstanceEntries.find(([, instance]) =>
+    resolveProviderInstanceEnabled(instance),
+  );
+  const configuredDrivers = new Set(providerInstanceEntries.map(([, instance]) => instance.driver));
+  const enabledLegacyProvider = Object.entries(settings.providers).find(
+    ([driver, provider]) =>
+      provider.enabled && !configuredDrivers.has(ProviderDriverKind.make(driver)),
+  );
+  const fallbackDriver =
+    enabledInstance?.[1].driver ??
+    (enabledLegacyProvider ? ProviderDriverKind.make(enabledLegacyProvider[0]) : undefined);
+  const fallbackInstanceId = enabledInstance
+    ? ProviderInstanceId.make(enabledInstance[0])
+    : fallbackDriver
+      ? ProviderInstanceId.make(fallbackDriver)
+      : undefined;
+  if (!fallbackDriver || !fallbackInstanceId) {
     return settings;
   }
 
   return {
     ...settings,
     textGenerationModelSelection: {
-      instanceId: ProviderInstanceId.make(fallback),
+      instanceId: fallbackInstanceId,
       model:
-        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallback] ??
-        DEFAULT_MODEL_BY_PROVIDER[fallback] ??
+        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallbackDriver] ??
+        DEFAULT_MODEL_BY_PROVIDER[fallbackDriver] ??
         DEFAULT_TEXT_GENERATION_MODEL,
     } satisfies ModelSelection,
   };


### PR DESCRIPTION
## What Changed

- Keep the existing legacy text-generation fallback order.
- When a legacy fallback has an explicit instance at the same default ID, honor that instance's enabled state.
- Add a regression covering disabled Codex alongside an unrelated enabled custom instance.

## Why

The enabled check uses `providerInstances`, but the fallback scanned only the legacy `providers` map. Because that map defaults Codex to enabled, disabling the explicit Codex instance could immediately select Codex again for titles, branch names, commit messages, and PR content.

The fallback now mirrors registry hydration's same-ID precedence without selecting arbitrary configured instances that may not have registered successfully.

Closes #7533

## Testing

- `vp test run apps/server/src/serverSettings.test.ts` (32 tests)
- `vp run --filter t3 typecheck`
- `vp lint apps/server/src/serverSettings.ts apps/server/src/serverSettings.test.ts`
- `vp fmt --check apps/server/src/serverSettings.ts apps/server/src/serverSettings.test.ts`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI code changed; screenshots and video are not applicable

Model: GPT-5.6 Sol
Harness: Codex in T3 Code
