### PR TITLE
feat(web): generate and preserve thread handover drafts

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -36,7 +36,9 @@ import {
 } from "../../state/composer-attachment-uploads";
 import Animated, {
   FadeIn,
+  FadeInDown,
   FadeOut,
+  FadeOutDown,
   type LayoutAnimationFunction,
   ReduceMotion,
   useAnimatedStyle,
@@ -118,6 +120,9 @@ export interface ThreadComposerProps {
   readonly selectedThread: OrchestrationThreadShell;
   readonly hasCompactableConversation: boolean;
   readonly serverConfig: T3ServerConfig | null;
+  readonly contextLimitReached: boolean;
+  readonly isGeneratingHandover: boolean;
+  readonly onGenerateHandover?: () => void;
   readonly queueCount: number;
   readonly environmentId: EnvironmentId;
   readonly projectCwd: string | null;
@@ -260,6 +265,38 @@ export function ComposerSurface(props: {
   );
 }
 
+const ComposerContextLimitPill = memo(function ComposerContextLimitPill(props: {
+  readonly isGenerating: boolean;
+  readonly onGenerate?: () => void;
+}) {
+  return (
+    <Animated.View
+      className="max-w-full flex-row items-center gap-2 rounded-full bg-card px-3 py-2 shadow-sm"
+      entering={FadeInDown.duration(180)}
+      exiting={FadeOutDown.duration(140)}
+    >
+      <View className="h-4 w-4 items-center justify-center rounded-full bg-amber-500">
+        <Text className="text-xs font-t3-bold leading-none text-white">!</Text>
+      </View>
+      <Text className="text-sm font-t3-bold leading-snug text-foreground">
+        Context limit reached
+      </Text>
+      {props.onGenerate ? (
+        <Pressable
+          accessibilityRole="button"
+          disabled={props.isGenerating}
+          onPress={props.onGenerate}
+          className="rounded-full bg-accent px-2.5 py-1 active:opacity-70"
+        >
+          <Text className="text-xs font-t3-bold text-white">
+            {props.isGenerating ? "Creating..." : "New draft"}
+          </Text>
+        </Pressable>
+      ) : null}
+    </Animated.View>
+  );
+});
+
 export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposerProps) {
   const { materialYouStyleLayoutActive, themeVariables: materialTheme } =
     useAppearancePreferences();
@@ -385,7 +422,11 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   });
   const sendBlockedReason = props.sendBlockedReason ?? attachmentBlockReason;
   const canSend =
-    hasContent && !voiceInput.blocksSubmission && sendBlockedReason === null && !modelUnavailable;
+    hasContent &&
+    !voiceInput.blocksSubmission &&
+    sendBlockedReason === null &&
+    !props.contextLimitReached &&
+    !modelUnavailable;
 
   // Keep the feed inset aligned with the card or compact dictation strip.
   useEffect(() => {
@@ -445,7 +486,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       if (openUsageLimits()) onChangeDraftMessage("");
       return;
     }
-    if (voiceInput.blocksSubmission) return;
+    if (voiceInput.blocksSubmission || props.contextLimitReached) return;
     const threadKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
     if (inFlightThreadIdsRef.current.has(threadKey)) return;
     inFlightThreadIdsRef.current.add(threadKey);
@@ -477,6 +518,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     props.environmentLabel,
     props.selectedThread.id,
     props.selectedThread.title,
+    props.contextLimitReached,
     voiceInput.blocksSubmission,
   ]);
 
@@ -609,6 +651,17 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
           </View>
         ) : null}
 
+        {props.contextLimitReached ? (
+          <View
+            className="absolute inset-x-0 bottom-full items-center gap-2 pb-2"
+            pointerEvents="box-none"
+          >
+            <ComposerContextLimitPill
+              isGenerating={props.isGeneratingHandover}
+              onGenerate={props.onGenerateHandover}
+            />
+          </View>
+        ) : null}
         {modelUnavailable ? (
           <Pressable accessibilityRole="button" className="px-3 py-2" onPress={openSettings}>
             <Text className="text-xs text-foreground">Model unavailable. Open model settings.</Text>

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -147,6 +147,9 @@ export interface ThreadDetailScreenProps {
   readonly queuedMessages: ReadonlyArray<QueuedThreadMessage>;
   readonly dispatchingMessageId: MessageId | null;
   readonly serverConfig: T3ServerConfig | null;
+  readonly contextLimitReached: boolean;
+  readonly isGeneratingHandover: boolean;
+  readonly onGenerateHandover?: () => void;
   readonly layoutVariant?: LayoutVariant;
   readonly usesAutomaticContentInsets?: boolean;
   readonly onHeaderMaterialVisibilityChange?: (visible: boolean) => void;
@@ -739,6 +742,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   ]);
 
   const handleSendMessage = useCallback(async () => {
+    if (props.contextLimitReached) return null;
     const targetThreadKey = selectedThreadKey;
     const hasUserMessage = selectedThreadFeed.some(
       (entry) => entry.type === "message" && entry.message.role === "user",
@@ -765,6 +769,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     return messageId;
   }, [
     anchorMessageId,
+    props.contextLimitReached,
     clearUsageLimitsFor,
     props.onSendMessage,
     props.selectedThread.latestTurn,
@@ -1035,6 +1040,9 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                     selectedThread={props.selectedThread}
                     hasCompactableConversation={hasCompactableConversation && !props.isCompacting}
                     serverConfig={props.serverConfig}
+                    contextLimitReached={props.contextLimitReached}
+                    isGeneratingHandover={props.isGeneratingHandover}
+                    onGenerateHandover={props.onGenerateHandover}
                     queueCount={props.selectedThreadQueueCount}
                     environmentId={props.environmentId}
                     projectCwd={props.threadCwd ?? props.projectWorkspaceRoot}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -2,10 +2,19 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import {
   StackActions,
   useFocusEffect,
+  useIsFocused,
   useNavigation,
   type StaticScreenProps,
 } from "@react-navigation/native";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 import * as Option from "effect/Option";
 import {
   DEFAULT_SERVER_SETTINGS,
@@ -74,7 +83,13 @@ import { useSelectedThreadGitState } from "../../state/use-selected-thread-git-s
 import { useSelectedThreadRequests } from "../../state/use-selected-thread-requests";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useThreadComposerState } from "../../state/use-thread-composer-state";
+import { threadContextReachedLimit } from "../../state/contextLimit";
 import { threadEnvironment } from "../../state/threads";
+import { waitForComposerDraftsLoaded } from "../../state/use-composer-drafts";
+import {
+  prepareThreadHandoverDraft,
+  threadHandoverDraftImportId,
+} from "../../state/threadHandoverDraft";
 import { projectThreadContentPresentation } from "./threadContentPresentation";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import {
@@ -95,6 +110,42 @@ interface ThreadInspectorSelection {
 }
 
 type NativeHeaderItems = ReadonlyArray<Record<string, unknown>>;
+
+interface MobileHandoverAttempt {
+  readonly handover: string;
+  readonly draftImportId: string;
+}
+
+const mobileHandoverAttempts = new Map<string, MobileHandoverAttempt>();
+const generatingMobileHandovers = new Set<string>();
+const mobileHandoverListeners = new Set<() => void>();
+const MAX_PENDING_MOBILE_HANDOVERS = 8;
+
+function saveMobileHandoverAttempt(sourceThreadKey: string, attempt: MobileHandoverAttempt): void {
+  mobileHandoverAttempts.delete(sourceThreadKey);
+  mobileHandoverAttempts.set(sourceThreadKey, attempt);
+  while (mobileHandoverAttempts.size > MAX_PENDING_MOBILE_HANDOVERS) {
+    const oldestKey = mobileHandoverAttempts.keys().next().value;
+    if (oldestKey === undefined) break;
+    mobileHandoverAttempts.delete(oldestKey);
+  }
+}
+
+function notifyMobileHandoverListeners(): void {
+  for (const listener of mobileHandoverListeners) {
+    listener();
+  }
+}
+
+function subscribeMobileHandoverState(listener: () => void): () => void {
+  mobileHandoverListeners.add(listener);
+  return () => mobileHandoverListeners.delete(listener);
+}
+
+function mobileHandoverStateSnapshot(threadKey: string | null): string {
+  if (threadKey === null) return "";
+  return `${generatingMobileHandovers.has(threadKey)}:${mobileHandoverAttempts.has(threadKey)}`;
+}
 
 function InspectorPaneRoleActivation() {
   useAdaptiveWorkspacePaneRole("inspector");
@@ -228,13 +279,17 @@ function ThreadRouteContent(
       },
     };
   }, [selectedThread, selectedThreadDetailState]);
-  const { selectedThreadCwd } = useSelectedThreadWorktree();
+  const { selectedThreadCwd, selectedThreadWorktreePath } = useSelectedThreadWorktree();
   const composer = useThreadComposerState();
   const gitState = useSelectedThreadGitState();
   const gitActions = useSelectedThreadGitActions();
   const requests = useSelectedThreadRequests();
   const interruptThreadTurn = useAtomCommand(threadEnvironment.interruptTurn, "thread interrupt");
+  const generateThreadHandover = useAtomCommand(threadEnvironment.generateHandover, {
+    reportFailure: false,
+  });
   const navigation = useNavigation();
+  const isFocused = useIsFocused();
   const params = props.route.params;
   const environmentIdRaw = firstRouteParam(params.environmentId);
   const environmentId = environmentIdRaw ? EnvironmentId.make(environmentIdRaw) : null;
@@ -315,6 +370,130 @@ function ThreadRouteContent(
         : null,
     [composer.interactionMode, composer.modelSelection, composer.runtimeMode, selectedThread],
   );
+  const serverConfig = routeEnvironmentRuntime?.serverConfig ?? null;
+  const selectedHandoverKeyRef = useRef(
+    selectedThread
+      ? threadHandoverDraftImportId(selectedThread.environmentId, selectedThread.id)
+      : null,
+  );
+  selectedHandoverKeyRef.current = selectedThread
+    ? threadHandoverDraftImportId(selectedThread.environmentId, selectedThread.id)
+    : null;
+  const currentHandoverKey = selectedThread
+    ? threadHandoverDraftImportId(selectedThread.environmentId, selectedThread.id)
+    : null;
+  const handoverState = useSyncExternalStore(
+    subscribeMobileHandoverState,
+    () => mobileHandoverStateSnapshot(currentHandoverKey),
+    () => mobileHandoverStateSnapshot(currentHandoverKey),
+  );
+  const isGeneratingHandover = handoverState.startsWith("true:");
+  const mountedRef = useRef(true);
+  const isFocusedRef = useRef(isFocused);
+  isFocusedRef.current = isFocused;
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  const handleGenerateHandover = useCallback(async () => {
+    if (
+      !selectedThread ||
+      !selectedThreadProject ||
+      !selectedThreadDetail ||
+      serverConfig?.environment.capabilities.threadHandoverGeneration !== true ||
+      currentHandoverKey === null
+    ) {
+      return;
+    }
+    const sourceThreadKey = currentHandoverKey;
+    if (generatingMobileHandovers.has(sourceThreadKey)) return;
+    generatingMobileHandovers.add(sourceThreadKey);
+    notifyMobileHandoverListeners();
+    try {
+      let attempt = mobileHandoverAttempts.get(sourceThreadKey);
+      if (attempt === undefined) {
+        const result = await generateThreadHandover({
+          environmentId: selectedThread.environmentId,
+          input: { threadId: selectedThread.id },
+        });
+        if (result._tag === "Failure") {
+          Alert.alert("Could not create handover", "Handover generation failed. Try again.");
+          return;
+        }
+        attempt = {
+          handover: result.value.handover,
+          draftImportId: threadHandoverDraftImportId(
+            selectedThread.environmentId,
+            selectedThread.id,
+          ),
+        };
+        saveMobileHandoverAttempt(sourceThreadKey, attempt);
+        notifyMobileHandoverListeners();
+      }
+      await waitForComposerDraftsLoaded();
+      if (
+        !mountedRef.current ||
+        !isFocusedRef.current ||
+        selectedHandoverKeyRef.current !== sourceThreadKey
+      ) {
+        return;
+      }
+
+      const destinationDraftKey = await prepareThreadHandoverDraft({
+        environmentId: selectedThread.environmentId,
+        projectId: selectedThread.projectId,
+        importId: attempt.draftImportId,
+        handover: attempt.handover,
+        workspaceSelection: {
+          mode: "local",
+          branch: selectedThread.branch,
+          worktreePath: selectedThreadWorktreePath,
+          startFromOrigin: false,
+        },
+      });
+
+      if (
+        !mountedRef.current ||
+        !isFocusedRef.current ||
+        selectedHandoverKeyRef.current !== sourceThreadKey
+      ) {
+        return;
+      }
+      navigation.navigate("NewTaskSheet", {
+        screen: "NewTaskDraft",
+        params: {
+          environmentId: String(selectedThread.environmentId),
+          projectId: String(selectedThread.projectId),
+          title: selectedThreadProject.title,
+          draftId: destinationDraftKey,
+        },
+      });
+      mobileHandoverAttempts.delete(sourceThreadKey);
+      notifyMobileHandoverListeners();
+    } catch (error) {
+      Alert.alert(
+        "Could not open handover",
+        error instanceof Error
+          ? error.message
+          : "The generated handover remains available to retry.",
+      );
+    } finally {
+      generatingMobileHandovers.delete(sourceThreadKey);
+      notifyMobileHandoverListeners();
+    }
+  }, [
+    currentHandoverKey,
+    generateThreadHandover,
+    isFocused,
+    navigation,
+    selectedThread,
+    selectedThreadDetail,
+    selectedThreadProject,
+    serverConfig?.environment.capabilities.threadHandoverGeneration,
+    selectedThreadWorktreePath,
+  ]);
 
   /* ─── Native header theming ──────────────────────────────────────── */
   const usesNativeHeaderGlass = NATIVE_LIQUID_GLASS_SUPPORTED;
@@ -835,7 +1014,13 @@ function ThreadRouteContent(
           detailDeleted: selectedThreadDetailState.status === "deleted",
           connectionState: routeConnectionState,
         });
-  const serverConfig = routeEnvironmentRuntime?.serverConfig ?? null;
+  const contextLimitReached =
+    serverConfig !== null &&
+    selectedThreadDetail !== null &&
+    threadContextReachedLimit(
+      selectedThreadDetail.activities,
+      serverConfig?.settings.threadContextTokenLimit,
+    );
   const renderThreadRouteBody = (showActionControls: boolean) => (
     <>
       <ThreadGitControls {...threadGitControlProps} showActionControls={showActionControls} />
@@ -893,6 +1078,13 @@ function ThreadRouteContent(
           onNativePasteImages={composer.onNativePasteImages}
           onRemoveDraftImage={composer.onRemoveDraftImage}
           serverConfig={serverConfig}
+          contextLimitReached={contextLimitReached}
+          isGeneratingHandover={isGeneratingHandover}
+          onGenerateHandover={
+            serverConfig?.environment.capabilities.threadHandoverGeneration === true
+              ? handleGenerateHandover
+              : undefined
+          }
           onStopThread={handleStopThread}
           onSendMessage={composer.onSendMessage}
           onReconnectEnvironment={handleReconnectEnvironment}

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1507,6 +1507,13 @@ const activityOrder = Order.combineAll<OrchestrationThreadActivity>([
   Order.mapInput(Order.String, (activity) => activity.id),
 ]);
 
+export function compareThreadActivityOrder(
+  left: OrchestrationThreadActivity,
+  right: OrchestrationThreadActivity,
+): -1 | 0 | 1 {
+  return activityOrder(left, right);
+}
+
 function isEmptyMessage(entry: RawThreadFeedEntry): boolean {
   if (entry.type !== "message") {
     return false;

--- a/apps/mobile/src/state/contextLimit.ts
+++ b/apps/mobile/src/state/contextLimit.ts
@@ -1,0 +1,24 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+
+import { compareThreadActivityOrder } from "../lib/threadActivity";
+
+export function threadContextReachedLimit(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  contextTokenLimit: number | undefined,
+): boolean {
+  if (contextTokenLimit === undefined) return false;
+  let latest:
+    | { readonly activity: OrchestrationThreadActivity; readonly usedTokens: number }
+    | undefined;
+  for (const activity of activities) {
+    if (activity?.kind !== "context-window.updated") continue;
+    const payload = activity.payload as Record<string, unknown> | undefined;
+    const usedTokens = payload?.usedTokens;
+    if (typeof usedTokens === "number" && Number.isFinite(usedTokens) && usedTokens >= 0) {
+      if (latest === undefined || compareThreadActivityOrder(latest.activity, activity) <= 0) {
+        latest = { activity, usedTokens };
+      }
+    }
+  }
+  return latest !== undefined && latest.usedTokens >= contextTokenLimit;
+}

--- a/apps/mobile/src/state/threadHandoverDraft.test.ts
+++ b/apps/mobile/src/state/threadHandoverDraft.test.ts
@@ -1,0 +1,65 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  clearComposerDraftContentState,
+  mergeComposerDraftContentState,
+} from "./use-composer-drafts";
+import { threadHandoverDraftImportId } from "./threadHandoverDraft";
+
+describe("threadHandoverDraftImportId", () => {
+  it("keeps retries idempotent across restart and allows another import after clear", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const threadId = ThreadId.make("thread-1");
+    const destinationDraftKey = "new-task:environment-1:project-1";
+    const firstImportId = threadHandoverDraftImportId(environmentId, threadId);
+    const written = mergeComposerDraftContentState({}, destinationDraftKey, {
+      text: "Generated handover",
+      attachments: [],
+      sourceShareId: firstImportId,
+    });
+    const edited = {
+      [destinationDraftKey]: {
+        ...written[destinationDraftKey]!,
+        text: "Edited generated handover",
+        workspaceSelection: {
+          mode: "worktree" as const,
+          branch: "user-edited",
+          worktreePath: "/worktrees/edited",
+        },
+      },
+    };
+
+    // A restarted process reconstructs the same receipt from the source
+    // thread. Regeneration cannot append over the user's edited draft.
+    const restartedImportId = threadHandoverDraftImportId(environmentId, threadId);
+    expect(restartedImportId).toBe(firstImportId);
+    expect(
+      mergeComposerDraftContentState(edited, destinationDraftKey, {
+        text: "Regenerated handover",
+        attachments: [],
+        sourceShareId: restartedImportId,
+      }),
+    ).toBe(edited);
+    expect(edited[destinationDraftKey]?.workspaceSelection?.branch).toBe("user-edited");
+
+    // Clear/send removes import receipts, making the same source eligible for
+    // a deliberate new handover draft.
+    const cleared = clearComposerDraftContentState(edited, destinationDraftKey);
+    const retried = mergeComposerDraftContentState(cleared, destinationDraftKey, {
+      text: "Regenerated handover",
+      attachments: [],
+      sourceShareId: restartedImportId,
+    });
+    expect(retried[destinationDraftKey]).toMatchObject({
+      text: "Regenerated handover",
+      importedShareIds: [restartedImportId],
+    });
+  });
+
+  it("keeps opaque environment and thread IDs unambiguous", () => {
+    expect(threadHandoverDraftImportId(EnvironmentId.make("a:b"), ThreadId.make("c"))).not.toBe(
+      threadHandoverDraftImportId(EnvironmentId.make("a"), ThreadId.make("b:c")),
+    );
+  });
+});

--- a/apps/mobile/src/state/threadHandoverDraft.ts
+++ b/apps/mobile/src/state/threadHandoverDraft.ts
@@ -1,0 +1,47 @@
+import type { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
+import { threadHandoverSourceKey } from "@t3tools/shared/threadReference";
+
+/**
+ * Stable receipt for importing one source thread's handover into its project
+ * draft. The receipt is persisted with the draft, so retries remain idempotent
+ * after navigation, module reload, or an app restart.
+ */
+export function threadHandoverDraftImportId(
+  environmentId: EnvironmentId,
+  threadId: ThreadId,
+): string {
+  return threadHandoverSourceKey(environmentId, threadId);
+}
+
+import { appAtomRegistry } from "./atom-registry";
+import {
+  composerDraftsAtom,
+  createNewTaskDraft,
+  mergeComposerDraftContent,
+  waitForComposerDraftsLoaded,
+  type ComposerDraftWorkspaceSelection,
+} from "./use-composer-drafts";
+
+/** Reopens the receipt-bearing draft after restart, or creates a new project-stamped draft. */
+export async function prepareThreadHandoverDraft(input: {
+  environmentId: EnvironmentId;
+  projectId: ProjectId;
+  importId: string;
+  handover: string;
+  workspaceSelection: ComposerDraftWorkspaceSelection;
+}): Promise<string> {
+  await waitForComposerDraftsLoaded();
+  const existing = Object.entries(appAtomRegistry.get(composerDraftsAtom)).find(
+    ([, draft]) =>
+      draft.project?.environmentId === input.environmentId &&
+      draft.project.projectId === input.projectId &&
+      draft.importedShareIds?.includes(input.importId),
+  );
+  const key = existing?.[0] ?? createNewTaskDraft(input);
+  await mergeComposerDraftContent(
+    key,
+    { text: input.handover, attachments: [], sourceShareId: input.importId },
+    { workspaceSelection: input.workspaceSelection },
+  );
+  return key;
+}

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -1,3 +1,4 @@
+import { prepareThreadHandoverDraft } from "./threadHandoverDraft";
 import { afterEach, describe, expect, it } from "@effect/vitest";
 import {
   CommandId,
@@ -165,6 +166,7 @@ import {
   findNewTaskDraftKeys,
   flushComposerDrafts,
   getComposerDraftSnapshot,
+  mergeComposerDraftContent,
   mergeComposerDraftContentState,
   migrateLegacyNewTaskDraft,
   releaseUnusedComposerAttachmentFiles,
@@ -176,6 +178,7 @@ import {
   retargetNewTaskDraft,
   setComposerDraftText,
   setComposerDraftAttachmentUpload,
+  updateComposerDraftSettings,
   waitForComposerDraftsLoaded,
   setStickyComposerModelSelection,
   stickyComposerModelSelectionAtom,
@@ -1320,6 +1323,143 @@ describe("mobile composer drafts", () => {
     });
   });
 
+  it("merges a handover only after hydration without replacing the saved draft", async () => {
+    const draftKey = "new-task:handover-draft";
+    const attachment = {
+      id: "saved-file",
+      type: "file" as const,
+      name: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 42,
+      fileUri: "file:///documents/t3-composer-attachments/report.pdf",
+    };
+    composerDraftFileMocks.setDocument({
+      schemaVersion: 1,
+      drafts: {
+        [draftKey]: {
+          text: "Old unsent prompt",
+          attachments: [attachment],
+          runtimeMode: "full-access",
+        },
+      },
+    });
+    composerDraftFileMocks.blockRead();
+
+    const merge = mergeComposerDraftContent(draftKey, {
+      text: "Generated handover",
+      attachments: [],
+    });
+    await Promise.resolve();
+    expect(composerDraftFileMocks.getWrites()).toHaveLength(0);
+
+    composerDraftFileMocks.releaseRead();
+    await merge;
+
+    expect(getComposerDraftSnapshot(draftKey)).toMatchObject({
+      text: "Old unsent prompt\n\nGenerated handover",
+      attachments: [attachment],
+      runtimeMode: "full-access",
+    });
+    expect(JSON.parse(composerDraftFileMocks.getDocument()).drafts[draftKey]).toMatchObject({
+      text: "Old unsent prompt\n\nGenerated handover",
+      attachments: [attachment],
+      runtimeMode: "full-access",
+    });
+  });
+
+  it("persists handover content, receipt, and workspace as one restart-safe draft", async () => {
+    const draftKey = "new-task:handover-draft";
+    const content = {
+      text: "Generated handover",
+      attachments: [],
+      sourceShareId: "handover:source-thread",
+    };
+    const sourceWorkspace = {
+      mode: "local" as const,
+      branch: "source-branch",
+      worktreePath: "/worktrees/source",
+      startFromOrigin: false,
+    };
+
+    await mergeComposerDraftContent(draftKey, content, {
+      workspaceSelection: sourceWorkspace,
+    });
+
+    expect(JSON.parse(composerDraftFileMocks.getDocument()).drafts[draftKey]).toMatchObject({
+      text: "Generated handover",
+      importedShareIds: ["handover:source-thread"],
+      workspaceSelection: sourceWorkspace,
+    });
+
+    appAtomRegistry.set(composerDraftsAtom, {});
+    resetComposerDraftsLoadState();
+    await waitForComposerDraftsLoaded();
+    expect(getComposerDraftSnapshot(draftKey)).toMatchObject({
+      text: "Generated handover",
+      importedShareIds: ["handover:source-thread"],
+      workspaceSelection: sourceWorkspace,
+    });
+
+    const editedWorkspace = {
+      ...sourceWorkspace,
+      branch: "user-edited",
+      worktreePath: "/worktrees/edited",
+    };
+    updateComposerDraftSettings(draftKey, { workspaceSelection: editedWorkspace });
+    await mergeComposerDraftContent(draftKey, content, {
+      workspaceSelection: sourceWorkspace,
+    });
+
+    expect(getComposerDraftSnapshot(draftKey).workspaceSelection).toEqual(editedWorkspace);
+    expect(
+      JSON.parse(composerDraftFileMocks.getDocument()).drafts[draftKey].workspaceSelection,
+    ).toEqual(editedWorkspace);
+  });
+
+  it("retries a failed handover write without replacing workspace edits", async () => {
+    const draftKey = "new-task:environment-1:project-1";
+    const content = {
+      text: "Generated handover",
+      attachments: [],
+      sourceShareId: "handover:source-thread",
+    };
+    const sourceWorkspace = {
+      mode: "local" as const,
+      branch: "source-branch",
+      worktreePath: "/worktrees/source",
+      startFromOrigin: false,
+    };
+    composerDraftFileMocks.setWriteError(new Error("storage unavailable"));
+
+    await expect(
+      mergeComposerDraftContent(draftKey, content, {
+        workspaceSelection: sourceWorkspace,
+      }),
+    ).rejects.toBeInstanceOf(ComposerDraftPersistenceError);
+
+    expect(getComposerDraftSnapshot(draftKey)).toMatchObject({
+      importedShareIds: ["handover:source-thread"],
+      workspaceSelection: sourceWorkspace,
+    });
+    const editedWorkspace = {
+      ...sourceWorkspace,
+      branch: "user-edited",
+      worktreePath: "/worktrees/edited",
+    };
+    updateComposerDraftSettings(draftKey, { workspaceSelection: editedWorkspace });
+    composerDraftFileMocks.setWriteError(null);
+
+    await mergeComposerDraftContent(draftKey, content, {
+      workspaceSelection: sourceWorkspace,
+    });
+    await flushComposerDrafts();
+
+    expect(getComposerDraftSnapshot(draftKey).workspaceSelection).toEqual(editedWorkspace);
+    expect(
+      JSON.parse(composerDraftFileMocks.getDocument()).drafts[draftKey].workspaceSelection,
+    ).toEqual(editedWorkspace);
+  });
+
   it.each(["read", "decode"] as const)(
     "preserves saved drafts and attachment files when the draft %s fails",
     async (failure) => {
@@ -1575,6 +1715,27 @@ describe("mobile composer drafts", () => {
       [draftKey]: { ...merged[draftKey]!, text: "User edited the imported context" },
     };
     expect(mergeComposerDraftContentState(edited, draftKey, content)).toBe(edited);
+  });
+
+  it("allows a handover retry after its previously imported draft was cleared or sent", () => {
+    const draftKey = "new-task:environment-1:project-1";
+    const content = {
+      text: "Handover context",
+      attachments: [],
+      sourceShareId: "handover:attempt-1",
+    };
+    const written = mergeComposerDraftContentState({}, draftKey, content);
+    const edited = { [draftKey]: { ...written[draftKey]!, text: "Edited handover" } };
+    expect(mergeComposerDraftContentState(edited, draftKey, content)).toBe(edited);
+
+    const cleared = clearComposerDraftContentState(edited, draftKey);
+    expect(cleared[draftKey]?.importedShareIds).toBeUndefined();
+    const retried = mergeComposerDraftContentState(cleared, draftKey, content);
+    expect(retried[draftKey]).toMatchObject({
+      text: "Handover context",
+      importedShareIds: ["handover:attempt-1"],
+    });
+    expect(mergeComposerDraftContentState(retried, draftKey, content)).toBe(retried);
   });
 
   it("preserves existing images when shared content exceeds the draft attachment limit", () => {
@@ -1985,4 +2146,46 @@ describe("mobile composer drafts", () => {
     });
     expect(composerAttachmentCleanupMocks.remove).not.toHaveBeenCalled();
   });
+});
+
+it("reopens a migrated handover receipt without duplicating or replacing an edited draft", async () => {
+  composerDraftFileMocks.setDocument({
+    schemaVersion: 1,
+    drafts: {
+      "new-task:environment-1:project-1": {
+        text: "User-edited handover",
+        attachments: [],
+        importedShareIds: ["handover:source"],
+        workspaceSelection: {
+          mode: "local",
+          branch: "user-branch",
+          worktreePath: "/user-worktree",
+          startFromOrigin: false,
+        },
+      },
+    },
+  });
+  const input = {
+    environmentId: EnvironmentId.make("environment-1"),
+    projectId: ProjectId.make("project-1"),
+    importId: "handover:source",
+    handover: "Regenerated handover",
+    workspaceSelection: {
+      mode: "local" as const,
+      branch: "original",
+      worktreePath: "/original",
+      startFromOrigin: false,
+    },
+  };
+  const key = await prepareThreadHandoverDraft(input);
+  expect(key).not.toBe("new-task:environment-1:project-1");
+  expect(getComposerDraftSnapshot(key)).toMatchObject({
+    text: "User-edited handover",
+    workspaceSelection: { branch: "user-branch" },
+    project: { environmentId: input.environmentId, projectId: input.projectId },
+  });
+  appAtomRegistry.set(composerDraftsAtom, {});
+  resetComposerDraftsLoadState();
+  expect(await prepareThreadHandoverDraft(input)).toBe(key);
+  expect(Object.keys(appAtomRegistry.get(composerDraftsAtom))).toEqual([key]);
 });

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -1122,6 +1122,7 @@ export function mergeComposerDraftContentState(
   current: Record<string, ComposerDraft>,
   draftKey: string,
   content: ComposerDraftContent,
+  settings?: Partial<ComposerDraftSettingsUpdate>,
 ): Record<string, ComposerDraft> {
   const existing = normalizeDraft(current[draftKey]);
   if (content.sourceShareId && existing.importedShareIds?.includes(content.sourceShareId)) {
@@ -1144,6 +1145,7 @@ export function mergeComposerDraftContentState(
     ? [...(existing.importedShareIds ?? []), content.sourceShareId]
     : existing.importedShareIds;
   if (
+    settings === undefined &&
     text === existing.text &&
     attachments.length === existing.attachments.length &&
     importedShareIds === existing.importedShareIds
@@ -1157,17 +1159,20 @@ export function mergeComposerDraftContentState(
       text,
       attachments,
       ...(importedShareIds ? { importedShareIds } : {}),
+      ...settings,
     },
   };
 }
 
 /**
- * Atomically moves an incoming share into a project-scoped composer draft.
- * The durable write happens before the share inbox item can be acknowledged.
+ * Atomically merges incoming content, its receipt, and optional destination
+ * settings into a project-scoped composer draft. The durable write happens
+ * before the share inbox item can be acknowledged.
  */
 export async function mergeComposerDraftContent(
   draftKey: string,
   content: ComposerDraftContent,
+  settings?: Partial<ComposerDraftSettingsUpdate>,
 ): Promise<{ readonly skippedAttachmentCount: number }> {
   ensureComposerDraftsLoaded();
   if (loadPromise !== null) {
@@ -1178,7 +1183,7 @@ export async function mergeComposerDraftContent(
     persistTimer = null;
   }
   const current = appAtomRegistry.get(composerDraftsAtom);
-  const next = mergeComposerDraftContentState(current, draftKey, content);
+  const next = mergeComposerDraftContentState(current, draftKey, content, settings);
   const currentAttachmentIds = new Set(
     normalizeDraft(current[draftKey]).attachments.map((attachment) => attachment.id),
   );

--- a/apps/mobile/src/state/use-thread-composer-state.test.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "@effect/vitest";
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+
+import { threadContextReachedLimit } from "./contextLimit.ts";
+
+function contextActivity(
+  usedTokens: number,
+  options: { readonly id?: string; readonly sequence?: number; readonly turnId?: string } = {},
+): OrchestrationThreadActivity {
+  return {
+    id: options.id ?? `usage-${usedTokens}`,
+    createdAt: "2026-08-31T00:00:00.000Z",
+    tone: "info",
+    kind: "context-window.updated",
+    summary: "Context window updated",
+    payload: { usedTokens, maxTokens: 400_000 },
+    turnId: options.turnId ?? null,
+    ...(options.sequence === undefined ? {} : { sequence: options.sequence }),
+  } as OrchestrationThreadActivity;
+}
+
+describe("threadContextReachedLimit", () => {
+  it("does not apply a limit before server configuration loads", () => {
+    expect(threadContextReachedLimit([contextActivity(300_000)], undefined)).toBe(false);
+  });
+
+  it("uses the configured limit", () => {
+    expect(threadContextReachedLimit([contextActivity(100_000)], 100_000)).toBe(true);
+    expect(threadContextReachedLimit([contextActivity(99_999)], 100_000)).toBe(false);
+  });
+
+  it("uses lifecycle order when persisted activities arrive out of order", () => {
+    const latest = contextActivity(120_000, { id: "latest", sequence: 20 });
+    const stale = contextActivity(300_000, { id: "stale", sequence: 10 });
+    const latestOverLimit = contextActivity(300_000, {
+      id: "latest-over-limit",
+      sequence: 30,
+    });
+
+    expect(threadContextReachedLimit([latest, stale], 250_000)).toBe(false);
+    expect(threadContextReachedLimit([stale, latest], 250_000)).toBe(false);
+    expect(threadContextReachedLimit([latestOverLimit, latest], 250_000)).toBe(true);
+  });
+
+  it("allows sending after a later compaction lowers context usage", () => {
+    const beforeCompaction = contextActivity(300_000, {
+      id: "before-compaction",
+      sequence: 10,
+      turnId: "turn-before-compaction",
+    });
+    const afterCompaction = contextActivity(20_000, {
+      id: "after-compaction",
+      sequence: 30,
+      turnId: "turn-after-compaction",
+    });
+
+    expect(threadContextReachedLimit([afterCompaction, beforeCompaction], 250_000)).toBe(false);
+  });
+});

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -62,6 +62,7 @@ import {
   composerAttachmentUploadBlockReason,
   composerAttachmentUploadsAtom,
 } from "./composer-attachment-uploads";
+import { threadContextReachedLimit } from "./contextLimit";
 
 export function appendReviewCommentToDraft(input: {
   readonly environmentId: EnvironmentId;
@@ -380,6 +381,20 @@ export function useThreadComposerState() {
             },
           }),
       });
+      return null;
+    }
+
+    if (
+      selectedThreadDetail &&
+      threadContextReachedLimit(
+        selectedThreadDetail.activities,
+        selectedEnvironmentRuntime?.serverConfig?.settings.threadContextTokenLimit,
+      )
+    ) {
+      Alert.alert(
+        "Thread context limit reached",
+        "Start a new thread before sending more work to this conversation.",
+      );
       return null;
     }
 

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -1,4 +1,5 @@
 // @effect-diagnostics nodeBuiltinImport:off
+import * as UsageLimitReservations from "../src/orchestration/UsageLimitReservations.ts";
 import * as NodeChildProcess from "node:child_process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -338,6 +339,7 @@ export const makeOrchestrationIntegrationHarness = (
       generateThreadTitle: () => Effect.succeed({ title: "New thread" }),
     } as unknown as TextGeneration["Service"]);
     const providerCommandReactorLayer = ProviderCommandReactorLive.pipe(
+      Layer.provideMerge(UsageLimitReservations.layer),
       Layer.provide(
         Layer.mock(ProviderAuthService)({
           tryHandlePromptCommand: () => Effect.succeed(false),

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -22,6 +22,7 @@ type WsRpcMethod = RpcGroup.Rpcs<typeof WsRpcGroup>["_tag"];
  */
 export const RPC_REQUIRED_SCOPES = {
   [ORCHESTRATION_WS_METHODS.dispatchCommand]: AuthOrchestrationOperateScope,
+  [ORCHESTRATION_WS_METHODS.generateHandover]: AuthOrchestrationOperateScope,
   [ORCHESTRATION_WS_METHODS.getWorkflowScript]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.getTurnDiff]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.getFullThreadDiff]: AuthOrchestrationReadScope,

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -7,7 +7,11 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
+import * as PubSub from "effect/PubSub";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import {
@@ -16,6 +20,8 @@ import {
   RELAY_URL_SECRET,
 } from "../cloud/config.ts";
 import * as ServerConfig from "../config.ts";
+import type { ProviderInstance } from "../provider/ProviderDriver.ts";
+import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstanceRegistry.ts";
 import * as ServerEnvironment from "./ServerEnvironment.ts";
 
 const isServerEnvironmentIdPersistenceError = Schema.is(
@@ -171,7 +177,101 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
       expect(second.capabilities.threadPullRequests).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
+      expect(second.capabilities.threadRestartContinuation).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);
+      expect(second.capabilities.threadHandoverGeneration).toBe(false);
+    }),
+  );
+
+  it.effect("advertises handover generation when the server has an enabled Codex instance", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-environment-handover-test-",
+      });
+      const codexDriver = ProviderDriverKind.make("codex");
+      const codexInstance = {
+        instanceId: ProviderInstanceId.make("codex-personal"),
+        driverKind: codexDriver,
+        continuationIdentity: {
+          driverKind: codexDriver,
+          continuationKey: "codex:instance:codex-personal",
+        },
+        displayName: undefined,
+        enabled: true,
+        snapshot: {} as ProviderInstance["snapshot"],
+        adapter: {} as ProviderInstance["adapter"],
+        textGeneration: {} as ProviderInstance["textGeneration"],
+      } satisfies ProviderInstance;
+      const registryLayer = Layer.succeed(ProviderInstanceRegistry.ProviderInstanceRegistry, {
+        getInstance: (instanceId) =>
+          Effect.succeed(instanceId === codexInstance.instanceId ? codexInstance : undefined),
+        listInstances: Effect.succeed([codexInstance]),
+        listUnavailable: Effect.succeed([]),
+        streamChanges: Stream.empty,
+        subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+      });
+
+      const descriptor = yield* Effect.gen(function* () {
+        const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
+        return yield* serverEnvironment.getDescriptor;
+      }).pipe(
+        Effect.provide(
+          ServerEnvironment.providerRuntimeLayer.pipe(
+            Layer.provide(registryLayer),
+            Layer.provide(ServerSecretStore.layer),
+            Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)),
+          ),
+        ),
+      );
+
+      expect(descriptor.capabilities.threadHandoverGeneration).toBe(true);
+    }),
+  );
+
+  it.effect("does not advertise handover generation for a Claude-only server", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-environment-claude-handover-test-",
+      });
+      const claudeDriver = ProviderDriverKind.make("claudeAgent");
+      const claudeInstance = {
+        instanceId: ProviderInstanceId.make("claude-personal"),
+        driverKind: claudeDriver,
+        continuationIdentity: {
+          driverKind: claudeDriver,
+          continuationKey: "claudeAgent:instance:claude-personal",
+        },
+        displayName: undefined,
+        enabled: true,
+        snapshot: {} as ProviderInstance["snapshot"],
+        adapter: {} as ProviderInstance["adapter"],
+        textGeneration: {} as ProviderInstance["textGeneration"],
+      } satisfies ProviderInstance;
+      const registryLayer = Layer.succeed(ProviderInstanceRegistry.ProviderInstanceRegistry, {
+        getInstance: (instanceId) =>
+          Effect.succeed(instanceId === claudeInstance.instanceId ? claudeInstance : undefined),
+        listInstances: Effect.succeed([claudeInstance]),
+        listUnavailable: Effect.succeed([]),
+        streamChanges: Stream.empty,
+        subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+      });
+
+      const descriptor = yield* Effect.gen(function* () {
+        const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
+        return yield* serverEnvironment.getDescriptor;
+      }).pipe(
+        Effect.provide(
+          ServerEnvironment.providerRuntimeLayer.pipe(
+            Layer.provide(registryLayer),
+            Layer.provide(ServerSecretStore.layer),
+            Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)),
+          ),
+        ),
+      );
+
+      expect(descriptor.capabilities.threadHandoverGeneration).toBe(false);
     }),
   );
 

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -9,6 +9,7 @@ import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
@@ -19,6 +20,9 @@ import { resolveServerSelfUpdateCapability } from "../cloud/selfUpdate.ts";
 import { resolveServiceLauncherMode } from "../cloud/serviceLauncherClient.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstanceRegistry.ts";
+import type { ProviderInstance } from "../provider/ProviderDriver.ts";
+import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import { resolveServerEnvironmentLabel } from "./ServerEnvironmentLabel.ts";
 import { detectServerEnvironmentMachineKind } from "./ServerEnvironmentMachine.ts";
 
@@ -179,85 +183,109 @@ const makeIdentity = Effect.gen(function* () {
   });
 });
 
+const makeWithProviderRegistry = (
+  providerInstanceRegistry: Option.Option<
+    ProviderInstanceRegistry.ProviderInstanceRegistry["Service"]
+  >,
+) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const serverConfig = yield* ServerConfig.ServerConfig;
+    const secrets = yield* ServerSecretStore.ServerSecretStore;
+    const identity = yield* ServerEnvironmentIdentity;
+    const hostPlatform = yield* HostProcessPlatform;
+    const hostArchitecture = yield* HostProcessArchitecture;
+    const environmentId = yield* identity.getEnvironmentId;
+    const cwdBaseName = path.basename(serverConfig.cwd).trim();
+    const label = yield* resolveServerEnvironmentLabel({ cwdBaseName });
+    const machine = yield* detectServerEnvironmentMachineKind();
+    const launcher = yield* resolveServiceLauncherMode();
+    const serverSelfUpdate = resolveServerSelfUpdateCapability({
+      desktopManaged: serverConfig.mode === "desktop",
+      launcherManaged: launcher.managed,
+    });
+    // Static is correct: the control fd is known at bootstrap, and the desktop
+    // app and its bundled server ship in one artifact, so a present fd means
+    // the app speaks the requestDesktopUpdate protocol. WSL backends never get
+    // the fd and correctly do not advertise.
+    const desktopAppUpdate =
+      serverSelfUpdate === "desktop-managed" &&
+      serverConfig.desktopTelemetryControlFd !== undefined;
+
+    const descriptor: ExecutionEnvironmentDescriptor = {
+      environmentId,
+      label,
+      platform: {
+        os: platformOs(hostPlatform),
+        arch: platformArch(hostArchitecture),
+        ...(machine === null ? {} : { machine }),
+      },
+      serverVersion: packageJson.version,
+      capabilities: {
+        repositoryIdentity: true,
+        connectionProbe: true,
+        attachmentUploads: true,
+        questionAttachments: true,
+        fileAttachments: { maxUploadBytes: PROVIDER_SEND_TURN_MAX_FILE_BYTES },
+        pullRequests: true,
+        threadSettlement: true,
+        threadAutoSettlement: true,
+        threadRestartContinuation: true,
+        threadSnooze: true,
+        environmentThemes: true,
+        usageLimitSources: true,
+        usagePriceOverrides: true,
+        threadPinning: true,
+        threadPinReorder: true,
+        threadActiveReorder: true,
+        threadTitleRegeneration: true,
+        threadPullRequests: true,
+        pullRequestStackActions: true,
+        threadPullRequestLinking: true,
+        environmentIcon: true,
+        ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
+        ...(serverSelfUpdate === "boot-service" || desktopAppUpdate
+          ? {
+              serverSelfUpdateProgress: true,
+              serverUpdateThreadContinuation: true,
+            }
+          : {}),
+        ...(desktopAppUpdate ? { desktopAppUpdate: true } : {}),
+      },
+    };
+
+    return ServerEnvironment.of({
+      getEnvironmentId: Effect.succeed(environmentId),
+      // The publish opt-in and relay link change at runtime (`t3 connect
+      // publish`, the client settings toggle), so the capability is read per
+      // descriptor request rather than baked in at startup.
+      getDescriptor: Effect.gen(function* () {
+        const agentActivityPublishing = yield* readAgentActivityPublishingActive(secrets);
+        const instances = Option.match(providerInstanceRegistry, {
+          onNone: () => Effect.succeed<ReadonlyArray<ProviderInstance>>([]),
+          onSome: (registry) => registry.listInstances,
+        });
+        const threadHandoverGeneration =
+          TextGeneration.findAvailableCodexInstance(yield* instances) !== undefined;
+        return {
+          ...descriptor,
+          capabilities: {
+            ...descriptor.capabilities,
+            agentActivityPublishing,
+            threadHandoverGeneration,
+          },
+        };
+      }),
+    });
+  });
+
 /** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
-  const path = yield* Path.Path;
-  const serverConfig = yield* ServerConfig.ServerConfig;
-  const secrets = yield* ServerSecretStore.ServerSecretStore;
-  const identity = yield* ServerEnvironmentIdentity;
-  const hostPlatform = yield* HostProcessPlatform;
-  const hostArchitecture = yield* HostProcessArchitecture;
-  const environmentId = yield* identity.getEnvironmentId;
-  const cwdBaseName = path.basename(serverConfig.cwd).trim();
-  const label = yield* resolveServerEnvironmentLabel({ cwdBaseName });
-  const machine = yield* detectServerEnvironmentMachineKind();
-  const launcher = yield* resolveServiceLauncherMode();
-  const serverSelfUpdate = resolveServerSelfUpdateCapability({
-    desktopManaged: serverConfig.mode === "desktop",
-    launcherManaged: launcher.managed,
-  });
-  // Static is correct: the control fd is known at bootstrap, and the desktop
-  // app and its bundled server ship in one artifact, so a present fd means
-  // the app speaks the requestDesktopUpdate protocol. WSL backends never get
-  // the fd and correctly do not advertise.
-  const desktopAppUpdate =
-    serverSelfUpdate === "desktop-managed" && serverConfig.desktopTelemetryControlFd !== undefined;
-
-  const descriptor: ExecutionEnvironmentDescriptor = {
-    environmentId,
-    label,
-    platform: {
-      os: platformOs(hostPlatform),
-      arch: platformArch(hostArchitecture),
-      ...(machine === null ? {} : { machine }),
-    },
-    serverVersion: packageJson.version,
-    capabilities: {
-      repositoryIdentity: true,
-      connectionProbe: true,
-      attachmentUploads: true,
-      questionAttachments: true,
-      fileAttachments: { maxUploadBytes: PROVIDER_SEND_TURN_MAX_FILE_BYTES },
-      pullRequests: true,
-      threadSettlement: true,
-      threadAutoSettlement: true,
-      threadRestartContinuation: true,
-      threadSnooze: true,
-      environmentThemes: true,
-      usageLimitSources: true,
-      usagePriceOverrides: true,
-      threadPinning: true,
-      threadPinReorder: true,
-      threadActiveReorder: true,
-      threadTitleRegeneration: true,
-      threadPullRequests: true,
-      pullRequestStackActions: true,
-      threadPullRequestLinking: true,
-      environmentIcon: true,
-      ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
-      ...(serverSelfUpdate === "boot-service" || desktopAppUpdate
-        ? {
-            serverSelfUpdateProgress: true,
-            serverUpdateThreadContinuation: true,
-          }
-        : {}),
-      ...(desktopAppUpdate ? { desktopAppUpdate: true } : {}),
-    },
-  };
-
-  return ServerEnvironment.of({
-    getEnvironmentId: Effect.succeed(environmentId),
-    // The publish opt-in and relay link change at runtime (`t3 connect
-    // publish`, the client settings toggle), so the capability is read per
-    // descriptor request rather than baked in at startup.
-    getDescriptor: readAgentActivityPublishingActive(secrets).pipe(
-      Effect.map((agentActivityPublishing) => ({
-        ...descriptor,
-        capabilities: { ...descriptor.capabilities, agentActivityPublishing },
-      })),
-    ),
-  });
+  const providerInstanceRegistry = yield* ProviderInstanceRegistry.ProviderInstanceRegistry;
+  return yield* makeWithProviderRegistry(Option.some(providerInstanceRegistry));
 });
+
+const makeConnectOnly = makeWithProviderRegistry(Option.none());
 
 export const identityLayer = Layer.effect(ServerEnvironmentIdentity, makeIdentity);
 
@@ -267,7 +295,13 @@ export const identityLayer = Layer.effect(ServerEnvironmentIdentity, makeIdentit
  * provide the external platform services, a ServerConfig, and the
  * ServerSecretStore backing the descriptor's publishing capability.
  */
-export const layer = Layer.effect(ServerEnvironment, make).pipe(
+export const layer = Layer.effect(ServerEnvironment, makeConnectOnly).pipe(
+  Layer.provideMerge(identityLayer),
+  Layer.provide(ProcessRunner.layer),
+);
+
+/** Normal server runtime, where provider-backed capabilities must not degrade silently. */
+export const providerRuntimeLayer = Layer.effect(ServerEnvironment, make).pipe(
   Layer.provideMerge(identityLayer),
   Layer.provide(ProcessRunner.layer),
 );

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -304,6 +304,10 @@ function createTextGeneration(
       Effect.succeed({
         title: "Update workflow",
       }),
+    generateHandover: () =>
+      Effect.succeed({
+        handover: "Continue the work.",
+      }),
     ...overrides,
   };
 
@@ -347,6 +351,17 @@ function createTextGeneration(
           (cause) =>
             new TextGenerationError({
               operation: "generateThreadTitle",
+              detail: "fake text generation failed",
+              ...(cause !== undefined ? { cause } : {}),
+            }),
+        ),
+      ),
+    generateHandover: (input) =>
+      implementation.generateHandover(input).pipe(
+        Effect.mapError(
+          (cause) =>
+            new TextGenerationError({
+              operation: "generateHandover",
               detail: "fake text generation failed",
               ...(cause !== undefined ? { cause } : {}),
             }),

--- a/apps/server/src/orchestration/ConcurrentTurnPolicy.test.ts
+++ b/apps/server/src/orchestration/ConcurrentTurnPolicy.test.ts
@@ -1,0 +1,76 @@
+import type { ProviderSession, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  evaluateTurnStartLimits,
+  evaluateHandoverStartLimits,
+  MAX_CONCURRENT_PROVIDER_TURNS,
+} from "./ConcurrentTurnPolicy.ts";
+
+const threadId = "thread-limited" as ThreadId;
+
+function session(index: number, status: ProviderSession["status"] = "running"): ProviderSession {
+  return {
+    threadId: `thread-${index}` as ThreadId,
+    status,
+  } as ProviderSession;
+}
+
+describe("evaluateTurnStartLimits", () => {
+  it("allows handover generation at the context ceiling", () => {
+    expect(evaluateHandoverStartLimits({ sessions: [] })).toBeUndefined();
+  });
+
+  it("counts each active thread once across sessions and reservations", () => {
+    const violation = evaluateTurnStartLimits({
+      threadId: "new-thread" as ThreadId,
+      sessions: [session(1), session(1), session(2)],
+      reservedTurnThreadIds: ["thread-1" as ThreadId, "thread-3" as ThreadId],
+    });
+
+    expect(violation).toBeUndefined();
+  });
+
+  it("blocks a new turn when the global concurrency ceiling is full", () => {
+    const violation = evaluateTurnStartLimits({
+      threadId,
+      sessions: Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS }, (_, index) => session(index)),
+    });
+
+    expect(violation?.code).toBe("concurrent-turn-limit");
+  });
+
+  it("counts a turn reservation before the provider reports it as running", () => {
+    const violation = evaluateTurnStartLimits({
+      threadId,
+      sessions: Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS - 1 }, (_, index) =>
+        session(index),
+      ),
+      reservedTurnThreadIds: ["reserved-thread" as ThreadId],
+    });
+
+    expect(violation?.code).toBe("concurrent-turn-limit");
+  });
+
+  it("counts handover reservations against the shared provider-work ceiling", () => {
+    const violation = evaluateTurnStartLimits({
+      threadId,
+      sessions: Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS - 1 }, (_, index) =>
+        session(index),
+      ),
+      reservedHandoverCount: 1,
+    });
+
+    expect(violation?.code).toBe("concurrent-turn-limit");
+  });
+
+  it("does not count ready sessions and permits an already-running thread", () => {
+    const sessions = [
+      ...Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS }, (_, index) => session(index)),
+      { ...session(99), threadId, status: "running" as const },
+      session(100, "ready"),
+    ];
+
+    expect(evaluateTurnStartLimits({ threadId, sessions })).toBeUndefined();
+  });
+});

--- a/apps/server/src/orchestration/ConcurrentTurnPolicy.ts
+++ b/apps/server/src/orchestration/ConcurrentTurnPolicy.ts
@@ -1,0 +1,58 @@
+import type { ProviderSession, ThreadId } from "@t3tools/contracts";
+export const MAX_CONCURRENT_PROVIDER_TURNS = 8;
+
+export type UsageLimitViolation = {
+  readonly code: "concurrent-turn-limit" | "handover-in-progress";
+  readonly detail: string;
+};
+
+function concurrentTurnLimitViolation(runningTurnCount: number): UsageLimitViolation | undefined {
+  if (runningTurnCount < MAX_CONCURRENT_PROVIDER_TURNS) {
+    return undefined;
+  }
+  return {
+    code: "concurrent-turn-limit",
+    detail: `T3 usage limit: ${runningTurnCount} provider turns are already running. The hard limit is ${MAX_CONCURRENT_PROVIDER_TURNS}. Wait for one to finish or interrupt it before starting more work.`,
+  };
+}
+
+function isRunningSession(session: ProviderSession): boolean {
+  return session.status === "connecting" || session.status === "running";
+}
+
+function runningTurnThreadIds(
+  sessions: ReadonlyArray<ProviderSession>,
+  reservedTurnThreadIds: ReadonlyArray<ThreadId>,
+): ReadonlySet<ThreadId> {
+  return new Set([
+    ...sessions.filter(isRunningSession).map((session) => session.threadId),
+    ...reservedTurnThreadIds,
+  ]);
+}
+
+export function evaluateTurnStartLimits(input: {
+  readonly threadId: ThreadId;
+  readonly sessions: ReadonlyArray<ProviderSession>;
+  readonly reservedTurnThreadIds?: ReadonlyArray<ThreadId>;
+  readonly reservedHandoverCount?: number;
+}): UsageLimitViolation | undefined {
+  const currentThreadIsRunning =
+    input.sessions.some(
+      (session) => session.threadId === input.threadId && isRunningSession(session),
+    ) || input.reservedTurnThreadIds?.includes(input.threadId) === true;
+  const runningTurnCount =
+    runningTurnThreadIds(input.sessions, input.reservedTurnThreadIds ?? []).size +
+    (input.reservedHandoverCount ?? 0);
+  return currentThreadIsRunning ? undefined : concurrentTurnLimitViolation(runningTurnCount);
+}
+
+export function evaluateHandoverStartLimits(input: {
+  readonly sessions: ReadonlyArray<ProviderSession>;
+  readonly reservedTurnThreadIds?: ReadonlyArray<ThreadId>;
+  readonly reservedHandoverCount?: number;
+}): UsageLimitViolation | undefined {
+  return concurrentTurnLimitViolation(
+    runningTurnThreadIds(input.sessions, input.reservedTurnThreadIds ?? []).size +
+      (input.reservedHandoverCount ?? 0),
+  );
+}

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -3330,6 +3330,21 @@ pending_approval_requests AS (
               ),
             );
 
+      const messagesEffect =
+        activityRead.mode === "raw" && activityRead.query?.includeMessages === false
+          ? Effect.succeed([])
+          : (bounds === undefined
+              ? listThreadMessageRowsByThread({ threadId })
+              : listThreadMessageRowsByThreadWindow({ threadId, ...bounds })
+            ).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getThreadDetailById:listMessages:query",
+                  "ProjectionSnapshotQuery.getThreadDetailById:listMessages:decodeRows",
+                ),
+              ),
+            );
+
       const [
         threadRow,
         messageRows,
@@ -3348,17 +3363,7 @@ pending_approval_requests AS (
             ),
           ),
         ),
-        (bounds === undefined
-          ? listThreadMessageRowsByThread({ threadId })
-          : listThreadMessageRowsByThreadWindow({ threadId, ...bounds })
-        ).pipe(
-          Effect.mapError(
-            toPersistenceSqlOrDecodeError(
-              "ProjectionSnapshotQuery.getThreadDetailById:listMessages:query",
-              "ProjectionSnapshotQuery.getThreadDetailById:listMessages:decodeRows",
-            ),
-          ),
-        ),
+        messagesEffect,
         listThreadProposedPlanRowsByThread({ threadId }).pipe(
           Effect.mapError(
             toPersistenceSqlOrDecodeError(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -19,6 +19,7 @@ import {
   EnvironmentId,
   EventId,
   MessageId,
+  type OrchestrationThreadActivity,
   ProjectId,
   ThreadId,
   TurnId,
@@ -59,6 +60,7 @@ import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import * as ThreadBackgroundLiveness from "../ThreadBackgroundLiveness.ts";
+import * as UsageLimitReservations from "../UsageLimitReservations.ts";
 import * as ThreadPlanProgress from "../ThreadPlanProgress.ts";
 import {
   providerErrorLabelFromInstanceHint,
@@ -178,6 +180,7 @@ describe("ProviderCommandReactor", () => {
     readonly beforeReadySessionDispatch?: () => Effect.Effect<void>;
     readonly beforeTurnStartDispatch?: () => Effect.Effect<void>;
     readonly afterTurnStartDispatch?: () => Effect.Effect<void>;
+    readonly listSessionsEffect?: ProviderServiceShape["listSessions"];
     readonly compactThreadEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly interruptTurnEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly stopSessionEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
@@ -361,7 +364,7 @@ describe("ProviderCommandReactor", () => {
       respondToRequest: respondToRequest as ProviderServiceShape["respondToRequest"],
       respondToUserInput: respondToUserInput as ProviderServiceShape["respondToUserInput"],
       stopSession: stopSession as ProviderServiceShape["stopSession"],
-      listSessions: () => Effect.succeed(runtimeSessions),
+      listSessions: input?.listSessionsEffect ?? (() => Effect.succeed(runtimeSessions)),
       getCapabilities: (_provider) =>
         Effect.succeed({
           sessionModelSwitch: input?.sessionModelSwitch ?? "in-session",
@@ -465,6 +468,7 @@ describe("ProviderCommandReactor", () => {
     const layer = ProviderCommandReactorLive.pipe(
       Layer.provideMerge(reactorOrchestrationLayer),
       Layer.provideMerge(projectionSnapshotLayer),
+      Layer.provideMerge(UsageLimitReservations.layer),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
       Layer.provide(Layer.mock(ProviderAuthService, { tryHandlePromptCommand })),
       Layer.provideMerge(makeProviderRegistryLayer(providerSnapshots as never)),
@@ -632,6 +636,65 @@ describe("ProviderCommandReactor", () => {
       },
     };
   }
+
+  effectIt.effect(
+    "records admission lookup failures and accepts the next turn without a leaked reservation",
+    () =>
+      Effect.gen(function* () {
+        let failLookup = true;
+        const failureChecked = yield* Deferred.make<void>();
+        const retryChecked = yield* Deferred.make<void>();
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            listSessionsEffect: () =>
+              (failLookup
+                ? Effect.die(
+                    new ProviderAdapterRequestError({
+                      provider: "codex",
+                      method: "listSessions",
+                      detail: "Runtime temporarily unavailable",
+                    }),
+                  )
+                : Effect.succeed([])
+              ).pipe(
+                Effect.ensuring(
+                  Deferred.succeed(failLookup ? failureChecked : retryChecked, undefined),
+                ),
+              ),
+          }),
+        );
+        const send = (suffix: string) =>
+          harness.engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.make(`cmd-admission-${suffix}`),
+            threadId: ThreadId.make("thread-1"),
+            message: {
+              messageId: asMessageId(`message-admission-${suffix}`),
+              role: "user",
+              text: "Continue this task",
+              attachments: [],
+            },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "approval-required",
+            createdAt: "2026-01-01T00:00:01.000Z",
+          });
+        yield* send("failure");
+        yield* Deferred.await(failureChecked);
+        yield* Effect.promise(harness.drain);
+        expect(harness.sendTurn).not.toHaveBeenCalled();
+        const snapshot = yield* Effect.promise(harness.readModel);
+        const thread = snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+        expect(
+          thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed"),
+        ).toBe(true);
+        expect(thread?.session?.status).toBe("error");
+        failLookup = false;
+        yield* send("retry");
+        yield* Deferred.await(retryChecked);
+        yield* Effect.promise(harness.drain);
+        expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+      }),
+  );
 
   effectIt.effect.each(["new", "ready", "stopped"] as const)(
     "handles sign-out for a %s thread before worktree repair, text helpers, or startup",
@@ -4295,6 +4358,102 @@ describe("ProviderCommandReactor", () => {
       yield* Deferred.await(started);
       yield* Effect.promise(harness.drain);
       expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+    }),
+  );
+
+  effectIt.effect("queues a message sent while an over-limit thread compacts", () =>
+    Effect.gen(function* () {
+      const releaseCompaction = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({ compactThreadEffect: () => Deferred.await(releaseCompaction) }),
+      );
+      const threadId = ThreadId.make("thread-1");
+      const now = "2026-01-01T00:00:00.000Z";
+      const dispatchTurn = (id: string, text: string, createdAt: string) =>
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`cmd-${id}`),
+          threadId,
+          message: {
+            messageId: asMessageId(`user-message-${id}`),
+            role: "user",
+            text,
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        });
+      const appendContextActivity = (
+        id: string,
+        activity: Pick<OrchestrationThreadActivity, "kind" | "summary" | "payload" | "createdAt">,
+      ) =>
+        harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.make(`cmd-${id}`),
+          threadId,
+          activity: {
+            id: EventId.make(id),
+            tone: "info",
+            turnId: null,
+            ...activity,
+          },
+          createdAt: activity.createdAt,
+        });
+
+      yield* dispatchTurn("before-over-limit", "hello", now);
+      yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-ready-over-limit-queue"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      });
+      yield* appendContextActivity("over-limit-queue-context", {
+        kind: "context-window.updated",
+        summary: "Context updated",
+        payload: { usedTokens: 300_000, maxTokens: 400_000 },
+        createdAt: now,
+      });
+      yield* dispatchTurn("over-limit-queue-compact", "/compact", "2026-01-01T00:00:01.000Z");
+      yield* Effect.promise(() => waitFor(() => harness.compactThread.mock.calls.length === 1));
+      yield* dispatchTurn(
+        "queued-over-limit",
+        "continue after compacting",
+        "2026-01-01T00:00:02.000Z",
+      );
+      yield* Effect.promise(harness.drain);
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+
+      yield* appendContextActivity("over-limit-queue-compacted", {
+        kind: "context-compaction",
+        summary: "Context compacted",
+        payload: { state: "compacted", beforeTokens: 300_000, afterTokens: 50_000 },
+        createdAt: "2026-01-01T00:00:03.000Z",
+      });
+      yield* Deferred.succeed(releaseCompaction, undefined);
+      yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 2));
+      expect(harness.sendTurn.mock.calls[1]?.[0]).toEqual(
+        expect.objectContaining({ input: "continue after compacting" }),
+      );
+      const thread = (yield* Effect.promise(() => harness.readModel())).threads.find(
+        (entry) => entry.id === threadId,
+      );
+      expect(
+        thread?.activities.some(
+          (activity) => activity.summary === "T3 usage limit stopped provider work",
+        ),
+      ).toBe(false);
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -174,6 +174,7 @@ describe("ProviderCommandReactor", () => {
     readonly titleRegenerationCompletionDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
     readonly serverActivation?: Effect.Effect<void>;
+    readonly afterActivityAppend?: (kind: string) => Effect.Effect<void>;
     readonly beforeReadySessionDispatch?: () => Effect.Effect<void>;
     readonly beforeTurnStartDispatch?: () => Effect.Effect<void>;
     readonly afterTurnStartDispatch?: () => Effect.Effect<void>;
@@ -445,7 +446,11 @@ describe("ProviderCommandReactor", () => {
             return (before?.() ?? Effect.void).pipe(
               Effect.andThen(engine.dispatch(command)),
               Effect.tap(() =>
-                isReplay ? (input?.afterTurnStartDispatch?.() ?? Effect.void) : Effect.void,
+                isReplay
+                  ? (input?.afterTurnStartDispatch?.() ?? Effect.void)
+                  : command.type === "thread.activity.append"
+                    ? (input?.afterActivityAppend?.(command.activity.kind) ?? Effect.void)
+                    : Effect.void,
               ),
             );
           },
@@ -4173,6 +4178,201 @@ describe("ProviderCommandReactor", () => {
       expect(thread?.settledOverride).toBe("settled");
       expect(thread?.session?.status).toBe("stopped");
       expect(thread?.session?.providerInstanceId).toBe(ProviderInstanceId.make("codex_work"));
+    }),
+  );
+  effectIt.effect.each([249_999, 250_000, 250_001])(
+    "enforces persisted context usage of %i tokens before provider work",
+    (usedTokens) =>
+      Effect.gen(function* () {
+        const decision = yield* Deferred.make<void>();
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            startSessionEffect: (session) =>
+              Deferred.succeed(decision, undefined).pipe(Effect.as(session)),
+            afterActivityAppend: (kind) =>
+              kind === "provider.turn.start.failed"
+                ? Deferred.succeed(decision, undefined).pipe(Effect.asVoid)
+                : Effect.void,
+          }),
+        );
+        yield* harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.make("context-admission-activity"),
+          threadId: ThreadId.make("thread-1"),
+          activity: {
+            id: EventId.make("context-admission-activity"),
+            kind: "context-window.updated",
+            tone: "info",
+            summary: "Context updated",
+            payload: { usedTokens, maxTokens: 400_000 },
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("context-admission-turn"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("context-admission-message"),
+            role: "user",
+            text: "Continue",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: "2026-01-01T00:00:01.000Z",
+        });
+        yield* Deferred.await(decision);
+        yield* Effect.promise(harness.drain);
+        expect(harness.sendTurn).toHaveBeenCalledTimes(usedTokens < 250_000 ? 1 : 0);
+        if (usedTokens >= 250_000) {
+          const snapshot = yield* Effect.promise(harness.readModel);
+          const thread = snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+          expect(
+            thread?.activities.some(
+              (activity) => activity.summary === "T3 usage limit stopped provider work",
+            ),
+          ).toBe(true);
+        }
+      }),
+  );
+
+  effectIt.effect("admits provider work after context compaction lowers usage", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          startSessionEffect: (session) =>
+            Deferred.succeed(started, undefined).pipe(Effect.as(session)),
+        }),
+      );
+      yield* harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make("context-admission-before-compaction"),
+        threadId: ThreadId.make("thread-1"),
+        activity: {
+          id: EventId.make("context-admission-before-compaction"),
+          kind: "context-window.updated",
+          tone: "info",
+          summary: "Context updated",
+          payload: { usedTokens: 300_000, maxTokens: 400_000 },
+          turnId: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make("context-admission-compacted"),
+        threadId: ThreadId.make("thread-1"),
+        activity: {
+          id: EventId.make("context-admission-compacted"),
+          kind: "context-compaction",
+          tone: "info",
+          summary: "Context compacted",
+          payload: { state: "compacted", beforeTokens: 300_000, afterTokens: 50_000 },
+          turnId: null,
+          createdAt: "2026-01-01T00:00:01.000Z",
+        },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("context-admission-after-compaction"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("context-admission-after-compaction"),
+          role: "user",
+          text: "Continue after compaction",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:02.000Z",
+      });
+      yield* Deferred.await(started);
+      yield* Effect.promise(harness.drain);
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+    }),
+  );
+
+  effectIt.effect("lets /compact bypass the context usage limit", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const threadId = ThreadId.make("thread-1");
+      const now = "2026-01-01T00:00:00.000Z";
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-message-before-over-limit-compact"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-before-over-limit-compact"),
+          role: "user",
+          text: "hello",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+      yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-ready-over-limit"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make("cmd-over-limit-context"),
+        threadId,
+        activity: {
+          id: EventId.make("over-limit-context"),
+          kind: "context-window.updated",
+          tone: "info",
+          summary: "Context updated",
+          payload: { usedTokens: 300_000, maxTokens: 400_000 },
+          turnId: null,
+          createdAt: now,
+        },
+        createdAt: now,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-over-limit-compact"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-over-limit-compact"),
+          role: "user",
+          text: "/compact",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      });
+      yield* Effect.promise(() => waitFor(() => harness.compactThread.mock.calls.length === 1));
+      yield* Effect.promise(harness.drain);
+      const thread = (yield* Effect.promise(() => harness.readModel())).threads.find(
+        (entry) => entry.id === threadId,
+      );
+      expect(
+        thread?.activities.some(
+          (activity) => activity.summary === "T3 usage limit stopped provider work",
+        ),
+      ).toBe(false);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -57,6 +57,7 @@ import {
 } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
+import * as UsageLimitReservations from "../UsageLimitReservations.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderAdapterValidationError = Schema.is(ProviderAdapterValidationError);
 const isProviderWorkspaceMissingError = Schema.is(ProviderWorkspaceMissingError);
@@ -330,6 +331,7 @@ const make = Effect.gen(function* () {
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;
   const serverSettingsService = yield* ServerSettingsService;
+  const usageLimitReservations = yield* UsageLimitReservations.UsageLimitReservations;
   const serverCommandId = (tag: string) =>
     crypto.randomUUIDv4.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
   const serverEventId = () => crypto.randomUUIDv4.pipe(Effect.map(EventId.make));
@@ -338,7 +340,6 @@ const make = Effect.gen(function* () {
     timeToLive: HANDLED_TURN_START_KEY_TTL,
     lookup: () => Effect.succeed(true),
   });
-
   const hasHandledTurnStartRecently = (key: string) =>
     Cache.getOption(handledTurnStartKeys, key).pipe(
       Effect.flatMap((cached) =>
@@ -1386,8 +1387,24 @@ const make = Effect.gen(function* () {
       });
       return true;
     }).pipe(Effect.catchCause((cause) => recoverTurnStartFailure(cause).pipe(Effect.as(true))));
+    if (authCommandHandled) {
+      return;
+    }
+    // Messages sent while a thread compacts wait for it, ahead of the admission
+    // and reservation gates, and replay once the session is restored.
+    if (
+      !isCompactCommand &&
+      !resumed &&
+      (compactingThreadIds.has(event.payload.threadId) ||
+        turnsAfterCompaction.has(event.payload.threadId))
+    ) {
+      const queued = turnsAfterCompaction.get(event.payload.threadId) ?? [];
+      queued.push(event);
+      turnsAfterCompaction.set(event.payload.threadId, queued);
+      return;
+    }
     const contextAdmissionAllowed = yield* Effect.gen(function* () {
-      if (authCommandHandled || isCompactCommand) return true;
+      if (isCompactCommand) return true;
       const usageLimitSettings = yield* serverSettingsService.getSettings;
       const latestThread = yield* projectionSnapshotQuery
         .getThreadDetailById(event.payload.threadId, {
@@ -1413,179 +1430,224 @@ const make = Effect.gen(function* () {
       return true;
     }).pipe(Effect.catchCause((cause) => recoverTurnStartFailure(cause).pipe(Effect.as(false))));
     if (!contextAdmissionAllowed) return;
-    if (authCommandHandled) {
-      return;
-    }
 
-    yield* ensureThreadWorktree(thread);
-
-    if (!hasOtherUserMessages && !isCompactCommand) {
-      const project = yield* resolveProject(thread.projectId);
-      const generationCwd =
-        resolveThreadWorkspaceCwd({
-          thread,
-          projects: project ? [project] : [],
-        }) ?? process.cwd();
-      const generationInput = {
-        messageText: assistantCitationsToPlainText(message.text),
-        ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
-        ...(event.payload.titleSeed !== undefined ? { titleSeed: event.payload.titleSeed } : {}),
-      };
-
-      yield* maybeGenerateAndRenameWorktreeBranchForFirstTurn({
+    const reservationKey = yield* crypto.randomUUIDv4;
+    let reservationHandedOff = false;
+    yield* Effect.acquireUseRelease(
+      usageLimitReservations.reserveTurn({
+        key: reservationKey,
         threadId: event.payload.threadId,
-        branch: thread.branch,
-        worktreePath: thread.worktreePath,
-        ...generationInput,
-      }).pipe(Effect.forkScoped);
+      }),
+      (violation) =>
+        Effect.gen(function* () {
+          if (violation) {
+            return yield* appendTurnStartFailure(
+              "T3 usage limit stopped provider work",
+              violation.detail,
+            );
+          }
 
-      if (canReplaceThreadTitle(thread.title, event.payload.titleSeed)) {
-        yield* maybeGenerateThreadTitleForFirstTurn({
-          threadId: event.payload.threadId,
-          cwd: generationCwd,
-          ...generationInput,
-        }).pipe(Effect.forkScoped);
-      }
-    }
+          yield* ensureThreadWorktree(thread);
 
-    let compactionSessionEnsured = false;
-    const handleCompactionFailure = (cause: Cause.Cause<unknown>) => {
-      if (Cause.hasInterruptsOnly(cause)) {
-        return Effect.void;
-      }
-      const detail = formatFailureDetail(cause);
-      if (!compactionSessionEnsured) {
-        return setThreadSessionErrorOnTurnStartFailure({
-          threadId: event.payload.threadId,
-          detail,
-          createdAt: event.payload.createdAt,
-        }).pipe(
-          Effect.flatMap(() => appendTurnStartFailure("Context compaction failed", detail)),
-          Effect.asVoid,
-        );
-      }
-      return appendTurnStartFailure("Context compaction failed", detail).pipe(
-        Effect.ensuring(
-          restoreCompaction(event.payload.threadId).pipe(
-            Effect.catchCause((restoreCause) =>
-              Effect.logWarning("failed to restore provider session after compaction failure", {
+          if (!hasOtherUserMessages && !isCompactCommand) {
+            const project = yield* resolveProject(thread.projectId);
+            const generationCwd =
+              resolveThreadWorkspaceCwd({
+                thread,
+                projects: project ? [project] : [],
+              }) ?? process.cwd();
+            const generationInput = {
+              messageText: assistantCitationsToPlainText(message.text),
+              ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+              ...(event.payload.titleSeed !== undefined
+                ? { titleSeed: event.payload.titleSeed }
+                : {}),
+            };
+
+            yield* maybeGenerateAndRenameWorktreeBranchForFirstTurn({
+              threadId: event.payload.threadId,
+              branch: thread.branch,
+              worktreePath: thread.worktreePath,
+              ...generationInput,
+            }).pipe(Effect.forkScoped);
+
+            if (canReplaceThreadTitle(thread.title, event.payload.titleSeed)) {
+              yield* maybeGenerateThreadTitleForFirstTurn({
                 threadId: event.payload.threadId,
-                cause: Cause.pretty(restoreCause),
-              }),
-            ),
-          ),
-        ),
-        Effect.asVoid,
-      );
-    };
-    const recoverCompactionFailure = (cause: Cause.Cause<unknown>) =>
-      handleCompactionFailure(cause).pipe(
-        Effect.catchCause((recoveryCause) =>
-          Effect.logWarning("provider command reactor failed to recover compaction failure", {
-            eventType: event.type,
+                cwd: generationCwd,
+                ...generationInput,
+              }).pipe(Effect.forkScoped);
+            }
+          }
+
+          let compactionSessionEnsured = false;
+          const handleCompactionFailure = (cause: Cause.Cause<unknown>) => {
+            if (Cause.hasInterruptsOnly(cause)) {
+              return Effect.void;
+            }
+            const detail = formatFailureDetail(cause);
+            if (!compactionSessionEnsured) {
+              return setThreadSessionErrorOnTurnStartFailure({
+                threadId: event.payload.threadId,
+                detail,
+                createdAt: event.payload.createdAt,
+              }).pipe(
+                Effect.flatMap(() => appendTurnStartFailure("Context compaction failed", detail)),
+                Effect.asVoid,
+              );
+            }
+            return appendTurnStartFailure("Context compaction failed", detail).pipe(
+              Effect.ensuring(
+                restoreCompaction(event.payload.threadId).pipe(
+                  Effect.catchCause((restoreCause) =>
+                    Effect.logWarning(
+                      "failed to restore provider session after compaction failure",
+                      {
+                        threadId: event.payload.threadId,
+                        cause: Cause.pretty(restoreCause),
+                      },
+                    ),
+                  ),
+                ),
+              ),
+              Effect.asVoid,
+            );
+          };
+          const recoverCompactionFailure = (cause: Cause.Cause<unknown>) =>
+            handleCompactionFailure(cause).pipe(
+              Effect.catchCause((recoveryCause) =>
+                Effect.logWarning("provider command reactor failed to recover compaction failure", {
+                  eventType: event.type,
+                  threadId: event.payload.threadId,
+                  cause: Cause.pretty(recoveryCause),
+                  originalCause: Cause.pretty(cause),
+                }),
+              ),
+            );
+          if (isCompactCommand) {
+            if (!hasOtherUserMessages) {
+              return yield* appendTurnStartFailure(
+                "Context compaction failed",
+                "Context compaction requires an existing conversation.",
+              );
+            }
+            const latestThread = yield* resolveThreadShell(event.payload.threadId);
+            if (
+              compactingThreadIds.has(event.payload.threadId) ||
+              turnsAfterCompaction.has(event.payload.threadId) ||
+              latestThread?.session?.status === "starting" ||
+              latestThread?.session?.status === "running"
+            ) {
+              yield* appendTurnStartFailure(
+                "Context compaction failed",
+                "Context compaction is unavailable while a provider turn is running.",
+              );
+              return;
+            }
+            compactingThreadIds.add(event.payload.threadId);
+            const clearCompacting = Effect.sync(
+              () => void compactingThreadIds.delete(event.payload.threadId),
+            );
+            // Compaction's slot ends once the session is restored; queued turns
+            // reserve their own when they replay.
+            const releaseReservation = usageLimitReservations.release(reservationKey);
+            yield* Effect.uninterruptibleMask((restore) =>
+              restore(
+                Effect.gen(function* () {
+                  yield* ensureSessionForThread(
+                    event.payload.threadId,
+                    event.payload.createdAt,
+                    event.payload.modelSelection !== undefined
+                      ? { modelSelection: event.payload.modelSelection, pendingTurnStart: true }
+                      : { pendingTurnStart: true },
+                  );
+                  compactionSessionEnsured = true;
+                  if (event.payload.modelSelection !== undefined) {
+                    threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+                  }
+                  yield* providerService.compactThread(
+                    event.payload.threadId,
+                    event.payload.modelSelection,
+                    event.payload.messageId,
+                  );
+                }).pipe(
+                  Effect.andThen(restoreCompaction(event.payload.threadId, true)),
+                  Effect.andThen(releaseReservation),
+                  Effect.andThen(clearCompacting),
+                  Effect.andThen(resumeTurnsAfterCompaction(event.payload.threadId)),
+                  Effect.catchCause((cause) =>
+                    recoverCompactionFailure(cause).pipe(
+                      Effect.ensuring(clearCompacting),
+                      Effect.andThen(
+                        cancelTurnsAfterCompaction(
+                          event.payload.threadId,
+                          "Context compaction failed. Send this message again to continue.",
+                        ),
+                      ),
+                    ),
+                  ),
+                  Effect.ensuring(releaseReservation),
+                ),
+              ).pipe(
+                Effect.forkScoped,
+                Effect.tap(() =>
+                  Effect.sync(() => {
+                    reservationHandedOff = true;
+                  }),
+                ),
+              ),
+            );
+            return;
+          }
+          const sendTurnRequest = yield* buildSendTurnRequestForThread({
             threadId: event.payload.threadId,
-            cause: Cause.pretty(recoveryCause),
-            originalCause: Cause.pretty(cause),
-          }),
-        ),
-      );
-    if (isCompactCommand) {
-      if (!hasOtherUserMessages) {
-        return yield* appendTurnStartFailure(
-          "Context compaction failed",
-          "Context compaction requires an existing conversation.",
-        );
-      }
-      const latestThread = yield* resolveThreadShell(event.payload.threadId);
-      if (
-        compactingThreadIds.has(event.payload.threadId) ||
-        turnsAfterCompaction.has(event.payload.threadId) ||
-        latestThread?.session?.status === "starting" ||
-        latestThread?.session?.status === "running"
-      ) {
-        yield* appendTurnStartFailure(
-          "Context compaction failed",
-          "Context compaction is unavailable while a provider turn is running.",
-        );
-        return;
-      }
-      compactingThreadIds.add(event.payload.threadId);
-      const clearCompacting = Effect.sync(
-        () => void compactingThreadIds.delete(event.payload.threadId),
-      );
-      yield* Effect.gen(function* () {
-        yield* ensureSessionForThread(
-          event.payload.threadId,
-          event.payload.createdAt,
-          event.payload.modelSelection !== undefined
-            ? { modelSelection: event.payload.modelSelection, pendingTurnStart: true }
-            : { pendingTurnStart: true },
-        );
-        compactionSessionEnsured = true;
-        if (event.payload.modelSelection !== undefined) {
-          threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
-        }
-        yield* providerService.compactThread(
-          event.payload.threadId,
-          event.payload.modelSelection,
-          event.payload.messageId,
-        );
-      }).pipe(
-        Effect.andThen(restoreCompaction(event.payload.threadId, true)),
-        Effect.andThen(clearCompacting),
-        Effect.andThen(resumeTurnsAfterCompaction(event.payload.threadId)),
-        Effect.catchCause((cause) =>
-          recoverCompactionFailure(cause).pipe(
-            Effect.ensuring(clearCompacting),
-            Effect.andThen(
-              cancelTurnsAfterCompaction(
-                event.payload.threadId,
-                "Context compaction failed. Send this message again to continue.",
+            messageText: message.text,
+            ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+            ...(event.payload.modelSelection !== undefined
+              ? { modelSelection: event.payload.modelSelection }
+              : {}),
+            interactionMode: event.payload.interactionMode,
+            createdAt: event.payload.createdAt,
+          }).pipe(
+            Effect.map(Option.some),
+            Effect.catchCause((cause) =>
+              handleTurnStartFailure(cause).pipe(Effect.as(Option.none())),
+            ),
+          );
+          if (Option.isNone(sendTurnRequest)) {
+            return;
+          }
+          // The forked send settles `sent` from here on, so drop the entry the post-processing hook uses.
+          if (resumed && event.commandId !== null) resumedTurnStarts.delete(event.commandId);
+          yield* Effect.uninterruptibleMask((restore) =>
+            restore(
+              providerService
+                .sendTurn(sendTurnRequest.value)
+                .pipe(
+                  Effect.asVoid,
+                  Effect.catchCause(recoverTurnStartFailure),
+                  Effect.ensuring(usageLimitReservations.release(reservationKey)),
+                  Effect.ensuring(
+                    resumed ? Deferred.succeed(resumed.sent, undefined) : Effect.void,
+                  ),
+                ),
+            ).pipe(
+              Effect.forkScoped,
+              Effect.tap(() =>
+                Effect.sync(() => {
+                  reservationHandedOff = true;
+                }),
               ),
             ),
-          ),
+          );
+        }),
+      (violation) =>
+        Effect.suspend(() =>
+          violation === undefined && !reservationHandedOff
+            ? usageLimitReservations.release(reservationKey)
+            : Effect.void,
         ),
-        Effect.forkScoped,
-      );
-      return;
-    }
-    if (
-      !resumed &&
-      (compactingThreadIds.has(event.payload.threadId) ||
-        turnsAfterCompaction.has(event.payload.threadId))
-    ) {
-      const queued = turnsAfterCompaction.get(event.payload.threadId) ?? [];
-      queued.push(event);
-      turnsAfterCompaction.set(event.payload.threadId, queued);
-      return;
-    }
-    const sendTurnRequest = yield* buildSendTurnRequestForThread({
-      threadId: event.payload.threadId,
-      messageText: message.text,
-      ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
-      ...(event.payload.modelSelection !== undefined
-        ? { modelSelection: event.payload.modelSelection }
-        : {}),
-      interactionMode: event.payload.interactionMode,
-      createdAt: event.payload.createdAt,
-    }).pipe(
-      Effect.map(Option.some),
-      Effect.catchCause((cause) => handleTurnStartFailure(cause).pipe(Effect.as(Option.none()))),
-    );
-
-    if (Option.isNone(sendTurnRequest)) {
-      return;
-    }
-
-    const send = providerService
-      .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure));
-    // The forked send settles `sent` from here on, so drop the entry the post-processing hook uses.
-    if (resumed && event.commandId !== null) resumedTurnStarts.delete(event.commandId);
-    yield* send.pipe(
-      Effect.ensuring(resumed ? Deferred.succeed(resumed.sent, undefined) : Effect.void),
-      Effect.forkScoped,
-    );
+    ).pipe(Effect.catchCause(recoverTurnStartFailure));
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1,3 +1,4 @@
+import { evaluateTurnStartLimits } from "../UsageLimitPolicy.ts";
 import {
   type ChatAttachment,
   CommandId,
@@ -1291,6 +1292,9 @@ const make = Effect.gen(function* () {
       return;
     }
     const { message, hasOtherUserMessages } = turnStart.value;
+    // Compaction is the only way an over-limit thread can lower its context,
+    // so /compact bypasses the usage-limit admission gate below.
+    const isCompactCommand = isCompactCommandMessage(message);
     const appendTurnStartFailure = (summary: string, detail: string) =>
       appendProviderFailureActivity({
         threadId: event.payload.threadId,
@@ -1382,13 +1386,39 @@ const make = Effect.gen(function* () {
       });
       return true;
     }).pipe(Effect.catchCause((cause) => recoverTurnStartFailure(cause).pipe(Effect.as(true))));
+    const contextAdmissionAllowed = yield* Effect.gen(function* () {
+      if (authCommandHandled || isCompactCommand) return true;
+      const usageLimitSettings = yield* serverSettingsService.getSettings;
+      const latestThread = yield* projectionSnapshotQuery
+        .getThreadDetailById(event.payload.threadId, {
+          activityKinds: ["context-window.updated", "context-compaction"],
+          includeMessages: false,
+        })
+        .pipe(Effect.map(Option.getOrUndefined));
+      if (!latestThread) {
+        yield* appendTurnStartFailure(
+          "Provider turn start failed",
+          "The thread disappeared before its provider turn could start.",
+        );
+        return false;
+      }
+      const violation = evaluateTurnStartLimits({
+        contextTokenLimit: usageLimitSettings.threadContextTokenLimit,
+        activities: latestThread.activities,
+      });
+      if (violation) {
+        yield* appendTurnStartFailure("T3 usage limit stopped provider work", violation.detail);
+        return false;
+      }
+      return true;
+    }).pipe(Effect.catchCause((cause) => recoverTurnStartFailure(cause).pipe(Effect.as(false))));
+    if (!contextAdmissionAllowed) return;
     if (authCommandHandled) {
       return;
     }
 
     yield* ensureThreadWorktree(thread);
 
-    const isCompactCommand = isCompactCommandMessage(message);
     if (!hasOtherUserMessages && !isCompactCommand) {
       const project = yield* resolveProject(thread.projectId);
       const generationCwd =

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -71,6 +71,8 @@ export interface ProjectionThreadDetailQuery {
    * the activity query. Omit this option to preserve the full detail response.
    */
   readonly activityKinds?: ReadonlyArray<string>;
+  /** Omit message rows when a server caller only needs thread metadata or activities. */
+  readonly includeMessages?: boolean;
 }
 
 /**

--- a/apps/server/src/orchestration/ThreadHandover.test.ts
+++ b/apps/server/src/orchestration/ThreadHandover.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "@effect/vitest";
+import { DEFAULT_TEXT_GENERATION_MODEL, ProviderInstanceId } from "@t3tools/contracts";
+
+import { formatThreadForHandover, makeHandoverModelSelection } from "./ThreadHandover.ts";
+
+describe("thread handover", () => {
+  it("pins handover generation to Luna with high reasoning", () => {
+    expect(makeHandoverModelSelection(ProviderInstanceId.make("codex"))).toEqual({
+      instanceId: "codex",
+      model: DEFAULT_TEXT_GENERATION_MODEL,
+      options: [{ id: "reasoningEffort", value: "high" }],
+    });
+    expect(makeHandoverModelSelection(ProviderInstanceId.make("codex-renamed"))).toMatchObject({
+      instanceId: "codex-renamed",
+      model: DEFAULT_TEXT_GENERATION_MODEL,
+    });
+  });
+
+  it("formats thread metadata and both sides of the conversation", () => {
+    const contents = formatThreadForHandover({
+      title: "Continue the migration",
+      branch: "feature/migrate",
+      worktreePath: "/tmp/migrate",
+      messages: [
+        { role: "system", text: "System instructions must stay private." },
+        { role: "user", text: "Move the worker." },
+        { role: "assistant", text: "The worker moved and tests passed." },
+      ],
+    } as unknown as Parameters<typeof formatThreadForHandover>[0]);
+
+    expect(contents).toContain("Title: Continue the migration");
+    expect(contents).toContain("Branch: feature/migrate");
+    expect(contents).toContain("## User\n\nMove the worker.");
+    expect(contents).toContain("## Assistant\n\nThe worker moved and tests passed.");
+    expect(contents).not.toContain("System instructions must stay private.");
+  });
+});

--- a/apps/server/src/orchestration/ThreadHandover.ts
+++ b/apps/server/src/orchestration/ThreadHandover.ts
@@ -1,0 +1,26 @@
+import {
+  DEFAULT_TEXT_GENERATION_MODEL,
+  ProviderInstanceId,
+  type ModelSelection,
+  type OrchestrationThread,
+} from "@t3tools/contracts";
+
+export function makeHandoverModelSelection(instanceId: ProviderInstanceId): ModelSelection {
+  return {
+    instanceId,
+    model: DEFAULT_TEXT_GENERATION_MODEL,
+    options: [{ id: "reasoningEffort", value: "high" }],
+  };
+}
+
+export function formatThreadForHandover(thread: OrchestrationThread): string {
+  const metadata = [
+    `Title: ${thread.title}`,
+    `Branch: ${thread.branch ?? "none"}`,
+    `Worktree: ${thread.worktreePath ?? "project checkout"}`,
+  ];
+  const messages = thread.messages
+    .filter((message) => message.role !== "system")
+    .map((message) => `## ${message.role === "user" ? "User" : "Assistant"}\n\n${message.text}`);
+  return ["# Thread metadata", ...metadata, "", "# Conversation", ...messages].join("\n");
+}

--- a/apps/server/src/orchestration/UsageLimitPolicy.test.ts
+++ b/apps/server/src/orchestration/UsageLimitPolicy.test.ts
@@ -1,0 +1,78 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+
+import { evaluateTurnStartLimits, DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT } from "./UsageLimitPolicy.ts";
+
+function contextActivity(usedTokens: number): OrchestrationThreadActivity {
+  return {
+    id: `usage-${usedTokens}`,
+    createdAt: "2026-08-31T00:00:00.000Z",
+    tone: "info",
+    kind: "context-window.updated",
+    summary: "Context window updated",
+    payload: { usedTokens, maxTokens: 400_000 },
+    turnId: null,
+  } as OrchestrationThreadActivity;
+}
+
+function compactionActivity(afterTokens?: number): OrchestrationThreadActivity {
+  return {
+    id: "context-compaction",
+    createdAt: "2026-08-31T00:01:00.000Z",
+    tone: "info",
+    kind: "context-compaction",
+    summary: "Context compacted",
+    payload:
+      afterTokens === undefined ? { state: "compacted" } : { state: "compacted", afterTokens },
+    turnId: null,
+  } as OrchestrationThreadActivity;
+}
+
+describe("evaluateTurnStartLimits", () => {
+  it("blocks a thread at the context ceiling", () => {
+    const violation = evaluateTurnStartLimits({
+      activities: [contextActivity(DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT)],
+    });
+
+    expect(violation?.code).toBe("context-limit");
+  });
+
+  it("uses the latest context snapshot", () => {
+    const violation = evaluateTurnStartLimits({
+      activities: [contextActivity(DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT), contextActivity(20_000)],
+    });
+
+    expect(violation).toBeUndefined();
+  });
+
+  it("uses the configured context ceiling", () => {
+    const violation = evaluateTurnStartLimits({
+      contextTokenLimit: 100_000,
+      activities: [contextActivity(100_000)],
+    });
+
+    expect(violation?.code).toBe("context-limit");
+    expect(violation?.detail).toContain("100,000");
+  });
+
+  it("does not reuse a pre-compaction context snapshot", () => {
+    expect(
+      evaluateTurnStartLimits({
+        activities: [contextActivity(DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT), compactionActivity()],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses a compaction's reported context size", () => {
+    expect(
+      evaluateTurnStartLimits({
+        activities: [contextActivity(300_000), compactionActivity(100_000)],
+      }),
+    ).toBeUndefined();
+    expect(
+      evaluateTurnStartLimits({
+        activities: [contextActivity(300_000), compactionActivity(260_000)],
+      })?.code,
+    ).toBe("context-limit");
+  });
+});

--- a/apps/server/src/orchestration/UsageLimitPolicy.ts
+++ b/apps/server/src/orchestration/UsageLimitPolicy.ts
@@ -1,0 +1,42 @@
+import {
+  DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT,
+  type OrchestrationThreadActivity,
+} from "@t3tools/contracts";
+export { DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT };
+export type UsageLimitViolation = { readonly code: "context-limit"; readonly detail: string };
+export function evaluateTurnStartLimits(input: {
+  readonly activities: ReadonlyArray<OrchestrationThreadActivity>;
+  readonly contextTokenLimit?: number;
+}): UsageLimitViolation | undefined {
+  const usedTokens = latestContextTokens(input.activities);
+  const contextTokenLimit = input.contextTokenLimit ?? DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT;
+  if (usedTokens !== undefined && usedTokens >= contextTokenLimit) {
+    return {
+      code: "context-limit",
+      detail: `T3 usage limit: this thread has used ${usedTokens.toLocaleString("en-US")} context tokens. The hard limit is ${contextTokenLimit.toLocaleString("en-US")}. Start a new thread so the old conversation is not sent to the provider again.`,
+    };
+  }
+  return undefined;
+}
+
+function latestContextTokens(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): number | undefined {
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (activity?.kind === "context-compaction") {
+      const payload = activity.payload as Record<string, unknown> | undefined;
+      const afterTokens = payload?.["afterTokens"];
+      return typeof afterTokens === "number" && Number.isFinite(afterTokens) && afterTokens >= 0
+        ? afterTokens
+        : undefined;
+    }
+    if (activity?.kind !== "context-window.updated") continue;
+    const payload = activity.payload as Record<string, unknown> | undefined;
+    const usedTokens = payload?.["usedTokens"];
+    if (typeof usedTokens === "number" && Number.isFinite(usedTokens) && usedTokens >= 0) {
+      return usedTokens;
+    }
+  }
+  return undefined;
+}

--- a/apps/server/src/orchestration/UsageLimitReservations.test.ts
+++ b/apps/server/src/orchestration/UsageLimitReservations.test.ts
@@ -1,0 +1,249 @@
+import type { ProviderSession, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Layer from "effect/Layer";
+import * as ProviderService from "../provider/Services/ProviderService.ts";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+
+import { MAX_CONCURRENT_PROVIDER_TURNS } from "./ConcurrentTurnPolicy.ts";
+import { make as makeService, layer, UsageLimitReservations } from "./UsageLimitReservations.ts";
+
+const make = (listSessions: ProviderService.ProviderService["Service"]["listSessions"]) =>
+  makeService.pipe(Effect.provide(Layer.mock(ProviderService.ProviderService)({ listSessions })));
+
+function session(index: number): ProviderSession {
+  return {
+    threadId: `running-${index}` as ThreadId,
+    status: "running",
+  } as ProviderSession;
+}
+
+function assertReleasedReservationRemainsVisible(kind: "turn" | "handover") {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      let runningSessions = Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS - 1 }, (_, index) =>
+        session(index),
+      );
+      let pauseSnapshot = false;
+      const snapshotStarted = yield* Deferred.make<void>();
+      const resumeSnapshot = yield* Deferred.make<void>();
+      const reservations = yield* make(() =>
+        Effect.gen(function* () {
+          const snapshot = [...runningSessions];
+          if (pauseSnapshot) {
+            yield* Deferred.succeed(snapshotStarted, undefined);
+            yield* Deferred.await(resumeSnapshot);
+          }
+          return snapshot;
+        }),
+      );
+      const reserve = kind === "turn" ? reservations.reserveTurn : reservations.reserveHandover;
+
+      expect(
+        yield* reserve({
+          key: `${kind}:eighth`,
+          threadId: "thread-eighth" as ThreadId,
+        }),
+      ).toBeUndefined();
+
+      pauseSnapshot = true;
+      const ninthReservation = yield* reserve({
+        key: `${kind}:ninth`,
+        threadId: "thread-ninth" as ThreadId,
+      }).pipe(Effect.forkChild);
+      yield* Deferred.await(snapshotStarted);
+      runningSessions = [
+        ...runningSessions,
+        {
+          ...session(MAX_CONCURRENT_PROVIDER_TURNS - 1),
+          threadId: "thread-eighth" as ThreadId,
+        },
+      ];
+      const releaseEighth = yield* reservations.release(`${kind}:eighth`).pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      expect(releaseEighth.pollUnsafe()).toBeUndefined();
+      yield* Deferred.succeed(resumeSnapshot, undefined);
+
+      expect(yield* Fiber.join(ninthReservation)).toMatchObject({
+        code: "concurrent-turn-limit",
+      });
+      yield* Fiber.join(releaseEighth);
+    }),
+  );
+}
+
+describe("UsageLimitReservations", () => {
+  it.effect("keeps a released turn reservation visible to an in-flight snapshot", () =>
+    assertReleasedReservationRemainsVisible("turn"),
+  );
+
+  it.effect("keeps a released handover reservation visible to an in-flight snapshot", () =>
+    assertReleasedReservationRemainsVisible("handover"),
+  );
+
+  it.effect("shares admission capacity between runtime consumers", () =>
+    Effect.gen(function* () {
+      const turnConsumer = yield* UsageLimitReservations;
+      const handoverConsumer = yield* UsageLimitReservations;
+      expect(
+        yield* turnConsumer.reserveTurn({
+          key: "turn:one",
+          threadId: "thread-one" as ThreadId,
+        }),
+      ).toBeUndefined();
+      expect(
+        yield* handoverConsumer.reserveHandover({
+          key: "handover:two",
+          threadId: "thread-two" as ThreadId,
+        }),
+      ).toMatchObject({ code: "concurrent-turn-limit" });
+      yield* turnConsumer.release("turn:one");
+      expect(
+        yield* handoverConsumer.reserveHandover({
+          key: "handover:two",
+          threadId: "thread-two" as ThreadId,
+        }),
+      ).toBeUndefined();
+    }).pipe(
+      Effect.provide(
+        layer.pipe(
+          Layer.provide(
+            Layer.mock(ProviderService.ProviderService)({
+              listSessions: () =>
+                Effect.succeed(
+                  Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS - 1 }, (_, index) =>
+                    session(index),
+                  ),
+                ),
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  it.effect("atomically reserves the final provider-work slot", () =>
+    Effect.gen(function* () {
+      const reservations = yield* make(() =>
+        Effect.succeed(
+          Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS - 1 }, (_, index) => session(index)),
+        ),
+      );
+
+      const results = yield* Effect.all(
+        [
+          reservations.reserveHandover({
+            key: "handover:one",
+            threadId: "thread-one" as ThreadId,
+          }),
+          reservations.reserveHandover({
+            key: "handover:two",
+            threadId: "thread-two" as ThreadId,
+          }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      expect(results.filter((result) => result === undefined)).toHaveLength(1);
+      expect(results.filter((result) => result?.code === "concurrent-turn-limit")).toHaveLength(1);
+    }),
+  );
+
+  it.effect("preserves same-thread followups when provider capacity is full", () =>
+    Effect.gen(function* () {
+      const reservations = yield* make(() =>
+        Effect.succeed(
+          Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS }, (_, index) => session(index)),
+        ),
+      );
+
+      expect(
+        yield* reservations.reserveTurn({
+          key: "turn:followup",
+          threadId: "running-0" as ThreadId,
+        }),
+      ).toBeUndefined();
+      yield* reservations.release("turn:followup");
+      expect(
+        yield* reservations.reserveTurn({
+          key: "turn:new-thread",
+          threadId: "thread-new" as ThreadId,
+        }),
+      ).toMatchObject({ code: "concurrent-turn-limit" });
+    }),
+  );
+
+  it.effect("releases admission synchronization when snapshot lookup is interrupted", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let pauseSnapshot = true;
+        const snapshotStarted = yield* Deferred.make<void>();
+        const resumeSnapshot = yield* Deferred.make<void>();
+        const reservations = yield* make(() =>
+          pauseSnapshot
+            ? Deferred.succeed(snapshotStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(resumeSnapshot)),
+                Effect.as<ReadonlyArray<ProviderSession>>([]),
+              )
+            : Effect.succeed([]),
+        );
+        const interruptedReservation = yield* reservations
+          .reserveTurn({
+            key: "turn:interrupted",
+            threadId: "thread-interrupted" as ThreadId,
+          })
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(snapshotStarted);
+        yield* Fiber.interrupt(interruptedReservation);
+
+        pauseSnapshot = false;
+        expect(
+          yield* reservations.reserveTurn({
+            key: "turn:after-interrupt",
+            threadId: "thread-after-interrupt" as ThreadId,
+          }),
+        ).toBeUndefined();
+      }),
+    ),
+  );
+
+  it.effect("releases a handover slot idempotently after completion", () =>
+    Effect.gen(function* () {
+      const reservations = yield* make(() =>
+        Effect.succeed(
+          Array.from({ length: MAX_CONCURRENT_PROVIDER_TURNS - 1 }, (_, index) => session(index)),
+        ),
+      );
+
+      expect(
+        yield* reservations.reserveHandover({
+          key: "handover:first",
+          threadId: "thread-first" as ThreadId,
+        }),
+      ).toBeUndefined();
+      yield* reservations.release("handover:first");
+      yield* reservations.release("handover:first");
+      expect(
+        yield* reservations.reserveHandover({
+          key: "handover:second",
+          threadId: "thread-second" as ThreadId,
+        }),
+      ).toBeUndefined();
+    }),
+  );
+
+  it.effect("rejects duplicate generation for one source thread", () =>
+    Effect.gen(function* () {
+      const reservations = yield* make(() => Effect.succeed([]));
+      const threadId = "thread-source" as ThreadId;
+
+      expect(
+        yield* reservations.reserveHandover({ key: "handover:first", threadId }),
+      ).toBeUndefined();
+      expect(
+        yield* reservations.reserveHandover({ key: "handover:second", threadId }),
+      ).toMatchObject({ code: "handover-in-progress" });
+    }),
+  );
+});

--- a/apps/server/src/orchestration/UsageLimitReservations.ts
+++ b/apps/server/src/orchestration/UsageLimitReservations.ts
@@ -1,0 +1,112 @@
+import type { ThreadId } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Layer from "effect/Layer";
+import * as Effect from "effect/Effect";
+import * as Semaphore from "effect/Semaphore";
+
+import type { ProviderServiceError } from "../provider/Errors.ts";
+import * as ProviderService from "../provider/Services/ProviderService.ts";
+import {
+  evaluateHandoverStartLimits,
+  evaluateTurnStartLimits,
+  type UsageLimitViolation,
+} from "./ConcurrentTurnPolicy.ts";
+
+type Reservation =
+  | { readonly kind: "turn"; readonly threadId: ThreadId }
+  | { readonly kind: "handover"; readonly threadId: ThreadId };
+
+export class UsageLimitReservations extends Context.Service<
+  UsageLimitReservations,
+  {
+    readonly reserveTurn: (input: {
+      readonly key: string;
+      readonly threadId: ThreadId;
+    }) => Effect.Effect<UsageLimitViolation | undefined, ProviderServiceError>;
+    readonly reserveHandover: (input: {
+      readonly key: string;
+      readonly threadId: ThreadId;
+    }) => Effect.Effect<UsageLimitViolation | undefined, ProviderServiceError>;
+    readonly release: (key: string) => Effect.Effect<void>;
+  }
+>()("t3/orchestration/UsageLimitReservations") {}
+
+export const make = Effect.gen(function* () {
+  const providerService = yield* ProviderService.ProviderService;
+  const reservations = new Map<string, Reservation>();
+  const reservationMutex = yield* Semaphore.make(1);
+
+  const release: UsageLimitReservations["Service"]["release"] = (key) =>
+    reservationMutex.withPermit(
+      Effect.sync(() => {
+        reservations.delete(key);
+      }),
+    );
+
+  const reserveTurn: UsageLimitReservations["Service"]["reserveTurn"] = Effect.fn(
+    "UsageLimitReservations.reserveTurn",
+  )(function* (input: Parameters<UsageLimitReservations["Service"]["reserveTurn"]>[0]) {
+    return yield* reservationMutex.withPermit(
+      Effect.gen(function* () {
+        const sessions = yield* providerService.listSessions();
+        return yield* Effect.sync(() => {
+          const values = [...reservations.values()];
+          const violation = evaluateTurnStartLimits({
+            threadId: input.threadId,
+            sessions,
+            reservedTurnThreadIds: values
+              .filter((reservation) => reservation.kind === "turn")
+              .map((reservation) => reservation.threadId),
+            reservedHandoverCount: values.filter((reservation) => reservation.kind === "handover")
+              .length,
+          });
+          if (violation) return violation;
+
+          reservations.set(input.key, { kind: "turn", threadId: input.threadId });
+          return undefined;
+        });
+      }),
+    );
+  });
+
+  const reserveHandover: UsageLimitReservations["Service"]["reserveHandover"] = Effect.fn(
+    "UsageLimitReservations.reserveHandover",
+  )(function* (input: Parameters<UsageLimitReservations["Service"]["reserveHandover"]>[0]) {
+    return yield* reservationMutex.withPermit(
+      Effect.gen(function* () {
+        const sessions = yield* providerService.listSessions();
+        return yield* Effect.sync(() => {
+          const values = [...reservations.values()];
+          if (
+            values.some(
+              (reservation) =>
+                reservation.kind === "handover" && reservation.threadId === input.threadId,
+            )
+          ) {
+            return {
+              code: "handover-in-progress",
+              detail: "A handover is already being generated for this thread.",
+            } satisfies UsageLimitViolation;
+          }
+
+          const violation = evaluateHandoverStartLimits({
+            sessions,
+            reservedTurnThreadIds: values
+              .filter((reservation) => reservation.kind === "turn")
+              .map((reservation) => reservation.threadId),
+            reservedHandoverCount: values.filter((reservation) => reservation.kind === "handover")
+              .length,
+          });
+          if (violation) return violation;
+
+          reservations.set(input.key, { kind: "handover", threadId: input.threadId });
+          return undefined;
+        });
+      }),
+    );
+  });
+
+  return UsageLimitReservations.of({ reserveTurn, reserveHandover, release });
+});
+
+export const layer = Layer.effect(UsageLimitReservations, make);

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -34,6 +34,7 @@ import * as ProviderSessionRuntime from "../persistence/ProviderSessionRuntime.t
 import { OrchestrationEngineLive } from "../orchestration/Layers/OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "../orchestration/Layers/ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "../orchestration/Layers/ProjectionSnapshotQuery.ts";
+import * as UsageLimitReservations from "../orchestration/UsageLimitReservations.ts";
 import { ProviderCommandReactorLive } from "../orchestration/Layers/ProviderCommandReactor.ts";
 import { OrchestrationCommandInvariantError } from "../orchestration/Errors.ts";
 import * as ThreadBackgroundLiveness from "../orchestration/ThreadBackgroundLiveness.ts";
@@ -905,6 +906,7 @@ it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
           Layer.provide(AnalyticsService.layerTest),
         );
         const reactorLayer = ProviderCommandReactorLive.pipe(
+          Layer.provide(UsageLimitReservations.layer),
           Layer.provideMerge(providerLayer),
           Layer.provide(
             Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -125,6 +125,7 @@ import { OrchestrationEventStoreLive } from "./persistence/Layers/OrchestrationE
 import { OrchestrationEventStore } from "./persistence/Services/OrchestrationEventStore.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import * as UsageLimitReservations from "./orchestration/UsageLimitReservations.ts";
 import * as ProviderService from "./provider/Services/ProviderService.ts";
 import { ProviderAuthService } from "./provider/Services/ProviderAuthService.ts";
 import { ProviderInstanceRegistry } from "./provider/Services/ProviderInstanceRegistry.ts";
@@ -136,6 +137,7 @@ import type { ProviderInstance } from "./provider/ProviderDriver.ts";
 import * as ProviderSessionDirectory from "./provider/Services/ProviderSessionDirectory.ts";
 import { ProviderAdapterRequestError } from "./provider/Errors.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/providerMaintenance.ts";
+import * as TextGeneration from "./textGeneration/TextGeneration.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServiceLauncherClient from "./cloud/serviceLauncherClient.ts";
@@ -784,9 +786,20 @@ const buildAppUnderTest = (options?: {
             streamChanges: Stream.empty,
             ...options?.layers?.providerRegistry,
           }),
+          UsageLimitReservations.layer.pipe(
+            Layer.provide(
+              Layer.mock(ProviderService.ProviderService)({
+                listSessions: () => Effect.succeed([]),
+                ...options?.layers?.providerService,
+              }),
+            ),
+          ),
           Layer.mock(ProviderService.ProviderService)({
             uploadFeedback: () => Effect.die("Provider feedback is not stubbed in this test"),
             ...options?.layers?.providerService,
+          }),
+          Layer.mock(TextGeneration.TextGeneration)({
+            generateHandover: () => Effect.die("Text generation is not stubbed in this test"),
           }),
           Layer.mock(ProviderAuthService)({
             ...options?.layers?.providerAuth,
@@ -5393,6 +5406,23 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(error._tag, "AgentSessionImportProjectNotFoundError");
       if (error._tag === "AgentSessionImportProjectNotFoundError") {
         assert.equal(error.projectId, projectId);
+      }
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("returns a typed handover error for a missing thread over websocket rpc", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const threadId = ThreadId.make("missing-handover-thread");
+      const error = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.generateHandover]({ threadId }).pipe(Effect.flip),
+        ),
+      );
+      assert.equal(error._tag, "OrchestrationGenerateHandoverError");
+      if (error._tag === "OrchestrationGenerateHandoverError") {
+        assert.equal(error.message, `Thread '${threadId}' was not found.`);
       }
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -35,6 +35,7 @@ import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionD
 import * as ProviderSessionRuntime from "./persistence/ProviderSessionRuntime.ts";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry.ts";
 import * as ModelManifest from "./provider/ModelManifest.ts";
+import * as UsageLimitReservations from "./orchestration/UsageLimitReservations.ts";
 import * as CodexResetCredit from "./provider/Layers/codexResetCredit.ts";
 import * as ProviderEventLoggers from "./provider/Layers/ProviderEventLoggers.ts";
 import { ProviderServiceLive } from "./provider/Layers/ProviderService.ts";
@@ -476,6 +477,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   ),
   Layer.provideMerge(GitLayerLive),
   Layer.provideMerge(VcsLayerLive),
+  Layer.provideMerge(UsageLimitReservations.layer),
   Layer.provideMerge(ProviderRuntimeLayerLive),
   Layer.provideMerge(Layer.mergeAll(TerminalLayerLive, PreviewLayerLive, DeviceLayerLive)),
   Layer.provideMerge(PersistenceLayerLive),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -413,7 +413,14 @@ const ProjectFaviconResolverLayerLive = ProjectFaviconResolver.layer.pipe(
   Layer.provide(T3ProjectFileLoader.layer),
 );
 
-const ServerEnvironmentLayerLive = ServerEnvironment.layer.pipe(
+const ProviderInstanceRegistryLayerLive = ProviderInstanceRegistryHydrationLive.pipe(
+  Layer.provideMerge(Layer.mergeAll(AntigravityInstallation.layer, CodexResetCredit.layer)),
+  Layer.provideMerge(Layer.mergeAll(ProviderEventLoggers.layer, ModelManifest.layer)),
+  Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
+);
+
+const ServerEnvironmentLayerLive = ServerEnvironment.providerRuntimeLayer.pipe(
+  Layer.provide(ProviderInstanceRegistryLayerLive),
   Layer.provide(ServerSecretStore.layer),
 );
 
@@ -492,7 +499,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // through this layer. Built-in drivers come from `BUILT_IN_DRIVERS`;
   // `providerInstances` hydration merges `settings.providers.<kind>`
   // with explicit `providerInstances` entries on boot.
-  Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+  Layer.provideMerge(ProviderInstanceRegistryLayerLive),
 ).pipe(
   Layer.provideMerge(AntigravityInstallation.layer),
   // Shared native/canonical NDJSON writers used by both the per-instance

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.ts
@@ -20,7 +20,7 @@ import { type AcpError, AcpRequestError } from "effect-acp/errors";
 import { applyAntigravityAcpModelSelection } from "../provider/acp/AntigravityAcpSupport.ts";
 import { removeAntigravitySessionFiles } from "../provider/acp/AntigravitySessionFiles.ts";
 import type { AcpSessionRuntime } from "../provider/acp/AcpSessionRuntime.ts";
-import type * as TextGeneration from "./TextGeneration.ts";
+import * as TextGeneration from "./TextGeneration.ts";
 import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
@@ -406,5 +406,6 @@ export const makeAntigravityTextGeneration = Effect.fn("makeAntigravityTextGener
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    generateHandover: TextGeneration.unsupportedHandoverGeneration("antigravity"),
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -413,5 +413,6 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    generateHandover: TextGeneration.unsupportedHandoverGeneration("claudeAgent"),
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/CodexTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.test.ts
@@ -233,7 +233,10 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
           body: "",
         }),
         launchArgs: "--enable settings-feature",
-        environment: { T3CODE_CODEX_LAUNCH_ARGS: " --strict-config --listen off " },
+        environment: {
+          PATH: process.env.PATH,
+          T3CODE_CODEX_LAUNCH_ARGS: " --strict-config --listen off ",
+        },
         requireArg: "--strict-config",
         forbidArg: "settings-feature",
       },
@@ -360,6 +363,31 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
           });
 
           expect(generated.title).toBe("Investigate websocket reconnect regressions aft...");
+        }),
+    ),
+  );
+
+  it.effect("generates handovers with Luna High", () =>
+    withFakeCodexEnv(
+      {
+        output: JSON.stringify({
+          handover: "\n# Goal\n\nContinue the migration.\n",
+        }),
+        requireArg: "gpt-5.6-luna",
+        requireReasoningEffort: "high",
+        stdinMustContain: "Thread contents:",
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateHandover({
+            cwd: process.cwd(),
+            threadContents: "User: Continue the migration",
+            modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.6-luna", [
+              { id: "reasoningEffort", value: "high" },
+            ]),
+          });
+
+          expect(generated.handover).toBe("# Goal\n\nContinue the migration.");
         }),
     ),
   );

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -24,6 +24,7 @@ import * as TextGeneration from "./TextGeneration.ts";
 import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
+  buildHandoverPrompt,
   buildPrContentPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
@@ -101,7 +102,8 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle",
+      | "generateThreadTitle"
+      | "generateHandover",
     value: unknown,
   ): Effect.Effect<string, TextGenerationError> =>
     encodeJsonString(value).pipe(
@@ -120,7 +122,8 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle",
+      | "generateThreadTitle"
+      | "generateHandover",
     attachments: TextGeneration.BranchNameGenerationInput["attachments"],
   ): Effect.fn.Return<MaterializedImageAttachments, TextGenerationError> {
     if (!attachments || attachments.length === 0) {
@@ -162,7 +165,8 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle";
+      | "generateThreadTitle"
+      | "generateHandover";
     cwd: string;
     prompt: string;
     outputSchemaJson: S;
@@ -405,10 +409,34 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       } satisfies TextGeneration.ThreadTitleGenerationResult;
     });
 
+  const generateHandover: TextGeneration.TextGeneration["Service"]["generateHandover"] = Effect.fn(
+    "CodexTextGeneration.generateHandover",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildHandoverPrompt({
+      threadContents: input.threadContents,
+    });
+    const generated = yield* runCodexJson({
+      operation: "generateHandover",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+    const handover = generated.handover.trim();
+    if (handover.length === 0) {
+      return yield* new TextGenerationError({
+        operation: "generateHandover",
+        detail: "Codex returned an empty handover.",
+      });
+    }
+    return { handover };
+  });
+
   return {
     generateCommitMessage,
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    generateHandover,
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/CursorTextGeneration.ts
+++ b/apps/server/src/textGeneration/CursorTextGeneration.ts
@@ -264,5 +264,6 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    generateHandover: TextGeneration.unsupportedHandoverGeneration("cursor"),
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/GrokTextGeneration.ts
+++ b/apps/server/src/textGeneration/GrokTextGeneration.ts
@@ -266,5 +266,6 @@ export const makeGrokTextGeneration = Effect.fn("makeGrokTextGeneration")(functi
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    generateHandover: TextGeneration.unsupportedHandoverGeneration("grok"),
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -456,5 +456,6 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    generateHandover: TextGeneration.unsupportedHandoverGeneration("opencode"),
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/TextGeneration.test.ts
+++ b/apps/server/src/textGeneration/TextGeneration.test.ts
@@ -5,7 +5,7 @@ import * as Result from "effect/Result";
 import * as Stream from "effect/Stream";
 import { describe, expect } from "vite-plus/test";
 
-import { ProviderInstanceId } from "@t3tools/contracts";
+import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
 
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
@@ -21,18 +21,20 @@ const makeStubTextGeneration = (
     generatePrContent: () => Effect.die("generatePrContent stub not configured for this test"),
     generateBranchName: () => Effect.die("generateBranchName stub not configured for this test"),
     generateThreadTitle: () => Effect.die("generateThreadTitle stub not configured for this test"),
+    generateHandover: () => Effect.die("generateHandover stub not configured for this test"),
     ...overrides,
   });
 
 const makeStubInstance = (
   instanceId: ProviderInstanceId,
   textGeneration: TextGeneration.TextGeneration["Service"],
+  driverKind: ProviderInstance["driverKind"] = instanceId as unknown as ProviderInstance["driverKind"],
 ): ProviderInstance =>
   ({
     instanceId,
-    driverKind: instanceId as unknown as ProviderInstance["driverKind"],
+    driverKind,
     continuationIdentity: {
-      driverKind: instanceId as unknown as ProviderInstance["driverKind"],
+      driverKind,
       continuationKey: `${instanceId}:test`,
     },
     displayName: undefined,
@@ -94,6 +96,56 @@ describe("makeTextGenerationFromRegistry", () => {
       expect(personalCalls).toEqual(["Refactor the routing layer"]);
     }),
   );
+
+  it.effect("delegates handover generation with its exact model selection", () =>
+    Effect.gen(function* () {
+      const instanceId = ProviderInstanceId.make("codex");
+      const selections: Array<{ readonly model: string; readonly effort: unknown }> = [];
+      const instance = makeStubInstance(
+        instanceId,
+        makeStubTextGeneration({
+          generateHandover: (input) => {
+            selections.push({
+              model: input.modelSelection.model,
+              effort: input.modelSelection.options?.find(
+                (option) => option.id === "reasoningEffort",
+              )?.value,
+            });
+            return Effect.succeed({ handover: "# Goal\n\nContinue the migration." });
+          },
+        }),
+      );
+
+      const tg = TextGeneration.makeTextGenerationFromRegistry(makeStubRegistry([instance]));
+      const result = yield* tg.generateHandover({
+        cwd: process.cwd(),
+        threadContents: "User: Continue the migration",
+        modelSelection: createModelSelection(instanceId, "gpt-5.6-luna", [
+          { id: "reasoningEffort", value: "high" },
+        ]),
+      });
+
+      expect(result.handover).toContain("Continue the migration");
+      expect(selections).toEqual([{ model: "gpt-5.6-luna", effort: "high" }]);
+    }),
+  );
+
+  it("finds an enabled Codex driver without assuming its instance id", () => {
+    const renamedCodex = makeStubInstance(
+      ProviderInstanceId.make("codex_work"),
+      makeStubTextGeneration({}),
+      ProviderDriverKind.make("codex"),
+    );
+    const disabledCodex = {
+      ...renamedCodex,
+      instanceId: ProviderInstanceId.make("codex_disabled"),
+      enabled: false,
+    };
+
+    expect(
+      TextGeneration.findAvailableCodexInstance([disabledCodex, renamedCodex])?.instanceId,
+    ).toBe("codex_work");
+  });
 
   it.effect("fails with TextGenerationError when the instance is unknown", () =>
     Effect.gen(function* () {

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -1,12 +1,27 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type { ChatAttachment, ModelSelection, ProviderInstanceId } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  type ChatAttachment,
+  type ModelSelection,
+  type ProviderInstanceId,
+} from "@t3tools/contracts";
 import { TextGenerationError } from "@t3tools/contracts";
 
 import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstanceRegistry.ts";
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import type { TextGenerationPolicy } from "./TextGenerationPolicy.ts";
+
+const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
+
+export function findAvailableCodexInstance(
+  instances: ReadonlyArray<ProviderInstance>,
+): ProviderInstance | undefined {
+  return instances.find(
+    (instance) => instance.enabled && instance.driverKind === CODEX_DRIVER_KIND,
+  );
+}
 
 export type TextGenerationProvider = "codex" | "claudeAgent" | "cursor" | "grok" | "opencode";
 
@@ -73,6 +88,17 @@ export interface ThreadTitleGenerationResult {
   title: string;
 }
 
+export interface HandoverGenerationInput {
+  cwd: string;
+  threadContents: string;
+  /** The handover action supplies GPT-5.6 Luna with high reasoning explicitly. */
+  modelSelection: ModelSelection;
+}
+
+export interface HandoverGenerationResult {
+  handover: string;
+}
+
 /**
  * TextGeneration - Service tag for commit and change request text generation.
  */
@@ -104,6 +130,11 @@ export class TextGeneration extends Context.Service<
     readonly generateThreadTitle: (
       input: ThreadTitleGenerationInput,
     ) => Effect.Effect<ThreadTitleGenerationResult, TextGenerationError>;
+
+    /** Generate the compact continuation document for an oversized thread. */
+    readonly generateHandover: (
+      input: HandoverGenerationInput,
+    ) => Effect.Effect<HandoverGenerationResult, TextGenerationError>;
   }
 >()("t3/textGeneration/TextGeneration") {}
 
@@ -111,7 +142,8 @@ type TextGenerationOp =
   | "generateCommitMessage"
   | "generatePrContent"
   | "generateBranchName"
-  | "generateThreadTitle";
+  | "generateThreadTitle"
+  | "generateHandover";
 
 const resolveInstance = (
   registry: ProviderInstanceRegistry.ProviderInstanceRegistry["Service"],
@@ -151,6 +183,20 @@ export const makeTextGenerationFromRegistry = (
       resolveInstance(registry, "generateThreadTitle", input.modelSelection.instanceId).pipe(
         Effect.flatMap((textGeneration) => textGeneration.generateThreadTitle(input)),
       ),
+    generateHandover: (input) =>
+      resolveInstance(registry, "generateHandover", input.modelSelection.instanceId).pipe(
+        Effect.flatMap((textGeneration) => textGeneration.generateHandover(input)),
+      ),
+  });
+
+export const unsupportedHandoverGeneration = (
+  provider: TextGenerationProvider | "antigravity",
+): TextGeneration["Service"]["generateHandover"] =>
+  Effect.fn(`${provider}.generateHandover.unsupported`)(function* () {
+    return yield* new TextGenerationError({
+      operation: "generateHandover",
+      detail: `${provider} does not support handover generation.`,
+    });
   });
 
 /** @public Service construction is part of the canonical Effect module API. */

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
+  buildHandoverPrompt,
   buildPrContentPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
@@ -212,6 +213,29 @@ describe("buildThreadTitlePrompt", () => {
       `Thread contents:\n[Earlier content truncated]\n\n${retainedContext}`,
     );
     expect(result.prompt.match(/\[Earlier content truncated\]/g)).toHaveLength(1);
+  });
+});
+
+describe("buildHandoverPrompt", () => {
+  it("asks for a continuation brief with the required state", () => {
+    const result = buildHandoverPrompt({
+      threadContents: "## User\n\nFix the worker.\n\n## Assistant\n\nTests passed.",
+    });
+
+    expect(result.prompt).toContain("unsent first message");
+    expect(result.prompt).toContain("Files changed");
+    expect(result.prompt).toContain("Verification");
+    expect(result.prompt).toContain("Fix the worker");
+  });
+
+  it("keeps the beginning and end of oversized threads", () => {
+    const result = buildHandoverPrompt({
+      threadContents: `ORIGINAL-GOAL\n${"middle ".repeat(30_000)}\nLATEST-STATE`,
+    });
+
+    expect(result.prompt).toContain("ORIGINAL-GOAL");
+    expect(result.prompt).toContain("[middle of thread omitted]");
+    expect(result.prompt).toContain("LATEST-STATE");
   });
 });
 

--- a/apps/server/src/textGeneration/TextGenerationPrompts.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.ts
@@ -320,3 +320,41 @@ export function buildThreadTitlePrompt(input: ThreadTitlePromptInput) {
 
   return { prompt, outputSchema };
 }
+
+const HANDOVER_THREAD_CONTENT_MAX_CHARS = 180_000;
+const HANDOVER_THREAD_CONTENT_HEAD_CHARS = 30_000;
+
+function limitHandoverThreadContents(contents: string): string {
+  if (contents.length <= HANDOVER_THREAD_CONTENT_MAX_CHARS) return contents;
+  const tailChars = HANDOVER_THREAD_CONTENT_MAX_CHARS - HANDOVER_THREAD_CONTENT_HEAD_CHARS;
+  return [
+    contents.slice(0, HANDOVER_THREAD_CONTENT_HEAD_CHARS),
+    "",
+    "[middle of thread omitted]",
+    "",
+    contents.slice(-tailChars),
+  ].join("\n");
+}
+
+export function buildHandoverPrompt(input: { readonly threadContents: string }) {
+  const prompt = `Write a compact Markdown handover for the next coding agent.
+Return JSON with exactly one key: handover.
+
+The handover will become the unsent first message in a new T3 Code thread. Write it as a direct continuation brief, not as commentary about summarizing. Include only facts supported by the thread.
+
+Use these sections:
+- Goal
+- Decisions and constraints
+- Work completed
+- Files changed
+- Verification
+- Open problems
+- Next action
+
+Keep exact file paths, commands, test results, error text, and user decisions when they matter. Separate completed work from proposed work. Do not claim a test passed unless the thread says it passed. Keep it short enough that the next thread avoids carrying the old context.
+
+Thread contents:
+${limitHandoverThreadContents(input.threadContents)}`;
+  const outputSchema = Schema.Struct({ handover: Schema.String });
+  return { prompt, outputSchema };
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -35,6 +35,7 @@ import {
   type GitActionProgressEvent,
   type GitManagerServiceError,
   OrchestrationDispatchCommandError,
+  OrchestrationGenerateHandoverError,
   type OrchestrationEvent,
   type OrchestrationShellStreamEvent,
   type OrchestrationShellStreamItem,
@@ -161,9 +162,16 @@ import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProjectConfig from "./vcs/VcsProjectConfig.ts";
 import * as PairingGrantStore from "./auth/PairingGrantStore.ts";
 import * as SessionStore from "./auth/SessionStore.ts";
+import {
+  formatThreadForHandover,
+  makeHandoverModelSelection,
+} from "./orchestration/ThreadHandover.ts";
+import * as UsageLimitReservations from "./orchestration/UsageLimitReservations.ts";
+import * as TextGeneration from "./textGeneration/TextGeneration.ts";
 import { failEnvironmentAuthInvalid, failEnvironmentInternal } from "./auth/http.ts";
 import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
+const isOrchestrationGenerateHandoverError = Schema.is(OrchestrationGenerateHandoverError);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const CONFIG_DISCOVERY_TIMEOUT = Duration.seconds(5);
@@ -541,6 +549,8 @@ const makeWsRpcLayer = (
       const portDiscovery = yield* PortScanner.PortDiscovery;
       const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
       const providerService = yield* ProviderService.ProviderService;
+      const textGeneration = yield* TextGeneration.TextGeneration;
+      const usageLimitReservations = yield* UsageLimitReservations.UsageLimitReservations;
       const providerSessionDirectory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const providerAuth = yield* ProviderAuthService;
@@ -1392,6 +1402,79 @@ const makeWsRpcLayer = (
                   ? cause
                   : new OrchestrationDispatchCommandError({
                       message: "Failed to dispatch orchestration command",
+                      cause,
+                    }),
+              ),
+            ),
+            { "rpc.aggregate": "orchestration" },
+          ),
+        [ORCHESTRATION_WS_METHODS.generateHandover]: ({ threadId }) =>
+          observeRpcEffect(
+            ORCHESTRATION_WS_METHODS.generateHandover,
+            Effect.gen(function* () {
+              const thread = yield* projectionSnapshotQuery.getThreadDetailById(threadId).pipe(
+                Effect.flatMap(
+                  Option.match({
+                    onNone: () =>
+                      Effect.fail(
+                        new OrchestrationGenerateHandoverError({
+                          message: `Thread '${threadId}' was not found.`,
+                        }),
+                      ),
+                    onSome: Effect.succeed,
+                  }),
+                ),
+              );
+              const project = yield* projectionSnapshotQuery
+                .getProjectShellById(thread.projectId)
+                .pipe(
+                  Effect.flatMap(
+                    Option.match({
+                      onNone: () =>
+                        Effect.fail(
+                          new OrchestrationGenerateHandoverError({
+                            message: `Project '${thread.projectId}' was not found.`,
+                          }),
+                        ),
+                      onSome: Effect.succeed,
+                    }),
+                  ),
+                );
+              const codexInstance = TextGeneration.findAvailableCodexInstance(
+                yield* providerInstances.listInstances,
+              );
+              if (!codexInstance) {
+                return yield* Effect.fail(
+                  new OrchestrationGenerateHandoverError({
+                    message: "No enabled Codex provider is available for handover generation.",
+                  }),
+                );
+              }
+              const reservationKey = `handover:${threadId}`;
+              const usageLimitViolation = yield* usageLimitReservations.reserveHandover({
+                key: reservationKey,
+                threadId,
+              });
+              if (usageLimitViolation) {
+                return yield* Effect.fail(
+                  new OrchestrationGenerateHandoverError({
+                    message: usageLimitViolation.detail,
+                  }),
+                );
+              }
+              return yield* textGeneration
+                .generateHandover({
+                  cwd: thread.worktreePath ?? project.workspaceRoot,
+                  threadContents: formatThreadForHandover(thread),
+                  modelSelection: makeHandoverModelSelection(codexInstance.instanceId),
+                })
+                .pipe(Effect.ensuring(usageLimitReservations.release(reservationKey)));
+            }).pipe(
+              Effect.mapError((cause) =>
+                isOrchestrationGenerateHandoverError(cause)
+                  ? cause
+                  : new OrchestrationGenerateHandoverError({
+                      message: "Failed to generate a thread handover.",
                       cause,
                     }),
               ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -69,7 +69,10 @@ import {
   resolveProjectScripts,
 } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
-import { resolveThreadReferenceCopyTarget } from "@t3tools/shared/threadReference";
+import {
+  resolveThreadReferenceCopyTarget,
+  threadHandoverSourceKey,
+} from "@t3tools/shared/threadReference";
 import {
   getTerminalLabel,
   nextTerminalId,
@@ -88,6 +91,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { flushSync } from "react-dom";
 import { useLocation, useNavigate } from "@tanstack/react-router";
@@ -251,6 +255,7 @@ import {
   useEnvironmentSettings,
 } from "../hooks/useSettings";
 import { useNowMinute } from "../hooks/useNowMinute";
+import { contextWindowReachedThreadLimit } from "../lib/contextWindow";
 import { usePanelAnimationSettings, usePanelPresence } from "../panelAnimations";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { useOpenPanelPullRequestUrl } from "../hooks/useOpenPanelPullRequestUrl";
@@ -358,6 +363,7 @@ import {
   ThreadErrorBanner,
 } from "./chat/ThreadErrorBanner";
 import type { ComposerBannerStackItem } from "./chat/ComposerBannerStack";
+import { buildContextLimitBannerItem } from "./chat/ContextLimitBanner";
 import { ComposerSurface } from "./chat/ComposerSurface";
 import {
   hasAvailableCompactionProvider,
@@ -483,6 +489,7 @@ import {
   supportsServerUpdateThreadContinuation,
 } from "../versionSkew";
 import { useAssetUrls } from "../assets/assetUrls";
+import { createPendingHandoverStore } from "../pendingHandoverStore";
 import { ATTACHMENT_ONLY_BOOTSTRAP_PROMPT } from "./chat/composerPromptHistory";
 
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
@@ -490,6 +497,7 @@ const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_USAGE_LIMIT_SOURCES: UsageLimitSourceSnapshots = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
+const pendingThreadHandovers = createPendingHandoverStore();
 function useDraftHeroLayoutTransition(isDraftHeroState: boolean) {
   const transitionGroupRef = useRef<HTMLDivElement | null>(null);
   const composerAnchorRef = useRef<HTMLDivElement | null>(null);
@@ -1423,6 +1431,18 @@ export default function ChatView(props: ChatViewProps) {
     [environmentId, threadId],
   );
   const routeThreadKey = useMemo(() => scopedThreadKey(routeThreadRef), [routeThreadRef]);
+  const routeHandoverKey = useMemo(
+    () => threadHandoverSourceKey(routeThreadRef.environmentId, routeThreadRef.threadId),
+    [routeThreadRef],
+  );
+  const routeHandoverKeyRef = useRef<string | null>(routeHandoverKey);
+  routeHandoverKeyRef.current = routeHandoverKey;
+  useEffect(() => {
+    routeHandoverKeyRef.current = routeHandoverKey;
+    return () => {
+      routeHandoverKeyRef.current = null;
+    };
+  }, [routeHandoverKey]);
   const updateProjectScriptSettings = useAtomCommand(serverEnvironment.updateSettings, {
     reportFailure: false,
   });
@@ -1433,6 +1453,9 @@ export default function ChatView(props: ChatViewProps) {
   const writeTerminal = useAtomCommand(terminalEnvironment.write, "terminal write");
   const closeTerminalMutation = useAtomCommand(terminalEnvironment.close, "terminal close");
   const createThread = useAtomCommand(threadEnvironment.create, { reportFailure: false });
+  const generateThreadHandover = useAtomCommand(threadEnvironment.generateHandover, {
+    reportFailure: false,
+  });
   const deleteThread = useAtomCommand(threadEnvironment.delete, { reportFailure: false });
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
@@ -2645,6 +2668,9 @@ export default function ChatView(props: ChatViewProps) {
     () => deriveLatestContextWindowSnapshot(threadActivities),
     [threadActivities],
   );
+  const activeThreadReachedContextLimit =
+    serverConfig !== null &&
+    contextWindowReachedThreadLimit(activeContextWindow, settings.threadContextTokenLimit);
   const workLogEntries = useMemo(() => deriveWorkLogEntries(threadActivities), [threadActivities]);
   // Native subagent fold: memoized by activity-list identity, shared by the
   // Agents surface, live strip, and workflow cards. v2Projection is null
@@ -5852,6 +5878,157 @@ export default function ChatView(props: ChatViewProps) {
     handleStopBackgroundWork,
     isStoppingBackgroundWork,
   ]);
+  useSyncExternalStore(
+    pendingThreadHandovers.subscribe,
+    pendingThreadHandovers.getVersion,
+    pendingThreadHandovers.getVersion,
+  );
+  const activeThreadHandoverKey = activeThread
+    ? threadHandoverSourceKey(activeThread.environmentId, activeThread.id)
+    : null;
+  const isGeneratingHandover = activeThreadHandoverKey
+    ? pendingThreadHandovers.isGenerating(activeThreadHandoverKey)
+    : false;
+  const pendingHandoverAttempt = activeThreadHandoverKey
+    ? pendingThreadHandovers.get(activeThreadHandoverKey)
+    : undefined;
+  const handleGenerateHandover = useCallback(async () => {
+    if (
+      !activeThread ||
+      !activeProject ||
+      !isServerThread ||
+      !activeThreadReachedContextLimit ||
+      isGeneratingHandover ||
+      activeThreadHandoverKey === null
+    ) {
+      return;
+    }
+    const sourceThreadKey = activeThreadHandoverKey;
+    if (pendingThreadHandovers.isGenerating(sourceThreadKey)) return;
+    pendingThreadHandovers.setGenerating(sourceThreadKey, true);
+    try {
+      let attempt = pendingThreadHandovers.get(sourceThreadKey);
+      if (attempt === undefined) {
+        const result = await generateThreadHandover({
+          environmentId: activeThread.environmentId,
+          input: { threadId: activeThread.id },
+        });
+        if (result._tag === "Failure") {
+          if (!isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Could not create handover",
+                description: error instanceof Error ? error.message : "Handover generation failed.",
+              }),
+            );
+          }
+          return;
+        }
+        attempt = { handover: result.value.handover };
+        pendingThreadHandovers.save(sourceThreadKey, attempt);
+      }
+      const handoverAttempt = attempt;
+      const handover = handoverAttempt.handover;
+
+      if (routeHandoverKeyRef.current !== sourceThreadKey) {
+        return;
+      }
+
+      const opened = await handleNewThread(
+        scopeProjectRef(activeThread.environmentId, activeProject.id),
+        {
+          branch: activeThread.branch,
+          worktreePath: activeThread.worktreePath,
+          envMode: activeThread.worktreePath ? "worktree" : "local",
+          startFromOrigin: false,
+          initialPrompt: handover,
+          ...(handoverAttempt.draftId === undefined
+            ? {}
+            : { reopenDraftId: handoverAttempt.draftId }),
+          onDraftReady: (draftId) => {
+            pendingThreadHandovers.save(sourceThreadKey, { ...handoverAttempt, draftId });
+          },
+        },
+      );
+      if (opened === null) {
+        try {
+          await writeTextToClipboard(handover, "thread handover");
+          toastManager.add(
+            stackedThreadToast({
+              type: "info",
+              title: "Handover saved",
+              description:
+                "The draft could not be opened, so the handover was copied to your clipboard. Try again from this thread.",
+            }),
+          );
+        } catch (error) {
+          throw new Error(
+            "The replacement draft could not be opened and the handover could not be copied.",
+            {
+              cause: error,
+            },
+          );
+        }
+        return;
+      }
+      pendingThreadHandovers.delete(sourceThreadKey);
+    } catch (error) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not create handover",
+          description: error instanceof Error ? error.message : "Handover generation failed.",
+        }),
+      );
+    } finally {
+      pendingThreadHandovers.setGenerating(sourceThreadKey, false);
+    }
+  }, [
+    activeProject,
+    activeThread,
+    activeThreadReachedContextLimit,
+    activeThreadHandoverKey,
+    generateThreadHandover,
+    handleNewThread,
+    isGeneratingHandover,
+    isServerThread,
+  ]);
+  const contextLimitBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
+    if (!activeThreadReachedContextLimit || !activeThread) return null;
+    const supportsGeneration =
+      activeProject !== null &&
+      serverConfig?.environment.capabilities.threadHandoverGeneration === true;
+    return buildContextLimitBannerItem({
+      threadId: activeThread.id,
+      tokenLimit: settings.threadContextTokenLimit,
+      canChangeTokenLimit: primaryEnvironment?.environmentId === environmentId,
+      supportsGeneration,
+      isGeneratingHandover,
+      hasSavedHandover: pendingHandoverAttempt !== undefined,
+      onChangeTokenLimit: () => {
+        void navigate({
+          to: "/settings/general",
+          hash: "thread-context-token-limit",
+          hashScrollIntoView: false,
+        });
+      },
+      onGenerateHandover: () => void handleGenerateHandover(),
+    });
+  }, [
+    activeThread,
+    activeThreadReachedContextLimit,
+    activeProject,
+    environmentId,
+    handleGenerateHandover,
+    isGeneratingHandover,
+    pendingHandoverAttempt,
+    navigate,
+    primaryEnvironment?.environmentId,
+    serverConfig?.environment.capabilities.threadHandoverGeneration,
+    settings.threadContextTokenLimit,
+  ]);
   // A woken thread announces itself in the open view, not just the sidebar
   // pill. Dismissing marks the wake as seen (same acknowledgment as the
   // pill); sending a message clears it as a side effect of the send path.
@@ -5924,6 +6101,7 @@ export default function ChatView(props: ChatViewProps) {
     ) ?? false;
   const compactThreadUnavailable =
     !activeThread ||
+    activeThreadReachedContextLimit ||
     !activeThreadHasCompactableConversation ||
     !activeProject ||
     !isServerThread ||
@@ -5938,11 +6116,13 @@ export default function ChatView(props: ChatViewProps) {
     showPlanFollowUpPrompt;
   const compactDisabled = compactThreadUnavailable;
   const compactDisabledReason = compactDisabled
-    ? !activeProject
-      ? "Choose a project before compacting"
-      : !manualCompactionProviderAvailable
-        ? "Compaction is unavailable for this provider"
-        : "Compacting is unavailable right now"
+    ? activeThreadReachedContextLimit
+      ? "Thread token limit reached. Hand over to a new thread"
+      : !activeProject
+        ? "Choose a project before compacting"
+        : !manualCompactionProviderAvailable
+          ? "Compaction is unavailable for this provider"
+          : "Compacting is unavailable right now"
     : null;
   const resumeCompactionBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
     if (
@@ -6040,12 +6220,14 @@ export default function ChatView(props: ChatViewProps) {
       resumeCompactionBannerItem === null ? [] : [resumeCompactionBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
+    const contextLimitItems = contextLimitBannerItem === null ? [] : [contextLimitBannerItem];
     // The user asked for this one, so it leads the notice tier instead of trailing it.
     const usageLimitsItems = usageLimitsBanner === null ? [] : [usageLimitsBanner];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
         ...feedbackBannerItems,
         ...usageLimitsItems,
+        ...contextLimitItems,
         ...systemComposerBannerItems,
         ...backgroundLivenessItems,
         ...resumeCompactionItems,
@@ -6054,6 +6236,7 @@ export default function ChatView(props: ChatViewProps) {
       ];
     }
     return [
+      ...contextLimitItems,
       ...feedbackBannerItems,
       ...usageLimitsItems,
       ...systemComposerBannerItems,
@@ -6103,6 +6286,7 @@ export default function ChatView(props: ChatViewProps) {
   }, [
     activeBranchMismatchKey,
     backgroundLivenessBannerItem,
+    contextLimitBannerItem,
     feedbackBannerItems,
     handleRestoreThreadBranch,
     isRestoringThreadBranch,
@@ -8660,9 +8844,11 @@ export default function ChatView(props: ChatViewProps) {
                             sendDisabledReason={
                               feedbackUploading
                                 ? "Sending feedback"
-                                : threadDetailLoading
-                                  ? "Messages loading"
-                                  : null
+                                : activeThreadReachedContextLimit && activePendingProgress === null
+                                  ? "Thread token limit reached"
+                                  : threadDetailLoading
+                                    ? "Messages loading"
+                                    : null
                             }
                             isPreparingWorktree={isPreparingWorktree}
                             bannerItems={composerBannerItems}

--- a/apps/web/src/components/chat/ContextLimitBanner.test.tsx
+++ b/apps/web/src/components/chat/ContextLimitBanner.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { buildContextLimitBannerItem } from "./ContextLimitBanner";
+
+describe("buildContextLimitBannerItem", () => {
+  it("keeps token-limit settings with the limit and reserves actions for handover", () => {
+    const item = buildContextLimitBannerItem({
+      threadId: "thread-1",
+      tokenLimit: 250_000,
+      canChangeTokenLimit: true,
+      supportsGeneration: true,
+      isGeneratingHandover: false,
+      hasSavedHandover: false,
+      onChangeTokenLimit: vi.fn(),
+      onGenerateHandover: vi.fn(),
+    });
+
+    const title = renderToStaticMarkup(<>{item.title}</>);
+    const actions = renderToStaticMarkup(<>{item.actions}</>);
+
+    expect(title).toContain("This thread has reached 250,000 tokens");
+    expect(title).toContain("Change thread token limit");
+    expect(actions).toContain("Handover to new thread");
+    expect(actions).not.toContain("Change thread token limit");
+  });
+
+  it("does not strand a settings control in the action area on an older server", () => {
+    const item = buildContextLimitBannerItem({
+      threadId: "thread-1",
+      tokenLimit: 250_000,
+      canChangeTokenLimit: true,
+      supportsGeneration: false,
+      isGeneratingHandover: false,
+      hasSavedHandover: false,
+      onChangeTokenLimit: vi.fn(),
+      onGenerateHandover: vi.fn(),
+    });
+
+    expect(renderToStaticMarkup(<>{item.title}</>)).toContain("Change thread token limit");
+    expect(item.actions).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/chat/ContextLimitBanner.tsx
+++ b/apps/web/src/components/chat/ContextLimitBanner.tsx
@@ -1,0 +1,69 @@
+import { CircleAlertIcon, SettingsIcon } from "lucide-react";
+
+import { Button } from "../ui/button";
+import type { ComposerBannerStackItem } from "./ComposerBannerStack";
+
+interface ContextLimitBannerInput {
+  readonly threadId: string;
+  readonly tokenLimit: number;
+  readonly canChangeTokenLimit: boolean;
+  readonly supportsGeneration: boolean;
+  readonly isGeneratingHandover: boolean;
+  readonly hasSavedHandover: boolean;
+  readonly onChangeTokenLimit: () => void;
+  readonly onGenerateHandover: () => void;
+}
+
+export function buildContextLimitBannerItem({
+  threadId,
+  tokenLimit,
+  canChangeTokenLimit,
+  supportsGeneration,
+  isGeneratingHandover,
+  hasSavedHandover,
+  onChangeTokenLimit,
+  onGenerateHandover,
+}: ContextLimitBannerInput): ComposerBannerStackItem {
+  return {
+    id: `context-limit:${threadId}`,
+    variant: "info",
+    priority: "urgent",
+    icon: <CircleAlertIcon />,
+    title: (
+      <span className="flex min-w-0 items-center gap-1">
+        <span>This thread has reached {tokenLimit.toLocaleString("en-US")} tokens</span>
+        {canChangeTokenLimit ? (
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            aria-label="Change thread token limit"
+            onClick={onChangeTokenLimit}
+          >
+            <SettingsIcon className="size-3.5" />
+            <span className="sr-only">Change thread token limit</span>
+          </Button>
+        ) : null}
+      </span>
+    ),
+    description: hasSavedHandover
+      ? "Your saved handover is ready. Open it in a new draft to review it before choosing the next model and reasoning level."
+      : supportsGeneration
+        ? "T3 will not start another turn here. Create a compact handover, then review it in a new draft before choosing the next model and reasoning level."
+        : "T3 will not start another turn here. Update the connected server to create an automatic handover, or start a new thread manually.",
+    actions:
+      supportsGeneration || hasSavedHandover ? (
+        <Button
+          size="xs"
+          variant="outline"
+          disabled={isGeneratingHandover}
+          onClick={onGenerateHandover}
+        >
+          {isGeneratingHandover
+            ? "Creating handover..."
+            : hasSavedHandover
+              ? "Open saved handover"
+              : "Handover to new thread"}
+        </Button>
+      ) : undefined,
+  };
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -31,6 +31,7 @@ import {
   MAX_PROMPT_FONT_SIZE,
   MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
   MAX_TERMINAL_FONT_SIZE,
+  MAX_THREAD_CONTEXT_TOKEN_LIMIT,
   MIN_CODE_FONT_SIZE,
   MIN_APPEARANCE_CONTRAST,
   MIN_GLASS_OPACITY,
@@ -39,6 +40,7 @@ import {
   MIN_PROMPT_FONT_SIZE,
   MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
   MIN_TERMINAL_FONT_SIZE,
+  MIN_THREAD_CONTEXT_TOKEN_LIMIT,
   type QuitConfirmationMode,
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
@@ -2391,6 +2393,55 @@ export function GeneralSettingsPanel() {
               }
               aria-label="Show skills in slash menu"
             />
+          }
+        />
+
+        <SettingsRow
+          serverScoped
+          {...searchableSetting("thread-context-token-limit")}
+          description="Stop new turns in a thread after its context reaches this size. Start a new thread to continue."
+          resetAction={
+            settings.threadContextTokenLimit !==
+            DEFAULT_UNIFIED_SETTINGS.threadContextTokenLimit ? (
+              <SettingResetButton
+                label="thread token limit"
+                onClick={() =>
+                  updateSettings({
+                    threadContextTokenLimit: DEFAULT_UNIFIED_SETTINGS.threadContextTokenLimit,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <div className="flex items-center gap-2">
+              <NumberField
+                value={settings.threadContextTokenLimit / 1_000}
+                min={MIN_THREAD_CONTEXT_TOKEN_LIMIT / 1_000}
+                max={MAX_THREAD_CONTEXT_TOKEN_LIMIT / 1_000}
+                step={10}
+                size="sm"
+                className="w-28"
+                onValueCommitted={(value) => {
+                  if (value === null) return;
+                  const nextLimit = Math.round(value) * 1_000;
+                  if (
+                    nextLimit < MIN_THREAD_CONTEXT_TOKEN_LIMIT ||
+                    nextLimit > MAX_THREAD_CONTEXT_TOKEN_LIMIT
+                  ) {
+                    return;
+                  }
+                  updateSettings({ threadContextTokenLimit: nextLimit });
+                }}
+              >
+                <NumberFieldGroup>
+                  <NumberFieldDecrement aria-label="Decrease thread token limit" />
+                  <NumberFieldInput aria-label="Thread token limit in thousands" />
+                  <NumberFieldIncrement aria-label="Increase thread token limit" />
+                </NumberFieldGroup>
+              </NumberField>
+              <span className="text-xs text-muted-foreground">thousand tokens</span>
+            </div>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -249,6 +249,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     ],
   },
   {
+    id: "thread-context-token-limit",
+    title: "Thread token limit",
+    to: "/settings/general",
+    searchTerms: ["context window usage hard limit handover new thread compact tokens"],
+  },
+  {
     id: "new-threads",
     title: "New threads",
     to: "/settings/projects",

--- a/apps/web/src/hooks/useHandleNewThread.test.ts
+++ b/apps/web/src/hooks/useHandleNewThread.test.ts
@@ -1,32 +1,64 @@
+import { EnvironmentId, ProjectId, type ScopedProjectRef } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => {
-  let completeProjectFileRead: (value: null) => void = () => undefined;
-  let projectFileRead = Promise.resolve<null>(null);
-  let storedDraft: {
+  type StoredDraft = {
     readonly draftId: string;
     readonly environmentId: string;
+    readonly logicalProjectKey: string;
     readonly promotedTo: null;
     readonly threadId: string;
-  } | null = null;
+  };
+  let completeProjectFileRead: (value: null) => void = () => undefined;
+  let projectFileRead = Promise.resolve<null>(null);
+  let storedDraft: StoredDraft | null = null;
+  let prompts: Record<string, string> = {};
+  let navigationFailure: Error | null = null;
+  let completeNavigation: (() => void) | null = null;
   const router = {
     state: {
       location: { href: "/" },
       matches: [{ params: {} }],
     },
     navigate: vi.fn(async (request: { readonly params: { readonly draftId: string } }) => {
+      if (navigationFailure !== null) throw navigationFailure;
+      if (completeNavigation !== null) {
+        await new Promise<void>((resolve) => {
+          completeNavigation = resolve;
+        });
+      }
       router.state.location.href = `/draft/${request.params.draftId}`;
     }),
   };
   const draftStore = {
-    getComposerDraft: vi.fn(() => ({})),
+    getComposerDraft: vi.fn((draftId: string) => ({ prompt: prompts[draftId] ?? "" })),
     getDraftSessionByLogicalProjectKey: vi.fn(() => storedDraft),
-    getDraftSession: vi.fn(() => null),
+    getDraftSession: vi.fn((draftId: string) =>
+      storedDraft?.draftId === draftId ? storedDraft : null,
+    ),
     getDraftThread: vi.fn(() => null),
     applyStickyState: vi.fn(),
     setDraftThreadContext: vi.fn(),
-    setLogicalProjectDraftThreadId: vi.fn(),
+    setLogicalProjectDraftThreadId: vi.fn(
+      (
+        logicalProjectKey: string,
+        projectRef: { readonly environmentId: string },
+        draftId: string,
+        state: { readonly threadId: string },
+      ) => {
+        storedDraft = {
+          draftId,
+          environmentId: projectRef.environmentId,
+          logicalProjectKey,
+          promotedTo: null,
+          threadId: state.threadId,
+        };
+      },
+    ),
     setModelSelection: vi.fn(),
+    setPrompt: vi.fn((draftId: string, prompt: string) => {
+      prompts[draftId] = prompt;
+    }),
   };
 
   return {
@@ -35,16 +67,39 @@ const testState = vi.hoisted(() => {
     get projectFileRead() {
       return projectFileRead;
     },
-    reset(nextStoredDraft: typeof storedDraft) {
-      storedDraft = nextStoredDraft;
+    editPrompt(draftId: string, prompt: string) {
+      prompts[draftId] = prompt;
+    },
+    prompt(draftId: string) {
+      return prompts[draftId];
+    },
+    reset(nextStoredDraft: Omit<StoredDraft, "logicalProjectKey"> | null) {
+      storedDraft =
+        nextStoredDraft === null
+          ? null
+          : { ...nextStoredDraft, logicalProjectKey: "remote-project" };
+      prompts = {};
+      navigationFailure = null;
+      completeNavigation = null;
       router.state.location.href = "/";
       router.navigate.mockClear();
       draftStore.setLogicalProjectDraftThreadId.mockClear();
+      draftStore.setPrompt.mockClear();
       projectFileRead = new Promise<null>((resolve) => {
         completeProjectFileRead = resolve;
       });
     },
     router,
+    holdNavigation() {
+      completeNavigation = () => undefined;
+    },
+    releaseNavigation() {
+      completeNavigation?.();
+      completeNavigation = null;
+    },
+    setNavigationFailure(error: Error | null) {
+      navigationFailure = error;
+    },
   };
 });
 
@@ -72,6 +127,8 @@ vi.mock("@t3tools/client-runtime/environment", () => ({
 }));
 vi.mock("@t3tools/contracts", () => ({
   DEFAULT_RUNTIME_MODE: "default",
+  EnvironmentId: { make: (value: string) => value },
+  ProjectId: { make: (value: string) => value },
   DEFAULT_SERVER_SETTINGS: {},
 }));
 vi.mock("@t3tools/shared/threadEnvMode", () => ({
@@ -94,7 +151,8 @@ vi.mock("../composerDraftStore", () => {
     getState: () => testState.draftStore,
   });
   return {
-    composerDraftHasUserContent: () => false,
+    composerDraftHasUserContent: (draft: { readonly prompt?: string }) =>
+      (draft.prompt?.length ?? 0) > 0,
     markPromotedDraftThreadByRef: vi.fn(),
     useComposerDraftStore,
   };
@@ -170,5 +228,91 @@ describe("useNewThreadHandler", () => {
     expect(testState.router.state.location.href).toBe("/usage");
     expect(testState.router.navigate).not.toHaveBeenCalled();
     expect(testState.draftStore.setLogicalProjectDraftThreadId).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["new", null, "draft-delayed"],
+    [
+      "reused",
+      {
+        draftId: "draft-existing",
+        environmentId: "environment-ssh",
+        promotedTo: null,
+        threadId: "thread-existing",
+      },
+      "draft-existing",
+    ],
+  ])("writes an initial prompt before navigating to a %s draft", async (_, draft, draftId) => {
+    testState.reset(draft);
+    const openThread = useNewThreadHandler();
+    const pendingOpen = openThread(
+      { environmentId: "environment-ssh", projectId: "project-remote" } as never,
+      { initialPrompt: "Generated handover" },
+    );
+
+    testState.completeProjectFileRead(null);
+    const opened = await pendingOpen;
+
+    expect(opened?.draftId).toBe(draftId);
+    expect(testState.draftStore.setPrompt).toHaveBeenCalledWith(draftId, "Generated handover");
+    expect(testState.router.navigate).toHaveBeenCalledOnce();
+    expect(testState.draftStore.setPrompt.mock.invocationCallOrder[0]!).toBeLessThan(
+      testState.router.navigate.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("reopens the initialized draft after navigation fails without overwriting edits", async () => {
+    testState.reset(null);
+    testState.setNavigationFailure(new Error("navigation failed"));
+    const openThread = useNewThreadHandler();
+    let retainedDraftId: string | undefined;
+    const open = () =>
+      openThread({ environmentId: "environment-ssh", projectId: "project-remote" } as never, {
+        initialPrompt: "Generated handover",
+        ...(retainedDraftId === undefined ? {} : { reopenDraftId: retainedDraftId as never }),
+        onDraftReady: (draftId) => {
+          retainedDraftId = draftId;
+        },
+      });
+
+    const firstOpen = open();
+    testState.completeProjectFileRead(null);
+    await expect(firstOpen).rejects.toThrow("navigation failed");
+    expect(retainedDraftId).toBe("draft-delayed");
+    testState.editPrompt("draft-delayed", "Edited handover");
+
+    testState.setNavigationFailure(null);
+    const reopened = await open();
+
+    expect(reopened?.draftId).toBe("draft-delayed");
+    expect(testState.prompt("draft-delayed")).toBe("Edited handover");
+    expect(testState.draftStore.setPrompt).toHaveBeenCalledOnce();
+    expect(testState.router.navigate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not deliver a raced handover into another invocation's draft", async () => {
+    testState.reset(null);
+    testState.holdNavigation();
+    const openThread = useNewThreadHandler();
+    const projectRef = {
+      environmentId: EnvironmentId.make("environment-ssh"),
+      projectId: ProjectId.make("project-remote"),
+    } satisfies ScopedProjectRef;
+    const ordinaryOpen = openThread(projectRef);
+    const onHandoverDraftReady = vi.fn();
+    const handoverOpen = openThread(projectRef, {
+      initialPrompt: "Generated handover",
+      onDraftReady: onHandoverDraftReady,
+    });
+
+    testState.completeProjectFileRead(null);
+
+    await expect(handoverOpen).resolves.toBeNull();
+    expect(testState.draftStore.setPrompt).not.toHaveBeenCalled();
+    expect(onHandoverDraftReady).not.toHaveBeenCalled();
+    expect(testState.router.navigate).toHaveBeenCalledOnce();
+
+    testState.releaseNavigation();
+    await expect(ordinaryOpen).resolves.toMatchObject({ draftId: "draft-delayed" });
   });
 });

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -78,6 +78,12 @@ export function useNewThreadHandler() {
         envMode?: DraftThreadEnvMode;
         startFromOrigin?: boolean;
         replace?: boolean;
+        /** Written before navigation so the composer cannot mount an empty draft. */
+        initialPrompt?: string;
+        /** Reopens a draft retained by a caller after its first navigation failed. */
+        reopenDraftId?: DraftId;
+        /** Runs after draft registration and prompt initialization, before navigation. */
+        onDraftReady?: (draftId: DraftId) => void;
       },
       // Which draft the thread ended up in, so a caller that has something to put in it — a
       // prepared checkout, a task to write — addresses that one rather than looking the project
@@ -95,7 +101,17 @@ export function useNewThreadHandler() {
         setDraftThreadContext,
         setLogicalProjectDraftThreadId,
         setModelSelection,
+        setPrompt,
       } = useComposerDraftStore.getState();
+      const writeInitialPrompt = (draftId: DraftId) => {
+        if (options?.initialPrompt !== undefined) {
+          setPrompt(draftId, options.initialPrompt);
+        }
+      };
+      const prepareDraft = (draftId: DraftId) => {
+        writeInitialPrompt(draftId);
+        options?.onDraftReady?.(draftId);
+      };
       const requestingRouteHref = router.state.location.href;
       const routeChangedSinceRequest = () => router.state.location.href !== requestingRouteHref;
       const currentRouteTarget = getCurrentRouteTarget();
@@ -167,6 +183,35 @@ export function useNewThreadHandler() {
       const logicalProjectKey = project
         ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
         : scopedProjectKey(projectRef);
+      const reopenDraftId = options?.reopenDraftId;
+      const reopenDraft = reopenDraftId === undefined ? null : getDraftSession(reopenDraftId);
+      if (
+        reopenDraftId !== undefined &&
+        reopenDraft !== null &&
+        reopenDraft.logicalProjectKey === logicalProjectKey &&
+        reopenDraft.promotedTo == null &&
+        readThreadShell(scopeThreadRef(reopenDraft.environmentId, reopenDraft.threadId)) === null
+      ) {
+        // A failed navigation already initialized this exact draft. Preserve
+        // any edits made since; only a cleared draft needs its prompt restored.
+        if (!composerDraftHasUserContent(getComposerDraft(reopenDraftId))) {
+          writeInitialPrompt(reopenDraftId);
+        }
+        options?.onDraftReady?.(reopenDraftId);
+        if (currentRouteTarget?.kind === "draft" && currentRouteTarget.draftId === reopenDraftId) {
+          return Promise.resolve({
+            draftId: reopenDraftId,
+            threadId: reopenDraft.threadId,
+          });
+        }
+        return router
+          .navigate({
+            to: "/draft/$draftId",
+            params: { draftId: reopenDraftId },
+            replace: options?.replace ?? false,
+          })
+          .then(() => ({ draftId: reopenDraftId, threadId: reopenDraft.threadId }));
+      }
       const hasBranchOption = options?.branch !== undefined;
       const hasWorktreePathOption = options?.worktreePath !== undefined;
       const hasEnvModeOption = options?.envMode !== undefined;
@@ -310,6 +355,7 @@ export function useNewThreadHandler() {
             draftId: emptyStoredDraftThread.draftId,
             threadId: emptyStoredDraftThread.threadId,
           };
+          prepareDraft(opened.draftId);
           // Re-read the route: the snapshot from before the await is stale
           // once a concurrent invocation's navigation lands, and navigating
           // again would push a duplicate history entry.
@@ -353,6 +399,7 @@ export function useNewThreadHandler() {
           interactionMode: latestActiveDraftThread.interactionMode,
           ...pickExplicitWorkspaceOptions(options),
         });
+        prepareDraft(currentRouteTarget.draftId);
         return Promise.resolve({
           draftId: currentRouteTarget.draftId,
           threadId: latestActiveDraftThread.threadId,
@@ -381,6 +428,13 @@ export function useNewThreadHandler() {
           racedDraft.draftId !== storedDraftThread?.draftId &&
           readThreadShell(scopeThreadRef(racedDraft.environmentId, racedDraft.threadId)) === null
         ) {
+          // A caller-specific prompt belongs to this invocation, not to the
+          // winner that registered while defaults were loading. Report the
+          // collision so the caller can retain/recover its payload instead of
+          // treating an untouched winner as a successful delivery.
+          if (options?.initialPrompt !== undefined) {
+            return null;
+          }
           // Same remap the reuse paths above perform: point the draft at the
           // caller's project member and apply explicit workspace options if
           // the caller passed any. Without explicit options the winner's
@@ -425,6 +479,7 @@ export function useNewThreadHandler() {
           // state. The project default wins when both are present.
           setModelSelection(draftId, modelSelectionOverride, { replaceOptions: true });
         }
+        prepareDraft(draftId);
         await router.navigate({
           to: "/draft/$draftId",
           params: { draftId },

--- a/apps/web/src/lib/contextWindow.test.ts
+++ b/apps/web/src/lib/contextWindow.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vite-plus/test";
 import { EventId, type OrchestrationThreadActivity, TurnId } from "@t3tools/contracts";
 
-import { deriveLatestContextWindowSnapshot, formatContextWindowTokens } from "./contextWindow";
+import {
+  contextWindowReachedThreadLimit,
+  deriveLatestContextWindowSnapshot,
+  formatContextWindowTokens,
+} from "./contextWindow";
 
-function makeActivity(id: string, kind: string, payload: unknown): OrchestrationThreadActivity {
+function makeActivity(
+  id: string,
+  kind: string,
+  payload: unknown,
+  options: { readonly sequence?: number; readonly createdAt?: string } = {},
+): OrchestrationThreadActivity {
   return {
     id: EventId.make(id),
     tone: "info",
@@ -11,7 +20,8 @@ function makeActivity(id: string, kind: string, payload: unknown): Orchestration
     summary: kind,
     payload,
     turnId: TurnId.make("turn-1"),
-    createdAt: "2026-03-23T00:00:00.000Z",
+    ...(options.sequence === undefined ? {} : { sequence: options.sequence }),
+    createdAt: options.createdAt ?? "2026-03-23T00:00:00.000Z",
   };
 }
 
@@ -63,6 +73,26 @@ describe("contextWindow", () => {
     });
   });
 
+  it("uses canonical activity order after compaction instead of array order", () => {
+    const snapshot = deriveLatestContextWindowSnapshot([
+      makeActivity(
+        "activity-current",
+        "context-window.updated",
+        { usedTokens: 20_000, maxTokens: 250_000 },
+        { sequence: 12, createdAt: "2026-03-23T00:02:00.000Z" },
+      ),
+      makeActivity(
+        "activity-stale",
+        "context-window.updated",
+        { usedTokens: 250_000, maxTokens: 250_000 },
+        { sequence: 11, createdAt: "2026-03-23T00:01:00.000Z" },
+      ),
+    ]);
+
+    expect(snapshot?.usedTokens).toBe(20_000);
+    expect(contextWindowReachedThreadLimit(snapshot)).toBe(false);
+  });
+
   it("formats compact token counts", () => {
     expect(formatContextWindowTokens(999)).toBe("999");
     expect(formatContextWindowTokens(1400)).toBe("1.4k");
@@ -82,5 +112,17 @@ describe("contextWindow", () => {
 
     expect(snapshot?.usedTokens).toBe(81_659);
     expect(snapshot?.totalProcessedTokens).toBe(748_126);
+  });
+
+  it("recognizes the hard thread limit from the latest snapshot", () => {
+    const snapshot = deriveLatestContextWindowSnapshot([
+      makeActivity("activity-1", "context-window.updated", {
+        usedTokens: 250_000,
+        maxTokens: 400_000,
+      }),
+    ]);
+
+    expect(contextWindowReachedThreadLimit(snapshot)).toBe(true);
+    expect(contextWindowReachedThreadLimit(snapshot, 300_000)).toBe(false);
   });
 });

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -1,4 +1,8 @@
-import type { OrchestrationThreadActivity, ThreadTokenUsageSnapshot } from "@t3tools/contracts";
+import {
+  DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT,
+  type OrchestrationThreadActivity,
+  type ThreadTokenUsageSnapshot,
+} from "@t3tools/contracts";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
@@ -28,8 +32,10 @@ export type ContextWindowSnapshot = NullableContextWindowUsage & {
 export function deriveLatestContextWindowSnapshot(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): ContextWindowSnapshot | null {
-  for (let index = activities.length - 1; index >= 0; index -= 1) {
-    const activity = activities[index];
+  let latest:
+    | { readonly activity: OrchestrationThreadActivity; readonly usedTokens: number }
+    | undefined;
+  for (const activity of activities) {
     if (!activity || activity.kind !== "context-window.updated") {
       continue;
     }
@@ -39,6 +45,15 @@ export function deriveLatestContextWindowSnapshot(
     if (usedTokens === null || usedTokens < 0) {
       continue;
     }
+
+    if (latest === undefined || compareContextWindowActivityOrder(latest.activity, activity) <= 0) {
+      latest = { activity, usedTokens };
+    }
+  }
+
+  if (latest !== undefined) {
+    const { activity, usedTokens } = latest;
+    const payload = asRecord(activity.payload);
 
     const maxTokens = asFiniteNumber(payload?.maxTokens);
     const usedPercentage =
@@ -74,6 +89,20 @@ export function deriveLatestContextWindowSnapshot(
   return null;
 }
 
+function compareContextWindowActivityOrder(
+  left: OrchestrationThreadActivity,
+  right: OrchestrationThreadActivity,
+): number {
+  const sequenceComparison =
+    (left.sequence ?? Number.MAX_SAFE_INTEGER) - (right.sequence ?? Number.MAX_SAFE_INTEGER);
+  if (sequenceComparison !== 0) return sequenceComparison;
+
+  const createdAtComparison = left.createdAt.localeCompare(right.createdAt);
+  if (createdAtComparison !== 0) return createdAtComparison;
+
+  return left.id.localeCompare(right.id);
+}
+
 export function formatContextWindowTokens(value: number | null): string {
   if (value === null || !Number.isFinite(value)) {
     return "0";
@@ -88,4 +117,11 @@ export function formatContextWindowTokens(value: number | null): string {
     return `${Math.round(value / 1_000)}k`;
   }
   return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}m`;
+}
+
+export function contextWindowReachedThreadLimit(
+  snapshot: ContextWindowSnapshot | null,
+  tokenLimit = DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT,
+): boolean {
+  return snapshot !== null && snapshot.usedTokens >= tokenLimit;
 }

--- a/apps/web/src/pendingHandoverStore.test.ts
+++ b/apps/web/src/pendingHandoverStore.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { DraftId } from "./composerDraftStore";
+import { createPendingHandoverStore } from "./pendingHandoverStore";
+
+describe("createPendingHandoverStore", () => {
+  it("notifies a remounted subscriber when an existing generation completes", () => {
+    const store = createPendingHandoverStore();
+    let oldNotifications = 0;
+    const unsubscribe = store.subscribe(() => {
+      oldNotifications += 1;
+    });
+    store.setGenerating("source", true);
+    unsubscribe();
+    let observedGenerating = store.isGenerating("source");
+    let observedHandover = store.get("source");
+    store.subscribe(() => {
+      observedGenerating = store.isGenerating("source");
+      observedHandover = store.get("source");
+    });
+    const previousVersion = store.getVersion();
+    store.save("source", { handover: "Saved continuation" });
+    store.setGenerating("source", false);
+    expect(observedGenerating).toBe(false);
+    expect(observedHandover).toEqual({ handover: "Saved continuation" });
+    expect(store.getVersion()).toBeGreaterThan(previousVersion);
+    expect(oldNotifications).toBe(1);
+    store.delete("source");
+    expect(observedHandover).toBeUndefined();
+  });
+  it("keeps a generated handover recoverable by source thread", () => {
+    const store = createPendingHandoverStore();
+    store.save("environment:source", { handover: "handover" });
+
+    expect(store.get("environment:source")).toEqual({ handover: "handover" });
+    expect(store.get("environment:other")).toBeUndefined();
+  });
+
+  it("evicts the oldest abandoned handover", () => {
+    const store = createPendingHandoverStore(2);
+    store.save("thread:one", { handover: "one" });
+    store.save("thread:two", { handover: "two" });
+    store.save("thread:three", { handover: "three" });
+
+    expect(store.get("thread:one")).toBeUndefined();
+    expect(store.get("thread:two")).toEqual({ handover: "two" });
+    expect(store.get("thread:three")).toEqual({ handover: "three" });
+    expect(store.size()).toBe(2);
+  });
+
+  it("refreshes an existing entry before eviction", () => {
+    const store = createPendingHandoverStore(2);
+    store.save("thread:one", { handover: "one" });
+    store.save("thread:two", { handover: "two" });
+    store.save("thread:one", {
+      handover: "one updated",
+      draftId: "draft-one" as DraftId,
+    });
+    store.save("thread:three", { handover: "three" });
+
+    expect(store.get("thread:one")).toEqual({
+      handover: "one updated",
+      draftId: "draft-one",
+    });
+    expect(store.get("thread:two")).toBeUndefined();
+  });
+});

--- a/apps/web/src/pendingHandoverStore.ts
+++ b/apps/web/src/pendingHandoverStore.ts
@@ -1,0 +1,67 @@
+import type { DraftId } from "./composerDraftStore";
+
+const DEFAULT_MAX_PENDING_HANDOVERS = 8;
+
+export interface PendingHandover {
+  readonly handover: string;
+  readonly draftId?: DraftId;
+}
+
+export interface PendingHandoverStore {
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly getVersion: () => number;
+  readonly isGenerating: (sourceThreadKey: string) => boolean;
+  readonly setGenerating: (sourceThreadKey: string, generating: boolean) => void;
+  readonly get: (sourceThreadKey: string) => PendingHandover | undefined;
+  readonly has: (sourceThreadKey: string) => boolean;
+  readonly save: (sourceThreadKey: string, handover: PendingHandover) => void;
+  readonly delete: (sourceThreadKey: string) => void;
+  readonly size: () => number;
+}
+
+export function createPendingHandoverStore(
+  maxEntries = DEFAULT_MAX_PENDING_HANDOVERS,
+): PendingHandoverStore {
+  const entries = new Map<string, PendingHandover>();
+
+  const generating = new Set<string>();
+  const listeners = new Set<() => void>();
+  let version = 0;
+  const notify = () => {
+    version += 1;
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getVersion: () => version,
+    isGenerating: (key) => generating.has(key),
+    setGenerating: (key, value) => {
+      if (generating.has(key) === value) return;
+      if (value) generating.add(key);
+      else generating.delete(key);
+      notify();
+    },
+    get: (sourceThreadKey) => entries.get(sourceThreadKey),
+    has: (sourceThreadKey) => entries.has(sourceThreadKey),
+    save: (sourceThreadKey, handover) => {
+      entries.delete(sourceThreadKey);
+      entries.set(sourceThreadKey, handover);
+      while (entries.size > maxEntries) {
+        const oldestKey = entries.keys().next().value;
+        if (oldestKey === undefined) break;
+        entries.delete(oldestKey);
+      }
+      notify();
+    },
+    delete: (sourceThreadKey) => {
+      if (entries.delete(sourceThreadKey)) notify();
+    },
+    size: () => entries.size,
+  };
+}

--- a/docs/user/concurrent-provider-work.md
+++ b/docs/user/concurrent-provider-work.md
@@ -1,0 +1,3 @@
+# Concurrent provider work
+
+T3 allows at most eight top-level provider turns at once. Ready sessions do not count. Admission reserves a slot before provider startup and releases it when startup fails or the admitted turn or compaction finishes; provider-owned subagents are outside this limit. Handover generation can share these reservations when enabled.

--- a/docs/user/thread-context-limits.md
+++ b/docs/user/thread-context-limits.md
@@ -1,0 +1,3 @@
+# Thread context limits
+
+T3 rejects new provider work when the latest reported thread context reaches the configured token limit. The default is 250,000 tokens; change it in General settings. Start a new thread when the limit is reached. The server applies the limit for every provider and client.

--- a/docs/user/thread-handovers.md
+++ b/docs/user/thread-handovers.md
@@ -1,0 +1,3 @@
+# Thread handovers
+
+When a thread reaches its configured context-token limit, create a compact handover to continue in a new thread. With an enabled Codex instance, **Handover to new thread** uses GPT 5.6 Luna with high reasoning to summarize the thread and opens a new draft in the same checkout. Review the draft and choose its model and reasoning level before sending. Saved handovers remain available after a failed navigation or capability change. Without generation support, start a new thread manually.

--- a/packages/client-runtime/src/operations/commands.ts
+++ b/packages/client-runtime/src/operations/commands.ts
@@ -1,6 +1,7 @@
 import {
   CommandId,
   ORCHESTRATION_WS_METHODS,
+  type OrchestrationGenerateHandoverInput,
   type ClientOrchestrationCommand,
 } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
@@ -57,6 +58,7 @@ export type RevertThreadCheckpointInput = CommandInput<"thread.checkpoint.revert
 export type StopThreadSessionInput = CommandInput<"thread.session.stop">;
 
 type DispatchTag = typeof ORCHESTRATION_WS_METHODS.dispatchCommand;
+type GenerateHandoverTag = typeof ORCHESTRATION_WS_METHODS.generateHandover;
 type CommandEffect = Effect.Effect<
   EnvironmentRpcSuccess<DispatchTag>,
   EnvironmentRpcFailure<DispatchTag> | EnvironmentRpcUnavailableError,
@@ -89,6 +91,13 @@ function timestampedCommandMetadata(input: {
 function dispatch(command: ClientOrchestrationCommand) {
   return request(ORCHESTRATION_WS_METHODS.dispatchCommand, command);
 }
+
+export const generateThreadHandover = (input: OrchestrationGenerateHandoverInput) =>
+  request(ORCHESTRATION_WS_METHODS.generateHandover, input) satisfies Effect.Effect<
+    EnvironmentRpcSuccess<GenerateHandoverTag>,
+    EnvironmentRpcFailure<GenerateHandoverTag> | EnvironmentRpcUnavailableError,
+    EnvironmentSupervisor
+  >;
 
 export const createProject: (input: CreateProjectInput) => CommandEffect = Effect.fn(
   "EnvironmentCommands.createProject",

--- a/packages/client-runtime/src/state/threadCommands.ts
+++ b/packages/client-runtime/src/state/threadCommands.ts
@@ -35,6 +35,7 @@ import {
   archiveThread,
   createThread,
   deleteThread,
+  generateThreadHandover,
   interruptThreadTurn,
   linkThreadPullRequest,
   respondToThreadApproval,
@@ -90,12 +91,19 @@ export function createThreadEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | Crypto.Crypto | R, E>,
 ) {
   const scheduler = createAtomCommandScheduler();
+  const handoverScheduler = createAtomCommandScheduler();
   const concurrency = {
     mode: "serial" as const,
     key: ({ environmentId, input }: { environmentId: string; input: { threadId: string } }) =>
       JSON.stringify([environmentId, input.threadId]),
   };
   return {
+    generateHandover: createEnvironmentCommand(runtime, {
+      label: "environment-data:commands:thread:generate-handover",
+      execute: generateThreadHandover,
+      scheduler: handoverScheduler,
+      concurrency,
+    }),
     create: createEnvironmentCommand(runtime, {
       label: "environment-data:commands:thread:create",
       execute: (input: CreateThreadInput) => createThread(input),

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -131,6 +131,8 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
       version-skew contract as threadSettlement. */
   threadPullRequests: Schema.optionalKey(Schema.Boolean),
   pullRequestStackActions: Schema.optionalKey(Schema.Boolean),
+  /** Server can generate a compact continuation handover without starting a provider turn. */
+  threadHandoverGeneration: Schema.optionalKey(Schema.Boolean),
   /** The update path clients should offer for this server. Absent on
       servers that must be relaunched manually (dev checkouts, Windows
       foreground runs, pre-update servers). */

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -33,6 +33,7 @@ import {
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
+  generateHandover: "orchestration.generateHandover",
   getWorkflowScript: "orchestration.getWorkflowScript",
   getTurnDiff: "orchestration.getTurnDiff",
   getFullThreadDiff: "orchestration.getFullThreadDiff",
@@ -2179,6 +2180,10 @@ export const OrchestrationRpcSchemas = {
     input: ClientOrchestrationCommand,
     output: DispatchResult,
   },
+  generateHandover: {
+    input: Schema.Struct({ threadId: ThreadId }),
+    output: Schema.Struct({ handover: TrimmedNonEmptyString }),
+  },
   getWorkflowScript: {
     input: OrchestrationGetWorkflowScriptInput,
     output: OrchestrationGetWorkflowScriptResult,
@@ -2208,6 +2213,19 @@ export const OrchestrationRpcSchemas = {
     output: OrchestrationShellStreamItem,
   },
 } as const;
+
+export type OrchestrationGenerateHandoverInput =
+  typeof OrchestrationRpcSchemas.generateHandover.input.Type;
+export type OrchestrationGenerateHandoverResult =
+  typeof OrchestrationRpcSchemas.generateHandover.output.Type;
+
+export class OrchestrationGenerateHandoverError extends Schema.TaggedError<OrchestrationGenerateHandoverError>()(
+  "OrchestrationGenerateHandoverError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export class OrchestrationGetSnapshotError extends Schema.TaggedError<OrchestrationGetSnapshotError>()(
   "OrchestrationGetSnapshotError",

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -83,6 +83,7 @@ import {
   ClientOrchestrationCommand,
   ORCHESTRATION_WS_METHODS,
   OrchestrationDispatchCommandError,
+  OrchestrationGenerateHandoverError,
   OrchestrationGetFullThreadDiffError,
   OrchestrationGetFullThreadDiffInput,
   OrchestrationGetSnapshotError,
@@ -1163,6 +1164,12 @@ const WsOrchestrationDispatchCommandRpc = Rpc.make(ORCHESTRATION_WS_METHODS.disp
   error: Schema.Union([OrchestrationDispatchCommandError, EnvironmentAuthorizationError]),
 });
 
+const WsOrchestrationGenerateHandoverRpc = Rpc.make(ORCHESTRATION_WS_METHODS.generateHandover, {
+  payload: OrchestrationRpcSchemas.generateHandover.input,
+  success: OrchestrationRpcSchemas.generateHandover.output,
+  error: Schema.Union([OrchestrationGenerateHandoverError, EnvironmentAuthorizationError]),
+});
+
 const WsOrchestrationGetWorkflowScriptRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getWorkflowScript, {
   payload: OrchestrationRpcSchemas.getWorkflowScript.input,
   success: OrchestrationRpcSchemas.getWorkflowScript.output,
@@ -1402,6 +1409,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSubscribeBackgroundPolicyRpc,
   WsSubscribeResourceTelemetryRpc,
   WsOrchestrationDispatchCommandRpc,
+  WsOrchestrationGenerateHandoverRpc,
   WsOrchestrationGetWorkflowScriptRpc,
   WsOrchestrationGetTurnDiffRpc,
   WsOrchestrationGetFullThreadDiffRpc,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -6,6 +6,7 @@ import {
   ClientSettingsSchema,
   ClientSettingsPatch,
   ClaudeSettings,
+  DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT,
   DEFAULT_SERVER_SETTINGS,
   resolveProviderInstanceEnabled,
   ServerSettings,
@@ -19,6 +20,22 @@ const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const decodeClaudeSettings = Schema.decodeUnknownSync(ClaudeSettings);
+
+describe("ServerSettings thread context token limit", () => {
+  it("defaults to the standard handover threshold", () => {
+    expect(decodeServerSettings({}).threadContextTokenLimit).toBe(
+      DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT,
+    );
+  });
+
+  it("accepts a custom threshold and rejects values outside the supported range", () => {
+    expect(decodeServerSettingsPatch({ threadContextTokenLimit: 180_000 })).toEqual({
+      threadContextTokenLimit: 180_000,
+    });
+    expect(() => decodeServerSettingsPatch({ threadContextTokenLimit: 49_999 })).toThrow();
+    expect(() => decodeServerSettingsPatch({ threadContextTokenLimit: 1_000_001 })).toThrow();
+  });
+});
 
 describe("ServerSettings usage price overrides", () => {
   const prices = { inputCostPerMillionTokens: 2, outputCostPerMillionTokens: 8 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -889,6 +889,17 @@ export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyle
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
 
+export const MIN_THREAD_CONTEXT_TOKEN_LIMIT = 50_000;
+export const MAX_THREAD_CONTEXT_TOKEN_LIMIT = 1_000_000;
+export const DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT = 250_000;
+export const ThreadContextTokenLimit = Schema.Int.check(
+  Schema.isBetween({
+    minimum: MIN_THREAD_CONTEXT_TOKEN_LIMIT,
+    maximum: MAX_THREAD_CONTEXT_TOKEN_LIMIT,
+  }),
+);
+export type ThreadContextTokenLimit = typeof ThreadContextTokenLimit.Type;
+
 export const BackgroundActivityProfile = Schema.Literals([
   "balanced",
   "performance",
@@ -936,6 +947,9 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(false)),
   ),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  threadContextTokenLimit: ThreadContextTokenLimit.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_THREAD_CONTEXT_TOKEN_LIMIT)),
+  ),
   // Retain the update-era key; recovery now needs an environment-owned opt-in.
   continueThreadsAfterServerUpdate: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(false)),
@@ -1243,6 +1257,7 @@ export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
+  threadContextTokenLimit: Schema.optionalKey(ThreadContextTokenLimit),
   continueThreadsAfterServerUpdate: Schema.optionalKey(Schema.Boolean),
   enableAgentBrowserAccess: Schema.optionalKey(Schema.Boolean),
   projectAgentBrowserAccessOverrides: Schema.optionalKey(

--- a/packages/shared/src/threadReference.test.ts
+++ b/packages/shared/src/threadReference.test.ts
@@ -1,7 +1,7 @@
 import type { ThreadPullRequestLink } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveThreadReferenceCopyTarget } from "./threadReference.ts";
+import { resolveThreadReferenceCopyTarget, threadHandoverSourceKey } from "./threadReference.ts";
 
 const crossRepositoryPullRequest: ThreadPullRequestLink = {
   host: "github.com",
@@ -114,5 +114,11 @@ describe("resolveThreadReferenceCopyTarget", () => {
       successTitle: "Thread ID copied",
       failureTitle: "Failed to copy thread ID",
     });
+  });
+});
+
+describe("threadHandoverSourceKey", () => {
+  it("keeps opaque environment and thread IDs unambiguous", () => {
+    expect(threadHandoverSourceKey("a:b", "c")).not.toBe(threadHandoverSourceKey("a", "b:c"));
   });
 });

--- a/packages/shared/src/threadReference.ts
+++ b/packages/shared/src/threadReference.ts
@@ -10,6 +10,10 @@ export interface ThreadReferenceCopyTarget {
   readonly failureTitle: string;
 }
 
+export function threadHandoverSourceKey(environmentId: string, threadId: string): string {
+  return `handover:${JSON.stringify([environmentId, threadId])}`;
+}
+
 export function resolveThreadReferenceCopyTarget(input: {
   readonly threadId: string;
   /** Undefined means no PR panel; null means its URL is not available yet. */


### PR DESCRIPTION
When a thread reaches its context limit, the user has no way to carry the work into a fresh thread without retyping the state by hand.

This adds a handover action on web and mobile. The server generates a continuation brief through an enabled Codex instance (`orchestration.generateHandover`, advertised by the `threadHandoverGeneration` capability), and the client opens it as an unsent draft in a new thread in the same checkout, so the user can pick the model and reasoning level before sending. Other providers return a typed "not supported" error. Web persists the generated brief before navigating and shows saved state after remount. Mobile records the import in a durable per-thread draft, so restarting or retrying reopens that draft without duplicating the brief or overwriting later edits.

**Depends on unmerged PRs.** This branch is cumulative: its first two commits are squashed copies of #10095 (hard context admission, at `61374dce6`) and #10097 (shared concurrency reservations, at `1061345fe`). Merge those first. The handover delta is the last commit only. This stays a draft until both land.

Rebased linearly onto `main` at `211618fd9`, with no merge commits. Conflict resolutions adopt upstream's composer imports, the mobile `GlassBlurTargetContext` wrapper, and the `threadPullRequests`/`pullRequestStackActions` capabilities. They also fit #10097's reservations into the compaction queue from #11107. Messages sent during compaction are queued ahead of the context-admission and reservation gates, so an over-limit thread no longer rejects them. They replay after compaction lowers usage, and each replay takes its own slot. A new `ProviderCommandReactor` test covers this.

Verification on `623afe900`:
- Server: 11 files, 446 tests pass (handover, text generation, prompts, environment descriptor, reservations, `ProviderCommandReactor`, the WebSocket missing-thread handover error in `server.test.ts`)
- Web: 4 files, 19 tests pass. Mobile: 3 files, 69 tests pass (includes restart/retry after migrating an older draft receipt). Shared: 9 pass. Contracts: 106 pass.
- `tsc --noEmit` passes for contracts, shared, client-runtime, server, web, and mobile. `vp lint` on changed files: 0 errors.

Still pending: before/after web and mobile screenshots, and a live provider handover run. The cross-provider (GPT-6 Astra) review was skipped because Codex weekly quota was below 10%.

Coordination trace: T3 thread 272cea79-ab91-4570-91a4-10aee73ba516

Originally implemented with GPT-6 Astra in the Codex harness; rebased and verified with Claude Opus 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
