### PR TITLE
fix(claude): isolate thread title generation

### DIFF
--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -71,6 +71,11 @@ function makeFakeClaudeBinary(dir: string) {
         '  fail("CLAUDE_CONFIG_DIR was " + (process.env.CLAUDE_CONFIG_DIR ?? ""), 5);',
         "}",
         "",
+        "const cwdMustNotBe = process.env.T3_FAKE_CLAUDE_CWD_MUST_NOT_BE;",
+        "if (cwdMustNotBe && process.cwd() === cwdMustNotBe) {",
+        '  fail("Claude ran from a forbidden cwd", 6);',
+        "}",
+        "",
         "const stderrText = process.env.T3_FAKE_CLAUDE_STDERR;",
         "if (stderrText) {",
         '  process.stderr.write(stderrText + "\\n");',
@@ -111,6 +116,7 @@ function withFakeClaudeEnv<A, E, R>(
     argsMustNotContain?: string;
     stdinMustContain?: string;
     configDirMustBe?: string;
+    cwdMustNotBe?: string;
     claudeConfig?: Partial<ClaudeSettings>;
   },
   effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
@@ -128,6 +134,7 @@ function withFakeClaudeEnv<A, E, R>(
     const previousArgsMustNotContain = process.env.T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN;
     const previousStdinMustContain = process.env.T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN;
     const previousConfigDirMustBe = process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE;
+    const previousCwdMustNotBe = process.env.T3_FAKE_CLAUDE_CWD_MUST_NOT_BE;
 
     yield* Effect.acquireRelease(
       Effect.sync(() => {
@@ -168,6 +175,12 @@ function withFakeClaudeEnv<A, E, R>(
           process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE = input.configDirMustBe;
         } else {
           delete process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE;
+        }
+
+        if (input.cwdMustNotBe !== undefined) {
+          process.env.T3_FAKE_CLAUDE_CWD_MUST_NOT_BE = input.cwdMustNotBe;
+        } else {
+          delete process.env.T3_FAKE_CLAUDE_CWD_MUST_NOT_BE;
         }
       }),
       () =>
@@ -214,6 +227,12 @@ function withFakeClaudeEnv<A, E, R>(
             delete process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE;
           } else {
             process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE = previousConfigDirMustBe;
+          }
+
+          if (previousCwdMustNotBe === undefined) {
+            delete process.env.T3_FAKE_CLAUDE_CWD_MUST_NOT_BE;
+          } else {
+            process.env.T3_FAKE_CLAUDE_CWD_MUST_NOT_BE = previousCwdMustNotBe;
           }
         }),
     );
@@ -300,6 +319,9 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
           },
         }),
         stdinMustContain: "Please investigate reconnect failures after restarting the session.",
+        argsMustContain: "--tools",
+        argsMustNotContain: "--dangerously-skip-permissions",
+        cwdMustNotBe: process.cwd(),
       },
       (textGeneration) =>
         Effect.gen(function* () {

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -7,6 +7,8 @@
  *
  * @module ClaudeTextGeneration
  */
+import { tmpdir } from "node:os";
+
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
@@ -110,6 +112,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     prompt,
     outputSchemaJson,
     modelSelection,
+    toolAccess = "default",
   }: {
     operation:
       | "generateCommitMessage"
@@ -120,6 +123,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     prompt: string;
     outputSchemaJson: S;
     modelSelection: ModelSelection;
+    toolAccess?: "default" | "none";
   }): Effect.fn.Return<S["Type"], TextGenerationError, S["DecodingServices"]> {
     const jsonSchemaStr = yield* encodeJsonForOperation(
       operation,
@@ -169,7 +173,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
           resolveClaudeApiModelId(modelSelection),
           ...(cliEffort ? ["--effort", cliEffort] : []),
           ...(settingsJson ? ["--settings", settingsJson] : []),
-          "--dangerously-skip-permissions",
+          ...(toolAccess === "none" ? ["--tools", ""] : ["--dangerously-skip-permissions"]),
         ],
         { env: claudeEnvironment },
       );
@@ -348,10 +352,13 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
 
       const generated = yield* runClaudeJson({
         operation: "generateThreadTitle",
-        cwd: input.cwd,
+        // A title is text-only. Keep the process outside the user's checkout
+        // and remove every tool so a model cannot act on the embedded prompt.
+        cwd: tmpdir(),
         prompt,
         outputSchemaJson: outputSchema,
         modelSelection: input.modelSelection,
+        toolAccess: "none",
       });
 
       return {


### PR DESCRIPTION
Fixes #8773.

Claude thread-title generation ran with permission bypass and the user project as its working directory. A prompt-injection failure could therefore modify the checkout while trying to produce a title.

Run this text-only operation from the system temporary directory with `--tools ""`, rather than passing permission bypass. The regression test verifies both the disabled tools and isolated working directory.

Verification: `vp fmt --check`, focused Claude text-generation tests (5 passing), and server typecheck (existing suggestions only).

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive change to how the Claude CLI is spawned for one operation; behavior now depends on `--tools ""` and a non-checkout cwd, with limited blast radius if the CLI disagrees.
> 
> **Overview**
> Hardens **Claude thread title** generation so a poisoned user message cannot drive tool use against the repo checkout.
> 
> `runClaudeJson` gains optional `toolAccess`: when set to `"none"`, the CLI is invoked with `--tools ""` instead of `--dangerously-skip-permissions`. **Only** `generateThreadTitle` uses that mode and spawns from `tmpdir()` rather than the caller’s `cwd`; commit/PR/branch flows are unchanged.
> 
> Tests extend the fake Claude stub with `cwdMustNotBe` and assert the thread-title path passes `--tools`, omits permission bypass, and does not run from the project directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 361eacee4f8742c6d7c9ac9d1dd539340bf90800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate `ClaudeTextGeneration.generateThreadTitle` by running CLI from temp dir and disabling tools
> - Thread title generation now spawns the Claude CLI from the OS temp directory (`tmpdir()`) instead of `input.cwd`, isolating it from the project working tree.
> - Adds a `toolAccess` parameter to `runClaudeJson` in [ClaudeTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/8907/files#diff-782736de45e734285d68cfe4a294d8a7d4ede95ff201d8ece36a89e0a020c576); when set to `'none'`, the CLI receives `--tools ''` instead of `--dangerously-skip-permissions`.
> - `generateThreadTitle` calls `runClaudeJson` with `toolAccess: 'none'` since title generation is text-only and needs no tools.
> - Tests in [ClaudeTextGeneration.test.ts](https://github.com/pingdotgg/t3code/pull/8907/files#diff-b80933ea128b7b8355e664cf3c9a325bba1303ad7c06db0044cbc2addede23bb) now assert `--tools` is present, `--dangerously-skip-permissions` is absent, and the CLI is not run from `process.cwd()`.
> - Behavioral Change: `runClaudeJson` default `toolAccess` is `'default'`, so existing callers keep `--dangerously-skip-permissions`; only `generateThreadTitle` uses the new `'none'` path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 361eace.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->