### PR TITLE
fix(mobile): Prevent mobile app new-thread submit redirect regression 

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -943,12 +943,17 @@ export function NewTaskDraftScreen(props: {
         clearWorkspaceSelection: true,
       });
     }
-    navigation.dispatch(
-      StackActions.replace("Thread", {
-        environmentId: String(result.value.environmentId),
-        threadId: String(result.value.threadId),
-      }),
-    );
+    // Let usePreventRemove commit its disabled state (submitting just went
+    // false) before replacing this route, otherwise the guard swallows the
+    // navigation and the user is stranded on a cleared form.
+    requestAnimationFrame(() => {
+      navigation.dispatch(
+        StackActions.replace("Thread", {
+          environmentId: String(result.value.environmentId),
+          threadId: String(result.value.threadId),
+        }),
+      );
+    });
   }
 
   if (!selectedProject) {


### PR DESCRIPTION
## What Changed

Deferred the success-path `StackActions.replace("Thread", ...)` in `NewTaskDraftScreen` by one frame with `requestAnimationFrame`, so the `usePreventRemove` guard commits its disabled state before the navigation dispatches.

## Why

86c9a9288 broke the redirect once the thread is submitted. It's a timing issue
### Before
https://github.com/user-attachments/assets/eaecff95-7120-49a2-a408-7c8f980e3690
### After

https://github.com/user-attachments/assets/f065ae30-01c5-42f5-89b4-f069e0473d33




## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes - not applicable
- [x] I included a video for animation/interaction changes

Fixed by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-frame timing change on the post-submit navigation path only; no auth, data, or API changes.
> 
> **Overview**
> Fixes a case where **successful new-thread submit** on Android could leave users on an **empty new-task screen** instead of the created thread.
> 
> After thread creation succeeds, the screen still calls `StackActions.replace("Thread", …)` with the new ids, but that dispatch now runs inside **`requestAnimationFrame`**. Submit clears `flow.submitting` in the same turn as navigation; **`usePreventRemove(flow.submitting)`** had not yet turned off, so it could **block the replace** while the composer draft was already cleared.
> 
> This mirrors the **existing one-frame defer** used when falling back to `replace("NewTask")` for the project picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc9e543889d77fb1c8a38345fc7f0e383c33ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android new-thread submit navigation using `requestAnimationFrame`
> In [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/8901/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2), wraps the `StackActions.replace` dispatch in `requestAnimationFrame` to defer route replacement by one frame. This prevents a remove-prevention guard from intercepting the navigation, so submitting a new thread draft lands on the created Thread screen on Android.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bc9e54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->