### PR TITLE
fix(claude): isolate capability probe settings

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -59,7 +59,11 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
-import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import {
+  makeClaudeCapabilitiesCacheKey,
+  makeClaudeCapabilitiesProbeContext,
+  makeClaudeContinuationGroupKey,
+} from "./ClaudeHome.ts";
 import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
@@ -125,6 +129,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         enabled,
         binaryPath: expandHomePath(config.binaryPath),
       } satisfies ClaudeSettings;
+      const capabilitiesProbeContext = yield* makeClaudeCapabilitiesProbeContext(
+        effectiveConfig,
+        processEnv,
+        cwd,
+      );
       const resolveMaintenance = yield* makeCachedProviderMaintenanceResolution(
         resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
           binaryPath: effectiveConfig.binaryPath,
@@ -167,11 +176,18 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         capacity: 1,
         timeToLive: CAPABILITIES_PROBE_TTL,
         lookup: () =>
-          probeClaudeCapabilities(effectiveConfig, processEnv, cwd).pipe(
-            Effect.provideService(Path.Path, path),
-          ),
+          probeClaudeCapabilities(
+            effectiveConfig,
+            capabilitiesProbeContext.environment,
+            capabilitiesProbeContext.cwd,
+            cwd,
+          ).pipe(Effect.provideService(Path.Path, path)),
       });
-      const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
+      const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(
+        effectiveConfig,
+        processEnv,
+        cwd,
+      );
 
       // Start the TTL-gated refresh without delaying provider readiness. The
       // next check observes a remote manifest after the background fetch lands.

--- a/apps/server/src/provider/Drivers/ClaudeHome.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.test.ts
@@ -8,8 +8,10 @@ import * as Path from "effect/Path";
 import {
   claudeSignedOutMessage,
   makeClaudeCapabilitiesCacheKey,
+  makeClaudeCapabilitiesProbeContext,
   makeClaudeContinuationGroupKey,
   makeClaudeEnvironment,
+  resolveClaudeConfigDirPath,
   resolveClaudeHomePath,
 } from "./ClaudeHome.ts";
 
@@ -21,7 +23,65 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         const resolved = path.resolve(NodeOS.homedir());
 
         expect(yield* resolveClaudeHomePath({ homePath: "" })).toBe(resolved);
+        expect(yield* resolveClaudeConfigDirPath({ homePath: "" })).toBe(
+          path.join(resolved, ".claude"),
+        );
+        expect((yield* makeClaudeCapabilitiesProbeContext({ homePath: "" })).cwd).toBe(
+          path.resolve(NodeOS.tmpdir()),
+        );
         expect(yield* makeClaudeEnvironment({ homePath: "" })).toBe(process.env);
+      }),
+    );
+
+    it.effect("resolves an environment config directory against the workspace cwd", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const workspaceCwd = path.join(NodeOS.tmpdir(), "t3-claude-workspace");
+        const environment = { CLAUDE_CONFIG_DIR: "profile" };
+
+        expect(yield* resolveClaudeConfigDirPath({ homePath: "" }, environment, workspaceCwd)).toBe(
+          path.join(workspaceCwd, "profile"),
+        );
+        const context = yield* makeClaudeCapabilitiesProbeContext(
+          { homePath: "" },
+          environment,
+          workspaceCwd,
+        );
+        expect(context.cwd).toBe(path.resolve(NodeOS.tmpdir()));
+        expect(context.environment.CLAUDE_CONFIG_DIR).toBe(path.join(workspaceCwd, "profile"));
+        expect(
+          yield* makeClaudeCapabilitiesCacheKey(
+            { binaryPath: "claude", homePath: "" },
+            environment,
+            workspaceCwd,
+          ),
+        ).toBe(`claude\0${path.join(workspaceCwd, "profile")}`);
+      }),
+    );
+
+    it.effect("uses inherited HOME or USERPROFILE for the default config directory", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const homeEnvironment = { HOME: path.join(NodeOS.tmpdir(), "claude-home-a") };
+        const userProfileEnvironment = { USERPROFILE: path.join(NodeOS.tmpdir(), "claude-home-b") };
+
+        expect(yield* resolveClaudeConfigDirPath({ homePath: "" }, homeEnvironment)).toBe(
+          path.join(homeEnvironment.HOME, ".claude"),
+        );
+        expect(yield* resolveClaudeConfigDirPath({ homePath: "" }, userProfileEnvironment)).toBe(
+          path.join(userProfileEnvironment.USERPROFILE, ".claude"),
+        );
+        expect(
+          yield* makeClaudeCapabilitiesCacheKey(
+            { binaryPath: "claude", homePath: "" },
+            homeEnvironment,
+          ),
+        ).not.toBe(
+          yield* makeClaudeCapabilitiesCacheKey(
+            { binaryPath: "claude", homePath: "" },
+            userProfileEnvironment,
+          ),
+        );
       }),
     );
 
@@ -35,7 +95,7 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         expect((yield* makeClaudeEnvironment({ homePath })).CLAUDE_CONFIG_DIR).toBe(resolved);
         expect(yield* makeClaudeContinuationGroupKey({ homePath })).toBe(`claude:home:${resolved}`);
         expect(yield* makeClaudeCapabilitiesCacheKey({ binaryPath: "claude", homePath })).toBe(
-          `claude\0${resolved}\0`,
+          `claude\0${resolved}`,
         );
       }),
     );
@@ -51,11 +111,12 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
       expect(message).toContain("then start a new thread");
     });
 
-    it.effect("separates capability probes by cwd", () =>
+    it.effect("separates capability probes by their resolved configuration directories", () =>
       Effect.gen(function* () {
-        const config = { binaryPath: "claude", homePath: "" };
-        const first = yield* makeClaudeCapabilitiesCacheKey(config, "/repo-a");
-        const second = yield* makeClaudeCapabilitiesCacheKey(config, "/repo-b");
+        const firstConfig = { binaryPath: "claude", homePath: "~/.claude-first" };
+        const secondConfig = { binaryPath: "claude", homePath: "~/.claude-second" };
+        const first = yield* makeClaudeCapabilitiesCacheKey(firstConfig);
+        const second = yield* makeClaudeCapabilitiesCacheKey(secondConfig);
         expect(first).not.toBe(second);
       }),
     );

--- a/apps/server/src/provider/Drivers/ClaudeHome.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.ts
@@ -17,6 +17,66 @@ export const resolveClaudeHomePath = Effect.fn("resolveClaudeHomePath")(function
   return path.resolve(homePath.length > 0 ? expandHomePath(homePath) : NodeOS.homedir());
 });
 
+/**
+ * Resolve the Claude config directory the spawned CLI uses. An explicit
+ * provider override wins, followed by the instance environment, then
+ * Claude's default `$HOME/.claude` location.
+ */
+export const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
+  config: Pick<ClaudeSettings, "homePath">,
+  environment?: NodeJS.ProcessEnv,
+  cwd?: string,
+): Effect.fn.Return<string, never, Path.Path> {
+  const path = yield* Path.Path;
+  const homePath = config.homePath.trim();
+  if (homePath.length > 0) {
+    return yield* resolveClaudeHomePath(config);
+  }
+
+  const resolvedEnvironment = environment ?? process.env;
+  // No tilde expansion here: the spawned CLI receives this env var verbatim
+  // (env vars are never shell-expanded), so a literal `~` must stay literal
+  // for discovery to scan the same directory the runtime would. A relative
+  // value is resolved against the workspace cwd — the subprocess's own cwd —
+  // for the same reason.
+  const environmentConfigDir = resolvedEnvironment.CLAUDE_CONFIG_DIR?.trim() ?? "";
+  if (environmentConfigDir.length > 0) {
+    return cwd ? path.resolve(cwd, environmentConfigDir) : path.resolve(environmentConfigDir);
+  }
+  const inheritedHome =
+    resolvedEnvironment.HOME?.trim() || resolvedEnvironment.USERPROFILE?.trim() || NodeOS.homedir();
+  return path.join(path.resolve(inheritedHome), ".claude");
+});
+
+/**
+ * Capability probes run from an existing neutral cwd because Claude treats
+ * `<cwd>/.claude/settings.json` as project settings. The intended config dir
+ * remains available through CLAUDE_CONFIG_DIR, including when it does not yet
+ * exist or arrived as a relative inherited environment variable.
+ */
+export const makeClaudeCapabilitiesProbeContext = Effect.fn("makeClaudeCapabilitiesProbeContext")(
+  function* (
+    config: Pick<ClaudeSettings, "homePath">,
+    environment?: NodeJS.ProcessEnv,
+    workspaceCwd?: string,
+  ): Effect.fn.Return<
+    { readonly cwd: string; readonly environment: NodeJS.ProcessEnv },
+    never,
+    Path.Path
+  > {
+    const path = yield* Path.Path;
+    const resolvedEnvironment = environment ?? process.env;
+    const configDirPath = yield* resolveClaudeConfigDirPath(config, environment, workspaceCwd);
+    return {
+      cwd: path.resolve(NodeOS.tmpdir()),
+      environment: {
+        ...resolvedEnvironment,
+        CLAUDE_CONFIG_DIR: configDirPath,
+      },
+    };
+  },
+);
+
 export const makeClaudeEnvironment = Effect.fn("makeClaudeEnvironment")(function* (
   config: Pick<ClaudeSettings, "homePath">,
   baseEnv?: NodeJS.ProcessEnv,
@@ -47,10 +107,11 @@ export const makeClaudeContinuationGroupKey = Effect.fn("makeClaudeContinuationG
 export const makeClaudeCapabilitiesCacheKey = Effect.fn("makeClaudeCapabilitiesCacheKey")(
   function* (
     config: Pick<ClaudeSettings, "binaryPath" | "homePath">,
-    cwd?: string,
+    environment?: NodeJS.ProcessEnv,
+    workspaceCwd?: string,
   ): Effect.fn.Return<string, never, Path.Path> {
-    const resolvedHomePath = yield* resolveClaudeHomePath(config);
-    return `${config.binaryPath}\0${resolvedHomePath}\0${cwd ?? ""}`;
+    const configDirPath = yield* resolveClaudeConfigDirPath(config, environment, workspaceCwd);
+    return `${config.binaryPath}\0${configDirPath}`;
   },
 );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -13,8 +13,6 @@
  *
  * @module provider/Drivers/ClaudeSkills
  */
-import * as NodeOS from "node:os";
-
 import type { ClaudeSettings, ServerProviderSkill } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -24,7 +22,7 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { fromLenientJson } from "@t3tools/shared/schemaJson";
 import { parse as parseYamlDocument } from "yaml";
 
-import { expandHomePath } from "../../pathExpansion.ts";
+import { resolveClaudeConfigDirPath } from "./ClaudeHome.ts";
 
 type ClaudeSkillScope = "user" | "project";
 
@@ -265,34 +263,6 @@ const readSkillOverrides = Effect.fn("readSkillOverrides")(function* (
   }
 
   return overridesByName;
-});
-
-/**
- * Resolve the Claude config directory the CLI would use, matching the
- * precedence the spawned CLI sees: the instance's `homePath` (exported as
- * `CLAUDE_CONFIG_DIR` by `makeClaudeEnvironment`), then a `CLAUDE_CONFIG_DIR`
- * already present in the process environment, then `~/.claude`.
- */
-const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
-  config: Pick<ClaudeSettings, "homePath">,
-  environment: NodeJS.ProcessEnv,
-  cwd?: string,
-): Effect.fn.Return<string, never, Path.Path> {
-  const path = yield* Path.Path;
-  const homePath = config.homePath.trim();
-  if (homePath.length > 0) {
-    return path.resolve(expandHomePath(homePath));
-  }
-  // No tilde expansion here: the spawned CLI receives this env var verbatim
-  // (env vars are never shell-expanded), so a literal `~` must stay literal
-  // for discovery to scan the same directory the runtime would. A relative
-  // value is resolved against the workspace cwd — the subprocess's own cwd —
-  // for the same reason.
-  const environmentConfigDir = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
-  if (environmentConfigDir.length > 0) {
-    return cwd ? path.resolve(cwd, environmentConfigDir) : path.resolve(environmentConfigDir);
-  }
-  return path.join(NodeOS.homedir(), ".claude");
 });
 
 /**

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -4,6 +4,7 @@ import { vi } from "vite-plus/test";
 import * as Deferred from "effect/Deferred";
 import * as Fiber from "effect/Fiber";
 import * as TestClock from "effect/testing/TestClock";
+import * as NodeOS from "node:os";
 import { ClaudeSettings } from "@t3tools/contracts";
 import * as NodeFSP from "node:fs/promises";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -13,6 +14,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
+import { makeClaudeCapabilitiesProbeContext } from "../Drivers/ClaudeHome.ts";
 import {
   buildClaudeCapabilitiesProbeQueryOptions,
   CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES,
@@ -33,12 +35,14 @@ it("isolates Claude capability probes without dropping workspace setting sources
       ENABLE_CLAUDEAI_MCP_SERVERS: "true",
       FORCE_CODE_TERMINAL: "1",
     },
-    cwd: "/workspace/project",
+    cwd: "/config/claude",
+    workspaceCwd: "/workspace/project",
   });
 
   assert.deepEqual(options.mcpServers, {});
   assert.equal(options.strictMcpConfig, true);
-  assert.equal(options.cwd, "/workspace/project");
+  assert.equal(options.cwd, "/config/claude");
+  assert.deepEqual(options.additionalDirectories, ["/workspace/project"]);
   assert.deepEqual(options.settingSources, [...CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES]);
   assert.deepEqual(options.settings, { disableAllHooks: true });
   assert.deepEqual(options.allowedTools, []);
@@ -53,13 +57,14 @@ it("isolates Claude capability probes without dropping workspace setting sources
 });
 
 it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
-  it.effect("serializes strict no-MCP options and still resolves account capabilities", () =>
+  it.effect("runs from an existing neutral cwd when the Claude config dir is missing", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-probe-sdk-" });
       const executablePath = path.join(tempDir, "fake-claude.mjs");
       const invocationPath = path.join(tempDir, "invocation.json");
+      const claudeConfigDir = path.join(tempDir, "missing-claude-config");
       // The probe aborts the SDK without awaiting the child's exit, and on
       // Windows a directory that is still some process's cwd cannot be
       // removed. Keep the workspace outside the scoped directory and let it
@@ -97,6 +102,7 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
           "writeFileSync(process.env.T3_PROBE_INVOCATION_PATH, JSON.stringify({",
           "  args,",
           "  cwd: process.cwd(),",
+          "  configDir: process.env.CLAUDE_CONFIG_DIR,",
           "  connectorEnv: process.env.ENABLE_CLAUDEAI_MCP_SERVERS,",
           "  mcpConfig,",
           "}));",
@@ -135,13 +141,23 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       );
       yield* fs.chmod(executablePath, 0o755);
 
-      const capabilities = yield* probeClaudeCapabilities(
-        decodeClaudeSettings({ binaryPath: executablePath }),
+      const settings = decodeClaudeSettings({
+        binaryPath: executablePath,
+        homePath: claudeConfigDir,
+      });
+      const context = yield* makeClaudeCapabilitiesProbeContext(
+        settings,
         {
           ...process.env,
           T3_PROBE_INVOCATION_PATH: invocationPath,
           ENABLE_CLAUDEAI_MCP_SERVERS: "true",
         },
+        workspaceCwd,
+      );
+      const capabilities = yield* probeClaudeCapabilities(
+        settings,
+        context.environment,
+        context.cwd,
         workspaceCwd,
       );
 
@@ -167,16 +183,22 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       const invocation = JSON.parse(yield* fs.readFileString(invocationPath)) as {
         readonly args: ReadonlyArray<string>;
         readonly cwd: string;
+        readonly configDir: string;
         readonly connectorEnv: string;
         readonly mcpConfig: unknown;
       };
-      assert.equal(invocation.cwd, yield* fs.realPath(workspaceCwd));
+      assert.equal(invocation.cwd, yield* fs.realPath(NodeOS.tmpdir()));
+      assert.notEqual(invocation.cwd, yield* fs.realPath(workspaceCwd));
+      assert.equal(invocation.configDir, path.resolve(claudeConfigDir));
       assert.equal(invocation.connectorEnv, "false");
       assert.equal(invocation.args.includes("--strict-mcp-config"), true);
       assert.equal(invocation.args.includes("--mcp-config"), false);
       assert.equal(invocation.mcpConfig, undefined);
 
       assert.equal(invocation.args.includes("--setting-sources=user,project,local"), true);
+      const addDirectoryFlagIndex = invocation.args.indexOf("--add-dir");
+      assert.notEqual(addDirectoryFlagIndex, -1);
+      assert.equal(invocation.args[addDirectoryFlagIndex + 1], workspaceCwd);
 
       const settingsFlagIndex = invocation.args.indexOf("--settings");
       assert.notEqual(settingsFlagIndex, -1);

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -186,6 +186,7 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
   readonly abortController: AbortController;
   readonly environment: NodeJS.ProcessEnv;
   readonly cwd: string | undefined;
+  readonly workspaceCwd: string | undefined;
 }): ClaudeQueryOptions {
   return {
     persistSession: false,
@@ -214,6 +215,9 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
       CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL: "1",
     },
     ...(input.cwd ? { cwd: input.cwd } : {}),
+    ...(input.workspaceCwd && input.workspaceCwd !== input.cwd
+      ? { additionalDirectories: [input.workspaceCwd] }
+      : {}),
     stderr: () => {},
   };
 }
@@ -331,6 +335,7 @@ const probeClaudeCapabilities = (
   claudeSettings: ClaudeSettings,
   environment?: NodeJS.ProcessEnv,
   cwd?: string,
+  workspaceCwd?: string,
 ) => {
   const abort = new AbortController();
   return Effect.gen(function* () {
@@ -352,6 +357,7 @@ const probeClaudeCapabilities = (
           abortController: abort,
           environment: claudeEnvironment,
           cwd,
+          workspaceCwd,
         }),
       });
       const init = await q.initializationResult();


### PR DESCRIPTION
Fixes #8818.

Claude capability probes inherited the server working directory. On desktop this can be the user home, letting `~/.claude/settings.json` override a provider instance that has its own `CLAUDE_CONFIG_DIR`.

Use the configured instance root as the probe cwd and include that isolated location in the capability cache identity. Normal project skill discovery remains on the server project cwd.

Verification: `vp fmt --check`, focused Claude home and capability-probe tests (6 passing), and server typecheck (existing suggestions only).

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes periodic health-check subprocess cwd/env and capability cache keys, which can alter reported auth/slash-command metadata until caches refresh; skill discovery path logic is consolidated but should match prior precedence.
> 
> **Overview**
> Fixes capability probes picking up the wrong Claude settings when the server process cwd is the user home (or otherwise exposes `<cwd>/.claude/settings.json`), which could override a provider instance’s intended config.
> 
> **Config resolution** is centralized in `resolveClaudeConfigDirPath` (provider `homePath` → `CLAUDE_CONFIG_DIR` → `HOME`/`USERPROFILE` + `.claude`, with relative env paths resolved against the workspace cwd). `ClaudeSkills` drops its duplicate resolver and uses the shared helper.
> 
> **Capability probes** now build context via `makeClaudeCapabilitiesProbeContext`: subprocess **cwd** is a neutral temp directory, while the resolved config dir is injected as **`CLAUDE_CONFIG_DIR`**. The real workspace is still passed through as **`additionalDirectories`** / `workspaceCwd` so project setting sources remain available without treating the workspace as the probe cwd.
> 
> **Cache identity** for probes changes from `binary + home + cwd` to **`binary + resolved config directory`**, so instances that share config but differ by workspace cwd can share probe results; the key format also drops the trailing separator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2afb666cf4442934b7f9560e68642d12af4a369f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate Claude capability probe settings from workspace cwd
> - Adds `resolveClaudeConfigDirPath` to centralize Claude config directory resolution, giving precedence to provider home override, then `CLAUDE_CONFIG_DIR`, then `HOME`/`USERPROFILE`/platform home. Relative `CLAUDE_CONFIG_DIR` paths are resolved against the workspace cwd.
> - Capability probes now run from a neutral temporary-directory cwd with the resolved config directory supplied via `CLAUDE_CONFIG_DIR` in the probe environment. The workspace cwd is forwarded as an `additionalDirectories` entry so the probe can still access it.
> - Changes the capability cache key to use the binary path and resolved configuration directory instead of the workspace cwd, so probes with the same config but different workspaces share cache entries.
> - Refactors `ClaudeSkills` to use the shared resolver, removing its private duplicate.
> - Behavioral Change: `makeClaudeCapabilitiesCacheKey` in [ClaudeHome.ts](https://github.com/pingdotgg/t3code/pull/8908/files#diff-73ba6e23eba4250edbecbe8239d07a8f0556ddef26400793eb1b7432199ea29d) now produces a different key format (binary + resolved config dir, no cwd or trailing separator); any persisted or cross-version cache consumers will see fresh cache misses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2afb666.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude capability detection when custom configuration directories are used.
  - Ensured probes run reliably from a neutral location while retaining access to the relevant workspace.
  - Improved handling of relative configuration paths and environment-based settings.
  - Updated capability caching to distinguish configurations based on their resolved directory.

- **Tests**
  - Expanded coverage for configuration resolution, capability probing, environment variables, and cache separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->