### PR TITLE
feat(web): add expand/collapse all control to the files surface

### DIFF
--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -5,8 +5,8 @@ import type {
 import type { EnvironmentId, ProjectEntry } from "@t3tools/contracts";
 import { FileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
-import { RotateCw } from "lucide-react";
-import { useEffect, useMemo, useRef } from "react";
+import { ChevronsDownUpIcon, ChevronsUpDownIcon, RotateCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
 import { Button } from "~/components/ui/button";
 import { InputGroup, InputGroupInput } from "~/components/ui/input-group";
@@ -21,6 +21,7 @@ import { readLocalApi } from "~/localApi";
 import { T3_PIERRE_ICONS } from "~/pierre-icons";
 
 import { createFileTreeDragMentionController } from "./fileTreeDragMention";
+import { areAllDirectoriesExpanded, setAllDirectoriesExpanded } from "./fileTreeExpansion";
 import { useProjectEntriesQuery } from "./projectFilesQueryState";
 
 interface FileBrowserPanelProps {
@@ -121,6 +122,10 @@ export default function FileBrowserPanel({
   );
   const entryKindsRef = useRef<ReadonlyMap<string, ProjectEntry["kind"]>>(entryKinds);
   const treePaths = useMemo(() => entries.map(treePath), [entries]);
+  const directoryPaths = useMemo(
+    () => entries.filter((entry) => entry.kind === "directory").map(treePath),
+    [entries],
+  );
   const previousTreePathsRef = useRef<readonly string[]>([]);
   const syncingSelectionRef = useRef(false);
   const treeSelectionPathRef = useRef<string | null>(null);
@@ -252,6 +257,18 @@ export default function FileBrowserPanel({
     unsafeCSS: TREE_UNSAFE_CSS,
   });
   const search = useFileTreeSearch(model);
+  const subscribeToTree = useCallback(
+    (onStoreChange: () => void) => model.subscribe(onStoreChange),
+    [model],
+  );
+  const allDirectoriesExpanded = useSyncExternalStore(
+    subscribeToTree,
+    () => areAllDirectoriesExpanded(model, directoryPaths),
+    () => false,
+  );
+  const toggleAllDirectories = () => {
+    setAllDirectoriesExpanded(model, directoryPaths, !allDirectoriesExpanded);
+  };
   const handleSearchValueChange = (value: string) => {
     if (value.trim().length === 0) {
       search.close();
@@ -376,6 +393,32 @@ export default function FileBrowserPanel({
           onValueChange={handleSearchValueChange}
           onClose={search.close}
         />
+        {directoryPaths.length > 0 ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  aria-label={
+                    allDirectoriesExpanded ? "Collapse all folders" : "Expand all folders"
+                  }
+                  onClick={toggleAllDirectories}
+                />
+              }
+            >
+              {allDirectoriesExpanded ? (
+                <ChevronsDownUpIcon className="size-3.5" />
+              ) : (
+                <ChevronsUpDownIcon className="size-3.5" />
+              )}
+            </TooltipTrigger>
+            <TooltipPopup>
+              {allDirectoriesExpanded ? "Collapse all folders" : "Expand all folders"}
+            </TooltipPopup>
+          </Tooltip>
+        ) : null}
       </div>
       {entriesQuery.error && entriesQuery.data === null ? (
         <div className="p-4 text-xs leading-relaxed text-destructive">{entriesQuery.error}</div>

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -3,10 +3,10 @@ import type {
   ContextMenuOpenContext as TreeContextMenuOpenContext,
 } from "@pierre/trees";
 import type { EnvironmentId, ProjectEntry } from "@t3tools/contracts";
-import { FileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
+import { FileTree, useFileTree, useFileTreeSearch, useFileTreeSelector } from "@pierre/trees/react";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { ChevronsDownUpIcon, ChevronsUpDownIcon, RotateCw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { Button } from "~/components/ui/button";
 import { InputGroup, InputGroupInput } from "~/components/ui/input-group";
@@ -257,14 +257,8 @@ export default function FileBrowserPanel({
     unsafeCSS: TREE_UNSAFE_CSS,
   });
   const search = useFileTreeSearch(model);
-  const subscribeToTree = useCallback(
-    (onStoreChange: () => void) => model.subscribe(onStoreChange),
-    [model],
-  );
-  const allDirectoriesExpanded = useSyncExternalStore(
-    subscribeToTree,
-    () => areAllDirectoriesExpanded(model, directoryPaths),
-    () => false,
+  const allDirectoriesExpanded = useFileTreeSelector(model, (currentModel) =>
+    areAllDirectoriesExpanded(currentModel, directoryPaths),
   );
   const toggleAllDirectories = () => {
     setAllDirectoriesExpanded(model, directoryPaths, !allDirectoriesExpanded);

--- a/apps/web/src/components/files/fileTreeExpansion.test.ts
+++ b/apps/web/src/components/files/fileTreeExpansion.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { areAllDirectoriesExpanded, setAllDirectoriesExpanded } from "./fileTreeExpansion";
+
+function makeModel(expanded: Record<string, boolean>) {
+  return {
+    getItem: (path: string) => ({
+      isDirectory: () => true as const,
+      isExpanded: () => expanded[path] ?? false,
+      expand: () => {
+        expanded[path] = true;
+      },
+      collapse: () => {
+        expanded[path] = false;
+      },
+    }),
+  };
+}
+
+describe("file tree expansion", () => {
+  it("requires at least one directory and detects whether all are expanded", () => {
+    const model = makeModel({ "src/": true, "test/": true });
+    expect(areAllDirectoriesExpanded(model, [])).toBe(false);
+    expect(areAllDirectoriesExpanded(model, ["src/", "test/"])).toBe(true);
+    expect(
+      areAllDirectoriesExpanded(makeModel({ "src/": true, "test/": false }), ["src/", "test/"]),
+    ).toBe(false);
+  });
+
+  it("expands and collapses every directory", () => {
+    const expanded = { "src/": true, "test/": false };
+    const model = makeModel(expanded);
+    setAllDirectoriesExpanded(model, ["src/", "test/"], true);
+    expect(expanded).toEqual({ "src/": true, "test/": true });
+    setAllDirectoriesExpanded(model, ["src/", "test/"], false);
+    expect(expanded).toEqual({ "src/": false, "test/": false });
+  });
+
+  it("skips directories already at the requested state", () => {
+    const model = makeModel({ "src/": true });
+    const item = model.getItem("src/");
+    const collapse = vi.spyOn(item, "collapse");
+    setAllDirectoriesExpanded(model, ["src/"], true);
+    expect(collapse).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/files/fileTreeExpansion.test.ts
+++ b/apps/web/src/components/files/fileTreeExpansion.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
 
 import { areAllDirectoriesExpanded, setAllDirectoriesExpanded } from "./fileTreeExpansion";
 

--- a/apps/web/src/components/files/fileTreeExpansion.test.ts
+++ b/apps/web/src/components/files/fileTreeExpansion.test.ts
@@ -2,18 +2,32 @@ import { describe, expect, it, vi } from "@effect/vitest";
 
 import { areAllDirectoriesExpanded, setAllDirectoriesExpanded } from "./fileTreeExpansion";
 
+type FakeDirectoryItem = {
+  isDirectory: () => true;
+  isExpanded: () => boolean;
+  expand: () => void;
+  collapse: () => void;
+};
+
 function makeModel(expanded: Record<string, boolean>) {
+  const items = new Map<string, FakeDirectoryItem>();
   return {
-    getItem: (path: string) => ({
-      isDirectory: () => true as const,
-      isExpanded: () => expanded[path] ?? false,
-      expand: () => {
-        expanded[path] = true;
-      },
-      collapse: () => {
-        expanded[path] = false;
-      },
-    }),
+    getItem: (path: string) => {
+      const existing = items.get(path);
+      if (existing !== undefined) return existing;
+      const item: FakeDirectoryItem = {
+        isDirectory: () => true,
+        isExpanded: () => expanded[path] ?? false,
+        expand: () => {
+          expanded[path] = true;
+        },
+        collapse: () => {
+          expanded[path] = false;
+        },
+      };
+      items.set(path, item);
+      return item;
+    },
   };
 }
 

--- a/apps/web/src/components/files/fileTreeExpansion.ts
+++ b/apps/web/src/components/files/fileTreeExpansion.ts
@@ -1,0 +1,55 @@
+export interface FileTreeExpansionModel {
+  getItem(path: string): unknown;
+}
+
+type DirectoryHandle = {
+  isDirectory(): boolean;
+  isExpanded(): boolean;
+  expand(): void;
+  collapse(): void;
+};
+
+function asDirectoryHandle(item: unknown): DirectoryHandle | null {
+  if (
+    typeof item !== "object" ||
+    item === null ||
+    !("isDirectory" in item) ||
+    typeof item.isDirectory !== "function" ||
+    !item.isDirectory() ||
+    !("isExpanded" in item) ||
+    typeof item.isExpanded !== "function" ||
+    !("expand" in item) ||
+    typeof item.expand !== "function" ||
+    !("collapse" in item) ||
+    typeof item.collapse !== "function"
+  ) {
+    return null;
+  }
+  return item as DirectoryHandle;
+}
+
+export function areAllDirectoriesExpanded(
+  model: FileTreeExpansionModel,
+  directoryPaths: readonly string[],
+): boolean {
+  return (
+    directoryPaths.length > 0 &&
+    directoryPaths.every((path) => {
+      const item = asDirectoryHandle(model.getItem(path));
+      return item !== null && item.isExpanded();
+    })
+  );
+}
+
+export function setAllDirectoriesExpanded(
+  model: FileTreeExpansionModel,
+  directoryPaths: readonly string[],
+  expanded: boolean,
+): void {
+  for (const path of directoryPaths) {
+    const item = asDirectoryHandle(model.getItem(path));
+    if (item === null || item.isExpanded() === expanded) continue;
+    if (expanded) item.expand();
+    else item.collapse();
+  }
+}


### PR DESCRIPTION
Closes #6794 

## What Changed

Added a compact toolbar control to the files surface that expands or collapses all folders. The control uses the existing `ChevronsDownUp` and `ChevronsUpDown` icon convention and updates when folders are toggled individually.

## Why

The files surface initially opens folders and previously required users to collapse or expand folders one at a time. This provides a single, predictable control for managing the whole tree.

## UI Changes

The files toolbar now includes an accessible expand/collapse-all button with a tooltip. 

Before:
<img width="685" height="1078" alt="image" src="https://github.com/user-attachments/assets/300fa06c-67b1-4cf8-9f3c-daea8f447373" />

After:
<img width="721" height="1038" alt="image" src="https://github.com/user-attachments/assets/6a2a393c-eb9e-436e-822b-60902d5329f0" />
<img width="718" height="1039" alt="image" src="https://github.com/user-attachments/assets/000e5894-766c-411b-91ef-7a3a2feb4587" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only file tree toolbar behavior with small, tested helpers and no auth, data, or API changes.
> 
> **Overview**
> Adds a **expand/collapse all folders** control to the project files toolbar when the listing includes at least one directory. The button toggles every folder in the Pierre file tree, switches between chevron icons, and exposes matching **aria-label** and tooltip text based on whether all directories are currently expanded.
> 
> Bulk behavior lives in new **`fileTreeExpansion`** helpers that walk known directory paths on the tree model, skip non-directory or already-matching nodes, and report aggregate expanded state. **`FileBrowserPanel`** derives directory paths from project entries and subscribes to that state with **`useFileTreeSelector`** so the control stays in sync when folders are opened or closed individually. Unit tests cover empty lists, bulk expand/collapse, and no-op updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142d8dff911d07ea7348990d8be82cf49bd59d85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add expand/collapse all folders toggle to `FileBrowserPanel` toolbar
> - Adds a toolbar button in `FileBrowserPanel` that toggles all directories open or closed at once, with icon/tooltip/aria-label reflecting the current state.
> - Introduces `areAllDirectoriesExpanded` and `setAllDirectoriesExpanded` helpers in [fileTreeExpansion.ts](https://github.com/pingdotgg/t3code/pull/8889/files#diff-ce9b4be5a6d3fa9146f7ba2415cf73e8d316a11d737c3ee504318adbc9390466), operating over a minimal `FileTreeExpansionModel` and skipping items already in the desired state.
> - Adds unit tests covering both helpers in [fileTreeExpansion.test.ts](https://github.com/pingdotgg/t3code/pull/8889/files#diff-39ed02eb0254050d9fe84a5f82e16379e8121f5d609a06c083f9c2dc23fa58d8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 142d8df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->