### PR TITLE
fix(chat): preserve assistant responses when folding

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1831,6 +1831,57 @@ describe("buildThreadFeed", () => {
     expect(collapsed[1]).toMatchObject({ type: "turn-fold", label: "Worked for 17s" });
   });
 
+  it("keeps spawned agents visible after their parent turn settles", () => {
+    const turnId = TurnId.make("turn-spawned-agent");
+    const thread = makeThread({
+      id: ThreadId.make("thread-spawned-agent"),
+      projectId: ProjectId.make("project-1"),
+      title: "Spawned agent",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:04.000Z",
+        assistantMessageId: MessageId.make("assistant-final"),
+      },
+      messages: [
+        {
+          id: MessageId.make("assistant-final"),
+          role: "assistant",
+          text: "The parent task is complete.",
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:03.000Z",
+          updatedAt: "2026-04-01T00:00:04.000Z",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("spawned-agent"),
+          kind: "task.progress",
+          tone: "tool",
+          summary: "Research agent is still running",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: {
+            agentKind: "agent",
+            taskId: "research-agent",
+          },
+        }),
+      ],
+    });
+
+    const rows = deriveThreadFeedPresentation(
+      buildThreadFeed(thread),
+      thread.latestTurn,
+      new Set(),
+    );
+
+    expect(rows.map((entry) => entry.id)).toEqual(["spawned-agent", "assistant-final"]);
+    expect(rows).not.toContainEqual(expect.objectContaining({ type: "turn-fold" }));
+  });
+
   it("keeps a substantive answer visible before trailing provider commentary", () => {
     const turnId = TurnId.make("turn-1");
     const thread = makeThread({

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1858,6 +1858,19 @@ describe("buildThreadFeed", () => {
       ],
       activities: [
         makeActivity({
+          id: EventId.make("tool-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Read files",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          turnId,
+          payload: {
+            title: "Read files",
+            itemType: "file_read",
+            status: "completed",
+          },
+        }),
+        makeActivity({
           id: EventId.make("spawned-agent"),
           kind: "task.progress",
           tone: "tool",
@@ -1878,8 +1891,11 @@ describe("buildThreadFeed", () => {
       new Set(),
     );
 
-    expect(rows.map((entry) => entry.id)).toEqual(["spawned-agent", "assistant-final"]);
-    expect(rows).not.toContainEqual(expect.objectContaining({ type: "turn-fold" }));
+    expect(rows.map((entry) => entry.id)).toEqual([
+      "turn-fold:turn-spawned-agent",
+      "agent-spawn:turn-spawned-agent",
+      "assistant-final",
+    ]);
   });
 
   it("keeps a substantive answer visible before trailing provider commentary", () => {
@@ -2899,7 +2915,7 @@ describe("quiet timeline: nested agents", () => {
     expect(allDone).toHaveLength(2);
   });
 
-  it("folds the tool call that launched an agent into its spawn card", () => {
+  it("absorbs the tool call that launched an agent into its spawn card", () => {
     const turnId = TurnId.make("turn-agent-tool");
     const at = (seconds: number) => `2026-04-01T00:00:${String(seconds).padStart(2, "0")}.000Z`;
     const feed = buildThreadFeed(
@@ -2978,7 +2994,7 @@ describe("quiet timeline: nested agents", () => {
     expect(rows).toEqual(["agent-started"]);
     expect(
       deriveThreadFeedPresentation(feed, null, new Set([turnId])).map((row) => row.type),
-    ).toEqual(["turn-fold", "agent-spawn"]);
+    ).toEqual(["agent-spawn"]);
   });
 
   it("presents a spawn batch as one card whose status line follows the newest member activity", () => {

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1831,7 +1831,7 @@ describe("buildThreadFeed", () => {
     expect(collapsed[1]).toMatchObject({ type: "turn-fold", label: "Worked for 17s" });
   });
 
-  it("folds assistant messages between the first and terminal messages", () => {
+  it("keeps a substantive answer visible before trailing provider commentary", () => {
     const turnId = TurnId.make("turn-1");
     const thread = makeThread({
       id: ThreadId.make("thread-middle-message"),
@@ -1849,7 +1849,7 @@ describe("buildThreadFeed", () => {
         {
           id: MessageId.make("assistant-first"),
           role: "assistant",
-          text: "The main result is ready.",
+          text: "The requested migration is complete, and all targeted checks now pass.",
           turnId,
           streaming: false,
           createdAt: "2026-04-01T00:00:01.000Z",
@@ -1858,7 +1858,7 @@ describe("buildThreadFeed", () => {
         {
           id: MessageId.make("assistant-middle"),
           role: "assistant",
-          text: "I am checking one more detail.",
+          text: "One final check is still running.",
           turnId,
           streaming: false,
           createdAt: "2026-04-01T00:00:03.000Z",
@@ -1867,7 +1867,7 @@ describe("buildThreadFeed", () => {
         {
           id: MessageId.make("assistant-final"),
           role: "assistant",
-          text: "Verification finished.",
+          text: "Done.",
           turnId,
           streaming: false,
           createdAt: "2026-04-01T00:00:05.000Z",
@@ -1881,7 +1881,7 @@ describe("buildThreadFeed", () => {
 
     expect(rows.map((entry) => entry.id)).toEqual([
       "assistant-first",
-      "turn-fold:turn-1",
+      "assistant-middle",
       "assistant-final",
     ]);
   });

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1637,7 +1637,13 @@ function deriveThreadFeedTurnFolds(
 
     const terminalAssistantMessageId = terminalAssistantMessageIdByTurn.get(turnId);
     const hiddenEntryIds = new Set(
-      entries.filter((entry) => entry.type === "activity-group").map((entry) => entry.id),
+      entries
+        .filter(
+          (entry) =>
+            entry.type === "activity-group" &&
+            !entry.activities.some((activity) => activity.workEntry.agentSpawn === true),
+        )
+        .map((entry) => entry.id),
     );
     if (hiddenEntryIds.size === 0) {
       continue;
@@ -1860,6 +1866,7 @@ function appendActivityGroupRows(
   const activities = omitSupersededLifecycleMarkers(
     entry.activities.filter(
       (activity) =>
+        activity.workEntry.agentSpawn === true ||
         !(activity.toolLike && activity.status === "neutral") ||
         (isWorking &&
           activity.lifecycleStatus === "inProgress" &&

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1585,13 +1585,9 @@ function deriveThreadFeedTurnFolds(
   feed: ReadonlyArray<ThreadFeedEntry>,
   latestTurn: ThreadFeedLatestTurn | null,
 ): ReadonlyMap<string, ThreadFeedTurnFold> {
-  const firstAssistantMessageIdByTurn = new Map<TurnId, string>();
   const terminalAssistantMessageIdByTurn = new Map<TurnId, string>();
   for (const entry of feed) {
     if (entry.type === "message" && entry.message.role === "assistant" && entry.message.turnId) {
-      if (!firstAssistantMessageIdByTurn.has(entry.message.turnId)) {
-        firstAssistantMessageIdByTurn.set(entry.message.turnId, entry.id);
-      }
       terminalAssistantMessageIdByTurn.set(entry.message.turnId, entry.id);
     }
   }
@@ -1639,15 +1635,9 @@ function deriveThreadFeedTurnFolds(
       continue;
     }
 
-    const firstAssistantMessageId = firstAssistantMessageIdByTurn.get(turnId);
     const terminalAssistantMessageId = terminalAssistantMessageIdByTurn.get(turnId);
     const hiddenEntryIds = new Set(
-      entries
-        .filter(
-          (entry) =>
-            entry.id !== firstAssistantMessageId && entry.id !== terminalAssistantMessageId,
-        )
-        .map((entry) => entry.id),
+      entries.filter((entry) => entry.type === "activity-group").map((entry) => entry.id),
     );
     if (hiddenEntryIds.size === 0) {
       continue;

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1534,12 +1534,13 @@ function groupAdjacentActivities(entries: ReadonlyArray<RawThreadFeedEntry>): Th
     }
 
     const isCompaction = entry.activity.workEntry.sourceActivityKind === "context-compaction";
-    if (isCompaction || firstActivityEntry?.turnId !== entry.turnId) {
+    const isAgentSpawn = entry.activity.workEntry.agentSpawn !== undefined;
+    if (isCompaction || isAgentSpawn || firstActivityEntry?.turnId !== entry.turnId) {
       flushGroup();
     }
     firstActivityEntry ??= entry;
     openGroupActivities.push(entry.activity);
-    if (isCompaction) {
+    if (isCompaction || isAgentSpawn) {
       flushGroup();
     }
   }
@@ -1641,7 +1642,7 @@ function deriveThreadFeedTurnFolds(
         .filter(
           (entry) =>
             entry.type === "activity-group" &&
-            !entry.activities.some((activity) => activity.workEntry.agentSpawn === true),
+            !entry.activities.some((activity) => activity.workEntry.agentSpawn !== undefined),
         )
         .map((entry) => entry.id),
     );
@@ -1866,7 +1867,7 @@ function appendActivityGroupRows(
   const activities = omitSupersededLifecycleMarkers(
     entry.activities.filter(
       (activity) =>
-        activity.workEntry.agentSpawn === true ||
+        activity.workEntry.agentSpawn !== undefined ||
         !(activity.toolLike && activity.status === "neutral") ||
         (isWorking &&
           activity.lifecycleStatus === "inProgress" &&

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1390,12 +1390,68 @@ describe("deriveMessagesTimelineRows", () => {
     expect(expandedRows.map((row) => row.id)).toEqual([
       "user-entry",
       "assistant-first-entry",
+      "turn-fold:turn-1",
       "work-entry-1",
       "assistant-final-entry",
     ]);
     expect(
       expandedRows.find((row) => row.kind === "turn-fold" && row.expanded === true),
     ).toBeDefined();
+  });
+
+  it("folds blank assistant commentary before the terminal response", () => {
+    const timelineEntries = [
+      {
+        id: "work-entry-1",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:01Z",
+        entry: {
+          id: "work-1",
+          createdAt: "2026-01-01T00:00:01Z",
+          turnId: "turn-1" as never,
+          label: "Ran command",
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "assistant-empty-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:02Z",
+        message: {
+          id: "assistant-empty" as never,
+          role: "assistant" as const,
+          text: "",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:02Z",
+          updatedAt: "2026-01-01T00:00:02Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "assistant-final-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:03Z",
+        message: {
+          id: "assistant-final" as never,
+          role: "assistant" as const,
+          text: "Done",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:03Z",
+          updatedAt: "2026-01-01T00:00:03Z",
+          streaming: false,
+        },
+      },
+    ];
+
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries,
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["turn-fold:turn-1", "assistant-final-entry"]);
   });
 
   it("keeps a tool group after the terminal response visible when the turn is folded", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1485,7 +1485,7 @@ describe("deriveMessagesTimelineRows", () => {
     ).toEqual(["turn-fold:turn-1", "assistant-final-entry"]);
   });
 
-  it("folds all assistant messages before the terminal message", () => {
+  it("keeps a substantive answer visible before trailing provider commentary", () => {
     const timelineEntries = [
       {
         id: "assistant-first-entry",
@@ -1494,7 +1494,7 @@ describe("deriveMessagesTimelineRows", () => {
         message: {
           id: "assistant-first" as never,
           role: "assistant" as const,
-          text: "The main result is ready.",
+          text: "The requested migration is complete, and all targeted checks now pass.",
           turnId: "turn-1" as never,
           createdAt: "2026-01-01T00:00:01Z",
           updatedAt: "2026-01-01T00:00:02Z",
@@ -1508,7 +1508,7 @@ describe("deriveMessagesTimelineRows", () => {
         message: {
           id: "assistant-middle" as never,
           role: "assistant" as const,
-          text: "I am checking one more detail.",
+          text: "One final check is still running.",
           turnId: "turn-1" as never,
           createdAt: "2026-01-01T00:00:03Z",
           updatedAt: "2026-01-01T00:00:04Z",
@@ -1522,7 +1522,7 @@ describe("deriveMessagesTimelineRows", () => {
         message: {
           id: "assistant-final" as never,
           role: "assistant" as const,
-          text: "Verification finished.",
+          text: "Done.",
           turnId: "turn-1" as never,
           createdAt: "2026-01-01T00:00:05Z",
           updatedAt: "2026-01-01T00:00:06Z",
@@ -1539,7 +1539,11 @@ describe("deriveMessagesTimelineRows", () => {
       supportsConversationRollback: false,
     });
 
-    expect(rows.map((row) => row.id)).toEqual(["turn-fold:turn-1", "assistant-final-entry"]);
+    expect(rows.map((row) => row.id)).toEqual([
+      "assistant-first-entry",
+      "assistant-middle-entry",
+      "assistant-final-entry",
+    ]);
   });
 
   it("derives a sane duration for a steer-superseded turn with one instant commentary message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1297,7 +1297,7 @@ describe("deriveMessagesTimelineRows", () => {
     expect(assistantRow?.assistantTurnDiffSummary).toBe(assistantTurnDiffSummary);
   });
 
-  it("folds the first assistant message and settled work before the terminal response", () => {
+  it("keeps assistant messages visible around settled work", () => {
     const timelineEntries = [
       {
         id: "user-entry",
@@ -1373,6 +1373,7 @@ describe("deriveMessagesTimelineRows", () => {
     expect(foldRow?.label).toBe("Worked for 22s");
     expect(collapsedRows.map((row) => row.id)).toEqual([
       "user-entry",
+      "assistant-first-entry",
       "turn-fold:turn-1",
       "assistant-final-entry",
     ]);
@@ -1388,7 +1389,6 @@ describe("deriveMessagesTimelineRows", () => {
 
     expect(expandedRows.map((row) => row.id)).toEqual([
       "user-entry",
-      "turn-fold:turn-1",
       "assistant-first-entry",
       "work-entry-1",
       "assistant-final-entry",

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -540,9 +540,9 @@ function workEntryIsActiveTurnActivity(entry: WorkLogEntry): boolean {
 }
 
 /**
- * Settled turns fold activity before their terminal assistant message behind
- * a "Worked for ..." row. A single ordinary activity after that message joins
- * the fold, while larger groups and failures stay visible as a trailing summary.
+ * Settled turns fold work activity behind a "Worked for ..." row while
+ * retaining assistant messages. A single ordinary activity after the terminal
+ * message joins the fold, while larger groups and failures remain visible.
  */
 function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
@@ -617,6 +617,9 @@ function deriveTurnFolds(input: {
       ? group.entries.findIndex((entry) => entry.id === group.terminalEntry?.id)
       : group.entries.length;
     for (const [index, entry] of group.entries.entries()) {
+      if (entry.kind !== "work") {
+        continue;
+      }
       if (entry.id === group.terminalEntry?.id) {
         continue;
       }
@@ -632,7 +635,7 @@ function deriveTurnFolds(input: {
       // Agent-spawn CTA rows never fold: workflows outlive their launching
       // turn (dynamic spawns, background execution), and folding the CTA
       // when the turn settles makes a still-running fleet invisible.
-      if (entry.kind === "work" && entry.entry.agentSpawn !== undefined) {
+      if (entry.entry.agentSpawn !== undefined) {
         continue;
       }
       hiddenEntryIds.add(entry.id);

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -618,6 +618,14 @@ function deriveTurnFolds(input: {
       : group.entries.length;
     for (const [index, entry] of group.entries.entries()) {
       if (entry.kind !== "work") {
+        if (
+          entry.kind === "message" &&
+          entry.message.role === "assistant" &&
+          entry.message.text.trim().length === 0 &&
+          !input.terminalAssistantMessageIds.has(entry.message.id)
+        ) {
+          hiddenEntryIds.add(entry.id);
+        }
         continue;
       }
       if (entry.id === group.terminalEntry?.id) {


### PR DESCRIPTION
Fixes #8879.

Settled turns previously selected the final assistant segment as the sole visible message. A trailing provider progress note could therefore hide the substantive response that preceded it.

Keep all assistant messages visible and fold only settled work activity in both web and mobile timelines.

Verification: `vp fmt --check` on the changed files and focused mobile thread activity tests (22 passing). The focused web logic suite cannot currently load because existing workspace dependencies for `@t3tools/client-runtime/codex-markdown-directives` are missing; mobile typecheck also has existing unrelated errors in its workspace.

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timeline presentation changes for all settled turns: more assistant and agent-spawn rows may appear where folding previously hid them; verify chat density and expand/collapse behavior in web and mobile.
> 
> **Overview**
> Fixes settled-turn folding so a trailing short assistant message no longer hides an earlier substantive answer (#8879).
> 
> **Web** `deriveTurnFolds` now collapses only eligible **work** rows into “Worked for …”; assistant messages stay visible, except empty non-terminal commentary. Agent-spawn, context-compaction, image previews, and post-terminal work still skip the fold.
> 
> **Mobile** `deriveThreadFeedTurnFolds` hides **activity groups** (routine tool work), not assistant messages. Agent-spawn activities get their own group via `groupAdjacentActivities` and are excluded from folds; `appendPresentedFeedEntry` keeps them even when they would be filtered as neutral tool noise.
> 
> Tests on web and mobile assert multi-message assistant turns, blank commentary folding, and spawned-agent rows after the parent turn completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5df854e8e57226aba90bb886de64c5c7a77d8d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve assistant responses and agent-spawn activities during settled-turn folding
> - Mobile: `deriveThreadFeedTurnFolds` no longer selects assistant messages for hiding, and `groupAdjacentActivities` isolates agent-spawn activities into their own groups so they are not merged or folded with adjacent work.
> - Mobile: `appendPresentedFeedEntry` now retains agent-spawn activities even when they would otherwise be filtered as neutral tool-like entries.
> - Web: `deriveTurnFolds` retains all nonblank assistant messages while folding eligible work entries; only nonterminal blank assistant commentary is folded. Agent-spawn, context-compaction, image-preview, and post-terminal work entries remain visible.
> - Tests on both platforms updated to assert substantive and trailing assistant messages stay visible, and spawned-agent activity remains a separate row.
> - Risk: feeds that relied on settled turns hiding preterminal assistant messages will now show those messages; check `deriveThreadFeedTurnFolds` in [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/8903/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5) and `deriveTurnFolds` in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/8903/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) if row counts change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5df854e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent-spawn activity now remains visible after the parent turn settles, including within collapsed activity views.
  * Nested agent activity is displayed independently rather than being hidden within adjacent turn summaries.
  * Assistant messages containing substantive content remain visible around collapsed work and provider commentary.
  * Empty assistant commentary before a terminal response is now folded into the turn summary for a cleaner timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->