### PR TITLE
fix(mobile): defer draft navigation until submission completes

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -289,10 +289,13 @@ export function NewTaskDraftScreen(props: {
     if (preventRemove || submitNavigationAction === null) {
       return;
     }
-    // setSubmitting(false) does not release the guard synchronously. Navigate
-    // after usePreventRemove has committed, for both sent and queued tasks.
-    setSubmitNavigationAction(null);
-    (navigation.getParent() ?? navigation).dispatch(submitNavigationAction);
+    // Give the guard update a frame to reach the parent sheet before navigating,
+    // just like the project-picker fallback below.
+    const frame = requestAnimationFrame(() => {
+      setSubmitNavigationAction(null);
+      (navigation.getParent() ?? navigation).dispatch(submitNavigationAction);
+    });
+    return () => cancelAnimationFrame(frame);
   }, [navigation, preventRemove, submitNavigationAction]);
   const hasImportedIncomingShare = Boolean(
     props.incomingShareId &&

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1,9 +1,11 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import {
+  CommonActions,
   StackActions,
   useFocusEffect,
   useNavigation,
   usePreventRemove,
+  type NavigationAction,
 } from "@react-navigation/native";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert, Platform, Pressable, ScrollView, View } from "react-native";
@@ -212,6 +214,9 @@ export function NewTaskDraftScreen(props: {
   const [isCancellingShareImport, setIsCancellingShareImport] = useState(false);
   const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
   const [isReturningToProjectPicker, setIsReturningToProjectPicker] = useState(false);
+  const [submitNavigationAction, setSubmitNavigationAction] = useState<NavigationAction | null>(
+    null,
+  );
   const [shareImportAttempt, setShareImportAttempt] = useState(0);
   const startedShareImportKeyRef = useRef<string | null>(null);
   const cancellingShareImportKeyRef = useRef<string | null>(null);
@@ -275,12 +280,20 @@ export function NewTaskDraftScreen(props: {
     voiceInput.elapsedSeconds,
   );
   const isVoiceInputPresented = voicePresentation.statusLabel !== null;
-  usePreventRemove(
+  const preventRemove =
     (isIncomingShareTransferPending && !isProjectPickerReturnActive) ||
-      isCancellingShareImport ||
-      flow.submitting,
-    () => undefined,
-  );
+    isCancellingShareImport ||
+    flow.submitting;
+  usePreventRemove(preventRemove, () => undefined);
+  useEffect(() => {
+    if (preventRemove || submitNavigationAction === null) {
+      return;
+    }
+    // setSubmitting(false) does not release the guard synchronously. Navigate
+    // after usePreventRemove has committed, for both sent and queued tasks.
+    setSubmitNavigationAction(null);
+    (navigation.getParent() ?? navigation).dispatch(submitNavigationAction);
+  }, [navigation, preventRemove, submitNavigationAction]);
   const hasImportedIncomingShare = Boolean(
     props.incomingShareId &&
     flow.draftKey &&
@@ -872,7 +885,7 @@ export function NewTaskDraftScreen(props: {
           clearWorkspaceSelection: true,
         });
       }
-      navigation.getParent()?.goBack();
+      setSubmitNavigationAction(CommonActions.goBack());
       return;
     }
 
@@ -943,7 +956,7 @@ export function NewTaskDraftScreen(props: {
         clearWorkspaceSelection: true,
       });
     }
-    navigation.dispatch(
+    setSubmitNavigationAction(
       StackActions.replace("Thread", {
         environmentId: String(result.value.environmentId),
         threadId: String(result.value.threadId),


### PR DESCRIPTION
## What Changed

Defer navigation away from the new task draft screen until task submission has fully completed, including sent and queued tasks.

## Why

The navigation guard was not released synchronously when submission ended, causing navigation actions to be dropped. Queue the intended navigation action and dispatch it after the guard is cleared.

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core new-task submit/exit navigation and timing with `usePreventRemove`; wrong ordering could leave users stuck on the draft or navigate before cleanup finishes.
> 
> **Overview**
> Fixes **dropped navigation after task submit or offline queue** on `NewTaskDraftScreen` by staging the intended React Navigation action instead of dispatching it while `usePreventRemove` is still active.
> 
> When `flow.submitting` (and related guards) clear, a **`submitNavigationAction`** effect runs on the next frame—matching the existing project-picker fallback—then dispatches **`CommonActions.goBack()`** after offline/outbox success or **`StackActions.replace("Thread", …)`** after online thread creation. Dispatch targets **`navigation.getParent() ?? navigation`**, so cancel/back still runs when there is no parent navigator (previously `getParent()?.goBack()` could no-op).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d787abbfb9a5cbeabd98ed95401c042c7ad5661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer draft navigation in `NewTaskDraftScreen` until submission completes
> - Navigation actions for cancel and submit are now stored in `submitNavigationAction` state instead of dispatched immediately.
> - A `useEffect` waits for `preventRemove` to clear, then dispatches the pending action on the parent navigator if present, else the current navigator, after one animation frame.
> - Risk: `cancel` now dispatches `CommonActions.goBack()` on the current navigator when no parent exists; previously it did nothing. The post-submit `StackActions.replace(...)` may now dispatch on the parent navigator instead of always the current one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d787ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->