### PR TITLE
fix(contracts): accept CLI event origins

### DIFF
--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -17,7 +17,7 @@ const layer = it.layer(
 );
 
 layer("OrchestrationEventStore", (it) => {
-  it.effect("stores json columns as strings and replays decoded events", () =>
+  it.effect("stores json columns as strings and replays CLI-origin events", () =>
     Effect.gen(function* () {
       const eventStore = yield* OrchestrationEventStore;
       const sql = yield* SqlClient.SqlClient;
@@ -34,6 +34,9 @@ layer("OrchestrationEventStore", (it) => {
         correlationId: CommandId.make("cmd-store-roundtrip"),
         metadata: {
           adapterKey: "codex",
+          origin: {
+            surface: "cli",
+          },
         },
         payload: {
           projectId: ProjectId.make("project-roundtrip"),
@@ -66,6 +69,7 @@ layer("OrchestrationEventStore", (it) => {
       assert.equal(replayed.length, 1);
       assert.equal(replayed[0]?.type, "project.created");
       assert.equal(replayed[0]?.metadata.adapterKey, "codex");
+      assert.deepEqual(replayed[0]?.metadata.origin, { surface: "cli" });
     }),
   );
 

--- a/packages/contracts/src/baseSchemas.ts
+++ b/packages/contracts/src/baseSchemas.ts
@@ -86,12 +86,12 @@ export const RpcClientId = NonNegativeInt.pipe(Schema.brand("RpcClientId"));
 export type RpcClientId = typeof RpcClientId.Type;
 
 /**
- * Which client app a connection comes from. Unlike
+ * Which client surface a connection or command comes from. Unlike
  * `AuthClientMetadataDeviceType` (a UA-style device class where web and
  * desktop are both "desktop"), this names the actual product surface.
  * Optional everywhere it appears: old clients never send it.
  */
-export const ClientSurface = Schema.Literals(["web", "desktop", "mobile"]);
+export const ClientSurface = Schema.Literals(["web", "desktop", "mobile", "cli"]);
 export type ClientSurface = typeof ClientSurface.Type;
 
 export const ClientOs = Schema.Literals([


### PR DESCRIPTION
Fixes #8789.

A persisted event with `metadata.origin.surface = "cli"` was rejected by the client-origin schema during startup replay. One such row made the event-store batch undecodable and prevented the server from restarting.

Accept the CLI surface in the shared contract and cover replay through the SQLite event store.

Verification: `vp fmt --check`, focused event-store tests (2 passing), and `@t3tools/contracts` typecheck.

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive contract change that aligns decoding with data already persisted; no auth or data-migration logic touched.
> 
> **Overview**
> Adds **`cli`** to the shared `ClientSurface` literal union so orchestration event metadata with `origin.surface: "cli"` decodes during SQLite event-store replay instead of failing the whole batch and blocking server startup.
> 
> The `ClientSurface` doc comment is tweaked to cover commands as well as connections. The orchestration event-store test now appends and replays an event with CLI origin metadata and asserts `metadata.origin` round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b476dd9e6e73d24b563a4e6f7393ba498d11e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `'cli'` literal to `ClientSurface` schema to accept CLI event origins
> Extends the `ClientSurface` type in [baseSchemas.ts](https://github.com/pingdotgg/t3code/pull/8905/files#diff-746f4b0dee08612461eb8188d8987e04d0309cc7b5c2fa33018c6f2a6cbb8667) to include `'cli'` as an allowed surface value, so CLI-origin events pass schema validation. Updates the `OrchestrationEventStore` test suite to assert CLI-origin events round-trip with `metadata.origin.surface = 'cli'`.
> - Risk: any code that exhaustively switches over `ClientSurface` values may now miss the new `'cli'` case at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b476dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->