### PR TITLE
fix(server): avoid treating Ubuntu binaries as Homebrew-managed

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -332,6 +332,21 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("does not treat an Ubuntu /usr/local/bin executable as Homebrew-managed", () => {
+    expect(
+      packageToolUpdate.resolve({
+        binaryPath: "/usr/local/bin/package-tool",
+        env: {
+          PATH: "",
+        },
+      }),
+    ).toEqual({
+      provider: driver("packageTool"),
+      packageName: "@example/package-tool",
+      update: null,
+    });
+  });
+
   it.effect(
     "switches native-package-tool to native updates when the binary resolves through the native installer",
     () =>

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -268,8 +268,7 @@ function isHomebrewCommandPath(commandPath: string): boolean {
     normalized.includes("/opt/homebrew/caskroom/") ||
     normalized.includes("/usr/local/caskroom/") ||
     normalized.includes("/homebrew/caskroom/") ||
-    normalized.startsWith("/opt/homebrew/bin/") ||
-    normalized.startsWith("/usr/local/bin/")
+    normalized.startsWith("/opt/homebrew/bin/")
   );
 }
 


### PR DESCRIPTION
## What Changed

- Stop treating every provider executable under `/usr/local/bin` as Homebrew-managed.
- Add regression coverage for an Ubuntu provider installed at `/usr/local/bin`.
- Continue recognizing Homebrew through `/opt/homebrew/bin` and resolved Cellar or Caskroom paths.

## Why

The provider update detection added in [#2312](https://github.com/pingdotgg/t3code/pull/2312) treats `/usr/local/bin` as a Homebrew-specific location. However, `/usr/local/bin` is a generic local installation prefix on Ubuntu and other Unix systems. This can cause T3 Code to offer a `brew upgrade` action for provider installations that Homebrew does not manage.

Removing the generic `/usr/local/bin` match fixes the classification without breaking Intel Mac Homebrew installations. T3 Code resolves the executable’s real path, so `/usr/local/Cellar` and `/usr/local/Caskroom` targets remain recognized.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-5.6 Sol  
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small heuristic change in provider update routing with targeted test coverage; no auth or data handling impact.
> 
> **Overview**
> **Provider maintenance** no longer classifies executables under **`/usr/local/bin`** as Homebrew-managed, so Linux installs in that generic prefix are not offered **`brew upgrade`** one-click updates.
> 
> Homebrew detection still uses **`/opt/homebrew/bin`** plus resolved **Cellar** and **Caskroom** paths (including **`/usr/local/cellar`** and **`/usr/local/caskroom`** on Intel Mac). A regression test asserts a provider at **`/usr/local/bin/package-tool`** resolves with **`update: null`** instead of a brew command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c207c08042285362e5b4e10c264b41f1089fcf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isHomebrewCommandPath` to not treat `/usr/local/bin` as Homebrew-managed
> Removes the condition in [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/8832/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14) that classified any path under `/usr/local/bin/` as Homebrew-managed. The function still detects Homebrew via cellar/caskroom paths and `/opt/homebrew/bin/`. Adds a test case in [providerMaintenance.test.ts](https://github.com/pingdotgg/t3code/pull/8832/files#diff-40e44f8465f8c4e465f1d73d81229b1ff72980f8fa6e6711363d9ef9c1fb54ad) covering an Ubuntu `/usr/local/bin` binary with an empty PATH.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c207c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->