### PR TITLE
fix(desktop): keep tooltips clear of the native window controls

### DIFF
--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,6 +1,11 @@
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
 import { cn } from "~/lib/utils";
+import { useWindowControlsOverlayHeight } from "~/lib/windowControlsOverlay";
+
+// Base UI's own default; restated because an object padding zeroes the sides we
+// do not list.
+const COLLISION_PADDING = 5;
 
 const TooltipCreateHandle = TooltipPrimitive.createHandle;
 
@@ -28,12 +33,23 @@ function TooltipPopup({
   variant?: "default" | "glass";
   anchor?: TooltipPrimitive.Positioner.Props["anchor"];
 }) {
+  // A tooltip that flips up out of a panel header lands in the native titlebar
+  // strip, which the OS paints its window controls over. Treat that strip as
+  // off-screen so the tooltip flips down instead of hiding under the controls.
+  const windowControlsOverlayHeight = useWindowControlsOverlayHeight();
+
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
         align={align}
         anchor={anchor}
         className="pointer-events-none z-[140] h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
+        collisionPadding={{
+          top: COLLISION_PADDING + windowControlsOverlayHeight,
+          right: COLLISION_PADDING,
+          bottom: COLLISION_PADDING,
+          left: COLLISION_PADDING,
+        }}
         data-slot="tooltip-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/lib/windowControlsOverlay.ts
+++ b/apps/web/src/lib/windowControlsOverlay.ts
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from "react";
+
 import { isWindowsPlatform } from "./utils";
 
 const WCO_CLASS_NAME = "wco";
@@ -6,6 +8,7 @@ const ELECTRON_WINDOWS_CLASS_NAME = "electron-windows";
 
 interface WindowControlsOverlayLike {
   readonly visible: boolean;
+  getTitlebarAreaRect(): DOMRect;
   addEventListener(type: "geometrychange", listener: EventListener): void;
   removeEventListener(type: "geometrychange", listener: EventListener): void;
 }
@@ -41,6 +44,40 @@ export function syncDocumentWindowControlsOverlayClass(): () => void {
   return () => {
     overlay.removeEventListener("geometrychange", update);
   };
+}
+
+function subscribeWindowControlsOverlayGeometry(listener: () => void): () => void {
+  const overlay = getWindowControlsOverlay();
+  if (!overlay) {
+    return () => {};
+  }
+
+  overlay.addEventListener("geometrychange", listener);
+  return () => {
+    overlay.removeEventListener("geometrychange", listener);
+  };
+}
+
+function getWindowControlsOverlayHeight(): number {
+  const overlay = getWindowControlsOverlay();
+  return overlay?.visible ? overlay.getTitlebarAreaRect().height : 0;
+}
+
+function getServerWindowControlsOverlayHeight(): number {
+  return 0;
+}
+
+/**
+ * Height of the strip the OS composites its own window controls into, or 0 when
+ * the page owns the whole viewport. Those controls paint above every DOM layer,
+ * so portaled popups have to stay out of the strip; no z-index can win it back.
+ */
+export function useWindowControlsOverlayHeight(): number {
+  return useSyncExternalStore(
+    subscribeWindowControlsOverlayGeometry,
+    getWindowControlsOverlayHeight,
+    getServerWindowControlsOverlayHeight,
+  );
 }
 
 export function getElectronPlatformClassNames(


### PR DESCRIPTION
Hovering the line-wrapping toggle in the diff panel toolbar showed its tooltip inside the titlebar strip, where the OS composites the minimize, maximize, and close buttons above every DOM layer. Raising `z-index` cannot win that, because the controls are not part of the page.

The tooltip positioner now reserves the window-controls-overlay height as collision padding, so a tooltip that would land in that strip flips below its trigger instead. The height comes from `navigator.windowControlsOverlay.getTitlebarAreaRect()` and tracks `geometrychange`, so it is 0 in the browser and follows the real strip in Electron. Fixing it in the shared `TooltipPopup` covers every tooltip near the top of the window, not just the one in the report.

Fixes #8882

## Before / After

Linux, Electron dev build, diff panel open, hovering "Disable line wrapping".

| Before | After |
| --- | --- |
| ![Tooltip hidden behind the maximize and close buttons](https://raw.githubusercontent.com/Gigioxx/t3code/1f08ba96187309bbe7f788137dedd5c07087a0b8/issue-8882-before.png) | ![Tooltip flipped below the toolbar, clear of the window controls](https://raw.githubusercontent.com/Gigioxx/t3code/1f08ba96187309bbe7f788137dedd5c07087a0b8/issue-8882-after.png) |

## Validation

- `vp fmt apps/web/src/components/ui/tooltip.tsx apps/web/src/lib/windowControlsOverlay.ts --check`
- `vp lint apps/web/src/components/ui/tooltip.tsx apps/web/src/lib/windowControlsOverlay.ts --report-unused-disable-directives`
- `vp run --filter @t3tools/web typecheck`
- Reproduced in the Electron dev app on Linux over CDP. The trigger sits at y 39.5 with a 40px overlay strip. Before the change the positioner reported `side="top"` at y 9.5, inside the strip; after it reports `side="bottom"` at y 71.5.
- Re-probed neighbouring tooltips in the same session: titlebar controls, diff toolbar, sidebar footer, and the composer. Placement is unchanged everywhere the strip is not in the way.

Built with Claude Opus 5 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI positioning change for tooltips with a safe SSR/default of zero height; no auth, data, or security impact.
> 
> **Overview**
> **Tooltips near the top of the Electron window no longer render under the OS titlebar controls** by treating that strip as a collision boundary on the shared `TooltipPopup` positioner.
> 
> `TooltipPopup` now passes explicit `collisionPadding` to Base UI’s positioner, with **extra top padding** equal to the window-controls overlay height (on top of the default 5px). When a tooltip would flip above a trigger into that strip, it flips below instead.
> 
> A new **`useWindowControlsOverlayHeight`** hook in `windowControlsOverlay.ts` reads `navigator.windowControlsOverlay.getTitlebarAreaRect().height` when the overlay is visible, subscribes to `geometrychange`, and returns **0** on the server or when the API is absent—so browser builds are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5afaae43fe577ef09d34730f22c850a4372202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep tooltips clear of native window controls via overlay-aware collision padding
> - Adds `useWindowControlsOverlayHeight` hook in [windowControlsOverlay.ts](https://github.com/pingdotgg/t3code/pull/8893/files#diff-0b4bc2286c6db8c805258eaec400a41bb45075d438330415672e821a0c99d9bf) using `useSyncExternalStore` to track the Window Controls Overlay titlebar height reactively (0 on server or when unavailable)
> - Updates `TooltipPopup` in [tooltip.tsx](https://github.com/pingdotgg/t3code/pull/8893/files#diff-97acc7c97f91957af019082b41210bb280e2dd2af1a011328a1549f5647431d9) to pass a `collisionPadding` object whose `top` equals a base `COLLISION_PADDING` (5) plus the overlay height, so tooltips flip away from the native titlebar area
> - Risk: tooltips on non-desktop browsers without a Window Controls Overlay behave as before (top padding stays 5); on desktop PWA installs, the top collision margin increases by the titlebar height, which may alter flip behavior for tooltips near the top edge
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f5afaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->