### PR TITLE
fix(web): new threads keep the viewed thread's model

### DIFF
--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -104,9 +104,10 @@ export function useNewThreadHandler() {
       } = useComposerDraftStore.getState();
       const currentRouteTarget = getCurrentRouteTarget();
       // A new thread carries the user's working mode from the thread being
-      // viewed. The target project's configured model still wins; runtime and
-      // interaction modes carry independently. Branch, worktree, and env mode
-      // come from configured defaults unless the caller passes them explicitly.
+      // viewed: model, runtime mode, and interaction mode. The target project's
+      // default model only fills in when there is nothing to carry. Branch,
+      // worktree, and env mode come from configured defaults unless the caller
+      // passes them explicitly.
       const carrySourceShell =
         currentRouteTarget?.kind === "server"
           ? readThreadShell(currentRouteTarget.threadRef)
@@ -304,8 +305,8 @@ export function useNewThreadHandler() {
           }
           // Model intent: an explicit human pick always stands. Seeds and
           // legacy entries alike re-resolve here — sticky first, mirroring
-          // the mint-fresh path, then the project default or carried
-          // selection on top. This runs even when the draft is already open:
+          // the mint-fresh path, then the carried selection or project
+          // default on top. This runs even when the draft is already open:
           // without it, a changed pin could never reach the draft the user
           // is looking at, because explicit picks are the only thing the
           // flag protects.
@@ -457,8 +458,8 @@ export function useNewThreadHandler() {
         applyStickyState(draftId);
         const modelSelectionOverride = resolveModelSelectionOverride(draftId);
         if (modelSelectionOverride) {
-          // Project defaults and carried selections both outrank global sticky
-          // state. The project default wins when both are present.
+          // Carried selections and project defaults both outrank global sticky
+          // state. The carried selection wins when both are present.
           setModelSelection(draftId, modelSelectionOverride, { replaceOptions: true });
         }
         carryComposerContentTo(draftId);

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -59,13 +59,32 @@ describe("chatThreadActions", () => {
     ).toEqual(CARRIED_SELECTION);
   });
 
-  it("keeps the project default above any carried selection", () => {
+  it("keeps the carried selection above the project default", () => {
     expect(
       resolveNewThreadModelSelectionOverride({
         projectDefaultSelection: PROJECT_DEFAULT_SELECTION,
         carrySelection: CARRIED_SELECTION,
         carrySourceDraftId: "draft-a",
         destinationDraftId: "draft-b",
+      }),
+    ).toEqual(CARRIED_SELECTION);
+  });
+
+  it("falls back to the project default when there is nothing to carry", () => {
+    expect(
+      resolveNewThreadModelSelectionOverride({
+        projectDefaultSelection: PROJECT_DEFAULT_SELECTION,
+        carrySelection: null,
+        carrySourceDraftId: null,
+        destinationDraftId: "draft-b",
+      }),
+    ).toEqual(PROJECT_DEFAULT_SELECTION);
+    expect(
+      resolveNewThreadModelSelectionOverride({
+        projectDefaultSelection: PROJECT_DEFAULT_SELECTION,
+        carrySelection: CARRIED_SELECTION,
+        carrySourceDraftId: "draft-a",
+        destinationDraftId: "draft-a",
       }),
     ).toEqual(PROJECT_DEFAULT_SELECTION);
   });

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -39,16 +39,19 @@ export function resolveNewDraftStartFromOrigin(input: {
   return input.envMode === "worktree" && input.newWorktreesStartFromOrigin;
 }
 
+// The model the user is looking at carries into the new thread. The project
+// default only fills in when there is nothing to carry: every project gets a
+// default seeded at creation, so letting it outrank the carried selection
+// would reset the model on every new thread.
 export function resolveNewThreadModelSelectionOverride(input: {
   readonly projectDefaultSelection: ModelSelection | null;
   readonly carrySelection: ModelSelection | null;
   readonly carrySourceDraftId: string | null;
   readonly destinationDraftId: string;
 }): ModelSelection | null {
-  return (
-    input.projectDefaultSelection ??
-    (input.carrySourceDraftId === input.destinationDraftId ? null : input.carrySelection)
-  );
+  const carrySelection =
+    input.carrySourceDraftId === input.destinationDraftId ? null : input.carrySelection;
+  return carrySelection ?? input.projectDefaultSelection;
 }
 
 export function resolveThreadActionProjectRef(


### PR DESCRIPTION
Since #6011 the project default model outranks the model carried from the thread being viewed. Every project gets a default seeded at creation (the first selectable provider's default), so in practice a new thread always reset to that model instead of keeping the one the user was working with. Runtime and interaction modes still carried; only the model was lost.

This flips the priority in `resolveNewThreadModelSelectionOverride`: the carried selection wins, and the project default only fills in when there is nothing to carry (fresh app, or the draft would carry from itself). Mobile is unaffected since its new-task flow has no viewed-thread carry.

## Validation

- `vp test run apps/web/src/lib/chatThreadActions.test.ts` (10 tests)
- `vp fmt --check` and `vp lint` on the touched files
- `vp run --filter @t3tools/web typecheck`

Built with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized priority change in new-thread model resolution with updated unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **New-thread model selection** no longer resets to the project default when the user was already working with a different model on the thread they were viewing.
> 
> `resolveNewThreadModelSelectionOverride` now prefers the **carried** composer/thread model over the project default (which is always seeded at project creation). The project default is only applied when there is nothing to carry—e.g. cold start or when the destination draft would carry from itself. Comments in `useHandleNewThread` are updated to match.
> 
> Tests are updated and extended to assert carried-over-wins, plus fallback to project default when carry is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759df789fc84f89b752a1fa7663af4fc1a77e050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveNewThreadModelSelectionOverride` to prefer carried model over project default
> - New threads now inherit the viewed thread's model, runtime mode, and interaction mode, with the carried model taking precedence over the project default.
> - [chatThreadActions.ts](https://github.com/pingdotgg/t3code/pull/8892/files#diff-6e655e056adaf8605b1381f1a37651405db18539fe8abe8eb1e810e5f95608e1) reverses the precedence in `resolveNewThreadModelSelectionOverride`: it returns the carried selection when present, and falls back to the project default only when there is nothing to carry (including when source and destination draft IDs match).
> - [chatThreadActions.test.ts](https://github.com/pingdotgg/t3code/pull/8892/files#diff-22c42880d62f934f879fff56b1324735f83bcb3892c355a8892a75c6fa8ff005) updates tests to expect carried-selection precedence and adds a fallback-to-default test.
> - Behavioral Change: `resolveNewThreadModelSelectionOverride` no longer lets the project default override a carried selection; consumers relying on the old order will see carried selections win.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 759df78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->