### PR TITLE
fix(web): mark pull request links as external

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1168,7 +1168,7 @@ export function PullRequestDetailPanel({
                         aria-label={`Open pull request #${detail.number} on host`}
                       >
                         #{detail.number}
-                        <ExternalLinkIcon aria-hidden className="size-3 translate-y-px" />
+                        <ExternalLinkIcon aria-hidden className="size-2.5" />
                       </button>
                     }
                   />
@@ -1204,7 +1204,7 @@ export function PullRequestDetailPanel({
                         aria-label={`Open pull request #${detail.number} on host`}
                       >
                         #{detail.number}
-                        <ExternalLinkIcon aria-hidden className="size-3 translate-y-px" />
+                        <ExternalLinkIcon aria-hidden className="size-2.5" />
                       </button>
                     }
                   />

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -16,6 +16,7 @@ import {
   BookOpenIcon,
   CircleDotIcon,
   ChevronDownIcon,
+  ExternalLinkIcon,
   FileDiffIcon,
   FolderGit2Icon,
   GitBranchIcon,
@@ -1161,12 +1162,13 @@ export function PullRequestDetailPanel({
                         onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}
                         onContextMenu={(event) => openNumberContextMenu(event, detail)}
                         className={cn(
-                          "shrink-0 font-medium underline-offset-2 hover:underline",
+                          "inline-flex shrink-0 cursor-pointer items-center gap-0.5 font-medium underline-offset-2 hover:underline",
                           statePresentation.toneClassName,
                         )}
                         aria-label={`Open pull request #${detail.number} on host`}
                       >
                         #{detail.number}
+                        <ExternalLinkIcon aria-hidden className="size-3" />
                       </button>
                     }
                   />
@@ -1196,12 +1198,13 @@ export function PullRequestDetailPanel({
                         onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}
                         onContextMenu={(event) => openNumberContextMenu(event, detail)}
                         className={cn(
-                          "shrink-0 font-medium underline-offset-2 hover:underline",
+                          "inline-flex shrink-0 cursor-pointer items-center gap-0.5 font-medium underline-offset-2 hover:underline",
                           statePresentation.toneClassName,
                         )}
                         aria-label={`Open pull request #${detail.number} on host`}
                       >
                         #{detail.number}
+                        <ExternalLinkIcon aria-hidden className="size-3" />
                       </button>
                     }
                   />

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1168,7 +1168,7 @@ export function PullRequestDetailPanel({
                         aria-label={`Open pull request #${detail.number} on host`}
                       >
                         #{detail.number}
-                        <ExternalLinkIcon aria-hidden className="size-3" />
+                        <ExternalLinkIcon aria-hidden className="size-3 translate-y-px" />
                       </button>
                     }
                   />
@@ -1204,7 +1204,7 @@ export function PullRequestDetailPanel({
                         aria-label={`Open pull request #${detail.number} on host`}
                       >
                         #{detail.number}
-                        <ExternalLinkIcon aria-hidden className="size-3" />
+                        <ExternalLinkIcon aria-hidden className="size-3 translate-y-px" />
                       </button>
                     }
                   />


### PR DESCRIPTION
The pull request number in the detail header opened the host, but it looked like plain text and kept the default cursor. This adds an external-link icon and a pointer cursor in both expanded and condensed header states.

## Before

![Pull request link before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7cfb5781817cdad3/121716e8-e085-4f95-ac5a-2854d0828f39-8722632e-33d4-44b7-a491-0cb15bea63d0.png)

## After

![Pull request link after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/51cbdd86b10f0a6e/after-smaller.png)

## Validation

- `vp fmt apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx --check`
- `vp lint apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx --report-unused-disable-directives`
- `vp run --filter @t3tools/web typecheck`
- Verified in the web client that the link renders an external-link SVG and computes to `cursor: pointer`

Built with GPT-5.6 Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only tweaks in the PR detail header; no changes to navigation, permissions, or data handling.
> 
> **Overview**
> Makes the **pull request number** in `PullRequestDetailPanel` read clearly as an external link in both the normal and **condensed** header layouts.
> 
> The `#number` control keeps the same `openExternal` click and context-menu behavior, but now uses **inline-flex** with **`cursor-pointer`**, a small gap, and an **`ExternalLinkIcon`** beside the number so it no longer looks like plain text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bc96b047bca7e667dbbb86ee8bf3584ff36d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ExternalLinkIcon` to pull request links in `PullRequestDetailPanel`
> Updates the two buttons that open a pull request on the host (regular and condensed render paths) to include an `ExternalLinkIcon` after the PR number, and adjusts their className to use `inline-flex`, `items-center`, `gap-0.5`, and `cursor-pointer`. Click behavior and tooltips are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31bc96b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

