### PR TITLE
fix(server): serialize OpenCode inventory commands

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -3,10 +3,15 @@ import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
 import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import {
   HostProcessEnvironment,
   HostProcessExecutablePath,
@@ -16,6 +21,72 @@ import {
 import { OpenCodeRuntime, OpenCodeRuntimeLive } from "./opencodeRuntime.ts";
 
 const testLayer = OpenCodeRuntimeLive.pipe(Layer.provideMerge(NodeServices.layer));
+
+it.effect("OpenCodeRuntime inventory runs CLI commands sequentially", () =>
+  Effect.gen(function* () {
+    const firstStarted = yield* Deferred.make<void>();
+    const releaseFirst = yield* Deferred.make<void>();
+    const spawnedArgs: Array<ReadonlyArray<string>> = [];
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.gen(function* () {
+        const args = command._tag === "StandardCommand" ? command.args : [];
+        spawnedArgs.push(args);
+        const isFirst = spawnedArgs.length === 1;
+        if (isFirst) {
+          yield* Deferred.succeed(firstStarted, undefined);
+        }
+        const stdout =
+          args[0] === "models"
+            ? Stream.encodeText(
+                Stream.make(
+                  'openai/gpt-test\n{"id":"gpt-test","providerID":"openai","name":"GPT Test"}\n',
+                ),
+              )
+            : Stream.empty;
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(spawnedArgs.length),
+          exitCode: isFirst
+            ? Deferred.await(releaseFirst).pipe(Effect.as(ChildProcessSpawner.ExitCode(0)))
+            : Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(isFirst),
+          kill: () => Effect.void,
+          unref: Effect.succeed(Effect.void),
+          stdin: Sink.drain,
+          stdout,
+          stderr: Stream.empty,
+          all: stdout,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+        });
+      }),
+    );
+    const runtimeLayer = OpenCodeRuntimeLive.pipe(
+      Layer.provideMerge(
+        Layer.mergeAll(
+          NodeServices.layer,
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        ),
+      ),
+    );
+    const runtime = yield* OpenCodeRuntime.pipe(Effect.provide(runtimeLayer));
+    const inventory = yield* runtime
+      .loadInventoryFromCli({ binaryPath: "opencode", cwd: "/workspace" })
+      .pipe(Effect.forkChild);
+
+    yield* Deferred.await(firstStarted);
+    yield* Effect.yieldNow;
+    NodeAssert.deepEqual(spawnedArgs, [["models", "--verbose"]]);
+
+    yield* Deferred.succeed(releaseFirst, undefined);
+    yield* Fiber.join(inventory);
+
+    NodeAssert.deepEqual(spawnedArgs, [
+      ["models", "--verbose"],
+      ["agent", "list"],
+      ["debug", "skill"],
+    ]);
+  }),
+);
 
 it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
   it.effect("keeps provider inventory when agent discovery fails", () =>

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -897,10 +897,11 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
           ...commandContext,
         }).pipe(Effect.exit);
 
-      // First attempt — run all inventory commands in parallel.
+      // OpenCode opens the same SQLite database for each command with no busy
+      // timeout, so overlapping inventory reads can fail with "database is locked".
       const [initialModelsResult, initialAgentsResult, initialSkillsResult] = yield* Effect.all(
         [runModelsCli(), runAgentsCli(), runSkillsCli()],
-        { concurrency: "unbounded" },
+        { concurrency: 1 },
       );
       let modelsResult = initialModelsResult;
       let agentsResult = initialAgentsResult;
@@ -918,7 +919,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
             needsAgentsRetry ? runAgentsCli() : Effect.succeed(agentsResult),
             needsSkillsRetry ? runSkillsCli() : Effect.succeed(skillsResult),
           ],
-          { concurrency: "unbounded" },
+          { concurrency: 1 },
         );
         modelsResult = m2;
         agentsResult = a2;


### PR DESCRIPTION
## What Changed

- Run OpenCode's `models`, `agent list`, and `debug skill` inventory commands sequentially.
- Serialize retry attempts the same way.
- Add a regression that holds the first command open and verifies the real inventory loader does not start the others concurrently.

## Why

The later reproduction on #8386 identified the actual failure: concurrent OpenCode inventory processes share a SQLite database with no busy timeout, so either the initial health check or its concurrent retry can fail immediately with `database is locked`. Serial execution removes that race without changing parsing or fallback behavior.

Fixes #8386.

## Verification

- `vp test run apps/server/src/provider/opencodeRuntime.inventory.test.ts` — 6 passed
- Server typecheck
- Focused lint and formatting checks

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows concurrency for CLI inventory only; parsing, retries, and SDK-based inventory paths are unchanged.
> 
> **Overview**
> **OpenCode CLI inventory loading no longer runs `models`, `agent list`, and `debug skill` in parallel.** Both the initial pass and the one-shot retry now use `Effect.all` with `concurrency: 1`, because overlapping OpenCode processes contend on the same SQLite DB (no busy timeout) and can fail with `database is locked`.
> 
> A new inventory test stubs `ChildProcessSpawner` so the first `models --verbose` process stays open until released, and asserts that no other inventory commands start until it finishes, then that all three run in the expected order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 196d12808f5c163086c4c09db61972d843223257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run OpenCode inventory CLI commands sequentially in `loadInventoryFromCli`
> Sets the `Effect.all` concurrency option from `"unbounded"` to 1 for the initial models, agents, and skills CLI calls and the retry block in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/8834/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8). Overlapping inventory reads can fail due to SQLite database locks, so commands now run one at a time. Adds a test in [opencodeRuntime.inventory.test.ts](https://github.com/pingdotgg/t3code/pull/8834/files#diff-619db6935d2a71d46247d119eb37b2dfcddb441b22711fb23c59dc48d226ded5) that uses a custom `ChildProcessSpawner` with `Deferred`s to assert that `agent list` and `debug skill` do not start until `models --verbose` completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 196d128.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->