### PR TITLE
fix(mobile): shimmer active tool rows

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -9,6 +9,7 @@ import {
   type ColorValue,
   Pressable,
   ScrollView,
+  StyleSheet,
   View,
 } from "react-native";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
@@ -143,7 +144,7 @@ function ShimmeringWorkContent(props: {
 
   return (
     <View
-      className="min-w-0 flex-1"
+      className="min-w-0 flex-1 overflow-hidden"
       onLayout={(event) => setAvailableWidth(event.nativeEvent.layout.width)}
     >
       <ShimmerWorkContent
@@ -164,7 +165,7 @@ function ShimmeringWorkContent(props: {
           style={[{ width: SHIMMER_WIDTH }, sweepStyle]}
         >
           <MaskedView
-            className="absolute inset-0"
+            style={StyleSheet.absoluteFill}
             maskElement={
               <Svg width="100%" height="100%">
                 <Defs>

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -942,8 +942,27 @@ describe("buildThreadFeed", () => {
       summary: "Running pnpm",
       summaryKind: "command",
       live: true,
-      shimmer: false,
+      shimmer: true,
     });
+    expect(rows[0]).toMatchObject({ live: false, shimmer: false });
+
+    const stoppedRows = deriveThreadFeedPresentation(feed, latestTurn, new Set());
+    expect(stoppedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
+      { live: false, shimmer: false },
+      { live: false, shimmer: false },
+    ]);
+
+    const completedRows = deriveThreadFeedPresentation(
+      feed,
+      { ...latestTurn, state: "completed", completedAt: "2026-04-01T00:00:04.000Z" },
+      new Set([turnId]),
+      new Set(),
+      latestTurn.startedAt,
+    );
+    expect(completedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
+      { live: false, shimmer: false },
+      { live: false, shimmer: false },
+    ]);
   });
 
   it("does not revive cached in-progress tools after work stops", () => {

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1512,10 +1512,8 @@ function appendToolGroupRows(
     ),
     hasFailure: activities.findLast((activity) => activity.toolLike)?.status === "failure",
     live,
-    shimmer:
-      isWorking &&
-      latestActivity.lifecycleStatus === "inProgress" &&
-      latestActivity.turnId === unsettledTurnId,
+    // Match the live label until the turn or contiguous tool run settles.
+    shimmer: live,
   });
   if (!expanded) {
     return;

--- a/docs/user/mobile-appearance.md
+++ b/docs/user/mobile-appearance.md
@@ -19,6 +19,3 @@ preview circle inside a card to change only that appearance.
 
 **System** follows the device appearance automatically. Theme, text, code, and terminal appearance
 preferences are stored on the device.
-
-Running tool rows shimmer while their tool run is active. The effect pauses when you leave the
-thread or put the app in the background, and respects your device's Reduce Motion setting.

--- a/docs/user/mobile-appearance.md
+++ b/docs/user/mobile-appearance.md
@@ -19,3 +19,6 @@ preview circle inside a card to change only that appearance.
 
 **System** follows the device appearance automatically. Theme, text, code, and terminal appearance
 preferences are stored on the device.
+
+Running tool rows shimmer while their tool run is active. The effect pauses when you leave the
+thread or put the app in the background, and respects your device's Reduce Motion setting.


### PR DESCRIPTION
## What Changed

Mobile running tool rows now keep the shimmer state aligned with the live work label for the active turn or contiguous tool run. The row content also clips the shimmer sweep correctly and uses `StyleSheet.absoluteFill` for the masked overlay.

This also documents the mobile behavior and updates focused tests for active, stopped, and completed tool rows.

## Why

Running tool rows could lose their shimmer even while the row was still presented as live. Using the same `live` presentation state for shimmer keeps the UI behavior consistent and ensures the effect stops when work is no longer active.

## UI Changes

The mobile thread work log now shimmers active running tool rows and stops the shimmer once the tool run or turn settles. Verified on an iPhone 17 Pro simulator using an isolated Running-row fixture. The 10-second recording shows the highlight sweeping across the icon and text, pausing, then repeating.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3c2ab64862f01448/mobile-running-shimmer.mp4

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile thread work-log presentation and layout only; no auth, data, or API changes.
> 
> **Overview**
> **Work-toggle rows** in the thread feed now set **`shimmer` from the same `live` flag** used for the running label, so the highlight stays on whenever the row is presented as active (including `activeTail`) and turns off when the turn or tool run settles—instead of only when the latest in-progress activity matched the unsettled turn.
> 
> In **`ShimmeringWorkContent`**, the shimmer sweep is **clipped to the row** via `overflow-hidden` on the wrapper and **`StyleSheet.absoluteFill`** on the `MaskedView` overlay (replacing Tailwind absolute positioning).
> 
> **Tests** expect shimmer on the live running row and assert stopped/completed presentations keep `shimmer: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b0ea82cbebf761eb2aaa2c45aac9ab6c3aa872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix shimmer on active tool rows to match `live` state in `appendToolGroupRows`
> - Changes the `shimmer` flag on work-toggle rows to follow the computed `live` boolean, so shimmer stays on while a group is live rather than only when the latest activity is in-progress for the unsettled turn.
> - Updates [ShimmeringWorkContent](https://github.com/pingdotgg/t3code/pull/8932/files#diff-06f278f3ca8d6524ea378cdd0d5fea4e0a691986d150c0b93b43724ed8d40909) to clip overflow on the root container and position the mask with `StyleSheet.absoluteFill` instead of a `MaskedView` className.
> - Extends [threadActivity tests](https://github.com/pingdotgg/t3code/pull/8932/files#diff-8fc154ca47cb1e024c4e1f266b22114cd6071c6cdac94118a62011bf81c3ccd2) to assert `shimmer` is true on live rows and false on stopped or completed turns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8b0ea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->