### PR TITLE
chore: disable CodeRabbit review status

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  review_status: false


### PR DESCRIPTION
## What Changed

Added `.coderabbit.yaml` to disable CodeRabbit's review status messages.

<img width="967" height="564" alt="image" src="https://github.com/user-attachments/assets/b135d83e-21a8-4a3f-ab01-8097f994ee04" />


## Why

Prevents CodeRabbit review status updates from appearing on change requests.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable `review_status` in CodeRabbit config
> Adds a `.coderabbit.yaml` file that sets `reviews.review_status` to false. This turns off the CodeRabbit review status output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a624f7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to disable automated review status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->