### PR TITLE
fix(server): background service no longer crash-loops on Linux npm 12 installs

### DIFF
--- a/apps/server/src/cli/servicePreflight.ts
+++ b/apps/server/src/cli/servicePreflight.ts
@@ -10,8 +10,8 @@ export const servicePreflightCommand = Command.make("__service-preflight", {
 }).pipe(
   Command.withHidden,
   Command.withHandler(({ databasePath, launcherProtocol }) =>
-    Console.log(JSON.stringify(runServicePreflight({ databasePath, launcherProtocol }))).pipe(
-      Effect.asVoid,
+    Effect.promise(() => runServicePreflight({ databasePath, launcherProtocol })).pipe(
+      Effect.flatMap((result) => Console.log(JSON.stringify(result))),
     ),
   ),
 );

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -57,6 +57,15 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
             validatedDirectory = staging.versionDir;
             assert.isFalse(yield* fs.exists(finalPaths.versionDir));
             assert.isTrue(yield* fs.exists(staging.entryPath));
+            // The manifest npm read while installing must let node-pty build.
+            const manifest = yield* fs.readFileString(
+              path.join(staging.versionDir, "package.json"),
+            );
+            // @effect-diagnostics-next-line preferSchemaOverJson:off - staged file written by the code under test.
+            assert.deepEqual((JSON.parse(manifest) as { allowScripts: unknown }).allowScripts, {
+              "node-pty": true,
+              "msgpackr-extract": true,
+            });
           }).pipe(Effect.orDie),
       });
 

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -18,6 +18,15 @@ import * as ProcessRunner from "../processRunner.ts";
 
 const PINNED_RUNTIME_DIR = "runtime";
 const PINNED_RUNTIME_INSTALL_TIMEOUT = Duration.minutes(10);
+// npm 12 skips dependency install scripts not covered by allowScripts and
+// still exits 0, silently dropping node-pty's native build. It rejects
+// --allow-scripts for project installs (unlike the global installs in
+// providerMaintenance.ts), so the staged manifest is the only place to grant this.
+const PINNED_RUNTIME_PACKAGE_JSON = `${JSON.stringify({
+  private: true,
+  // Keep this native subset aligned with pnpm-workspace.yaml#allowBuilds.
+  allowScripts: { "node-pty": true, "msgpackr-extract": true },
+})}\n`;
 // Boot-service setup and remote update can construct separate layers. Serialize
 // the complete install transaction across every caller in this process.
 const pinnedRuntimeInstallLock = Semaphore.makeUnsafe(1);
@@ -151,6 +160,14 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
   };
 
   return yield* Effect.gen(function* () {
+    yield* fs
+      .writeFileString(input.path.join(stagingDir, "package.json"), PINNED_RUNTIME_PACKAGE_JSON)
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new PinnedRuntimeInstallError({ step: "configuring native dependency builds", cause }),
+        ),
+      );
     const installStep = "installing the pinned t3 runtime (this can take a few minutes)";
     yield* runner
       .run({

--- a/apps/server/src/cloud/servicePreflight.test.ts
+++ b/apps/server/src/cloud/servicePreflight.test.ts
@@ -3,24 +3,34 @@ import { expect, it } from "@effect/vitest";
 import { runServicePreflight } from "./servicePreflight.ts";
 import { SERVICE_LAUNCHER_PROTOCOL } from "./serviceProtocol.ts";
 
-it("requires the database-snapshot launcher protocol", () => {
-  expect(
+it("requires the database-snapshot launcher protocol", async () => {
+  await expect(
     runServicePreflight({
       databasePath: "/missing/state.sqlite",
       launcherProtocol: SERVICE_LAUNCHER_PROTOCOL - 1,
       version: "1.2.3",
     }),
-  ).toMatchObject({ status: "blocked", version: "1.2.3" });
+  ).resolves.toMatchObject({ status: "blocked", version: "1.2.3" });
 
-  expect(
+  await expect(
     runServicePreflight({
       databasePath: "/missing/state.sqlite",
       launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
       version: "1.2.3",
     }),
-  ).toEqual({
+  ).resolves.toEqual({
     status: "ready",
     version: "1.2.3",
     launcherProtocol: SERVICE_LAUNCHER_PROTOCOL,
   });
+});
+
+it("blocks a runtime whose node-pty does not load", async () => {
+  const result = await runServicePreflight(
+    { databasePath: "/missing/state.sqlite", launcherProtocol: SERVICE_LAUNCHER_PROTOCOL },
+    () => Promise.reject(new Error("Cannot find module 'pty.node'")),
+  );
+
+  expect(result).toMatchObject({ status: "blocked" });
+  expect(result.status === "blocked" && result.reason).toContain("Cannot find module 'pty.node'");
 });

--- a/apps/server/src/cloud/servicePreflight.ts
+++ b/apps/server/src/cloud/servicePreflight.ts
@@ -13,12 +13,17 @@ export type ServicePreflightResult =
       readonly reason: string;
     };
 
-export function runServicePreflight(input: {
-  /** Older servers always pass this flag when invoking a staged preflight. */
-  readonly databasePath: string;
-  readonly launcherProtocol: number;
-  readonly version?: string;
-}): ServicePreflightResult {
+// Loading node-pty is part of the proof: npm can skip its native build and
+// still exit 0, leaving a runtime that boots but cannot open terminals.
+export async function runServicePreflight(
+  input: {
+    /** Older servers always pass this flag when invoking a staged preflight. */
+    readonly databasePath: string;
+    readonly launcherProtocol: number;
+    readonly version?: string;
+  },
+  loadNodePty: () => Promise<unknown> = () => import("node-pty"),
+): Promise<ServicePreflightResult> {
   const version = input.version ?? packageJson.version;
   if (input.launcherProtocol !== SERVICE_LAUNCHER_PROTOCOL) {
     return {
@@ -26,6 +31,16 @@ export function runServicePreflight(input: {
       version,
       reason:
         "This release requires a newer T3 Code service launcher. Update it on the server machine.",
+    };
+  }
+  try {
+    await loadNodePty();
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    return {
+      status: "blocked",
+      version,
+      reason: `node-pty's native binary is missing from this runtime (${detail}). On Linux it compiles during install; check that npm was allowed to run install scripts and that build tools are present.`,
     };
   }
 


### PR DESCRIPTION
## What Changed

The installer now stages a `package.json` that allows install scripts for `node-pty` and `msgpackr-extract` — npm 12 rejects `--allow-scripts` for project-scoped installs, so the manifest is the only place to grant this.

The `__service-preflight` that self-update runs against a staged runtime now also loads `node-pty`, so a runtime whose native binary is missing is reported as blocked with an actionable reason instead of being published.

`npx t3` does not use the pinned runtime and is unaffected; that path is #6350's territory.

## Why

npm 12 blocks dependency install scripts by default while still exiting successfully. The pinned runtime installer trusted that exit code, wrote its success sentinel without a `pty.node` binary, and could publish a runtime that crash-looped the background service on Linux.

Verified on Linux x64 with npm 12.0.2:

- Before: the default install exited 0, warned that scripts were blocked, and produced no `build/Release/pty.node`.
- After: the staged `allowScripts` manifest compiled `build/Release/pty.node`.
- Passing `--allow-scripts` failed with `EALLOWSCRIPTS`.
- With `allow-scripts=<other-package>` in a user-level `~/.npmrc`, npm 12 refuses every project-scoped install with `EALLOWSCRIPTS` (exit 1), manifest or not. That case now fails loudly at the install step instead of crash-looping; removing the stale key from `~/.npmrc` is the fix on such a machine.

Fixes #7475

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable)
- [x] I included a video for animation/interaction changes (not applicable)

Implemented by Fable 5.1 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes boot/self-update install semantics so previously “successful” installs without `pty.node` now fail; behavior is intentional but affects critical runtime publishing on Linux/npm 12.
> 
> **Overview**
> Fixes Linux background-service crash-loops when **npm 12** completes a pinned `t3` runtime install with exit code 0 but **skips** `node-pty`’s native build because install scripts are blocked by default.
> 
> The pinned runtime installer now **writes a staged `package.json`** with `allowScripts` for `node-pty` and `msgpackr-extract` (project installs can’t use `--allow-scripts`, so the manifest is the lever). After `npm install`, it **checks for `pty.node`** under Release, Debug, or host `prebuilds/<platform>-<arch>/` and **fails before publishing** if `node-pty` is present without any binary.
> 
> Tests mock npm 12 behavior and add coverage for the missing-binary failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 237647de8025f5490a482bbddac1c4efb3d4e42b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `node-pty` native build during pinned runtime install
> - Adds a staged `package.json` (`PINNED_RUNTIME_PACKAGE_JSON`) with `allowScripts` enabling native build scripts for `node-pty` and `msgpackr-extract` so npm runs them during install.
> - After `npm install`, verifies the `pty.node` binary exists in `build/Release`, `build/Debug`, or `prebuilds/<platform>-<arch>/` for the host platform and architecture. Aborts with a `PinnedRuntimeInstallError` if the binary is missing.
> - Updates tests in [pinnedRuntime.test.ts](https://github.com/pingdotgg/t3code/pull/8858/files#diff-1937e937286135087a07abf3ef962719a67ecb201224aa6ea8ae8bf730fe2e19) to simulate npm skipping scripts while exiting 0, and adds a test asserting the install fails when the `pty.node` binary is absent.
> - Behavioral Change: installs that previously succeeded without a native `pty.node` binary now fail at the "verifying the node-pty native build" step before publishing any version directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 237647d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
## What Changed

The installer now stages a `package.json` that allows install scripts for `node-pty` and `msgpackr-extract` — npm 12 rejects `--allow-scripts` for project-scoped installs, so the manifest is the only place to grant this. Before writing the sentinel, it verifies that an installed `node-pty` has a Release, Debug, or host-specific prebuilt binary. A missing binary fails the install and removes the staging tree.

## Why

npm 12 blocks dependency install scripts by default while still exiting successfully. The pinned runtime installer trusted that exit code, wrote its success sentinel without a `pty.node` binary, and could publish a runtime that crash-looped the background service on Linux.

Verified on Linux x64 with npm 12.0.2:

- Before: the default install exited 0, warned that scripts were blocked, and produced no `build/Release/pty.node`.
- After: the staged `allowScripts` manifest compiled `build/Release/pty.node`.
- Passing `--allow-scripts` failed with `EALLOWSCRIPTS`.

Fixes #7475

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable)
- [x] I included a video for animation/interaction changes (not applicable)

Implemented by Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes boot-time pinned runtime installation and publish gating; incorrect verification or manifest could block updates or still ship a broken runtime, but the change adds safeguards rather than weakening checks.
> 
> **Overview**
> **Pinned runtime installs** now work around npm 12’s default script blocking for prefix installs: before `npm install`, the staging directory gets a private `package.json` with `allowScripts` enabled for `node-pty` and `msgpackr-extract` (aligned with workspace `allowBuilds`), since `--allow-scripts` is not available for this install path.
> 
> After npm succeeds, the installer **no longer trusts exit code alone**. If `node-pty` is present but none of `build/Release/pty.node`, `build/Debug/pty.node`, or the host prebuild path exist, the install fails with a dedicated verification step and the staged tree is not published.
> 
> Tests model npm 12 behavior (scripts gated by `allowScripts`) and add coverage for the failure when npm returns 0 without a native binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d747c04c4dc8c32503c277cc08cf5b0daafda482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
## What Changed

The installer now stages a `package.json` that allows install scripts for `node-pty` and `msgpackr-extract` — npm 12 rejects `--allow-scripts` for project-scoped installs, so the manifest is the only place to grant this. Before writing the sentinel, it verifies that an installed `node-pty` has a Release, Debug, or host-specific prebuilt binary. A missing binary fails the install and removes the staging tree.

## Why

npm 12 blocks dependency install scripts by default while still exiting successfully. The pinned runtime installer trusted that exit code, wrote its success sentinel without a `pty.node` binary, and could publish a runtime that crash-looped the background service on Linux.

Verified on Linux x64 with npm 12.0.2:

- Before: the default install exited 0, warned that scripts were blocked, and produced no `build/Release/pty.node`.
- After: the staged `allowScripts` manifest compiled `build/Release/pty.node`.
- Passing `--allow-scripts` failed with `EALLOWSCRIPTS`.

Fixes #7475

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable)
- [x] I included a video for animation/interaction changes (not applicable)

Implemented by Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d747c04c4dc8c32503c277cc08cf5b0daafda482. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

