### PR TITLE
fix(server): verify repositories before checkpointing

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -530,6 +530,36 @@ describe("CheckpointReactor", () => {
     ).toBe("v2\n");
   });
 
+  it("skips checkpoint capture when git metadata is incomplete", async () => {
+    const invalidCwd = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-invalid-git-"));
+    NodeFS.mkdirSync(NodePath.join(invalidCwd, ".git"));
+    tempDirs.push(invalidCwd);
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      projectWorkspaceRoot: invalidCwd,
+      threadWorktreePath: invalidCwd,
+      providerSessionCwd: invalidCwd,
+    });
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-invalid-git"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-invalid-git"),
+      payload: { state: "completed" },
+    });
+
+    await harness.drain();
+
+    const snapshot = await harness.readModel();
+    const thread = snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(
+      thread?.activities.some((activity) => activity.kind === "checkpoint.capture.failed"),
+    ).toBe(false);
+  });
+
   it("refreshes local git status state on turn completion using the session cwd", async () => {
     const gitStatusRefreshCalls: string[] = [];
     const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -35,7 +35,6 @@ import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts"
 import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import type { OrchestrationDispatchError } from "../Errors.ts";
-import { isGitRepository } from "../../git/Utils.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
 
@@ -177,8 +176,6 @@ const make = Effect.gen(function* () {
     return project ? [project] : [];
   });
 
-  const isGitWorkspace = (cwd: string) => isGitRepository(cwd);
-
   // Resolves the workspace CWD for checkpoint operations, preferring the
   // active provider session CWD and falling back to the thread/project config.
   // Returns undefined when no CWD can be determined or the workspace is not
@@ -188,7 +185,7 @@ const make = Effect.gen(function* () {
     readonly thread: { readonly projectId: ProjectId; readonly worktreePath: string | null };
     readonly projects: ReadonlyArray<{ readonly id: ProjectId; readonly workspaceRoot: string }>;
     readonly preferSessionRuntime: boolean;
-  }): Effect.fn.Return<string | undefined> {
+  }): Effect.fn.Return<string | undefined, CheckpointStoreError> {
     const fromSession = yield* resolveSessionRuntimeForThread(input.threadId);
     const fromThread = resolveThreadWorkspaceCwd({
       thread: input.thread,
@@ -209,7 +206,7 @@ const make = Effect.gen(function* () {
     if (!cwd) {
       return undefined;
     }
-    if (!isGitWorkspace(cwd)) {
+    if (!(yield* checkpointStore.isGitRepository(cwd))) {
       return undefined;
     }
     return cwd;
@@ -713,7 +710,7 @@ const make = Effect.gen(function* () {
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
-    if (!isGitWorkspace(sessionRuntime.value.cwd)) {
+    if (!(yield* checkpointStore.isGitRepository(sessionRuntime.value.cwd))) {
       yield* appendRevertFailureActivity({
         threadId: event.payload.threadId,
         turnCount: event.payload.turnCount,


### PR DESCRIPTION
## What Changed

- use the checkpoint store's VCS-backed repository detection before checkpoint capture and revert operations
- add regression coverage for an incomplete `.git` directory that Git itself rejects

## Why

The checkpoint reactor previously treated any `<cwd>/.git` path as proof of a repository. A polyrepo parent or other non-repository directory with partial Git metadata passed that check, then failed in `VcsDriverRegistry.resolve`, producing repeated checkpoint warnings and failure activities.

Reusing `CheckpointStore.isGitRepository` keeps the pre-check consistent with the VCS driver that performs checkpoint operations.

Fixes #8873

## Test Plan

- `vp test run apps/server/src/orchestration/Layers/CheckpointReactor.test.ts`
- `vp lint --report-unused-disable-directives apps/server/src/orchestration/Layers/CheckpointReactor.ts apps/server/src/orchestration/Layers/CheckpointReactor.test.ts`
- `vp fmt --check apps/server/src/orchestration/Layers/CheckpointReactor.ts apps/server/src/orchestration/Layers/CheckpointReactor.test.ts`
- `vp run --filter t3 typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Generated with GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to pre-flight repo checks in checkpoint capture/revert; behavior improves for invalid repos with no impact on real git workspaces.
> 
> **Overview**
> **CheckpointReactor** no longer treats the presence of a `.git` path as proof of a valid repo. **Resolve checkpoint CWD** and **checkpoint revert** now call **`CheckpointStore.isGitRepository`**, which uses the same VCS detection as checkpoint capture, so polyrepo parents or other dirs with partial Git metadata are skipped quietly instead of failing in the driver.
> 
> A regression test covers a workspace with only an empty `.git` folder: turn completion should not emit **`checkpoint.capture.failed`** activities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933faf8c494a85d1d973a9e5f3572ac2e3b1a367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify git repositories via `checkpointStore` in `CheckpointReactor`
> - Replaces local `isGitWorkspace` checks with `checkpointStore.isGitRepository` in `resolveCheckpointCwd` and the `start` worker's revert handler
> - `resolveCheckpointCwd` returns `undefined` if the path is not a valid git repository
> - Adds a test case for invalid git workspaces (empty `.git` directory) to ensure `checkpoint.capture.failed` activities are not recorded
> - Behavioral Change: `resolveCheckpointCwd` can now fail with `CheckpointStoreError` from the `checkpointStore` dependency
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 933faf8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->