### PR TITLE
fix(contracts): decode CLI event origins

### DIFF
--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -572,6 +572,30 @@ it.effect("defaults settled fields when decoding historical thread data", () =>
   }),
 );
 
+it.effect("decodes persisted orchestration events with CLI origin metadata", () =>
+  Effect.gen(function* () {
+    const event = yield* decodeOrchestrationEvent({
+      sequence: 43_854,
+      eventId: "event-cli-origin-1",
+      aggregateKind: "project",
+      aggregateId: "project-1",
+      type: "project.meta-updated",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      commandId: "cmd-cli-origin-1",
+      causationEventId: null,
+      correlationId: "cmd-cli-origin-1",
+      metadata: { origin: { surface: "cli" } },
+      payload: {
+        projectId: "project-1",
+        title: "Updated from CLI",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    assert.deepStrictEqual(event.metadata.origin, { surface: "cli" });
+  }),
+);
+
 it.effect("decodes thread archived and unarchived events", () =>
   Effect.gen(function* () {
     const archived = yield* decodeOrchestrationEvent({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1401,13 +1401,21 @@ export const OrchestrationClientOrigin = Schema.Struct({
 });
 export type OrchestrationClientOrigin = typeof OrchestrationClientOrigin.Type;
 
+// Historical event stores can contain CLI-authored project metadata events.
+// Keep that compatibility at the persistence boundary: ClientSurface still
+// describes only web, desktop, and mobile connection/auth surfaces.
+const PersistedOrchestrationOrigin = Schema.Struct({
+  surface: Schema.optional(Schema.Union([ClientSurface, Schema.Literal("cli")])),
+  appVersion: Schema.optional(TrimmedNonEmptyString),
+});
+
 export const OrchestrationEventMetadata = Schema.Struct({
   providerTurnId: Schema.optional(TrimmedNonEmptyString),
   providerItemId: Schema.optional(ProviderItemId),
   adapterKey: Schema.optional(TrimmedNonEmptyString),
   requestId: Schema.optional(ApprovalRequestId),
   ingestedAt: Schema.optional(IsoDateTime),
-  origin: Schema.optional(OrchestrationClientOrigin),
+  origin: Schema.optional(PersistedOrchestrationOrigin),
 });
 export type OrchestrationEventMetadata = typeof OrchestrationEventMetadata.Type;
 


### PR DESCRIPTION
## What Changed

- Accept `"cli"` as an origin surface when decoding persisted orchestration-event metadata.
- Keep live client connection/auth surfaces restricted to `web | desktop | mobile`.
- Add a regression for the reported `project.meta-updated` event shape.

## Why

A T3-written event with `metadata.origin.surface: "cli"` currently fails startup decoding and can leave a server crash-looping. Keeping the compatibility value at the persistence boundary fixes existing event stores without widening live client surface contracts.

Fixes #8789.

## Verification

- `vp test run packages/contracts/src/orchestration.test.ts` — 50 passed
- Contracts typecheck
- Server typecheck
- Focused lint and formatting checks

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow decode-time backward compatibility at the event-store boundary; no change to live client surface contracts or command dispatch.
> 
> **Overview**
> Fixes startup failures when replaying orchestration events whose metadata includes **`origin.surface: "cli"`** (e.g. CLI-authored `project.meta-updated`), which previously failed schema decode and could crash-loop the server.
> 
> **`OrchestrationEventMetadata.origin`** now decodes via a persistence-only **`PersistedOrchestrationOrigin`** that accepts **`cli`** in addition to **`ClientSurface`** (`web` / `desktop` / `mobile`). **`OrchestrationClientOrigin`** is unchanged for live client stamping and auth surfaces.
> 
> Adds a contract test that **`decodeOrchestrationEvent`** accepts a representative CLI-origin event shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb482d2507047def81d42f0c379b372bf400253f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept `origin.surface = 'cli'` in `OrchestrationEventMetadata` decoding
> Introduces `PersistedOrchestrationOrigin` schema in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/8823/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) that allows `surface` to be either `ClientSurface` or the literal `"cli"`, with an optional `appVersion` string. Changes the `origin` field of `OrchestrationEventMetadata` to use this new schema for historical event store compatibility. Adds a test confirming persisted events with CLI origin metadata decode correctly. Risk: consumers that relied on `origin` strictly conforming to `OrchestrationClientOrigin` may need to handle the additional `"cli"` surface value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb482d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->