### PR TITLE
fix(web): hide invalid slash skill completions

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -146,7 +146,10 @@ import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
 import { ComposerControl, ComposerControlIcon, ComposerSelectControl } from "./ComposerControl";
 import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
-import { searchSlashCommandItems } from "./composerSlashCommandSearch";
+import {
+  searchSlashCommandItems,
+  slashCommandItemsForPromptPosition,
+} from "./composerSlashCommandSearch";
 import {
   getComposerPromptInjectionState,
   getComposerProviderState,
@@ -1360,11 +1363,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           skill.description ??
           (skill.scope ? `${skill.scope} skill` : ""),
       }));
-      const slashCommandItems = [
-        ...builtInSlashCommandItems,
-        ...providerSlashCommandItems,
-        ...skillItems,
-      ];
+      const slashCommandItems = slashCommandItemsForPromptPosition(
+        [...builtInSlashCommandItems, ...providerSlashCommandItems, ...skillItems],
+        composerTrigger.rangeStart === 0,
+      );
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vite-plus/test";
 import { ProviderDriverKind } from "@t3tools/contracts";
 
 import type { ComposerCommandItem } from "./ComposerCommandMenu";
-import { searchSlashCommandItems } from "./composerSlashCommandSearch";
+import {
+  searchSlashCommandItems,
+  slashCommandItemsForPromptPosition,
+} from "./composerSlashCommandSearch";
 
 describe("searchSlashCommandItems", () => {
   const claudeDriver = ProviderDriverKind.make("claudeAgent");
@@ -169,6 +172,40 @@ describe("searchSlashCommandItems", () => {
     ] satisfies Array<Extract<ComposerCommandItem, { type: "slash-command" | "skill" }>>;
 
     expect(searchSlashCommandItems(items, "").map((item) => item.id)).toEqual([
+      "slash:model",
+      "skill:claudeAgent:unslop",
+    ]);
+  });
+
+  it("hides skills from slash completion after the first message line", () => {
+    const items = [
+      {
+        id: "slash:model",
+        type: "slash-command",
+        command: "model",
+        label: "/model",
+        description: "Switch model",
+      },
+      {
+        id: "skill:claudeAgent:unslop",
+        type: "skill",
+        provider: claudeDriver,
+        skill: {
+          name: "unslop",
+          path: "/skills/unslop/SKILL.md",
+          enabled: true,
+        },
+        label: "/skill:unslop",
+        description: "Cut AI tells from writing",
+      },
+    ] satisfies Array<
+      Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" | "skill" }>
+    >;
+
+    expect(slashCommandItemsForPromptPosition(items, false).map((item) => item.id)).toEqual([
+      "slash:model",
+    ]);
+    expect(slashCommandItemsForPromptPosition(items, true).map((item) => item.id)).toEqual([
       "slash:model",
       "skill:claudeAgent:unslop",
     ]);

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -12,6 +12,16 @@ type SlashSearchItem = Extract<
   { type: "slash-command" | "provider-slash-command" | "skill" }
 >;
 
+export function slashCommandItemsForPromptPosition(
+  items: ReadonlyArray<SlashSearchItem>,
+  isAtPromptStart: boolean,
+): SlashSearchItem[] {
+  if (isAtPromptStart) {
+    return [...items];
+  }
+  return items.filter((item) => item.type !== "skill");
+}
+
 function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {
   if (item.type === "skill") {
     if (query === "skill") {


### PR DESCRIPTION
Fixes #8758.

The slash menu offered skills at the start of any line, even though providers can only invoke them when the command begins the full prompt. Selecting one in a later line silently produced a non-running command.

Filter skill entries from slash completion outside prompt position zero while keeping built-in and provider slash commands available there.

Verification: `vp fmt --check` and focused slash command search tests (7 passing).

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX fix to slash-completion filtering with no auth, data, or provider invocation changes beyond what users can already type.
> 
> **Overview**
> Fixes invalid **skill** suggestions in the composer slash menu when `/` is typed on a later line of the message.
> 
> Adds **`slashCommandItemsForPromptPosition`**, which drops `skill`-typed menu entries unless the slash trigger is at **prompt offset zero** (`composerTrigger.rangeStart === 0`). Built-in and provider slash commands still appear on any line. **`ChatComposer`** runs the combined slash list through this filter before **`searchSlashCommandItems`**.
> 
> Tests cover that skills remain at prompt start and are omitted when `isAtPromptStart` is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa97778b2309cfd59c53bdf6bcf08d6140499c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide skill items from slash command completions unless cursor is at prompt start
> - Adds `slashCommandItemsForPromptPosition` to filter out `skill`-type items when the cursor is not at position 0 in [composerSlashCommandSearch.ts](https://github.com/pingdotgg/t3code/pull/8904/files#diff-a81f587c9b12a9a903e8f20bc37bca999eeb757e6d9e08f8a6afd0b9ef2541d9)
> - `ChatComposer` now wraps the combined built-in, provider, and skill item list with this function before searching, passing `composerTrigger.rangeStart === 0` as the start flag
> - Tests cover skills being hidden mid-prompt and shown at the start
> - Risk: only `skill` items are filtered by position; if other item types should also be position-sensitive, they are unaffected
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized caa9777.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->