### PR TITLE
fix(server): allow long thread IDs in HTTP routes

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -103,7 +103,7 @@ const collectQueueUntil = Effect.fn("TransferBudget.collectQueueUntil")(function
 
 import * as BackgroundPolicy from "./background/BackgroundPolicy.ts";
 import * as ServerConfig from "./config.ts";
-import { makeRoutesLayer } from "./server.ts";
+import { HTTP_ROUTER_CONFIG, makeRoutesLayer } from "./server.ts";
 import {
   isThreadDetailEvent,
   resolveAvailableEditorsForConfig,
@@ -629,6 +629,7 @@ const buildAppUnderTest = (options?: {
       {
         disableListenLog: true,
         disableLogger: true,
+        routerConfig: HTTP_ROUTER_CONFIG,
       },
     ).pipe(
       Layer.provide(
@@ -1524,6 +1525,41 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       assert.equal(response.status, 200);
       assert.deepEqual(body, testEnvironmentDescriptor);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("serves snapshots for MCP handoff thread IDs above the router default", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make(
+        "thread:mcp:abfba0d2-b591-4b7e-aad1-e943d89811fa:handoff%3A0ae5edf4-2ea3-4ee3-ba7c-48de3ac92896%3A2026-08-24T17%3A08%3A52.138Z:0",
+      );
+      const thread = {
+        ...makeDefaultOrchestrationReadModel().threads[0]!,
+        id: threadId,
+      };
+      yield* buildAppUnderTest({
+        layers: {
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: (requestedThreadId) =>
+              Effect.succeed(
+                requestedThreadId === threadId
+                  ? Option.some({ snapshotSequence: 1, thread })
+                  : Option.none(),
+              ),
+          },
+        },
+      });
+
+      const response = yield* fetchEffect(
+        yield* getHttpServerUrl(`/api/orchestration/threads/${encodeURIComponent(threadId)}`),
+        { headers: { cookie: yield* getAuthenticatedSessionCookieHeader() } },
+      );
+      const snapshot = yield* responseJsonEffect<{
+        readonly thread: { readonly id: ThreadId };
+      }>(response);
+
+      assert.equal(response.status, 200);
+      assert.equal(snapshot.thread.id, threadId);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -123,6 +123,12 @@ import * as RelayClient from "@t3tools/shared/relayClient";
 import { disableTailscaleServe, ensureTailscaleServe } from "@t3tools/tailscale";
 import { forkParked, ServerActivation } from "./serverActivation.ts";
 
+// MCP handoff thread IDs include escaped provenance and can exceed find-my-way's
+// 100-character default for one path segment.
+export const HTTP_ROUTER_CONFIG = {
+  maxParamLength: 512,
+} as const;
+
 // Effect's default preemptive shutdown waits 20s before finalizing request scopes.
 // T3's primary transport is long-lived WebSocket RPC, whose Effect scope finalizer
 // already closes the websocket gracefully. Do not add an artificial drain before
@@ -675,6 +681,7 @@ export const makeServerLayer = Layer.unwrap(
 
     const routesLayer = HttpRouter.serve(makeRoutesLayer.pipe(Layer.provide(launcherLayer)), {
       disableLogger: !config.logWebSocketEvents,
+      routerConfig: HTTP_ROUTER_CONFIG,
     }).pipe(Layer.tap(() => Deferred.succeed(routesReady, undefined).pipe(Effect.orDie)));
     const serverApplicationLayer = Layer.mergeAll(
       routesLayer,


### PR DESCRIPTION
Fixes #8860.

MCP handoff thread IDs can exceed the HTTP router default of 100 characters, causing valid thread snapshot requests to return a route-level 404.

Raise the server router parameter limit to 512 and cover an authenticated snapshot request for a representative MCP handoff ID.

Verification: focused server regression test and t3 server package typecheck.

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing configuration change with a bounded param length; no auth or data-model changes, covered by a new integration test.
> 
> **Overview**
> **Raises the HTTP router path-parameter limit** from find-my-way’s default (100) to **512** via a shared `HTTP_ROUTER_CONFIG`, wired into production `HttpRouter.serve` and the integration test harness so behavior matches.
> 
> This fixes **404s on authenticated thread snapshot requests** when the `:threadId` segment is a long MCP handoff ID (escaped provenance in the path).
> 
> Adds a regression test that requests `/api/orchestration/threads/...` with a representative MCP handoff thread ID and asserts a **200** snapshot response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c9188b0b5c6dd55a35dc674b2c19d7ce44e556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `HttpRouter` `maxParamLength` to 512 for MCP handoff thread IDs
> MCP handoff thread IDs can exceed the router's default single-segment parameter length limit. Adds a new `HTTP_ROUTER_CONFIG` constant with `maxParamLength` set to 512 in [server.ts](https://github.com/pingdotgg/t3code/pull/8898/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) and passes it to `HttpRouter.serve` in `makeServerLayer`. Adds a test verifying that a long thread ID resolves correctly on the `/api/orchestration/threads/{id}` route.
> - Behavioral Change: all single-segment path parameters on routes served by `makeServerLayer` now accept values up to 512 characters instead of the previous default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4c9188.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->