### PR TITLE
fix(web): use circle alert for failed tool calls

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1473,7 +1473,7 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain("lucide-x");
+    expect(markup).toContain("lucide-circle-alert");
     expect(markup).toContain('aria-label="Tool call failed"');
     // Ordinary tool failures render muted, not red.
     expect(markup).not.toContain("text-destructive");
@@ -1511,7 +1511,7 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain("lucide-x");
+    expect(markup).toContain("lucide-circle-alert");
     expect(markup).toContain("text-destructive");
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1579,7 +1579,7 @@ function LiveActivityContent({
   announceFailure?: boolean;
   highlighted?: boolean;
 }) {
-  const resolvedIconName = failed ? "x" : iconName;
+  const resolvedIconName = failed ? "circle-alert" : iconName;
 
   return (
     <div
@@ -2554,7 +2554,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
   const showFailedIndicator = workEntryDisplayIndicatesToolFailure(workEntry);
   const entryIconName =
-    showWarningIndicator || showFailedIndicator ? "x" : workEntryIconName(workEntry);
+    showWarningIndicator || showFailedIndicator ? "circle-alert" : workEntryIconName(workEntry);
   const displayText = workEntryPreview(workEntry, workspaceRoot) ?? toolWorkEntryHeading(workEntry);
   const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
   const canExpand = expandedBody !== null;


### PR DESCRIPTION
Failed tool calls use a bare X that reads like a close control and looks narrow beside the other timeline icons. This switches live and settled failure rows to the existing CircleAlert icon while preserving the current muted and destructive color treatments. Verified with the focused MessagesTimeline suite (39 tests), targeted lint, and the web typecheck.

Generated with gpt-5.6-sol in the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only icon swap in the chat timeline with matching test updates; no logic or styling rules changed.
> 
> **Overview**
> Failed and warning states in the chat work log no longer use the narrow **X** icon, which could read like a dismiss control. **Live** activity rows and **settled** work entries now show **`circle-alert`** when a tool fails or a runtime warning is indicated.
> 
> **Muted vs red styling is unchanged:** ordinary tool failures stay secondary/muted; severe orchestration errors (e.g. provider turn start failed) still use **`text-destructive`**. Tests in `MessagesTimeline.test.tsx` were updated to assert **`lucide-circle-alert`** instead of **`lucide-x`** for those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5d3d86fa1ee1d7866fa2134fd780e0aa35157d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `circle-alert` icon for failed tool calls in `MessagesTimeline`
> Updates `LiveActivityContent` and `PlainWorkEntryRow` to render the `circle-alert` icon instead of `x` when a failure or warning indicator is set. Test expectations in [MessagesTimeline.test.tsx](https://github.com/pingdotgg/t3code/pull/8840/files#diff-ed3eb7f66cdae04c2cff32c0f2feb550aea5dddf9fe3af32adc68f50c0832a61) are updated to match. Color treatment and all other rendering logic remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b5d3d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->