### PR TITLE
feat(server): add experimental Hermes ACP provider

### DIFF
--- a/apps/server/src/provider/Drivers/HermesDriver.ts
+++ b/apps/server/src/provider/Drivers/HermesDriver.ts
@@ -1,0 +1,127 @@
+import {
+  HermesSettings,
+  ProviderDriverKind,
+  TextGenerationError,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as TextGeneration from "../../textGeneration/TextGeneration.ts";
+import { makeHermesAdapter } from "../Layers/HermesAdapter.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import { buildServerProvider } from "../providerSnapshot.ts";
+
+const DRIVER_KIND = ProviderDriverKind.make("hermes");
+const decodeHermesSettings = Schema.decodeSync(HermesSettings);
+const HERMES_DEFAULT_MODEL = {
+  slug: "default",
+  name: "Hermes profile default",
+  isCustom: false,
+  capabilities: createModelCapabilities({ optionDescriptors: [] }),
+} as const;
+
+export type HermesDriverEnv = ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto | Path.Path;
+
+const makeUnsupportedTextGeneration = (): TextGeneration.TextGeneration["Service"] => {
+  const unsupported = (operation: string) =>
+    Effect.fail(
+      new TextGenerationError({
+        operation,
+        detail: "Hermes text generation is not supported by this provider spike.",
+      }),
+    );
+  return TextGeneration.TextGeneration.of({
+    generateCommitMessage: () => unsupported("generateCommitMessage"),
+    generatePrContent: () => unsupported("generatePrContent"),
+    generateBranchName: () => unsupported("generateBranchName"),
+    generateThreadTitle: () => unsupported("generateThreadTitle"),
+  });
+};
+
+export const HermesDriver: ProviderDriver<HermesSettings, HermesDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Hermes",
+    supportsMultipleInstances: true,
+  },
+  configSchema: HermesSettings,
+  defaultConfig: () => decodeHermesSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies HermesSettings;
+      const adapter = yield* makeHermesAdapter(effectiveConfig, {
+        environment: mergeProviderInstanceEnvironment(environment),
+        instanceId,
+      });
+      const checkedAt = DateTime.formatIso(yield* DateTime.now);
+      const snapshot: ServerProvider = {
+        ...buildServerProvider({
+          presentation: {
+            displayName: displayName ?? "Hermes",
+            badgeLabel: "Experimental",
+            showInteractionModeToggle: false,
+          },
+          enabled,
+          checkedAt,
+          models: [HERMES_DEFAULT_MODEL],
+          probe: enabled
+            ? {
+                installed: true,
+                version: null,
+                status: "warning",
+                auth: { status: "unknown" },
+                message: "Hermes ACP availability is verified when a session starts.",
+              }
+            : {
+                installed: false,
+                version: null,
+                status: "warning",
+                auth: { status: "unknown" },
+                message: "Hermes is disabled in T3 Code settings.",
+              },
+        }),
+        instanceId,
+        driver: DRIVER_KIND,
+        ...(accentColor ? { accentColor } : {}),
+        continuation: { groupKey: continuationIdentity.continuationKey },
+      };
+      const maintenanceCapabilities = makeManualOnlyProviderMaintenanceCapabilities({
+        provider: DRIVER_KIND,
+        packageName: null,
+      });
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot: {
+          maintenanceCapabilities,
+          getSnapshot: Effect.succeed(snapshot),
+          refresh: Effect.succeed(snapshot),
+          streamChanges: Stream.empty,
+        },
+        adapter,
+        textGeneration: makeUnsupportedTextGeneration(),
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/HermesAdapter.ts
+++ b/apps/server/src/provider/Layers/HermesAdapter.ts
@@ -1,0 +1,613 @@
+import {
+  ApprovalRequestId,
+  EventId,
+  type HermesSettings,
+  type ProviderApprovalDecision,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeHermesAcpRuntime } from "../acp/HermesAcpSupport.ts";
+import type { HermesAdapterShape } from "../Services/HermesAdapter.ts";
+
+const PROVIDER = ProviderDriverKind.make("hermes");
+const HERMES_RESUME_VERSION = 1 as const;
+
+export interface HermesAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly instanceId?: ProviderInstanceId;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  readonly request: EffectAcpSchema.RequestPermissionRequest;
+}
+
+interface HermesSessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  activeTurnId: TurnId | undefined;
+  promptsInFlight: number;
+  stopped: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseHermesResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== HERMES_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+function selectPermissionOptionId(
+  request: EffectAcpSchema.RequestPermissionRequest,
+  decision: ProviderApprovalDecision,
+): string | undefined {
+  if (decision === "cancel") return undefined;
+  const preferredKind =
+    decision === "acceptForSession"
+      ? "allow_always"
+      : decision === "accept"
+        ? "allow_once"
+        : "reject_once";
+  const preferred = request.options
+    .find((option) => option.kind === preferredKind)
+    ?.optionId.trim();
+  if (preferred) return preferred;
+  if (decision === "acceptForSession") {
+    return request.options.find((option) => option.kind === "allow_once")?.optionId.trim();
+  }
+  return undefined;
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  return Effect.forEach(
+    pendingApprovals.values(),
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    { discard: true },
+  );
+}
+
+export function makeHermesAdapter(
+  hermesSettings: HermesSettings,
+  options?: HermesAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("hermes");
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const crypto = yield* Crypto.Crypto;
+    const sessions = new Map<ThreadId, HermesSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Hermes runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const makeEventStamp = () =>
+      Effect.all({
+        eventId: Effect.map(randomUUIDv4, EventId.make),
+        createdAt: nowIso,
+      });
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+    const mapCallbackFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process Hermes ACP callback.",
+              cause,
+            }),
+        ),
+      );
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing = Option.fromNullishOr(current.get(threadId));
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<HermesSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      return !ctx || ctx.stopped
+        ? Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }))
+        : Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: HermesSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        if (ctx.notificationFiber) yield* Fiber.interrupt(ctx.notificationFiber);
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: HermesAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) yield* stopSessionInternal(existing);
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+          let ctx!: HermesSessionContext;
+          const resumeSessionId = parseHermesResume(input.resumeCursor)?.sessionId;
+          const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+          const acp = yield* makeHermesAcpRuntime({
+            hermesSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...(mcpSession
+              ? {
+                  mcpServers: [
+                    {
+                      type: "http" as const,
+                      name: "t3-code",
+                      url: mcpSession.endpoint,
+                      headers: [{ name: "Authorization", value: mcpSession.authorizationHeader }],
+                    },
+                  ],
+                }
+              : {}),
+          }).pipe(
+            Effect.provideService(Crypto.Crypto, crypto),
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((request) =>
+              mapCallbackFailure(
+                Effect.gen(function* () {
+                  if (input.runtimeMode === "full-access") {
+                    const optionId =
+                      request.options.find((option) => option.kind === "allow_always")?.optionId ??
+                      request.options.find((option) => option.kind === "allow_once")?.optionId;
+                    if (optionId) return { outcome: { outcome: "selected" as const, optionId } };
+                  }
+
+                  const permissionRequest = parsePermissionRequest(request);
+                  const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                  const runtimeRequestId = RuntimeRequestId.make(requestId);
+                  const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                  pendingApprovals.set(requestId, { decision, request });
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestOpenedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      detail: permissionRequest.detail ?? "Hermes requested permission.",
+                      args: request,
+                      source: "acp.jsonrpc",
+                      method: "session/request_permission",
+                      rawPayload: request,
+                    }),
+                  );
+                  const resolved = yield* Deferred.await(decision);
+                  pendingApprovals.delete(requestId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestResolvedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      decision: resolved,
+                    }),
+                  );
+                  const optionId = selectPermissionOptionId(request, resolved);
+                  return optionId
+                    ? { outcome: { outcome: "selected" as const, optionId } }
+                    : { outcome: { outcome: "cancelled" as const } };
+                }),
+              ),
+            );
+            return yield* acp.start();
+          }).pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+            ),
+          );
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: HERMES_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+          ctx = {
+            threadId: input.threadId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            turns: [],
+            activeTurnId: undefined,
+            promptsInFlight: 0,
+            stopped: false,
+          };
+
+          ctx.notificationFiber = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                switch (event._tag) {
+                  case "EventStreamBarrier":
+                    yield* Deferred.succeed(event.acknowledge, undefined);
+                    return;
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle:
+                          event._tag === "AssistantItemStarted" ? "item.started" : "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* offerRuntimeEvent(
+                      makeAcpPlanUpdatedEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        payload: event.payload,
+                        source: "acp.jsonrpc",
+                        method: "session/update",
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process Hermes runtime notification.", { cause }),
+            ),
+            Effect.forkIn(ctx.scope),
+          );
+
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Hermes ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: HermesAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+        const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+        const text = input.input?.trim();
+        if (!text) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Hermes turns require non-empty text.",
+          });
+        }
+        ctx.promptsInFlight += 1;
+        return yield* Effect.gen(function* () {
+          ctx.activeTurnId = turnId;
+          ctx.session = {
+            ...ctx.session,
+            activeTurnId: turnId,
+            updatedAt: yield* nowIso,
+          };
+          if (!steeringTurnId) {
+            yield* offerRuntimeEvent({
+              type: "turn.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              turnId,
+              payload: {},
+            });
+          }
+          const prompt: Array<EffectAcpSchema.ContentBlock> = [{ type: "text", text }];
+          const result = yield* ctx.acp
+            .prompt({ prompt })
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              ),
+            );
+          const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
+          if (turnRecord) turnRecord.items.push({ prompt, result });
+          else ctx.turns.push({ id: turnId, items: [{ prompt, result }] });
+          if (ctx.promptsInFlight === 1) {
+            yield* offerRuntimeEvent({
+              type: "turn.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              turnId,
+              payload: {
+                state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                stopReason: result.stopReason ?? null,
+              },
+            });
+          }
+          return { threadId: input.threadId, turnId, resumeCursor: ctx.session.resumeCursor };
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
+            }),
+          ),
+        );
+      });
+
+    const interruptTurn: HermesAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* Effect.ignore(
+          ctx.acp.cancel.pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+            ),
+          ),
+        );
+      });
+    const respondToRequest: HermesAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+    const respondToUserInput: HermesAdapterShape["respondToUserInput"] = (threadId, requestId) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "session/elicitation",
+          detail: `Hermes structured user input is not supported yet: ${requestId}`,
+        });
+      });
+    const readThread: HermesAdapterShape["readThread"] = (threadId) =>
+      Effect.map(requireSession(threadId), (ctx) => ({ threadId, turns: ctx.turns }));
+    const rollbackThread: HermesAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        ctx.turns.splice(Math.max(0, ctx.turns.length - numTurns));
+        return { threadId, turns: ctx.turns };
+      });
+    const stopSession: HermesAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(threadId, Effect.flatMap(requireSession(threadId), stopSessionInternal));
+    const listSessions: HermesAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (ctx) => ({ ...ctx.session })));
+    const hasSession: HermesAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const ctx = sessions.get(threadId);
+        return ctx !== undefined && !ctx.stopped;
+      });
+    const stopAll: HermesAdapterShape["stopAll"] = () =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to emit Hermes session shutdown event.", { cause }),
+        ),
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+      ),
+    );
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "unsupported" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      readThread,
+      rollbackThread,
+      stopAll,
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    } satisfies HermesAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -10,7 +10,7 @@
  *
  *  2. **Many drivers, one registry** — the "all drivers slice" describe
  *     block below configures one instance of every shipped driver
- *     (`codex`, `claudeAgent`, `cursor`, `grok`, `opencode`) in a single
+ *     (`codex`, `claudeAgent`, `cursor`, `grok`, `hermes`, `opencode`) in a single
  *     `ProviderInstanceConfigMap` and asserts the registry boots them all
  *     without cross-contamination. This proves the driver SPI is uniform
  *     across every provider — any driver plugs into the registry through
@@ -18,8 +18,7 @@
  *
  * Every instance in these tests is configured with `enabled: false` so the
  * provider-status checks short-circuit to pending/disabled snapshots
- * without trying to spawn real `codex` / `claude` / `agent` / `grok` / `opencode`
- * binaries. That keeps the assertions focused on registry routing
+ * without trying to spawn real provider binaries. That keeps the assertions focused on registry routing
  * behaviour rather than the runtime details of each provider.
  */
 import { describe, expect, it } from "@effect/vitest";
@@ -29,6 +28,7 @@ import {
   type CodexSettings,
   type CursorSettings,
   type GrokSettings,
+  type HermesSettings,
   type OpenCodeSettings,
   ProviderDriverKind,
   type ProviderInstanceConfigMap,
@@ -48,6 +48,7 @@ import { ClaudeDriver } from "../Drivers/ClaudeDriver.ts";
 import { CodexDriver } from "../Drivers/CodexDriver.ts";
 import { CursorDriver } from "../Drivers/CursorDriver.ts";
 import { GrokDriver } from "../Drivers/GrokDriver.ts";
+import { HermesDriver } from "../Drivers/HermesDriver.ts";
 import { OpenCodeDriver } from "../Drivers/OpenCodeDriver.ts";
 import * as ModelManifest from "../ModelManifest.ts";
 import { OpenCodeRuntimeLive } from "../opencodeRuntime.ts";
@@ -124,6 +125,12 @@ const makeGrokConfig = (overrides: Partial<GrokSettings>): GrokSettings => ({
   enabled: false,
   binaryPath: "grok",
   customModels: [],
+  ...overrides,
+});
+
+const makeHermesConfig = (overrides: Partial<HermesSettings>): HermesSettings => ({
+  enabled: false,
+  binaryPath: "hermes",
   ...overrides,
 });
 
@@ -325,12 +332,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const claudeId = ProviderInstanceId.make("claude_default");
       const cursorId = ProviderInstanceId.make("cursor_default");
       const grokId = ProviderInstanceId.make("grok_default");
+      const hermesId = ProviderInstanceId.make("hermes_default");
       const openCodeId = ProviderInstanceId.make("opencode_default");
 
       const codexDriverKind = ProviderDriverKind.make("codex");
       const claudeDriverKind = ProviderDriverKind.make("claudeAgent");
       const cursorDriverKind = ProviderDriverKind.make("cursor");
       const grokDriverKind = ProviderDriverKind.make("grok");
+      const hermesDriverKind = ProviderDriverKind.make("hermes");
       const openCodeDriverKind = ProviderDriverKind.make("opencode");
 
       const configMap: ProviderInstanceConfigMap = {
@@ -361,6 +370,12 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
           enabled: false,
           config: makeGrokConfig({}),
         },
+        [hermesId]: {
+          driver: hermesDriverKind,
+          displayName: "Hermes",
+          enabled: false,
+          config: makeHermesConfig({}),
+        },
         [openCodeId]: {
           driver: openCodeDriverKind,
           displayName: "OpenCode",
@@ -370,7 +385,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       };
 
       const { registry } = yield* makeProviderInstanceRegistry<BuiltInDriversEnv>({
-        drivers: [CodexDriver, ClaudeDriver, CursorDriver, GrokDriver, OpenCodeDriver],
+        drivers: [
+          CodexDriver,
+          ClaudeDriver,
+          CursorDriver,
+          GrokDriver,
+          HermesDriver,
+          OpenCodeDriver,
+        ],
         configMap,
       });
 
@@ -380,9 +402,9 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(unavailable).toEqual([]);
 
       const instances = yield* registry.listInstances;
-      expect(instances).toHaveLength(5);
+      expect(instances).toHaveLength(6);
       expect(instances.map((instance) => instance.instanceId).toSorted()).toEqual(
-        [codexId, claudeId, cursorId, grokId, openCodeId].toSorted(),
+        [codexId, claudeId, cursorId, grokId, hermesId, openCodeId].toSorted(),
       );
 
       // Instance lookup by id resolves each instance to its own bundle —
@@ -392,16 +414,19 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const claude = yield* registry.getInstance(claudeId);
       const cursor = yield* registry.getInstance(cursorId);
       const grok = yield* registry.getInstance(grokId);
+      const hermes = yield* registry.getInstance(hermesId);
       const openCode = yield* registry.getInstance(openCodeId);
       expect(codex?.driverKind).toBe(codexDriverKind);
       expect(claude?.driverKind).toBe(claudeDriverKind);
       expect(cursor?.driverKind).toBe(cursorDriverKind);
       expect(grok?.driverKind).toBe(grokDriverKind);
+      expect(hermes?.driverKind).toBe(hermesDriverKind);
       expect(openCode?.driverKind).toBe(openCodeDriverKind);
       expect(codex?.displayName).toBe("Codex");
       expect(claude?.displayName).toBe("Claude");
       expect(cursor?.displayName).toBe("Cursor");
       expect(grok?.displayName).toBe("Grok");
+      expect(hermes?.displayName).toBe("Hermes");
       expect(openCode?.displayName).toBe("OpenCode");
 
       // Every instance owns its own set of closures — no sharing across
@@ -414,6 +439,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         claude!.adapter,
         cursor!.adapter,
         grok!.adapter,
+        hermes!.adapter,
         openCode!.adapter,
       ];
       expect(new Set(adapters).size).toBe(adapters.length);
@@ -422,6 +448,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         claude!.textGeneration,
         cursor!.textGeneration,
         grok!.textGeneration,
+        hermes!.textGeneration,
         openCode!.textGeneration,
       ];
       expect(new Set(textGenerations).size).toBe(textGenerations.length);
@@ -430,6 +457,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         claude!.snapshot,
         cursor!.snapshot,
         grok!.snapshot,
+        hermes!.snapshot,
         openCode!.snapshot,
       ];
       expect(new Set(snapshots).size).toBe(snapshots.length);
@@ -465,6 +493,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(grokSnapshot.driver).toBe(grokDriverKind);
       expect(grokSnapshot.enabled).toBe(false);
       expect(grokSnapshot.continuation?.groupKey).toBe(`${grokDriverKind}:instance:${grokId}`);
+
+      const hermesSnapshot = yield* hermes!.snapshot.getSnapshot;
+      expect(hermesSnapshot.instanceId).toBe(hermesId);
+      expect(hermesSnapshot.driver).toBe(hermesDriverKind);
+      expect(hermesSnapshot.enabled).toBe(false);
+      expect(hermesSnapshot.continuation?.groupKey).toBe(
+        `${hermesDriverKind}:instance:${hermesId}`,
+      );
 
       const openCodeSnapshot = yield* openCode!.snapshot.getSnapshot;
       expect(openCodeSnapshot.instanceId).toBe(openCodeId);

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1972,6 +1972,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 "codex",
                 "cursor",
                 "grok",
+                "hermes",
                 "opencode",
               ]);
               assert.strictEqual(cursorProvider?.enabled, false);

--- a/apps/server/src/provider/Services/HermesAdapter.ts
+++ b/apps/server/src/provider/Services/HermesAdapter.ts
@@ -1,0 +1,4 @@
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+export interface HermesAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/HermesAcpCliProbe.test.ts
+++ b/apps/server/src/provider/acp/HermesAcpCliProbe.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Optional integration check against a real `hermes acp` install.
+ * Enable with: T3_HERMES_ACP_PROBE=1 vp test run apps/server/src/provider/acp/HermesAcpCliProbe.test.ts
+ */
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import {
+  HermesSettings,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { describe, expect } from "vite-plus/test";
+
+import { makeHermesAdapter } from "../Layers/HermesAdapter.ts";
+
+const decodeHermesSettings = Schema.decodeSync(HermesSettings);
+
+describe.runIf(process.env.T3_HERMES_ACP_PROBE === "1")("Hermes ACP CLI probe", () => {
+  it.effect("completes a real Hermes turn through the provider adapter", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("hermes-live-probe");
+      const adapter = yield* makeHermesAdapter(
+        decodeHermesSettings({ enabled: true, binaryPath: "hermes" }),
+      );
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("hermes"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("hermes"),
+          model: "default",
+        },
+      });
+      expect(session.provider).toBe("hermes");
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Reply with only T3_HERMES_OK.",
+        attachments: [],
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      const output = events
+        .filter((event) => event.type === "content.delta")
+        .map((event) => event.payload.delta)
+        .join("");
+      expect(output).toContain("T3_HERMES_OK");
+      expect(events.at(-1)?.type).toBe("turn.completed");
+
+      yield* adapter.stopSession(threadId);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/provider/acp/HermesAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/HermesAcpSupport.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildHermesAcpSpawnInput } from "./HermesAcpSupport.ts";
+
+describe("buildHermesAcpSpawnInput", () => {
+  it("builds the default Hermes ACP command", () => {
+    expect(buildHermesAcpSpawnInput(undefined, "/tmp/project")).toEqual({
+      command: "hermes",
+      args: ["acp"],
+      cwd: "/tmp/project",
+    });
+  });
+
+  it("uses the configured binary and environment", () => {
+    expect(
+      buildHermesAcpSpawnInput({ binaryPath: "/opt/hermes/bin/hermes" }, "/tmp/project", {
+        HERMES_PROFILE: "work",
+      }),
+    ).toEqual({
+      command: "/opt/hermes/bin/hermes",
+      args: ["acp"],
+      cwd: "/tmp/project",
+      env: { HERMES_PROFILE: "work" },
+    });
+  });
+});

--- a/apps/server/src/provider/acp/HermesAcpSupport.ts
+++ b/apps/server/src/provider/acp/HermesAcpSupport.ts
@@ -1,0 +1,57 @@
+import type { HermesSettings } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import type * as EffectAcpErrors from "effect-acp/errors";
+
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+
+type HermesAcpRuntimeSettings = Pick<HermesSettings, "binaryPath">;
+
+export interface HermesAcpRuntimeInput extends Omit<
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly hermesSettings: HermesAcpRuntimeSettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+export function buildHermesAcpSpawnInput(
+  hermesSettings: HermesAcpRuntimeSettings | null | undefined,
+  cwd: string,
+  environment?: NodeJS.ProcessEnv,
+): AcpSessionRuntime.AcpSpawnInput {
+  return {
+    command: hermesSettings?.binaryPath || "hermes",
+    args: ["acp"],
+    cwd,
+    ...(environment ? { env: environment } : {}),
+  };
+}
+
+export const makeHermesAcpRuntime = (
+  input: HermesAcpRuntimeInput,
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Crypto.Crypto | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildHermesAcpSpawnInput(input.hermesSettings, input.cwd, input.environment),
+        authMethodId: "hermes-setup",
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
+  });

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
+import { HermesDriver, type HermesDriverEnv } from "./Drivers/HermesDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
@@ -37,6 +38,7 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
+  | HermesDriverEnv
   | OpenCodeDriverEnv;
 
 /**
@@ -49,5 +51,6 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   GrokDriver,
+  HermesDriver,
   OpenCodeDriver,
 ];

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -541,10 +541,12 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         '{"providers":{"opencode":{"serverUrl":"http://127.0.0.1:4096"}}}',
       );
       yield* recordProviderUsage("opencode");
+      yield* recordProviderUsage("hermes");
 
       const settings = yield* serverSettings.getSettings;
 
       assert.isFalse(settings.providers.grok.enabled);
+      assert.isTrue(settings.providers.hermes.enabled);
       assert.isTrue(settings.providers.opencode.enabled);
       assert.isFalse(settings.providers.cursor.enabled);
       assert.equal(settings.providers.opencode.serverUrl, "http://127.0.0.1:4096");
@@ -964,6 +966,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
             enabled: false,
           },
           grok: {
+            enabled: false,
+          },
+          hermes: {
             enabled: false,
           },
           opencode: {

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -236,6 +236,7 @@ const PersistedOptionalProviderSettings = Schema.Struct({
     Schema.Struct({
       cursor: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       grok: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
+      hermes: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       opencode: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
     }),
   ),
@@ -264,6 +265,7 @@ function restoreUsedProviders(
       instance.enabled === undefined &&
       (instance.driver === "cursor" ||
         instance.driver === "grok" ||
+        instance.driver === "hermes" ||
         instance.driver === "opencode") &&
       usedProviderInstances.has(instanceId)
         ? { ...instance, enabled: true }
@@ -282,6 +284,10 @@ function restoreUsedProviders(
       grok: {
         ...settings.providers.grok,
         enabled: persisted.providers?.grok?.enabled ?? usedProviders.has("grok"),
+      },
+      hermes: {
+        ...settings.providers.hermes,
+        enabled: persisted.providers?.hermes?.enabled ?? usedProviders.has("hermes"),
       },
       opencode: {
         ...settings.providers.opencode,
@@ -333,6 +339,7 @@ const PERSISTED_SERVER_SETTINGS_DEFAULTS = {
     ...DEFAULT_SERVER_SETTINGS.providers,
     cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: undefined },
     grok: { ...DEFAULT_SERVER_SETTINGS.providers.grok, enabled: undefined },
+    hermes: { ...DEFAULT_SERVER_SETTINGS.providers.hermes, enabled: undefined },
     opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: undefined },
   },
 };
@@ -443,13 +450,13 @@ const make = Effect.gen(function* () {
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM projection_thread_sessions
-      WHERE provider_name IN ('cursor', 'grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'hermes', 'opencode')
       UNION
       SELECT DISTINCT
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM provider_session_runtime
-      WHERE provider_name IN ('cursor', 'grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'hermes', 'opencode')
     `.pipe(
       Effect.mapError(
         (cause) =>

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)
 - [Background service (Linux)](./user/background-service.md)
-- Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md) · [OpenCode](./user/providers-opencode.md)
+- Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md) · [Hermes Agent](./user/providers-hermes.md) · [OpenCode](./user/providers-opencode.md)
 
 Mobile app: [apps/mobile/README.md](../apps/mobile/README.md)
 

--- a/docs/user/providers-hermes.md
+++ b/docs/user/providers-hermes.md
@@ -1,0 +1,26 @@
+# Hermes Agent
+
+The Hermes provider is experimental. T3 Code starts `hermes acp` on the connected environment and
+uses that environment's Hermes configuration, credentials, tools, and session store.
+
+## Set up Hermes
+
+Install and configure Hermes Agent on the environment that runs the T3 server. Confirm that this
+command starts without a setup error:
+
+```bash
+hermes acp --check
+```
+
+Open **Settings > Providers**, add or enable Hermes, and leave **Binary path** as `hermes`. Set an
+absolute binary path when `hermes` is not on the T3 server's `PATH`.
+
+The provider verifies the ACP connection when you start a session. If startup fails, run
+`hermes acp --check` in the same environment and fix the reported Hermes setup or authentication
+problem.
+
+## Current limits
+
+T3 Code uses the model and provider configured by Hermes Agent. The T3 model picker does not select
+a Hermes model. Hermes also cannot generate thread titles, branch names, commit messages, or pull
+request text through T3 Code yet.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -259,6 +259,7 @@ describe("provider enabled defaults", () => {
     expect(decoded.providers.claudeAgent.enabled).toBe(true);
     expect(decoded.providers.cursor.enabled).toBe(false);
     expect(decoded.providers.grok.enabled).toBe(false);
+    expect(decoded.providers.hermes.enabled).toBe(false);
     expect(decoded.providers.opencode.enabled).toBe(false);
   });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -520,6 +520,26 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const HermesSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("hermes").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Hermes Agent binary.",
+        providerSettingsForm: { placeholder: "hermes", clearWhenEmpty: "omit" },
+      }),
+    ),
+  },
+  {
+    order: ["binaryPath"],
+  },
+);
+export type HermesSettings = typeof HermesSettings.Type;
+
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
     // Off by default (like Cursor and Grok): the binding is not yet stable
@@ -724,6 +744,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    hermes: HermesSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
@@ -870,6 +891,11 @@ const GrokSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const HermesSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -918,6 +944,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
+      hermes: Schema.optionalKey(HermesSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
     }),
   ),


### PR DESCRIPTION
## Why

T3 Code can use Hermes Agent through Hermes's ACP server instead of adding a second transport or forking Hermes. This keeps T3 Code's existing orchestration, persistence, remote access, and clients intact.

## Scope

- Add the experimental `hermes` provider settings and built-in `HermesDriver`.
- Add `HermesAdapter` for ACP session start, resume, prompts, streaming events, permissions, cancellation, rollback, and shutdown.
- Forward T3 MCP session credentials to the Hermes ACP process.
- Add focused registry and settings coverage.
- Add an opt-in real-CLI probe that starts `hermes acp`, sends a turn through the T3 adapter, and checks the streamed response.
- Document setup and current limits in `docs/user/providers-hermes.md`.

## Tradeoffs

The provider uses the model configured by Hermes Agent and exposes one placeholder model to T3 Code. T3 model selection and text generation for titles, branches, commits, and pull requests remain unsupported.

## Blast Radius

The provider is disabled by default and marked experimental. Existing providers and default settings keep their current behavior. Enabling Hermes starts a scoped `hermes acp` subprocess on the connected T3 environment.

## Verification

- `vp test run` passed 141 focused tests. The environment-gated live probe stayed skipped in this run.
- `T3_HERMES_ACP_PROBE=1 vp test run` passed 3 ACP tests against the installed Hermes Agent. The probe started a real ACP process, sent a T3 provider turn, and received streamed output.
- Server and contracts typechecks passed.
- Targeted lint passed.
- `hermes acp --check` returned `Hermes ACP check OK`.
- `git diff --check` passed.

Built with GPT-5.6 using Hermes Agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling Hermes spawns scoped `hermes acp` subprocesses and handles ACP permissions/MCP auth forwarding, but the binding stays disabled by default and does not alter existing provider defaults.
> 
> **Overview**
> Adds an **experimental, opt-in Hermes Agent provider** that talks to Hermes through its ACP server (`hermes acp`) instead of a custom transport.
> 
> **Server provider stack:** New `HermesDriver` registers with built-in drivers and exposes an experimental snapshot (placeholder model, no T3 text-generation for titles/branches/commits/PRs). `HermesAdapter` manages ACP sessions—start/resume, prompts, streaming runtime events, permission approvals (with full-access auto-allow), cancel, thread rollback, and shutdown—while forwarding T3 MCP credentials to the Hermes process when available.
> 
> **Settings & contracts:** `HermesSettings` (binary path, default **disabled**) is wired into server settings, patches, and provider-history restore logic alongside Cursor/Grok/OpenCode.
> 
> **Tests & docs:** Registry/settings coverage, spawn-command tests, an env-gated live CLI probe (`T3_HERMES_ACP_PROBE=1`), and user docs for setup and current limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ff1f627fff5089aaed191aef69ec92d1964e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add experimental Hermes ACP provider driver and settings
> - Adds `HermesDriver`, `HermesAdapter`, and `makeHermesAcpRuntime` to support Hermes as a built-in provider via ACP; spawns the `hermes acp` runtime and streams session/thread/turn events through a PubSub stream.
> - Provider snapshots report warning status when enabled (auth unknown, availability verified on session start) and disabled status when not enabled; reports a single `default` model.
> - Text generation operations (commit messages, PR content, branch names, thread titles) are explicitly unsupported and return `TextGenerationError` via `makeUnsupportedTextGeneration`.
> - Adds `HermesSettings` schema with `enabled` (default false) and `binaryPath` (default 'hermes') to `ServerSettings` and `ServerSettingsPatch`; `restoreUsedProviders` and SQL history queries now include `hermes` so prior opt-ins auto-restore.
> - Behavioral Change: `HermesDriver` is inserted into `BUILT_IN_DRIVERS` between Grok and OpenCode, so provider listings and instance counts now include Hermes by default; existing in-tree assertions in `ProviderRegistry.test.ts`, `ProviderInstanceRegistryLive.test.ts`, `serverSettings.test.ts`, and `contracts/src/settings.test.ts` are updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e8ff1f6. 9 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->