### PR TITLE
fix(web): stop the sidebar "All projects" dropdown from overflowing its glass background

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3493,7 +3493,10 @@ export default function Sidebar() {
                     </span>
                     <ChevronDownIcon className="-mr-px size-4 shrink-0" />
                   </MenuTrigger>
-                  <MenuPopup align="start" className="w-(--anchor-width)">
+                  <MenuPopup
+                    align="start"
+                    className="min-w-(--anchor-width) max-w-[min(600px,var(--available-width))]"
+                  >
                     <MenuRadioGroup
                       value={projectScopeKey ?? "all"}
                       onValueChange={(value) =>

--- a/apps/web/src/components/ui/menu.test.tsx
+++ b/apps/web/src/components/ui/menu.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
-import { Menu, MenuRadioGroup, MenuRadioItem } from "./menu";
+import { hasExplicitWidthClass, Menu, MenuRadioGroup, MenuRadioItem } from "./menu";
 
 describe("menu radio item geometry", () => {
   it("keeps radio-item icons on the same text grid as menu items", () => {
@@ -19,5 +19,21 @@ describe("menu radio item geometry", () => {
     );
 
     expect(html).toContain("-mx-0.5");
+  });
+});
+
+describe("menu popup width classes", () => {
+  it("grows the sidebar project dropdown with the longest project name instead of pinning to the trigger width", () => {
+    // Sidebar passes this to MenuPopup so the "All projects" scope dropdown
+    // can widen past the trigger while staying inside the viewport.
+    const className = "min-w-(--anchor-width) max-w-[min(600px,var(--available-width))]";
+
+    expect(hasExplicitWidthClass(className)).toBe(true);
+    // Any explicit width utility, not just the ones above, suppresses the
+    // default min-w-32 fallback that otherwise pins popups to their trigger.
+    expect(hasExplicitWidthClass("w-(--anchor-width)")).toBe(true);
+    expect(hasExplicitWidthClass("min-w-32")).toBe(true);
+    expect(hasExplicitWidthClass("flex items-center gap-2")).toBe(false);
+    expect(hasExplicitWidthClass(undefined)).toBe(false);
   });
 });

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -12,6 +12,14 @@ const Menu = MenuPrimitive.Root;
 
 const MenuPortal = MenuPrimitive.Portal;
 
+export function hasExplicitWidthClass(className: string | undefined): boolean {
+  if (typeof className !== "string") return false;
+  return className.split(/\s+/).some((classToken) => {
+    const utility = classToken.split(":").at(-1) ?? classToken;
+    return /^(?:min-|max-)?w-/.test(utility);
+  });
+}
+
 function MenuTrigger({ className, children, ...props }: MenuPrimitive.Trigger.Props) {
   return (
     <MenuPrimitive.Trigger className={className} data-slot="menu-trigger" {...props}>
@@ -36,13 +44,6 @@ function MenuPopup({
   side?: MenuPrimitive.Positioner.Props["side"];
   anchor?: MenuPrimitive.Positioner.Props["anchor"];
 }) {
-  const hasExplicitWidthClass =
-    typeof className === "string" &&
-    className.split(/\s+/).some((classToken) => {
-      const utility = classToken.split(":").at(-1) ?? classToken;
-      return /^(?:min-|max-)?w-/.test(utility);
-    });
-
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
@@ -57,13 +58,15 @@ function MenuPopup({
         <MenuPrimitive.Popup
           className={cn(
             "dropdown-glass relative flex origin-(--transform-origin) rounded-lg shadow-[0_16px_40px_-18px_rgb(0_0_0/55%)] outline-none focus:outline-none dark:shadow-[0_18px_44px_-18px_rgb(0_0_0/80%)]",
-            !hasExplicitWidthClass && "min-w-32",
+            !hasExplicitWidthClass(className) && "min-w-32",
             className,
           )}
           data-slot="menu-popup"
           {...props}
         >
-          <div className="max-h-(--available-height) w-full overflow-y-auto p-1">{children}</div>
+          <div className="max-h-(--available-height) min-w-0 w-full overflow-y-auto p-1">
+            {children}
+          </div>
         </MenuPrimitive.Popup>
       </MenuPrimitive.Positioner>
     </MenuPrimitive.Portal>


### PR DESCRIPTION
## Problem

In the sidebar, when a project name is longer than the "All projects" scope dropdown trigger, the popup grows wide enough to hold the name but its glass background stays pinned to the trigger width, leaving the text overflowing onto a transparent strip.

Closes #8725

## Fix

Three small changes in the menu primitives:

- **Sidebar**: switched the scope dropdown popup from `w-(--anchor-width)` to `min-w-(--anchor-width) max-w-[min(600px,var(--available-width))]`, so it can widen past the trigger while staying inside the viewport.
- **`MenuPopup`**: the scrollable content container now has `min-w-0`, which lets flex items shrink below their min-content size instead of spilling out of the rounded glass panel.
- **`hasExplicitWidthClass`**: extracted the width-utility check out of `MenuPopup` and exported it as a pure function, so the default `min-w-32` fallback is suppressed whenever a caller supplies an explicit width class. Covered by a focused unit test.

## Notes

Verified in the local preview. No before/after screenshots attached — I couldn't capture them from the preview; happy to add if useful.

Model: Claude Code (deepseek-v4-flash)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only menu sizing and layout in the sidebar and shared menu primitive; no auth, data, or API changes.
> 
> **Overview**
> Fixes the sidebar **All projects** scope menu where long project names widened the list but the **dropdown glass** stayed trigger-width, so text spilled past the rounded panel.
> 
> The scope `MenuPopup` now uses **`min-w-(--anchor-width)`** with a viewport cap (`max-w-[min(600px,var(--available-width))]`) instead of a fixed **`w-(--anchor-width)`**, so the panel can grow with content without overflowing the screen.
> 
> In **`MenuPopup`**, the scrollable inner wrapper gets **`min-w-0`** so flex children can shrink inside the glass, and **`hasExplicitWidthClass`** is exported and reused to decide when to skip the default **`min-w-32`** when callers pass explicit width utilities. Unit tests cover that helper for the sidebar class string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2a3dc5d3dc99f301bfb295385624600420b44a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar "All projects" dropdown overflow by constraining `MenuPopup` width
> - The project scope dropdown in `Sidebar` now uses `min-w-(--anchor-width) max-w-[min(600px,var(--available-width))]` instead of a fixed `w-(--anchor-width)`, letting it expand up to 600px or available viewport width.
> - Adds and exports `hasExplicitWidthClass` in [menu.tsx](https://github.com/pingdotgg/t3code/pull/8846/files#diff-e0c9f33f4f308eae4b7e310785187bc81767e547539de6fcd955fa42aaccc621), which detects Tailwind width utilities (`w-`, `min-w-`, `max-w-`) including responsive prefixes. `MenuPopup` uses this to decide whether to apply its `min-w-32` fallback.
> - Adds `min-w-0` to the `MenuPopup` inner scroll container so children can shrink below intrinsic min-width, reducing clipping.
> - Adds test coverage in [menu.test.tsx](https://github.com/pingdotgg/t3code/pull/8846/files#diff-918496d3f871edba9c825ac241745d5bae7de421cfb5678e68a77ac316679f6e) for the new utility.
> - Behavioral Change: `MenuPopup` consumers passing `min-w-*` or `max-w-*` classes now skip the default `min-w-32` fallback, whereas previously only `w-*` classes did so.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b2a3dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->