### PR TITLE
fix(server): cleanup tasklist/findstr orphaned processes on Windows (#8575)

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -614,6 +614,15 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
       // Connected claude.ai MCP servers are discovered outside filesystem
       // config; disable them independently for this health check.
       ENABLE_CLAUDEAI_MCP_SERVERS: "false",
+      // Disable Claude's IDE detection (tasklist | findstr) and related
+      // auto-install hooks. The probe fires every few minutes and each
+      // detection spawns tasklist.exe/findstr.exe (and git.exe) children on
+      // Windows that can remain orphaned when the probe completes, times
+      // out, or is aborted (#8575). These vars mirror the manual workaround
+      // and prevent the child processes from ever spawning.
+      CLAUDE_CODE_AUTO_CONNECT_IDE: "0",
+      CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL: "1",
+      FORCE_CODE_TERMINAL: "1",
     },
     ...(input.cwd ? { cwd: input.cwd } : {}),
     stderr: () => {},
@@ -727,14 +736,20 @@ const probeClaudeCapabilities = (
   claudeSettings: ClaudeSettings,
   environment?: NodeJS.ProcessEnv,
   cwd?: string,
-) => {
-  const abort = new AbortController();
-  return Effect.gen(function* () {
+) =>
+  Effect.gen(function* () {
     const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
     const executablePath = yield* resolveClaudeSdkExecutablePath(
       claudeSettings.binaryPath,
       claudeEnvironment,
     );
+    const abort = new AbortController();
+    // The SDK query owns the Claude CLI child process. On Windows the CLI
+    // spawns IDE-detection children (tasklist.exe | findstr.exe) and git
+    // probes that become orphaned if the parent is aborted without a tree
+    // kill. Aborting the controller terminates the entire query, and the
+    // ensuring finalizer guarantees the abort runs on success, failure,
+    // timeout, or fiber interruption so no child tree is left behind (#8575).
     return yield* Effect.tryPromise(async () => {
       const q = claudeQuery({
         // Never yield — we only need initialization data, not a conversation.
@@ -766,21 +781,17 @@ const probeClaudeCapabilities = (
         apiProvider: account?.apiProvider,
         slashCommands: parseClaudeInitializationCommands(init.commands),
       } satisfies ClaudeCapabilitiesProbe;
-    });
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => abort.abort())),
+      Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),
+    );
   }).pipe(
-    Effect.ensuring(
-      Effect.sync(() => {
-        if (!abort.signal.aborted) abort.abort();
-      }),
-    ),
-    Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),
     Effect.result,
     Effect.map((result) => {
       if (Result.isFailure(result)) return undefined;
       return Option.isSome(result.success) ? result.success.value : undefined;
     }),
   );
-};
 
 const runClaudeCommand = Effect.fn("runClaudeCommand")(function* (
   claudeSettings: ClaudeSettings,


### PR DESCRIPTION
Fixes pingdotgg/t3code#8575

Periodic Claude provider refresh leaked orphaned 	asklist.exe/indstr.exe (and git.exe) children on Windows. See fork PR https://github.com/dlowzzxx/t3code/pull/1 for details.

Changes: prevent IDE detection via env vars and ensure AbortController cleanup guarantees child-process tree termination on completion/timeout/interruption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the periodic Claude SDK capability probe and Windows subprocess cleanup; no auth, API, or user-session paths are affected.
> 
> **Overview**
> Fixes **orphaned `tasklist.exe` / `findstr.exe` / `git.exe` processes** on Windows during the periodic Claude capabilities health probe (#8575).
> 
> The probe’s SDK options now set **`CLAUDE_CODE_AUTO_CONNECT_IDE`**, **`CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`**, and **`FORCE_CODE_TERMINAL`** so IDE detection and auto-install hooks never run during this short-lived check.
> 
> **`probeClaudeCapabilities`** is tightened so the **`AbortController` is always aborted** via `Effect.ensuring` on success, failure, timeout, or interruption, with timeout scoped on the inner `tryPromise` so the CLI child tree is torn down reliably when the probe ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c8a2258df806678e9c828e1b1847018cf4be2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix orphaned `tasklist`/`findstr` processes by ensuring `AbortController` abort in `probeClaudeCapabilities`
> - Refactors `probeClaudeCapabilities` in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/8864/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) to abort the `AbortController` via `Effect.ensuring` finalizer tied to the SDK query, preventing orphaned child processes on Windows
> - Narrows the `Effect.timeoutOption` to apply only to the SDK query segment rather than the entire generator setup
> - Adds `CLAUDE_CODE_AUTO_CONNECT_IDE`, `CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL`, and `FORCE_CODE_TERMINAL` env vars to `buildClaudeCapabilitiesProbeQueryOptions` to prevent IDE detection and auto-install hooks during the periodic probe
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78c8a22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->