### PR TITLE
fix(web): show update changelog in downloaded toast

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -3575,7 +3575,7 @@ export default function LegacySidebar() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            showDesktopUpdateDownloadedToast(bridge, result.state);
+            showDesktopUpdateDownloadedToast(result.state);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);

--- a/apps/web/src/components/desktopUpdate.releaseNotes.tsx
+++ b/apps/web/src/components/desktopUpdate.releaseNotes.tsx
@@ -1,0 +1,36 @@
+import type { DesktopUpdateReleaseNote } from "@t3tools/contracts";
+
+import { Separator } from "./ui/separator";
+
+function keyReleaseNoteItems(items: ReadonlyArray<string>) {
+  const occurrences = new Map<string, number>();
+  return items.map((item) => {
+    const occurrence = occurrences.get(item) ?? 0;
+    occurrences.set(item, occurrence + 1);
+    return { item, key: JSON.stringify([item, occurrence]) };
+  });
+}
+
+export function DesktopUpdateReleaseNotes({
+  releaseNotes,
+}: {
+  readonly releaseNotes: ReadonlyArray<DesktopUpdateReleaseNote>;
+}) {
+  return releaseNotes.map((releaseNote, index) => (
+    <div key={releaseNote.version}>
+      {index > 0 && <Separator className="my-3 bg-border/60" />}
+      <section>
+        <h3 className="text-foreground text-xs leading-4 font-semibold">
+          {index === 0 ? "What's changed" : `Changes in ${releaseNote.version}`}
+        </h3>
+        <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
+          {keyReleaseNoteItems(releaseNote.items).map(({ item, key }) => (
+            <li className="list-disc break-words" key={key}>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  ));
+}

--- a/apps/web/src/components/desktopUpdate.toast.test.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.test.tsx
@@ -47,6 +47,7 @@ describe("showDesktopUpdateDownloadedToast", () => {
         expandableContent: <DesktopUpdateReleaseNotes releaseNotes={releaseNotes} />,
         expandableLabels: { collapse: "Hide changes", expand: "View changes" },
       },
+      timeout: 0,
       type: "success",
       title: "Update downloaded",
       description: "Restart the app from the update button to install it.",

--- a/apps/web/src/components/desktopUpdate.toast.test.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.test.tsx
@@ -59,6 +59,7 @@ describe("showDesktopUpdateDownloadedToast", () => {
 
     expect(testState.addToast).toHaveBeenCalledWith({
       data: undefined,
+      timeout: 0,
       type: "success",
       title: "Update downloaded",
       description: "Restart the app from the update button to install it.",

--- a/apps/web/src/components/desktopUpdate.toast.test.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.test.tsx
@@ -1,42 +1,14 @@
-import { isValidElement, type ReactElement, type ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { DesktopUpdateState } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const testState = vi.hoisted(() => ({
-  addToast: vi.fn(),
-}));
+const testState = vi.hoisted(() => ({ addToast: vi.fn() }));
 
 vi.mock("./ui/toast", () => ({
   toastManager: { add: testState.addToast },
 }));
 
+import { DesktopUpdateReleaseNotes } from "./desktopUpdate.releaseNotes";
 import { showDesktopUpdateDownloadedToast } from "./desktopUpdate.toast";
-
-type ClickableElement = ReactElement<{ readonly onClick?: () => void }>;
-
-/** Walks the rendered description, invoking function components, to find the link button. */
-function findReleaseNotesLink(node: ReactNode): ClickableElement | null {
-  if (Array.isArray(node)) {
-    for (const child of node) {
-      const found = findReleaseNotesLink(child);
-      if (found) return found;
-    }
-    return null;
-  }
-  if (!isValidElement(node)) return null;
-  const element = node as ReactElement<{ readonly children?: ReactNode }>;
-  if (element.type === "button") return element as ClickableElement;
-  if (typeof element.type === "function") {
-    const render = element.type as (props: unknown) => ReactNode;
-    return findReleaseNotesLink(render(element.props));
-  }
-  return findReleaseNotesLink(element.props.children);
-}
-
-function getDescription(): ReactNode {
-  const toast = testState.addToast.mock.calls[0]?.[0] as { description?: ReactNode } | undefined;
-  return toast?.description ?? null;
-}
 
 function downloadedState(overrides: Partial<DesktopUpdateState> = {}): DesktopUpdateState {
   return {
@@ -60,62 +32,35 @@ function downloadedState(overrides: Partial<DesktopUpdateState> = {}): DesktopUp
 }
 
 describe("showDesktopUpdateDownloadedToast", () => {
-  beforeEach(() => {
-    testState.addToast.mockReset();
-  });
+  beforeEach(() => testState.addToast.mockReset());
 
-  it("opens the downloaded version's release notes", async () => {
-    const openExternal = vi.fn().mockResolvedValue(true);
+  it("shows the downloaded release notes in an in-app disclosure", () => {
+    const releaseNotes = [
+      { version: "0.0.30", items: ["Fix updater toast", "Fix updater toast"] },
+      { version: "0.0.29", items: ["Improve downloads"] },
+    ];
 
-    showDesktopUpdateDownloadedToast({ openExternal }, downloadedState());
-    const link = findReleaseNotesLink(getDescription());
-    link?.props.onClick?.();
-    await vi.waitFor(() => {
-      expect(openExternal).toHaveBeenCalledWith(
-        "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30",
-      );
-    });
-    expect(testState.addToast).toHaveBeenCalledTimes(1);
-  });
+    showDesktopUpdateDownloadedToast(downloadedState({ releaseNotes }));
 
-  it("falls back to the version the download was started for", async () => {
-    const openExternal = vi.fn().mockResolvedValue(true);
-
-    // The `update-downloaded` event can land after the download RPC resolves.
-    showDesktopUpdateDownloadedToast(
-      { openExternal },
-      downloadedState({ downloadedVersion: null }),
-    );
-    findReleaseNotesLink(getDescription())?.props.onClick?.();
-
-    await vi.waitFor(() => {
-      expect(openExternal).toHaveBeenCalledWith(
-        "https://github.com/pingdotgg/t3code/releases/tag/v0.0.30",
-      );
+    expect(testState.addToast).toHaveBeenCalledWith({
+      data: {
+        expandableContent: <DesktopUpdateReleaseNotes releaseNotes={releaseNotes} />,
+        expandableLabels: { collapse: "Hide changes", expand: "View changes" },
+      },
+      type: "success",
+      title: "Update downloaded",
+      description: "Restart the app from the update button to install it.",
     });
   });
 
-  it("omits the link when the updater reports no version at all", () => {
-    showDesktopUpdateDownloadedToast(
-      { openExternal: vi.fn() },
-      downloadedState({ availableVersion: null, downloadedVersion: null }),
-    );
+  it("omits the disclosure when release notes are unavailable", () => {
+    showDesktopUpdateDownloadedToast(downloadedState());
 
-    expect(findReleaseNotesLink(getDescription())).toBeNull();
-  });
-
-  it.each([
-    ["returns false", vi.fn().mockResolvedValue(false)],
-    ["rejects", vi.fn().mockRejectedValue(new Error("open failed"))],
-  ])("shows an error when opening release notes %s", async (_description, openExternal) => {
-    showDesktopUpdateDownloadedToast({ openExternal }, downloadedState());
-    findReleaseNotesLink(getDescription())?.props.onClick?.();
-
-    await vi.waitFor(() => {
-      expect(testState.addToast).toHaveBeenLastCalledWith({
-        type: "error",
-        title: "Unable to open release notes",
-      });
+    expect(testState.addToast).toHaveBeenCalledWith({
+      data: undefined,
+      type: "success",
+      title: "Update downloaded",
+      description: "Restart the app from the update button to install it.",
     });
   });
 });

--- a/apps/web/src/components/desktopUpdate.toast.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.tsx
@@ -1,59 +1,19 @@
-import type { DesktopBridge, DesktopUpdateState } from "@t3tools/contracts";
-import { ArrowRightIcon } from "lucide-react";
+import type { DesktopUpdateState } from "@t3tools/contracts";
 
-import {
-  getDesktopUpdateDownloadedVersion,
-  getDesktopUpdateReleaseUrl,
-} from "./desktopUpdate.logic";
+import { DesktopUpdateReleaseNotes } from "./desktopUpdate.releaseNotes";
 import { toastManager } from "./ui/toast";
 
-type DesktopUpdateShell = Pick<DesktopBridge, "openExternal">;
-
-function ReleaseNotesLink({
-  shell,
-  releaseUrl,
-}: {
-  shell: DesktopUpdateShell;
-  releaseUrl: string;
-}) {
-  return (
-    <button
-      className="ml-2 inline cursor-pointer text-muted-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
-      onClick={() => {
-        void (async () => {
-          try {
-            if (await shell.openExternal(releaseUrl)) return;
-          } catch {
-            // Surface rejected IPC calls through the same user-visible fallback.
-          }
-          toastManager.add({ type: "error", title: "Unable to open release notes" });
-        })();
-      }}
-      type="button"
-    >
-      Read more
-      <ArrowRightIcon
-        aria-hidden
-        className="ml-1 inline size-3 -rotate-45 align-[-0.125em]"
-        strokeWidth={2.25}
-      />
-    </button>
-  );
-}
-
-export function showDesktopUpdateDownloadedToast(
-  shell: DesktopUpdateShell,
-  state: DesktopUpdateState,
-): void {
-  const releaseUrl = getDesktopUpdateReleaseUrl(getDesktopUpdateDownloadedVersion(state));
+export function showDesktopUpdateDownloadedToast(state: DesktopUpdateState): void {
+  const hasReleaseNotes = state.releaseNotes.length > 0;
   toastManager.add({
+    data: hasReleaseNotes
+      ? {
+          expandableContent: <DesktopUpdateReleaseNotes releaseNotes={state.releaseNotes} />,
+          expandableLabels: { collapse: "Hide changes", expand: "View changes" },
+        }
+      : undefined,
     type: "success",
     title: "Update downloaded",
-    description: (
-      <>
-        Restart the app from the update button to install it.
-        {releaseUrl ? <ReleaseNotesLink releaseUrl={releaseUrl} shell={shell} /> : null}
-      </>
-    ),
+    description: "Restart the app from the update button to install it.",
   });
 }

--- a/apps/web/src/components/desktopUpdate.toast.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.tsx
@@ -12,6 +12,7 @@ export function showDesktopUpdateDownloadedToast(state: DesktopUpdateState): voi
           expandableLabels: { collapse: "Hide changes", expand: "View changes" },
         }
       : undefined,
+    timeout: 0,
     type: "success",
     title: "Update downloaded",
     description: "Restart the app from the update button to install it.",

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -18,8 +18,8 @@ import {
   shouldToastDesktopUpdateActionResult,
 } from "../desktopUpdate.logic";
 import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
+import { DesktopUpdateReleaseNotes } from "../desktopUpdate.releaseNotes";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
-import { Separator } from "../ui/separator";
 import { SidebarMenuItem } from "../ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
@@ -55,15 +55,6 @@ function resolveSidebarUpdatePresentation({
   } as const;
 }
 
-function keyReleaseNoteItems(items: ReadonlyArray<string>) {
-  const occurrences = new Map<string, number>();
-  return items.map((item) => {
-    const occurrence = occurrences.get(item) ?? 0;
-    occurrences.set(item, occurrence + 1);
-    return { item, key: JSON.stringify([item, occurrence]) };
-  });
-}
-
 function SidebarUpdateReleaseNotesTooltip({
   state,
   tooltip,
@@ -94,23 +85,7 @@ function SidebarUpdateReleaseNotesTooltip({
         )}
       </div>
       <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
-        {state.releaseNotes.map((releaseNote, index) => (
-          <div key={releaseNote.version}>
-            {index > 0 && <Separator className="my-3 bg-border/60" />}
-            <section>
-              <h3 className="text-foreground text-xs leading-4 font-semibold">
-                {index === 0 ? "What's changed" : `Changes in ${releaseNote.version}`}
-              </h3>
-              <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
-                {keyReleaseNoteItems(releaseNote.items).map(({ item, key }) => (
-                  <li className="list-disc break-words" key={key}>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </section>
-          </div>
-        ))}
+        <DesktopUpdateReleaseNotes releaseNotes={state.releaseNotes} />
       </div>
     </div>
   );
@@ -193,7 +168,7 @@ function SidebarUpdateControl() {
         .downloadUpdate()
         .then((result) => {
           if (result.completed) {
-            showDesktopUpdateDownloadedToast(bridge, result.state);
+            showDesktopUpdateDownloadedToast(result.state);
           }
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);


### PR DESCRIPTION
## What Changed

The update-downloaded toast now shows the downloaded release notes in an in-app expandable "View changes" disclosure. The sidebar tooltip and toast share the same release-note renderer, and both modern and legacy sidebar flows use the updated toast.

## Why

After an update finished downloading, the toast linked to GitHub to show the changelog even though the sidebar update button already displayed it in-app. This keeps the completed-download flow consistent and avoids sending users out of the app.

## UI Changes

Before: the completed-download toast displayed a "Read more" link that opened the GitHub release page.
<img width="360" height="88" alt="image" src="https://github.com/user-attachments/assets/897a1d28-932a-49d4-b9fe-818c29b2a81e" />

After: the toast displays a "View changes" disclosure that expands the release notes in place. No external page opens.
<img width="586" height="199" alt="image" src="https://github.com/user-attachments/assets/7d8fa479-c215-42c4-90e9-87d21e651b0d" />
<img width="751" height="448" alt="image" src="https://github.com/user-attachments/assets/e0f7728d-4117-4605-ba76-cfd3c66c69d6" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Verified manually with the local mock updater using nightly artifacts. Focused toast tests, web typecheck, lint, formatting, and diff checks pass.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only UI in the update toast and sidebar; no auth, data, or updater protocol changes beyond dropping external link handling.
> 
> **Overview**
> The **update-downloaded** success toast no longer opens GitHub for the changelog. When `DesktopUpdateState.releaseNotes` is present, the toast adds an in-app **View changes** / **Hide changes** disclosure via existing toast `expandableContent`, rendering the same bullet lists as the sidebar.
> 
> `showDesktopUpdateDownloadedToast` now takes only `state` (no `DesktopBridge` / `openExternal`). **LegacySidebar** and **SidebarUpdatePill** call sites were updated accordingly. Release-note markup was extracted into shared **`DesktopUpdateReleaseNotes`** (with stable keys for duplicate items); the nightly sidebar tooltip uses that component instead of inlined JSX.
> 
> Tests were rewritten around the disclosure payload and the case where release notes are empty (`data` omitted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c7452ac6947443b1e30887bc9167be196c6678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show release notes inline in desktop update-downloaded toast
> - Replaces the external 'Read more' link in the update-downloaded toast with an expandable in-app disclosure that renders the changelog via a new shared `DesktopUpdateReleaseNotes` component.
> - Removes the `DesktopBridge`/shell argument from `showDesktopUpdateDownloadedToast`; the function now accepts only `DesktopUpdateState` and no longer opens an external browser.
> - Reuses `DesktopUpdateReleaseNotes` in [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/8870/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf), removing its local release-notes rendering and keying helper.
> - Updates tests in [desktopUpdate.toast.test.tsx](https://github.com/pingdotgg/t3code/pull/8870/files#diff-8f8ed39aca00d7dd75ffe9015f5ad849baa49a42328002dd6f08c27587c98fe4) to assert the expandable content and the no-release-notes case.
> - Behavioral Change: toast omits the disclosure entirely when `releaseNotes` are unavailable, and no external link or error handling remains.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3fae66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->