### PR TITLE
fix(cloud): back off relay connector restarts

### DIFF
--- a/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
@@ -8,6 +8,7 @@ import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as RelayClient from "@t3tools/shared/relayClient";
 
@@ -240,7 +241,7 @@ describe("CloudManagedEndpointRuntime", () => {
     }),
   );
 
-  it.effect("supervises the active connector and restarts it after process exit", () =>
+  it.effect("waits before restarting an exited connector", () =>
     Effect.gen(function* () {
       const spawned: Array<number> = [];
       const killed: Array<number> = [];
@@ -275,6 +276,12 @@ describe("CloudManagedEndpointRuntime", () => {
         tunnelId: "tunnel-1",
       });
       yield* Deferred.succeed(firstExit, ChildProcessSpawner.ExitCode(1));
+      yield* Effect.yieldNow;
+
+      expect(spawned).toEqual([400]);
+      yield* TestClock.adjust("4 seconds");
+      expect(spawned).toEqual([400]);
+      yield* TestClock.adjust("1 second");
       yield* Deferred.await(secondSpawned);
 
       expect(started).toMatchObject({ status: "running", pid: 400 });

--- a/apps/server/src/cloud/ManagedEndpointRuntime.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.ts
@@ -99,6 +99,8 @@ const stopConnector = (connector: ActiveConnector | null) =>
       )
     : Effect.void;
 
+const RELAY_CONNECTOR_RESTART_DELAY = "5 seconds";
+
 export const make = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const relayClient = yield* RelayClient.RelayClient;
@@ -115,14 +117,14 @@ export const make = Effect.gen(function* () {
   const superviseConnector = (connector: ActiveConnector) =>
     Effect.gen(function* () {
       const result = yield* Effect.result(connector.child.exitCode);
-      yield* reconcileSemaphore.withPermits(1)(
+      const restartConfig = yield* reconcileSemaphore.withPermits(1)(
         Effect.gen(function* () {
           const active = yield* Ref.get(activeRef);
           if (
             active?.child.pid !== connector.child.pid ||
             active.configKey !== connector.configKey
           ) {
-            return;
+            return null;
           }
           yield* Ref.set(activeRef, null);
           yield* stopConnector(connector);
@@ -133,7 +135,7 @@ export const make = Effect.gen(function* () {
             desiredConfig.providerKind !== "cloudflare_tunnel" ||
             runtimeConfigKey(desiredConfig) !== connector.configKey
           ) {
-            return;
+            return null;
           }
 
           yield* Effect.logWarning("Relay client exited; restarting", {
@@ -144,6 +146,26 @@ export const make = Effect.gen(function* () {
             tunnelId: connector.config.tunnelId,
             tunnelName: connector.config.tunnelName,
           });
+          return desiredConfig;
+        }),
+      );
+      if (!restartConfig) {
+        return;
+      }
+
+      // Do not hold the reconcile lock while waiting: a user can still change
+      // or disable T3 Connect instead of waiting behind a failed child.
+      yield* Effect.sleep(RELAY_CONNECTOR_RESTART_DELAY);
+      yield* reconcileSemaphore.withPermits(1)(
+        Effect.gen(function* () {
+          const desiredConfig = yield* Ref.get(desiredConfigRef);
+          if (
+            !desiredConfig ||
+            desiredConfig.providerKind !== "cloudflare_tunnel" ||
+            runtimeConfigKey(desiredConfig) !== connector.configKey
+          ) {
+            return;
+          }
           yield* reconcileConfig(desiredConfig);
         }),
       );


### PR DESCRIPTION
Fixes #8760.

An immediately failing relay child was restarted in a tight loop, creating processes and trace records until the server exhausted its heap.

Wait five seconds before retrying a connector exit. The wait intentionally releases the configuration lock so users can disable or change T3 Connect immediately.

Verification: `vp fmt --check`, focused managed endpoint runtime tests (8 passing), and server typecheck (existing suggestions only).

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connector supervision and config locking timing for cloud relay processes; mis-timed restarts or lock handling could affect T3 Connect availability or responsiveness to config changes.
> 
> **Overview**
> Fixes a tight restart loop when the Cloudflare relay child exits immediately, which could spawn processes and trace records until the server ran out of heap.
> 
> **`superviseConnector`** now waits **5 seconds** (`RELAY_CONNECTOR_RESTART_DELAY`) before calling reconcile again. The delay runs **outside** the reconcile semaphore so `applyConfig` can still disable or change T3 Connect without blocking behind a failing child. After the wait, it re-reads `desiredConfig` and only restarts if the same tunnel config is still wanted.
> 
> The supervisor test was renamed and updated to use **`TestClock`**: it asserts no second spawn for the first 4 seconds after exit, then restart after the full 5 second delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14468ba66debdf98bf76e00d136c348d152d28d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delay relay connector restarts by 5 seconds in `ManagedEndpointRuntime`
> Introduces `RELAY_CONNECTOR_RESTART_DELAY` (5 seconds) in [ManagedEndpointRuntime.ts](https://github.com/pingdotgg/t3code/pull/8906/files#diff-7e51d782034aeae3187abebda413ecbd44a5d6b4f7caf5ede93d4e38a474ec53). After a managed Cloudflare connector exits, the runtime now sleeps before attempting a restart and releases the reconcile semaphore during the wait, so other operations are not blocked. After the delay, it re-validates that the desired config still matches the exited connector before calling `reconcgeConfig`; if the config changed, the restart is skipped. Updates the supervision test to use `TestClock` and assert the 5-second wait with no immediate respawn.
> - Behavioral Change: restarts of exited relay connectors are now delayed by 5 seconds and gated on a second config validation; callers expecting immediate respawn will observe the delay. The reconcile semaphore is released during the delay, opening a window where config changes can cancel the restart.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14468ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->