### PR TITLE
fix(relay): stop reporting environment credential rejections as unreachable

### DIFF
--- a/infra/relay/src/environments/EnvironmentConnector.test.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.test.ts
@@ -544,7 +544,7 @@ describe("EnvironmentConnector", () => {
       expect(result).toMatchObject({
         environmentId: "env-connector-test",
         status: "offline",
-        error: "Managed endpoint request failed: Environment is unavailable.",
+        error: "Managed endpoint health request failed: Environment is unavailable.",
         traceId: expect.any(String),
       });
     }).pipe(Effect.provide(connectorTestLayer(execute)));
@@ -809,7 +809,7 @@ describe("EnvironmentConnector", () => {
 
       return Effect.gen(function* () {
         const connector = yield* EnvironmentConnector.EnvironmentConnector;
-        const result = yield* Effect.exit(
+        const result = yield* Effect.result(
           connector.connect({
             userId: "user_123",
             environmentId: "env-connector-test",
@@ -817,15 +817,23 @@ describe("EnvironmentConnector", () => {
           }),
         );
 
-        expect(result._tag).toBe("Failure");
-        if (result._tag === "Failure") {
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
           // Before the fix, any failed mint request — including a well-typed
           // error the environment actually returned — collapsed into
           // EnvironmentMintRequestFailed ("endpoint_request_failed"), telling
           // the client the endpoint was unreachable when it had, in fact,
           // answered.
-          expect(result.cause.toString()).toContain("EnvironmentMintResponseInvalid");
-          expect(result.cause.toString()).not.toContain("EnvironmentMintRequestFailed");
+          expect(result.failure._tag).toBe("EnvironmentMintResponseInvalid");
+          // The underlying environment response must not be discarded: it's
+          // the only way to see why the mint request was actually rejected.
+          expect(result.failure).toMatchObject({
+            _tag: "EnvironmentMintResponseInvalid",
+            cause: expect.objectContaining({
+              _tag: "EnvironmentHttpInternalServerError",
+              message: "Could not issue cloud connection credential.",
+            }),
+          });
         }
       }).pipe(Effect.provide(connectorTestLayer(execute)));
     },

--- a/infra/relay/src/environments/EnvironmentConnector.test.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.test.ts
@@ -25,7 +25,12 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
 import * as Tracer from "effect/Tracer";
-import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import {
+  HttpClient,
+  HttpClientError,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http";
 
 import * as EnvironmentLinks from "./EnvironmentLinks.ts";
 import * as RelayConfiguration from "../Config.ts";
@@ -539,7 +544,7 @@ describe("EnvironmentConnector", () => {
       expect(result).toMatchObject({
         environmentId: "env-connector-test",
         status: "offline",
-        error: "Managed endpoint health request failed: Environment is unavailable.",
+        error: "Managed endpoint request failed: Environment is unavailable.",
         traceId: expect.any(String),
       });
     }).pipe(Effect.provide(connectorTestLayer(execute)));
@@ -783,6 +788,85 @@ describe("EnvironmentConnector", () => {
         expect(result.cause.toString()).toContain("EnvironmentMintResponseInvalid");
       }
     }).pipe(Effect.provide(connectorTestLayer(execute)));
+  });
+
+  it.effect(
+    "reports an invalid response, not a request failure, when the environment rejects a mint request",
+    () => {
+      const execute = (request: HttpClientRequest.HttpClientRequest) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            Response.json(
+              {
+                _tag: "EnvironmentHttpInternalServerError",
+                message: "Could not issue cloud connection credential.",
+              },
+              { status: 500 },
+            ),
+          ),
+        );
+
+      return Effect.gen(function* () {
+        const connector = yield* EnvironmentConnector.EnvironmentConnector;
+        const result = yield* Effect.exit(
+          connector.connect({
+            userId: "user_123",
+            environmentId: "env-connector-test",
+            clientProofKeyThumbprint: "client-proof-key-thumbprint",
+          }),
+        );
+
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          // Before the fix, any failed mint request — including a well-typed
+          // error the environment actually returned — collapsed into
+          // EnvironmentMintRequestFailed ("endpoint_request_failed"), telling
+          // the client the endpoint was unreachable when it had, in fact,
+          // answered.
+          expect(result.cause.toString()).toContain("EnvironmentMintResponseInvalid");
+          expect(result.cause.toString()).not.toContain("EnvironmentMintRequestFailed");
+        }
+      }).pipe(Effect.provide(connectorTestLayer(execute)));
+    },
+  );
+
+  it.effect("reports a request failure when the managed endpoint is truly unreachable", () => {
+    const failingHttpClient = HttpClient.make((request) =>
+      Effect.fail(
+        new HttpClientError.HttpClientError({
+          reason: new HttpClientError.TransportError({
+            request,
+            cause: new Error("connect ECONNREFUSED"),
+          }),
+        }),
+      ),
+    );
+    const layer = EnvironmentConnector.layer.pipe(
+      Layer.provide(NodeCryptoLayer.layer),
+      Layer.provide(Layer.succeed(EnvironmentLinks.EnvironmentLinks, makeLinks())),
+      Layer.provide(
+        Layer.succeed(ManagedEndpointAllocations.ManagedEndpointAllocations, makeAllocations()),
+      ),
+      Layer.provide(RelayConfiguration.layer(settings)),
+      Layer.provide(Layer.succeed(HttpClient.HttpClient, failingHttpClient)),
+    );
+
+    return Effect.gen(function* () {
+      const connector = yield* EnvironmentConnector.EnvironmentConnector;
+      const result = yield* Effect.exit(
+        connector.connect({
+          userId: "user_123",
+          environmentId: "env-connector-test",
+          clientProofKeyThumbprint: "client-proof-key-thumbprint",
+        }),
+      );
+
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        expect(result.cause.toString()).toContain("EnvironmentMintRequestFailed");
+      }
+    }).pipe(Effect.provide(layer));
   });
 
   it.effect("times out hung managed endpoint mint requests", () => {

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -111,6 +111,10 @@ export class EnvironmentMintResponseInvalid extends Schema.TaggedErrorClass<Envi
   {
     environmentId: Schema.String,
     operation: Schema.Literals(["connect", "status"]),
+    // Only set when this wraps a real failure (a decoded EnvironmentHttp*Error
+    // response, or a schema decode error) instead of a proof-verification
+    // mismatch, which has no underlying error to attach.
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -169,10 +173,13 @@ function isEnvironmentResponseInvalid(cause: unknown): boolean {
   return isEnvironmentCloudResponseError(cause) || Schema.isSchemaError(cause);
 }
 
-function environmentRequestFailureMessage(cause: unknown): string {
+// Only the status() path returns this over the wire (as the "offline" status
+// error), so its wording stays health-specific even though the underlying
+// classification is now shared with connect()'s (log-only) failure reason.
+function environmentHealthRequestFailureMessage(cause: unknown): string {
   return isEnvironmentCloudResponseError(cause)
-    ? `Managed endpoint request failed: ${cause.message}`
-    : "Managed endpoint request failed.";
+    ? `Managed endpoint health request failed: ${cause.message}`
+    : "Managed endpoint health request failed.";
 }
 
 function environmentRequestFailureReason(cause: unknown): string {
@@ -518,7 +525,7 @@ const make = Effect.gen(function* () {
           endpoint,
           status: "offline" as const,
           checkedAt,
-          error: environmentRequestFailureMessage(responseOption.value.cause),
+          error: environmentHealthRequestFailureMessage(responseOption.value.cause),
           traceId,
         };
       }
@@ -668,6 +675,7 @@ const make = Effect.gen(function* () {
           return yield* new EnvironmentMintResponseInvalid({
             environmentId: input.environmentId,
             operation: "connect",
+            cause: mintResult.cause,
           });
         }
         return yield* new EnvironmentMintRequestFailed({

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -151,7 +151,7 @@ const decodeMintResponseProof = Schema.decodeUnknownEffect(
 const decodeHealthResponseProof = Schema.decodeUnknownEffect(
   RelayEnvironmentHealthResponseProofPayload,
 );
-const isEnvironmentHealthError = Schema.is(
+const isEnvironmentCloudResponseError = Schema.is(
   Schema.Union([
     EnvironmentHttpBadRequestError,
     EnvironmentHttpUnauthorizedError,
@@ -161,14 +161,22 @@ const isEnvironmentHealthError = Schema.is(
   ]),
 );
 
-function environmentHealthRequestFailureMessage(cause: unknown): string {
-  return isEnvironmentHealthError(cause)
-    ? `Managed endpoint health request failed: ${cause.message}`
-    : "Managed endpoint health request failed.";
+// A schema decode failure or a well-typed EnvironmentHttpCloudErrors response
+// both mean the endpoint was reached and answered, just not with a usable
+// credential/health payload. Only genuine transport failures (connection
+// refused, DNS, TLS, timeout) mean the endpoint itself is unreachable.
+function isEnvironmentResponseInvalid(cause: unknown): boolean {
+  return isEnvironmentCloudResponseError(cause) || Schema.isSchemaError(cause);
 }
 
-function environmentHealthRequestFailureReason(cause: unknown): string {
-  if (isEnvironmentHealthError(cause)) {
+function environmentRequestFailureMessage(cause: unknown): string {
+  return isEnvironmentCloudResponseError(cause)
+    ? `Managed endpoint request failed: ${cause.message}`
+    : "Managed endpoint request failed.";
+}
+
+function environmentRequestFailureReason(cause: unknown): string {
+  if (isEnvironmentCloudResponseError(cause)) {
     return cause._tag;
   }
   if (HttpClientError.isHttpClientError(cause)) {
@@ -493,7 +501,7 @@ const make = Effect.gen(function* () {
         };
       }
       if (responseOption.value._tag === "Failure") {
-        const failureReason = environmentHealthRequestFailureReason(responseOption.value.cause);
+        const failureReason = environmentRequestFailureReason(responseOption.value.cause);
         yield* Effect.annotateCurrentSpan({
           "relay.environment_health.outcome": "failure",
           "relay.environment_health.failure_reason": failureReason,
@@ -510,7 +518,7 @@ const make = Effect.gen(function* () {
           endpoint,
           status: "offline" as const,
           checkedAt,
-          error: environmentHealthRequestFailureMessage(responseOption.value.cause),
+          error: environmentRequestFailureMessage(responseOption.value.cause),
           traceId,
         };
       }
@@ -621,32 +629,54 @@ const make = Effect.gen(function* () {
         ),
       );
       const environmentClient = yield* makeEnvironmentClient(endpoint.httpBaseUrl);
-      const decoded = yield* environmentClient.connect
+      const traceId = yield* currentTraceId;
+      const mintOption = yield* environmentClient.connect
         .t3MintCredential({ payload: { proof } })
         .pipe(
           withoutRedirects,
-          Effect.mapError(
-            (cause) =>
-              new EnvironmentMintRequestFailed({
-                environmentId: input.environmentId,
-                operation: "connect",
-                cause,
-              }),
-          ),
+          Effect.match({
+            onFailure: (cause) => ({ _tag: "Failure" as const, cause }),
+            onSuccess: (response) => ({ _tag: "Success" as const, response }),
+          }),
           Effect.timeoutOption(Duration.millis(ENVIRONMENT_MINT_REQUEST_TIMEOUT_MS)),
-          Effect.flatMap(
-            Option.match({
-              onNone: () =>
-                Effect.fail(
-                  new EnvironmentMintRequestTimedOut({
-                    environmentId: input.environmentId,
-                    timeoutMs: ENVIRONMENT_MINT_REQUEST_TIMEOUT_MS,
-                  }),
-                ),
-              onSome: Effect.succeed,
-            }),
-          ),
         );
+      if (Option.isNone(mintOption)) {
+        return yield* new EnvironmentMintRequestTimedOut({
+          environmentId: input.environmentId,
+          timeoutMs: ENVIRONMENT_MINT_REQUEST_TIMEOUT_MS,
+        });
+      }
+      const mintResult = mintOption.value;
+      if (mintResult._tag === "Failure") {
+        const failureReason = environmentRequestFailureReason(mintResult.cause);
+        yield* Effect.annotateCurrentSpan({
+          "relay.environment_mint.outcome": "failure",
+          "relay.environment_mint.failure_reason": failureReason,
+          "relay.environment_mint.trace_id": traceId,
+        });
+        yield* Effect.logWarning("Managed endpoint mint request failed", {
+          environmentId: link.environmentId,
+          endpoint: endpoint.httpBaseUrl,
+          failureReason,
+          traceId,
+        });
+        // The endpoint was reached and answered (a decoded application error,
+        // or a response that didn't match the expected schema): that's a
+        // different failure than the endpoint being unreachable, so it must
+        // not be reported as "endpoint unavailable".
+        if (isEnvironmentResponseInvalid(mintResult.cause)) {
+          return yield* new EnvironmentMintResponseInvalid({
+            environmentId: input.environmentId,
+            operation: "connect",
+          });
+        }
+        return yield* new EnvironmentMintRequestFailed({
+          environmentId: input.environmentId,
+          operation: "connect",
+          cause: mintResult.cause,
+        });
+      }
+      const decoded = mintResult.response;
       const verified = yield* verifyEnvironmentResponse({
         response: decoded,
         environmentId: input.environmentId,


### PR DESCRIPTION
## Summary
- `EnvironmentConnector.connect()` — the relay code path T3 Connect uses whenever a client opens a thread — collapsed every mint-credential failure into `EnvironmentMintRequestFailed` / `endpoint_request_failed`, including well-typed errors the environment itself returned (401/409/500) and response schema mismatches. That told users "the endpoint is unreachable" even when the environment had answered, with no way to tell the two apart, and nothing was logged about the real cause.
- Classify the failure the same way `getEnvironmentStatus()` already does: a decoded application error or a response schema failure now maps to the existing `EnvironmentMintResponseInvalid` (`endpoint_response_invalid`); genuine transport failures keep `EnvironmentMintRequestFailed` (`endpoint_request_failed`). Also logs the classified reason against the request's trace ID.
- No wire-contract changes — `endpoint_response_invalid` already existed and every client version already understands it.

Fixes #8844

## Test plan
- [x] `vp test run infra/relay/src/environments/EnvironmentConnector.test.ts` (17/17, includes two new regression tests)
- [x] `vp test run infra/relay/src/http/Api.test.ts` (11/11)
- [x] `vp run t3code-relay#typecheck`
- [x] `vp lint` on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which error clients see on the connect/mint path (better diagnostics, same wire codes), affecting a core T3 Connect flow without new API surface.
> 
> **Overview**
> **T3 Connect** mint failures no longer all surface as “endpoint unreachable.” When `EnvironmentConnector.connect()` calls the managed environment’s mint endpoint, **typed HTTP error responses** (e.g. 500 with `EnvironmentHttpInternalServerError`) and **schema decode failures** now return **`EnvironmentMintResponseInvalid`** (`endpoint_response_invalid`) instead of **`EnvironmentMintRequestFailed`** (`endpoint_request_failed`). **Transport-level failures** (e.g. `ECONNREFUSED`) and **timeouts** are unchanged.
> 
> The mint path now mirrors the existing health/status classification: shared helpers (`isEnvironmentCloudResponseError`, `environmentRequestFailureReason`) and **warning logs** with trace ID and `relay.environment_mint.failure_reason`. **`EnvironmentMintResponseInvalid`** gains an optional **`cause`** when the invalid response wraps a decoded environment error or schema error (proof-verification mismatches still omit it).
> 
> Two regression tests lock in invalid-response vs unreachable behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 644424b819c0bb8535f89a8f96df948bd21bddaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `EnvironmentConnector.connect` to distinguish invalid environment responses from unreachable endpoints
> - `EnvironmentConnector.connect` now returns `EnvironmentMintResponseInvalid` (with preserved `cause`) when a reachable endpoint returns a typed `EnvironmentHttp*Error` or schema-invalid response, instead of misclassifying it as `EnvironmentMintRequestFailed`
> - Genuine transport failures still return `EnvironmentMintRequestFailed`; timeouts now return `EnvironmentMintRequestTimedOut` directly without wrapping in an Option-flatMap failure
> - `EnvironmentMintResponseInvalid` gains an optional `cause` field (`Schema.optional(Schema.Defect())`) to carry the underlying decoded environment error or schema decode error
> - New `isEnvironmentResponseInvalid` helper classifies responses; `environmentRequestFailureReason` replaces the health-specific version and is reused for both health and mint paths
> - Behavioral Change: callers that previously saw `EnvironmentMintRequestFailed` for 500-level or schema-invalid responses will now see `EnvironmentMintResponseInvalid`; the old `isEnvironmentHealthError` util is renamed to `isEnvironmentCloudResponseError`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e43b90c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->