### PR TITLE
fix(web): preserve explicit preview navigation URLs

### DIFF
--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -25,7 +25,7 @@ describe("browser target resolver", () => {
     });
   });
 
-  it("maps localhost URL navigation onto a remote Tailscale IPv4 host", async () => {
+  it("preserves explicit loopback URL navigation for a remote Tailscale environment", async () => {
     readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://100.65.180.100:3773" });
     const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
     expect(
@@ -35,13 +35,29 @@ describe("browser target resolver", () => {
       }),
     ).toEqual({
       requestedUrl: "http://localhost:5173/dashboard?mode=test#results",
-      resolvedUrl: "http://100.65.180.100:5173/dashboard?mode=test#results",
-      resolutionKind: "direct-private-network",
+      resolvedUrl: "http://localhost:5173/dashboard?mode=test#results",
+      resolutionKind: "direct",
       environmentId: "environment-1",
     });
   });
 
-  it("preserves URL credentials when mapping localhost onto a remote host", async () => {
+  it("preserves explicit IPv4 loopback URL navigation for a private network environment", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://192.168.1.50:3773" });
+    const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
+    expect(
+      resolveBrowserNavigationTarget(EnvironmentId.make("environment-1"), {
+        kind: "url",
+        url: "http://127.0.0.1:5999/",
+      }),
+    ).toEqual({
+      requestedUrl: "http://127.0.0.1:5999/",
+      resolvedUrl: "http://127.0.0.1:5999/",
+      resolutionKind: "direct",
+      environmentId: "environment-1",
+    });
+  });
+
+  it("preserves URL credentials on explicit loopback navigation", async () => {
     readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://100.65.180.100:3773" });
     const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
     expect(
@@ -49,10 +65,10 @@ describe("browser target resolver", () => {
         kind: "url",
         url: "http://user:p%40ss@localhost:5173/dashboard",
       }).resolvedUrl,
-    ).toBe("http://user:p%40ss@100.65.180.100:5173/dashboard");
+    ).toBe("http://user:p%40ss@localhost:5173/dashboard");
   });
 
-  it("maps credentialed localhost URLs onto private IPv6 hosts", async () => {
+  it("preserves credentialed loopback URLs for private IPv6 environments", async () => {
     readPreparedConnection.mockReturnValue({
       httpBaseUrl: "http://[fd7a:115c:a1e0::53]:3773",
     });
@@ -62,10 +78,10 @@ describe("browser target resolver", () => {
         kind: "url",
         url: "http://user:p%40ss@localhost:5173/dashboard?mode=test#results",
       }).resolvedUrl,
-    ).toBe("http://user:p%40ss@[fd7a:115c:a1e0::53]:5173/dashboard?mode=test#results");
+    ).toBe("http://user:p%40ss@localhost:5173/dashboard?mode=test#results");
   });
 
-  it("maps schemeless localhost navigation onto a remote environment host", async () => {
+  it("preserves schemeless localhost navigation for a remote environment", async () => {
     readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://192.168.1.25:3773" });
     const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
     expect(
@@ -73,7 +89,7 @@ describe("browser target resolver", () => {
         kind: "url",
         url: "localhost:3000/app",
       }).resolvedUrl,
-    ).toBe("http://192.168.1.25:3000/app");
+    ).toBe("localhost:3000/app");
   });
 
   it("keeps localhost navigation local for a local environment", async () => {
@@ -117,12 +133,12 @@ describe("browser target resolver", () => {
         port: 5173,
       }),
     ).toThrow(/authenticated preview gateway/);
-    expect(() =>
+    expect(
       resolveBrowserNavigationTarget(EnvironmentId.make("environment-1"), {
         kind: "url",
         url: "http://localhost:5173",
       }),
-    ).toThrow(/authenticated preview gateway/);
+    ).toMatchObject({ resolvedUrl: "http://localhost:5173", resolutionKind: "direct" });
   });
 
   it("normalizes schemeless localhost server-picker values", async () => {
@@ -134,6 +150,14 @@ describe("browser target resolver", () => {
     expect(
       resolveDiscoveredServerUrl(EnvironmentId.make("environment-1"), "0.0.0.0:3000/app"),
     ).toBe("http://localhost:3000/app");
+  });
+
+  it("maps discovered loopback servers onto a remote environment host", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://192.168.1.25:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(EnvironmentId.make("environment-1"), "localhost:3000/app"),
+    ).toBe("http://192.168.1.25:3000/app");
   });
 
   it("preserves localhost server-picker values when the prepared base is 127.0.0.1", async () => {

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -207,30 +207,6 @@ export function resolveBrowserNavigationTarget(
   target: BrowserNavigationTarget,
 ): PreviewUrlResolution {
   if (target.kind === "url") {
-    let parsed: URL | null = null;
-    try {
-      parsed = new URL(normalizePreviewUrl(target.url));
-    } catch {
-      // Preserve the existing direct-navigation behavior so the preview host
-      // reports malformed URL errors through its normal navigation path.
-    }
-    if (parsed && isLoopbackHost(parsed.hostname)) {
-      const environmentUrl = readEnvironmentUrl(environmentId);
-      if (parsed.hostname === "0.0.0.0" || !isLocalLoopbackHost(environmentUrl.hostname)) {
-        return resolveEnvironmentPortTarget(
-          environmentId,
-          {
-            kind: "environment-port",
-            port: Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80)),
-            protocol: parsed.protocol === "https:" ? "https" : "http",
-            path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
-          },
-          environmentUrl,
-          target.url,
-          parsed,
-        );
-      }
-    }
     return {
       requestedUrl: target.url,
       resolvedUrl: target.url,
@@ -244,10 +220,20 @@ export function resolveBrowserNavigationTarget(
 export function resolveDiscoveredServerUrl(environmentId: EnvironmentId, rawUrl: string): string {
   try {
     const normalizedUrl = normalizePreviewUrl(rawUrl);
-    return resolveBrowserNavigationTarget(environmentId, {
-      kind: "url",
-      url: normalizedUrl,
-    }).resolvedUrl;
+    const parsed = new URL(normalizedUrl);
+    if (!isLoopbackHost(parsed.hostname)) return normalizedUrl;
+    return resolveEnvironmentPortTarget(
+      environmentId,
+      {
+        kind: "environment-port",
+        port: Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80)),
+        protocol: parsed.protocol === "https:" ? "https" : "http",
+        path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+      },
+      readEnvironmentUrl(environmentId),
+      rawUrl,
+      parsed,
+    ).resolvedUrl;
   } catch {
     return rawUrl;
   }


### PR DESCRIPTION
Fixes #8885.

Explicit preview URLs, including loopback URLs, were rewritten to the environment host before navigation. That can direct a valid client-local URL to an unreachable address and report misleading success.

Keep explicit URL targets unchanged; discovered local-server entries continue to use the explicit environment-port resolution path.

Verification: focused browser target resolver tests (19 passing). Web typecheck remains blocked by existing missing optional modules and unrelated Clerk type errors.

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Splits URL resolution between user-entered navigation and discovered servers; a mistake in either path would break remote previews or reintroduce unreachable loopback rewrites.
> 
> **Overview**
> Fixes incorrect rewriting of **explicit** preview navigation targets (loopback URLs, credentials, schemeless `localhost`) to the remote environment host, which could send client-local addresses to unreachable hosts.
> 
> `resolveBrowserNavigationTarget` now returns **`kind: "url"`** targets unchanged with `resolutionKind: "direct"`. **Environment-port** resolution and private-network mapping are unchanged.
> 
> Loopback-to-remote-host mapping moves to **`resolveDiscoveredServerUrl`** only (server-picker / discovered dev servers), so picking `localhost:3000` on a remote environment still resolves to that host’s IP while typed URLs stay as entered.
> 
> Tests are updated to match; explicit `http://localhost:5173` against a public relay base no longer throws the authenticated-gateway error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a7407a96e3299854ac18b9d0ece00745702c4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve explicit loopback URLs in `resolveBrowserNavigationTarget`
> - `resolveBrowserNavigationTarget` now returns all `url`-kind targets unchanged with `resolutionKind: 'direct'`, instead of remapping loopback hosts (e.g. `localhost`, `127.0.0.1`) to the environment host via `resolveEnvironmentPortTarget`
> - `resolveDiscoveredServerUrl` no longer delegates to `resolveBrowserNavigationTarget`; it independently normalizes the URL, maps loopback hosts to the environment host via `resolveEnvironmentPortTarget`, and returns non-loopback URLs as-is
> - Tests updated to verify explicit loopback URLs (including credentialed, schemeless, and IPv4 forms) stay unchanged across remote, private-network, and relay environments
> - Behavioral Change: explicit navigation to a loopback URL no longer redirects through the environment host; discovered server URLs still do. Reviewers should check `resolveBrowserNavigationTarget` in [browserTargetResolver.ts](https://github.com/pingdotgg/t3code/pull/8902/files#diff-d3c7988731a040ddf1171c7c3b826a4b211a89884507fdb562b4bb24fe5aba39) for any remaining callers that relied on loopback remapping for explicit URLs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49a7407.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->