### PR TITLE
fix(web): widen sync banners and simplify the working timer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2435,21 +2435,6 @@ function ChatViewContent(props: ChatViewProps) {
     () => deriveActivePlanState(threadActivities, activeLatestTurn?.turnId ?? undefined),
     [activeLatestTurn?.turnId, threadActivities],
   );
-  // Current step for the in-chat working row: only for the running turn's own
-  // plan (deriveActivePlanState falls back to older turns' plans, which must
-  // not label fresh work). Falls back to the first pending step so an
-  // all-pending freshly written plan labels the row, matching the composer and
-  // the server's planProgress.
-  const workingStepLabel = useMemo(() => {
-    if (!activePlan || activePlan.turnId !== (activeLatestTurn?.turnId ?? null)) {
-      return null;
-    }
-    return (
-      activePlan.steps.find((step) => step.status === "inProgress")?.step ??
-      activePlan.steps.find((step) => step.status === "pending")?.step ??
-      null
-    );
-  }, [activeLatestTurn?.turnId, activePlan]);
   const showPlanFollowUpPrompt = shouldShowPlanFollowUpPrompt({
     pendingUserInputCount: pendingUserInputs.length,
     interactionMode,
@@ -7240,7 +7225,6 @@ function ChatViewContent(props: ChatViewProps) {
                 onOpenAgents={addAgentsSurface}
                 key={activeThread.id}
                 isWorking={isWorking}
-                workingStepLabel={workingStepLabel}
                 activeTurnStartedAt={activeWorkStartedAt}
                 listRef={legendListRef}
                 timelineEntries={timelineEntries}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3439,14 +3439,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           />
           {!activityStackItem && (props.threadSyncPhase || inlineTasksBadge) ? (
             <ComposerBanner.Attachment>
-              <ComposerBanner.Root
-                width={
-                  props.threadSyncPhase && !showComposerTopDrawer && !isComposerCollapsedMobile
-                    ? "content"
-                    : "fill"
-                }
-                data-chat-composer-activity-strip="true"
-              >
+              <ComposerBanner.Root data-chat-composer-activity-strip="true">
                 {props.threadSyncPhase ? (
                   <ComposerActivityRow phase={props.threadSyncPhase} />
                 ) : (

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -171,8 +171,6 @@ interface TimelineRowActivityState {
   isWorking: boolean;
   isRevertingCheckpoint: boolean;
   latestTurnId: TurnId | null;
-  /** Current plan step label for the working row, when the turn has a plan. */
-  workingStepLabel: string | null;
 }
 
 const TimelineRowCtx = createContext<TimelineRowSharedState>(null!);
@@ -227,7 +225,6 @@ interface MessagesTimelineProps {
   agentPanelModel?: AgentPanelModel;
   onOpenAgents?: () => void;
   isWorking: boolean;
-  workingStepLabel?: string | null;
   activeTurnStartedAt: string | null;
   listRef: React.RefObject<LegendListRef | null>;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
@@ -273,7 +270,6 @@ interface MessagesTimelineProps {
 
 export const MessagesTimeline = memo(function MessagesTimeline({
   isWorking,
-  workingStepLabel = null,
   activeTurnStartedAt,
   agentPanelModel = EMPTY_AGENT_PANEL_MODEL,
   onOpenAgents = NOOP_OPEN_AGENTS,
@@ -583,9 +579,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       isWorking,
       isRevertingCheckpoint,
       latestTurnId: latestTurn?.turnId ?? null,
-      workingStepLabel,
     }),
-    [isRevertingCheckpoint, isWorking, latestTurn?.turnId, workingStepLabel],
+    [isRevertingCheckpoint, isWorking, latestTurn?.turnId],
   );
 
   // Stable renderItem — no closure deps. Row components read shared state
@@ -1323,7 +1318,6 @@ function ProposedPlanTimelineRow({
 }
 
 function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "working" }> }) {
-  const { workingStepLabel } = use(TimelineRowActivityCtx);
   return (
     <div>
       <div className="border-b border-border/60 pb-2 pt-1">
@@ -1337,11 +1331,6 @@ function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "workin
               "Working..."
             )}
           </span>
-          {workingStepLabel ? (
-            <span className="ml-2 min-w-0 truncate text-muted-foreground/55">
-              · {workingStepLabel}
-            </span>
-          ) : null}
         </div>
       </div>
       {row.showThinking ? (

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -37,6 +37,10 @@ when starting a thread or changing an existing thread's model.
 
 ## Notices above the composer
 
+On web and desktop, loading and syncing statuses fill the available banner width beside the
+stash tab. Task progress appears above the composer, while the timeline's working timer shows
+only elapsed time.
+
 On web and desktop, additional notices peek out above the attached banner. Hover over the peek
 to reveal them, or focus **Show other notices** with `Tab` and press `Enter` or `Space`. Press
 `Escape` to close the stack and return focus to that control. On a touchscreen, tap the peek to


### PR DESCRIPTION
Loading and syncing could shrink to a small tab even when the banner column had room. The working timer repeated the active task already shown above the composer.

Loading and syncing now fill the available banner column. Stash keeps its separate compact tab. The timeline keeps the elapsed-time timer and Thinking state, but no longer shows the task label. Task progress remains in the composer and stays hidden while loading or syncing.

The screenshots below use the same scripted fixture, dark theme, and viewport for main (`9842518c9a`) and this change. Fixtures and screenshots are not included in the commit.

Syncing fills the available width when there is no Stash tab.

| Before | After |
| --- | --- |
| ![Before: compact Syncing tab](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/12f96fe823e7f54a/pr-syncing-before.png) | ![After: Syncing spans the banner width](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3f699cbfa9d80181/pr-syncing-after.png) |

Loading fills the space beside Stash without changing the Stash tab.

| Before | After |
| --- | --- |
| ![Before: compact Loading tab beside Stash](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e2038c7d6c7244ff/pr-loading-stash-before.png) | ![After: Loading fills the column beside Stash](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3ff2842f364fb094/pr-loading-stash-after.png) |

The working timer shows elapsed time only. The task summary stays above the composer.

| Before | After |
| --- | --- |
| ![Before: task label appears beside the timer and above the composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3489d9e84147980f/pr-timer-before.png) | ![After: timer without the duplicate task label](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ed6bd47fc304c093/pr-timer-after.png) |

Verified at desktop and narrow web widths, with and without Stash and with stacked notices. Confirmed the timer still advances and task progress remains in the composer. All 140 focused tests, web typecheck, and targeted lint pass. This changes the shared web/desktop UI; native mobile is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only presentation changes in chat composer and timeline with no auth, data, or API impact.
> 
> **Overview**
> **Composer banners** for loading and syncing now use the default full-width layout instead of a compact `content`-width tab, so they fill the banner column beside the stash tab when space allows.
> 
> **Timeline working row** no longer shows the current plan step label next to “Working for …”; elapsed time and thinking state stay, while task progress remains in the composer banner stack above the input.
> 
> User docs for composer notices were updated to describe this split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f116dfab236237d978fa178c5f60a3077b696c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `workingStepLabel` from `MessagesTimeline` and widen sync banners in `ChatComposer`
> - Removes the `workingStepLabel` prop and context value from `MessagesTimeline` and `ChatViewContent`, so the working timer shows only elapsed time or "Working..." with no step label suffix.
> - Removes the conditional `width` prop on `ComposerBanner.Root` in `ChatComposer`, letting the activity strip banner use its default width for loading/syncing statuses.
> - Updates [composer.md](https://github.com/pingdotgg/t3code/pull/8855/files#diff-6c496fed927e1ba2296273bdfca78fd482921ebd76a32bb9d0c534f7bda35b63) to document the new banner and timer behavior.
> - Behavioral Change: the working row header no longer renders the `· {workingStepLabel}` text; callers passing `workingStepLabel` to `MessagesTimeline` will get a TypeScript error since the prop is removed from `MessagesTimelineProps`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f116dfa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->