### PR TITLE
fix(server): Grok status check uses grok models, not a full ACP session

### DIFF
--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -10,6 +10,7 @@ import {
   buildGrokModelCapabilities,
   buildInitialGrokProviderSnapshot,
   checkGrokProviderStatus,
+  parseGrokModelsCliOutput,
 } from "./GrokProvider.ts";
 
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
@@ -264,7 +265,7 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
     }),
   );
 
-  it.effect("reports an error when ACP model discovery is unavailable", () =>
+  it.effect("does not mark Grok broken when the CLI is installed but lists no models", () =>
     Effect.gen(function* () {
       const snapshot = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -284,10 +285,118 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
         }),
       );
 
-      expect(snapshot.status).toBe("error");
+      expect(snapshot.status).toBe("ready");
       expect(snapshot.installed).toBe(true);
       expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build"]);
-      expect(snapshot.message).toContain("ACP startup failed");
     }),
   );
+
+  it.effect("discovers models and auth from `grok models` instead of an ACP session", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-models-" });
+          const grokPath = path.join(dir, "grok");
+          yield* fs.writeFileString(
+            grokPath,
+            [
+              "#!/bin/sh",
+              'if [ "$1" = "--version" ]; then',
+              '  printf "grok 1.0.5\\n"',
+              "  exit 0",
+              "fi",
+              'if [ "$1" = "models" ]; then',
+              "  cat <<'EOF'",
+              "You are logged in with grok.com.",
+              "",
+              "Default model: grok-4.6",
+              "",
+              "Available models:",
+              "  * grok-4.6 (default)",
+              "  - grok-4.5",
+              "EOF",
+              "  exit 0",
+              "fi",
+              "exit 1",
+              "",
+            ].join("\n"),
+          );
+          yield* fs.chmod(grokPath, 0o755);
+
+          return yield* checkGrokProviderStatus(
+            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("ready");
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.version).toBe("1.0.5");
+      expect(snapshot.auth).toEqual({
+        status: "authenticated",
+        type: "cached_token",
+        label: "Grok Subscription",
+      });
+      expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-4.6", "grok-4.5"]);
+    }),
+  );
+
+  it.effect("warns instead of erroring when Grok is installed but not logged in", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-nologin-" });
+          const grokPath = path.join(dir, "grok");
+          yield* fs.writeFileString(
+            grokPath,
+            [
+              "#!/bin/sh",
+              'if [ "$1" = "--version" ]; then',
+              '  printf "grok 1.0.5\\n"',
+              "  exit 0",
+              "fi",
+              'printf "You are not logged in.\\nPlease run grok login.\\n"',
+              "exit 0",
+              "",
+            ].join("\n"),
+          );
+          yield* fs.chmod(grokPath, 0o755);
+
+          return yield* checkGrokProviderStatus(
+            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("warning");
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.auth.status).toBe("unauthenticated");
+      expect(snapshot.message).toContain("grok login");
+    }),
+  );
+});
+
+describe("parseGrokModelsCliOutput", () => {
+  it("reads login state and bullet model ids from grok models", () => {
+    const parsed = parseGrokModelsCliOutput(`You are logged in with grok.com.
+
+Default model: grok-4.6
+
+Available models:
+  * grok-4.6 (default)
+  - grok-4.5
+`);
+    expect(parsed.authenticated).toBe(true);
+    expect(parsed.models.map((model) => model.slug)).toEqual(["grok-4.6", "grok-4.5"]);
+  });
+
+  it("detects a logged-out CLI without treating it as a missing install", () => {
+    const parsed = parseGrokModelsCliOutput("You are not logged in.\nPlease run grok login.\n");
+    expect(parsed.authenticated).toBe(false);
+    expect(parsed.models).toEqual([]);
+  });
 });

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -2,14 +2,13 @@ import {
   type GrokSettings,
   type ModelCapabilities,
   type ServerProvider,
+  type ServerProviderAuth,
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
-import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import { HttpClient } from "effect/unstable/http";
@@ -18,6 +17,7 @@ import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
 import {
+  AUTH_PROBE_TIMEOUT_MS,
   buildServerProvider,
   isCommandMissingCause,
   parseGenericCliVersion,
@@ -31,7 +31,6 @@ import {
 } from "../providerMaintenance.ts";
 import {
   isValidGrokReasoningEffortToken,
-  makeGrokAcpRuntime,
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
 import { discoverGrokSkills } from "../Drivers/GrokSkills.ts";
@@ -46,7 +45,6 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
 });
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
-const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
@@ -201,54 +199,79 @@ export function buildGrokModelCapabilities(model: EffectAcpSchema.ModelInfo): Mo
     : EMPTY_CAPABILITIES;
 }
 
-function buildGrokDiscoveredModelsFromSessionModelState(
-  modelState: EffectAcpSchema.SessionModelState | null | undefined,
-): ReadonlyArray<ServerProviderModel> {
-  if (!modelState || modelState.availableModels.length === 0) {
-    return [];
-  }
+export function parseGrokModelsCliOutput(output: string): {
+  readonly authenticated: boolean | null;
+  readonly models: ReadonlyArray<ServerProviderModel>;
+} {
+  const authenticated = /you are logged in/i.test(output)
+    ? true
+    : /not logged in|please (?:run )?grok login|unauthenticated/i.test(output)
+      ? false
+      : null;
+
   const seen = new Set<string>();
-  return modelState.availableModels
-    .map((model): ServerProviderModel | undefined => {
-      const slug = resolveGrokAcpBaseModelId(model.modelId);
-      if (!slug || seen.has(slug)) {
-        return undefined;
-      }
-      seen.add(slug);
-      return {
-        slug,
-        name: model.name.trim() || slug,
-        isCustom: false,
-        capabilities: buildGrokModelCapabilities(model),
-      };
-    })
-    .filter((model): model is ServerProviderModel => model !== undefined);
+  const models: ServerProviderModel[] = [];
+  const addModel = (rawSlug: string) => {
+    const slug = resolveGrokAcpBaseModelId(rawSlug.replace(/[(),]/g, ""));
+    if (!slug || seen.has(slug)) {
+      return;
+    }
+    seen.add(slug);
+    models.push({
+      slug,
+      name: displayNameFromGrokModelSlug(slug),
+      isCustom: false,
+      capabilities: EMPTY_CAPABILITIES,
+    });
+  };
+
+  const defaultMatch = output.match(/^\s*Default model:\s+(\S+)/im);
+  if (defaultMatch?.[1]) {
+    addModel(defaultMatch[1]);
+  }
+  for (const line of output.split(/\r?\n/)) {
+    const bullet = line.match(/^\s*[*\-]\s+(\S+)/);
+    if (bullet?.[1]) {
+      addModel(bullet[1]);
+    }
+  }
+
+  return { authenticated, models };
 }
 
-const discoverGrokModelsViaAcp = (
-  grokSettings: GrokSettings,
-  environment: NodeJS.ProcessEnv = process.env,
-) =>
-  Effect.gen(function* () {
-    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const acp = yield* makeGrokAcpRuntime({
-      grokSettings,
-      environment,
-      childProcessSpawner,
-      cwd: process.cwd(),
-      clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
-    });
-    const started = yield* acp.start();
-    return buildGrokDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
-  }).pipe(Effect.scoped);
+function displayNameFromGrokModelSlug(slug: string): string {
+  return slug
+    .split(/[-_]/g)
+    .map((part) => (part.toLowerCase() === "grok" ? "Grok" : part))
+    .join(" ");
+}
 
-const runGrokVersionCommand = (
+function grokAuthFromModelsCli(authenticated: boolean | null): ServerProviderAuth {
+  if (authenticated === true) {
+    return {
+      status: "authenticated",
+      type: "cached_token",
+      label: "Grok Subscription",
+    };
+  }
+  if (authenticated === false) {
+    return {
+      status: "unauthenticated",
+      type: "cached_token",
+      label: "Grok Subscription",
+    };
+  }
+  return { status: "unknown" };
+}
+
+const runGrokCliCommand = (
   grokSettings: GrokSettings,
+  args: ReadonlyArray<string>,
   environment: NodeJS.ProcessEnv = process.env,
 ) =>
   Effect.gen(function* () {
     const command = grokSettings.binaryPath || "grok";
-    const spawnCommand = yield* resolveSpawnCommand(command, ["--version"], {
+    const spawnCommand = yield* resolveSpawnCommand(command, args, {
       env: environment,
     });
     return yield* spawnAndCollect(
@@ -264,11 +287,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
   cwd?: string,
-): Effect.fn.Return<
-  ServerProviderDraft,
-  never,
-  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
-> {
+): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
 
@@ -288,7 +307,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
-  const versionResult = yield* runGrokVersionCommand(grokSettings, environment).pipe(
+  const versionResult = yield* runGrokCliCommand(grokSettings, ["--version"], environment).pipe(
     Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
     Effect.result,
   );
@@ -356,13 +375,14 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
 
   const skills = yield* discoverGrokSkills(grokSettings, environment, cwd);
 
-  const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
-    Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
-    Effect.exit,
+  const modelsResult = yield* runGrokCliCommand(grokSettings, ["models"], environment).pipe(
+    Effect.timeoutOption(AUTH_PROBE_TIMEOUT_MS),
+    Effect.result,
   );
-  if (Exit.isFailure(discoveryExit)) {
-    yield* Effect.logWarning("Grok ACP model discovery failed", {
-      errorTag: causeErrorTag(discoveryExit.cause),
+
+  if (Result.isFailure(modelsResult)) {
+    yield* Effect.logWarning("Grok CLI model listing failed.", {
+      errorTag: modelsResult.failure._tag,
     });
     return buildServerProvider({
       presentation: GROK_PRESENTATION,
@@ -373,15 +393,16 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       probe: {
         installed: true,
         version,
-        status: "error",
+        status: "warning",
         auth: { status: "unknown" },
-        message: "Grok CLI is installed but ACP startup failed. Check server logs for details.",
+        message: "Grok CLI is installed but `grok models` failed. Chats may still work.",
       },
     });
   }
-  if (Option.isNone(discoveryExit.value)) {
+
+  if (Option.isNone(modelsResult.success)) {
     yield* Effect.logWarning(
-      `Grok ACP model discovery timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+      `Grok CLI model listing timed out after ${AUTH_PROBE_TIMEOUT_MS}ms.`,
     );
     return buildServerProvider({
       presentation: GROK_PRESENTATION,
@@ -392,17 +413,57 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       probe: {
         installed: true,
         version,
-        status: "error",
+        status: "warning",
         auth: { status: "unknown" },
-        message: `Grok CLI is installed but ACP startup timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+        message: `Grok CLI is installed but \`grok models\` timed out after ${AUTH_PROBE_TIMEOUT_MS}ms. Chats may still work.`,
       },
     });
   }
-  const discoveredModels = discoveryExit.value.value;
+
+  const modelsOutput = modelsResult.success.value;
+  if (modelsOutput.code !== 0) {
+    yield* Effect.logWarning("Grok CLI model listing exited with a non-zero status.", {
+      exitCode: modelsOutput.code,
+    });
+    return buildServerProvider({
+      presentation: GROK_PRESENTATION,
+      enabled: grokSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      skills,
+      probe: {
+        installed: true,
+        version,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Grok CLI is installed but `grok models` failed. Chats may still work.",
+      },
+    });
+  }
+
+  const parsedModels = parseGrokModelsCliOutput(`${modelsOutput.stdout}\n${modelsOutput.stderr}`);
   const models =
-    discoveredModels.length > 0
-      ? grokModelsFromSettings(grokSettings.customModels, discoveredModels)
+    parsedModels.models.length > 0
+      ? grokModelsFromSettings(grokSettings.customModels, parsedModels.models)
       : fallbackModels;
+  const auth = grokAuthFromModelsCli(parsedModels.authenticated);
+
+  if (auth.status === "unauthenticated") {
+    return buildServerProvider({
+      presentation: GROK_PRESENTATION,
+      enabled: grokSettings.enabled,
+      checkedAt,
+      models,
+      skills,
+      probe: {
+        installed: true,
+        version,
+        status: "warning",
+        auth,
+        message: "Grok CLI is installed but not logged in. Run `grok login`.",
+      },
+    });
+  }
 
   return buildServerProvider({
     presentation: GROK_PRESENTATION,
@@ -414,7 +475,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       installed: true,
       version,
       status: "ready",
-      auth: { status: "unknown" },
+      auth,
     },
   });
 });


### PR DESCRIPTION
Fixes #7746.

## What changed

Grok provider health no longer starts `grok agent stdio` + `session/new`.

It now:

1. Runs `grok --version` (unchanged).
2. Discovers skills via `grok inspect --json` (unchanged).
3. Runs `grok models` to get available models and login state.
4. Marks the provider **ready** when the CLI is installed and logged in.
5. Marks **warning** (not error) if model listing fails/times out, or if Grok is installed but not logged in.

## Why

The old probe created a full ACP session under a 15s deadline. `session/new` boots workspace skills/MCP for the current cwd. On a real machine that misses 15s, T3 writes `status: "error"` to `~/.t3/caches/grok.json` with `Grok CLI is installed but ACP startup timed out after 15000ms`, even while `grok --version` and `grok models` succeed in under a second.

This is a rebase of the approach in #7747 onto current main so skill discovery is kept.

## Tests

Adds coverage for:

- installed CLI with no model list stays **ready** (not error)
- `grok models` login + slugs become snapshot auth/models
- logged-out CLI is **warning** with `grok login` guidance
- `parseGrokModelsCliOutput` unit cases

Verified locally against Grok CLI 1.0.13: after this change the provider snapshot is `status: ready`, `auth.status: authenticated`, models `grok-4.6` / `grok-4.5`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Grok readiness is reported and which models appear in the UI snapshot; parsing depends on `grok models` text format, but chat still uses ACP separately.
> 
> **Overview**
> **Grok provider health checks no longer spin up an ACP session** (`grok agent stdio` + `session/new`) to discover models. That path often hit the old 15s deadline and cached `status: error` even when the CLI was fine.
> 
> `checkGrokProviderStatus` now runs **`grok models`** after `--version` and skill discovery. Output is parsed by new **`parseGrokModelsCliOutput`** for login state and model slugs; snapshot **auth** reflects logged-in vs logged-out (`warning` + `grok login` guidance).
> 
> **Model-list failures, timeouts, and non-zero exits are warnings** (with fallback models), not hard errors. An installed CLI with no parsed models stays **ready** with built-in `grok-build`. ACP-based model discovery and the `Crypto` dependency on the status effect are removed from this probe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07efb9a6c0cf7ab07f0b337a55891a4f5e57e4d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace ACP session model discovery with `grok models` CLI in `checkGrokProviderStatus`
> - Status check now runs `grok models` and parses output via `parseGrokModelsCliOutput` to get models and auth state instead of starting an ACP runtime
> - Installation without login yields `warning` with `auth=unauthenticated`; `grok models` failures/timeouts now report `warning` instead of `error` and preserve fallback models
> - Adds `runGrokCliCommand` helper to generalize CLI execution beyond `--version`, and `grokAuthFromModelsCli` to map parse results to `ServerProviderAuth`
> - Removes `discoverGrokModelsViaAcp`, `buildGrokDiscoveredModelsFromSessionModelState`, `GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS`, and `Crypto` from the effect environment
> - Behavioral Change: `checkGrokProviderStatus` returns `warning` (not `error`) for missing login or CLI failures, and sets `probe.auth` to `authenticated`/`unauthenticated` instead of `unknown`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 07efb9a. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->