### PR TITLE
fix(web): fold interim turn responses

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -452,7 +452,7 @@ describe("deriveMessagesTimelineRows", () => {
     expect(assistantRow?.assistantTurnDiffSummary).toBe(assistantTurnDiffSummary);
   });
 
-  it("keeps the first and terminal assistant messages visible around settled work", () => {
+  it("folds the first assistant message and settled work before the terminal response", () => {
     const timelineEntries = [
       {
         id: "user-entry",
@@ -528,7 +528,6 @@ describe("deriveMessagesTimelineRows", () => {
     expect(foldRow?.label).toBe("Worked for 22s");
     expect(collapsedRows.map((row) => row.id)).toEqual([
       "user-entry",
-      "assistant-first-entry",
       "turn-fold:turn-1",
       "assistant-final-entry",
     ]);
@@ -544,8 +543,8 @@ describe("deriveMessagesTimelineRows", () => {
 
     expect(expandedRows.map((row) => row.id)).toEqual([
       "user-entry",
-      "assistant-first-entry",
       "turn-fold:turn-1",
+      "assistant-first-entry",
       "work-toggle:work-entry-1",
       "assistant-final-entry",
     ]);
@@ -554,7 +553,7 @@ describe("deriveMessagesTimelineRows", () => {
     ).toBeDefined();
   });
 
-  it("folds assistant messages between the first and terminal messages", () => {
+  it("folds all assistant messages before the terminal message", () => {
     const timelineEntries = [
       {
         id: "assistant-first-entry",
@@ -608,11 +607,7 @@ describe("deriveMessagesTimelineRows", () => {
       revertTurnCountByUserMessageId: new Map(),
     });
 
-    expect(rows.map((row) => row.id)).toEqual([
-      "assistant-first-entry",
-      "turn-fold:turn-1",
-      "assistant-final-entry",
-    ]);
+    expect(rows.map((row) => row.id)).toEqual(["turn-fold:turn-1", "assistant-final-entry"]);
   });
 
   it("derives a sane duration for a steer-superseded turn with one instant commentary message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -521,10 +521,9 @@ function timelineEntryTurnId(entry: TimelineEntry): TurnId | null {
 }
 
 /**
- * Settled turns keep their first and terminal assistant messages visible.
- * Everything between them folds behind a "Worked for ..." row anchored at
- * the first hidden entry. Keeping both ends prevents a short follow-up from
- * hiding a substantive opening response while still bounding noisy turns.
+ * Settled turns keep only their terminal assistant message visible.
+ * Everything before it folds behind a "Worked for ..." row anchored at the
+ * first hidden entry, so the duration leads directly into the final response.
  */
 function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
@@ -594,12 +593,9 @@ function deriveTurnFolds(input: {
     if (group.hasStreamingMessage) {
       continue;
     }
-    const firstAssistantEntry = group.entries.find(
-      (entry): entry is Extract<TimelineEntry, { kind: "message" }> => entry.kind === "message",
-    );
     const hiddenEntryIds = new Set<string>();
     for (const entry of group.entries) {
-      if (entry.id === firstAssistantEntry?.id || entry.id === group.terminalEntry?.id) {
+      if (entry.id === group.terminalEntry?.id) {
         continue;
       }
       // Agent-spawn CTA rows never fold: workflows outlive their launching


### PR DESCRIPTION
Completed turns kept the first assistant update visible above the elapsed work row, which duplicated interim commentary after the turn settled. This folds every pre-final assistant response behind the elapsed work row while preserving the terminal response below it. Verified with 84 focused timeline tests, the web typecheck, targeted lint, and formatting checks.

Produced with gpt-5.6-sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timeline folding logic in the web chat component, covered by existing timeline unit tests with no API or data changes.
> 
> **Overview**
> **Settled chat turns** now show only the **final assistant message** below the elapsed-work row. Interim assistant replies and tool/work activity that used to stay visible above the “Worked for …” fold are hidden until the user expands the turn.
> 
> `deriveTurnFolds` in `MessagesTimeline.logic.ts` no longer exempts the first assistant entry from `hiddenEntryIds`—only the terminal assistant message and agent-spawn work rows stay out of the fold. Collapsed timelines go **user → turn-fold → final answer** instead of keeping an opening assistant bubble on top; expanding the fold still reveals the first assistant message and work toggles in order.
> 
> Tests were renamed and updated to match the new collapsed/expanded row order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a363238612ff7f9ab3a215987324949bdf1950c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fold all interim assistant messages in settled turns in `deriveTurnFolds`
> Settled non-streaming turns now hide every assistant message before the terminal one behind the fold, instead of keeping the first assistant message visible. Agent-spawn work entries remain excluded from folding.
> - Updated [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/8828/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) by removing the first-assistant-message preservation condition and its associated entry computation.
> - Adjusted expectations in [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/8828/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72) to match the new collapsed-row ordering.
> - Risk: any UI logic or snapshot relying on the first assistant message staying visible in a settled turn will break; check consumers of `deriveTurnFolds` output and any pinned snapshot tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a36323.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->