### PR TITLE
fix(web): align composer notices and stash

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4983,16 +4983,9 @@ function ChatViewContent(props: ChatViewProps) {
       id: `thread-${isSnoozed ? "snoozed" : "settled"}:${activeThread?.id ?? "unknown"}`,
       variant: "info",
       icon: isSnoozed ? <AlarmClockIcon /> : <CheckCircle2Icon />,
-      title: isSnoozed ? (
-        "This thread is snoozed"
-      ) : (
-        <>
-          This thread is settled{" "}
-          <span className="font-normal text-muted-foreground">Send a message to unsettle</span>
-        </>
-      ),
+      title: `This thread is ${isSnoozed ? "snoozed" : "settled"}`,
       density: isSnoozed ? "compact" : "comfortable",
-      alignIconToFirstLineOnWrap: !isSnoozed,
+      inlineDescription: isSnoozed ? undefined : "Send a message to unsettle",
       description: isSnoozed
         ? "Sending a message wakes it and moves it back to Active in the sidebar."
         : undefined,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4981,10 +4981,18 @@ function ChatViewContent(props: ChatViewProps) {
       id: `thread-${isSnoozed ? "snoozed" : "settled"}:${activeThread?.id ?? "unknown"}`,
       variant: "info",
       icon: isSnoozed ? <AlarmClockIcon /> : <CheckCircle2Icon />,
-      title: `This thread is ${isSnoozed ? "snoozed" : "settled"}`,
+      title: isSnoozed ? (
+        "This thread is snoozed"
+      ) : (
+        <>
+          This thread is settled{" "}
+          <span className="font-normal text-muted-foreground">Send a message to unsettle</span>
+        </>
+      ),
       description: isSnoozed
         ? "Sending a message wakes it and moves it back to Active in the sidebar."
-        : "Sending a message moves it back to Active in the sidebar.",
+        : undefined,
+      className: cn(!isSnoozed && "[--composer-banner-padding-block:--spacing(1.25)]"),
       actions: (
         <Button
           size="xs"

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2248,6 +2248,7 @@ function ChatViewContent(props: ChatViewProps) {
             <>
               <Button
                 size="xs"
+                variant="ghost"
                 disabled={environmentReconnecting}
                 onClick={() =>
                   void handleReconnectActiveEnvironment(
@@ -2259,7 +2260,7 @@ function ChatViewContent(props: ChatViewProps) {
               </Button>
               <Button
                 size="xs"
-                variant="outline"
+                variant="ghost"
                 onClick={() => void navigate({ to: "/settings/connections" })}
               >
                 Connections
@@ -2329,6 +2330,7 @@ function ChatViewContent(props: ChatViewProps) {
               desktopAppUpdate={versionMismatchDesktopAppUpdate}
               targetVersion={versionMismatch.clientVersion}
               label={updateFailed ? "Retry" : "Update"}
+              variant="ghost"
             />
           ),
         ...(updateInProgress || (!updateFailed && !versionMismatchDismissKey)
@@ -4989,14 +4991,15 @@ function ChatViewContent(props: ChatViewProps) {
           <span className="font-normal text-muted-foreground">Send a message to unsettle</span>
         </>
       ),
+      density: isSnoozed ? "compact" : "comfortable",
+      alignIconToFirstLineOnWrap: !isSnoozed,
       description: isSnoozed
         ? "Sending a message wakes it and moves it back to Active in the sidebar."
         : undefined,
-      className: cn(!isSnoozed && "[--composer-banner-padding-block:--spacing(1.25)]"),
       actions: (
         <Button
           size="xs"
-          variant="outline"
+          variant="ghost"
           disabled={isSnoozed ? isUnsnoozing : isUnsettling}
           onClick={() =>
             void (isSnoozed ? handleUnsnoozeActiveThread() : handleUnsettleActiveThread())
@@ -5080,7 +5083,7 @@ function ChatViewContent(props: ChatViewProps) {
     const compactAction = (
       <Button
         size="xs"
-        variant="outline"
+        variant="ghost"
         disabled={compactDisabled}
         onClick={() => {
           if (compactDisabled) return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -24,10 +24,7 @@ import {
   RuntimeMode,
   TerminalOpenInput,
 } from "@t3tools/contracts";
-import {
-  connectionStatusTitle,
-  type EnvironmentConnectionPresentation,
-} from "@t3tools/client-runtime/connection";
+import { type EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
 import { wasBootstrapThreadDeleted } from "@t3tools/client-runtime/errors";
 import { type CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import { effectiveSnoozed, threadWokeAt } from "@t3tools/client-runtime/state/thread-settled";
@@ -2233,17 +2230,16 @@ function ChatViewContent(props: ChatViewProps) {
             />
           ),
           title: `${unavailableConnection.phase === "connecting" ? "Connecting" : "Reconnecting"} to ${activeEnvironmentUnavailableState.label}`,
-          description: "It may be finishing an update. One moment.",
+          description: "Finishing an update",
         });
       } else {
         items.push({
           id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
           variant: unavailableConnection.phase === "error" ? "error" : "warning",
           icon: <WifiOffIcon />,
-          title: `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(unavailableConnection)}`,
+          title: `${activeEnvironmentUnavailableState.label} is ${unavailableConnection.phase === "error" ? "offline" : "reconnecting"}`,
           description:
-            unavailableConnection.error ??
-            "Reconnect this environment before sending messages or running actions.",
+            unavailableConnection.phase === "error" ? "Reconnect to continue" : "Trying again",
           actions: (
             <>
               <Button
@@ -2311,13 +2307,10 @@ function ChatViewContent(props: ChatViewProps) {
         description:
           !updateInProgress &&
           !updateFailed &&
-          versionMismatchSelfUpdate === "desktop-managed" &&
-          !versionMismatchDesktopAppUpdate
-            ? serverUpdateGuidance(versionMismatchSelfUpdate, versionMismatchServerLabel)
+          versionMismatchSelfUpdate !== null &&
+          (versionMismatchSelfUpdate !== "desktop-managed" || !versionMismatchDesktopAppUpdate)
+            ? serverUpdateGuidance(versionMismatchSelfUpdate)
             : undefined,
-        // The desktop-managed guidance is already the description; the action
-        // slot would only repeat it. When the desktop app accepts remote
-        // update requests, the action button takes over instead.
         actions:
           updateInProgress ||
           !versionMismatch ||
@@ -4968,8 +4961,8 @@ function ChatViewContent(props: ChatViewProps) {
       id: `thread-woke:${activeThread?.id ?? "unknown"}`,
       variant: "info",
       icon: <AlarmClockIcon />,
-      title: "This thread woke from snooze",
-      description: "Dismiss to clear the Woke indicator, or send a message to keep going.",
+      title: "Thread woke from snooze",
+      description: "Send a message to continue",
       dismissLabel: "Dismiss Woke notification",
       onDismiss: acknowledgeActiveThreadWoke,
     };
@@ -4984,11 +4977,7 @@ function ChatViewContent(props: ChatViewProps) {
       variant: "info",
       icon: isSnoozed ? <AlarmClockIcon /> : <CheckCircle2Icon />,
       title: `This thread is ${isSnoozed ? "snoozed" : "settled"}`,
-      density: isSnoozed ? "compact" : "comfortable",
-      inlineDescription: isSnoozed ? undefined : "Send a message to unsettle",
-      description: isSnoozed
-        ? "Sending a message wakes it and moves it back to Active in the sidebar."
-        : undefined,
+      description: `Send a message to ${isSnoozed ? "wake" : "unsettle"}`,
       actions: (
         <Button
           size="xs"
@@ -5091,7 +5080,7 @@ function ChatViewContent(props: ChatViewProps) {
       variant: "info",
       icon: <Minimize2Icon />,
       title: "Resume with less context",
-      description: `${formatContextWindowTokens(activeContextWindow.usedTokens)} tokens from an older session`,
+      description: `${formatContextWindowTokens(activeContextWindow.usedTokens)} tokens from earlier`,
       actions: compactDisabledReason ? (
         <Tooltip>
           <TooltipTrigger render={<span className="inline-flex">{compactAction}</span>} />
@@ -5168,7 +5157,6 @@ function ChatViewContent(props: ChatViewProps) {
             </Tooltip>
           </span>
         ),
-        className: "dark:shadow-none",
         actions: (
           <Button
             size="xs"

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2237,9 +2237,8 @@ function ChatViewContent(props: ChatViewProps) {
           id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
           variant: unavailableConnection.phase === "error" ? "error" : "warning",
           icon: <WifiOffIcon />,
-          title: `${activeEnvironmentUnavailableState.label} is ${unavailableConnection.phase === "error" ? "offline" : "reconnecting"}`,
-          description:
-            unavailableConnection.phase === "error" ? "Reconnect to continue" : "Trying again",
+          title: `${activeEnvironmentUnavailableState.label} is ${environmentReconnecting ? "reconnecting" : "offline"}`,
+          description: environmentReconnecting ? "Trying again" : "Reconnect to continue",
           actions: (
             <>
               <Button

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -80,7 +80,7 @@ export function ServerUpdateAction({
   desktopAppUpdate = false,
   targetVersion,
   label = "Update",
-  variant,
+  variant = "outline",
 }: {
   readonly environmentId: EnvironmentId;
   readonly serverLabel: string;
@@ -173,11 +173,7 @@ export function ServerUpdateAction({
   if (selfUpdate === null) {
     const command = manualServerUpdateCommand(targetVersion);
     return (
-      <Button
-        size="xs"
-        variant={variant ?? "outline"}
-        onClick={() => copyToClipboard(command, { command })}
-      >
+      <Button size="xs" variant={variant} onClick={() => copyToClipboard(command, { command })}>
         Copy update command
       </Button>
     );

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -4,6 +4,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import type { ComponentProps } from "react";
 
 import { requestConfirmDialog } from "~/confirmDialog";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
@@ -79,6 +80,7 @@ export function ServerUpdateAction({
   desktopAppUpdate = false,
   targetVersion,
   label = "Update",
+  variant,
 }: {
   readonly environmentId: EnvironmentId;
   readonly serverLabel: string;
@@ -88,6 +90,7 @@ export function ServerUpdateAction({
   readonly desktopAppUpdate?: boolean;
   readonly targetVersion: string;
   readonly label?: string;
+  readonly variant?: ComponentProps<typeof Button>["variant"];
 }) {
   const isDesktopAppUpdate = selfUpdate === "desktop-managed";
   const updateServer = useAtomCommand(serverEnvironment.updateServer, {
@@ -170,14 +173,18 @@ export function ServerUpdateAction({
   if (selfUpdate === null) {
     const command = manualServerUpdateCommand(targetVersion);
     return (
-      <Button size="xs" variant="outline" onClick={() => copyToClipboard(command, { command })}>
+      <Button
+        size="xs"
+        variant={variant ?? "outline"}
+        onClick={() => copyToClipboard(command, { command })}
+      >
         Copy update command
       </Button>
     );
   }
 
   return (
-    <Button size="xs" variant="outline" onClick={() => void handleUpdate()}>
+    <Button size="xs" variant={variant} onClick={() => void handleUpdate()}>
       {label}
     </Button>
   );

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -246,7 +246,7 @@ function Actions({ className, ...props }: ComponentProps<"span">) {
       data-slot="composer-banner-actions"
       className={cn(
         "col-start-3 row-start-1 flex flex-wrap items-center justify-end gap-1",
-        "@max-[400px]:has-[>:nth-child(2)]:col-start-2 @max-[400px]:has-[>:nth-child(2)]:col-end-4 @max-[400px]:has-[>:nth-child(2)]:row-start-2 @max-[400px]:has-[>:nth-child(2)]:-ms-2 @max-[400px]:has-[>:nth-child(2)]:justify-start",
+        "@max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:col-start-2 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:col-end-4 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:row-start-2 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:-ms-2 @max-[400px]:group-data-[composer-banner-layout=wrap-actions]/banner-row:has-[>:nth-child(2)]:justify-start",
         className,
       )}
       {...props}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -246,7 +246,7 @@ function Actions({ className, ...props }: ComponentProps<"span">) {
       data-slot="composer-banner-actions"
       className={cn(
         "col-start-3 row-start-1 flex flex-wrap items-center justify-end gap-1",
-        "@max-[400px]:has-[>:nth-child(2)]:col-start-2 @max-[400px]:has-[>:nth-child(2)]:col-end-4 @max-[400px]:has-[>:nth-child(2)]:row-start-2 @max-[400px]:has-[>:nth-child(2)]:justify-start",
+        "@max-[400px]:has-[>:nth-child(2)]:col-start-2 @max-[400px]:has-[>:nth-child(2)]:col-end-4 @max-[400px]:has-[>:nth-child(2)]:row-start-2 @max-[400px]:has-[>:nth-child(2)]:-ms-2 @max-[400px]:has-[>:nth-child(2)]:justify-start",
         className,
       )}
       {...props}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -149,7 +149,7 @@ function Root({
   width = "fill",
   ...props
 }: ComponentProps<"div"> & {
-  density?: "default" | "compact";
+  density?: "default" | "compact" | "comfortable";
   placement?: "attached" | "floating";
   variant?: ComposerBannerVariant;
   width?: "fill" | "content";
@@ -160,6 +160,7 @@ function Root({
         "min-w-0 px-1 pt-(--composer-banner-padding-block) pb-[calc(var(--chat-composer-attachment-overlap)+var(--composer-banner-padding-block))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] [--composer-banner-padding-block:--spacing(1)] sm:[--composer-banner-icon-column:--spacing(6)]",
         density === "compact" &&
           "[--composer-banner-padding-block:--spacing(0.75)] sm:[--composer-banner-padding-block:--spacing(0.25)]",
+        density === "comfortable" && "[--composer-banner-padding-block:--spacing(1.25)]",
         width === "content" ? "w-fit max-w-full flex-none" : "@container",
         className,
       )}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -186,7 +186,7 @@ function Row({
       "not-has-[>[data-slot=composer-banner-actions]]:grid-cols-[var(--composer-banner-icon-column)_minmax(0,1fr)]",
       "[&:is(button)]:cursor-pointer [&:is(button)]:rounded-[0.5rem] [&:is(button)]:focus-visible:outline-2 [&:is(button)]:focus-visible:-outline-offset-2 [&:is(button)]:focus-visible:outline-ring",
       layout === "wrap-actions" &&
-        "@max-[400px]:flex @max-[400px]:flex-wrap @max-[400px]:gap-y-1 @max-[400px]:*:data-[slot=composer-banner-actions]:ms-auto @max-[400px]:*:data-[slot=composer-banner-actions]:max-w-full @max-[400px]:has-[>[data-slot=composer-banner-icon]]:*:data-[slot=composer-banner-actions]:max-w-[calc(100%-var(--composer-banner-icon-column)-(--spacing(1)))] @max-[400px]:*:data-[slot=composer-banner-content]:min-h-(--composer-banner-icon-column) @max-[400px]:*:data-[slot=composer-banner-content]:flex-[1_1_10rem]",
+        "@max-[400px]:*:data-[slot=composer-banner-content]:min-h-(--composer-banner-icon-column)",
       className,
     ),
     "data-composer-banner-row": "true",
@@ -246,6 +246,7 @@ function Actions({ className, ...props }: ComponentProps<"span">) {
       data-slot="composer-banner-actions"
       className={cn(
         "col-start-3 row-start-1 flex flex-wrap items-center justify-end gap-1",
+        "@max-[400px]:has-[>:nth-child(2)]:col-start-2 @max-[400px]:has-[>:nth-child(2)]:col-end-4 @max-[400px]:has-[>:nth-child(2)]:row-start-2 @max-[400px]:has-[>:nth-child(2)]:justify-start",
         className,
       )}
       {...props}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -157,9 +157,9 @@ function Root({
   return (
     <Surface
       className={cn(
-        "min-w-0 px-3 pt-(--composer-banner-padding-block) pb-[calc(var(--chat-composer-attachment-overlap)+var(--composer-banner-padding-block))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] [--composer-banner-padding-block:--spacing(2)] sm:px-4 sm:[--composer-banner-icon-column:--spacing(6)]",
+        "min-w-0 px-1 pt-(--composer-banner-padding-block) pb-[calc(var(--chat-composer-attachment-overlap)+var(--composer-banner-padding-block))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] [--composer-banner-padding-block:--spacing(1)] sm:[--composer-banner-icon-column:--spacing(6)]",
         density === "compact" &&
-          "[--composer-banner-padding-block:5px] sm:[--composer-banner-padding-block:3px]",
+          "[--composer-banner-padding-block:--spacing(0.5)] sm:[--composer-banner-padding-block:0px]",
         width === "content" ? "w-fit max-w-full flex-none" : "@container",
         className,
       )}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -155,7 +155,7 @@ function Root({
   return (
     <Surface
       className={cn(
-        "min-w-0 px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)+(--spacing(1)))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] sm:px-4 sm:[--composer-banner-icon-column:--spacing(6)]",
+        "min-w-0 px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)+(--spacing(2)))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] sm:px-4 sm:[--composer-banner-icon-column:--spacing(6)]",
         width === "content" ? "w-fit max-w-full flex-none" : "@container",
         className,
       )}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -149,7 +149,7 @@ function Root({
   width = "fill",
   ...props
 }: ComponentProps<"div"> & {
-  density?: "default" | "compact" | "comfortable";
+  density?: "default" | "comfortable";
   placement?: "attached" | "floating";
   variant?: ComposerBannerVariant;
   width?: "fill" | "content";
@@ -158,8 +158,6 @@ function Root({
     <Surface
       className={cn(
         "min-w-0 px-1 pt-(--composer-banner-padding-block) pb-[calc(var(--chat-composer-attachment-overlap)+var(--composer-banner-padding-block))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] [--composer-banner-padding-block:--spacing(1)] sm:[--composer-banner-icon-column:--spacing(6)]",
-        density === "compact" &&
-          "[--composer-banner-padding-block:--spacing(0.75)] sm:[--composer-banner-padding-block:--spacing(0.25)]",
         density === "comfortable" && "[--composer-banner-padding-block:--spacing(1.25)]",
         width === "content" ? "w-fit max-w-full flex-none" : "@container",
         className,

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -155,7 +155,7 @@ function Root({
   return (
     <Surface
       className={cn(
-        "min-w-0 p-1 pb-[calc(var(--chat-composer-attachment-overlap)+(--spacing(1)))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] sm:[--composer-banner-icon-column:--spacing(6)]",
+        "min-w-0 px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)+(--spacing(1)))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] sm:px-4 sm:[--composer-banner-icon-column:--spacing(6)]",
         width === "content" ? "w-fit max-w-full flex-none" : "@container",
         className,
       )}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -143,11 +143,13 @@ function Column({ className, ...props }: ComponentProps<"div">) {
 
 function Root({
   className,
+  density = "default",
   placement = "attached",
   variant = "default",
   width = "fill",
   ...props
 }: ComponentProps<"div"> & {
+  density?: "default" | "compact";
   placement?: "attached" | "floating";
   variant?: ComposerBannerVariant;
   width?: "fill" | "content";
@@ -155,7 +157,9 @@ function Root({
   return (
     <Surface
       className={cn(
-        "min-w-0 px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)+(--spacing(2)))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] sm:px-4 sm:[--composer-banner-icon-column:--spacing(6)]",
+        "min-w-0 px-3 pt-(--composer-banner-padding-block) pb-[calc(var(--chat-composer-attachment-overlap)+var(--composer-banner-padding-block))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] [--composer-banner-padding-block:--spacing(2)] sm:px-4 sm:[--composer-banner-icon-column:--spacing(6)]",
+        density === "compact" &&
+          "[--composer-banner-padding-block:5px] sm:[--composer-banner-padding-block:3px]",
         width === "content" ? "w-fit max-w-full flex-none" : "@container",
         className,
       )}

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -159,7 +159,7 @@ function Root({
       className={cn(
         "min-w-0 px-1 pt-(--composer-banner-padding-block) pb-[calc(var(--chat-composer-attachment-overlap)+var(--composer-banner-padding-block))] text-xs/4 [--composer-banner-icon-column:--spacing(7)] [--composer-banner-padding-block:--spacing(1)] sm:[--composer-banner-icon-column:--spacing(6)]",
         density === "compact" &&
-          "[--composer-banner-padding-block:--spacing(0.5)] sm:[--composer-banner-padding-block:0px]",
+          "[--composer-banner-padding-block:--spacing(0.75)] sm:[--composer-banner-padding-block:--spacing(0.25)]",
         width === "content" ? "w-fit max-w-full flex-none" : "@container",
         className,
       )}

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -270,8 +270,15 @@ function ComposerBannerStackAlert({
         <ComposerBanner.Icon className="h-(--composer-banner-icon-column) self-start">
           {item.icon}
         </ComposerBanner.Icon>
-        <ComposerBanner.Content className="overflow-hidden whitespace-nowrap">
-          <span className="min-w-0 truncate font-medium leading-7 sm:leading-6">{item.title}</span>
+        <ComposerBanner.Content className="whitespace-nowrap">
+          <span
+            className={cn(
+              "min-w-0 font-medium leading-7 sm:leading-6",
+              typeof item.title === "string" && "truncate",
+            )}
+          >
+            {item.title}
+          </span>
           {item.description ? (
             <span className="min-w-0 shrink-[9999] truncate text-muted-foreground">
               {item.description}

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -266,10 +266,8 @@ function ComposerBannerStackAlert({
       role="alert"
       placement={attached ? "attached" : "floating"}
       variant={item.variant}
-      className={cn(
-        item.description && "pt-[3px] pb-[calc(var(--chat-composer-attachment-overlap)+3px)]",
-        item.className,
-      )}
+      density={item.description ? "compact" : "default"}
+      className={item.className}
     >
       <ComposerBanner.Row layout="wrap-actions">
         <ComposerBanner.Icon className={item.description ? "h-lh self-start" : undefined}>

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -267,14 +267,14 @@ function ComposerBannerStackAlert({
       placement={attached ? "attached" : "floating"}
       variant={item.variant}
       density={item.description ? "compact" : "default"}
-      className={item.className}
+      className={cn("px-3 sm:px-4", item.className)}
     >
       <ComposerBanner.Row layout="wrap-actions">
         <ComposerBanner.Icon className={item.description ? "h-lh self-start" : undefined}>
           {item.icon}
         </ComposerBanner.Icon>
         <ComposerBanner.Content
-          className={item.description ? "flex-col items-start gap-0.5" : undefined}
+          className={item.description ? "flex-col items-start gap-0" : undefined}
         >
           <span className="w-full min-w-0 font-medium">{item.title}</span>
           {item.description ? (

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -1,6 +1,8 @@
+import { InfoIcon } from "lucide-react";
 import { useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
 import { cn } from "~/lib/utils";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ComposerBanner, type ComposerBannerVariant } from "./ComposerBanner";
 
 // Match the duration-220 exit transition before removing a dismissed notice.
@@ -280,9 +282,27 @@ function ComposerBannerStackAlert({
             {item.title}
           </span>
           {item.description ? (
-            <span className="min-w-0 shrink-[9999] truncate text-muted-foreground">
-              {item.description}
-            </span>
+            <>
+              <span className="min-w-0 shrink-[9999] truncate text-muted-foreground @max-[400px]:hidden">
+                {item.description}
+              </span>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-label="Show notice details"
+                      className="hidden size-6 flex-none items-center justify-center rounded-md text-muted-foreground hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring @max-[400px]:inline-flex"
+                    >
+                      <InfoIcon className="size-3.5" />
+                    </button>
+                  }
+                />
+                <TooltipPopup side="top" className="max-w-72 whitespace-normal text-pretty">
+                  {item.description}
+                </TooltipPopup>
+              </Tooltip>
+            </>
           ) : null}
         </ComposerBanner.Content>
         {item.actions || item.onDismiss ? (

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -266,7 +266,10 @@ function ComposerBannerStackAlert({
       role="alert"
       placement={attached ? "attached" : "floating"}
       variant={item.variant}
-      className={item.className}
+      className={cn(
+        item.description && "pt-[3px] pb-[calc(var(--chat-composer-attachment-overlap)+3px)]",
+        item.className,
+      )}
     >
       <ComposerBanner.Row layout="wrap-actions">
         <ComposerBanner.Icon className={item.description ? "h-lh self-start" : undefined}>

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -12,6 +12,8 @@ export interface ComposerBannerStackItem {
   readonly priority?: "urgent" | "activity" | "notice";
   readonly icon: ReactNode;
   readonly title: ReactNode;
+  readonly density?: "default" | "compact" | "comfortable";
+  readonly alignIconToFirstLineOnWrap?: boolean;
   readonly description?: ReactNode;
   readonly children?: ReactNode;
   readonly actions?: ReactNode;
@@ -254,7 +256,7 @@ function ComposerBannerStackAlert({
       <ComposerBanner.Root
         placement={attached ? "attached" : "floating"}
         variant={item.variant}
-        className={cn("px-3 sm:px-4", item.className)}
+        className={item.className}
       >
         {item.content}
       </ComposerBanner.Root>
@@ -266,11 +268,19 @@ function ComposerBannerStackAlert({
       role="alert"
       placement={attached ? "attached" : "floating"}
       variant={item.variant}
-      density={item.description ? "compact" : "default"}
-      className={cn("px-3 sm:px-4", item.className)}
+      density={item.density ?? (item.description ? "compact" : "default")}
+      className={item.className}
     >
       <ComposerBanner.Row layout="wrap-actions">
-        <ComposerBanner.Icon className={item.description ? "h-lh self-start" : undefined}>
+        <ComposerBanner.Icon
+          className={
+            item.description
+              ? "h-lh self-start"
+              : item.alignIconToFirstLineOnWrap
+                ? "@max-[400px]:h-lh @max-[400px]:self-start"
+                : undefined
+          }
+        >
           {item.icon}
         </ComposerBanner.Icon>
         <ComposerBanner.Content

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -269,7 +269,9 @@ function ComposerBannerStackAlert({
       className={item.className}
     >
       <ComposerBanner.Row layout="wrap-actions">
-        <ComposerBanner.Icon className="h-lh self-start">{item.icon}</ComposerBanner.Icon>
+        <ComposerBanner.Icon className={item.description ? "h-lh self-start" : undefined}>
+          {item.icon}
+        </ComposerBanner.Icon>
         <ComposerBanner.Content className="flex-col items-start gap-0.5">
           <span className="w-full min-w-0 font-medium">{item.title}</span>
           {item.description ? (

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -273,7 +273,9 @@ function ComposerBannerStackAlert({
         <ComposerBanner.Content className="overflow-hidden whitespace-nowrap">
           <span className="min-w-0 truncate font-medium leading-7 sm:leading-6">{item.title}</span>
           {item.description ? (
-            <span className="min-w-0 truncate text-muted-foreground">{item.description}</span>
+            <span className="min-w-0 shrink-[9999] truncate text-muted-foreground">
+              {item.description}
+            </span>
           ) : null}
         </ComposerBanner.Content>
         {item.actions || item.onDismiss ? (

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -287,10 +287,15 @@ function ComposerBannerStackAlert({
         <ComposerBanner.Content
           className={cn(
             item.description && "flex-col items-start gap-0",
-            hasInlineDescription && "flex-wrap gap-y-0 leading-7 sm:leading-6",
+            hasInlineDescription && "flex-wrap gap-y-0",
           )}
         >
-          <span className={cn("min-w-0 font-medium", !hasInlineDescription && "w-full")}>
+          <span
+            className={cn(
+              "min-w-0 font-medium",
+              hasInlineDescription ? "leading-7 sm:leading-6" : "w-full",
+            )}
+          >
             {item.title}
           </span>
           {hasInlineDescription ? " " : null}

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -12,19 +12,16 @@ export interface ComposerBannerStackItem {
   readonly priority?: "urgent" | "activity" | "notice";
   readonly icon: ReactNode;
   readonly title: ReactNode;
-  readonly density?: "default" | "compact" | "comfortable";
-  readonly inlineDescription?: ReactNode;
   readonly description?: ReactNode;
   readonly children?: ReactNode;
   readonly actions?: ReactNode;
-  readonly className?: string;
   readonly dismissLabel?: string;
   readonly onDismiss?: () => void;
 }
 
 export type ComposerBannerStackContent = Pick<
   ComposerBannerStackItem,
-  "id" | "variant" | "priority" | "className"
+  "id" | "variant" | "priority"
 > & { readonly content: ReactNode };
 
 type ComposerBannerStackEntry = ComposerBannerStackItem | ComposerBannerStackContent;
@@ -254,56 +251,29 @@ function ComposerBannerStackAlert({
   if ("content" in item) {
     return (
       <ComposerBanner.Root
+        density="comfortable"
         placement={attached ? "attached" : "floating"}
         variant={item.variant}
-        className={item.className}
       >
         {item.content}
       </ComposerBanner.Root>
     );
   }
-  const hasInlineDescription = item.inlineDescription !== undefined;
-
   return (
     <ComposerBanner.Root
       role="alert"
       placement={attached ? "attached" : "floating"}
       variant={item.variant}
-      density={item.density ?? (item.description ? "compact" : "default")}
-      className={item.className}
+      density="comfortable"
     >
       <ComposerBanner.Row layout="wrap-actions">
-        <ComposerBanner.Icon
-          className={
-            item.description
-              ? "h-lh self-start"
-              : hasInlineDescription
-                ? "h-(--composer-banner-icon-column) self-start"
-                : undefined
-          }
-        >
+        <ComposerBanner.Icon className="h-(--composer-banner-icon-column) self-start">
           {item.icon}
         </ComposerBanner.Icon>
-        <ComposerBanner.Content
-          className={cn(
-            item.description && "flex-col items-start gap-0",
-            hasInlineDescription && "flex-wrap gap-y-0",
-          )}
-        >
-          <span
-            className={cn(
-              "min-w-0 font-medium",
-              hasInlineDescription ? "leading-7 sm:leading-6" : "w-full",
-            )}
-          >
-            {item.title}
-          </span>
-          {hasInlineDescription ? " " : null}
-          {hasInlineDescription ? (
-            <span className="min-w-0 text-muted-foreground">{item.inlineDescription}</span>
-          ) : null}
+        <ComposerBanner.Content className="overflow-hidden whitespace-nowrap">
+          <span className="min-w-0 truncate font-medium leading-7 sm:leading-6">{item.title}</span>
           {item.description ? (
-            <span className="text-muted-foreground">{item.description}</span>
+            <span className="min-w-0 truncate text-muted-foreground">{item.description}</span>
           ) : null}
         </ComposerBanner.Content>
         {item.actions || item.onDismiss ? (

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -2,7 +2,8 @@ import { InfoIcon } from "lucide-react";
 import { useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
 import { cn } from "~/lib/utils";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { Button } from "../ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { ComposerBanner, type ComposerBannerVariant } from "./ComposerBanner";
 
 // Match the duration-220 exit transition before removing a dismissed notice.
@@ -283,25 +284,31 @@ function ComposerBannerStackAlert({
           </span>
           {item.description ? (
             <>
-              <span className="min-w-0 shrink-[9999] truncate text-muted-foreground @max-[400px]:hidden">
+              <span className="min-w-0 shrink-[9999] truncate text-muted-foreground @max-[400px]:sr-only">
                 {item.description}
               </span>
-              <Tooltip>
-                <TooltipTrigger
+              <Popover>
+                <PopoverTrigger
+                  openOnHover
                   render={
-                    <button
-                      type="button"
+                    <Button
+                      size="icon-xs"
+                      variant="ghost"
                       aria-label="Show notice details"
-                      className="hidden size-6 flex-none items-center justify-center rounded-md text-muted-foreground hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring @max-[400px]:inline-flex"
-                    >
-                      <InfoIcon className="size-3.5" />
-                    </button>
+                      className="hidden flex-none text-muted-foreground hover:text-foreground @max-[400px]:inline-flex"
+                    />
                   }
-                />
-                <TooltipPopup side="top" className="max-w-72 whitespace-normal text-pretty">
+                >
+                  <InfoIcon className="size-3.5" />
+                </PopoverTrigger>
+                <PopoverPopup
+                  tooltipStyle
+                  side="top"
+                  className="max-w-72 whitespace-normal text-pretty"
+                >
                   {item.description}
-                </TooltipPopup>
-              </Tooltip>
+                </PopoverPopup>
+              </Popover>
             </>
           ) : null}
         </ComposerBanner.Content>

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -269,20 +269,12 @@ function ComposerBannerStackAlert({
       className={item.className}
     >
       <ComposerBanner.Row layout="wrap-actions">
-        <ComposerBanner.Icon className={item.description ? "min-h-4 self-start" : undefined}>
-          {item.icon}
-        </ComposerBanner.Icon>
-        <ComposerBanner.Content
-          className={item.description ? "flex-col items-start gap-0" : "font-medium"}
-        >
+        <ComposerBanner.Icon>{item.icon}</ComposerBanner.Icon>
+        <ComposerBanner.Content className="flex-col items-start gap-0.5">
+          <span className="w-full min-w-0 font-medium">{item.title}</span>
           {item.description ? (
-            <>
-              <span className="font-medium">{item.title}</span>
-              <span className="text-muted-foreground">{item.description}</span>
-            </>
-          ) : (
-            item.title
-          )}
+            <span className="text-muted-foreground">{item.description}</span>
+          ) : null}
         </ComposerBanner.Content>
         {item.actions || item.onDismiss ? (
           <ComposerBanner.Actions>

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -254,7 +254,7 @@ function ComposerBannerStackAlert({
       <ComposerBanner.Root
         placement={attached ? "attached" : "floating"}
         variant={item.variant}
-        className={item.className}
+        className={cn("px-3 sm:px-4", item.className)}
       >
         {item.content}
       </ComposerBanner.Root>

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -13,7 +13,7 @@ export interface ComposerBannerStackItem {
   readonly icon: ReactNode;
   readonly title: ReactNode;
   readonly density?: "default" | "compact" | "comfortable";
-  readonly alignIconToFirstLineOnWrap?: boolean;
+  readonly inlineDescription?: ReactNode;
   readonly description?: ReactNode;
   readonly children?: ReactNode;
   readonly actions?: ReactNode;
@@ -262,6 +262,7 @@ function ComposerBannerStackAlert({
       </ComposerBanner.Root>
     );
   }
+  const hasInlineDescription = item.inlineDescription !== undefined;
 
   return (
     <ComposerBanner.Root
@@ -276,17 +277,26 @@ function ComposerBannerStackAlert({
           className={
             item.description
               ? "h-lh self-start"
-              : item.alignIconToFirstLineOnWrap
-                ? "@max-[400px]:h-lh @max-[400px]:self-start"
+              : hasInlineDescription
+                ? "h-(--composer-banner-icon-column) self-start"
                 : undefined
           }
         >
           {item.icon}
         </ComposerBanner.Icon>
         <ComposerBanner.Content
-          className={item.description ? "flex-col items-start gap-0" : undefined}
+          className={cn(
+            item.description && "flex-col items-start gap-0",
+            hasInlineDescription && "flex-wrap gap-y-0 leading-7 sm:leading-6",
+          )}
         >
-          <span className="w-full min-w-0 font-medium">{item.title}</span>
+          <span className={cn("min-w-0 font-medium", !hasInlineDescription && "w-full")}>
+            {item.title}
+          </span>
+          {hasInlineDescription ? " " : null}
+          {hasInlineDescription ? (
+            <span className="min-w-0 text-muted-foreground">{item.inlineDescription}</span>
+          ) : null}
           {item.description ? (
             <span className="text-muted-foreground">{item.description}</span>
           ) : null}

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -269,7 +269,7 @@ function ComposerBannerStackAlert({
       className={item.className}
     >
       <ComposerBanner.Row layout="wrap-actions">
-        <ComposerBanner.Icon>{item.icon}</ComposerBanner.Icon>
+        <ComposerBanner.Icon className="h-lh self-start">{item.icon}</ComposerBanner.Icon>
         <ComposerBanner.Content className="flex-col items-start gap-0.5">
           <span className="w-full min-w-0 font-medium">{item.title}</span>
           {item.description ? (

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -272,7 +272,9 @@ function ComposerBannerStackAlert({
         <ComposerBanner.Icon className={item.description ? "h-lh self-start" : undefined}>
           {item.icon}
         </ComposerBanner.Icon>
-        <ComposerBanner.Content className="flex-col items-start gap-0.5">
+        <ComposerBanner.Content
+          className={item.description ? "flex-col items-start gap-0.5" : undefined}
+        >
           <span className="w-full min-w-0 font-medium">{item.title}</span>
           {item.description ? (
             <span className="text-muted-foreground">{item.description}</span>

--- a/apps/web/src/components/chat/ComposerStashBadge.tsx
+++ b/apps/web/src/components/chat/ComposerStashBadge.tsx
@@ -35,9 +35,10 @@ export const ComposerStashBadge = memo(function ComposerStashBadge(props: {
 
   return (
     <ComposerBanner.Root
+      density="comfortable"
       width="content"
       data-composer-shoulder-tab
-      className="ml-auto [--composer-banner-padding-block:--spacing(1.25)]"
+      className="ml-auto"
     >
       <ComposerBanner.Row
         render={<button type="button" />}

--- a/apps/web/src/components/chat/ComposerStashBadge.tsx
+++ b/apps/web/src/components/chat/ComposerStashBadge.tsx
@@ -34,7 +34,11 @@ export const ComposerStashBadge = memo(function ComposerStashBadge(props: {
   );
 
   return (
-    <ComposerBanner.Root width="content" data-composer-shoulder-tab className="ml-auto">
+    <ComposerBanner.Root
+      width="content"
+      data-composer-shoulder-tab
+      className="ml-auto [--composer-banner-padding-block:--spacing(1.25)]"
+    >
       <ComposerBanner.Row
         render={<button type="button" />}
         data-prompt-stash-badge="true"

--- a/apps/web/src/components/chat/ComposerTasksBadge.tsx
+++ b/apps/web/src/components/chat/ComposerTasksBadge.tsx
@@ -123,7 +123,9 @@ export const ComposerTasksBadge = memo(function ComposerTasksBadge({
   return placement === "inline" ? (
     row
   ) : (
-    <ComposerBanner.Root data-composer-shoulder-tab>{row}</ComposerBanner.Root>
+    <ComposerBanner.Root density="comfortable" data-composer-shoulder-tab>
+      {row}
+    </ComposerBanner.Root>
   );
 });
 

--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -215,14 +215,8 @@ describe("versionSkew", () => {
   });
 
   it("matches version-drift guidance to the advertised update path", () => {
-    expect(serverUpdateGuidance("respawn", "Remote server")).toBe(
-      "Update the Remote server so they stay in sync.",
-    );
-    expect(serverUpdateGuidance("desktop-managed", "Desktop server")).toBe(
-      "Update the desktop app that runs the Desktop server.",
-    );
-    expect(serverUpdateGuidance(null, "Local server")).toBe(
-      "Relaunch the Local server with the copied command to sync them.",
-    );
+    expect(serverUpdateGuidance("respawn")).toBe("Update to stay in sync");
+    expect(serverUpdateGuidance("desktop-managed")).toBe("Update the desktop app");
+    expect(serverUpdateGuidance(null)).toBe("Copy the update command");
   });
 });

--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -217,6 +217,5 @@ describe("versionSkew", () => {
   it("matches version-drift guidance to the advertised update path", () => {
     expect(serverUpdateGuidance("respawn")).toBe("Update to stay in sync");
     expect(serverUpdateGuidance("desktop-managed")).toBe("Update the desktop app");
-    expect(serverUpdateGuidance(null)).toBe("Copy the update command");
   });
 });

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -111,20 +111,15 @@ export function manualServerUpdateCommand(targetVersion: string): string {
   return `npx t3@${targetVersion}`;
 }
 
-/** One sentence telling the user how to resolve version skew for a server,
-    matched to the update path it offers. */
-export function serverUpdateGuidance(
-  capability: ServerSelfUpdateCapability | null,
-  serverLabel: string,
-): string {
+export function serverUpdateGuidance(capability: ServerSelfUpdateCapability | null): string {
   switch (capability) {
     case "boot-service":
     case "respawn":
-      return `Update the ${serverLabel} so they stay in sync.`;
+      return "Update to stay in sync";
     case "desktop-managed":
-      return `Update the desktop app that runs the ${serverLabel}.`;
+      return "Update the desktop app";
     default:
-      return `Relaunch the ${serverLabel} with the copied command to sync them.`;
+      return "Copy the update command";
   }
 }
 

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -111,16 +111,8 @@ export function manualServerUpdateCommand(targetVersion: string): string {
   return `npx t3@${targetVersion}`;
 }
 
-export function serverUpdateGuidance(capability: ServerSelfUpdateCapability | null): string {
-  switch (capability) {
-    case "boot-service":
-    case "respawn":
-      return "Update to stay in sync";
-    case "desktop-managed":
-      return "Update the desktop app";
-    default:
-      return "Copy the update command";
-  }
+export function serverUpdateGuidance(capability: ServerSelfUpdateCapability): string {
+  return capability === "desktop-managed" ? "Update the desktop app" : "Update to stay in sync";
 }
 
 export function buildVersionMismatchDismissalKey(


### PR DESCRIPTION
Fixes composer notice spacing and alignment without changing unrelated composer surfaces.

- keeps height, padding, icon position, and one-row text in `ComposerBanner` and `ComposerBannerStack`
- keeps single actions inline on narrow composers and left-aligns multi-action rows beneath the title
- replaces narrow truncated descriptions with an info tooltip containing the complete copy
- removes per-banner layout overrides so new notices inherit the same safe layout
- shortens copy for connection, update, resume, woke, snoozed, and settled notices
- applies the shared layout to connection, update, background activity, resume, thread-state, branch, task, and activity notices
- keeps notice actions ghosted and aligns notice icons with stash/task tabs

Verified with focused lint, web typecheck, 6 test files (213 tests), and real-browser passes at 768 px and 375 px. No horizontal overflow.

### Before / after

Each row uses the same six fixed-height case slots in the same order, with every composer pinned to the slot bottom. Before is merge-base main at d937e3075. After is the current PR head.

Each fixture uses copy checked against its ChatView call sites, the production composer wrapper hierarchy, the production stash shoulder, and that checkout's ComposerBanner and ComposerBannerStack components.

#### Wide composer, 768px

| Before, merge-base main | After, PR head |
| --- | --- |
| ![Before, merge-base main, wide composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d1f4d86e001288bc/pr8890-baseline-before-wide.png) | ![After, PR head, wide composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/84edf7e4ce9b9298/pr8890-baseline-after-wide.png) |

#### Narrow composer, 375px

| Before, merge-base main | After, current PR head |
| --- | --- |
| ![Before, merge-base main, narrow composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/080cc39ebb7fc10a/pr8890-baseline-before-narrow.png) | ![After, current PR head, responsive composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/97d98cb57f96f190/pr8890-baseline-after-narrow.png) |

#### Expanded three-banner stack, wide

| Before | After |
| --- | --- |
| ![Before, expanded stack, wide composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d0a666464b639ff9/pr8890-baseline-before-wide-expanded.png) | ![After, expanded stack, wide composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0be9ef0629f1311f/pr8890-baseline-after-wide-expanded.png) |

#### Expanded three-banner stack, narrow

| Before | After |
| --- | --- |
| ![Before, expanded stack, narrow composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/df440f4aa283bcab/pr8890-baseline-before-narrow-expanded.png) | ![After, expanded stack, narrow composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/1c2d445e649ad9e5/pr8890-baseline-after-narrow-expanded.png) |

Cases cover environment offline with and without stash, compaction, settled thread with stash, connecting with no actions, and an expanded woke, offline, and compaction stack with stash count 99.

Built with GPT-5.6 in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align composer notices and stash with comfortable density and ghost button variants
> - Adds a `comfortable` density option to `ComposerBanner.Root` with smaller block padding; applies it to stack alerts, `ComposerStashBadge`, and tab-placement `ComposerTasksBadge`
> - Reworks `ComposerBannerStackAlert` to use fixed-height icon columns, single-line titles, and an info-icon popover that reveals hidden descriptions on screens up to 400px
> - Simplifies `serverUpdateGuidance` to two fixed results: `desktop-managed` returns desktop-app guidance, all other self-update capabilities return generic "Update to stay in sync" guidance; the server-label parameter is removed
> - Shortens connection-status banner copy and switches banner action controls (reconnect, Connections, ServerUpdateAction) to the ghost button variant; `ServerUpdateAction` gains a configurable `variant` prop defaulting to `outline`
> - Behavioral Change: `serverUpdateGuidance` signature drops the server-label argument; callers in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8890/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and tests in [versionSkew.test.ts](https://github.com/pingdotgg/t3code/pull/8890/files#diff-69503ecd8c6fcfa217f27b90629ef768050cbac6b31d11057858572d3d35dd20) are updated, but any out-of-tree consumers will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e77029f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->