### PR TITLE
fix(server): close sessions when provider turns abort

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -921,6 +921,189 @@ describe("ProviderRuntimeIngestion", () => {
     await waitForThread(harness.readModel, (thread) => thread.session?.status === "ready");
   });
 
+  it("closes the session lifecycle when the active turn is aborted", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    // Regression: an interrupt whose abort lands while the provider is already
+    // idle emits `turn.aborted` instead of `turn.completed`. Without an
+    // ingestion handler the thread stayed "running" with a dangling active
+    // turn forever: stop looked like a no-op and settling was refused.
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-abort-lifecycle"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-lifecycle"),
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-abort-lifecycle",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-abort-lifecycle"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-lifecycle"),
+      itemId: asItemId("item-abort-lifecycle"),
+      payload: { streamKind: "assistant_text", delta: "partial answer" },
+    });
+    harness.emit({
+      type: "turn.proposed.delta",
+      eventId: asEventId("evt-plan-delta-abort-lifecycle"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-lifecycle"),
+      payload: { delta: "## Partial plan\n\n- keep this" },
+    });
+
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-lifecycle"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-lifecycle"),
+      payload: { reason: "Interrupted by user." },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.session?.status === "ready" &&
+        entry.session?.activeTurnId === null &&
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-abort-lifecycle" && !message.streaming,
+        ) &&
+        entry.proposedPlans.some(
+          (plan: ProviderRuntimeTestProposedPlan) =>
+            plan.id === "plan:thread-1:turn:turn-abort-lifecycle",
+        ),
+    );
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) => message.id === "assistant:item-abort-lifecycle",
+      )?.text,
+    ).toBe("partial answer");
+    expect(
+      thread.proposedPlans.find(
+        (plan: ProviderRuntimeTestProposedPlan) =>
+          plan.id === "plan:thread-1:turn:turn-abort-lifecycle",
+      )?.planMarkdown,
+    ).toBe("## Partial plan\n\n- keep this");
+  });
+
+  it("ignores stale turn.aborted events", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-abort-guarded"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-guarded-main"),
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-abort-guarded-main",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-abort-guarded"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-guarded-main"),
+      itemId: asItemId("item-abort-guarded-main"),
+      payload: { streamKind: "assistant_text", delta: "still running" },
+    });
+    harness.emit({
+      type: "turn.proposed.delta",
+      eventId: asEventId("evt-plan-delta-abort-guarded"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-guarded-main"),
+      payload: { delta: "## Active plan\n\n- do not finalize" },
+    });
+
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-guarded-stale"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-guarded-stale"),
+      payload: { reason: "Interrupted by user." },
+    });
+
+    await harness.drain();
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("running");
+    expect(thread?.session?.activeTurnId).toBe("turn-abort-guarded-main");
+    expect(
+      thread?.messages.some(
+        (message: ProviderRuntimeTestMessage) => message.id === "assistant:item-abort-guarded-main",
+      ),
+    ).toBe(false);
+    expect(
+      thread?.proposedPlans.some(
+        (plan: ProviderRuntimeTestProposedPlan) =>
+          plan.id === "plan:thread-1:turn:turn-abort-guarded-main",
+      ),
+    ).toBe(false);
+
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-session-exited-abort-guarded"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: { reason: "Provider stopped", exitKind: "graceful" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.status === "stopped" && entry.session?.activeTurnId === null,
+    );
+
+    // The formerly active turn is no longer authoritative after session exit.
+    // A delayed or duplicate abort must not revive the stopped session as ready.
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-guarded-late"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-abort-guarded-main"),
+      payload: { reason: "Interrupted by user." },
+    });
+
+    await harness.drain();
+    const finalReadModel = await harness.readModel();
+    const finalThread = finalReadModel.threads.find(
+      (entry) => entry.id === ThreadId.make("thread-1"),
+    );
+    expect(finalThread?.session?.status).toBe("stopped");
+    expect(finalThread?.session?.activeTurnId).toBeNull();
+  });
+
   it("ignores non-active turn completion when runtime omits thread id", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1534,6 +1534,12 @@ const make = Effect.gen(function* () {
           : false;
 
       const shouldApplyThreadLifecycle = (() => {
+        if (event.type === "turn.aborted") {
+          // Delayed or duplicate aborts must not overwrite newer lifecycle state.
+          return (
+            activeTurnId !== null && eventTurnId !== undefined && sameId(activeTurnId, eventTurnId)
+          );
+        }
         if (!STRICT_PROVIDER_LIFECYCLE_GUARD) {
           return true;
         }
@@ -1576,7 +1582,8 @@ const make = Effect.gen(function* () {
         event.type === "session.exited" ||
         event.type === "thread.started" ||
         event.type === "turn.started" ||
-        event.type === "turn.completed"
+        event.type === "turn.completed" ||
+        event.type === "turn.aborted"
       ) {
         const status = (() => {
           switch (event.type) {
@@ -1592,6 +1599,9 @@ const make = Effect.gen(function* () {
               return normalizeRuntimeTurnState(event.payload.state) === "failed"
                 ? "error"
                 : "ready";
+            case "turn.aborted":
+              // The provider session remains alive and reusable after an abort.
+              return "ready";
             case "session.started":
             case "thread.started":
               // Provider thread/session start notifications can arrive during an
@@ -1602,7 +1612,9 @@ const make = Effect.gen(function* () {
         const nextActiveTurnId =
           event.type === "turn.started"
             ? (eventTurnId ?? null)
-            : event.type === "turn.completed" || event.type === "session.exited"
+            : event.type === "turn.completed" ||
+                event.type === "turn.aborted" ||
+                event.type === "session.exited"
               ? null
               : event.type === "session.state.changed" &&
                   !sessionStatusAllowsActiveTurn(
@@ -1843,7 +1855,10 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (event.type === "turn.completed") {
+      if (
+        event.type === "turn.completed" ||
+        (event.type === "turn.aborted" && shouldApplyThreadLifecycle)
+      ) {
         const detailedThread = yield* getLoadedThreadDetail();
         const messages = detailedThread?.messages ?? [];
         const proposedPlans = detailedThread?.proposedPlans ?? [];
@@ -1976,7 +1991,10 @@ const make = Effect.gen(function* () {
       } else if (!conflictsWithActiveTurn) {
         if (event.type === "turn.plan.updated") {
           threadPlanProgress.recordPlanProgress(thread.id, event.payload.plan);
-        } else if (event.type === "turn.completed" || event.type === "turn.aborted") {
+        } else if (
+          event.type === "turn.completed" ||
+          (event.type === "turn.aborted" && shouldApplyThreadLifecycle)
+        ) {
           threadPlanProgress.clearThreadPlanProgress(thread.id);
         }
       }


### PR DESCRIPTION
## Problem

An interrupted provider turn can emit canonical `turn.aborted` without a following `turn.completed`. Runtime ingestion already recorded the abort and cleared plan progress, but it did not close the durable thread-session lifecycle. The session could remain `running` with a dangling `activeTurnId`, leaving the UI stuck on “Working” and refusing settlement even after Stop succeeded.

Fixes #8802.

## Fix

Treat an authoritative `turn.aborted` as a lifecycle-closing event:

- accept it only when its turn ID exactly matches the currently active turn, so delayed, duplicate, untargeted, and conflicting aborts cannot overwrite newer lifecycle state;
- move the still-live provider session to `ready`, clear `activeTurnId`, and clear the previous error through the existing ready-state path;
- finalize buffered assistant output and proposed plans through the existing turn-completion path;
- clear plan progress only when the abort passes the same lifecycle guard.

This is provider-agnostic. `ready` is intentional because the provider session remains alive and reusable after the turn is interrupted.

## Verification

- Repeated the original OpenCode/Z.AI insufficient-balance reproduction against this source build using the existing live environment data. After the same retry/failure sequence, Stop succeeded, “Working” cleared, and the persisted session no longer remained active.
- Confirmed the canonical `turn.aborted` in the provider event log and the durable projections: `active_turn_id = null`, the session was no longer `running`, and the turn projected as `interrupted`.
- `vp test run` across runtime ingestion, provider command reactor, ProviderService, and OpenCodeAdapter: **6 files, 224 tests passed**.
- Server typecheck exited successfully; targeted lint, formatting, and `git diff --check` passed.

## Related work

- #6018 covers the same missing ingestion transition with broader ordering/projection coverage and different `interrupted` session semantics. This PR keeps the live provider session reusable as `ready` and is limited to the incident path plus stale-abort guards.
- #8813 concerns the OpenCode adapter interrupt path. On current `main`, the adapter already emits `turn.aborted`; this change consumes that event in orchestration.
- #7368 and #4524 involve abort failures rather than a successful abort whose lifecycle event was not applied.

Prepared with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration session lifecycle and turn-settlement paths; guards limit blast radius, but incorrect abort matching could still affect thread readiness or UI “working” state.
> 
> **Overview**
> Fixes threads that stayed **running** with a dangling `activeTurnId` when a provider emitted **`turn.aborted`** instead of **`turn.completed`** after interrupt (e.g. OpenCode), which blocked Stop/settle and left the UI on “Working”.
> 
> **Provider runtime ingestion** now treats an **authoritative** `turn.aborted` like turn settlement: session → **`ready`**, **`activeTurnId` cleared**, partial assistant text and proposed plans finalized, and plan progress cleared. The provider session is left **reusable** (`ready`, not `stopped`).
> 
> **Guards** apply lifecycle updates only when the abort’s turn id **matches the active turn**, so wrong-turn, duplicate, or post-`session.exited` aborts cannot overwrite newer state.
> 
> Regression tests cover the happy path and stale/late abort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891ab7d9fa00ff10603e3f25996cda487d0cfda7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `turn.aborted` to close active session and finalize messages in `ProviderRuntimeIngestion`
> - `turn.aborted` now transitions the session to `ready`, clears `activeTurnId`, and finalizes the assistant message and proposed plan — matching the existing `turn.completed` handling.
> - A lifecycle guard via `shouldApplyThreadLifecycle` ensures only aborts whose `turnId` matches the current `activeTurnId` are processed; stale or duplicate aborts no longer modify the session or clear plan progress.
> - Adds tests in [ProviderRuntimeIngestion.test.ts](https://github.com/pingdotgg/t3code/pull/8859/files#diff-ea511ca36a45f5254c8f22ac107b5469fed67d652de6af2c5d2763bf00ce53c3) covering both the active-turn abort path and the stale-abort rejection path.
> - Risk: late `turn.aborted` events arriving after `session.exited` are now ignored; any out-of-tree logic relying on stale aborts clearing plan progress will no longer see that effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 891ab7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
