### PR TITLE
fix(ssh): bound remote command output

### DIFF
--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -12,6 +12,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   baseSshArgs,
+  collectProcessOutput,
   getLastNonEmptyOutputLine,
   parseSshResolveOutput,
   resolveRemoteT3CliPackageSpec,
@@ -144,6 +145,25 @@ describe("ssh command", () => {
       );
     }),
   );
+
+  it.effect("bounds process output while preserving its valid tail", () => {
+    const outputLimitBytes = 1024 * 1024;
+    const truncationMarker = "[Earlier SSH output truncated]\n\n";
+    const finalLine = '{"credential":"pairing-token"}\n';
+    const retainedAscii = `${"x".repeat(outputLimitBytes - finalLine.length - 1)}${finalLine}`;
+    const stream = Stream.make(
+      encoder.encode(`é${retainedAscii.slice(0, -finalLine.length)}`),
+      encoder.encode(finalLine),
+    );
+
+    return Effect.gen(function* () {
+      const output = yield* collectProcessOutput(stream);
+
+      assert.isTrue(output.startsWith(truncationMarker));
+      assert.isFalse(output.includes("�"));
+      assert.isTrue(output.endsWith(retainedAscii));
+    });
+  });
 
   it.effect("includes stdout in non-zero command failures when stderr is empty", () => {
     const spawner = ChildProcessSpawner.make(() =>

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -165,6 +165,20 @@ describe("ssh command", () => {
     });
   });
 
+  it.effect("keeps the tail of a single oversized process chunk", () => {
+    const outputLimitBytes = 1024 * 1024;
+    const truncationMarker = "[Earlier SSH output truncated]\n\n";
+    const finalLine = '{"credential":"pairing-token"}\n';
+    const retainedTail = `${"x".repeat(outputLimitBytes - finalLine.length)}${finalLine}`;
+    const stream = Stream.make(encoder.encode(`discarded${retainedTail}`));
+
+    return Effect.gen(function* () {
+      const output = yield* collectProcessOutput(stream);
+
+      assert.equal(output, `${truncationMarker}${retainedTail}`);
+    });
+  });
+
   it.effect("includes stdout in non-zero command failures when stderr is empty", () => {
     const spawner = ChildProcessSpawner.make(() =>
       Effect.succeed(makeFailedProcess({ stdout: "Pairing token creation failed\n" })),

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -16,6 +16,8 @@ import { SshCommandError, SshInvalidTargetError } from "./errors.ts";
 
 const PUBLISHABLE_T3_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 const DEFAULT_SSH_COMMAND_TIMEOUT_MS = 60_000;
+const MAX_SSH_PROCESS_OUTPUT_BYTES = 1024 * 1024;
+const SSH_PROCESS_OUTPUT_TRUNCATED_MARKER = "[Earlier SSH output truncated]\n\n";
 const MAX_SSH_ERROR_OUTPUT_LENGTH = 4_000;
 
 /**
@@ -33,6 +35,13 @@ const encoder = new TextEncoder();
 export interface SshCommandResult {
   readonly stdout: string;
   readonly stderr: string;
+}
+
+interface ProcessOutputState {
+  readonly buffer: Uint8Array;
+  readonly length: number;
+  readonly writeOffset: number;
+  readonly truncated: boolean;
 }
 
 export interface RunSshCommandOptions extends SshAuthOptions {
@@ -122,15 +131,71 @@ export function getLastNonEmptyOutputLine(stdout: string): string | null {
   );
 }
 
+/** Keep the latest SSH diagnostics and machine-readable result while continuing to drain the process. */
 export const collectProcessOutput = <E>(
   stream: Stream.Stream<Uint8Array, E>,
 ): Effect.Effect<string, E> =>
   stream.pipe(
-    Stream.decodeText(),
     Stream.runFold(
-      () => "",
-      (acc, chunk) => acc + chunk,
+      (): ProcessOutputState => ({
+        buffer: new Uint8Array(MAX_SSH_PROCESS_OUTPUT_BYTES),
+        length: 0,
+        writeOffset: 0,
+        truncated: false,
+      }),
+      (state, chunk): ProcessOutputState => {
+        if (chunk.byteLength >= MAX_SSH_PROCESS_OUTPUT_BYTES) {
+          state.buffer.set(chunk.subarray(chunk.byteLength - MAX_SSH_PROCESS_OUTPUT_BYTES));
+          return {
+            buffer: state.buffer,
+            length: MAX_SSH_PROCESS_OUTPUT_BYTES,
+            writeOffset: 0,
+            truncated:
+              state.truncated ||
+              state.length > 0 ||
+              chunk.byteLength > MAX_SSH_PROCESS_OUTPUT_BYTES,
+          };
+        }
+
+        const firstPartLength = Math.min(
+          chunk.byteLength,
+          MAX_SSH_PROCESS_OUTPUT_BYTES - state.writeOffset,
+        );
+        state.buffer.set(chunk.subarray(0, firstPartLength), state.writeOffset);
+        if (firstPartLength < chunk.byteLength) {
+          state.buffer.set(chunk.subarray(firstPartLength));
+        }
+        const nextLength = state.length + chunk.byteLength;
+        return {
+          buffer: state.buffer,
+          length: Math.min(nextLength, MAX_SSH_PROCESS_OUTPUT_BYTES),
+          writeOffset: (state.writeOffset + chunk.byteLength) % MAX_SSH_PROCESS_OUTPUT_BYTES,
+          truncated: state.truncated || nextLength > MAX_SSH_PROCESS_OUTPUT_BYTES,
+        };
+      },
     ),
+    Effect.map((state) => {
+      let retainedBytes: Uint8Array;
+      if (state.length < MAX_SSH_PROCESS_OUTPUT_BYTES || state.writeOffset === 0) {
+        retainedBytes = state.buffer.subarray(0, state.length);
+      } else {
+        retainedBytes = new Uint8Array(MAX_SSH_PROCESS_OUTPUT_BYTES);
+        const firstPart = state.buffer.subarray(state.writeOffset);
+        retainedBytes.set(firstPart);
+        retainedBytes.set(state.buffer.subarray(0, state.writeOffset), firstPart.byteLength);
+      }
+
+      let retainedStart = 0;
+      while (state.truncated && retainedStart < retainedBytes.byteLength) {
+        const byte = retainedBytes[retainedStart];
+        if (byte === undefined || (byte & 0xc0) !== 0x80) {
+          break;
+        }
+        retainedStart += 1;
+      }
+      const output = new TextDecoder().decode(retainedBytes.subarray(retainedStart));
+      return state.truncated ? `${SSH_PROCESS_OUTPUT_TRUNCATED_MARKER}${output}` : output;
+    }),
   );
 
 function redactSshErrorOutput(output: string): string {

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -138,16 +138,20 @@ export const collectProcessOutput = <E>(
   stream.pipe(
     Stream.runFold(
       (): ProcessOutputState => ({
-        buffer: new Uint8Array(MAX_SSH_PROCESS_OUTPUT_BYTES),
+        buffer: new Uint8Array(0),
         length: 0,
         writeOffset: 0,
         truncated: false,
       }),
       (state, chunk): ProcessOutputState => {
         if (chunk.byteLength >= MAX_SSH_PROCESS_OUTPUT_BYTES) {
-          state.buffer.set(chunk.subarray(chunk.byteLength - MAX_SSH_PROCESS_OUTPUT_BYTES));
+          const buffer =
+            state.buffer.byteLength === MAX_SSH_PROCESS_OUTPUT_BYTES
+              ? state.buffer
+              : new Uint8Array(MAX_SSH_PROCESS_OUTPUT_BYTES);
+          buffer.set(chunk.subarray(chunk.byteLength - MAX_SSH_PROCESS_OUTPUT_BYTES));
           return {
-            buffer: state.buffer,
+            buffer,
             length: MAX_SSH_PROCESS_OUTPUT_BYTES,
             writeOffset: 0,
             truncated:
@@ -157,18 +161,32 @@ export const collectProcessOutput = <E>(
           };
         }
 
+        const nextLength = state.length + chunk.byteLength;
+        const retainedLength = Math.min(nextLength, MAX_SSH_PROCESS_OUTPUT_BYTES);
+        let buffer = state.buffer;
+        if (buffer.byteLength < retainedLength) {
+          const nextCapacity = Math.min(
+            MAX_SSH_PROCESS_OUTPUT_BYTES,
+            Math.max(
+              retainedLength,
+              buffer.byteLength === 0 ? chunk.byteLength : buffer.byteLength * 2,
+            ),
+          );
+          buffer = new Uint8Array(nextCapacity);
+          buffer.set(state.buffer.subarray(0, state.length));
+        }
+
         const firstPartLength = Math.min(
           chunk.byteLength,
           MAX_SSH_PROCESS_OUTPUT_BYTES - state.writeOffset,
         );
-        state.buffer.set(chunk.subarray(0, firstPartLength), state.writeOffset);
+        buffer.set(chunk.subarray(0, firstPartLength), state.writeOffset);
         if (firstPartLength < chunk.byteLength) {
-          state.buffer.set(chunk.subarray(firstPartLength));
+          buffer.set(chunk.subarray(firstPartLength));
         }
-        const nextLength = state.length + chunk.byteLength;
         return {
-          buffer: state.buffer,
-          length: Math.min(nextLength, MAX_SSH_PROCESS_OUTPUT_BYTES),
+          buffer,
+          length: retainedLength,
           writeOffset: (state.writeOffset + chunk.byteLength) % MAX_SSH_PROCESS_OUTPUT_BYTES,
           truncated: state.truncated || nextLength > MAX_SSH_PROCESS_OUTPUT_BYTES,
         };


### PR DESCRIPTION
The desktop process accumulated every byte of SSH command output until the command exited. A noisy or compromised remote host could keep growing desktop memory use until the timeout.

## What changed

`collectProcessOutput` now stores the newest 1 MiB from each stdout or stderr stream. The buffer starts empty, grows with received output, and operates as a ring once it reaches the cap. It keeps reading after the cap so the child process can exit normally.

When earlier bytes are discarded, the returned text starts with `[Earlier SSH output truncated]`. Decoding resumes at a valid UTF-8 boundary. Keeping the tail preserves launch and pairing JSON, plus the latest authentication diagnostics.

## Why

The shared collector handles stdout and stderr for short-lived SSH commands and stderr during tunnel startup. Bounding output there covers every current SSH process reader without changing any public contract or tunnel behavior. There is no UI change.

## Tests

- `vp test run packages/ssh/src/command.test.ts packages/ssh/src/tunnel.test.ts packages/ssh/src/auth.test.ts` (25 tests passed)
- `vp run --filter @t3tools/ssh typecheck`
- `vp lint packages/ssh/src/command.ts packages/ssh/src/command.test.ts`
- `vp fmt --check packages/ssh/src/command.ts packages/ssh/src/command.test.ts`

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] UI screenshots are not applicable.
- [x] An animation or interaction video is not applicable.

Generated with GPT-5.6 using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what callers see when SSH stdout/stderr exceeds 1 MiB (shared by `runSshCommand` and tunnel code), though the intent is to preserve the tail; mitigates unbounded memory growth from remote output.
> 
> **Overview**
> Caps memory from noisy or hostile SSH child processes by rewriting **`collectProcessOutput`** to fold raw **`Uint8Array`** chunks into a **1 MiB** ring buffer instead of growing a decoded string without limit. The stream is still fully drained so the process can exit normally.
> 
> When output exceeds the cap, the returned string is prefixed with **`[Earlier SSH output truncated]\n\n`**, keeps only the **newest** bytes (so trailing pairing JSON and recent diagnostics remain), and skips leading UTF-8 continuation bytes so decoding does not emit replacement characters. Oversized single chunks keep just their tail.
> 
> Two unit tests cover multi-chunk truncation with a non-ASCII prefix and a single chunk larger than the limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e77ee600509ee034811c4f014b25437ae1a2376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound SSH remote command output to 1 MiB in `collectProcessOutput`
> - Rewrites `collectProcessOutput` in [command.ts](https://github.com/pingdotgg/t3code/pull/8891/files#diff-4f1aef4b11679d8551404a853942f04f47c3a80c050bc25b784d2b0c48ec9e5e) from naive chunk concatenation to a byte-oriented ring buffer capped at `MAX_SSH_PROCESS_OUTPUT_BYTES` (1 MiB)
> - For oversized chunks, retains only the tail; on completion, reconstructs retained bytes in order, skips leading UTF-8 continuation bytes, and decodes once
> - Prefixes output with `SSH_PROCESS_OUTPUT_TRUNCATED_MARKER` when earlier output was discarded
> - Adds tests in [command.test.ts](https://github.com/pingdotgg/t3code/pull/8891/files#diff-bbba9b2a73b04eb45e4c5318eac47890661fbb9c0c8f75424bc430d3f349a6a6) for multi-chunk bounded buffering and single oversized chunk truncation
> - Behavioral Change: remote command output is now truncated to the most recent 1 MiB; callers that previously relied on full output will see only the tail plus a truncation marker
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e77ee6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited captured SSH process output to 1 MiB to prevent excessive memory use.
  * Preserved the most recent output when truncation occurs.
  * Added a clear truncation marker and improved UTF-8 handling to avoid replacement characters.
  * Reduced memory usage for smaller SSH outputs by allocating storage only as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->