### PR TITLE
fix(clients): inherit model preferences for unconfigured projects

### DIFF
--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -102,7 +102,7 @@ describe("mobile model options", () => {
     ]);
   });
 
-  it("normalizes a legacy fallback selection against current capabilities", () => {
+  it("does not materialize catalog defaults for missing stored options", () => {
     const config = {
       providers: [
         {
@@ -144,7 +144,14 @@ describe("mobile model options", () => {
     });
 
     expect(option?.capabilities?.optionDescriptors?.[0]?.id).toBe("serviceTier");
-    expect(option?.selection.options).toEqual([{ id: "serviceTier", value: "default" }]);
+    expect(option?.selection.options).toBeUndefined();
+
+    const [explicitOption] = buildModelOptions(config, {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-test",
+      options: [{ id: "serviceTier", value: "priority" }],
+    });
+    expect(explicitOption?.selection.options).toEqual([{ id: "serviceTier", value: "priority" }]);
   });
 
   it("rejects stored selections whose provider is not usable", () => {

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -4,7 +4,7 @@ import type {
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
 import {
-  buildProviderOptionSelectionsFromDescriptors,
+  buildExplicitProviderOptionSelectionsFromDescriptors,
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
 
@@ -45,11 +45,12 @@ function normalizeSelectionOptions(
   if (!capabilities) {
     return selection;
   }
-  const options = buildProviderOptionSelectionsFromDescriptors(
+  const options = buildExplicitProviderOptionSelectionsFromDescriptors(
     getProviderOptionDescriptors({
       caps: capabilities,
       selections: selection.options,
     }),
+    selection.options,
   );
   return options
     ? { ...selection, options }

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -30,7 +30,6 @@ import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSn
 import { OrchestrationLayerLive } from "../orchestration/runtimeLayer.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "../persistence/Layers/Sqlite.ts";
 import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
-import * as ServerRuntimeStartup from "../serverRuntimeStartup.ts";
 import {
   clearPersistedServerRuntimeState,
   readPersistedServerRuntimeState,
@@ -481,7 +480,6 @@ const projectAddCommand = Command.make("add", {
           projectId,
           title,
           workspaceRoot,
-          defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(),
           createdAt: DateTime.formatIso(yield* DateTime.now),
         });
         return `Added project ${projectId} (${title}) at ${workspaceRoot}.`;

--- a/apps/server/src/orchestration/decider.projectModelSelection.test.ts
+++ b/apps/server/src/orchestration/decider.projectModelSelection.test.ts
@@ -1,0 +1,76 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  CommandId,
+  OrchestrationEvent,
+  ProjectId,
+  ProviderInstanceId,
+  type ModelSelection,
+} from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+const createdAt = "2026-08-30T00:00:00.000Z";
+const projectId = ProjectId.make("project-model-default");
+const selection: ModelSelection = {
+  instanceId: ProviderInstanceId.make("codex"),
+  model: "gpt-5.6-sol",
+  options: [{ id: "reasoningEffort", value: "high" }],
+};
+
+const decodeEvent = Schema.decodeUnknownSync(OrchestrationEvent);
+
+function decodeSingleEvent(result: unknown, sequence: number): OrchestrationEvent {
+  const candidate = Array.isArray(result) ? result[0] : result;
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    (Array.isArray(result) && result.length !== 1)
+  ) {
+    throw new Error("Expected exactly one orchestration event.");
+  }
+  return decodeEvent({ ...candidate, sequence });
+}
+
+it.effect("treats project creation as unconfigured and metadata updates as explicit defaults", () =>
+  Effect.gen(function* () {
+    const created = yield* decideOrchestrationCommand({
+      command: {
+        type: "project.create",
+        commandId: CommandId.make("command-project-create"),
+        projectId,
+        title: "Project",
+        workspaceRoot: "/tmp/project-model-default",
+        // Older clients supplied an automatic seed here. The domain must not
+        // interpret that legacy field as a user-configured project default.
+        defaultModelSelection: selection,
+        createdAt,
+      },
+      readModel: createEmptyReadModel(createdAt),
+    });
+    const createdEvent = decodeSingleEvent(created, 1);
+    if (createdEvent.type !== "project.created") {
+      throw new Error("Expected one project.created event.");
+    }
+    expect(createdEvent.payload.defaultModelSelection).toBeNull();
+
+    const withProject = yield* projectEvent(createEmptyReadModel(createdAt), createdEvent);
+    const updated = yield* decideOrchestrationCommand({
+      command: {
+        type: "project.meta.update",
+        commandId: CommandId.make("command-project-default-update"),
+        projectId,
+        defaultModelSelection: selection,
+      },
+      readModel: withProject,
+    });
+    const updatedEvent = decodeSingleEvent(updated, 2);
+    if (updatedEvent.type !== "project.meta-updated") {
+      throw new Error("Expected one project.meta-updated event.");
+    }
+    expect(updatedEvent.payload.defaultModelSelection).toEqual(selection);
+  }).pipe(Effect.provide(NodeServices.layer)),
+);

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -249,7 +249,10 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           projectId: command.projectId,
           title: command.title,
           workspaceRoot: command.workspaceRoot,
-          defaultModelSelection: command.defaultModelSelection ?? null,
+          // Project creation has no user model choice. Older clients sent an
+          // automatic seed in this field, but only a metadata update records
+          // an explicit project default.
+          defaultModelSelection: null,
           faviconPath: null,
           scripts: [],
           createdAt: command.createdAt,

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -56,6 +56,7 @@ import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
 import Migration0041 from "./Migrations/041_AuthSessionClientConnection.ts";
 import Migration0042 from "./Migrations/042_ProjectionThreadLinkedPullRequest.ts";
 import Migration0043 from "./Migrations/043_ProjectionThreadsUnsettledAt.ts";
+import Migration0044 from "./Migrations/044_ClearAutomaticProjectModelDefaults.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -111,6 +112,7 @@ export const migrationEntries = [
   [41, "AuthSessionClientConnection", Migration0041],
   [42, "ProjectionThreadLinkedPullRequest", Migration0042],
   [43, "ProjectionThreadsUnsettledAt", Migration0043],
+  [44, "ClearAutomaticProjectModelDefaults", Migration0044],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/044_ClearAutomaticProjectModelDefaults.test.ts
+++ b/apps/server/src/persistence/Migrations/044_ClearAutomaticProjectModelDefaults.test.ts
@@ -1,0 +1,128 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("044_ClearAutomaticProjectModelDefaults", (it) => {
+  it.effect("clears create-time seeds while preserving explicit project default writes", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 43 });
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          default_thread_env_mode,
+          favicon_path,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES
+          ('project-auto', 'Auto', '/tmp/auto', '{"instanceId":"codex","model":"gpt-5.6-sol"}', NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z', NULL),
+          ('project-title-only', 'Title only', '/tmp/title-only', '{"instanceId":"codex","model":"gpt-5.6-sol"}', NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z', NULL),
+          ('project-explicit-reset', 'Explicit reset', '/tmp/explicit-reset', NULL, NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z', NULL),
+          ('project-explicit-same', 'Explicit same', '/tmp/explicit-same', '{"instanceId":"codex","model":"gpt-5.6-sol","options":[{"id":"reasoningEffort","value":"high"}]}', NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z', NULL),
+          ('project-no-create-event', 'No create event', '/tmp/no-create', '{"instanceId":"codex","model":"custom-model"}', NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z', NULL)
+      `;
+
+      yield* sql`
+        INSERT INTO orchestration_events (
+          event_id,
+          aggregate_kind,
+          stream_id,
+          stream_version,
+          event_type,
+          occurred_at,
+          command_id,
+          causation_event_id,
+          correlation_id,
+          actor_kind,
+          payload_json,
+          metadata_json
+        )
+        VALUES
+          ('event-auto-create', 'project', 'project-auto', 0, 'project.created', '2026-08-01T00:00:00.000Z', 'command-auto-create', NULL, 'command-auto-create', 'client', '{"projectId":"project-auto","title":"Auto","workspaceRoot":"/tmp/auto","defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol"},"faviconPath":null,"scripts":[],"createdAt":"2026-08-01T00:00:00.000Z","updatedAt":"2026-08-01T00:00:00.000Z"}', '{}'),
+          ('event-title-create', 'project', 'project-title-only', 0, 'project.created', '2026-08-01T00:00:00.000Z', 'command-title-create', NULL, 'command-title-create', 'client', '{"projectId":"project-title-only","title":"Title only","workspaceRoot":"/tmp/title-only","defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol"},"faviconPath":null,"scripts":[],"createdAt":"2026-08-01T00:00:00.000Z","updatedAt":"2026-08-01T00:00:00.000Z"}', '{}'),
+          ('event-title-update', 'project', 'project-title-only', 1, 'project.meta-updated', '2026-08-02T00:00:00.000Z', 'command-title-update', NULL, 'command-title-update', 'client', '{"projectId":"project-title-only","title":"Renamed","updatedAt":"2026-08-02T00:00:00.000Z"}', '{}'),
+          ('event-reset-create', 'project', 'project-explicit-reset', 0, 'project.created', '2026-08-01T00:00:00.000Z', 'command-reset-create', NULL, 'command-reset-create', 'client', '{"projectId":"project-explicit-reset","title":"Explicit reset","workspaceRoot":"/tmp/explicit-reset","defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol"},"faviconPath":null,"scripts":[],"createdAt":"2026-08-01T00:00:00.000Z","updatedAt":"2026-08-01T00:00:00.000Z"}', '{}'),
+          ('event-reset-update', 'project', 'project-explicit-reset', 1, 'project.meta-updated', '2026-08-02T00:00:00.000Z', 'command-reset-update', NULL, 'command-reset-update', 'client', '{"projectId":"project-explicit-reset","defaultModelSelection":null,"updatedAt":"2026-08-02T00:00:00.000Z"}', '{}'),
+          ('event-explicit-create', 'project', 'project-explicit-same', 0, 'project.created', '2026-08-01T00:00:00.000Z', 'command-explicit-create', NULL, 'command-explicit-create', 'client', '{"projectId":"project-explicit-same","title":"Explicit same","workspaceRoot":"/tmp/explicit-same","defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol"},"faviconPath":null,"scripts":[],"createdAt":"2026-08-01T00:00:00.000Z","updatedAt":"2026-08-01T00:00:00.000Z"}', '{}'),
+          ('event-explicit-update', 'project', 'project-explicit-same', 1, 'project.meta-updated', '2026-08-02T00:00:00.000Z', 'command-explicit-update', NULL, 'command-explicit-update', 'client', '{"projectId":"project-explicit-same","defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol","options":[{"id":"reasoningEffort","value":"high"}]},"updatedAt":"2026-08-02T00:00:00.000Z"}', '{}')
+      `;
+
+      yield* runMigrations({ toMigrationInclusive: 44 });
+
+      const projectRows = yield* sql<{
+        readonly projectId: string;
+        readonly defaultModelSelection: string | null;
+      }>`
+        SELECT
+          project_id AS "projectId",
+          default_model_selection_json AS "defaultModelSelection"
+        FROM projection_projects
+        ORDER BY project_id
+      `;
+      assert.deepStrictEqual(
+        projectRows.map((row) => ({
+          projectId: row.projectId,
+          selection: row.defaultModelSelection ? JSON.parse(row.defaultModelSelection) : null,
+        })),
+        [
+          { projectId: "project-auto", selection: null },
+          { projectId: "project-explicit-reset", selection: null },
+          {
+            projectId: "project-explicit-same",
+            selection: {
+              instanceId: "codex",
+              model: "gpt-5.6-sol",
+              options: [{ id: "reasoningEffort", value: "high" }],
+            },
+          },
+          {
+            projectId: "project-no-create-event",
+            selection: { instanceId: "codex", model: "custom-model" },
+          },
+          { projectId: "project-title-only", selection: null },
+        ],
+      );
+
+      const createdEvents = yield* sql<{
+        readonly streamId: string;
+        readonly payloadJson: string;
+      }>`
+        SELECT stream_id AS "streamId", payload_json AS "payloadJson"
+        FROM orchestration_events
+        WHERE event_type = 'project.created'
+        ORDER BY stream_id
+      `;
+      assert.deepStrictEqual(
+        createdEvents.map((row) => ({
+          streamId: row.streamId,
+          defaultModelSelection: JSON.parse(row.payloadJson).defaultModelSelection,
+        })),
+        [
+          { streamId: "project-auto", defaultModelSelection: null },
+          {
+            streamId: "project-explicit-reset",
+            defaultModelSelection: { instanceId: "codex", model: "gpt-5.6-sol" },
+          },
+          {
+            streamId: "project-explicit-same",
+            defaultModelSelection: { instanceId: "codex", model: "gpt-5.6-sol" },
+          },
+          { streamId: "project-title-only", defaultModelSelection: null },
+        ],
+      );
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/044_ClearAutomaticProjectModelDefaults.ts
+++ b/apps/server/src/persistence/Migrations/044_ClearAutomaticProjectModelDefaults.ts
@@ -1,0 +1,52 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // Project creation never exposed a user model choice. A later metadata
+  // event containing this field is the persisted evidence that the user set
+  // or reset the project default, even when its value matches the old seed.
+  yield* sql`
+    WITH automatically_seeded_projects AS (
+      SELECT created.stream_id AS project_id
+      FROM orchestration_events AS created
+      WHERE created.aggregate_kind = 'project'
+        AND created.event_type = 'project.created'
+        AND json_type(created.payload_json, '$.defaultModelSelection') IS NOT NULL
+        AND json_type(created.payload_json, '$.defaultModelSelection') <> 'null'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM orchestration_events AS configured
+          WHERE configured.aggregate_kind = 'project'
+            AND configured.stream_id = created.stream_id
+            AND configured.event_type = 'project.meta-updated'
+            AND json_type(configured.payload_json, '$.defaultModelSelection') IS NOT NULL
+        )
+    )
+    UPDATE projection_projects
+    SET default_model_selection_json = NULL
+    WHERE project_id IN (SELECT project_id FROM automatically_seeded_projects)
+  `;
+
+  yield* sql`
+    UPDATE orchestration_events AS created
+    SET payload_json = json_set(
+      created.payload_json,
+      '$.defaultModelSelection',
+      json('null')
+    )
+    WHERE created.aggregate_kind = 'project'
+      AND created.event_type = 'project.created'
+      AND json_type(created.payload_json, '$.defaultModelSelection') IS NOT NULL
+      AND json_type(created.payload_json, '$.defaultModelSelection') <> 'null'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM orchestration_events AS configured
+        WHERE configured.aggregate_kind = 'project'
+          AND configured.stream_id = created.stream_id
+          AND configured.event_type = 'project.meta-updated'
+          AND json_type(configured.payload_json, '$.defaultModelSelection') IS NOT NULL
+      )
+  `;
+});

--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -16,8 +16,8 @@ import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSna
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 
-it("uses the canonical Codex default for auto-bootstrapped model selection", () => {
-  assert.deepStrictEqual(ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(), {
+it("uses the canonical Codex default for the auto-bootstrapped welcome thread", () => {
+  assert.deepStrictEqual(ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(), {
     instanceId: ProviderInstanceId.make("codex"),
     model: DEFAULT_MODEL,
   });
@@ -147,7 +147,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
               id: bootstrapProjectId,
               title: "Startup Project",
               workspaceRoot: "/tmp/startup-project",
-              defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(),
+              defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(),
               scripts: [],
               createdAt: "2026-01-01T00:00:00.000Z",
               updatedAt: "2026-01-01T00:00:00.000Z",
@@ -185,7 +185,13 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
 
 it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when missing", () =>
   Effect.gen(function* () {
-    const dispatchCalls = yield* Ref.make<ReadonlyArray<string>>([]);
+    const dispatchCalls = yield* Ref.make<
+      ReadonlyArray<{
+        readonly type: string;
+        readonly defaultModelSelection?: unknown;
+        readonly modelSelection?: unknown;
+      }>
+    >([]);
     const targets = yield* ServerRuntimeStartup.resolveAutoBootstrapWelcomeTargets.pipe(
       Effect.provideService(ServerConfig.ServerConfig, {
         cwd: "/tmp/startup-project",
@@ -211,7 +217,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
       Effect.provideService(OrchestrationEngine.OrchestrationEngineService, {
         readEvents: () => Stream.empty,
         dispatch: (command) =>
-          Ref.update(dispatchCalls, (calls) => [...calls, command.type]).pipe(
+          Ref.update(dispatchCalls, (calls) => [...calls, command]).pipe(
             Effect.as({ sequence: 1 }),
           ),
         streamDomainEvents: Stream.empty,
@@ -222,7 +228,16 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
 
     assert.equal(typeof targets.bootstrapProjectId, "string");
     assert.equal(typeof targets.bootstrapThreadId, "string");
-    assert.deepStrictEqual(yield* Ref.get(dispatchCalls), ["project.create", "thread.create"]);
+    const commands = yield* Ref.get(dispatchCalls);
+    assert.deepStrictEqual(
+      commands.map((command) => command.type),
+      ["project.create", "thread.create"],
+    );
+    assert.equal("defaultModelSelection" in commands[0]!, false);
+    assert.deepStrictEqual(
+      commands[1]?.modelSelection,
+      ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(),
+    );
   }),
 );
 

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -166,7 +166,7 @@ export const launchStartupHeartbeat = recordStartupHeartbeat.pipe(
   Effect.asVoid,
 );
 
-export const getAutoBootstrapDefaultModelSelection = (): ModelSelection => ({
+export const getAutoBootstrapThreadModelSelection = (): ModelSelection => ({
   instanceId: ProviderInstanceId.make("codex"),
   model: DEFAULT_MODEL,
 });
@@ -199,26 +199,25 @@ export const resolveAutoBootstrapWelcomeTargets = Effect.gen(function* () {
         serverConfig.cwd,
       );
       let nextProjectId: ProjectId;
-      let nextProjectDefaultModelSelection: ModelSelection;
+      let nextThreadModelSelection: ModelSelection;
 
       if (Option.isNone(existingProject)) {
         const createdAt = DateTime.formatIso(yield* DateTime.now);
         nextProjectId = ProjectId.make(yield* randomUUID);
         const bootstrapProjectTitle = path.basename(serverConfig.cwd) || "project";
-        nextProjectDefaultModelSelection = getAutoBootstrapDefaultModelSelection();
+        nextThreadModelSelection = getAutoBootstrapThreadModelSelection();
         yield* orchestrationEngine.dispatch({
           type: "project.create",
           commandId: CommandId.make(yield* randomUUID),
           projectId: nextProjectId,
           title: bootstrapProjectTitle,
           workspaceRoot: serverConfig.cwd,
-          defaultModelSelection: nextProjectDefaultModelSelection,
           createdAt,
         });
       } else {
         nextProjectId = existingProject.value.id;
-        nextProjectDefaultModelSelection =
-          existingProject.value.defaultModelSelection ?? getAutoBootstrapDefaultModelSelection();
+        nextThreadModelSelection =
+          existingProject.value.defaultModelSelection ?? getAutoBootstrapThreadModelSelection();
       }
 
       const existingThreadId =
@@ -232,7 +231,7 @@ export const resolveAutoBootstrapWelcomeTargets = Effect.gen(function* () {
           threadId: createdThreadId,
           projectId: nextProjectId,
           title: "New thread",
-          modelSelection: nextProjectDefaultModelSelection,
+          modelSelection: nextThreadModelSelection,
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "full-access",
           branch: null,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -147,11 +147,7 @@ import {
 } from "./ThreadCommandSubtitle";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
-import {
-  deriveProviderInstanceEntries,
-  resolveDefaultProviderModelSelection,
-  type ProviderInstanceEntry,
-} from "../providerInstances";
+import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
 import { resolveShortcutCommand, threadJumpIndexFromCommand } from "../keybindings";
 import { CommandDialog, CommandDialogPopup, CommandFooterAction } from "./ui/command";
 import { Button } from "./ui/button";
@@ -1756,10 +1752,6 @@ function OpenCommandPaletteDialog(props: {
       }
 
       const projectId = newProjectId();
-      const targetEnvironmentProviders =
-        environments.find((environment) => environment.environmentId === input.environmentId)
-          ?.serverConfig?.providers ??
-        (input.environmentId === primaryEnvironmentId ? providers : []);
       const createResult = await createProject({
         environmentId: input.environmentId,
         input: {
@@ -1767,10 +1759,7 @@ function OpenCommandPaletteDialog(props: {
           title: inferProjectTitleFromPath(cwd),
           workspaceRoot: cwd,
           createWorkspaceRootIfMissing: true,
-          defaultModelSelection: resolveDefaultProviderModelSelection(
-            targetEnvironmentProviders,
-            null,
-          ),
+          defaultModelSelection: null,
         },
       });
       if (createResult._tag === "Failure") {

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -69,7 +69,7 @@ describe("getComposerProviderState", () => {
     );
   });
 
-  it("returns descriptor defaults when no selections are provided", () => {
+  it("uses descriptor defaults for display without dispatching them as overrides", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,
       model: MODEL,
@@ -86,7 +86,7 @@ describe("getComposerProviderState", () => {
     expect(state).toEqual({
       provider: PROVIDER,
       promptEffort: "high",
-      modelOptionsForDispatch: selections(["effort", "high"]),
+      modelOptionsForDispatch: undefined,
     });
   });
 
@@ -165,9 +165,7 @@ describe("getComposerProviderState", () => {
     });
 
     expect(state.promptEffort).toBe("high");
-    expect(state.modelOptionsForDispatch).toEqual(
-      selections(["effort", "high"], ["contextWindow", "200k"], ["agent", "plan"]),
-    );
+    expect(state.modelOptionsForDispatch).toEqual(selections(["agent", "plan"]));
   });
 
   it("drops the plan agent from dispatch when legacy plan mode is disabled", () => {
@@ -219,7 +217,7 @@ describe("getComposerProviderState", () => {
       planModeEnabled: false,
     });
 
-    expect(state.modelOptionsForDispatch).toEqual(selections(["agent", "research"]));
+    expect(state.modelOptionsForDispatch).toBeUndefined();
   });
 
   it("returns undefined dispatch options when the model declares no descriptors", () => {

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -6,7 +6,7 @@ import {
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import {
-  buildProviderOptionSelectionsFromDescriptors,
+  buildExplicitProviderOptionSelectionsFromDescriptors,
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
@@ -94,7 +94,10 @@ export function getComposerProviderState(input: ComposerProviderStateInput): Com
   return {
     provider,
     promptEffort,
-    modelOptionsForDispatch: buildProviderOptionSelectionsFromDescriptors(descriptors),
+    modelOptionsForDispatch: buildExplicitProviderOptionSelectionsFromDescriptors(
+      descriptors,
+      modelOptions,
+    ),
     ...(ultrathinkActive
       ? {
           composerFrameClassName: "ultrathink-frame",

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -708,6 +708,8 @@ export const ProjectCreateCommand = Schema.Struct({
   title: TrimmedNonEmptyString,
   workspaceRoot: TrimmedNonEmptyString,
   createWorkspaceRootIfMissing: Schema.optional(Schema.Boolean),
+  // Retained for older clients that sent an automatic create-time seed. The
+  // server ignores it; explicit project defaults use project.meta.update.
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   createdAt: IsoDateTime,
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -3,6 +3,7 @@ import { ProviderDriverKind, ProviderInstanceId, type ModelCapabilities } from "
 
 import {
   applyClaudePromptEffortPrefix,
+  buildExplicitProviderOptionSelectionsFromDescriptors,
   buildProviderOptionSelectionsFromDescriptors,
   createModelCapabilities,
   createModelSelection,
@@ -111,6 +112,22 @@ describe("descriptor helpers", () => {
       { id: "reasoningEffort", value: "high" },
       { id: "fastMode", value: true },
     ]);
+  });
+
+  it("builds dispatch options only from explicit selections", () => {
+    const descriptors = getProviderOptionDescriptors({
+      caps: codexCaps,
+      selections: [{ id: "fastMode", value: true }],
+    });
+
+    expect(buildExplicitProviderOptionSelectionsFromDescriptors(descriptors, undefined)).toBe(
+      undefined,
+    );
+    expect(
+      buildExplicitProviderOptionSelectionsFromDescriptors(descriptors, [
+        { id: "fastMode", value: true },
+      ]),
+    ).toEqual([{ id: "fastMode", value: true }]);
   });
 
   it("stores option selection arrays in model selections", () => {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -212,6 +212,20 @@ export function buildProviderOptionSelectionsFromDescriptors(
   return nextSelections.length > 0 ? nextSelections : undefined;
 }
 
+export function buildExplicitProviderOptionSelectionsFromDescriptors(
+  descriptors: ReadonlyArray<ProviderOptionDescriptor> | null | undefined,
+  selections: ReadonlyArray<ProviderOptionSelection> | null | undefined,
+): Array<ProviderOptionSelection> | undefined {
+  if (!selections || selections.length === 0) {
+    return undefined;
+  }
+  const explicitIds = new Set(selections.map((selection) => selection.id));
+  const normalized = buildProviderOptionSelectionsFromDescriptors(descriptors)?.filter(
+    (selection) => explicitIds.has(selection.id),
+  );
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
 export function getModelSelectionOptionDescriptors(
   modelSelection: ModelSelection | null | undefined,
   caps?: ModelCapabilities | null | undefined,


### PR DESCRIPTION
New projects currently persist an automatically chosen provider and model as a project override. Fresh drafts then replace the app-wide sticky selection, and missing options such as reasoning effort become explicit catalog defaults sent to the provider.

This change treats project creation as unconfigured. Only a later `project.meta.update` write represents a deliberate project default. The server bootstrap, web command palette, CLI, and shared mobile creation path now converge on that rule at the domain boundary. Web and mobile still use capability defaults for display, but dispatch only options that T3 actually stored. Explicit unsent-draft choices and explicit project defaults keep their existing precedence.

Migration 44 rewrites create-time seeds only when the project event stream contains no metadata update that wrote `defaultModelSelection`. It never compares model slugs or option values, so an explicit same-value selection and an explicit reset both survive. Projection rows without corresponding `project.created` evidence are intentionally left unchanged because their provenance is ambiguous.

Closes #8829

## Validation

- `vp test run` across 22 focused files covering project creation, event decisions, projections, old and new migrations, web and mobile precedence, persisted drafts, grouped projects, provider availability, and Codex option forwarding: 405 tests passed.
- Package-scoped type checks passed for `@t3tools/contracts`, `@t3tools/shared`, `@t3tools/client-runtime`, `t3`, `@t3tools/web`, and `@t3tools/mobile`.
- Targeted lint and formatting checks passed for all changed files.
- `git diff --check` passed.
- No browser pass was needed because this change has no visible UI changes.

## AutoReview

AutoReview loop 1 completed clean with no accepted or actionable P0/P1 findings using Codex, `gpt-5.6-sol`, High reasoning, and Fast service tier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 117bb162646e6dab0b61fb8f0228901729085285. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Built with GPT-5.6-Sol using High reasoning and Fast service tier through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop auto-seeding `defaultModelSelection` on `project.create` and dispatch only explicit model options
> - Server now ignores `defaultModelSelection` on `project.create` commands and always records `null` in the created event, so new projects start unconfigured and inherit model preferences at runtime
> - All clients (web, mobile, CLI) stop sending `defaultModelSelection` during project creation; the web and mobile composers switch to `buildExplicitProviderOptionSelectionsFromDescriptors` so only user-chosen options are dispatched while catalog defaults remain for UI display only
> - Server startup (`resolveAutoBootstrapWelcomeTargets`) no longer sets `defaultModelSelection` on `project.create`; instead it resolves the model selection for the welcome `thread.create` from the project default or canonical default
> - Migration `044_ClearAutomaticProjectModelDefaults` clears `default_model_selection_json` in `projection_projects` and sets `payload_json.defaultModelSelection` to null on matching `project.created` events for projects that received automatic seeds with no subsequent explicit `project.meta.update`
> - Risk: migration 044 uses a `NOT EXISTS` subquery on `project.meta.updated` events to distinguish auto-seeded from explicitly configured projects; projects where an explicit update was never recorded will lose their `default_model_selection_json` and fall back to canonical defaults at runtime
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 117bb16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->