### PR TITLE
fix(codex): accept rate limit errors on thread resume

### DIFF
--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -194,6 +194,36 @@ const Codex0150DefinitionSchemas: Record<string, Schema.Json> = {
   },
 };
 
+function applyCodex0151DefinitionCompatibility(
+  exportName: string,
+  definitionName: string,
+  definitionSchema: Schema.Json,
+): Schema.Json {
+  if (
+    exportName !== "V2ThreadResumeResponse" ||
+    definitionName !== "CodexErrorInfo" ||
+    typeof definitionSchema !== "object"
+  ) {
+    return definitionSchema;
+  }
+
+  const schema = definitionSchema as {
+    readonly oneOf?: ReadonlyArray<{ readonly enum?: ReadonlyArray<string> }>;
+  };
+  const [firstVariant, ...remainingVariants] = schema.oneOf ?? [];
+  if (!firstVariant?.enum || firstVariant.enum.includes("rateLimitExceeded")) {
+    return definitionSchema;
+  }
+
+  return {
+    ...definitionSchema,
+    oneOf: [
+      { ...firstVariant, enum: [...firstVariant.enum, "rateLimitExceeded"] },
+      ...remainingVariants,
+    ],
+  };
+}
+
 const getGeneratedPaths = Effect.fn("getGeneratedPaths")(function* () {
   const path = yield* Path.Path;
   const generatedDir = path.join(import.meta.dirname, "..", "src", "_generated");
@@ -606,7 +636,8 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
 
     for (const [definitionName, definitionSchema] of Object.entries(parsed.definitions ?? {})) {
       const compatibleDefinitionSchema =
-        Codex0150DefinitionSchemas[definitionName] ?? definitionSchema;
+        Codex0150DefinitionSchemas[definitionName] ??
+        applyCodex0151DefinitionCompatibility(file.exportName, definitionName, definitionSchema);
       aggregateSchemas[localDefinitionNames.get(definitionName)!] = stripNullDefaults(
         normalizeNullableTypes(
           rewriteExternalRefs(

--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -199,8 +199,12 @@ function applyCodex0151DefinitionCompatibility(
   definitionName: string,
   definitionSchema: Schema.Json,
 ): Schema.Json {
+  const isThreadResponse =
+    exportName === "V2ThreadReadResponse" ||
+    exportName === "V2ThreadResumeResponse" ||
+    exportName === "V2ThreadRollbackResponse";
   if (
-    exportName !== "V2ThreadResumeResponse" ||
+    !isThreadResponse ||
     definitionName !== "CodexErrorInfo" ||
     typeof definitionSchema !== "object"
   ) {

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -16851,6 +16851,7 @@ export type V2ThreadReadResponse__CodexErrorInfo =
   | "badRequest"
   | "threadRollbackFailed"
   | "sandboxError"
+  | "rateLimitExceeded"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -16874,6 +16875,7 @@ export const V2ThreadReadResponse__CodexErrorInfo = Schema.Union(
       "badRequest",
       "threadRollbackFailed",
       "sandboxError",
+      "rateLimitExceeded",
       "other",
     ]),
     Schema.Struct({
@@ -17484,6 +17486,7 @@ export type V2ThreadRollbackResponse__CodexErrorInfo =
   | "badRequest"
   | "threadRollbackFailed"
   | "sandboxError"
+  | "rateLimitExceeded"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -17507,6 +17510,7 @@ export const V2ThreadRollbackResponse__CodexErrorInfo = Schema.Union(
       "badRequest",
       "threadRollbackFailed",
       "sandboxError",
+      "rateLimitExceeded",
       "other",
     ]),
     Schema.Struct({

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -17204,6 +17204,7 @@ export type V2ThreadResumeResponse__CodexErrorInfo =
   | "badRequest"
   | "threadRollbackFailed"
   | "sandboxError"
+  | "rateLimitExceeded"
   | "other"
   | { readonly httpConnectionFailed: { readonly httpStatusCode?: number | null } }
   | { readonly responseStreamConnectionFailed: { readonly httpStatusCode?: number | null } }
@@ -17227,6 +17228,7 @@ export const V2ThreadResumeResponse__CodexErrorInfo = Schema.Union(
       "badRequest",
       "threadRollbackFailed",
       "sandboxError",
+      "rateLimitExceeded",
       "other",
     ]),
     Schema.Struct({

--- a/packages/effect-codex-app-server/src/schema.test.ts
+++ b/packages/effect-codex-app-server/src/schema.test.ts
@@ -4,6 +4,9 @@ import * as Schema from "effect/Schema";
 import * as CodexSchema from "./schema.ts";
 
 const isGetAccountResponse = Schema.is(CodexSchema.V2GetAccountResponse);
+const isThreadReadResponse = Schema.is(CodexSchema.V2ThreadReadResponse);
+const isThreadResumeResponse = Schema.is(CodexSchema.V2ThreadResumeResponse);
+const isThreadRollbackResponse = Schema.is(CodexSchema.V2ThreadRollbackResponse);
 
 it("accepts Codex 0.150 multi-agent values", () => {
   const schemas = [
@@ -75,15 +78,44 @@ it("accepts Codex 0.150 multi-agent values", () => {
 });
 
 it("accepts Codex rate limit errors for thread responses", () => {
-  const schemas = [
-    CodexSchema.V2ThreadReadResponse__CodexErrorInfo,
-    CodexSchema.V2ThreadResumeResponse__CodexErrorInfo,
-    CodexSchema.V2ThreadRollbackResponse__CodexErrorInfo,
-  ];
-
-  for (const schema of schemas) {
-    assert.equal(Schema.is(schema)("rateLimitExceeded"), true);
-  }
+  const failedThread = {
+    cliVersion: "0.150.0",
+    createdAt: 0,
+    cwd: "/tmp/project",
+    ephemeral: false,
+    id: "thread-1",
+    modelProvider: "openai",
+    preview: "",
+    sessionId: "session-1",
+    source: "cli",
+    status: { type: "idle" },
+    turns: [
+      {
+        error: {
+          codexErrorInfo: "rateLimitExceeded",
+          message: "Rate limit exceeded",
+        },
+        id: "turn-1",
+        items: [],
+        status: "failed",
+      },
+    ],
+    updatedAt: 0,
+  };
+  assert.equal(isThreadReadResponse({ thread: failedThread }), true);
+  assert.equal(
+    isThreadResumeResponse({
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      cwd: "/tmp/project",
+      model: "gpt-5.6-sol",
+      modelProvider: "openai",
+      sandbox: { type: "dangerFullAccess" },
+      thread: failedThread,
+    }),
+    true,
+  );
+  assert.equal(isThreadRollbackResponse({ thread: failedThread }), true);
 });
 
 it("accepts Codex 0.150 account plan values", () => {

--- a/packages/effect-codex-app-server/src/schema.test.ts
+++ b/packages/effect-codex-app-server/src/schema.test.ts
@@ -74,6 +74,13 @@ it("accepts Codex 0.150 multi-agent values", () => {
   assert.equal(Schema.is(CodexSchema.V2ThreadResumeResponse)(resumeResponse), true);
 });
 
+it("accepts Codex rate limit errors when resuming a thread", () => {
+  assert.equal(
+    Schema.is(CodexSchema.V2ThreadResumeResponse__CodexErrorInfo)("rateLimitExceeded"),
+    true,
+  );
+});
+
 it("accepts Codex 0.150 account plan values", () => {
   const planTypes = [
     "self_serve_business_prolite",

--- a/packages/effect-codex-app-server/src/schema.test.ts
+++ b/packages/effect-codex-app-server/src/schema.test.ts
@@ -74,11 +74,16 @@ it("accepts Codex 0.150 multi-agent values", () => {
   assert.equal(Schema.is(CodexSchema.V2ThreadResumeResponse)(resumeResponse), true);
 });
 
-it("accepts Codex rate limit errors when resuming a thread", () => {
-  assert.equal(
-    Schema.is(CodexSchema.V2ThreadResumeResponse__CodexErrorInfo)("rateLimitExceeded"),
-    true,
-  );
+it("accepts Codex rate limit errors for thread responses", () => {
+  const schemas = [
+    CodexSchema.V2ThreadReadResponse__CodexErrorInfo,
+    CodexSchema.V2ThreadResumeResponse__CodexErrorInfo,
+    CodexSchema.V2ThreadRollbackResponse__CodexErrorInfo,
+  ];
+
+  for (const schema of schemas) {
+    assert.equal(Schema.is(schema)("rateLimitExceeded"), true);
+  }
 });
 
 it("accepts Codex 0.150 account plan values", () => {


### PR DESCRIPTION
Fixes #8875.

A persisted Codex rateLimitExceeded value was rejected while decoding thread/resume, making affected historical threads permanently unresumable.

The generated resume schema now accepts the value, and the generator retains the narrow compatibility override so the next protocol refresh preserves it.

Verification: focused schema test and effect-codex-app-server typecheck.

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a backward-compatible enum variant to runtime validation only; no auth or persistence logic changes.
> 
> **Overview**
> Fixes decoding failures when persisted thread data includes **`rateLimitExceeded`** in turn errors, which blocked **read**, **resume**, and **rollback** for affected threads.
> 
> Adds **`applyCodex0151DefinitionCompatibility`** in the schema generator so **`CodexErrorInfo`** on **`V2ThreadReadResponse`**, **`V2ThreadResumeResponse`**, and **`V2ThreadRollbackResponse`** gains that enum value when upstream JSON schema omits it (same pattern as existing 0.150 overrides). Regenerated **`schema.gen.ts`** and a focused test assert all three response schemas accept the value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4b9fa0af9c8e0eea5b996938fd6b0cac53bacb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add rate-limit error variant to thread response schemas in `codex-app-server`
> - Adds a compatibility transformation in [generate.ts](https://github.com/pingdotgg/t3code/pull/8897/files#diff-560473cbb6e8d5dcb7711cbe1b22019753b863e14f3d956a5a2e509fdedea368) that appends the rate-limit error value to the `CodexErrorInfo` enum for thread read, resume, and rollback responses when the upstream definition lacks it.
> - The transformation preserves existing Codex 0.150 compatibility overrides and only applies when no override is present.
> - Regenerates [schema.gen.ts](https://github.com/pingdotgg/t3code/pull/8897/files#diff-c283b8cf9097ca9d1030e7acabd5d3c70e2a5ca2bfaf229f79512ba96ed58296) and adds tests in [schema.test.ts](https://github.com/pingdotgg/t3code/pull/8897/files#diff-2912bd8ff7cdd905fd768f119080c3d493102a78d5d464b72be82e48868a7079) verifying all three response schemas accept a failed turn with the rate-limit error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a4b9fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->