### PR TITLE
fix(server): load archived threads by exact id

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -577,6 +577,25 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
             '2026-04-06T00:00:05.000Z',
             '2026-04-06T00:00:06.000Z',
             NULL
+          ),
+          (
+            'thread-deleted',
+            'project-archive-test',
+            'Deleted Thread',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            '2026-04-06T00:00:07.000Z',
+            '2026-04-06T00:00:08.000Z',
+            NULL,
+            '2026-04-06T00:00:09.000Z'
           )
       `;
 
@@ -604,6 +623,34 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
         [ThreadId.make("thread-archived")],
       );
       assert.equal(archivedShellSnapshot.threads[0]?.archivedAt, "2026-04-06T00:00:06.000Z");
+
+      const archivedDetail = yield* snapshotQuery.getThreadDetailSnapshot(
+        ThreadId.make("thread-archived"),
+      );
+      assert.equal(archivedDetail._tag, "Some");
+      if (archivedDetail._tag === "Some") {
+        assert.equal(archivedDetail.value.thread.id, ThreadId.make("thread-archived"));
+        assert.equal(archivedDetail.value.thread.archivedAt, "2026-04-06T00:00:06.000Z");
+      }
+
+      const archivedShell = yield* snapshotQuery.getThreadShellById(
+        ThreadId.make("thread-archived"),
+      );
+      assert.equal(archivedShell._tag, "Some");
+      if (archivedShell._tag === "Some") {
+        assert.equal(archivedShell.value.archivedAt, "2026-04-06T00:00:06.000Z");
+      }
+
+      const deletedDetail = yield* snapshotQuery.getThreadDetailSnapshot(
+        ThreadId.make("thread-deleted"),
+      );
+      assert.equal(deletedDetail._tag, "None");
+
+      const shellSnapshotAfterDetailRead = yield* snapshotQuery.getShellSnapshot();
+      assert.deepEqual(
+        shellSnapshotAfterDetailRead.threads.map((thread) => thread.id),
+        [ThreadId.make("thread-active")],
+      );
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -932,7 +932,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
-  const getActiveThreadRowById = SqlSchema.findOneOption({
+  const getReadableThreadRowById = SqlSchema.findOneOption({
     Request: ThreadIdLookupInput,
     Result: ProjectionThreadDbRowSchema,
     execute: ({ threadId }) =>
@@ -968,7 +968,6 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         FROM projection_threads
         WHERE thread_id = ${threadId}
           AND deleted_at IS NULL
-          AND archived_at IS NULL
         LIMIT 1
       `,
   });
@@ -2448,7 +2447,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
   const getThreadShellById: ProjectionSnapshotQueryShape["getThreadShellById"] = (threadId) =>
     Effect.gen(function* () {
       const [threadRow, latestTurnRow, sessionRow] = yield* Effect.all([
-        getActiveThreadRowById({ threadId }).pipe(
+        getReadableThreadRowById({ threadId }).pipe(
           Effect.mapError(
             toPersistenceSqlOrDecodeError(
               "ProjectionSnapshotQuery.getThreadShellById:getThread:query",
@@ -2536,7 +2535,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         latestTurnRow,
         sessionRow,
       ] = yield* Effect.all([
-        getActiveThreadRowById({ threadId }).pipe(
+        getReadableThreadRowById({ threadId }).pipe(
           Effect.mapError(
             toPersistenceSqlOrDecodeError(
               "ProjectionSnapshotQuery.getThreadDetailById:getThread:query",

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -157,21 +157,21 @@ export interface ProjectionSnapshotQueryShape {
   ) => Effect.Effect<Option.Option<ProjectionFullThreadDiffContext>, ProjectionRepositoryError>;
 
   /**
-   * Read a single active thread shell row by id.
+   * Read a single intact thread shell row by id, including archived threads.
    */
   readonly getThreadShellById: (
     threadId: ThreadId,
   ) => Effect.Effect<Option.Option<OrchestrationThreadShell>, ProjectionRepositoryError>;
 
   /**
-   * Read a single active thread detail snapshot by id.
+   * Read a single intact thread detail snapshot by id, including archived threads.
    */
   readonly getThreadDetailById: (
     threadId: ThreadId,
   ) => Effect.Effect<Option.Option<OrchestrationThread>, ProjectionRepositoryError>;
 
   /**
-   * Read a single active thread detail together with the projection snapshot
+   * Read a single intact thread detail, including archived threads, together with the projection snapshot
    * sequence in one consistent transaction, so the returned `snapshotSequence`
    * exactly matches the state reflected in `thread` (no interleaving projector
    * update between the two reads).


### PR DESCRIPTION
## Summary
- allow exact-id thread shell and detail reads to return intact archived threads
- keep archived threads excluded from the active shell list
- keep deleted thread tombstones unreadable

This fixes the server-side read-model asymmetry behind archived thread detail/subscription failures. It is related to #6128; #7183 separately addresses archived draft ID reuse in the composer.

## Verification
- bun run --cwd apps/server test -- src/orchestration/Layers/ProjectionSnapshotQuery.test.ts (21 passed)
- bun lint
- bun typecheck
- bun fmt --check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow read-path change with explicit tests; listing, search, and deleted-thread semantics are unchanged.
> 
> **Overview**
> Fixes read-model behavior so **exact thread ID** lookups can return **archived** threads while **list/shell** queries still only surface non-archived threads.
> 
> The projection layer renames the by-id SQL helper to `getReadableThreadRowById` and drops the `archived_at IS NULL` filter for `getThreadShellById`, `getThreadDetailById`, and `getThreadDetailSnapshot`. Rows with `deleted_at` set stay excluded, so deleted tombstones still resolve to `None`. Service docs now describe these APIs as reading **intact** threads (active or archived).
> 
> Tests seed a deleted thread and assert archived detail/shell reads succeed with `archivedAt`, deleted detail is `None`, and `getShellSnapshot` still lists only active threads after those reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3432a56082826ca7eaae18470b1b80a6c552c887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load archived threads by exact id in `getReadableThreadRowById`
> - Renames `getActiveThreadRowById` to `getReadableThreadRowById` and removes the `archived_at IS NULL` SQL filter, while keeping `deleted_at IS NULL`. Thread id lookups now return archived-but-not-deleted threads.
> - Updates `getThreadShellById` and `getThreadDetailById` handlers to call the renamed helper so both shell and detail reads include archived threads.
> - Extends the `ProjectionSnapshotQuery` test suite to verify archived threads are included with `archivedAt` preserved, deleted threads are excluded, and shell snapshots stay limited to active threads after a detail read.
> - Behavioral Change: `getThreadShellById` and `getThreadDetailById` in [ProjectionSnapshotQuery.ts](https://github.com/pingdotgg/t3code/pull/8926/files#diff-7f517291c1a9a2bf839691915f2f1c92d2553a298bd2d6144574615878e82209) now return results for archived threads; any caller relying on archived threads being filtered out by these handlers will see different results.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3432a56. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->