### PR TITLE
fix(mobile): replace Callstack glass with Expo glass

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -45,7 +45,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@callstack/liquid-glass": "^0.7.1",
     "@clerk/expo": "catalog:",
     "@effect/atom-react": "catalog:",
     "@expo-google-fonts/dm-sans": "^0.4.2",

--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -1,5 +1,5 @@
 import * as Haptics from "expo-haptics";
-import { isLiquidGlassSupported, LiquidGlassView } from "@callstack/liquid-glass";
+import { GlassView } from "expo-glass-effect";
 import { SymbolView } from "../../components/AppSymbol";
 import { useCallback, useEffect, useRef } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, useColorScheme, View } from "react-native";
@@ -11,11 +11,12 @@ import { APP_BAR_HEIGHT } from "../../lib/layoutMetrics";
 import { themeColorWithAlpha } from "../../lib/mobileTheme";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
+import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import type { GitActionProgress } from "../../state/use-vcs-action-state";
 
 const OVERLAY_LAYOUT_TRANSITION = LinearTransition.duration(220);
 const OVERLAY_TOP_GAP = 8;
-const AnimatedLiquidGlassView = Animated.createAnimatedComponent(LiquidGlassView);
+const AnimatedGlassView = Animated.createAnimatedComponent(GlassView);
 
 export function GitActionProgressOverlay(props: {
   readonly progress: GitActionProgress;
@@ -52,7 +53,7 @@ export function GitActionProgressOverlay(props: {
 
   return (
     <Animated.View
-      entering={isLiquidGlassSupported ? undefined : FadeIn.duration(200)}
+      entering={NATIVE_LIQUID_GLASS_SUPPORTED ? undefined : FadeIn.duration(200)}
       exiting={FadeOut.duration(150)}
       className="absolute inset-x-3 z-[100]"
       style={{ top: insets.top + APP_BAR_HEIGHT + OVERLAY_TOP_GAP }}
@@ -102,7 +103,7 @@ function OverlayContent(props: { readonly progress: GitActionProgress }) {
     </>
   );
 
-  if (isLiquidGlassSupported) {
+  if (NATIVE_LIQUID_GLASS_SUPPORTED) {
     return (
       <Animated.View
         layout={OVERLAY_LAYOUT_TRANSITION}
@@ -116,10 +117,10 @@ function OverlayContent(props: { readonly progress: GitActionProgress }) {
           shadowRadius: 18,
         }}
       >
-        <AnimatedLiquidGlassView
+        <AnimatedGlassView
           colorScheme={isDarkMode ? "dark" : "light"}
-          effect="regular"
-          interactive
+          glassEffectStyle="regular"
+          isInteractive
           layout={OVERLAY_LAYOUT_TRANSITION}
           tintColor={glassTint}
           style={{
@@ -136,7 +137,7 @@ function OverlayContent(props: { readonly progress: GitActionProgress }) {
           >
             {content}
           </Animated.View>
-        </AnimatedLiquidGlassView>
+        </AnimatedGlassView>
       </Animated.View>
     );
   }

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -1,8 +1,4 @@
-import {
-  isLiquidGlassSupported,
-  LiquidGlassContainerView,
-  LiquidGlassView,
-} from "@callstack/liquid-glass";
+import { GlassContainer, GlassView } from "expo-glass-effect";
 import { useEffect, useState } from "react";
 import { Text as SystemText, View } from "react-native";
 import Animated, {
@@ -18,6 +14,7 @@ import { withUniwind } from "uniwind";
 
 import { AppText as Text } from "../../components/AppText";
 import { ControlPill } from "../../components/ControlPill";
+import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 
 const CONTROL_HEIGHT = 44;
 const CONTROL_COMPOSER_GAP = 8;
@@ -31,9 +28,15 @@ const CONTROL_TIMING = {
 } as const;
 const CONTROL_SEPARATION = (16 + CONTROL_HEIGHT) / 2;
 
-const UniwindLiquidGlassView = withUniwind(LiquidGlassView);
-const UniwindLiquidGlassContainerView = withUniwind(LiquidGlassContainerView);
-const AnimatedLiquidGlassView = Animated.createAnimatedComponent(UniwindLiquidGlassView);
+// Expo reapplies glass after native layout and window reattachment, when UIKit
+// can otherwise leave the label visible but lose the material behind it.
+const UniwindGlassView = withUniwind(GlassView, {
+  style: { fromClassName: "className" },
+});
+const UniwindGlassContainer = withUniwind(GlassContainer, {
+  style: { fromClassName: "className" },
+});
+const AnimatedGlassView = Animated.createAnimatedComponent(UniwindGlassView);
 
 export const FLOATING_WORKING_CONTROL_COVERAGE = CONTROL_HEIGHT + CONTROL_COMPOSER_GAP;
 
@@ -68,29 +71,29 @@ export function FloatingWorkingControl(props: {
       pointerEvents="box-none"
       className="absolute left-0 right-0 z-20 items-center"
       style={{ top: -FLOATING_WORKING_CONTROL_COVERAGE }}
-      entering={isLiquidGlassSupported ? undefined : CONTROL_ENTERING}
-      exiting={isLiquidGlassSupported ? undefined : CONTROL_EXITING}
+      entering={NATIVE_LIQUID_GLASS_SUPPORTED ? undefined : CONTROL_ENTERING}
+      exiting={NATIVE_LIQUID_GLASS_SUPPORTED ? undefined : CONTROL_EXITING}
     >
-      {props.startedAt !== null && isLiquidGlassSupported ? (
-        <UniwindLiquidGlassContainerView
+      {props.startedAt !== null && NATIVE_LIQUID_GLASS_SUPPORTED ? (
+        <UniwindGlassContainer
           spacing={GLASS_MERGE_SPACING}
           pointerEvents="box-none"
           className="flex-row items-center gap-4"
         >
-          <AnimatedLiquidGlassView
+          <AnimatedGlassView
             colorScheme={props.colorScheme}
-            effect="regular"
+            glassEffectStyle="regular"
             pointerEvents="none"
             className="h-11 justify-center overflow-hidden rounded-full"
             style={timerStyle}
           >
             <WorkingDuration startedAt={props.startedAt} />
-          </AnimatedLiquidGlassView>
+          </AnimatedGlassView>
 
-          <AnimatedLiquidGlassView
+          <AnimatedGlassView
             colorScheme={props.colorScheme}
-            effect="regular"
-            interactive
+            glassEffectStyle="regular"
+            isInteractive
             pointerEvents={props.showScrollToEnd ? "auto" : "none"}
             accessibilityElementsHidden={!props.showScrollToEnd}
             importantForAccessibility={props.showScrollToEnd ? "auto" : "no-hide-descendants"}
@@ -100,8 +103,8 @@ export function FloatingWorkingControl(props: {
             <Animated.View style={arrowContentStyle}>
               <ScrollToEndButton disabled={!props.showScrollToEnd} onPress={props.onScrollToEnd} />
             </Animated.View>
-          </AnimatedLiquidGlassView>
-        </UniwindLiquidGlassContainerView>
+          </AnimatedGlassView>
+        </UniwindGlassContainer>
       ) : props.startedAt !== null ? (
         <View pointerEvents="box-none" className="flex-row items-center gap-4">
           <Animated.View
@@ -128,15 +131,15 @@ export function FloatingWorkingControl(props: {
             />
           </Animated.View>
         </View>
-      ) : isLiquidGlassSupported ? (
-        <UniwindLiquidGlassView
+      ) : NATIVE_LIQUID_GLASS_SUPPORTED ? (
+        <UniwindGlassView
           colorScheme={props.colorScheme}
-          effect="regular"
-          interactive
+          glassEffectStyle="regular"
+          isInteractive
           className="h-11 w-11 items-center justify-center overflow-hidden rounded-full"
         >
           <ScrollToEndButton onPress={props.onScrollToEnd} />
-        </UniwindLiquidGlassView>
+        </UniwindGlassView>
       ) : (
         <ControlPill
           accessibilityLabel="Scroll to end"

--- a/docs/user/mobile-appearance.md
+++ b/docs/user/mobile-appearance.md
@@ -4,8 +4,8 @@ T3 Code Mobile includes the T3 Code, T3 Chat, Grove, Ocean, Ember, and Iris them
 light and dark colors that apply throughout the app, including code reviews, file previews, the
 terminal, native headers, and sheets.
 
-On supported iOS versions, the new-task and thread composers use the system glass material.
-Other platforms use a themed background.
+On supported iOS versions, the new-task and thread composers, working timer, and scroll-to-end
+button use the system glass material. Other platforms use a themed background.
 
 To change themes:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,6 @@ importers:
 
   apps/mobile:
     dependencies:
-      '@callstack/liquid-glass':
-        specifier: ^0.7.1
-        version: 0.7.1(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@clerk/expo':
         specifier: 4.2.0
         version: 4.2.0(patch_hash=72e426f44fc1cde16fc2cbba3d1e96cdca7c6d957faa73d0fe6b43948608a6c1)(1fcd0592788ddcf326eeeb90d875ed47)
@@ -1699,12 +1696,6 @@ packages:
     resolution: {integrity: sha512-Dsoe4reWe69MyILmMwU6iISIceTW7YIFqbyym7haf9DhUvqkYfMAyp7GMM21JzV0SpG9A2BwzFVP7iq9mmxrpA==}
     cpu: [x64]
     os: [win32]
-
-  '@callstack/liquid-glass@0.7.1':
-    resolution: {integrity: sha512-N2rzs8g3kneI5G/98AZdVtjc6OUFBBFwPxVGVMoXUEI7QiioB4+aWwbImg5h8Z3Vb/T+fgLYWmmNhi27wHwE4g==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
 
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
@@ -11397,11 +11388,6 @@ snapshots:
 
   '@bruits/satteri-win32-x64-msvc@0.9.3':
     optional: true
-
-  '@callstack/liquid-glass@0.7.1(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   '@capsizecss/unpack@4.0.1':
     dependencies:


### PR DESCRIPTION
## What changed

Replace the floating working/scroll controls and Git action overlay with `expo-glass-effect`, then remove `@callstack/liquid-glass` from the mobile dependencies and lockfile. Keep the existing merge animation, Git overlay height transitions, tint, and platform fallbacks.

## Why

The working label can remain visible after its native glass disappears. Expo's existing implementation reapplies the effect after layout and window reattachment, covering a lifecycle gap in the Callstack implementation. Both overlays now use the same native capability check as the rest of mobile.

## UI evidence

Light mode: a real commit in a disposable repository. Hook output expands the overlay, progress text updates, and the result changes to success.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5ab9c80e60357b65/git-glass-success.mp4

Dark mode: the hook rejects a second commit. The overlay grows, shows the error, and automatically dismisses with the glass intact.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4ab8701b73cf75cd/git-glass-dark-error.mp4

<details>
<summary>Reported working-control defect and migrated Git overlay screenshot</summary>

Reported defect: the working label has lost its glass background.

<img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f43ebf285bb75cbc/5328a5c9-d329-47ef-b772-9be24f2b4911-62bee1ce-1a60-434a-b521-ea585daea6a4.png" width="320" alt="Working label with missing glass background" />

Migrated Git overlay after the successful test commit.

<img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3a4c8206fd8fc43a/success.png" width="320" alt="Expo glass Git overlay showing the successful commit" />

</details>

## Validation

- Mobile typecheck, targeted lint, formatting, and frozen-lockfile install passed.
- Recorded on an iPhone 17 Pro simulator running iOS 27. Inspected animation frames to confirm the height transition. Invoked the commit-sheet actions through the native debugger against an isolated server and repository.
- Used the existing development client; a fresh native build was blocked by the Mac's full disk. The recordings cover the Git overlay. The intermittent working-control disappearance was not reproduced.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/8862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dependency swap on mobile overlays with unchanged fallbacks; no auth, data, or API changes.
> 
> **Overview**
> **Replaces `@callstack/liquid-glass` with `expo-glass-effect`** for the Git action progress overlay and floating working / scroll-to-end controls, and drops the Callstack dependency from the mobile app.
> 
> Both surfaces now use `GlassView` / `GlassContainer` with the shared `NATIVE_LIQUID_GLASS_SUPPORTED` gate (same as other mobile glass). Prop names shift to Expo’s API (`glassEffectStyle`, `isInteractive`), and the working control wires `withUniwind` for class-based styling on glass views. Non-iOS or unsupported devices keep the existing card / `ControlPill` fallbacks and fade animations.
> 
> User docs note that the working timer and scroll-to-end button also use system glass on supported iOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6536f0b5745b9f38e1532d131f970b2f7764d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `@callstack/liquid-glass` with `expo-glass-effect` in mobile overlays
> - Switches glass rendering in `GitActionProgressOverlay.tsx` and `floating-working-control.tsx` to use `GlassView` and `GlassContainer` from `expo-glass-effect`
> - Replaces the `isLiquidGlassSupported` check with `NATIVE_LIQUID_GLASS_SUPPORTED` to gate animations and fallback rendering
> - Updates glass component props from `effect`/`interactive` to `glassEffectStyle`/`isInteractive`
> - Risk: `NATIVE_LIQUID_GLASS_SUPPORTED` (imported from `native/native-glass`) now dictates whether components render glass effects or fall back to standard `Animated.View` in `GitActionProgressOverlay.tsx` and `floating-working-control.tsx`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2c6536f. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->