### PR TITLE
fix(web): prevent chat metadata overlap

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -265,8 +265,10 @@ function useLabelsOverflow(element: HTMLDivElement | null): boolean {
     let needed = 0;
     let groups = 0;
     for (const child of current.children) {
-      if (!(child instanceof HTMLElement) || child.offsetWidth <= 1) continue;
-      needed += contentWidth(child);
+      if (!(child instanceof HTMLElement)) continue;
+      const width = contentWidth(child);
+      if (width <= 1) continue;
+      needed += width;
       groups += 1;
     }
     needed += stripGap * Math.max(0, groups - 1);
@@ -356,7 +358,7 @@ function useLabelsOverflow(element: HTMLDivElement | null): boolean {
   // Label widths can change without the strip box moving (font family or
   // size preferences), so re-measure on every render as well as on resize
   // and font loads.
-  useEffect(() => {
+  useLayoutEffect(() => {
     measure();
   });
 
@@ -487,7 +489,7 @@ export const BranchToolbar = memo(function BranchToolbar({
           onUsePreviousWorktree={onUsePreviousWorktree}
         />
       ) : (
-        <div className="flex min-w-0 flex-1 items-center gap-1">
+        <div className="flex min-w-10 flex-1 items-center gap-1">
           {showEnvironmentIndicator && availableEnvironments && (
             <>
               <BranchToolbarEnvironmentSelector
@@ -520,7 +522,7 @@ export const BranchToolbar = memo(function BranchToolbar({
 
       {showGitControls ? (
         <BranchToolbarBranchSelector
-          className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"
+          className="min-w-0 flex-1 justify-end md:ml-auto md:flex-initial"
           environmentId={environmentId}
           threadId={threadId}
           {...(draftId ? { draftId } : {})}

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -51,20 +51,25 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
   if (envLocked) {
     return (
       <span
-        className="inline-flex h-7 shrink-0 items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs"
+        className="inline-flex h-7 min-w-0 items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:h-6 sm:text-xs"
         data-composer-context-control
       >
         {activeWorktreePath ? (
-          <>
-            <FolderGitIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
-          </>
+          <FolderGitIcon className="size-3 shrink-0" />
         ) : (
-          <>
-            <FolderIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
-          </>
+          <FolderIcon className="size-3 shrink-0" />
         )}
+        <span
+          data-composer-label
+          className="min-w-0 max-w-[240px] group-data-[compact]/composer-context:max-w-0"
+        >
+          <span
+            data-composer-label-motion
+            className="block w-full min-w-0 max-w-[240px] origin-left truncate transition-[opacity,transform] duration-180 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-[compact]/composer-context:[transform:translateX(-0.25rem)_scaleX(0.95)] group-data-[compact]/composer-context:opacity-0 motion-reduce:transform-none motion-reduce:transition-opacity"
+          >
+            {resolveLockedWorkspaceLabel(activeWorktreePath)}
+          </span>
+        </span>
       </span>
     );
   }

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -288,7 +288,7 @@ export const ChatHeader = memo(function ChatHeader({
       className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
       onContextMenu={handleHeaderContextMenu}
     >
-      <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1">
+      <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1 overflow-hidden">
         {/* The project always leads the header: knowing which project a
             thread lives in is priority zero, and the thread title alone
             doesn't answer it. */}

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -297,7 +297,7 @@ export const ChatHeader = memo(function ChatHeader({
             doesn't answer it. */}
         {activeProjectName ? (
           <>
-            <WorkspaceBreadcrumbItem>
+            <WorkspaceBreadcrumbItem className="shrink">
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -305,7 +305,7 @@ export const ChatHeader = memo(function ChatHeader({
                       type="button"
                       aria-label={`New thread in ${activeProjectName}`}
                       onClick={onNewThreadInProject}
-                      className="inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                      className="inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                     />
                   }
                 >
@@ -323,7 +323,7 @@ export const ChatHeader = memo(function ChatHeader({
             <WorkspaceBreadcrumbSeparator />
           </>
         ) : null}
-        <WorkspaceBreadcrumbItem current className="flex-1">
+        <WorkspaceBreadcrumbItem current className="min-w-10 flex-1">
           {renamingTitle !== null ? (
             <input
               autoFocus

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -288,7 +288,10 @@ export const ChatHeader = memo(function ChatHeader({
       className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
       onContextMenu={handleHeaderContextMenu}
     >
-      <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1 overflow-hidden">
+      <WorkspaceBreadcrumb
+        ariaLabel="Thread breadcrumb"
+        className="flex-1 overflow-clip [overflow-clip-margin:2px]"
+      >
         {/* The project always leads the header: knowing which project a
             thread lives in is priority zero, and the thread title alone
             doesn't answer it. */}


### PR DESCRIPTION
## Problem

Opening a pull request panel can narrow the chat column before the composer metadata recalculates its compact state. During those first frames, the locked workspace label, pull request tag, and branch name paint over one another. The thread breadcrumb at the top of the chat can similarly paint beyond its allocated space and into the fixed header actions.

## Fix

Keep the workspace control wide enough for its icon while allowing the pull request and branch group to shrink within the remaining space. Locked workspace labels now use the same compact-label path as interactive labels, and overflow measurement includes flex groups even when their own layout box has collapsed. Re-measure after React layout so thread metadata changes settle before paint.

Constrain the chat breadcrumb to its flexible column so long project and thread labels cannot paint underneath the fixed action controls.

## UI changes

Before — the pull request tag and branch name cross the workspace metadata while the chat narrows:

![Before: composer metadata overlaps while the chat column narrows](https://github.com/user-attachments/assets/318e1375-9afc-4e8f-9ced-025d30ca9554)

After — the workspace collapses to its icon and the pull request and branch controls stay in their own space:

![After: compact composer metadata remains separated](https://github.com/user-attachments/assets/25fc6b83-fd94-4f1d-aa1c-bc61f03855e8)

Motion verification — switching from a short default branch back to the long pull request branch and reopening the panel:

https://github.com/user-attachments/assets/15f7b3a1-94dc-4d5a-8f35-22aedcc870f5

## Verification

- `bun run fmt:check apps/web/src/components/BranchToolbar.tsx apps/web/src/components/BranchToolbarEnvModeSelector.tsx apps/web/src/components/chat/ChatHeader.tsx`
- `bun run lint apps/web/src/components/BranchToolbar.tsx apps/web/src/components/BranchToolbarEnvModeSelector.tsx apps/web/src/components/chat/ChatHeader.tsx`
- `bun run --cwd apps/web typecheck`
- `git diff --check`
- Browser-verified at the recording's 359 px chat width and across widths from 494 px down to 194 px.
- Sampled every animation frame while opening the pull request panel; the metadata controls remained separated on all 40 frames.

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout, measurement, and CSS-only changes in the web UI with no auth, data, or API impact.
> 
> **Overview**
> Fixes visual overlap when the chat column narrows (e.g. opening the pull request panel) before composer/header layout settles.
> 
> **Composer (`BranchToolbar`)** — Overflow detection now sums each flex group’s **content** width (not a collapsed `offsetWidth`), and re-measures in **`useLayoutEffect`** so compact mode updates before paint. Flex tweaks reserve at least icon width for the environment strip (`min-w-10`) and let the branch selector size to content on medium+ (`flex-initial`).
> 
> **Locked workspace label (`BranchToolbarEnvModeSelector`)** — Uses the same `data-composer-label` truncation and compact-mode motion as interactive controls, so the label can collapse to the icon instead of painting over PR/branch metadata.
> 
> **Chat header (`ChatHeader`)** — The thread breadcrumb is clipped within its flex column (`overflow-clip`) with tighter shrink/min-width on project and title items so long labels don’t draw under the fixed header actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b173986098f9ffa1b113fabfe87396d316169bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat metadata overlap in `ChatHeader` and `BranchToolbar`
> - Fixes overflow detection in `useLabelsOverflow` by computing group widths from summed in-flow content widths instead of `offsetWidth`, and switches measurement from `useEffect` to `useLayoutEffect` so it runs before paint.
> - Adjusts layout classes in [BranchToolbar.tsx](https://github.com/pingdotgg/t3code/pull/8851/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10) and [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/8851/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c): left container minimum width raised to `min-w-10`, branch selector uses `flex-initial`, breadcrumb items get `overflow-clip` and shrinking behavior.
> - Restructures the locked environment label in [BranchToolbarEnvModeSelector.tsx](https://github.com/pingdotgg/t3code/pull/8851/files#diff-f6e603d70ca6bba6f4bb6ec0c74ab245223570c8a33c292fb1d25529770f3f67) into a truncatable, compactable span with `max-width: 240px` while keeping the icon visible.
> - Risk: the new `useLayoutEffect`-based measurement and content-width calculation can change when overflow is reported and when label compaction triggers; verify that compaction animations fire at the correct breakpoints across viewport sizes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b173986.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->