### PR TITLE
fix(web): make WSL settings searchable

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
+  isWslSettingsRowVisible,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
 
@@ -14,6 +15,25 @@ const baseWslState: DesktopWslState = {
   distros: [],
   preflightError: null,
 };
+
+describe("isWslSettingsRowVisible", () => {
+  it("shows the retry row when the WSL state failed to load", () => {
+    expect(isWslSettingsRowVisible({ state: null, error: "load failed" })).toBe(true);
+  });
+
+  it("hides an unavailable and unused WSL snapshot", () => {
+    expect(
+      isWslSettingsRowVisible({
+        state: { ...baseWslState, available: false, wslOnly: false },
+        error: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows an available WSL snapshot", () => {
+    expect(isWslSettingsRowVisible({ state: baseWslState, error: null })).toBe(true);
+  });
+});
 
 describe("applyWslEnableSelection", () => {
   it("clears WSL-only and updates the distro before enabling both backends", async () => {

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -11,6 +11,14 @@ export function isQrShareableEndpoint(endpoint: AdvertisedEndpoint): boolean {
   return endpoint.status !== "unavailable" && endpoint.reachability !== "loopback";
 }
 
+export function isWslSettingsRowVisible(input: {
+  readonly state: DesktopWslState | null;
+  readonly error: string | null;
+}): boolean {
+  const { state, error } = input;
+  return state ? state.available || state.enabled || state.wslOnly : error !== null;
+}
+
 export type QrEndpointOption = {
   /** Unique per endpoint instance (AdvertisedEndpoint.id); safe as a React key. */
   readonly id: string;

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -43,6 +43,7 @@ import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls
 import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
+  isWslSettingsRowVisible,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
 import {
@@ -2766,7 +2767,10 @@ export function ConnectionsSettings() {
       // retry so the row doesn't flicker away, and the button reflects the
       // loading state. With no error we simply haven't loaded yet (or WSL
       // management isn't available), so render nothing.
-      if (desktopWslError && canManageLocalBackend) {
+      if (
+        isWslSettingsRowVisible({ state: null, error: desktopWslError }) &&
+        canManageLocalBackend
+      ) {
         return (
           <SettingsRow
             {...searchableSetting("wsl-backend")}
@@ -2794,8 +2798,10 @@ export function ConnectionsSettings() {
     // be stranded on a WSL preference they can't clear, so render a recovery
     // row that switches back to Windows. When WSL is unavailable AND unused,
     // there's nothing to recover — keep the section hidden as before.
+    if (!isWslSettingsRowVisible({ state: desktopWslState, error: desktopWslError })) {
+      return null;
+    }
     if (!desktopWslState.available) {
-      if (!desktopWslState.enabled && !desktopWslState.wslOnly) return null;
       return (
         <SettingsRow
           {...searchableSetting("wsl-backend")}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -2769,7 +2769,7 @@ export function ConnectionsSettings() {
       if (desktopWslError && canManageLocalBackend) {
         return (
           <SettingsRow
-            title="WSL backend"
+            {...searchableSetting("wsl-backend")}
             description="Couldn't load the WSL backend state."
             status={<span className="block text-destructive">{desktopWslError}</span>}
             control={
@@ -2798,7 +2798,7 @@ export function ConnectionsSettings() {
       if (!desktopWslState.enabled && !desktopWslState.wslOnly) return null;
       return (
         <SettingsRow
-          title="WSL backend"
+          {...searchableSetting("wsl-backend")}
           description="WSL is no longer available, so the Windows backend is running instead. Switch off the WSL backend to clear this preference."
           status={
             desktopWslError ? (
@@ -2835,7 +2835,7 @@ export function ConnectionsSettings() {
     return (
       <>
         <SettingsRow
-          title="WSL backend"
+          {...searchableSetting("wsl-backend")}
           description="Run a second backend inside a WSL distro alongside the Windows one. Pick a distro to start it; pick Off to stop it. Projects opened against the WSL backend live on the Linux side; Windows projects stay where they are."
           status={
             desktopWslError ? (

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -85,12 +85,12 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const desktopWsl = useEnvironmentQuery(isElectron ? desktopWslStateAtom : null);
   const searchableItems = useMemo(() => {
     const wslState = desktopWsl.data;
-    if (
-      wslState?.available ||
-      wslState?.enabled ||
-      wslState?.wslOnly ||
-      desktopWsl.error !== null
-    ) {
+    // Mirror renderWslRow: the retry row renders only without a snapshot,
+    // while a stale snapshot plus a failed refresh follows the snapshot path.
+    const rowRenders = wslState
+      ? wslState.available || wslState.enabled || wslState.wslOnly
+      : desktopWsl.error !== null;
+    if (rowRenders) {
       return SETTINGS_SEARCH_ITEMS;
     }
     return SETTINGS_SEARCH_ITEMS.filter((item) => item.id !== "wsl-backend");

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -85,7 +85,12 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const desktopWsl = useEnvironmentQuery(isElectron ? desktopWslStateAtom : null);
   const searchableItems = useMemo(() => {
     const wslState = desktopWsl.data;
-    if (wslState?.available || wslState?.enabled || wslState?.wslOnly) {
+    if (
+      wslState?.available ||
+      wslState?.enabled ||
+      wslState?.wslOnly ||
+      desktopWsl.error !== null
+    ) {
       return SETTINGS_SEARCH_ITEMS;
     }
     return SETTINGS_SEARCH_ITEMS.filter((item) => item.id !== "wsl-backend");

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -7,6 +7,8 @@ import {
   type ComponentType,
   type KeyboardEvent,
 } from "react";
+import { useEnvironmentQuery } from "~/state/query";
+import { desktopWslStateAtom } from "~/state/desktopWslState";
 import {
   ArchiveIcon,
   BlocksIcon,
@@ -21,6 +23,7 @@ import {
 } from "lucide-react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 
+import { isElectron } from "~/env";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd } from "../ui/kbd";
@@ -38,6 +41,7 @@ import { SidebarUtilityMenu } from "../sidebar/SidebarChrome";
 import { scrollToSettingsTarget } from "./settingsLayout";
 import {
   searchSettings,
+  SETTINGS_SEARCH_ITEMS,
   SETTINGS_SECTION_LABELS,
   type SettingsPath,
   type SettingsSearchItem,
@@ -78,7 +82,15 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [activeResultIndex, setActiveResultIndex] = useState(0);
-  const results = useMemo(() => searchSettings(query), [query]);
+  const desktopWsl = useEnvironmentQuery(isElectron ? desktopWslStateAtom : null);
+  const searchableItems = useMemo(() => {
+    const wslState = desktopWsl.data;
+    if (wslState?.available || wslState?.enabled || wslState?.wslOnly) {
+      return SETTINGS_SEARCH_ITEMS;
+    }
+    return SETTINGS_SEARCH_ITEMS.filter((item) => item.id !== "wsl-backend");
+  }, [desktopWsl.data]);
+  const results = useMemo(() => searchSettings(query, searchableItems), [query, searchableItems]);
   const isSearching = query.trim().length > 0;
   const hasResults = results.length > 0;
 

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -100,6 +100,10 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const hasResults = results.length > 0;
 
   useEffect(() => {
+    setActiveResultIndex((index) => Math.min(index, Math.max(results.length - 1, 0)));
+  }, [results.length]);
+
+  useEffect(() => {
     const result = results[activeResultIndex];
     if (!result) return;
     document

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -94,7 +94,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
       return SETTINGS_SEARCH_ITEMS;
     }
     return SETTINGS_SEARCH_ITEMS.filter((item) => item.id !== "wsl-backend");
-  }, [desktopWsl.data]);
+  }, [desktopWsl.data, desktopWsl.error]);
   const results = useMemo(() => searchSettings(query, searchableItems), [query, searchableItems]);
   const isSearching = query.trim().length > 0;
   const hasResults = results.length > 0;

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -24,6 +24,7 @@ import {
 import { useLocation, useNavigate } from "@tanstack/react-router";
 
 import { isElectron } from "~/env";
+import { isWslSettingsRowVisible } from "./ConnectionsSettings.logic";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd } from "../ui/kbd";
@@ -85,11 +86,10 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   const desktopWsl = useEnvironmentQuery(isElectron ? desktopWslStateAtom : null);
   const searchableItems = useMemo(() => {
     const wslState = desktopWsl.data;
-    // Mirror renderWslRow: the retry row renders only without a snapshot,
-    // while a stale snapshot plus a failed refresh follows the snapshot path.
-    const rowRenders = wslState
-      ? wslState.available || wslState.enabled || wslState.wslOnly
-      : desktopWsl.error !== null;
+    const rowRenders = isWslSettingsRowVisible({
+      state: wslState,
+      error: desktopWsl.error,
+    });
     if (rowRenders) {
       return SETTINGS_SEARCH_ITEMS;
     }

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -71,6 +71,16 @@ describe("searchSettings", () => {
   it("hides desktop-only settings from browser search", () => {
     expect(SETTINGS_SEARCH_ITEMS.some((item) => item.id === "quit-confirmation")).toBe(true);
     expect(searchSettings("quit confirmation")).toEqual([]);
+    expect(searchSettings("wsl")).toEqual([]);
+  });
+
+  it("registers the WSL backend as a desktop-only setting", () => {
+    expect(SETTINGS_SEARCH_ITEMS).toContainEqual({
+      id: "wsl-backend",
+      title: "WSL backend",
+      to: "/settings/connections",
+      desktopOnly: true,
+    });
   });
 
   it("keeps catalog result ids unique", () => {

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -80,6 +80,7 @@ describe("searchSettings", () => {
       title: "WSL backend",
       to: "/settings/connections",
       desktopOnly: true,
+      windowsOnly: true,
     });
   });
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -260,6 +260,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/connections",
   },
   {
+    id: "wsl-backend",
+    title: "WSL backend",
+    to: "/settings/connections",
+    desktopOnly: true,
+  },
+  {
     id: "archive",
     title: "Archived threads",
     to: "/settings/archived",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -1,4 +1,5 @@
 import { isElectron } from "~/env";
+import { isWindowsPlatform } from "~/lib/utils";
 
 export type SettingsPath =
   | "/settings/general"
@@ -18,6 +19,9 @@ export interface SettingsSearchItem {
   // Its row only renders in the desktop app, so a browser result would land on
   // an anchor that isn't there.
   readonly desktopOnly?: boolean;
+  // Its row only renders on Windows desktop, so other desktop platforms must
+  // not expose a result that points to a missing anchor.
+  readonly windowsOnly?: boolean;
 }
 
 /**
@@ -264,6 +268,7 @@ export const SETTINGS_SEARCH_ITEMS = [
     title: "WSL backend",
     to: "/settings/connections",
     desktopOnly: true,
+    windowsOnly: true,
   },
   {
     id: "archive",
@@ -310,6 +315,8 @@ export function searchSettings(
   return items.filter(
     (item) =>
       (isElectron || item.desktopOnly !== true) &&
+      (!item.windowsOnly ||
+        isWindowsPlatform(typeof navigator === "undefined" ? "" : navigator.platform)) &&
       normalizeSearchText(item.title).includes(normalizedQuery),
   );
 }


### PR DESCRIPTION
## What Changed

Registered the WSL backend row in the Settings search catalog and added a stable anchor to the WSL row states.

## Why

Searching for `WSL` previously returned no results because Settings search only matched catalog entries, while the WSL row was not registered. The entry is desktop-only because WSL management is unavailable in the browser client.

## UI Changes

The WSL backend setting now appears when searching `WSL` in Settings and navigates to the WSL control in Connections.

Before:
<img width="366" height="352" alt="image" src="https://github.com/user-attachments/assets/b67acc86-1fb2-40be-9471-a702e8c5e868" />

After:
<img width="370" height="366" alt="image" src="https://github.com/user-attachments/assets/e906fc1d-bd4e-41ce-94c0-62b2b5c75df6" />
<img width="1311" height="202" alt="image" src="https://github.com/user-attachments/assets/b1a91215-7772-4e46-a37e-dd053d776e2b" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings search and visibility wiring with unit tests; no auth, data, or backend behavior changes.
> 
> **Overview**
> **WSL backend** is now discoverable from Settings search on Windows desktop, with search results staying aligned with whether the Connections row actually renders.
> 
> A shared **`isWslSettingsRowVisible`** predicate replaces inline visibility checks in Connections: the row stays visible on load errors, when WSL is available, or when the user still has WSL enabled or WSL-only; it stays hidden when WSL is unavailable and unused. All WSL **`SettingsRow`** variants use **`searchableSetting("wsl-backend")`** so search can scroll to a stable anchor.
> 
> The settings catalog gains a **`wsl-backend`** entry (`desktopOnly` + new **`windowsOnly`**), and **`searchSettings`** can take a filtered item list and drops Windows-only hits on non-Windows platforms. The sidebar search builds that list from live WSL state so **`wsl-backend`** does not appear when the row would be hidden, and clamps the active result index when the list shrinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b8cbd7aa3b36af32d9174292729564f41b6fe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make WSL settings searchable via `searchableSetting("wsl-backend")` and `isWslSettingsRowVisible`
> - Adds the `isWslSettingsRowVisible` predicate in [ConnectionsSettings.logic.ts](https://github.com/pingdotgg/t3code/pull/8881/files#diff-a7a170d2c0884c270c94cda8b4f4498c1488857ae1c1cfda21e6233e15ec0110) to centralize when the WSL settings row should render, based on availability, enablement, `wslOnly` flag, or a load error
> - Registers a new `wsl-backend` entry in `SETTINGS_SEARCH_ITEMS` with `desktopOnly` and `windowsOnly` flags, and extends `searchSettings` to filter `windowsOnly` items on non-Windows platforms
> - Wires all WSL `SettingsRow` render sites in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/8881/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) to spread `searchableSetting("wsl-backend")` for a stable search anchor id and title
> - Updates [SettingsSidebarNav.tsx](https://github.com/pingdotgg/t3code/pull/8881/files#diff-0c64e545aee60962b27c61f412d1b564c5896199b9538212702b7da60246d134) to query desktop WSL state and conditionally include the `wsl-backend` search item, with an effect to keep the keyboard navigation index in bounds
> - Risk: `windowsOnly` filtering relies on `navigator.platform`; browsers that report an unexpected platform string could hide the WSL result on Windows
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33b8cbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->