### PR TITLE
fix(mobile): preserve saved environments across catalog recovery

### DIFF
--- a/apps/mobile/src/connection/catalog-store.ts
+++ b/apps/mobile/src/connection/catalog-store.ts
@@ -108,7 +108,11 @@ export const make = Effect.fn("mobile.connectionStorage.makeCatalogStore")(funct
               Option.match({
                 onNone: () =>
                   Effect.fail(
-                    catalogError("recover", "No valid connection catalog backup is available."),
+                    new ConnectionTransientError({
+                      reason: "remote-unavailable",
+                      detail:
+                        "Could not recover the local connection catalog: No valid connection catalog backup is available.",
+                    }),
                   ),
                 onSome: Effect.succeed,
               }),

--- a/apps/mobile/src/connection/catalog-store.ts
+++ b/apps/mobile/src/connection/catalog-store.ts
@@ -14,6 +14,7 @@ import * as MobileSecureStorage from "../persistence/mobile-secure-storage";
 import { migrateLegacyConnectionCatalog } from "./migration";
 
 export const CONNECTION_CATALOG_KEY = "t3code.connection-catalog.v1";
+export const CONNECTION_CATALOG_BACKUP_KEY = "t3code.connection-catalog.v1.backup";
 export const LEGACY_CONNECTIONS_KEY = "t3code.connections";
 
 function catalogError(operation: string, cause: unknown) {
@@ -74,10 +75,21 @@ export const make = Effect.fn("mobile.connectionStorage.makeCatalogStore")(funct
           );
     if (legacyRaw !== null && legacyRaw.trim() !== "") {
       const encoded = yield* encodeCatalog(catalog);
+      yield* setItem(CONNECTION_CATALOG_BACKUP_KEY, encoded);
       yield* setItem(CONNECTION_CATALOG_KEY, encoded);
       yield* deleteItem(LEGACY_CONNECTIONS_KEY);
     }
     return catalog;
+  });
+
+  const restoreBackup = Effect.fn("mobile.connectionStorage.restoreBackup")(function* () {
+    const backupRaw = yield* getItem(CONNECTION_CATALOG_BACKUP_KEY);
+    if (backupRaw === null || backupRaw.trim() === "") {
+      return Option.none<ConnectionCatalogDocumentType>();
+    }
+    const catalog = yield* decodeCatalog(backupRaw);
+    yield* setItem(CONNECTION_CATALOG_KEY, backupRaw);
+    return Option.some(catalog);
   });
 
   const loadUnlocked = Effect.fn("mobile.connectionStorage.loadCatalog")(function* () {
@@ -90,14 +102,29 @@ export const make = Effect.fn("mobile.connectionStorage.makeCatalogStore")(funct
     if (raw !== null && raw.trim() !== "") {
       catalog = yield* decodeCatalog(raw).pipe(
         Effect.catch((error) =>
-          Effect.logWarning("Discarding corrupt mobile connection catalog", error).pipe(
-            Effect.andThen(deleteItem(CONNECTION_CATALOG_KEY)),
-            Effect.andThen(loadLegacyCatalog()),
+          Effect.logWarning("Recovering corrupt mobile connection catalog from backup", error).pipe(
+            Effect.andThen(restoreBackup()),
+            Effect.flatMap(
+              Option.match({
+                onNone: () =>
+                  Effect.fail(
+                    catalogError("recover", "No valid connection catalog backup is available."),
+                  ),
+                onSome: Effect.succeed,
+              }),
+            ),
           ),
         ),
       );
     } else {
-      catalog = yield* loadLegacyCatalog();
+      catalog = yield* restoreBackup().pipe(
+        Effect.flatMap(
+          Option.match({
+            onNone: loadLegacyCatalog,
+            onSome: Effect.succeed,
+          }),
+        ),
+      );
     }
     yield* Ref.set(state, Option.some(catalog));
     return catalog;
@@ -110,6 +137,7 @@ export const make = Effect.fn("mobile.connectionStorage.makeCatalogStore")(funct
         Effect.gen(function* () {
           const next = transform(yield* loadUnlocked());
           const encoded = yield* encodeCatalog(next);
+          yield* setItem(CONNECTION_CATALOG_BACKUP_KEY, encoded);
           yield* setItem(CONNECTION_CATALOG_KEY, encoded);
           yield* Ref.set(state, Option.some(next));
         }),

--- a/apps/mobile/src/connection/storage.test.ts
+++ b/apps/mobile/src/connection/storage.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "@effect/vitest";
+import {
+  BearerConnectionCredential,
+  BearerConnectionProfile,
+  BearerConnectionRegistration,
+  BearerConnectionTarget,
+} from "@t3tools/client-runtime/connection";
+import {
+  ConnectionCatalogDocument,
+  EMPTY_CONNECTION_CATALOG_DOCUMENT,
+  registerConnectionInCatalog,
+} from "@t3tools/client-runtime/platform";
+import { EnvironmentId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { vi } from "vite-plus/test";
 
 vi.mock("react-native", () => ({
@@ -12,7 +25,12 @@ vi.mock("expo-secure-store", () => ({
   setItemAsync: vi.fn(),
 }));
 
-import { CONNECTION_CATALOG_KEY, LEGACY_CONNECTIONS_KEY, make } from "./catalog-store";
+import {
+  CONNECTION_CATALOG_BACKUP_KEY,
+  CONNECTION_CATALOG_KEY,
+  LEGACY_CONNECTIONS_KEY,
+  make,
+} from "./catalog-store";
 import { MobileSecureStorage } from "../persistence/mobile-secure-storage";
 
 function makeStorage(initial: Readonly<Record<string, string>>) {
@@ -34,7 +52,44 @@ function makeStorage(initial: Readonly<Record<string, string>>) {
 }
 
 describe("mobile connection catalog storage", () => {
-  it.effect("recovers from a corrupt current catalog", () =>
+  const encodedCatalog = Schema.encodeEffect(Schema.fromJsonString(ConnectionCatalogDocument));
+  const fixtureCatalog = registerConnectionInCatalog(
+    EMPTY_CONNECTION_CATALOG_DOCUMENT,
+    new BearerConnectionRegistration({
+      target: new BearerConnectionTarget({
+        environmentId: EnvironmentId.make("saved-environment"),
+        label: "Saved environment",
+        connectionId: "bearer:saved-environment",
+      }),
+      profile: new BearerConnectionProfile({
+        connectionId: "bearer:saved-environment",
+        environmentId: EnvironmentId.make("saved-environment"),
+        label: "Saved environment",
+        httpBaseUrl: "https://saved.example.test",
+        wsBaseUrl: "wss://saved.example.test",
+      }),
+      credential: new BearerConnectionCredential({ token: "saved-token" }),
+    }),
+  );
+
+  it.effect("recovers a corrupt current catalog from its durable backup", () =>
+    Effect.gen(function* () {
+      const encoded = yield* encodedCatalog(fixtureCatalog);
+      const memory = makeStorage({
+        [CONNECTION_CATALOG_KEY]: "{not-json",
+        [CONNECTION_CATALOG_BACKUP_KEY]: encoded,
+      });
+      const catalog = yield* make().pipe(
+        Effect.provideService(MobileSecureStorage, memory.storage),
+      );
+
+      expect((yield* catalog.read).targets).toHaveLength(1);
+      expect(memory.values.get(CONNECTION_CATALOG_KEY)).toBe(encoded);
+      expect(memory.deleted).toEqual([]);
+    }),
+  );
+
+  it.effect("fails closed without deleting a corrupt catalog when no backup exists", () =>
     Effect.gen(function* () {
       const memory = makeStorage({
         [CONNECTION_CATALOG_KEY]: "{not-json",
@@ -43,8 +98,10 @@ describe("mobile connection catalog storage", () => {
         Effect.provideService(MobileSecureStorage, memory.storage),
       );
 
-      expect((yield* catalog.read).targets).toEqual([]);
-      expect(memory.deleted).toEqual([CONNECTION_CATALOG_KEY]);
+      const error = yield* Effect.flip(catalog.read);
+      expect(error.detail).toContain("No valid connection catalog backup is available");
+      expect(memory.values.get(CONNECTION_CATALOG_KEY)).toBe("{not-json");
+      expect(memory.deleted).toEqual([]);
     }),
   );
 
@@ -60,13 +117,15 @@ describe("mobile connection catalog storage", () => {
       expect((yield* catalog.read).targets).toEqual([]);
       expect(memory.deleted).toEqual([LEGACY_CONNECTIONS_KEY]);
       expect(memory.values.has(CONNECTION_CATALOG_KEY)).toBe(true);
+      expect(memory.values.has(CONNECTION_CATALOG_BACKUP_KEY)).toBe(true);
     }),
   );
 
-  it.effect("falls back to valid legacy data when the current catalog is corrupt", () =>
+  it.effect("restores a missing current catalog from backup before consulting legacy data", () =>
     Effect.gen(function* () {
+      const encoded = yield* encodedCatalog(fixtureCatalog);
       const memory = makeStorage({
-        [CONNECTION_CATALOG_KEY]: "{not-json",
+        [CONNECTION_CATALOG_BACKUP_KEY]: encoded,
         [LEGACY_CONNECTIONS_KEY]: JSON.stringify({
           connections: [
             {
@@ -87,11 +146,13 @@ describe("mobile connection catalog storage", () => {
       );
 
       expect((yield* catalog.read).targets).toHaveLength(1);
-      expect(memory.deleted).toEqual([CONNECTION_CATALOG_KEY, LEGACY_CONNECTIONS_KEY]);
+      expect(memory.values.get(CONNECTION_CATALOG_KEY)).toBe(encoded);
+      expect(memory.deleted).toEqual([]);
 
       yield* catalog.update((document) => document);
       expect(memory.values.has(CONNECTION_CATALOG_KEY)).toBe(true);
-      expect(memory.values.has(LEGACY_CONNECTIONS_KEY)).toBe(false);
+      expect(memory.values.has(CONNECTION_CATALOG_BACKUP_KEY)).toBe(true);
+      expect(memory.values.has(LEGACY_CONNECTIONS_KEY)).toBe(true);
     }),
   );
 });


### PR DESCRIPTION
## Summary

- mirror each successfully encoded mobile connection catalog to a backup SecureStore key before publishing the primary value
- recover a missing or undecodable primary catalog from that backup and restore the primary key
- fail closed without deleting the only saved catalog when no valid backup exists
- preserve the existing legacy migration path while seeding both durable copies

## Why

The mobile catalog currently keeps connection targets, profiles, and credentials in one SecureStore document. If that document cannot be decoded, startup deletes it and continues with an empty catalog. A transient or version-related decode failure can therefore make every saved environment disappear and force the user to pair again.

This change keeps a last-known-good copy and treats unrecoverable catalog damage as an explicit persistence error instead of destructive empty state.

## Verification

- `vp fmt --check apps/mobile/src/connection/catalog-store.ts apps/mobile/src/connection/storage.test.ts`
- `vp test run apps/mobile/src/connection/storage.test.ts` (4 passed)
- `pnpm --filter @t3tools/mobile typecheck`
- `vp lint apps/mobile/src/connection/catalog-store.ts apps/mobile/src/connection/storage.test.ts --report-unused-disable-directives`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local persistence recovery semantics: corrupt catalogs without a backup now surface errors on read instead of silently resetting, so startup flows must tolerate that path.
> 
> **Overview**
> Fixes mobile saved environments disappearing when the primary SecureStore catalog fails to decode. The app now keeps a **last-known-good backup** (`CONNECTION_CATALOG_BACKUP_KEY`) and writes it on every successful encode (updates and legacy migration) before updating the primary key.
> 
> On load, a corrupt primary catalog is **restored from backup** instead of being deleted and replaced with an empty catalog or legacy migration. If the primary is missing, backup is tried **before** legacy data. When the primary is corrupt and no valid backup exists, load **fails with an explicit error** and leaves the corrupt blob in place rather than wiping user data.
> 
> Tests now assert backup recovery, fail-closed behavior without deletion, and backup precedence over legacy when the primary is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3678f50e266d0329de53ecb20e1c2a64c72191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add backup key to mobile `connectionStorage` for catalog recovery
> - Introduces `CONNECTION_CATALOG_BACKUP_KEY` and writes a backup copy alongside the primary key on every catalog update and during legacy migration
> - Adds `restoreBackup` effect; `loadCatalog` now restores from the backup when the primary is corrupt or missing instead of deleting the corrupt primary and falling back to legacy
> - Risk: `loadCatalog` now fails closed with `ConnectionTransientError` (reason `remote-unavailable`) when the primary is corrupt and no valid backup exists; legacy data is only consulted when the primary is missing and no backup is available
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac3678f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->