### PR TITLE
fix(server): isolate Claude capability probe cwd

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -164,7 +164,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
             Effect.provideService(Path.Path, path),
           ),
       });
-      const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
+      const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(
+        effectiveConfig,
+        processEnv,
+        cwd,
+      );
 
       // Kick the TTL-gated manifest refresh in the background and classify
       // with the in-memory manifest, so a slow or hung fetch never delays the

--- a/apps/server/src/provider/Drivers/ClaudeHome.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.test.ts
@@ -7,6 +7,7 @@ import * as Path from "effect/Path";
 
 import {
   makeClaudeCapabilitiesCacheKey,
+  makeClaudeCapabilitiesProbeContext,
   makeClaudeContinuationGroupKey,
   makeClaudeEnvironment,
   resolveClaudeHomePath,
@@ -20,6 +21,9 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         const resolved = path.resolve(NodeOS.homedir());
 
         expect(yield* resolveClaudeHomePath({ homePath: "" })).toBe(resolved);
+        expect((yield* makeClaudeCapabilitiesProbeContext({ homePath: "" })).cwd).toBe(
+          path.resolve(NodeOS.tmpdir()),
+        );
         expect(yield* makeClaudeEnvironment({ homePath: "" })).toBe(process.env);
       }),
     );
@@ -31,20 +35,39 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         const resolved = path.resolve(NodeOS.homedir(), ".claude-work");
 
         expect(yield* resolveClaudeHomePath({ homePath })).toBe(resolved);
+        const probeContext = yield* makeClaudeCapabilitiesProbeContext({ homePath });
+        expect(probeContext.cwd).toBe(path.resolve(NodeOS.tmpdir()));
+        expect(probeContext.environment.CLAUDE_CONFIG_DIR).toBe(resolved);
         expect((yield* makeClaudeEnvironment({ homePath })).CLAUDE_CONFIG_DIR).toBe(resolved);
         expect(yield* makeClaudeContinuationGroupKey({ homePath })).toBe(`claude:home:${resolved}`);
         expect(yield* makeClaudeCapabilitiesCacheKey({ binaryPath: "claude", homePath })).toBe(
-          `claude\0${resolved}\0`,
+          `claude\0${resolved}`,
         );
       }),
     );
 
-    it.effect("separates capability probes by cwd", () =>
+    it.effect("keeps a relative inherited config dir stable when the probe cwd changes", () =>
       Effect.gen(function* () {
-        const config = { binaryPath: "claude", homePath: "" };
-        const first = yield* makeClaudeCapabilitiesCacheKey(config, "/repo-a");
-        const second = yield* makeClaudeCapabilitiesCacheKey(config, "/repo-b");
-        expect(first).not.toBe(second);
+        const path = yield* Path.Path;
+        const workspaceCwd = path.join(NodeOS.tmpdir(), "claude-workspace");
+        const resolvedConfigDir = path.resolve(workspaceCwd, "relative-config");
+        const environment = { CLAUDE_CONFIG_DIR: "relative-config" };
+
+        const probeContext = yield* makeClaudeCapabilitiesProbeContext(
+          { homePath: "" },
+          environment,
+          workspaceCwd,
+        );
+
+        expect(probeContext.cwd).toBe(path.resolve(NodeOS.tmpdir()));
+        expect(probeContext.environment.CLAUDE_CONFIG_DIR).toBe(resolvedConfigDir);
+        expect(
+          yield* makeClaudeCapabilitiesCacheKey(
+            { binaryPath: "claude", homePath: "" },
+            environment,
+            workspaceCwd,
+          ),
+        ).toBe(`claude\0${resolvedConfigDir}`);
       }),
     );
 

--- a/apps/server/src/provider/Drivers/ClaudeHome.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.ts
@@ -34,6 +34,42 @@ export const makeClaudeEnvironment = Effect.fn("makeClaudeEnvironment")(function
   };
 });
 
+/**
+ * Build the environment and neutral cwd used by Claude's capability probe.
+ *
+ * Claude treats `<cwd>/.claude/settings.json` as project settings, so the
+ * probe runs from the existing OS temp directory instead of the server or
+ * config directory. A relative inherited `CLAUDE_CONFIG_DIR` is made absolute
+ * first so changing cwd does not change which credentials Claude reads.
+ */
+export const makeClaudeCapabilitiesProbeContext = Effect.fn("makeClaudeCapabilitiesProbeContext")(
+  function* (
+    config: Pick<ClaudeSettings, "homePath">,
+    baseEnv?: NodeJS.ProcessEnv,
+    cwd?: string,
+  ): Effect.fn.Return<
+    { readonly cwd: string; readonly environment: NodeJS.ProcessEnv },
+    never,
+    Path.Path
+  > {
+    const path = yield* Path.Path;
+    const environment = yield* makeClaudeEnvironment(config, baseEnv);
+    const configDir = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
+    const normalizedConfigDir =
+      configDir.length > 0 && !path.isAbsolute(configDir)
+        ? path.resolve(cwd ?? process.cwd(), configDir)
+        : configDir;
+
+    return {
+      cwd: path.resolve(NodeOS.tmpdir()),
+      environment:
+        normalizedConfigDir !== configDir
+          ? { ...environment, CLAUDE_CONFIG_DIR: normalizedConfigDir }
+          : environment,
+    };
+  },
+);
+
 export const makeClaudeContinuationGroupKey = Effect.fn("makeClaudeContinuationGroupKey")(
   function* (config: Pick<ClaudeSettings, "homePath">): Effect.fn.Return<string, never, Path.Path> {
     const resolvedHomePath = yield* resolveClaudeHomePath(config);
@@ -44,9 +80,12 @@ export const makeClaudeContinuationGroupKey = Effect.fn("makeClaudeContinuationG
 export const makeClaudeCapabilitiesCacheKey = Effect.fn("makeClaudeCapabilitiesCacheKey")(
   function* (
     config: Pick<ClaudeSettings, "binaryPath" | "homePath">,
+    environment?: NodeJS.ProcessEnv,
     cwd?: string,
   ): Effect.fn.Return<string, never, Path.Path> {
     const resolvedHomePath = yield* resolveClaudeHomePath(config);
-    return `${config.binaryPath}\0${resolvedHomePath}\0${cwd ?? ""}`;
+    const probeContext = yield* makeClaudeCapabilitiesProbeContext(config, environment, cwd);
+    const configDir = probeContext.environment.CLAUDE_CONFIG_DIR?.trim() || resolvedHomePath;
+    return `${config.binaryPath}\0${configDir}`;
   },
 );

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -1,3 +1,5 @@
+import * as NodeOS from "node:os";
+
 import { ClaudeSettings } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
@@ -14,7 +16,7 @@ import {
 
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
-it("isolates Claude capability probes without dropping workspace setting sources", () => {
+it("isolates Claude capability probes without dropping filesystem setting sources", () => {
   const abortController = new AbortController();
   const options = buildClaudeCapabilitiesProbeQueryOptions({
     executablePath: "/usr/bin/claude",
@@ -23,12 +25,12 @@ it("isolates Claude capability probes without dropping workspace setting sources
       HOME: "/home/user",
       ENABLE_CLAUDEAI_MCP_SERVERS: "true",
     },
-    cwd: "/workspace/project",
+    cwd: "/claude-config",
   });
 
   assert.deepEqual(options.mcpServers, {});
   assert.equal(options.strictMcpConfig, true);
-  assert.equal(options.cwd, "/workspace/project");
+  assert.equal(options.cwd, "/claude-config");
   assert.deepEqual(options.settingSources, [...CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES]);
   assert.deepEqual(options.settings, { disableAllHooks: true });
   assert.deepEqual(options.allowedTools, []);
@@ -40,15 +42,14 @@ it("isolates Claude capability probes without dropping workspace setting sources
 });
 
 it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
-  it.effect("serializes strict no-MCP options and still resolves account capabilities", () =>
+  it.effect("runs from an existing neutral cwd when the Claude config dir is missing", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-probe-sdk-" });
       const executablePath = path.join(tempDir, "fake-claude.mjs");
       const invocationPath = path.join(tempDir, "invocation.json");
-      const workspaceCwd = path.join(tempDir, "workspace");
-      yield* fs.makeDirectory(workspaceCwd, { recursive: true });
+      const claudeConfigDir = path.join(tempDir, "missing-claude-config");
 
       yield* fs.writeFileString(
         executablePath,
@@ -67,6 +68,7 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
           "writeFileSync(process.env.T3_PROBE_INVOCATION_PATH, JSON.stringify({",
           "  args,",
           "  cwd: process.cwd(),",
+          "  configDir: process.env.CLAUDE_CONFIG_DIR,",
           "  connectorEnv: process.env.ENABLE_CLAUDEAI_MCP_SERVERS,",
           "  mcpConfig,",
           "}));",
@@ -97,13 +99,12 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       yield* fs.chmod(executablePath, 0o755);
 
       const capabilities = yield* probeClaudeCapabilities(
-        decodeClaudeSettings({ binaryPath: executablePath }),
+        decodeClaudeSettings({ binaryPath: executablePath, homePath: claudeConfigDir }),
         {
           ...process.env,
           T3_PROBE_INVOCATION_PATH: invocationPath,
           ENABLE_CLAUDEAI_MCP_SERVERS: "true",
         },
-        workspaceCwd,
       );
 
       assert.deepEqual(capabilities, {
@@ -124,10 +125,13 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       const invocation = JSON.parse(yield* fs.readFileString(invocationPath)) as {
         readonly args: ReadonlyArray<string>;
         readonly cwd: string;
+        readonly configDir: string;
         readonly connectorEnv: string;
         readonly mcpConfig: unknown;
       };
-      assert.equal(invocation.cwd, yield* fs.realPath(workspaceCwd));
+      assert.equal(invocation.cwd, yield* fs.realPath(NodeOS.tmpdir()));
+      assert.notEqual(invocation.cwd, yield* fs.realPath(process.cwd()));
+      assert.equal(invocation.configDir, path.resolve(claudeConfigDir));
       assert.equal(invocation.connectorEnv, "false");
       assert.equal(invocation.args.includes("--strict-mcp-config"), true);
       assert.equal(invocation.args.includes("--mcp-config"), false);

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -40,7 +40,10 @@ import {
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
-import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
+import {
+  makeClaudeCapabilitiesProbeContext,
+  makeClaudeEnvironment,
+} from "../Drivers/ClaudeHome.ts";
 import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
@@ -593,7 +596,7 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
   readonly executablePath: string;
   readonly abortController: AbortController;
   readonly environment: NodeJS.ProcessEnv;
-  readonly cwd: string | undefined;
+  readonly cwd: string;
 }): ClaudeQueryOptions {
   return {
     persistSession: false,
@@ -615,7 +618,7 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
       // config; disable them independently for this health check.
       ENABLE_CLAUDEAI_MCP_SERVERS: "false",
     },
-    ...(input.cwd ? { cwd: input.cwd } : {}),
+    cwd: input.cwd,
     stderr: () => {},
   };
 }
@@ -730,10 +733,14 @@ const probeClaudeCapabilities = (
 ) => {
   const abort = new AbortController();
   return Effect.gen(function* () {
-    const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
+    const probeContext = yield* makeClaudeCapabilitiesProbeContext(
+      claudeSettings,
+      environment,
+      cwd,
+    );
     const executablePath = yield* resolveClaudeSdkExecutablePath(
       claudeSettings.binaryPath,
-      claudeEnvironment,
+      probeContext.environment,
     );
     return yield* Effect.tryPromise(async () => {
       const q = claudeQuery({
@@ -746,8 +753,8 @@ const probeClaudeCapabilities = (
         options: buildClaudeCapabilitiesProbeQueryOptions({
           executablePath,
           abortController: abort,
-          environment: claudeEnvironment,
-          cwd,
+          environment: probeContext.environment,
+          cwd: probeContext.cwd,
         }),
       });
       const init = await q.initializationResult();


### PR DESCRIPTION
## What Changed

- Run Claude capability probes from the existing OS temp directory instead of the server or configured Claude directory.
- Preserve relative inherited `CLAUDE_CONFIG_DIR` semantics by resolving it against the original server cwd before the probe switches cwd.
- Key the probe cache by the effective config directory.
- Keep project skill discovery and actual provider sessions on their existing working directories.
- Add SDK-boundary coverage for a configured directory that does not exist yet, plus relative-config coverage.

## Why

When the desktop server starts in `$HOME`, Claude treats `$HOME/.claude/settings.json` as project settings. Those settings can override an isolated `CLAUDE_CONFIG_DIR`, misclassify the account, and make the probe hit its timeout. An existing neutral cwd prevents that settings leak without making the health check fail for a new config path. Absolutizing inherited relative config paths preserves which credentials the probe reads.

Fixes #8818.

## Verification

- Claude home/probe tests — 6 passed
- Focused provider-registry probe test — 1 passed
- Server typecheck
- Changed-file lint and format checks
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Built with GPT-5.6 Sol in T3 Code through the Codex harness.