### PR TITLE
fix(web): stop clipping descenders in diff file headers

### DIFF
--- a/apps/web/src/components/diffs/StyledDiffCodeView.tsx
+++ b/apps/web/src/components/diffs/StyledDiffCodeView.tsx
@@ -84,7 +84,7 @@ const DIFF_VIEW_UNSAFE_CSS = `${DIFF_SURFACE_THEME_UNSAFE_CSS}
   align-items: center !important;
   font-family: var(--font-sans) !important;
   font-size: 12px !important;
-  line-height: 1 !important;
+  line-height: 16px !important;
   min-height: 32px !important;
   padding-block: 6px !important;
   padding-inline: 8px 12px !important;
@@ -196,12 +196,12 @@ const DIFF_VIEW_UNSAFE_CSS = `${DIFF_SURFACE_THEME_UNSAFE_CSS}
 
 [data-diffs-header] [data-header-content] {
   align-items: center !important;
-  line-height: 1 !important;
+  line-height: 16px !important;
 }
 
 [data-diffs-header] [data-metadata] {
   align-items: center !important;
-  line-height: 1 !important;
+  line-height: 16px !important;
   font-variant-numeric: tabular-nums;
 }
 
@@ -210,7 +210,7 @@ const DIFF_VIEW_UNSAFE_CSS = `${DIFF_SURFACE_THEME_UNSAFE_CSS}
   font-family: var(--font-mono) !important;
   font-size: 11px !important;
   font-variant-numeric: tabular-nums;
-  line-height: 1 !important;
+  line-height: 16px !important;
 }
 
 [data-diffs-header] [data-change-icon],


### PR DESCRIPTION
pierre's filenames have overflow hidden on them, so line-height 1 on the names clipped off the descenders and the underline on hover. fixed here by setting to 16px instead.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Diff file headers use `line-height: 16px` instead of `1`. Same 32px slot, nothing else.

## Why

Pierre truncates long paths with `overflow: hidden`. `line-height: 1` made that box 12px tall, so descenders in names like `game-stats.tsx` got chopped. 16px still fits under the 20px collapse button that already fills the 32px virtualizer metric.

## UI Changes

Before:

<img width="555" height="43" alt="Screenshot 2026-08-31 at 8 50 50 AM" src="https://github.com/user-attachments/assets/1d23b9dd-5829-4710-8d83-cfd9da328a81" />

(notice clipping)

After:

https://github.com/user-attachments/assets/d055976c-6856-41d4-9634-00a552b576e4

no clipping, underline visible

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only tweak to diff header typography with no logic, API, or security impact.
> 
> **Overview**
> Diff file header chrome in `StyledDiffCodeView` now uses **`line-height: 16px`** instead of **`line-height: 1`** on the main header row and on header content, metadata, and addition/deletion counts.
> 
> That gives truncated filenames enough vertical room inside Pierre’s `overflow: hidden` title area so **descenders** (e.g. in `game-stats.tsx`) and the **hover underline** on `[data-title]` are no longer clipped, while the existing **32px** `diffHeaderHeight` layout is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6b0e86358f0d58657232e1bb9973efc05cfe66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix descender clipping in diff file header CSS
> Updates CSS rules in `DIFF_VIEW_UNSAFE_CSS` to set `line-height: 16px` instead of `1` for `[data-diffs-header]` and its child metadata and count elements. This restores vertical space so descenders render fully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c6b0e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->