### PR TITLE
fix(server): ignore replayed Claude resume snapshots

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3990,6 +3990,94 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("ignores an assistant snapshot replayed at the Claude resume cursor", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const replayedAssistantUuid = "assistant-before-resume";
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: RESUME_THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        resumeCursor: {
+          threadId: RESUME_THREAD_ID,
+          resume: "550e8400-e29b-41d4-a716-446655440000",
+          resumeSessionAt: replayedAssistantUuid,
+          turnCount: 3,
+        },
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: RESUME_THREAD_ID,
+        input: "/compact",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "compact_boundary",
+        compact_metadata: {
+          trigger: "manual",
+          pre_tokens: 200,
+          post_tokens: 40,
+        },
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+        uuid: "compact-boundary-after-resume",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "assistant",
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+        uuid: replayedAssistantUuid,
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-message-before-resume",
+          role: "assistant",
+          content: [{ type: "text", text: "Error during compaction: API Error: 502" }],
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+        uuid: "result-after-resume",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(
+        runtimeEvents.some(
+          (event) => event.type === "thread.state.changed" && event.payload.state === "compacted",
+        ),
+        true,
+      );
+      assert.equal(
+        runtimeEvents.some(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+        ),
+        false,
+      );
+      assert.equal(
+        runtimeEvents.some(
+          (event) =>
+            event.type === "item.completed" && event.payload.itemType === "assistant_message",
+        ),
+        false,
+      );
+
+      const thread = yield* adapter.readThread(RESUME_THREAD_ID);
+      assert.deepEqual(thread.turns.at(-1)?.items, []);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("preserves durable resume ids across Claude resume hooks", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -312,6 +312,7 @@ interface ClaudeSessionContext {
   lastKnownContextWindow: number | undefined;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   lastKnownTotalProcessedTokens: number | undefined;
+  readonly resumeAssistantUuid: string | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   stopped: boolean;
@@ -2873,6 +2874,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    // Claude can replay the assistant snapshot at the persisted resume cursor
+    // after a session restart or compaction. Its native UUID is the durable
+    // identity, so processing it again would append already-persisted text as
+    // a new canonical assistant item.
+    if (message.uuid === context.resumeAssistantUuid) {
+      return;
+    }
+
     // Subagent-owned assistant snapshots (parent_tool_use_id set) are the
     // subagent's own conversation, not the parent's. Emitting them created
     // interleaved "Agent N done"-adjacent leak messages and spawned synthetic
@@ -4412,6 +4421,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastKnownContextWindow: initialContextWindow,
         lastKnownTokenUsage: undefined,
         lastKnownTotalProcessedTokens: undefined,
+        resumeAssistantUuid: resumeState?.resumeSessionAt,
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
         stopped: false,


### PR DESCRIPTION
## What Changed

- Preserve the Claude assistant UUID that a session initially resumes from.
- Ignore any assistant snapshot replayed with that durable UUID instead of appending it to the new turn.
- Add a regression test covering a successful compact boundary followed by the historical snapshot replay.

## Why

Claude can re-emit the assistant snapshot at the persisted resume cursor after a restart or compaction. Treating that snapshot as new output duplicates historical text in the current turn. The native UUID is the durable identity, so filtering the initial cursor replay makes resume ingestion idempotent without suppressing later assistant messages.

Fixes #4930.

## Verification

- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` — 80 tests passed
- `vp run --filter t3 typecheck`
- Changed-file lint and format checks
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude resume message ingestion in the provider adapter; wrong filtering could hide legitimate assistant output on resumed sessions, but scope is limited to the initial resume UUID match.
> 
> **Overview**
> Fixes duplicate assistant text when Claude **re-emits the assistant snapshot at the persisted resume cursor** after restart or compaction (e.g. following `/compact`).
> 
> The adapter now stores **`resumeAssistantUuid`** from `resumeCursor.resumeSessionAt` at session start and **skips processing** any incoming `assistant` message whose SDK `uuid` matches that value, so historical content is not appended as new turn output. Compaction and other handling still run; only the cursor replay is dropped.
> 
> A regression test simulates compact boundary + replayed assistant snapshot and asserts **no** assistant `content.delta` / `item.completed` events and an empty turn items list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57700355f4eec6a61d389af10026edb374cca9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore replayed assistant snapshots at Claude resume cursor in `handleAssistantMessage`
> Adds a `resumeAssistantUuid` field to `ClaudeSessionContext` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/8842/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), set from `resumeState?.resumeSessionAt` during session init. The `handleAssistantMessage` function now early-returns when an incoming assistant message's `message.uuid` matches this value, preventing replayed snapshots from being processed into runtime events or thread items.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5770035.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->