### PR TITLE
feat(web): search individual settings by detail

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -8,6 +8,7 @@ import {
   enumerateCommandPaletteItems,
   filterPinnedBrowseEntries,
   filterCommandPaletteGroups,
+  normalizeSearchText,
   reduceCommandPaletteUiState,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
@@ -270,6 +271,75 @@ describe("buildThreadActionItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0]?.items.map((item) => item.value)).toEqual(["thread:project-context-only"]);
+  });
+
+  it("ranks an order-independent setting title match above a split context match", () => {
+    const settingsSearchItems = [
+      {
+        kind: "action" as const,
+        value: "setting:context-match",
+        searchTerms: ["Pairing settings", "remote backend"],
+        title: "Context match",
+        icon: null,
+        run: async () => undefined,
+      },
+      {
+        kind: "action" as const,
+        value: "setting:remote-pairing",
+        searchTerms: ["Remote pairing", "connections"],
+        title: "Remote pairing",
+        icon: null,
+        run: async () => undefined,
+      },
+    ];
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [],
+      query: "pairing remote",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      settingsSearchItems,
+      threadSearchItems: [],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.value).toBe("settings-search");
+    expect(groups[0]?.items.map((item) => item.value)).toEqual([
+      "setting:remote-pairing",
+      "setting:context-match",
+    ]);
+  });
+
+  it("keeps accent-insensitive setting results", () => {
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [],
+      query: "thè\u{1ab0}mes",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      settingsSearchItems: [
+        {
+          kind: "action",
+          value: "setting:theme",
+          searchTerms: ["Themes", "Appearance"],
+          title: "Themes",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["setting:theme"]);
+  });
+
+  it("normalizes case independently of the host locale", () => {
+    const localeLowerCase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockReturnValue("gıt");
+    try {
+      expect(normalizeSearchText("GIT")).toBe("git");
+      expect(localeLowerCase).not.toHaveBeenCalled();
+    } finally {
+      localeLowerCase.mockRestore();
+    }
   });
 
   it("keeps message excerpts searchable without replacing thread metadata", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -9,8 +9,11 @@ import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
 import { type ReactNode } from "react";
 import { sortThreads } from "../lib/threadSort";
+import { normalizeSearchText } from "../lib/utils";
 import { formatRelativeTimeLabel } from "../timestampFormat";
 import { type Project, type SidebarThreadSummary, type Thread } from "../types";
+
+export { normalizeSearchText } from "../lib/utils";
 
 export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-icon-muted";
@@ -138,10 +141,6 @@ export function enumerateCommandPaletteItems(
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
-export function normalizeSearchText(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, " ");
-}
-
 export function buildProjectActionItems(input: {
   projects: ReadonlyArray<Project>;
   valuePrefix: string;
@@ -255,9 +254,16 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
   });
 }
 
-function rankSearchFieldMatch(field: string, normalizedQuery: string): number {
+function rankSearchFieldMatch(
+  field: string,
+  normalizedQuery: string,
+  queryTokens: ReadonlyArray<string>,
+): number {
   const normalizedField = normalizeSearchText(field);
-  if (normalizedField.length === 0 || !normalizedField.includes(normalizedQuery)) {
+  if (
+    normalizedField.length === 0 ||
+    !queryTokens.every((token) => normalizedField.includes(token))
+  ) {
     return Number.NEGATIVE_INFINITY;
   }
   if (normalizedField === normalizedQuery) {
@@ -266,12 +272,16 @@ function rankSearchFieldMatch(field: string, normalizedQuery: string): number {
   if (normalizedField.startsWith(normalizedQuery)) {
     return 2;
   }
-  return 1;
+  if (normalizedField.includes(normalizedQuery)) {
+    return 1;
+  }
+  return 0;
 }
 
 function rankCommandPaletteItemMatch(
   item: CommandPaletteActionItem | CommandPaletteSubmenuItem,
   normalizedQuery: string,
+  queryTokens: ReadonlyArray<string>,
 ): number {
   const terms = item.searchTerms.filter((term) => term.length > 0);
   if (terms.length === 0) {
@@ -279,7 +289,7 @@ function rankCommandPaletteItemMatch(
   }
 
   for (const [index, field] of terms.entries()) {
-    const fieldRank = rankSearchFieldMatch(field, normalizedQuery);
+    const fieldRank = rankSearchFieldMatch(field, normalizedQuery, queryTokens);
     if (fieldRank !== Number.NEGATIVE_INFINITY) {
       return 1_000 - index * 100 + fieldRank;
     }
@@ -293,6 +303,7 @@ export function filterCommandPaletteGroups(input: {
   query: string;
   isInSubmenu: boolean;
   projectSearchItems: ReadonlyArray<CommandPaletteActionItem>;
+  settingsSearchItems?: ReadonlyArray<CommandPaletteActionItem>;
   threadSearchItems: ReadonlyArray<CommandPaletteActionItem>;
 }): CommandPaletteGroup[] {
   const isActionsFilter = input.query.startsWith(">");
@@ -305,6 +316,7 @@ export function filterCommandPaletteGroups(input: {
     }
     return [...input.activeGroups];
   }
+  const queryTokens = normalizedQuery.split(" ");
 
   let baseGroups = [...input.activeGroups];
   if (isActionsFilter) {
@@ -322,6 +334,13 @@ export function filterCommandPaletteGroups(input: {
         items: input.projectSearchItems,
       });
     }
+    if (input.settingsSearchItems && input.settingsSearchItems.length > 0) {
+      searchableGroups.push({
+        value: "settings-search",
+        label: "Settings",
+        items: input.settingsSearchItems,
+      });
+    }
     if (input.threadSearchItems.length > 0) {
       searchableGroups.push({
         value: "threads-search",
@@ -334,14 +353,14 @@ export function filterCommandPaletteGroups(input: {
   return searchableGroups.flatMap((group) => {
     const items = Arr.filterMap(group.items, (item, index) => {
       const haystack = normalizeSearchText(item.searchTerms.join(" "));
-      if (!haystack.includes(normalizedQuery)) {
+      if (!queryTokens.every((token) => haystack.includes(token))) {
         return Result.failVoid;
       }
 
       return Result.succeed({
         item,
         index,
-        rank: rankCommandPaletteItemMatch(item, normalizedQuery),
+        rank: rankCommandPaletteItemMatch(item, normalizedQuery, queryTokens),
       });
     })
       .toSorted((left, right) => right.rank - left.rank || left.index - right.index)

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -32,7 +32,7 @@ import {
   type SourceControlRepositoryInfo,
   PRIMARY_LOCAL_ENVIRONMENT_ID,
 } from "@t3tools/contracts";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import * as Option from "effect/Option";
 import {
   ArrowLeftIcon,
@@ -104,6 +104,7 @@ import {
 } from "../lib/utils";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
+import { useAvailableSettingsSearchItems } from "./settings/useAvailableSettingsSearchItems";
 import {
   applyWslEnvironmentConfiguration,
   parseWslUncPath,
@@ -140,6 +141,7 @@ import { ProjectFavicon } from "./ProjectFavicon";
 import { ProjectFilePicker } from "./files/ProjectFilePicker";
 import { ProjectContentSearchDialog } from "./search/ProjectContentSearchDialog";
 import { toggleThemeEditorForTheme } from "./settings/themeEditorStore";
+import { searchSettings, SETTINGS_SECTION_LABELS } from "./settings/settingsSearch";
 import {
   COMMAND_PALETTE_META_ICON_CLASS,
   CommandPaletteMetaDot,
@@ -563,6 +565,7 @@ function OpenCommandPaletteDialog(props: {
   readonly clearOpenIntent: () => void;
 }) {
   const navigate = useNavigate();
+  const pathname = useLocation({ select: (location) => location.pathname });
   const { clearOpenIntent, openIntent, openOverlayMode, setOpen } = props;
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
@@ -585,6 +588,7 @@ function OpenCommandPaletteDialog(props: {
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const availableSettingsSearchItems = useAvailableSettingsSearchItems();
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
@@ -1637,7 +1641,19 @@ function OpenCommandPaletteDialog(props: {
     actionItems.push({
       kind: "action",
       value: "action:project-settings",
-      searchTerms: ["project", "settings", "scripts", "model", "grouping", "checkout"],
+      searchTerms: [
+        "project",
+        "settings",
+        "name",
+        "icon",
+        "scripts",
+        "model",
+        "workspace",
+        "grouping",
+        "checkout",
+        "remove",
+        "t3.json",
+      ],
       title: "Project settings",
       description: contextualProjectGroup.displayName,
       icon: <FolderIcon className={ITEM_ICON_CLASS} />,
@@ -1651,6 +1667,25 @@ function OpenCommandPaletteDialog(props: {
   }
 
   const rootGroups = buildRootGroups({ actionItems, recentThreadItems });
+  const settingsSearchItems: CommandPaletteActionItem[] = searchSettings(
+    deferredQuery,
+    availableSettingsSearchItems,
+  ).map((item) => ({
+    kind: "action",
+    value: `setting:${item.id}`,
+    searchTerms: [item.title, SETTINGS_SECTION_LABELS[item.to], ...(item.searchTerms ?? [])],
+    title: item.title,
+    description: `Settings · ${SETTINGS_SECTION_LABELS[item.to]}`,
+    icon: <SettingsIcon className={ITEM_ICON_CLASS} />,
+    run: async () => {
+      await navigate({
+        to: item.to,
+        hash: item.targetId ?? item.id,
+        replace: pathname === item.to,
+        hashScrollIntoView: false,
+      });
+    },
+  }));
   const sourceSelectionViewValue =
     addProjectEnvironmentId === null ? null : `sources:${addProjectEnvironmentId}`;
   const activeGroups =
@@ -1668,6 +1703,7 @@ function OpenCommandPaletteDialog(props: {
     query: deferredQuery,
     isInSubmenu: currentView !== null,
     projectSearchItems: projectSearchItems,
+    settingsSearchItems,
     threadSearchItems: allThreadItems,
   });
 

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1670,7 +1670,7 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
     <>
       {window.desktopBridge ? (
         <SettingsRow
-          title="T3 Connect"
+          title={searchableSetting("t3-connect").title}
           description={
             managedTunnelActive
               ? "This environment is available to your other devices through T3 Connect."
@@ -1688,7 +1688,7 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
         />
       ) : null}
       <SettingsRow
-        title="Publish agent activity"
+        title={searchableSetting("publish-agent-activity").title}
         description="Send activity from this environment to your mobile clients for push notifications and Live Activities. Works without a T3 Connect tunnel."
         control={
           <CloudLinkSwitch
@@ -2908,7 +2908,7 @@ export function ConnectionsSettings() {
 
   const renderTailscaleRow = () => (
     <SettingsRow
-      title="Tailscale HTTPS"
+      title={searchableSetting("tailscale-https").title}
       description={
         tailscaleHttpsEndpoint
           ? tailscaleHttpsEndpoint.status === "available"
@@ -2958,7 +2958,7 @@ export function ConnectionsSettings() {
   );
   const renderNetworkAccessRow = () => (
     <SettingsRow
-      title="Network access"
+      title={searchableSetting("network-access").title}
       description={
         isLocalBackendNetworkAccessible ? (
           <NetworkAccessDescription
@@ -2990,7 +2990,7 @@ export function ConnectionsSettings() {
   );
   const renderDisabledNetworkAccessRow = () => (
     <SettingsRow
-      title="Network access"
+      title={searchableSetting("network-access").title}
       description={
         currentAuthPolicy === "remote-reachable"
           ? "This backend is already configured for remote access. Network exposure changes must be made where the server is launched."
@@ -3022,7 +3022,7 @@ export function ConnectionsSettings() {
     <SettingsPageContainer>
       {canManageLocalBackend ? (
         <>
-          <SettingsSection title="This environment">
+          <SettingsSection {...searchableSetting("connections-environment")}>
             {primaryVersionMismatch || primaryServerUpdateState.status !== "idle" ? (
               <SettingsRow
                 title={
@@ -3377,7 +3377,7 @@ export function ConnectionsSettings() {
           </Dialog>
         </>
       ) : (
-        <SettingsSection title="This environment">
+        <SettingsSection {...searchableSetting("connections-environment")}>
           <SettingsRow
             title="Administrative access"
             description="Pairing links and client-session management require the access:write scope for this backend."

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -31,15 +31,29 @@ const settingsState = vi.hoisted(() => ({
   updateSettings: vi.fn(),
 }));
 
+const settingsSearchState = vi.hoisted(() => ({
+  targetId: null as string | null,
+  effects: [] as Array<() => void>,
+}));
+
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
   const { reactHookHarness } = await import("../../test/reactHookHarness");
   return {
     ...actual,
     useCallback: reactHookHarness.useCallback,
+    useEffect: (effect: () => void) => settingsSearchState.effects.push(effect),
     useMemo: reactHookHarness.useMemo,
     useRef: reactHookHarness.useRef,
     useState: reactHookHarness.useState,
+  };
+});
+
+vi.mock("./settingsLayout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./settingsLayout")>();
+  return {
+    ...actual,
+    useSettingsSearchTargetId: () => settingsSearchState.targetId,
   };
 });
 
@@ -131,6 +145,17 @@ function isAddProviderButton(element: ReactElement<Record<string, unknown>>): bo
   return element.props["aria-label"] === "Add provider";
 }
 
+function findAdvancedPanel(panel: ReactElement<Record<string, unknown>>) {
+  return visitElements(
+    panel,
+    (element) => element.props.className === "mt-1" && typeof element.props.open === "boolean",
+  );
+}
+
+function flushEffects(): void {
+  for (const effect of settingsSearchState.effects.splice(0)) effect();
+}
+
 async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -144,6 +169,8 @@ describe("EnvironmentProviderSettings routing", () => {
     settingsState.readEnvironmentIds = [];
     settingsState.updateEnvironmentIds = [];
     settingsState.updateSettings.mockReset();
+    settingsSearchState.targetId = null;
+    settingsSearchState.effects = [];
     commands.refresh.mockReset().mockResolvedValue({ _tag: "Success" });
     commands.updateProvider.mockReset().mockResolvedValue({ _tag: "Success" });
   });
@@ -233,6 +260,17 @@ describe("EnvironmentProviderSettings routing", () => {
       visitElements(panel, (element) => element.props["aria-label"] === "Refresh provider status"),
     ).not.toBeNull();
     expect(visitElements(panel, isAddProviderButton)).not.toBeNull();
+  });
+
+  it("opens Advanced when search targets the provider health interval", () => {
+    settingsSearchState.targetId = "provider-health-check-interval";
+    let panel = renderPanel();
+
+    expect(findAdvancedPanel(panel)?.props.open).toBe(false);
+    flushEffects();
+
+    panel = renderPanel();
+    expect(findAdvancedPanel(panel)?.props.open).toBe(true);
   });
 
   it("deletes and resets provider configuration without erasing shared preferences", () => {

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
+  isProviderSettingsEnvironmentAvailable,
   resolvePrimaryOperateAccess,
   resolveRemoteOperateAccess,
   resolveSelectedProviderEnvironmentId,
@@ -20,6 +21,27 @@ const environments = [
 ] as const;
 
 describe("provider environment selection", () => {
+  it("requires a connected environment with server config for searchable provider settings", () => {
+    expect(
+      isProviderSettingsEnvironmentAvailable({
+        connectionPhase: "connected",
+        hasServerConfig: true,
+      }),
+    ).toBe(true);
+    expect(
+      isProviderSettingsEnvironmentAvailable({
+        connectionPhase: "reconnecting",
+        hasServerConfig: true,
+      }),
+    ).toBe(false);
+    expect(
+      isProviderSettingsEnvironmentAvailable({
+        connectionPhase: "connected",
+        hasServerConfig: false,
+      }),
+    ).toBe(false);
+  });
+
   it("sorts the primary environment first and the rest by label", () => {
     expect(
       buildProviderEnvironmentOptions(environments, primaryId).map(

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
@@ -10,6 +10,13 @@ export interface ProviderEnvironmentOptionLike {
   readonly label: string;
 }
 
+export function isProviderSettingsEnvironmentAvailable(input: {
+  readonly connectionPhase: EnvironmentConnectionPhase;
+  readonly hasServerConfig: boolean;
+}): boolean {
+  return input.connectionPhase === "connected" && input.hasServerConfig;
+}
+
 export function buildProviderEnvironmentOptions<T extends ProviderEnvironmentOptionLike>(
   environments: ReadonlyArray<T>,
   primaryEnvironmentId: EnvironmentId | null,

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -33,7 +33,7 @@ import {
   RefreshCwIcon,
   TerminalIcon,
 } from "lucide-react";
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { isDesktopLocalConnectionTarget } from "../../connection/desktopLocal";
 import { isElectron } from "../../env";
@@ -93,10 +93,12 @@ import {
   SettingsRow,
   SettingsSection,
   useRelativeTimeTick,
+  useSettingsSearchTargetId,
 } from "./settingsLayout";
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
+  isProviderSettingsEnvironmentAvailable,
   type ProviderEnvironmentAccess,
   type ProviderOperateAccess,
   resolvePrimaryOperateAccess,
@@ -189,7 +191,7 @@ function EnvironmentUnavailableRow({
   // No spinner: this state can persist indefinitely for a wedged device, and a
   // continuously repainting animation would run the whole time.
   return (
-    <SettingsSection title="Providers">
+    <SettingsSection {...searchableSetting("providers")}>
       {deviceTabs}
       <SettingsRow title={title} description={description} />
     </SettingsSection>
@@ -197,8 +199,17 @@ function EnvironmentUnavailableRow({
 }
 
 export function ProviderSettingsPanel() {
+  return (
+    <SettingsPageContainer className="gap-8">
+      <ProviderSettingsPanelContent />
+    </SettingsPageContainer>
+  );
+}
+
+function ProviderSettingsPanelContent() {
   const { environments, isReady } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const searchTargetId = useSettingsSearchTargetId();
   const options = useMemo(
     () => buildProviderEnvironmentOptions(environments, primaryEnvironmentId),
     [environments, primaryEnvironmentId],
@@ -216,6 +227,27 @@ export function ProviderSettingsPanel() {
   );
   const selectedEnvironment =
     options.find((environment) => environment.environmentId === effectiveEnvironmentId) ?? null;
+  const selectedEnvironmentCanRenderSettings =
+    selectedEnvironment !== null &&
+    isProviderSettingsEnvironmentAvailable({
+      connectionPhase: selectedEnvironment.connection.phase,
+      hasServerConfig: selectedEnvironment.serverConfig !== null,
+    });
+  const searchableEnvironmentId = options.find((environment) =>
+    isProviderSettingsEnvironmentAvailable({
+      connectionPhase: environment.connection.phase,
+      hasServerConfig: environment.serverConfig !== null,
+    }),
+  )?.environmentId;
+  useEffect(() => {
+    if (
+      searchTargetId === searchableSetting("provider-health-check-interval").id &&
+      !selectedEnvironmentCanRenderSettings &&
+      searchableEnvironmentId !== undefined
+    ) {
+      setSelectedEnvironmentId(searchableEnvironmentId);
+    }
+  }, [searchTargetId, searchableEnvironmentId, selectedEnvironmentCanRenderSettings]);
   const onlyPrimaryDevice =
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
@@ -266,9 +298,9 @@ export function ProviderSettingsPanel() {
     ) : null;
 
   return (
-    <SettingsPageContainer className="gap-8">
+    <>
       {options.length === 0 ? (
-        <SettingsSection title="Providers">
+        <SettingsSection {...searchableSetting("providers")}>
           <SettingsRow
             title={isReady ? "No connected devices" : "Loading devices"}
             description={
@@ -287,7 +319,7 @@ export function ProviderSettingsPanel() {
           deviceTabs={deviceTabs}
         />
       ) : null}
-    </SettingsPageContainer>
+    </>
   );
 }
 
@@ -429,11 +461,18 @@ export function EnvironmentProviderSettings({
   const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
   const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const searchTargetId = useSettingsSearchTargetId();
   const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
     ReadonlySet<ProviderDriverKind>
   >(() => new Set());
   const refreshingRef = useRef(false);
   const updatingDriversRef = useRef<Set<ProviderDriverKind>>(new Set());
+
+  useEffect(() => {
+    if (searchTargetId === searchableSetting("provider-health-check-interval").id) {
+      setAdvancedOpen(true);
+    }
+  }, [searchTargetId]);
 
   const providerUpdateCandidates = useMemo(
     () => collectProviderUpdateCandidates(serverProviders),
@@ -915,9 +954,10 @@ export function EnvironmentProviderSettings({
                 className={readOnly ? "opacity-50 select-none" : undefined}
               >
                 <SettingsRow
+                  id={searchableSetting("provider-health-check-interval").id}
                   title={
                     <span className="inline-flex items-center gap-1.5">
-                      Health check interval
+                      {searchableSetting("provider-health-check-interval").title}
                       <PolicyTooltip>
                         This interval is configured here, then the shared Background activity policy
                         decides whether provider probes may run when the timer fires. Custom

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -790,7 +790,9 @@ function BackgroundActivityAdvancedDialog({
 
             <div className="flex flex-col gap-3 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="min-w-0 space-y-1">
-                <div className="text-sm font-medium">Git fetch interval</div>
+                <div className="text-sm font-medium">
+                  {searchableSetting("git-fetch-interval").title}
+                </div>
                 <p className="text-xs leading-relaxed text-muted-foreground">
                   Refresh remote branch status in the background.
                 </p>
@@ -2009,7 +2011,7 @@ export function GeneralSettingsPanel() {
         />
         {settings.sidebarAutoSettleAfterDays !== null ? (
           <SettingsRow
-            title="Days of inactivity before auto-settle"
+            title={searchableSetting("days-before-auto-settle").title}
             description="Any new activity un-settles a thread automatically."
             control={
               <AutoSettleDaysInput
@@ -2142,9 +2144,10 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          id={searchableSetting("background-activity").id}
           title={
             <span className="inline-flex items-center gap-1.5">
-              Background activity
+              {searchableSetting("background-activity").title}
               <PolicyTooltip>
                 This shared policy gates background work such as Git refreshes and provider health
                 probes after their individual intervals elapse.

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -7,8 +7,6 @@ import {
   type ComponentType,
   type KeyboardEvent,
 } from "react";
-import { useEnvironmentQuery } from "~/state/query";
-import { desktopWslStateAtom } from "~/state/desktopWslState";
 import {
   ArchiveIcon,
   BlocksIcon,
@@ -23,8 +21,6 @@ import {
 } from "lucide-react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 
-import { isElectron } from "~/env";
-import { isWslSettingsRowVisible } from "./ConnectionsSettings.logic";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd } from "../ui/kbd";
@@ -42,11 +38,11 @@ import { SidebarUtilityMenu } from "../sidebar/SidebarChrome";
 import { scrollToSettingsTarget } from "./settingsLayout";
 import {
   searchSettings,
-  SETTINGS_SEARCH_ITEMS,
   SETTINGS_SECTION_LABELS,
   type SettingsPath,
   type SettingsSearchItem,
 } from "./settingsSearch";
+import { useAvailableSettingsSearchItems } from "./useAvailableSettingsSearchItems";
 
 const SETTINGS_SECTION_ICONS: Readonly<
   Record<SettingsPath, ComponentType<{ className?: string }>>
@@ -83,18 +79,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [activeResultIndex, setActiveResultIndex] = useState(0);
-  const desktopWsl = useEnvironmentQuery(isElectron ? desktopWslStateAtom : null);
-  const searchableItems = useMemo(() => {
-    const wslState = desktopWsl.data;
-    const rowRenders = isWslSettingsRowVisible({
-      state: wslState,
-      error: desktopWsl.error,
-    });
-    if (rowRenders) {
-      return SETTINGS_SEARCH_ITEMS;
-    }
-    return SETTINGS_SEARCH_ITEMS.filter((item) => item.id !== "wsl-backend");
-  }, [desktopWsl.data, desktopWsl.error]);
+  const searchableItems = useAvailableSettingsSearchItems();
   const results = useMemo(() => searchSettings(query, searchableItems), [query, searchableItems]);
   const isSearching = query.trim().length > 0;
   const hasResults = results.length > 0;

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react";
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import type {
   BackgroundActivitySettings,
   SourceControlProviderKind,
@@ -59,7 +59,9 @@ import {
   PolicyTooltip,
   SettingResetButton,
   SettingsPageContainer,
+  SettingsSearchTarget,
   SettingsSection,
+  useSettingsSearchTargetId,
 } from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
 
@@ -267,6 +269,13 @@ function DiscoveryItemRow({
   const authAccount = auth ? optionLabel(auth.account) : null;
   const [isExpanded, setIsExpanded] = useState(false);
   const hasDetails = children !== undefined;
+  const searchTargetId = useSettingsSearchTargetId();
+
+  useEffect(() => {
+    if (item.kind === "git" && searchTargetId === searchableSetting("git-fetch-interval").id) {
+      setIsExpanded(true);
+    }
+  }, [item.kind, searchTargetId]);
 
   return (
     <div
@@ -345,13 +354,14 @@ function GitFetchIntervalSettings() {
   );
   const canResetFetchInterval =
     automaticGitFetchIntervalSeconds !== defaultAutomaticGitFetchIntervalSeconds;
+  const setting = searchableSetting("git-fetch-interval");
 
   return (
-    <div className="grid gap-3">
+    <SettingsSearchTarget id={setting.id} className="grid gap-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 space-y-1">
           <div className="flex min-w-0 items-center gap-1">
-            <span className="text-xs font-medium text-foreground">Fetch interval</span>
+            <span className="text-xs font-medium text-foreground">{setting.title}</span>
             <PolicyTooltip>
               This interval is configured for Git only. The shared Background activity policy still
               decides whether Git refreshes may run when the timer fires. Custom intervals appear as
@@ -407,7 +417,7 @@ function GitFetchIntervalSettings() {
           <span className="text-xs text-muted-foreground">seconds</span>
         </div>
       </div>
-    </div>
+    </SettingsSearchTarget>
   );
 }
 

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -21,6 +21,7 @@ import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../
 import { Switch } from "../ui/switch";
 import { Textarea } from "../ui/textarea";
 import { SettingResetButton, SettingsRow, SettingsSection } from "./settingsLayout";
+import { searchableSetting } from "./settingsSearch";
 
 const MODE_OPTIONS: Record<SourceControlWritingStyleMode, { label: string; description: string }> =
   {
@@ -73,7 +74,7 @@ export function SourceControlWritingSettingsSection() {
   return (
     <SettingsSection title="Text generation">
       <SettingsRow
-        title="Source control writing style"
+        {...searchableSetting("source-control-writing-style")}
         description={MODE_OPTIONS[style.mode].description}
         resetAction={
           isSourceControlWritingStyleDirty ? (
@@ -137,7 +138,7 @@ export function SourceControlWritingSettingsSection() {
       </SettingsRow>
 
       <SettingsRow
-        title="Follow change request templates"
+        {...searchableSetting("follow-change-request-templates")}
         description="Structures change request descriptions using the current repository's template when one is available."
         resetAction={
           style.followChangeRequestTemplates !== defaults.followChangeRequestTemplates ? (
@@ -169,7 +170,7 @@ export function SourceControlWritingSettingsSection() {
       />
 
       <SettingsRow
-        title="Source control writer model"
+        {...searchableSetting("source-control-writer-model")}
         description="Optional model override for change descriptions, change request titles and descriptions, and branch or bookmark names. Off uses the global text generation model."
         control={
           <div className="flex flex-wrap items-center justify-end gap-2">

--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -41,6 +41,7 @@ import { Button } from "../ui/button";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
 import { ThemeImportDialog } from "./ThemeImportDialog";
+import { searchableSetting } from "./settingsSearch";
 import { useThemeEditorStore } from "./themeEditorStore";
 import {
   STANDARD_THEME_CARDS,
@@ -892,11 +893,13 @@ export function ThemeLibrary({
         Choose how T3 Code looks. Use a built-in theme or make your own.
       </p>
       <h3 className="px-3 text-sm font-medium tracking-[-0.005em] text-foreground sm:px-4">
-        Color scheme
+        {searchableSetting("color-scheme").title}
       </h3>
       {renderModeTiles()}
       <div className="flex min-h-8 flex-wrap items-center justify-between gap-3 px-3 pt-2 sm:px-4">
-        <h3 className="text-sm font-medium tracking-[-0.005em] text-foreground">Themes</h3>
+        <h3 className="text-sm font-medium tracking-[-0.005em] text-foreground">
+          {searchableSetting("theme").title}
+        </h3>
         <div className="flex flex-wrap items-center justify-end gap-2">
           <Button
             size="xs"

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -84,6 +84,18 @@ function useSettingsSearchTarget<T extends HTMLElement>(id: string | undefined) 
   return targetRef;
 }
 
+export function SettingsSearchTarget({
+  children,
+  ...targetProps
+}: ComponentPropsWithoutRef<"div">) {
+  const targetRef = useSettingsSearchTarget<HTMLDivElement>(targetProps.id);
+  return (
+    <div {...targetProps} ref={targetRef} tabIndex={targetProps.id ? -1 : targetProps.tabIndex}>
+      {children}
+    </div>
+  );
+}
+
 /** Info affordance explaining how a setting interacts with the shared background policy. */
 export function PolicyTooltip({ children }: { readonly children: string }) {
   return (

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  filterAvailableSettingsSearchItems,
   searchableSetting,
   searchSettings,
   SETTINGS_SEARCH_ITEMS,
@@ -12,16 +13,19 @@ const ITEMS: ReadonlyArray<SettingsSearchItem> = [
     id: "word-wrap",
     title: "Word wrap",
     to: "/settings/general",
+    searchTerms: ["long lines in code previews"],
   },
   {
     id: "network-access",
     title: "Network access",
     to: "/settings/connections",
+    searchTerms: ["remote pairing backend"],
   },
   {
     id: "providers",
     title: "Providers",
     to: "/settings/providers",
+    searchTerms: ["claude codex agents"],
   },
   {
     id: "provider-updates",
@@ -36,16 +40,25 @@ const ITEMS: ReadonlyArray<SettingsSearchItem> = [
 ];
 
 describe("searchSettings", () => {
-  it("matches only setting titles", () => {
+  it("matches titles, sections, and remembered setting details", () => {
     expect(searchSettings("word", ITEMS).map((item) => item.id)).toEqual(["word-wrap"]);
     expect(searchSettings("network", ITEMS).map((item) => item.id)).toEqual(["network-access"]);
-    expect(searchSettings("connections", ITEMS)).toEqual([]);
-    expect(searchSettings("claude", ITEMS)).toEqual([]);
+    expect(searchSettings("connections", ITEMS).map((item) => item.id)).toEqual(["network-access"]);
+    expect(searchSettings("claude", ITEMS).map((item) => item.id)).toEqual(["providers"]);
+    expect(searchSettings("long lines", ITEMS).map((item) => item.id)).toEqual(["word-wrap"]);
   });
 
   it("matches normalized title substrings", () => {
     expect(searchSettings("  WORD   WRAP  ", ITEMS).map((item) => item.id)).toEqual(["word-wrap"]);
     expect(searchSettings("glass").map((item) => item.id)).toEqual(["setting-glass-opacity"]);
+    expect(searchSettings("thè\u{1ab0}mes")[0]?.id).toBe("theme");
+    const localeLowerCase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockReturnValue("gıt");
+    try {
+      expect(searchSettings("GIT")[0]?.id).toBe("git-fetch-interval");
+      expect(localeLowerCase).not.toHaveBeenCalled();
+    } finally {
+      localeLowerCase.mockRestore();
+    }
     expect(searchSettings("xyzzy")).toEqual([]);
   });
 
@@ -54,6 +67,27 @@ describe("searchSettings", () => {
       "provider-updates",
       "automatic-updates",
     ]);
+  });
+
+  it("matches query words across fields and ranks the strongest result first", () => {
+    expect(searchSettings("pairing remote", ITEMS).map((item) => item.id)).toEqual([
+      "network-access",
+    ]);
+    expect(
+      searchSettings("remote pairing")
+        .slice(0, 2)
+        .map((item) => item.id),
+    ).toEqual(["network-access", "connections-environment"]);
+  });
+
+  it("finds settings that used to be reachable only through their section", () => {
+    expect(searchSettings("pull request template")[0]?.id).toBe("follow-change-request-templates");
+    expect(searchSettings("git security keys")[0]?.id).toBe("git-fetch-interval");
+    expect(searchSettings("push notifications")[0]?.id).toBe("publish-agent-activity");
+    expect(searchSettings("battery saver")[0]?.id).toBe("background-activity");
+    expect(searchSettings("binary path")[0]?.id).toBe("providers");
+    expect(searchSettings("authorized clients")[0]?.id).toBe("connections-environment");
+    expect(searchSettings("administrative access")[0]?.id).toBe("connections-environment");
   });
 
   it("lists thread confirmations in panel order", () => {
@@ -74,14 +108,47 @@ describe("searchSettings", () => {
     expect(searchSettings("wsl")).toEqual([]);
   });
 
+  it("hides macOS-only settings on other platforms", () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    try {
+      expect(searchSettings("font smoothing")).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("registers the WSL backend as a desktop-only setting", () => {
-    expect(SETTINGS_SEARCH_ITEMS).toContainEqual({
+    expect(SETTINGS_SEARCH_ITEMS.find((item) => item.id === "wsl-backend")).toMatchObject({
       id: "wsl-backend",
       title: "WSL backend",
       to: "/settings/connections",
       desktopOnly: true,
       windowsOnly: true,
     });
+  });
+
+  it("hides settings whose controls are unavailable", () => {
+    const available = filterAvailableSettingsSearchItems({
+      hasCloudPublicConfig: false,
+      hasPrimaryEnvironment: false,
+      hasProviderSettingsEnvironment: false,
+      canManageLocalBackend: false,
+      isWslSettingsRowVisible: false,
+    });
+
+    const gatedIds = new Set<string>([
+      "follow-change-request-templates",
+      "git-fetch-interval",
+      "network-access",
+      "publish-agent-activity",
+      "provider-health-check-interval",
+      "source-control-writer-model",
+      "source-control-writing-style",
+      "t3-connect",
+      "tailscale-https",
+      "wsl-backend",
+    ]);
+    expect(available.map((item) => item.id).filter((id) => gatedIds.has(id))).toEqual([]);
   });
 
   it("keeps catalog result ids unique", () => {
@@ -111,10 +178,11 @@ describe("searchSettings", () => {
   });
 
   it("routes browser recording quality to integrations", () => {
-    expect(searchSettings("recording frame rate")[0]).toMatchObject({
+    const result = searchSettings("recording frame rate")[0];
+    expect(result).toMatchObject({
       id: "browser-recording-frame-rate",
       to: "/settings/integrations",
-      targetId: "browser",
     });
+    expect(result).not.toHaveProperty("targetId");
   });
 });

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -1,5 +1,5 @@
 import { isElectron } from "~/env";
-import { isWindowsPlatform } from "~/lib/utils";
+import { isMacPlatform, isWindowsPlatform, normalizeSearchText } from "~/lib/utils";
 
 export type SettingsPath =
   | "/settings/general"
@@ -16,12 +16,28 @@ export interface SettingsSearchItem {
   readonly title: string;
   readonly to: SettingsPath;
   readonly targetId?: string;
+  /** Descriptions, option labels, and aliases people may remember instead of the title. */
+  readonly searchTerms?: ReadonlyArray<string>;
   // Its row only renders in the desktop app, so a browser result would land on
   // an anchor that isn't there.
   readonly desktopOnly?: boolean;
+  readonly macOnly?: boolean;
   // Its row only renders on Windows desktop, so other desktop platforms must
   // not expose a result that points to a missing anchor.
   readonly windowsOnly?: boolean;
+  readonly cloudOnly?: boolean;
+  readonly primaryOnly?: boolean;
+  readonly providerSettingsOnly?: boolean;
+  readonly localBackendManagementOnly?: boolean;
+  readonly wslAvailableOnly?: boolean;
+}
+
+export interface SettingsSearchAvailability {
+  readonly hasCloudPublicConfig: boolean;
+  readonly hasPrimaryEnvironment: boolean;
+  readonly hasProviderSettingsEnvironment: boolean;
+  readonly canManageLocalBackend: boolean;
+  readonly isWslSettingsRowVisible: boolean;
 }
 
 /**
@@ -40,16 +56,16 @@ export const SETTINGS_SECTION_LABELS: Readonly<Record<SettingsPath, string>> = {
 };
 
 /**
- * Every searchable setting, in result order. This catalog is the single
- * source of truth for anchor ids and visible titles: panels render both via
- * `searchableSetting`, so a retitle (or, later, a translation pass) happens
- * here once instead of separately in the panel and the index.
+ * Searchable settings and stable destinations, in result order. Rows with a
+ * dedicated anchor render their id and title via `searchableSetting`; items
+ * that may not be mounted point at their nearest stable section instead.
  */
 export const SETTINGS_SEARCH_ITEMS = [
   {
     id: "color-scheme",
     title: "Color scheme",
     to: "/settings/appearance",
+    searchTerms: ["appearance light dark system mode"],
     // The scheme tiles sit at the top of the Appearance section.
     targetId: "appearance",
   },
@@ -57,6 +73,7 @@ export const SETTINGS_SEARCH_ITEMS = [
     id: "theme",
     title: "Themes",
     to: "/settings/appearance",
+    searchTerms: ["appearance colors palette custom import"],
     // Theme cards live directly under the scheme tiles; the section is the
     // stable scroll destination for both.
     targetId: "appearance",
@@ -66,17 +83,20 @@ export const SETTINGS_SEARCH_ITEMS = [
     id: "setting-appearance-contrast",
     title: "Contrast",
     to: "/settings/appearance",
+    searchTerms: ["colors borders interface"],
   },
   {
     // Prefixed because the slider control already owns the `glass-opacity` id.
     id: "setting-glass-opacity",
     title: "Glass opacity",
     to: "/settings/appearance",
+    searchTerms: ["transparent transparency solid menus dialogs composer"],
   },
   {
     id: "environment-identification",
     title: "Environment identification",
     to: "/settings/appearance",
+    searchTerms: ["dev nightly artwork pill label hide none"],
     // The setting is stage-dependent, so its parent section is the stable destination.
     targetId: "appearance",
   },
@@ -84,204 +104,339 @@ export const SETTINGS_SEARCH_ITEMS = [
     id: "interface-font",
     title: "Interface font",
     to: "/settings/appearance",
+    searchTerms: ["typography family size system sans"],
   },
   {
     id: "prompt-font",
     title: "Prompt font",
     to: "/settings/appearance",
+    searchTerms: ["typography family size composer input"],
   },
   {
     id: "code-font",
     title: "Code font",
     to: "/settings/appearance",
+    searchTerms: ["typography family size monospace code blocks diffs file previews"],
   },
   {
     id: "terminal-font",
     title: "Terminal font",
     to: "/settings/appearance",
+    searchTerms: ["typography family size monospace output"],
   },
   {
     id: "font-smoothing",
     title: "Font smoothing",
     to: "/settings/appearance",
+    searchTerms: ["typography text grayscale anti aliasing macos thin"],
+    macOnly: true,
   },
   {
     id: "word-wrap",
     title: "Word wrap",
     to: "/settings/appearance",
+    searchTerms: ["long lines code blocks tables diffs file previews"],
   },
   {
     id: "project-grouping",
     title: "Project grouping",
     to: "/settings/general",
+    searchTerms: ["combine matching repositories environments sidebar"],
   },
   {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",
+    searchTerms: ["sidebar inactivity days no activity automatically"],
   },
   {
     id: "auto-settle-merged-threads",
     title: "Auto-settle merged threads",
     to: "/settings/general",
+    searchTerms: ["pull request merge closed automatically sidebar"],
+  },
+  {
+    id: "days-before-auto-settle",
+    title: "Days of inactivity before auto-settle",
+    to: "/settings/general",
+    targetId: "auto-settle-inactive-threads",
+    searchTerms: ["thread timeout activity sidebar"],
   },
   {
     id: "time-format",
     title: "Time format",
     to: "/settings/general",
+    searchTerms: ["timestamp clock locale system browser os 12 hour 24 hour"],
   },
   {
     id: "hide-whitespace-changes",
     title: "Hide whitespace changes",
     to: "/settings/general",
+    searchTerms: ["diff ignore spaces edits default"],
   },
   {
     id: "skills-in-slash-menu",
     title: "Show skills in slash menu",
     to: "/settings/general",
+    searchTerms: ["command menu dollar $ slash /"],
   },
   {
     id: "provider-update-checks",
     title: "Provider update checks",
     to: "/settings/general",
+    searchTerms: ["installed cli versions newer available codex claude cursor grok opencode"],
+  },
+  {
+    id: "background-activity",
+    title: "Background activity",
+    to: "/settings/general",
+    searchTerms: [
+      "balanced performance battery saver advanced git fetch provider health refresh host power monitor idle policy",
+    ],
   },
   {
     id: "new-threads",
     title: "New threads",
     to: "/settings/general",
+    searchTerms: ["default workspace mode draft local worktree"],
   },
   {
     id: "start-from-origin",
     title: "Start from origin",
     to: "/settings/general",
     targetId: "new-threads",
+    searchTerms: ["new worktrees latest matching remote branch local"],
   },
   {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",
+    searchTerms: ["base directory folder browser path home"],
   },
   {
     id: "unpin-confirmation",
     title: "Unpin confirmation",
     to: "/settings/general",
+    searchTerms: ["ask before thread pinned section"],
   },
   {
     id: "archive-confirmation",
     title: "Archive confirmation",
     to: "/settings/general",
+    searchTerms: ["ask before thread second click inline action"],
   },
   {
     id: "delete-confirmation",
     title: "Delete confirmation",
     to: "/settings/general",
+    searchTerms: ["ask before thread chat history"],
   },
   {
     id: "quit-confirmation",
     title: "Hold to quit",
     to: "/settings/general",
+    searchTerms: ["confirmation shortcut desktop app exit"],
     desktopOnly: true,
   },
   {
     id: "text-generation-model",
     title: "Text generation model",
     to: "/settings/general",
+    searchTerms: ["generated thread titles source control content default provider"],
   },
   {
     id: "diagnostics",
     title: "Diagnostics",
     to: "/settings/general",
+    searchTerms: ["logs traces processes resource history failures spans cpu memory"],
   },
   {
     id: "legacy-plan-mode",
     title: "Plan mode (legacy)",
     to: "/settings/general",
+    searchTerms: ["build plan composer old"],
   },
   {
     id: "legacy-token-streaming",
     title: "Stream token by token (legacy)",
     to: "/settings/general",
+    searchTerms: ["response output old compatibility"],
   },
   {
     id: "legacy-sidebar",
     title: "Sidebar (legacy)",
     to: "/settings/general",
+    searchTerms: ["project thread tree old flat list"],
   },
   {
     id: "keybindings",
     title: "Keybindings",
     to: "/settings/keybindings",
+    searchTerms: ["keyboard shortcuts hotkeys commands bindings json"],
   },
   {
     id: "providers",
     title: "Providers",
     to: "/settings/providers",
+    searchTerms: [
+      "agents cli codex claude cursor grok opencode instances authentication api key models configuration binary path config directory endpoint arguments environment variables display name accent color custom favorite hidden auto compact",
+    ],
+  },
+  {
+    id: "provider-health-check-interval",
+    title: "Health check interval",
+    to: "/settings/providers",
+    searchTerms: ["refresh availability versions auth state models background probes seconds off"],
+    providerSettingsOnly: true,
   },
   {
     id: "agent-browser-access",
     title: "Agent browser access",
     to: "/settings/integrations",
-    targetId: "browser",
+    searchTerms: ["allow open drive preview tools sessions"],
   },
   {
     id: "browser-default-viewport",
     title: "Default browser viewport",
     to: "/settings/integrations",
-    targetId: "browser",
+    searchTerms: ["preview size width height device desktop mobile rotate"],
   },
   {
     id: "browser-default-zoom",
     title: "Default browser zoom",
     to: "/settings/integrations",
-    targetId: "browser",
+    searchTerms: ["preview page scale tabs percent"],
   },
   {
     id: "browser-default-appearance",
     title: "Default browser appearance",
     to: "/settings/integrations",
-    targetId: "browser",
+    searchTerms: ["preview color scheme light dark system os"],
   },
   {
     id: "browser-recording-frame-rate",
     title: "Browser recording frame rate",
     to: "/settings/integrations",
-    targetId: "browser",
   },
   {
     id: "browser-auto-show-floating-preview",
     title: "Auto-show floating preview",
     to: "/settings/integrations",
-    targetId: "browser",
+    searchTerms: ["agent opens browser pop into view hide"],
   },
   {
     id: "source-control",
     title: "Source control",
     to: "/settings/source-control",
+    searchTerms: [
+      "version control git github gitlab bitbucket azure devops hosting integrations credentials scan server environment",
+    ],
   },
   {
-    id: "remote-environments",
-    title: "Remote environments",
+    id: "git-fetch-interval",
+    title: "Git fetch interval",
+    to: "/settings/source-control",
+    searchTerms: [
+      "automatic remote branch refresh background credentials security keys seconds off",
+    ],
+    primaryOnly: true,
+  },
+  {
+    id: "source-control-writing-style",
+    title: "Source control writing style",
+    to: "/settings/source-control",
+    searchTerms: [
+      "repository conventions conventional commits custom instructions change descriptions request titles",
+    ],
+    primaryOnly: true,
+  },
+  {
+    id: "follow-change-request-templates",
+    title: "Follow change request templates",
+    to: "/settings/source-control",
+    searchTerms: ["repository pr pull request description structure"],
+    primaryOnly: true,
+  },
+  {
+    id: "source-control-writer-model",
+    title: "Source control writer model",
+    to: "/settings/source-control",
+    searchTerms: [
+      "override generated commit change request pr titles descriptions branch bookmark",
+    ],
+    primaryOnly: true,
+  },
+  {
+    id: "network-access",
+    title: "Network access",
     to: "/settings/connections",
+    targetId: "connections-environment",
+    searchTerms: ["expose backend remote pairing local machine interfaces host restart"],
+    localBackendManagementOnly: true,
+  },
+  {
+    id: "tailscale-https",
+    title: "Tailscale HTTPS",
+    to: "/settings/connections",
+    targetId: "connections-environment",
+    searchTerms: ["serve magicdns endpoint remote secure network"],
+    desktopOnly: true,
+    localBackendManagementOnly: true,
   },
   {
     id: "wsl-backend",
     title: "WSL backend",
     to: "/settings/connections",
+    searchTerms: [
+      "windows subsystem linux distro second server projects stop windows backend restart",
+    ],
     desktopOnly: true,
     windowsOnly: true,
+    localBackendManagementOnly: true,
+    wslAvailableOnly: true,
+  },
+  {
+    id: "t3-connect",
+    title: "T3 Connect",
+    to: "/settings/connections",
+    targetId: "connections-environment",
+    searchTerms: ["managed tunnel cloud other devices remote"],
+    desktopOnly: true,
+    cloudOnly: true,
+  },
+  {
+    id: "publish-agent-activity",
+    title: "Publish agent activity",
+    to: "/settings/connections",
+    targetId: "connections-environment",
+    searchTerms: ["mobile push notifications live activities cloud tunnel"],
+    cloudOnly: true,
+  },
+  {
+    id: "connections-environment",
+    title: "This environment",
+    to: "/settings/connections",
+    searchTerms: [
+      "connections server backend local remote access administrative permissions scope pairing links qr code authorized clients sessions revoke endpoint",
+    ],
+  },
+  {
+    id: "remote-environments",
+    title: "Remote environments",
+    to: "/settings/connections",
+    searchTerms: ["add pair backend host code ssh config agent tunnel saved t3 connect"],
   },
   {
     id: "archive",
     title: "Archived threads",
     to: "/settings/archived",
+    searchTerms: ["restore reopen deleted history projects"],
   },
 ] as const satisfies ReadonlyArray<SettingsSearchItem>;
 
 export type SettingsSearchItemId = (typeof SETTINGS_SEARCH_ITEMS)[number]["id"];
 
-const SEARCH_ITEMS_BY_ID = Object.fromEntries(
-  SETTINGS_SEARCH_ITEMS.map((item) => [item.id, item]),
-) as Readonly<Record<SettingsSearchItemId, SettingsSearchItem>>;
+const SEARCH_ITEMS_BY_ID = new Map(SETTINGS_SEARCH_ITEMS.map((item) => [item.id, item] as const));
 
 /**
  * `id` and `title` props for the element a search item anchors to. Panels
@@ -292,17 +447,22 @@ export function searchableSetting(id: SettingsSearchItemId): {
   readonly id: string;
   readonly title: string;
 } {
-  const { id: anchorId, title } = SEARCH_ITEMS_BY_ID[id];
+  const { id: anchorId, title } = SEARCH_ITEMS_BY_ID.get(id)!;
   return { id: anchorId, title };
 }
 
-function normalizeSearchText(value: string): string {
-  return value
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLocaleLowerCase()
-    .replace(/\s+/g, " ")
-    .trim();
+export function filterAvailableSettingsSearchItems(
+  availability: SettingsSearchAvailability,
+): ReadonlyArray<SettingsSearchItem> {
+  const items: ReadonlyArray<SettingsSearchItem> = SETTINGS_SEARCH_ITEMS;
+  return items.filter(
+    (item) =>
+      (!item.cloudOnly || availability.hasCloudPublicConfig) &&
+      (!item.primaryOnly || availability.hasPrimaryEnvironment) &&
+      (!item.providerSettingsOnly || availability.hasProviderSettingsEnvironment) &&
+      (!item.localBackendManagementOnly || availability.canManageLocalBackend) &&
+      (!item.wslAvailableOnly || availability.isWslSettingsRowVisible),
+  );
 }
 
 export function searchSettings(
@@ -311,12 +471,38 @@ export function searchSettings(
 ): ReadonlyArray<SettingsSearchItem> {
   const normalizedQuery = normalizeSearchText(query);
   if (normalizedQuery.length === 0) return [];
+  const queryTokens = normalizedQuery.split(" ");
+  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
 
-  return items.filter(
-    (item) =>
-      (isElectron || item.desktopOnly !== true) &&
-      (!item.windowsOnly ||
-        isWindowsPlatform(typeof navigator === "undefined" ? "" : navigator.platform)) &&
-      normalizeSearchText(item.title).includes(normalizedQuery),
-  );
+  return items
+    .flatMap((item, index) => {
+      if (!isElectron && item.desktopOnly === true) return [];
+      if (item.macOnly && !isMacPlatform(platform)) return [];
+      if (item.windowsOnly && !isWindowsPlatform(platform)) return [];
+
+      const title = normalizeSearchText(item.title);
+      const fields = [
+        title,
+        normalizeSearchText(SETTINGS_SECTION_LABELS[item.to]),
+        ...(item.searchTerms ?? []).map(normalizeSearchText),
+      ];
+      if (!queryTokens.every((token) => fields.some((field) => field.includes(token)))) return [];
+
+      const exactPhraseField = fields.findIndex((field) => field.includes(normalizedQuery));
+      const rank =
+        title === normalizedQuery
+          ? 5
+          : title.startsWith(normalizedQuery)
+            ? 4
+            : title.includes(normalizedQuery)
+              ? 3
+              : queryTokens.every((token) => title.includes(token))
+                ? 2
+                : exactPhraseField >= 0
+                  ? 1
+                  : 0;
+      return [{ item, index, rank }];
+    })
+    .toSorted((left, right) => right.rank - left.rank || left.index - right.index)
+    .map(({ item }) => item);
 }

--- a/apps/web/src/components/settings/useAvailableSettingsSearchItems.ts
+++ b/apps/web/src/components/settings/useAvailableSettingsSearchItems.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { AuthAccessWriteScope } from "@t3tools/contracts";
+
+import { hasCloudPublicConfig } from "~/cloud/publicConfig";
+import { isElectron } from "~/env";
+import { desktopWslStateAtom } from "~/state/desktopWslState";
+import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
+import { useEnvironmentQuery } from "~/state/query";
+import { usePrimarySessionState } from "~/environments/primary";
+import { isWslSettingsRowVisible } from "./ConnectionsSettings.logic";
+import { isProviderSettingsEnvironmentAvailable } from "./ProviderSettingsPanel.logic";
+import { filterAvailableSettingsSearchItems } from "./settingsSearch";
+
+export function useAvailableSettingsSearchItems() {
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const { environments } = useEnvironments();
+  const primarySessionState = usePrimarySessionState();
+  const desktopWsl = useEnvironmentQuery(isElectron ? desktopWslStateAtom : null);
+  const canManageLocalBackend =
+    isElectron ||
+    ((primarySessionState.data?.authenticated &&
+      primarySessionState.data.scopes?.includes(AuthAccessWriteScope)) ??
+      false);
+
+  return useMemo(
+    () =>
+      filterAvailableSettingsSearchItems({
+        hasCloudPublicConfig: hasCloudPublicConfig(),
+        hasPrimaryEnvironment: primaryEnvironmentId !== null,
+        hasProviderSettingsEnvironment: environments.some((environment) =>
+          isProviderSettingsEnvironmentAvailable({
+            connectionPhase: environment.connection.phase,
+            hasServerConfig: environment.serverConfig !== null,
+          }),
+        ),
+        canManageLocalBackend,
+        isWslSettingsRowVisible: isWslSettingsRowVisible({
+          state: desktopWsl.data,
+          error: desktopWsl.error,
+        }),
+      }),
+    [canManageLocalBackend, desktopWsl.data, desktopWsl.error, environments, primaryEnvironmentId],
+  );
+}

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -20,6 +20,10 @@ export function isLinuxPlatform(platform: string): boolean {
   return /linux/i.test(platform);
 }
 
+export function normalizeSearchText(value: string): string {
+  return value.normalize("NFKD").replace(/\p{M}/gu, "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
 export function getLocalFileManagerName(platform: string): string {
   if (isMacPlatform(platform)) {
     return "Finder";

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -59,10 +59,11 @@ shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
 already pinned. Its default shortcut is `mod+shift+p`, and it does not run while the terminal has
 focus. See [Organizing threads](./thread-sidebar.md) for how pinned threads are ordered.
 
-The command palette searches active thread titles, projects, branches, user messages, and final
-agent responses across connected environments. Message matches show one labeled excerpt while
-keeping the thread's project, branch, and machine context visible. Message search begins after two
-characters and uses SQLite's ASCII case-insensitive matching.
+The command palette searches settings, active thread titles, projects, branches, user messages, and
+final agent responses across connected environments. A setting result opens its exact control or
+section. Message matches show one labeled excerpt while keeping the thread's project, branch, and
+machine context visible. Message search begins after two characters and uses SQLite's ASCII
+case-insensitive matching.
 
 The full command list and the current defaults are shown in **Settings** → **Keybindings**, which
 always matches the build you are running. Use that rather than a copied list.


### PR DESCRIPTION
Settings search now matches individual setting titles, section names, and detailed keywords, with token-aware ranking for live results. The command palette uses the same availability-filtered catalog and opens the exact rendered row.

Validation: 65 focused unit tests, web typecheck, lint, formatting, and live browser passes for "pull request template", "default browser zoom", "administrative access", and "git fetch interval" at their exact destinations. The shared preview capture endpoint is unavailable, so the requested recording is still pending.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global search/navigation and can change the selected provider environment when deep-linking; behavior is well-tested but affects a high-traffic UX path.
> 
> **Overview**
> Adds **settings-aware search** to the command palette and upgrades the settings sidebar search to use the same catalog, ranking, and availability rules.
> 
> **Search behavior** now matches across setting titles, section names, and `searchTerms` aliases using **order-independent tokens**, **accent-insensitive** normalization (`normalizeSearchText` in shared `utils`), and stronger ranking (exact title beats split keyword matches). Command palette filtering uses the same token logic for projects, threads, and the new **Settings** result group.
> 
> **Catalog & gating**: `SETTINGS_SEARCH_ITEMS` grows with per-item keywords and flags (`cloudOnly`, `primaryOnly`, `providerSettingsOnly`, etc.). `useAvailableSettingsSearchItems` / `filterAvailableSettingsSearchItems` hide rows the UI cannot show (platform, WSL, permissions, connection state) instead of ad hoc WSL filtering in the sidebar.
> 
> **Deep links**: Selecting a setting navigates to the right panel with a hash anchor; panels pull titles/ids from `searchableSetting`. Collapsed targets (e.g. provider **Advanced**, Git fetch interval) **auto-expand** when opened from search; provider health-interval search may **switch** to the first connected environment that can render provider settings.
> 
> User docs note that ⌘K now searches settings and jumps to the control or section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c45550ba3928d1ae43e501d4b4449817431bca43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add individual settings search with deep-linking to command palette
> - Adds accent-insensitive, locale-independent text normalization via shared `normalizeSearchText` in [utils.ts](https://github.com/pingdotgg/t3code/pull/8831/files#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767); command palette and settings search both consume it
> - Settings search now tokenizes queries and requires all tokens to match across title, section, and `searchTerms`; ranking favors exact, prefix, and substring matches
> - Enriches the `SETTINGS_SEARCH_ITEMS` catalog with `searchTerms`, platform/session gating flags (`macOnly`, `cloudOnly`, `providerSettingsOnly`, etc.), and stable ids for deep-link anchors
> - New `SettingsSearchTarget` component and `useSettingsSearchTargetId` hook let panels auto-scroll, focus, and expand the matching control when navigated from search results
> - Many settings panels (`ConnectionsSettings`, `ProviderSettingsPanel`, `SourceControlSettings`, `ThemeSettings`, etc.) now source titles/ids from `searchableSetting()` for catalog consistency
> - Behavioral Change: `rankSearchFieldMatch` returns `0` instead of `1` when tokens match but the full query is not a substring; settings that do not contain every query token are now filtered out
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c45550b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Built by `gpt-5.6-sol` using the Codex harness.