### PR TITLE
fix(ssh): give each managed launch a fresh remote server log

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,4 +1,7 @@
+// @effect-diagnostics nodeBuiltinImport:off - the executed suite runs the generated launch script through a real POSIX shell.
 import { assert, describe, it } from "@effect/vitest";
+import { afterAll } from "vite-plus/test";
+import * as NodeChildProcess from "node:child_process";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
 import * as Duration from "effect/Duration";
@@ -445,5 +448,116 @@ describe("ssh tunnel scripts", () => {
       assert.equal(spawnedCommands.filter((args) => args.includes("-N")).length, 2);
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+});
+
+// The launch script's failure diagnostic only misbehaves when a real shell runs
+// the failure branch against a log left over from a previous run, so the suite
+// below executes the real generated script. Find a shell that has the tools it
+// needs; anywhere else the executed suite skips.
+const REQUIRED_SHELL_TOOLS = ["nohup", "mktemp", "cmp", "tail"] as const;
+
+const posixShellRunner = (() => {
+  // Candidates rather than a platform switch: wsl.exe simply fails to spawn
+  // where it does not exist, which is the same answer as a missing tool.
+  const candidates = [
+    { file: "bash", args: [] as ReadonlyArray<string> },
+    { file: "wsl.exe", args: ["-e", "bash"] as ReadonlyArray<string> },
+  ];
+  const probe = REQUIRED_SHELL_TOOLS.map((tool) => `command -v ${tool} >/dev/null || exit 1`).join(
+    "\n",
+  );
+  return (
+    candidates.find((candidate) => {
+      const result = NodeChildProcess.spawnSync(candidate.file, [...candidate.args, "-c", probe], {
+        encoding: "utf8",
+      });
+      return result.status === 0;
+    }) ?? null
+  );
+})();
+
+const runShell = (script: string, args: ReadonlyArray<string> = []) => {
+  if (posixShellRunner === null) throw new Error("no POSIX shell runner available");
+  // The launch script arrives on stdin with the state key as $1 in production too.
+  const result = NodeChildProcess.spawnSync(
+    posixShellRunner.file,
+    [...posixShellRunner.args, "-s", "--", ...args],
+    { input: script, encoding: "utf8" },
+  );
+  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+};
+
+const sh = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+
+// Reading the generated script proves what it says, not what it does. An
+// append-mode launch satisfied every text assertion and still blamed a silent
+// server's failure on the previous run's log, because [ -s "$LOG_FILE" ] stayed
+// true forever once any run had logged. So run the real script in a throwaway
+// HOME seeded with a stale log, with a fake `node` that picks a port, fails
+// readiness immediately, and lets the runner exit without writing a byte.
+describe.skipIf(posixShellRunner === null)("remote launch script (executed)", () => {
+  const fixtures: Array<string> = [];
+
+  afterAll(() => {
+    for (const work of fixtures) runShell(`set -eu\nrm -rf ${sh(work)}`);
+    fixtures.length = 0;
+  });
+
+  it("reports a silent launch instead of tailing the previous run's log", () => {
+    const setup = runShell(
+      [
+        "set -eu",
+        "work=$(mktemp -d)",
+        'mkdir -p "$work/bin" "$work/home/.t3/ssh-launch/launch-test"',
+        // One fake node serves the launch script's three contracts, told apart
+        // by argv: `node - <state>/port ...` picks a port, `node - <runtime
+        // file>` finds no external server, `node - <ms> ...` probes readiness,
+        // and `node <script> serve ...` is the runner, which must exit silently.
+        'cat > "$work/bin/node" <<\'T3_FAKE_NODE\'',
+        "#!/bin/sh",
+        'case "${2-}" in',
+        "  */server-runtime.json) exit 1 ;;",
+        "  */port) printf '43117'; exit 0 ;;",
+        "esac",
+        '[ "${1-}" = "-" ] && exit 1',
+        "exit 0",
+        "T3_FAKE_NODE",
+        'chmod 700 "$work/bin/node"',
+        "printf 'STALE_PREVIOUS_RUN\\n' > \"$work/home/.t3/ssh-launch/launch-test/server.log\"",
+        "printf 'work:%s\\n' \"$work\"",
+      ].join("\n"),
+    );
+    assert.strictEqual(setup.status, 0, setup.stderr);
+    const workLine = setup.stdout.split("\n").find((line) => line.startsWith("work:"));
+    if (workLine === undefined) throw new Error(`missing work dir in setup output: ${setup.stdout}`);
+    const work = workLine.slice("work:".length).trim();
+    fixtures.push(work);
+
+    // The script reads $HOME and finds node on $PATH, so the overrides ride in
+    // the script itself, ahead of the generated text.
+    const launch = runShell(
+      [
+        `HOME=${sh(`${work}/home`)}`,
+        "export HOME",
+        `PATH=${sh(`${work}/bin`)}":$PATH"`,
+        "export PATH",
+        buildRemoteLaunchScript({ nodeScriptPath: `${work}/serve.mjs` }),
+      ].join("\n"),
+      ["launch-test"],
+    );
+
+    assert.strictEqual(launch.status, 1, launch.stderr);
+    assert.include(launch.stderr, "Remote T3 server did not become ready");
+    // The whole point: a launch that wrote nothing must say so, not replay
+    // whatever the previous server left in the log.
+    assert.include(launch.stderr, "It wrote nothing to");
+    assert.notInclude(launch.stderr, "STALE_PREVIOUS_RUN");
+
+    const logBytes = runShell(
+      `set -eu\nwc -c < ${sh(`${work}/home/.t3/ssh-launch/launch-test/server.log`)}`,
+    );
+    assert.strictEqual(logBytes.status, 0, logBytes.stderr);
+    assert.strictEqual(logBytes.stdout.trim(), "0");
   });
 });

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,6 +1,6 @@
-// @effect-diagnostics nodeBuiltinImport:off - the executed suite runs the generated launch script through a real POSIX shell.
 import { assert, describe, it } from "@effect/vitest";
 import { afterAll } from "vite-plus/test";
+// @effect-diagnostics-next-line nodeBuiltinImport:off - the executed suite runs the generated launch script through a real POSIX shell.
 import * as NodeChildProcess from "node:child_process";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -590,6 +590,7 @@ if [ -z "$REMOTE_PORT" ]; then
     printf 'Failed to find an available port on the remote host. Ensure node is available on PATH.\\n' >&2
     exit 1
   fi
+  rm -f "$LOG_FILE"
   nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
   REMOTE_PID="$!"
   printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"


### PR DESCRIPTION
## What changed

One line in the generated remote launch script, `packages/ssh/src/tunnel.ts`:

```sh
rm -f "$LOG_FILE"
nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve ... >>"$LOG_FILE" 2>&1 < /dev/null &
```

## Why it should exist

The readiness failure branch tells two cases apart by file size:

```sh
if [ -s "$LOG_FILE" ]; then
  tail -n 80 "$LOG_FILE" >&2
else
  printf 'It wrote nothing to %s, so it exited before producing any output.\n' "$LOG_FILE" >&2
fi
```

That empty-log arm came from #5132, to name the case where the remote server exits without
logging anything. The launch opens the log with `>>` and nothing clears it, so `[ -s ]` is true
from the first run that logs onward and the arm is unreachable after that. A server that dies
silently is reported with the previous run's error, which sends you after the wrong problem. The
file also grows without bound across managed restarts.

## Why unlink and not truncate

`wait_for_pid_exit` gives up after 20 x 0.1s (`tunnel.ts:495-502`), so a server that ignores the
kill is still holding its descriptor when the next launch runs. Measured separately from the test,
with a survivor holding the append-mode descriptor the launch gave it:

| launch does | resulting log | `[ -s ]` takes |
|---|---|---|
| `>` truncate | 5 bytes | the tail branch |
| `rm -f` then `>>` | 0 bytes | the wrote-nothing branch |

Truncating hands the new file to the old writer. Unlinking leaves it with the old one. The test
below passes under either form, so treat the table as the reason for the choice, not as something
the test proves.

## Test

One executed case in `packages/ssh/src/tunnel.test.ts`. It seeds `server.log` with a marker,
installs a fake `node` that picks a port, fails readiness at once, and lets the runner exit
without writing a byte, then runs the real `buildRemoteLaunchScript()` output through a shell. It
asserts exit 1, stderr containing "It wrote nothing to", no marker in stderr, and a 0-byte log.

Against the append-only script it fails at the "It wrote nothing to" assertion. It follows the
executed-shell pattern already in `apps/desktop/src/wsl/DesktopWslEnvironment.test.ts`, including
the shell probe that skips where the tools are missing.

`vp test run src/tunnel.test.ts`: 1 file, 14 tests, all pass. `tsgo --noEmit` clean.

Nothing else reads this path. The only other reference is the on-demand tail script at
`tunnel.ts:649`, which opens by path per SSH invocation, so unlinking strands no descriptor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to generated remote launch shell behavior and failure diagnostics only; no auth or data-path changes.
> 
> **Overview**
> **Each managed remote SSH launch now deletes the existing `server.log` before starting the server**, so readiness failures can tell a silent new run from one that actually logged output.
> 
> Previously the log was only opened in append mode, so `[ -s "$LOG_FILE" ]` stayed true after the first run and a server that exited without writing anything could surface **stale tail output** instead of the *"It wrote nothing to …"* message.
> 
> Adds an **executed** test in `tunnel.test.ts` that runs the real `buildRemoteLaunchScript()` output under bash/WSL with a seeded stale log and a fake `node`; the suite skips when required POSIX tools are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c84d1db64bacd01d1f418d595a751c82c341d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale log tailing by deleting `$LOG_FILE` before `nohup` in SSH launch script
> - The generated remote launch script in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/8930/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) now runs `rm -f "$LOG_FILE"` immediately before starting the managed server, so readiness and output checks see only the current run's log.
> - Adds an end-to-end test suite in [tunnel.test.ts](https://github.com/pingdotgg/t3code/pull/8930/files#diff-76d3724ec8959625b119aff8272a5d733f73551706a487e303ddbd13e10a06ad) that executes the generated script in a real POSIX shell, using a fake `node` binary and a seeded stale `server.log` to verify a silent launch is reported instead of old log content.
> - Tests conditionally skip when no suitable shell with `nohup`, `mktemp`, `cmp`, and `tail` is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c84d1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->