### PR TITLE
perf(provider): bound persisted session lookups

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -284,7 +284,11 @@ const hasMetricSnapshot = (
       Object.entries(attributes).every(([key, value]) => snapshot.attributes?.[key] === value),
   );
 
-function makeProviderServiceLayer() {
+function makeProviderServiceLayer(
+  input: {
+    readonly directory?: ProviderSessionDirectory.ProviderSessionDirectory["Service"];
+  } = {},
+) {
   const codex = makeFakeCodexAdapter();
   const claude = makeFakeCodexAdapter(CLAUDE_AGENT_DRIVER);
   const cursor = makeFakeCodexAdapter(CURSOR_DRIVER);
@@ -301,7 +305,10 @@ function makeProviderServiceLayer() {
   const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
     Layer.provide(SqlitePersistenceMemory),
   );
-  const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+  const directoryLayer =
+    input.directory === undefined
+      ? ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer))
+      : Layer.succeed(ProviderSessionDirectory.ProviderSessionDirectory, input.directory);
 
   const layer = it.layer(
     Layer.mergeAll(
@@ -2204,6 +2211,53 @@ validation.layer("ProviderServiceLive validation", (it) => {
       if (Option.isSome(runtime)) {
         assert.equal(runtime.value.threadId, session.threadId);
       }
+    }),
+  );
+});
+
+const activeSessionThreadId = asThreadId("thread-active-session");
+const historicalSessionThreadId = asThreadId("thread-historical-session");
+const listThreadIds = vi.fn(() =>
+  Effect.succeed([activeSessionThreadId, historicalSessionThreadId]),
+);
+const getBinding = vi.fn((threadId: ThreadId) =>
+  Effect.succeed(
+    Option.some({
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: codexInstanceId,
+    }),
+  ),
+);
+const boundedListing = makeProviderServiceLayer({
+  directory: {
+    upsert: () => Effect.void,
+    getProvider: () => Effect.die("ProviderService.listSessions does not use getProvider"),
+    getBinding,
+    listThreadIds,
+    listBindings: () => Effect.die("ProviderService.listSessions does not use listBindings"),
+  },
+});
+
+boundedListing.layer("ProviderServiceLive session listing", (it) => {
+  it.effect("looks up bindings for active sessions without scanning historical threads", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      yield* boundedListing.codex.startSession({
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId: activeSessionThreadId,
+        cwd: "/tmp/project-active-session",
+        runtimeMode: "full-access",
+      });
+      listThreadIds.mockClear();
+      getBinding.mockClear();
+
+      const sessions = yield* provider.listSessions();
+
+      assert.equal(sessions.length, 1);
+      assert.equal(listThreadIds.mock.calls.length, 0);
+      assert.deepEqual(getBinding.mock.calls, [[activeSessionThreadId]]);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -996,21 +996,21 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         ),
       );
       const activeSessions = sessionsByProvider.flatMap((sessions) => sessions);
-      const persistedBindings = yield* directory.listThreadIds().pipe(
-        Effect.flatMap((threadIds) =>
-          Effect.forEach(
-            threadIds,
-            (threadId) =>
-              directory
-                .getBinding(threadId)
-                .pipe(
-                  Effect.orElseSucceed(() =>
-                    Option.none<ProviderSessionDirectory.ProviderRuntimeBinding>(),
-                  ),
-                ),
-            { concurrency: "unbounded" },
-          ),
-        ),
+      // Only live adapter sessions appear in this response. Resolving every
+      // historical binding here makes each call scale with the full thread
+      // history instead of the active session set.
+      const persistedBindings = yield* Effect.forEach(
+        [...new Set(activeSessions.map((session) => session.threadId))],
+        (threadId) =>
+          directory
+            .getBinding(threadId)
+            .pipe(
+              Effect.orElseSucceed(() =>
+                Option.none<ProviderSessionDirectory.ProviderRuntimeBinding>(),
+              ),
+            ),
+        { concurrency: "unbounded" },
+      ).pipe(
         Effect.orElseSucceed(
           () => [] as Array<Option.Option<ProviderSessionDirectory.ProviderRuntimeBinding>>,
         ),


### PR DESCRIPTION
Fixes #8794.

`listSessions` enumerated every persisted thread and performed a binding lookup for each one, although it returns only sessions currently held by live provider adapters. The work grew with total thread history and stalled turn starts.

Look up bindings only for deduplicated active session thread ids. The regression test proves the historical thread scan is not invoked.

Verification: `vp fmt --check`, focused ProviderService tests (39 passing), and server typecheck (existing suggestions only).

Model and harness: GPT-5 Codex via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow performance refactor on session listing with regression coverage; response shape stays tied to live adapter sessions, so omitting historical binding scans should not change observable output.
> 
> **Overview**
> **`listSessions`** no longer walks every persisted thread via `directory.listThreadIds()`; it only calls **`getBinding`** for the deduplicated **`threadId`** values on sessions returned from live provider adapters, so work scales with active sessions instead of full thread history.
> 
> Tests inject a mock **`ProviderSessionDirectory`** (optional on **`makeProviderServiceLayer`**) and assert **`listThreadIds`** is never called while **`getBinding`** runs only for the active thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a319843e007d1afcfb3c1e08cb0b36001aad67cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound persisted session lookups in `ProviderService.listSessions`
> - `listSessions` in [ProviderService.ts](https://github.com/pingdotgg/t3code/pull/8909/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775) no longer calls `directory.listThreadIds()`; it collects unique thread IDs from `activeSessions` and resolves bindings only for those via `Effect.forEach` over a `Set`.
> - Adds tests in [ProviderService.test.ts](https://github.com/pingdotgg/t3code/pull/8909/files#diff-cbac8cf0b9c33ddbfff2137001d4b9ef6d645a0b205efcf6c714b12efab70f14) using a custom `ProviderSessionDirectory` service to verify `listThreadIds` is not called and `getBinding` runs only for active session thread IDs.
> - Behavioral Change: sessions for persisted threads not in `activeSessions` are no longer returned by `listSessions`; callers depending on listing inactive/historical sessions will see fewer results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a319843.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->