### PR TITLE
fix(server): route provider turns without thread history

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -150,6 +150,7 @@ describe("ProviderCommandReactor", () => {
     readonly requiresNewThreadForModelChange?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly failThreadDetailReads?: boolean;
     readonly interruptTurnEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly stopSessionEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly startSessionEffect?: (
@@ -373,6 +374,20 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(RepositoryIdentityResolver.layer),
       Layer.provide(SqlitePersistenceMemory),
     );
+    const reactorProjectionSnapshotLayer =
+      input?.failThreadDetailReads === true
+        ? Layer.effect(
+            ProjectionSnapshotQuery,
+            Effect.gen(function* () {
+              const query = yield* ProjectionSnapshotQuery;
+              return ProjectionSnapshotQuery.of({
+                ...query,
+                getThreadDetailById: () =>
+                  Effect.die("provider turn routing must not hydrate thread detail"),
+              });
+            }),
+          ).pipe(Layer.provide(projectionSnapshotLayer))
+        : projectionSnapshotLayer;
     let titleRegenerationCompletionDispatchAttempts = 0;
     const reactorOrchestrationLayer = Layer.effect(
       OrchestrationEngineService,
@@ -401,7 +416,7 @@ describe("ProviderCommandReactor", () => {
     ).pipe(Layer.provide(orchestrationLayer));
     const layer = ProviderCommandReactorLive.pipe(
       Layer.provideMerge(reactorOrchestrationLayer),
-      Layer.provideMerge(projectionSnapshotLayer),
+      Layer.provideMerge(reactorProjectionSnapshotLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
       Layer.provideMerge(makeProviderRegistryLayer(providerSnapshots as never)),
       Layer.provideMerge(
@@ -428,6 +443,7 @@ describe("ProviderCommandReactor", () => {
       ),
       Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
+      Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -567,6 +583,34 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
   });
+
+  effectIt.effect("routes a provider turn without hydrating thread detail history", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness({ failThreadDetailReads: true }));
+      const now = "2026-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-without-detail"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-without-detail"),
+          role: "user",
+          text: "route without thread history",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+
+      yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
+      expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+        threadId: ThreadId.make("thread-1"),
+        input: "route without thread history",
+      });
+    }),
+  );
 
   effectIt.effect("projects starting before a slow provider session finishes", () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -31,6 +31,8 @@ import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
+import { ProjectionThreadMessageRepository } from "../../persistence/Services/ProjectionThreadMessages.ts";
+import { ProjectionThreadMessageRepositoryLive } from "../../persistence/Layers/ProjectionThreadMessages.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
@@ -306,6 +308,7 @@ const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const orchestrationEngine = yield* OrchestrationEngineService;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+  const projectionThreadMessages = yield* ProjectionThreadMessageRepository;
   const providerService = yield* ProviderService;
   const providerRegistry = yield* ProviderRegistry;
   const gitWorkflow = yield* GitWorkflowService;
@@ -404,7 +407,7 @@ const make = Effect.gen(function* () {
     readonly detail: string;
     readonly createdAt: string;
   }) {
-    const thread = yield* resolveThread(input.threadId);
+    const thread = yield* resolveThreadShell(input.threadId);
     if (!thread) {
       return;
     }
@@ -479,7 +482,13 @@ const make = Effect.gen(function* () {
     );
   });
 
-  const resolveThread = Effect.fnUntraced(function* (threadId: ThreadId) {
+  const resolveThreadShell = Effect.fnUntraced(function* (threadId: ThreadId) {
+    return yield* projectionSnapshotQuery
+      .getThreadShellById(threadId)
+      .pipe(Effect.map(Option.getOrUndefined));
+  });
+
+  const resolveThreadDetail = Effect.fnUntraced(function* (threadId: ThreadId) {
     return yield* projectionSnapshotQuery
       .getThreadDetailById(threadId)
       .pipe(Effect.map(Option.getOrUndefined));
@@ -525,7 +534,7 @@ const make = Effect.gen(function* () {
       readonly pendingTurnStart?: boolean;
     },
   ) {
-    const thread = yield* resolveThread(threadId);
+    const thread = yield* resolveThreadShell(threadId);
     if (!thread) {
       return yield* Effect.die(new Error(`Thread '${threadId}' was not found in read model.`));
     }
@@ -780,7 +789,7 @@ const make = Effect.gen(function* () {
     readonly interactionMode?: "default" | "plan";
     readonly createdAt: string;
   }) {
-    const thread = yield* resolveThread(input.threadId);
+    const thread = yield* resolveThreadShell(input.threadId);
     if (!thread) {
       return yield* Effect.die(
         new Error(`Thread '${input.threadId}' was not found in read model.`),
@@ -921,7 +930,7 @@ const make = Effect.gen(function* () {
           );
         if (!generated) return;
 
-        const thread = yield* resolveThread(input.threadId);
+        const thread = yield* resolveThreadShell(input.threadId);
         if (!thread) return;
         if (!canReplaceThreadTitle(thread.title, input.titleSeed)) {
           return;
@@ -953,7 +962,7 @@ const make = Effect.gen(function* () {
       return { _tag: "Superseded" } as const;
     }
 
-    const thread = yield* resolveThread(event.payload.threadId);
+    const thread = yield* resolveThreadDetail(event.payload.threadId);
     if (!thread || thread.titleRegeneration?.requestId !== requestId) {
       return { _tag: "Superseded" } as const;
     }
@@ -986,7 +995,7 @@ const make = Effect.gen(function* () {
       return { _tag: "Completed", title: undefined } as const;
     }
 
-    const latestThread = yield* resolveThread(event.payload.threadId);
+    const latestThread = yield* resolveThreadDetail(event.payload.threadId);
     if (
       !latestThread ||
       latestThread.titleRegeneration?.requestId !== requestId ||
@@ -1123,13 +1132,16 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const thread = yield* resolveThread(event.payload.threadId);
+    const thread = yield* resolveThreadShell(event.payload.threadId);
     if (!thread) {
       return;
     }
 
-    const message = thread.messages.find((entry) => entry.id === event.payload.messageId);
-    if (!message || message.role !== "user") {
+    const turnStartContext = yield* projectionThreadMessages.getTurnStartContext({
+      threadId: event.payload.threadId,
+      messageId: event.payload.messageId,
+    });
+    if (Option.isNone(turnStartContext) || turnStartContext.value.message.role !== "user") {
       yield* appendProviderFailureActivity({
         threadId: event.payload.threadId,
         kind: "provider.turn.start.failed",
@@ -1140,11 +1152,11 @@ const make = Effect.gen(function* () {
       });
       return;
     }
+    const { message, userMessageCount } = turnStartContext.value;
 
     yield* ensureThreadWorktree(thread);
 
-    const isFirstUserMessageTurn =
-      thread.messages.filter((entry) => entry.role === "user").length === 1;
+    const isFirstUserMessageTurn = userMessageCount === 1;
     if (isFirstUserMessageTurn) {
       const project = yield* resolveProject(thread.projectId);
       const generationCwd =
@@ -1236,7 +1248,7 @@ const make = Effect.gen(function* () {
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-interrupt-requested" }>,
   ) {
-    const thread = yield* resolveThread(event.payload.threadId);
+    const thread = yield* resolveThreadShell(event.payload.threadId);
     if (!thread) {
       return;
     }
@@ -1259,7 +1271,7 @@ const make = Effect.gen(function* () {
 
       const detail = formatFailureDetail(cause);
       return Effect.gen(function* () {
-        const latestThread = yield* resolveThread(event.payload.threadId);
+        const latestThread = yield* resolveThreadShell(event.payload.threadId);
         const latestSession = latestThread?.session;
         if (
           !latestSession ||
@@ -1287,7 +1299,7 @@ const make = Effect.gen(function* () {
             );
           }),
         );
-        const stoppedThread = yield* resolveThread(event.payload.threadId);
+        const stoppedThread = yield* resolveThreadShell(event.payload.threadId);
         const stoppedSession = stoppedThread?.session;
         if (
           !stoppedSession ||
@@ -1331,7 +1343,7 @@ const make = Effect.gen(function* () {
   const processApprovalResponseRequested = Effect.fn("processApprovalResponseRequested")(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.approval-response-requested" }>,
   ) {
-    const thread = yield* resolveThread(event.payload.threadId);
+    const thread = yield* resolveThreadShell(event.payload.threadId);
     if (!thread) {
       return;
     }
@@ -1375,7 +1387,7 @@ const make = Effect.gen(function* () {
     function* (
       event: Extract<ProviderIntentEvent, { type: "thread.user-input-response-requested" }>,
     ) {
-      const thread = yield* resolveThread(event.payload.threadId);
+      const thread = yield* resolveThreadShell(event.payload.threadId);
       if (!thread) {
         return;
       }
@@ -1419,7 +1431,7 @@ const make = Effect.gen(function* () {
   const processSessionStopRequested = Effect.fn("processSessionStopRequested")(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.session-stop-requested" }>,
   ) {
-    const thread = yield* resolveThread(event.payload.threadId);
+    const thread = yield* resolveThreadShell(event.payload.threadId);
     if (!thread) {
       return;
     }
@@ -1463,7 +1475,7 @@ const make = Effect.gen(function* () {
         yield* threadTitleRegenerationWorker.enqueue(event);
         return;
       case "thread.runtime-mode-set": {
-        const thread = yield* resolveThread(event.payload.threadId);
+        const thread = yield* resolveThreadShell(event.payload.threadId);
         if (!thread?.session || thread.session.status === "stopped") {
           return;
         }
@@ -1571,4 +1583,6 @@ const make = Effect.gen(function* () {
   } satisfies ProviderCommandReactorShape;
 });
 
-export const ProviderCommandReactorLive = Layer.effect(ProviderCommandReactor, make);
+export const ProviderCommandReactorLive = Layer.effect(ProviderCommandReactor, make).pipe(
+  Layer.provide(ProjectionThreadMessageRepositoryLive),
+);

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
@@ -111,4 +111,63 @@ layer("ProjectionThreadMessageRepository", (it) => {
       assert.deepEqual(rows[0]?.attachments, []);
     }),
   );
+
+  it.effect("reads only the message context needed to start a provider turn", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadMessageRepository;
+      const threadId = ThreadId.make("thread-turn-start-context");
+      const otherThreadId = ThreadId.make("thread-turn-start-context-other");
+      const firstMessageId = MessageId.make("message-turn-start-context-first");
+      const secondMessageId = MessageId.make("message-turn-start-context-second");
+      const createdAt = "2026-02-28T19:20:00.000Z";
+
+      yield* Effect.forEach(
+        [
+          {
+            messageId: firstMessageId,
+            threadId,
+            role: "user" as const,
+            text: "first user message",
+          },
+          {
+            messageId: MessageId.make("message-turn-start-context-assistant"),
+            threadId,
+            role: "assistant" as const,
+            text: "assistant message",
+          },
+          {
+            messageId: secondMessageId,
+            threadId,
+            role: "user" as const,
+            text: "second user message",
+          },
+        ],
+        (message) =>
+          repository.upsert({
+            ...message,
+            turnId: null,
+            isStreaming: false,
+            createdAt,
+            updatedAt: createdAt,
+          }),
+        { discard: true },
+      );
+
+      const context = yield* repository.getTurnStartContext({
+        threadId,
+        messageId: secondMessageId,
+      });
+      assert.equal(context._tag, "Some");
+      if (context._tag === "Some") {
+        assert.equal(context.value.message.text, "second user message");
+        assert.equal(context.value.userMessageCount, 2);
+      }
+
+      const wrongThread = yield* repository.getTurnStartContext({
+        threadId: otherThreadId,
+        messageId: secondMessageId,
+      });
+      assert.equal(wrongThread._tag, "None");
+    }),
+  );
 });

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -10,6 +10,7 @@ import { ChatAttachment } from "@t3tools/contracts";
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
   GetProjectionThreadMessageInput,
+  GetProjectionThreadTurnStartContextInput,
   ProjectionThreadMessageRepository,
   type ProjectionThreadMessageRepositoryShape,
   DeleteProjectionThreadMessagesInput,
@@ -23,6 +24,10 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
   }),
 );
+const ProjectionThreadTurnStartContextDbRowSchema = Schema.Struct({
+  ...ProjectionThreadMessageDbRowSchema.fields,
+  userMessageCount: Schema.Number,
+});
 
 function toProjectionThreadMessage(
   row: Schema.Schema.Type<typeof ProjectionThreadMessageDbRowSchema>,
@@ -116,6 +121,34 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
       `,
   });
 
+  const getProjectionThreadTurnStartContextRow = SqlSchema.findOneOption({
+    Request: GetProjectionThreadTurnStartContextInput,
+    Result: ProjectionThreadTurnStartContextDbRowSchema,
+    execute: ({ threadId, messageId }) =>
+      sql`
+        SELECT
+          message_id AS "messageId",
+          thread_id AS "threadId",
+          turn_id AS "turnId",
+          role,
+          text,
+          attachments_json AS "attachments",
+          is_streaming AS "isStreaming",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt",
+          (
+            SELECT COUNT(*)
+            FROM projection_thread_messages AS user_messages
+            WHERE user_messages.thread_id = ${threadId}
+              AND user_messages.role = 'user'
+          ) AS "userMessageCount"
+        FROM projection_thread_messages
+        WHERE thread_id = ${threadId}
+          AND message_id = ${messageId}
+        LIMIT 1
+      `,
+  });
+
   const listProjectionThreadMessageRows = SqlSchema.findAll({
     Request: ListProjectionThreadMessagesInput,
     Result: ProjectionThreadMessageDbRowSchema,
@@ -159,6 +192,21 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
       Effect.map(Option.map(toProjectionThreadMessage)),
     );
 
+  const getTurnStartContext: ProjectionThreadMessageRepositoryShape["getTurnStartContext"] = (
+    input,
+  ) =>
+    getProjectionThreadTurnStartContextRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionThreadMessageRepository.getTurnStartContext:query"),
+      ),
+      Effect.map(
+        Option.map((row) => ({
+          message: toProjectionThreadMessage(row),
+          userMessageCount: row.userMessageCount,
+        })),
+      ),
+    );
+
   const listByThreadId: ProjectionThreadMessageRepositoryShape["listByThreadId"] = (input) =>
     listProjectionThreadMessageRows(input).pipe(
       Effect.mapError(
@@ -177,6 +225,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
   return {
     upsert,
     getByMessageId,
+    getTurnStartContext,
     listByThreadId,
     deleteByThreadId,
   } satisfies ProjectionThreadMessageRepositoryShape;

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -44,6 +44,18 @@ export const GetProjectionThreadMessageInput = Schema.Struct({
 });
 export type GetProjectionThreadMessageInput = typeof GetProjectionThreadMessageInput.Type;
 
+export const GetProjectionThreadTurnStartContextInput = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+});
+export type GetProjectionThreadTurnStartContextInput =
+  typeof GetProjectionThreadTurnStartContextInput.Type;
+
+export interface ProjectionThreadTurnStartContext {
+  readonly message: ProjectionThreadMessage;
+  readonly userMessageCount: number;
+}
+
 export const DeleteProjectionThreadMessagesInput = Schema.Struct({
   threadId: ThreadId,
 });
@@ -68,6 +80,13 @@ export interface ProjectionThreadMessageRepositoryShape {
   readonly getByMessageId: (
     input: GetProjectionThreadMessageInput,
   ) => Effect.Effect<Option.Option<ProjectionThreadMessage>, ProjectionRepositoryError>;
+
+  /**
+   * Read the requested message and user-message count needed to start a provider turn.
+   */
+  readonly getTurnStartContext: (
+    input: GetProjectionThreadTurnStartContextInput,
+  ) => Effect.Effect<Option.Option<ProjectionThreadTurnStartContext>, ProjectionRepositoryError>;
 
   /**
    * List projected thread messages for a thread.


### PR DESCRIPTION
## What Changed

- Route provider session and turn control through lightweight thread-shell reads.
- Add a narrow projection query for the requested user message and user-message count needed during turn startup.
- Keep full thread-detail hydration only for explicit title regeneration, where conversation text is required.
- Add focused regressions covering the message context query and proving provider turns start without reading thread-detail history.

## Why

`ProviderCommandReactor` previously hydrated full thread detail while routing provider turns. That read decodes retained activity payloads, including large tool outputs, even though provider startup only needs thread metadata and the requested user message.

On long-lived threads, repeatedly decoding that history can exhaust the server’s V8 heap before the prompt reaches the provider. Using thread shells plus a narrow indexed message query keeps the provider control path independent of conversation-history size without changing stored data, provider behaviour, or client contracts.

## Validation

- `vp test run apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts`
- `vp run --filter t3 typecheck`
- Focused lint and formatting checks
- `vp run --filter t3 build:bundle`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because this is a server-only change
- [x] Video is not applicable because there are no UI or interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core provider turn-start and session orchestration read paths; behavior should be equivalent but mis-sync between projection messages and detail could affect first-turn side effects or turn-start failures.
> 
> **Overview**
> **Provider turn routing no longer loads full thread detail** (messages and heavy activity payloads). Session control, interrupts, approvals, and turn startup now use **thread shells** via `getThreadShellById`, while **title regeneration** still uses **thread detail** when conversation text is required.
> 
> Turn start resolves the user message and **first-turn detection** through a new **`ProjectionThreadMessageRepository.getTurnStartContext`** SQL path (single message row plus user-message count) instead of scanning `thread.messages` from a hydrated detail snapshot. **`ProviderCommandReactorLive`** now provides **`ProjectionThreadMessageRepositoryLive`**.
> 
> Tests add repository coverage for `getTurnStartContext` and a reactor harness option that fails `getThreadDetailById` to assert turns still reach **`sendTurn`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bddf93bfb91068b5cc635f02a2e026df55bcd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route provider turns without hydrating full thread detail history
> - Adds `getTurnStartContext` to `ProjectionThreadMessageRepository`, returning just the requested message and a `userMessageCount` via a correlated SQL subquery, instead of loading the full thread detail
> - Rewires `ProviderCommandReactor` to use `resolveThreadShell` (session/runtime metadata only) for most handlers; `resolveThreadDetail` is now limited to `regenerateThreadTitle`
> - `processTurnStartRequested` fetches the user message and counts from the message repository rather than scanning `thread.messages`
> - Behavioral Change: `ProviderCommandReactorLive` now provides `ProjectionThreadMessageRepositoryLive`; turn-start routing no longer depends on `ProjectionSnapshotQuery.getThreadDetailById` succeeding
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8bddf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->