### PR TITLE
fix(claude): classify MCP tool lifecycle events

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1029,14 +1029,8 @@ describe("ClaudeAdapterLive", () => {
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const itemEventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter(
-          (event) =>
-            event.type === "item.started" ||
-            event.type === "item.updated" ||
-            event.type === "item.completed",
-        ),
-        Stream.take(3),
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -1074,23 +1068,37 @@ describe("ClaudeAdapterLive", () => {
       } satisfies SDKMessage);
 
       harness.query.emit({
-        type: "user",
+        type: "stream_event",
         session_id: "sdk-session-mcp-tool",
         uuid: "00000000-0000-4000-8000-000000000002",
         parent_tool_use_id: null,
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: "tool-mcp-1",
-              content: "Created issue T3-123",
-            },
-          ],
+        event: {
+          type: "content_block_start",
+          index: 1,
+          content_block: {
+            type: "mcp_tool_result",
+            tool_use_id: "tool-mcp-1",
+            is_error: false,
+            content: [{ type: "text", text: "Created issue T3-123", citations: null }],
+          },
         },
       } satisfies SDKMessage);
 
-      const itemEvents = Array.from(yield* Fiber.join(itemEventsFiber));
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-mcp-tool",
+        uuid: "00000000-0000-4000-8000-000000000003",
+      } as unknown as SDKMessage);
+
+      const itemEvents = Array.from(yield* Fiber.join(runtimeEventsFiber)).filter(
+        (event) =>
+          event.type === "item.started" ||
+          event.type === "item.updated" ||
+          event.type === "item.completed",
+      );
       assert.deepEqual(
         itemEvents.map((event) => {
           switch (event.type) {
@@ -1106,6 +1114,22 @@ describe("ClaudeAdapterLive", () => {
           ["item.completed", "mcp_tool_call"],
         ],
       );
+
+      const expectedToolData = {
+        toolName: "mcp__linear__create_issue",
+        input: { title: "Regression" },
+        result: {
+          type: "mcp_tool_result",
+          tool_use_id: "tool-mcp-1",
+          content: [{ type: "text", text: "Created issue T3-123", citations: null }],
+          is_error: false,
+        },
+      };
+      for (const event of itemEvents) {
+        if (event.type === "item.updated" || event.type === "item.completed") {
+          assert.deepEqual(event.payload.data, expectedToolData);
+        }
+      }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1115,19 +1115,29 @@ describe("ClaudeAdapterLive", () => {
         ],
       );
 
-      const expectedToolData = {
-        toolName: "mcp__linear__create_issue",
-        input: { title: "Regression" },
-        result: {
-          type: "mcp_tool_result",
-          tool_use_id: "tool-mcp-1",
-          content: [{ type: "text", text: "Created issue T3-123", citations: null }],
-          is_error: false,
-        },
+      const expectedToolItem = {
+        type: "mcpToolCall",
+        id: "tool-mcp-1",
+        server: "linear",
+        tool: "mcp__linear__create_issue",
+        arguments: { title: "Regression" },
       };
       for (const event of itemEvents) {
+        if (event.type === "item.started") {
+          assert.deepEqual(event.payload.data, { item: expectedToolItem });
+        }
         if (event.type === "item.updated" || event.type === "item.completed") {
-          assert.deepEqual(event.payload.data, expectedToolData);
+          assert.deepEqual(event.payload.data, {
+            item: {
+              ...expectedToolItem,
+              result: {
+                type: "mcp_tool_result",
+                tool_use_id: "tool-mcp-1",
+                content: [{ type: "text", text: "Created issue T3-123", citations: null }],
+                is_error: false,
+              },
+            },
+          });
         }
       }
     }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1024,6 +1024,94 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("keeps native MCP classification through tool completion", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const itemEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "item.started" ||
+            event.type === "item.updated" ||
+            event.type === "item.completed",
+        ),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "create an issue",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-mcp-tool",
+        uuid: "00000000-0000-4000-8000-000000000001",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "mcp_tool_use",
+            id: "tool-mcp-1",
+            name: "mcp__linear__create_issue",
+            server_name: "linear",
+            input: {
+              title: "Regression",
+            },
+          },
+        },
+      } satisfies SDKMessage);
+
+      harness.query.emit({
+        type: "user",
+        session_id: "sdk-session-mcp-tool",
+        uuid: "00000000-0000-4000-8000-000000000002",
+        parent_tool_use_id: null,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-mcp-1",
+              content: "Created issue T3-123",
+            },
+          ],
+        },
+      } satisfies SDKMessage);
+
+      const itemEvents = Array.from(yield* Fiber.join(itemEventsFiber));
+      assert.deepEqual(
+        itemEvents.map((event) => {
+          switch (event.type) {
+            case "item.started":
+            case "item.updated":
+            case "item.completed":
+              return [event.type, event.payload.itemType];
+          }
+        }),
+        [
+          ["item.started", "mcp_tool_call"],
+          ["item.updated", "mcp_tool_call"],
+          ["item.completed", "mcp_tool_call"],
+        ],
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("does not emit turn.completed for a result with no active turn", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -27,6 +27,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Predicate from "effect/Predicate";
 import * as Random from "effect/Random";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
@@ -1140,6 +1141,186 @@ describe("ClaudeAdapterLive", () => {
           });
         }
       }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("completes MCP tools when concurrent sidechains reuse a block index", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "run two agents",
+        attachments: [],
+      });
+
+      const sdkSessionId = "sdk-session-mcp-sidechains";
+      const calls = [
+        {
+          taskId: "task-mcp-a",
+          description: "Agent A",
+          parentToolUseId: "parent-tool-a",
+          toolUseId: "tool-mcp-a",
+          toolName: "mcp__linear__get_issue",
+          serverName: "linear",
+          partialJson: '{"issueId":"T3-101"}',
+          resultText: "Linear result",
+          taskUuid: "00000000-0000-4000-8000-000000000010",
+          startUuid: "00000000-0000-4000-8000-000000000011",
+          deltaUuid: "00000000-0000-4000-8000-000000000012",
+          resultUuid: "00000000-0000-4000-8000-000000000013",
+        },
+        {
+          taskId: "task-mcp-b",
+          description: "Agent B",
+          parentToolUseId: "parent-tool-b",
+          toolUseId: "tool-mcp-b",
+          toolName: "mcp__github__get_issue",
+          serverName: "github",
+          partialJson: '{"issueNumber":202}',
+          resultText: "GitHub result",
+          taskUuid: "00000000-0000-4000-8000-000000000014",
+          startUuid: "00000000-0000-4000-8000-000000000015",
+          deltaUuid: "00000000-0000-4000-8000-000000000016",
+          resultUuid: "00000000-0000-4000-8000-000000000017",
+        },
+      ] as const;
+
+      for (const call of calls) {
+        harness.query.emit({
+          type: "system",
+          subtype: "task_started",
+          task_id: call.taskId,
+          description: call.description,
+          task_type: "local_agent",
+          tool_use_id: call.parentToolUseId,
+          uuid: call.taskUuid,
+          session_id: sdkSessionId,
+        } as unknown as SDKMessage);
+      }
+
+      for (const call of calls) {
+        harness.query.emit({
+          type: "stream_event",
+          session_id: sdkSessionId,
+          uuid: call.startUuid,
+          parent_tool_use_id: call.parentToolUseId,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "mcp_tool_use",
+              id: call.toolUseId,
+              name: call.toolName,
+              server_name: call.serverName,
+              input: {},
+            },
+          },
+        } satisfies SDKMessage);
+      }
+
+      for (const call of calls) {
+        harness.query.emit({
+          type: "stream_event",
+          session_id: sdkSessionId,
+          uuid: call.deltaUuid,
+          parent_tool_use_id: call.parentToolUseId,
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: {
+              type: "input_json_delta",
+              partial_json: call.partialJson,
+            },
+          },
+        } satisfies SDKMessage);
+      }
+
+      for (const call of calls) {
+        harness.query.emit({
+          type: "stream_event",
+          session_id: sdkSessionId,
+          uuid: call.resultUuid,
+          parent_tool_use_id: call.parentToolUseId,
+          event: {
+            type: "content_block_start",
+            index: 1,
+            content_block: {
+              type: "mcp_tool_result",
+              tool_use_id: call.toolUseId,
+              is_error: false,
+              content: [{ type: "text", text: call.resultText, citations: null }],
+            },
+          },
+        } satisfies SDKMessage);
+      }
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: sdkSessionId,
+        uuid: "mcp-sidechains-result",
+      } as unknown as SDKMessage);
+
+      const completedItems = Array.from(yield* Fiber.join(runtimeEventsFiber)).flatMap((event) => {
+        if (event.type !== "item.completed" || event.payload.itemType !== "mcp_tool_call") {
+          return [];
+        }
+        const data = event.payload.data;
+        assert.ok(Predicate.isObject(data));
+        const item = data.item;
+        assert.ok(Predicate.isObject(item));
+        assert.ok(Predicate.isObject(item.result));
+        return [
+          {
+            itemId: String(event.itemId),
+            agentId: event.payload.agentId,
+            parentToolUseId: event.payload.parentToolUseId,
+            server: item.server,
+            arguments: item.arguments,
+            resultToolUseId: item.result.tool_use_id,
+            resultContent: item.result.content,
+          },
+        ];
+      });
+      assert.deepEqual(completedItems, [
+        {
+          itemId: "tool-mcp-a",
+          agentId: "task-mcp-a",
+          parentToolUseId: "parent-tool-a",
+          server: "linear",
+          arguments: { issueId: "T3-101" },
+          resultToolUseId: "tool-mcp-a",
+          resultContent: [{ type: "text", text: "Linear result", citations: null }],
+        },
+        {
+          itemId: "tool-mcp-b",
+          agentId: "task-mcp-b",
+          parentToolUseId: "parent-tool-b",
+          server: "github",
+          arguments: { issueNumber: 202 },
+          resultToolUseId: "tool-mcp-b",
+          resultContent: [{ type: "text", text: "GitHub result", citations: null }],
+        },
+      ]);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2619,7 +2619,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
 
       const toolName = block.name;
-      const itemType = classifyToolItemType(toolName);
+      const itemType =
+        block.type === "mcp_tool_use" ? "mcp_tool_call" : classifyToolItemType(toolName);
       const toolInput =
         typeof block.input === "object" && block.input !== null
           ? (block.input as Record<string, unknown>)

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -212,6 +212,7 @@ interface ToolInFlight {
   readonly itemId: string;
   readonly itemType: CanonicalItemType;
   readonly toolName: string;
+  readonly mcpServerName?: string;
   readonly title: string;
   readonly detail?: string;
   readonly input: Record<string, unknown>;
@@ -220,6 +221,31 @@ interface ToolInFlight {
   /** Owning agent when this tool ran inside a subagent (see attribution note). */
   readonly agentId?: string;
   readonly parentToolUseId?: string;
+}
+
+function toolLifecycleData(input: {
+  readonly tool: ToolInFlight;
+  readonly result?: Record<string, unknown>;
+}): Record<string, unknown> {
+  const { tool, result } = input;
+  if (tool.itemType !== "mcp_tool_call") {
+    return {
+      toolName: tool.toolName,
+      input: tool.input,
+      ...(result !== undefined ? { result } : {}),
+    };
+  }
+
+  return {
+    item: {
+      type: "mcpToolCall",
+      id: tool.itemId,
+      ...(tool.mcpServerName ? { server: tool.mcpServerName } : {}),
+      tool: tool.toolName,
+      arguments: tool.input,
+      ...(result !== undefined ? { result } : {}),
+    },
+  };
 }
 
 interface ClaudeTaskState {
@@ -2321,10 +2347,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           status: status === "completed" ? "completed" : "failed",
           title: tool.title,
           ...(tool.detail ? { detail: tool.detail } : {}),
-          data: {
-            toolName: tool.toolName,
-            input: tool.input,
-          },
+          data: toolLifecycleData({ tool }),
         },
         providerRefs: nativeProviderRefs(context, {
           providerItemId: tool.itemId,
@@ -2410,11 +2433,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const [index, tool] = toolEntry;
     const itemStatus = toolResult.isError ? "failed" : "completed";
     const toolUseResult = readClaudeToolUseResult(message);
-    const toolData = {
-      toolName: tool.toolName,
-      input: tool.input,
-      result: toolResult.block,
-    };
+    const toolData = toolLifecycleData({ tool, result: toolResult.block });
 
     const updatedStamp = yield* makeEventStamp();
     yield* offerRuntimeEvent({
@@ -2715,10 +2734,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             ...(nextTool.detail ? { detail: nextTool.detail } : {}),
             ...(nextTool.agentId ? { agentId: nextTool.agentId } : {}),
             ...(nextTool.parentToolUseId ? { parentToolUseId: nextTool.parentToolUseId } : {}),
-            data: {
-              toolName: nextTool.toolName,
-              input: nextTool.input,
-            },
+            data: toolLifecycleData({ tool: nextTool }),
           },
           providerRefs: nativeProviderRefs(context, {
             providerItemId: nextTool.itemId,
@@ -2815,6 +2831,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         itemId,
         itemType,
         toolName,
+        ...(block.type === "mcp_tool_use" ? { mcpServerName: block.server_name } : {}),
         title: titleForTool(itemType),
         detail,
         input: toolInput,
@@ -2841,10 +2858,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ...(tool.detail ? { detail: tool.detail } : {}),
           ...(tool.agentId ? { agentId: tool.agentId } : {}),
           ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
-          data: {
-            toolName: tool.toolName,
-            input: toolInput,
-          },
+          data: toolLifecycleData({ tool }),
         },
         providerRefs: nativeProviderRefs(context, {
           providerItemId: tool.itemId,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -210,6 +210,7 @@ interface PendingUserInput {
 
 interface ToolInFlight {
   readonly itemId: string;
+  readonly streamBlockKey: string;
   readonly itemType: CanonicalItemType;
   readonly toolName: string;
   readonly mcpServerName?: string;
@@ -221,6 +222,12 @@ interface ToolInFlight {
   /** Owning agent when this tool ran inside a subagent (see attribution note). */
   readonly agentId?: string;
   readonly parentToolUseId?: string;
+}
+
+function inFlightToolBlockKey(parentToolUseId: string | null | undefined, index: number): string {
+  return parentToolUseId === null || parentToolUseId === undefined
+    ? `root:${index}`
+    : `sidechain:${parentToolUseId}:${index}`;
 }
 
 function toolLifecycleData(input: {
@@ -321,7 +328,8 @@ interface ClaudeSessionContext {
     id: TurnId;
     items: Array<unknown>;
   }>;
-  readonly inFlightTools: Map<number, ToolInFlight>;
+  readonly inFlightTools: Map<string, ToolInFlight>;
+  readonly inFlightToolIdsByBlock: Map<string, string>;
   readonly claudeTasks: Map<string, ClaudeTaskState>;
   readonly taskAgents: Map<string, ClaudeTaskAgentState>;
   /**
@@ -2332,7 +2340,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    for (const [index, tool] of context.inFlightTools.entries()) {
+    for (const [toolUseId, tool] of context.inFlightTools.entries()) {
       const toolStamp = yield* makeEventStamp();
       yield* offerRuntimeEvent({
         type: "item.completed",
@@ -2358,10 +2366,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           payload: result ?? { status },
         },
       });
-      context.inFlightTools.delete(index);
+      context.inFlightTools.delete(toolUseId);
     }
     // Clear any remaining stale entries (e.g. from interrupted content blocks)
     context.inFlightTools.clear();
+    context.inFlightToolIdsByBlock.clear();
 
     for (const block of turnState.assistantTextBlockOrder) {
       yield* completeAssistantTextBlock(context, block, {
@@ -2423,14 +2432,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
   ) {
     const { message, rawMethod, toolResult } = input;
-    const toolEntry = Array.from(context.inFlightTools.entries()).find(
-      ([, tool]) => tool.itemId === toolResult.toolUseId,
-    );
-    if (!toolEntry) {
+    const tool = context.inFlightTools.get(toolResult.toolUseId);
+    if (!tool) {
       return;
     }
 
-    const [index, tool] = toolEntry;
     const itemStatus = toolResult.isError ? "failed" : "completed";
     const toolUseResult = readClaudeToolUseResult(message);
     const toolData = toolLifecycleData({ tool, result: toolResult.block });
@@ -2565,7 +2571,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
     }
 
-    context.inFlightTools.delete(index);
+    context.inFlightTools.delete(tool.itemId);
+    if (context.inFlightToolIdsByBlock.get(tool.streamBlockKey) === tool.itemId) {
+      context.inFlightToolIdsByBlock.delete(tool.streamBlockKey);
+    }
   });
 
   const handleStreamEvent = Effect.fn("handleStreamEvent")(function* (
@@ -2577,6 +2586,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const { event } = message;
+    const parentToolUseId =
+      "parent_tool_use_id" in message && typeof message.parent_tool_use_id === "string"
+        ? message.parent_tool_use_id
+        : undefined;
 
     // Subagent-owned stream traffic (parent_tool_use_id set) must not write
     // into the parent transcript: with forwardSubagentText off the SDK still
@@ -2585,9 +2598,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // narration into the chat (live-test finding). Their results reach the
     // UI via the task.* lifecycle; their tool blocks are attributed and
     // re-homed by the quiet-timeline filter.
-    const streamParentToolUseId = (message as { parent_tool_use_id?: string | null })
-      .parent_tool_use_id;
-    if (streamParentToolUseId !== null && streamParentToolUseId !== undefined) {
+    if (parentToolUseId !== undefined) {
       // Drop only the subagent's narration (text/thinking); tool_use blocks
       // and their input_json_delta frames must flow so attributed tool items
       // keep their inputs (review finding: dropping deltas emptied inputs).
@@ -2679,7 +2690,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
 
       if (event.delta.type === "input_json_delta") {
-        const tool = context.inFlightTools.get(event.index);
+        const toolUseId = context.inFlightToolIdsByBlock.get(
+          inFlightToolBlockKey(parentToolUseId, event.index),
+        );
+        const tool = toolUseId ? context.inFlightTools.get(toolUseId) : undefined;
         if (!tool || typeof event.delta.partial_json !== "string") {
           return;
         }
@@ -2698,7 +2712,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           parsedInput && Object.keys(parsedInput).length > 0
             ? toolInputFingerprint(parsedInput)
             : undefined;
-        context.inFlightTools.set(event.index, nextTool);
+        context.inFlightTools.set(tool.itemId, nextTool);
 
         if (
           !parsedInput ||
@@ -2712,7 +2726,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ...nextTool,
           lastEmittedInputFingerprint: nextFingerprint,
         };
-        context.inFlightTools.set(event.index, nextTool);
+        context.inFlightTools.set(tool.itemId, nextTool);
 
         const stamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({
@@ -2823,12 +2837,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       // clients can re-home them out of the main timeline (quiet-timeline
       // guarantee): the SDK forwards subagent tool_use blocks tagged with the
       // spawning Task tool's id as parent_tool_use_id.
-      const parentToolUseId =
-        (message as { parent_tool_use_id?: string | null }).parent_tool_use_id ?? undefined;
       const owningAgentId = agentIdForParentToolUse(context.taskAgents, parentToolUseId);
+      const streamBlockKey = inFlightToolBlockKey(parentToolUseId, index);
 
       const tool: ToolInFlight = {
         itemId,
+        streamBlockKey,
         itemType,
         toolName,
         ...(block.type === "mcp_tool_use" ? { mcpServerName: block.server_name } : {}),
@@ -2840,7 +2854,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(owningAgentId ? { agentId: owningAgentId } : {}),
         ...(parentToolUseId ? { parentToolUseId } : {}),
       };
-      context.inFlightTools.set(index, tool);
+      context.inFlightTools.set(tool.itemId, tool);
+      context.inFlightToolIdsByBlock.set(streamBlockKey, tool.itemId);
 
       const stamp = yield* makeEventStamp();
       yield* offerRuntimeEvent({
@@ -2883,7 +2898,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
         return;
       }
-      const tool = context.inFlightTools.get(index);
+      const toolUseId = context.inFlightToolIdsByBlock.get(
+        inFlightToolBlockKey(parentToolUseId, index),
+      );
+      const tool = toolUseId ? context.inFlightTools.get(toolUseId) : undefined;
       if (!tool) {
         return;
       }
@@ -3265,9 +3283,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         // in-flight tool carries agentId from parent_tool_use_id) is
         // agent-internal: a subagent's background shell, not parent work.
         const launchingTool = message.tool_use_id
-          ? Array.from(context.inFlightTools.values()).find(
-              (tool) => tool.itemId === message.tool_use_id,
-            )
+          ? context.inFlightTools.get(message.tool_use_id)
           : undefined;
         const owningAgentId = launchingTool?.agentId;
         // Model/effort: the Agent tool's input carries explicit overrides;
@@ -3894,7 +3910,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
       const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
       const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
-      const inFlightTools = new Map<number, ToolInFlight>();
+      const inFlightTools = new Map<string, ToolInFlight>();
+      const inFlightToolIdsByBlock = new Map<string, string>();
       const claudeTasks = new Map<string, ClaudeTaskState>();
       const taskAgents = new Map<string, ClaudeTaskAgentState>();
       const pendingTaskModels = new Map<string, string>();
@@ -4449,6 +4466,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         pendingUserInputs,
         turns: [],
         inFlightTools,
+        inFlightToolIdsByBlock,
         claudeTasks,
         taskAgents,
         pendingTaskModels,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -106,6 +106,12 @@ type ClaudeToolResultStreamKind = Extract<
   RuntimeContentStreamKind,
   "command_output" | "file_change_output"
 >;
+interface ClaudeToolResult {
+  readonly toolUseId: string;
+  readonly block: Record<string, unknown>;
+  readonly text: string;
+  readonly isError: boolean;
+}
 type ClaudeSdkEffort = NonNullable<ClaudeQueryOptions["effort"]>;
 
 function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
@@ -1483,12 +1489,7 @@ function toolResultStreamKind(itemType: CanonicalItemType): ClaudeToolResultStre
   }
 }
 
-function toolResultBlocksFromUserMessage(message: SDKMessage): Array<{
-  readonly toolUseId: string;
-  readonly block: Record<string, unknown>;
-  readonly text: string;
-  readonly isError: boolean;
-}> {
+function toolResultBlocksFromUserMessage(message: SDKMessage): Array<ClaudeToolResult> {
   if (message.type !== "user") {
     return [];
   }
@@ -1498,12 +1499,7 @@ function toolResultBlocksFromUserMessage(message: SDKMessage): Array<{
     return [];
   }
 
-  const blocks: Array<{
-    readonly toolUseId: string;
-    readonly block: Record<string, unknown>;
-    readonly text: string;
-    readonly isError: boolean;
-  }> = [];
+  const blocks: Array<ClaudeToolResult> = [];
 
   for (const entry of content) {
     if (!entry || typeof entry !== "object") {
@@ -2395,6 +2391,164 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     yield* updateResumeCursor(context);
   });
 
+  const handleToolResult = Effect.fn("handleToolResult")(function* (
+    context: ClaudeSessionContext,
+    input: {
+      readonly message: SDKMessage;
+      readonly rawMethod: string;
+      readonly toolResult: ClaudeToolResult;
+    },
+  ) {
+    const { message, rawMethod, toolResult } = input;
+    const toolEntry = Array.from(context.inFlightTools.entries()).find(
+      ([, tool]) => tool.itemId === toolResult.toolUseId,
+    );
+    if (!toolEntry) {
+      return;
+    }
+
+    const [index, tool] = toolEntry;
+    const itemStatus = toolResult.isError ? "failed" : "completed";
+    const toolUseResult = readClaudeToolUseResult(message);
+    const toolData = {
+      toolName: tool.toolName,
+      input: tool.input,
+      result: toolResult.block,
+    };
+
+    const updatedStamp = yield* makeEventStamp();
+    yield* offerRuntimeEvent({
+      type: "item.updated",
+      eventId: updatedStamp.eventId,
+      provider: PROVIDER,
+      createdAt: updatedStamp.createdAt,
+      threadId: context.session.threadId,
+      ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+      itemId: asRuntimeItemId(tool.itemId),
+      payload: {
+        itemType: tool.itemType,
+        status: toolResult.isError ? "failed" : "inProgress",
+        title: tool.title,
+        ...(tool.detail ? { detail: tool.detail } : {}),
+        ...(tool.agentId ? { agentId: tool.agentId } : {}),
+        ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
+        data: toolData,
+      },
+      providerRefs: nativeProviderRefs(context, {
+        providerItemId: tool.itemId,
+      }),
+      raw: {
+        source: "claude.sdk.message",
+        method: rawMethod,
+        payload: message,
+      },
+    });
+
+    const streamKind = toolResultStreamKind(tool.itemType);
+    if (streamKind && toolResult.text.length > 0 && context.turnState) {
+      const deltaStamp = yield* makeEventStamp();
+      yield* offerRuntimeEvent({
+        type: "content.delta",
+        eventId: deltaStamp.eventId,
+        provider: PROVIDER,
+        createdAt: deltaStamp.createdAt,
+        threadId: context.session.threadId,
+        turnId: context.turnState.turnId,
+        itemId: asRuntimeItemId(tool.itemId),
+        payload: {
+          streamKind,
+          delta: toolResult.text,
+        },
+        providerRefs: nativeProviderRefs(context, {
+          providerItemId: tool.itemId,
+        }),
+        raw: {
+          source: "claude.sdk.message",
+          method: rawMethod,
+          payload: message,
+        },
+      });
+    }
+
+    const completedStamp = yield* makeEventStamp();
+    yield* offerRuntimeEvent({
+      type: "item.completed",
+      eventId: completedStamp.eventId,
+      provider: PROVIDER,
+      createdAt: completedStamp.createdAt,
+      threadId: context.session.threadId,
+      ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+      itemId: asRuntimeItemId(tool.itemId),
+      payload: {
+        itemType: tool.itemType,
+        status: itemStatus,
+        title: tool.title,
+        ...(tool.detail ? { detail: tool.detail } : {}),
+        ...(tool.agentId ? { agentId: tool.agentId } : {}),
+        ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
+        data: toolData,
+      },
+      providerRefs: nativeProviderRefs(context, {
+        providerItemId: tool.itemId,
+      }),
+      raw: {
+        source: "claude.sdk.message",
+        method: rawMethod,
+        payload: message,
+      },
+    });
+
+    // The Workflow tool's result carries the run handles (runId, scriptPath,
+    // transcriptDir, sessionUrl). Attach them to the workflow's task agent so
+    // the next task.* payload advertises them to clients.
+    if (!toolResult.isError && tool.toolName.toLowerCase() === "workflow" && toolUseResult) {
+      const workflowTaskId = trimmedString(toolUseResult.taskId);
+      if (workflowTaskId) {
+        const runHandles: TaskRunHandles = {
+          ...(trimmedString(toolUseResult.runId)
+            ? { runId: trimmedString(toolUseResult.runId) }
+            : {}),
+          ...(trimmedString(toolUseResult.scriptPath)
+            ? { scriptPath: trimmedString(toolUseResult.scriptPath) }
+            : {}),
+          ...(trimmedString(toolUseResult.transcriptDir)
+            ? { transcriptDir: trimmedString(toolUseResult.transcriptDir) }
+            : {}),
+          ...(sanitizeSessionUrl(toolUseResult.sessionUrl)
+            ? { sessionUrl: sanitizeSessionUrl(toolUseResult.sessionUrl) }
+            : {}),
+        };
+        const existing = context.taskAgents.get(workflowTaskId);
+        context.taskAgents.set(workflowTaskId, {
+          taskId: workflowTaskId,
+          toolUseId: existing?.toolUseId ?? tool.itemId,
+          description: existing?.description,
+          subagentType: existing?.subagentType,
+          taskType: existing?.taskType ?? "local_workflow",
+          workflowName: existing?.workflowName,
+          skipTranscript: existing?.skipTranscript ?? false,
+          runHandles,
+          owningAgentId: existing?.owningAgentId,
+          model: existing?.model,
+          effort: existing?.effort,
+        });
+      }
+    }
+
+    if (
+      !toolResult.isError &&
+      applyClaudeTaskToolResult(context.claudeTasks, tool, toolUseResult)
+    ) {
+      yield* emitClaudeTaskPlanUpdated(context, {
+        toolUseId: tool.itemId,
+        rawMethod,
+        rawPayload: message,
+      });
+    }
+
+    context.inFlightTools.delete(index);
+  });
+
   const handleStreamEvent = Effect.fn("handleStreamEvent")(function* (
     context: ClaudeSessionContext,
     message: SDKMessage,
@@ -2422,7 +2576,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         event.type === "content_block_start" &&
         event.content_block.type !== "tool_use" &&
         event.content_block.type !== "server_tool_use" &&
-        event.content_block.type !== "mcp_tool_use";
+        event.content_block.type !== "mcp_tool_use" &&
+        event.content_block.type !== "mcp_tool_result";
       const dropDelta =
         event.type === "content_block_delta" &&
         (event.delta.type === "text_delta" || event.delta.type === "thinking_delta");
@@ -2604,6 +2759,24 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     if (event.type === "content_block_start") {
       const { index, content_block: block } = event;
+      if (block.type === "mcp_tool_result") {
+        yield* handleToolResult(context, {
+          message,
+          rawMethod: "claude/stream_event/content_block_start/mcp_tool_result",
+          toolResult: {
+            toolUseId: block.tool_use_id,
+            block: {
+              type: block.type,
+              tool_use_id: block.tool_use_id,
+              content: block.content,
+              is_error: block.is_error,
+            },
+            text: extractTextContent(block.content),
+            isError: block.is_error,
+          },
+        });
+        return;
+      }
       if (block.type === "text") {
         yield* ensureAssistantTextBlock(context, index, {
           fallbackText: extractContentBlockText(block),
@@ -2716,153 +2889,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     for (const toolResult of toolResultBlocksFromUserMessage(message)) {
-      const toolEntry = Array.from(context.inFlightTools.entries()).find(
-        ([, tool]) => tool.itemId === toolResult.toolUseId,
-      );
-      if (!toolEntry) {
-        continue;
-      }
-
-      const [index, tool] = toolEntry;
-      const itemStatus = toolResult.isError ? "failed" : "completed";
-      const toolUseResult = readClaudeToolUseResult(message);
-      const toolData = {
-        toolName: tool.toolName,
-        input: tool.input,
-        result: toolResult.block,
-      };
-
-      const updatedStamp = yield* makeEventStamp();
-      yield* offerRuntimeEvent({
-        type: "item.updated",
-        eventId: updatedStamp.eventId,
-        provider: PROVIDER,
-        createdAt: updatedStamp.createdAt,
-        threadId: context.session.threadId,
-        ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
-        itemId: asRuntimeItemId(tool.itemId),
-        payload: {
-          itemType: tool.itemType,
-          status: toolResult.isError ? "failed" : "inProgress",
-          title: tool.title,
-          ...(tool.detail ? { detail: tool.detail } : {}),
-          ...(tool.agentId ? { agentId: tool.agentId } : {}),
-          ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
-          data: toolData,
-        },
-        providerRefs: nativeProviderRefs(context, {
-          providerItemId: tool.itemId,
-        }),
-        raw: {
-          source: "claude.sdk.message",
-          method: "claude/user",
-          payload: message,
-        },
+      yield* handleToolResult(context, {
+        message,
+        rawMethod: "claude/user",
+        toolResult,
       });
-
-      const streamKind = toolResultStreamKind(tool.itemType);
-      if (streamKind && toolResult.text.length > 0 && context.turnState) {
-        const deltaStamp = yield* makeEventStamp();
-        yield* offerRuntimeEvent({
-          type: "content.delta",
-          eventId: deltaStamp.eventId,
-          provider: PROVIDER,
-          createdAt: deltaStamp.createdAt,
-          threadId: context.session.threadId,
-          turnId: context.turnState.turnId,
-          itemId: asRuntimeItemId(tool.itemId),
-          payload: {
-            streamKind,
-            delta: toolResult.text,
-          },
-          providerRefs: nativeProviderRefs(context, {
-            providerItemId: tool.itemId,
-          }),
-          raw: {
-            source: "claude.sdk.message",
-            method: "claude/user",
-            payload: message,
-          },
-        });
-      }
-
-      const completedStamp = yield* makeEventStamp();
-      yield* offerRuntimeEvent({
-        type: "item.completed",
-        eventId: completedStamp.eventId,
-        provider: PROVIDER,
-        createdAt: completedStamp.createdAt,
-        threadId: context.session.threadId,
-        ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
-        itemId: asRuntimeItemId(tool.itemId),
-        payload: {
-          itemType: tool.itemType,
-          status: itemStatus,
-          title: tool.title,
-          ...(tool.detail ? { detail: tool.detail } : {}),
-          ...(tool.agentId ? { agentId: tool.agentId } : {}),
-          ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
-          data: toolData,
-        },
-        providerRefs: nativeProviderRefs(context, {
-          providerItemId: tool.itemId,
-        }),
-        raw: {
-          source: "claude.sdk.message",
-          method: "claude/user",
-          payload: message,
-        },
-      });
-
-      // The Workflow tool's result carries the run handles (runId, scriptPath,
-      // transcriptDir, sessionUrl). Attach them to the workflow's task agent so
-      // the next task.* payload advertises them to clients.
-      if (!toolResult.isError && tool.toolName.toLowerCase() === "workflow" && toolUseResult) {
-        const workflowTaskId = trimmedString(toolUseResult.taskId);
-        if (workflowTaskId) {
-          const runHandles: TaskRunHandles = {
-            ...(trimmedString(toolUseResult.runId)
-              ? { runId: trimmedString(toolUseResult.runId) }
-              : {}),
-            ...(trimmedString(toolUseResult.scriptPath)
-              ? { scriptPath: trimmedString(toolUseResult.scriptPath) }
-              : {}),
-            ...(trimmedString(toolUseResult.transcriptDir)
-              ? { transcriptDir: trimmedString(toolUseResult.transcriptDir) }
-              : {}),
-            ...(sanitizeSessionUrl(toolUseResult.sessionUrl)
-              ? { sessionUrl: sanitizeSessionUrl(toolUseResult.sessionUrl) }
-              : {}),
-          };
-          const existing = context.taskAgents.get(workflowTaskId);
-          context.taskAgents.set(workflowTaskId, {
-            taskId: workflowTaskId,
-            toolUseId: existing?.toolUseId ?? tool.itemId,
-            description: existing?.description,
-            subagentType: existing?.subagentType,
-            taskType: existing?.taskType ?? "local_workflow",
-            workflowName: existing?.workflowName,
-            skipTranscript: existing?.skipTranscript ?? false,
-            runHandles,
-            owningAgentId: existing?.owningAgentId,
-            model: existing?.model,
-            effort: existing?.effort,
-          });
-        }
-      }
-
-      if (
-        !toolResult.isError &&
-        applyClaudeTaskToolResult(context.claudeTasks, tool, toolUseResult)
-      ) {
-        yield* emitClaudeTaskPlanUpdated(context, {
-          toolUseId: tool.itemId,
-          rawMethod: "claude/user",
-          rawPayload: message,
-        });
-      }
-
-      context.inFlightTools.delete(index);
     }
   });
 


### PR DESCRIPTION
## What Changed

- Classify native Claude `mcp_tool_use` blocks as `mcp_tool_call` lifecycle items before name-based heuristics.
- Process native `mcp_tool_result` blocks through the normal tool lifecycle and expose MCP details through the canonical `data.item` shape used by web, desktop, and mobile.
- Cover `item.started`, `item.updated`, and `item.completed` for an MCP tool whose name contains `create`.
- Isolate in-flight tool state by tool-use ID and sidechain-scoped content-block key so concurrent subagents can reuse block indexes without dropping results.

## Why

Claude exposes MCP tool calls with a native block type, but T3 Code discarded it and reclassified only by tool name. Names such as `mcp__linear__create_issue` matched the file-change heuristic first, so clients rendered and projected them as file edits.

The adapter now trusts the SDK discriminant at the provider boundary, pairs native results by `tool_use_id`, and removes completed MCP tools before generic turn cleanup. It also normalizes MCP data once at that boundary so every client receives the same server, tool, arguments, and result fields. Approval classification remains unchanged because that path requires separate cross-client handling.

Concurrent subagents can reuse the same content-block index because the index is local to each sidechain. The old session-wide index map allowed one tool to overwrite another, which dropped the earlier result.

## Validation

- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` (81 tests passed)
- `vp run --filter t3 typecheck`
- Targeted `vp lint` on both changed files (one pre-existing warning outside the changed hunk)
- Targeted `vp fmt --check`
- Cross-surface work-log and payload-projection tests (125 tests passed)
- Standards review: no blocking findings
- Spec review: no findings

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] Motion or interaction video is not applicable

Model: GPT-5.6 Sol
Harness: Codex via T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider runtime event shapes and tool-tracking for all Claude tool streams; MCP consumers must read `data.item`, and incorrect block-key pairing could mis-attribute concurrent subagent tools.
> 
> **Overview**
> Fixes Claude adapter handling so native **`mcp_tool_use`** / **`mcp_tool_result`** SDK blocks are treated as **`mcp_tool_call`** lifecycle items instead of being misclassified by tool name (e.g. `create_issue` matching file-change heuristics).
> 
> **In-flight tool tracking** is keyed by **`tool_use_id`** with a **`parent_tool_use_id` + block index** map so parallel subagent sidechains that reuse the same stream index still pair deltas and results correctly.
> 
> Streamed **`mcp_tool_result`** blocks now complete tools through a shared **`handleToolResult`** path (same as user-message tool results), and **`toolLifecycleData`** emits the canonical nested **`data.item`** shape (server, tool, arguments, result) for MCP calls while non-MCP tools keep the flat **`toolName` / `input`** payload.
> 
> Tests cover end-to-end **`item.started` → `updated` → `completed`** for MCP tools and concurrent sidechain MCP completions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85d4ec50deeb8bfd0baee0a2bdd336328fcafc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP tool lifecycle classification and sidechain collisions in `ClaudeAdapter`
> - Classifies MCP `tool_use` items as `mcp_tool_call` and includes `server_name` attribution in lifecycle events via a new `toolLifecycleData` helper
> - Fixes concurrent sidechain collisions by keying `inFlightTools` by `toolUseId` and adding `inFlightToolIdsByBlock` to disambiguate content blocks using `parent_tool_use_id` and block index
> - Centralizes tool result handling into a new `handleToolResult` helper for both stream events and user messages, ensuring consistent event emission and state cleanup
> - Preserves `mcp_tool_result` blocks for subagent streams that were previously dropped by narration-drop logic
> - Behavioral Change: `ClaudeSessionContext` changes the `inFlightTools` map key from `number` (block index) to `string` (`toolUseId`), and adds the new `inFlightToolIdsByBlock` map to track block-to-tool mappings
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d85d4ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected classification of native MCP tool calls in Claude sessions.
  - Runtime events now consistently identify MCP tool activity throughout its lifecycle, including when tools complete.
  - MCP tool results now stream and appear with the correct tool, server, arguments, and result details.
  - Preserved existing handling for non-MCP tool results.

- **Tests**
  - Added coverage confirming MCP tool calls retain the correct classification across started, updated, and completed events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->