### PR TITLE
feat(connect): print stored oauth access token

### DIFF
--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -18,6 +18,7 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as DateTime from "effect/DateTime";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServer from "effect/unstable/http/HttpServer";
 import * as HttpApi from "effect/unstable/httpapi/HttpApi";
@@ -48,6 +49,7 @@ import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import { environmentAuthenticatedAuthLayer } from "./auth/http.ts";
+import { ConnectTokenUnavailableError } from "./cli/connect.ts";
 
 import packageJson from "../package.json" with { type: "json" };
 
@@ -71,6 +73,7 @@ class ProjectCliHttpApi extends HttpApi.make("environment").add(EnvironmentOrche
 
 const connectCli = makeCli({ cloudEnabled: true });
 const noConnectCli = makeCli({ cloudEnabled: false });
+const isConnectTokenUnavailableError = Schema.is(ConnectTokenUnavailableError);
 const runCli = (args: ReadonlyArray<string>, command = cli) =>
   Command.runWith(command, { version: "0.0.0" })(args);
 const runConnectCli = (args: ReadonlyArray<string>) => runCli(args, connectCli);
@@ -322,6 +325,52 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
       assert.isFalse(decoded.desired);
       assert.isTrue(decoded.authenticated);
     }),
+  );
+
+  it.effect("prints only the stored T3 Connect OAuth access token", () =>
+    Effect.gen(function* () {
+      const baseDir = NodeFS.mkdtempSync(
+        NodePath.join(NodeOS.tmpdir(), "t3-cli-cloud-token-test-"),
+      );
+      const { secretsDir } = yield* ServerConfig.deriveServerPaths(baseDir, undefined);
+      NodeFS.mkdirSync(secretsDir, { recursive: true });
+      NodeFS.writeFileSync(
+        NodePath.join(secretsDir, "cloud-cli-oauth-token.bin"),
+        // @effect-diagnostics-next-line preferSchemaOverJson:off - Test fixture matches the persisted CLI token representation.
+        JSON.stringify({
+          accessToken: "access-token",
+          refreshToken: "refresh-token",
+          expiresAtEpochMs: Number.MAX_SAFE_INTEGER,
+          identity: "person@example.test",
+        }),
+      );
+
+      const before = (yield* TestConsole.logLines).length;
+      yield* runConnectCli(["connect", "token", "--base-dir", baseDir]);
+      const output = (yield* TestConsole.logLines).slice(before);
+
+      assert.deepEqual(output, ["access-token"]);
+      assert.notInclude(output.join("\n"), "refresh-token");
+      assert.notInclude(output.join("\n"), "person@example.test");
+    }).pipe(Effect.provide(Layer.mergeAll(CliRuntimeLayer, TestConsole.layer))),
+  );
+
+  it.effect("requires an existing T3 Connect authorization before printing a token", () =>
+    Effect.gen(function* () {
+      const baseDir = NodeFS.mkdtempSync(
+        NodePath.join(NodeOS.tmpdir(), "t3-cli-cloud-token-missing-test-"),
+      );
+      const before = (yield* TestConsole.logLines).length;
+      const error = yield* runConnectCli(["connect", "token", "--base-dir", baseDir]).pipe(
+        Effect.flip,
+      );
+
+      if (!isConnectTokenUnavailableError(error)) {
+        assert.fail(`Expected ConnectTokenUnavailableError, got ${String(error)}`);
+      }
+      assert.include(error.message, "Run `t3 connect login` first");
+      assert.deepEqual((yield* TestConsole.logLines).slice(before), []);
+    }).pipe(Effect.provide(Layer.mergeAll(CliRuntimeLayer, TestConsole.layer))),
   );
 
   it.effect("disables headless connect without a running server", () =>

--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -63,6 +63,15 @@ const jsonFlag = Flag.boolean("json").pipe(
 
 const isCloudCliTokenManagerError = Schema.is(CliTokenManager.CloudCliTokenManagerError);
 
+export class ConnectTokenUnavailableError extends Schema.TaggedErrorClass<ConnectTokenUnavailableError>()(
+  "ConnectTokenUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "No usable T3 Connect authorization is stored. Run `t3 connect login` first.";
+  }
+}
+
 const headlessFlag = Flag.boolean("headless").pipe(
   Flag.withDescription("Authorize without a local browser using out-of-band OAuth."),
   Flag.withDefault(false),
@@ -513,6 +522,28 @@ const connectLoginCommand = Command.make("login", {
   ),
 );
 
+const connectTokenCommand = Command.make("token", {
+  ...projectLocationFlags,
+}).pipe(
+  Command.withDescription("Print a refreshed T3 Connect OAuth access token for scripting."),
+  Command.withHandler((flags) =>
+    runCloudCommand(
+      flags,
+      Effect.gen(function* () {
+        const tokens = yield* CliTokenManager.CloudCliTokenManager;
+        const existing = yield* tokens.getExisting.pipe(
+          Effect.mapError(() => new ConnectTokenUnavailableError()),
+        );
+        if (Option.isNone(existing)) {
+          return yield* new ConnectTokenUnavailableError();
+        }
+        yield* Console.log(existing.value.accessToken);
+      }),
+      { quietLogs: true },
+    ),
+  ),
+);
+
 const connectLinkCommand = Command.make("link", {
   ...projectLocationFlags,
   headless: headlessFlag,
@@ -715,6 +746,7 @@ export const connectCommand = Command.make("connect", {
   ),
   Command.withSubcommands([
     connectLoginCommand,
+    connectTokenCommand,
     connectLinkCommand,
     connectPublishCommand,
     connectStatusCommand,

--- a/docs/internals/t3-connect.md
+++ b/docs/internals/t3-connect.md
@@ -107,6 +107,7 @@ The connect command group is:
 ```sh
 t3 connect            # default: onboarding
 t3 connect login
+t3 connect token      # print the current OAuth access token
 t3 connect link       # --publish-only
 t3 connect status     # --json
 t3 connect publish    # --disable
@@ -117,7 +118,9 @@ t3 connect logout
 `t3 serve` is a separate top-level command, not a connect subcommand.
 
 `t3 connect login` opens the Clerk authorization flow and stores the CLI credential without enabling
-cloud exposure. `t3 connect link` installs the pinned managed `cloudflared` binary when needed,
+cloud exposure. `t3 connect token` prints only the current OAuth access token, refreshing it when
+needed; it never prints the stored refresh token or starts an interactive login. `t3 connect link`
+installs the pinned managed `cloudflared` binary when needed,
 authorizes when needed, and records durable intent to expose the environment. It works without a
 running T3 server. The next `t3 serve` or `t3 start` reconciles the relay link and launches the
 managed tunnel. `t3 connect unlink` records disabled intent immediately, stops a reachable running

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -271,6 +271,23 @@ Typical uses:
 
 Use `t3 auth --help` and the nested subcommand help pages for the full reference.
 
+### Using T3 Connect Authorization in Scripts
+
+After signing in with `t3 connect login`, scripts can request the current short-lived OAuth access
+token without reading T3 Code's stored credential:
+
+```sh
+T3_CONNECT_TOKEN="$(t3 connect token)" your-command
+```
+
+The command refreshes the stored authorization when needed and writes only the access token to
+standard output. It never prints the refresh token or starts an interactive login. If authorization
+is missing, expired, or revoked, run `t3 connect login` again.
+
+Treat the printed value like a password. Avoid putting it directly in command arguments, shell
+history, logs, or long-lived environment variables. Prefer passing it only to the process that needs
+it, as in the example above.
+
 ### Deregister a T3 Connect Environment
 
 Open your account menu and choose **T3 Connect** to see every environment registered to your


### PR DESCRIPTION
## Problem

Scripts and headless clients can sign in with `t3 connect login`, but there is no supported way to consume the stored OAuth authorization without reading the credential file or copying a token manually.

## Solution

Add `t3 connect token`, which refreshes an existing CLI credential when needed and prints only the short-lived access token to stdout. It never prints the refresh token or starts an interactive login; missing or unusable authorization points the user back to `t3 connect login`.

The user and internals docs cover script usage and the token-handling precautions.

## Verification

- `env -u T3_SERVICE_LAUNCHER_CONTEXT ./node_modules/.bin/vp test run apps/server/src/bin.test.ts apps/server/src/cloud/CliTokenManager.test.ts`
- `env -u T3_SERVICE_LAUNCHER_CONTEXT ./node_modules/.bin/vp run --filter t3 typecheck`
- `./node_modules/.bin/vp lint apps/server/src/cli/connect.ts apps/server/src/bin.test.ts`
- `./node_modules/.bin/vp fmt --check apps/server/src/cli/connect.ts apps/server/src/bin.test.ts docs/internals/t3-connect.md docs/user/remote-access.md`

Authored by GPT-5.6 Sol with the Codex harness through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3 connect token` subcommand to print stored OAuth access token
> - Introduces a new `token` subcommand under `t3 connect` that prints the current (refreshed if needed) OAuth access token to stdout, without printing the refresh token or identity.
> - Adds the `ConnectTokenUnavailableError` tagged error class, thrown when no usable authorization is stored; the error message directs users to run `t3 connect login`.
> - The handler runs via `CloudCliTokenManager.getExisting` under `runCloudCommand` with `quietLogs` so only the token is emitted to stdout.
> - Adds tests in [bin.test.ts](https://github.com/pingdotgg/t3code/pull/8838/files#diff-94f2a1c34e7815e43d7fbf62ddcccb7ece13c7ec57e628dcfadbedb93c853a4d) covering both the success path (prints access token only) and the failure path (no token, fails with `ConnectTokenUnavailableError`, no console output).
> - Updates [t3-connect.md](https://github.com/pingdotgg/t3code/pull/8838/files#diff-66b29665c8e001b0ae9ca92f9461d961ef7cf7e7257dce2366bcc3e69462fc4e) and [remote-access.md](https://github.com/pingdotgg/t3code/pull/8838/files#diff-e6cd63b1b8b5df551539c3cbb1790b40f70baa2a5ed146d56f1c7044d7adcb8a) with CLI reference and scripting guidance.
> - Behavioral Change: stdout from `t3 connect token` is just the access token string, suitable for piping into scripts; all other log output is suppressed via `quietLogs`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f961111.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->