### PR TITLE
fix(app): show threads from unreachable environments as offline

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -55,6 +55,7 @@ const STATUS_LABEL_BY_STATUS: Partial<
   approval: { label: "Approval", className: "text-adaptive-amber-700-300" },
   input: { label: "Input", className: "text-adaptive-indigo-600-300" },
   working: { label: "Working", className: "text-adaptive-sky-600-400" },
+  offline: { label: "Offline", className: "text-adaptive-zinc-500-400" },
   failed: { label: "Failed", className: "text-adaptive-red-700-300" },
 };
 

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -193,6 +193,44 @@ describe("resolveThreadListV2Status", () => {
       "ready",
     );
   });
+
+  it("reads live states as offline while the environment is unavailable", () => {
+    const running = makeThread({
+      id: ThreadId.make("t"),
+      title: "t",
+      session: {
+        threadId: ThreadId.make("t"),
+        status: "running",
+        providerName: "Codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: NOW,
+      },
+    });
+    expect(resolveThreadListV2Status({ ...running, environmentUnavailable: true })).toBe("offline");
+    expect(
+      resolveThreadListV2Status({
+        ...running,
+        hasPendingApprovals: true,
+        environmentUnavailable: true,
+      }),
+    ).toBe("offline");
+    // A cached failure is a historical fact, and quiet threads stay quiet.
+    expect(
+      resolveThreadListV2Status({
+        ...running,
+        session: { ...running.session!, status: "error" },
+        environmentUnavailable: true,
+      }),
+    ).toBe("failed");
+    expect(
+      resolveThreadListV2Status(
+        makeThread({ id: ThreadId.make("t"), title: "t", environmentUnavailable: true }),
+      ),
+    ).toBe("ready");
+  });
 });
 
 describe("resolveThreadListV2SwipeActions", () => {
@@ -315,6 +353,21 @@ describe("sortThreadsForListV2", () => {
       { id: "middle", createdAt: "2026-06-01T10:00:00.000Z" },
     ]);
     expect(sorted.map((thread) => thread.id)).toEqual(["old-unsettled", "newest", "middle"]);
+  });
+
+  it("sinks threads from unavailable environments below reachable ones", () => {
+    const sorted = sortThreadsForListV2([
+      { id: "offline-newest", createdAt: "2026-06-01T12:00:00.000Z", environmentUnavailable: true },
+      { id: "reachable-old", createdAt: "2026-06-01T08:00:00.000Z" },
+      { id: "offline-old", createdAt: "2026-06-01T09:00:00.000Z", environmentUnavailable: true },
+      { id: "reachable-new", createdAt: "2026-06-01T10:00:00.000Z" },
+    ]);
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      "reachable-new",
+      "reachable-old",
+      "offline-newest",
+      "offline-old",
+    ]);
   });
 });
 

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -14,6 +14,7 @@ import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
 import {
   activeThreadAnchorTimestampMs,
+  environmentUnavailableRank,
   sortPinnedThreadsByOrderKey,
 } from "@t3tools/client-runtime/state/thread-sort";
 import type { EnvironmentId, ProjectId, ThreadLinkedPullRequest } from "@t3tools/contracts";
@@ -30,7 +31,7 @@ export { snoozeWakeLabel };
  * (approval), "in motion" (working), and "broken" (failed). Ready is the
  * unlabeled resting state.
  */
-export type ThreadListV2Status = "approval" | "input" | "working" | "failed" | "ready";
+export type ThreadListV2Status = "approval" | "input" | "working" | "offline" | "failed" | "ready";
 export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooze" | "unsnooze";
 
 export interface ThreadListV2ChangeRequestState extends ChangeRequestSettleSource {
@@ -158,6 +159,23 @@ export function resolveThreadListV2Enabled(input: {
 }
 
 export function resolveThreadListV2Status(
+  thread: Pick<
+    EnvironmentThreadShell,
+    "hasPendingApprovals" | "hasPendingUserInput" | "session" | "environmentUnavailable"
+  >,
+): ThreadListV2Status {
+  const status = resolveConnectedThreadListV2Status(thread);
+  // Same stale-claim rule as web's resolveSidebarThreadStatus.
+  if (
+    thread.environmentUnavailable &&
+    (status === "approval" || status === "input" || status === "working")
+  ) {
+    return "offline";
+  }
+  return status;
+}
+
+function resolveConnectedThreadListV2Status(
   thread: Pick<EnvironmentThreadShell, "hasPendingApprovals" | "hasPendingUserInput" | "session">,
 ): ThreadListV2Status {
   if (thread.hasPendingApprovals) {
@@ -198,7 +216,9 @@ function firstValidTimestampMs(...candidates: ReadonlyArray<string | null | unde
  * list — a row holds its position between lifecycle transitions. The anchor
  * is creation time until an un-settle re-anchors it (see
  * activeThreadAnchorTimestampMs), so an un-settled thread surfaces at the
- * top instead of sinking back to its creation-order slot. Mirrors web's
+ * top instead of sinking back to its creation-order slot. The one status
+ * that does move a row is environment availability: threads on an
+ * unreachable environment sink below reachable ones. Mirrors web's
  * sortThreadsForSidebar.
  */
 export function sortThreadsForListV2<
@@ -206,12 +226,14 @@ export function sortThreadsForListV2<
     readonly id: string;
     readonly createdAt: string;
     readonly unsettledAt?: string | null | undefined;
+    readonly environmentUnavailable?: boolean;
   },
 >(threads: readonly T[]): T[] {
   // .sort() on a copy, not .toSorted(): Hermes doesn't ship the ES2023
   // change-by-copy array methods.
   return [...threads].sort(
     (left, right) =>
+      environmentUnavailableRank(left) - environmentUnavailableRank(right) ||
       activeThreadAnchorTimestampMs(right) - activeThreadAnchorTimestampMs(left) ||
       left.id.localeCompare(right.id),
   );

--- a/apps/mobile/src/features/threads/threadPresentation.ts
+++ b/apps/mobile/src/features/threads/threadPresentation.ts
@@ -13,7 +13,8 @@ export type ThreadStatusKind =
   | "working"
   | "connecting"
   | "error"
-  | "plan-ready";
+  | "plan-ready"
+  | "offline";
 
 export interface ThreadStatusPresentation extends StatusTone {
   readonly kind: ThreadStatusKind;
@@ -41,12 +42,33 @@ function isLatestTurnSettled(
   return session.status !== "running";
 }
 
+const OFFLINE_STATUS: ThreadStatusPresentation = {
+  kind: "offline",
+  label: "Offline",
+  pillClassName: "bg-adaptive-zinc-500-a12-a16",
+  textClassName: "text-adaptive-zinc-600-300",
+  ...THREAD_STATUS_NEUTRAL_ICON,
+  pulse: false,
+};
+
 /**
  * Resolves the user-facing status of a thread, in priority order. Returns
  * `null` for quiescent threads so rows stay free of "Idle"-style noise.
  * Mirrors `resolveThreadStatusPill` in apps/web/src/components/Sidebar.logic.ts.
  */
 export function resolveThreadStatus(
+  thread: EnvironmentThreadShell,
+): ThreadStatusPresentation | null {
+  const status = resolveConnectedThreadStatus(thread);
+  // Same stale-claim rule as web's resolveSidebarThreadStatus; a cached
+  // error is a historical fact and stays.
+  if (thread.environmentUnavailable && status !== null && status.kind !== "error") {
+    return OFFLINE_STATUS;
+  }
+  return status;
+}
+
+function resolveConnectedThreadStatus(
   thread: EnvironmentThreadShell,
 ): ThreadStatusPresentation | null {
   if (thread.hasPendingApprovals) {

--- a/apps/mobile/src/state/threads.ts
+++ b/apps/mobile/src/state/threads.ts
@@ -22,6 +22,7 @@ export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
 );
 export const environmentThreadShells = createEnvironmentThreadShellAtoms({
   catalogValueAtom: environmentCatalog.catalogValueAtom,
+  connectionStateAtom: environmentCatalog.stateAtom,
   snapshotAtom: environmentSnapshotAtom,
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -676,6 +676,31 @@ describe("resolveSidebarThreadStatus", () => {
     );
   });
 
+  it("reads live states as offline while the environment is unavailable", () => {
+    expect(resolveSidebarThreadStatus({ ...idle, session, environmentUnavailable: true })).toBe(
+      "offline",
+    );
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        hasPendingApprovals: true,
+        session,
+        environmentUnavailable: true,
+      }),
+    ).toBe("offline");
+    // Historical facts survive: a cached failure is still a failure.
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        session: { ...session, status: "error" as const },
+        environmentUnavailable: true,
+      }),
+    ).toBe("failed");
+    expect(
+      resolveSidebarThreadStatus({ ...idle, session: null, environmentUnavailable: true }),
+    ).toBe("ready");
+  });
+
   it("prioritizes awaiting input over a running session, below approval", () => {
     expect(resolveSidebarThreadStatus({ ...idle, hasPendingUserInput: true, session })).toBe(
       "input",
@@ -832,6 +857,32 @@ describe("sortThreadsForSidebar", () => {
     ]);
 
     expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);
+  });
+
+  it("sinks threads from unavailable environments below reachable ones", () => {
+    const sorted = sortThreadsForSidebar([
+      {
+        id: "offline-newest",
+        createdAt: "2026-03-09T12:00:00.000Z",
+        environmentUnavailable: true,
+      },
+      sortable({ id: "reachable-old", createdAt: "2026-03-09T08:00:00.000Z" }),
+      {
+        id: "offline-old",
+        createdAt: "2026-03-09T09:00:00.000Z",
+        environmentUnavailable: true,
+      },
+      sortable({ id: "reachable-new", createdAt: "2026-03-09T10:00:00.000Z" }),
+    ]);
+
+    // Reachable rows keep their static order on top; offline rows keep
+    // theirs below.
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      "reachable-new",
+      "reachable-old",
+      "offline-newest",
+      "offline-old",
+    ]);
   });
 
   it("surfaces an un-settled thread at the top via its re-entry stamp", () => {
@@ -1176,6 +1227,52 @@ describe("resolveThreadStatusPill", () => {
         thread: baseThread,
       }),
     ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("reads live pills as offline while the environment is unavailable", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: { ...baseThread, environmentUnavailable: true },
+      }),
+    ).toMatchObject({ label: "Offline", pulse: false });
+    expect(
+      resolveThreadStatusPill({
+        thread: { ...baseThread, hasPendingApprovals: true, environmentUnavailable: true },
+      }),
+    ).toMatchObject({ label: "Offline", pulse: false });
+  });
+
+  it("keeps completed and quiet pills while the environment is unavailable", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          interactionMode: "default" as const,
+          latestTurn: makeLatestTurn(),
+          lastVisitedAt: "2026-03-09T10:04:00.000Z",
+          session: {
+            ...baseThread.session,
+            status: "ready" as const,
+            activeTurnId: null,
+          },
+          environmentUnavailable: true,
+        },
+      }),
+    ).toMatchObject({ label: "Completed" });
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          latestTurn: makeLatestTurn(),
+          session: {
+            ...baseThread.session,
+            status: "ready" as const,
+            activeTurnId: null,
+          },
+          environmentUnavailable: true,
+        },
+      }),
+    ).toBeNull();
   });
 
   it("shows plan ready when a settled plan turn has a proposed plan ready for follow-up", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -4,6 +4,7 @@ import type { ContextMenuItem } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import {
   activeThreadAnchorTimestampMs,
+  environmentUnavailableRank,
   getThreadSortTimestamp,
   sortThreads,
   toSortableTimestamp,
@@ -132,7 +133,8 @@ export interface ThreadStatusPill {
     | "Completed"
     | "Pending Approval"
     | "Awaiting Input"
-    | "Plan Ready";
+    | "Plan Ready"
+    | "Offline";
   colorClass: string;
   dotClass: string;
   pulse: boolean;
@@ -149,6 +151,7 @@ const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
   "Plan Ready": 3,
   Monitoring: 2,
   Completed: 1,
+  Offline: 0,
 };
 
 type ThreadStatusInput = Pick<
@@ -160,6 +163,7 @@ type ThreadStatusInput = Pick<
   | "latestTurn"
   | "session"
   | "backgroundLiveness"
+  | "environmentUnavailable"
 > & {
   lastVisitedAt?: string | undefined;
 };
@@ -464,15 +468,37 @@ export type SidebarThreadStatus =
   | "input"
   | "working"
   | "monitoring"
+  | "offline"
   | "failed"
   | "ready";
 
 type SidebarThreadStatusInput = Pick<
   SidebarThreadSummary,
-  "hasPendingApprovals" | "hasPendingUserInput" | "session" | "backgroundLiveness"
+  | "hasPendingApprovals"
+  | "hasPendingUserInput"
+  | "session"
+  | "backgroundLiveness"
+  | "environmentUnavailable"
 >;
 
 export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): SidebarThreadStatus {
+  const status = resolveConnectedSidebarThreadStatus(thread);
+  // The canonical stale-claim rule, mirrored by every status resolver on web
+  // and mobile: an unreachable environment cannot run, ask, or be answered,
+  // so live states from its cached snapshot read as Offline. Failed and
+  // resting states are historical facts and stay as they are.
+  if (
+    thread.environmentUnavailable &&
+    (status === "approval" || status === "input" || status === "working" || status === "monitoring")
+  ) {
+    return "offline";
+  }
+  return status;
+}
+
+function resolveConnectedSidebarThreadStatus(
+  thread: SidebarThreadStatusInput,
+): SidebarThreadStatus {
   if (thread.hasPendingApprovals) {
     return "approval";
   }
@@ -538,15 +564,20 @@ export function firstValidTimestamp(
 // activeThreadAnchorTimestampMs), so an un-settled thread surfaces at the
 // top instead of sinking back to its creation-order slot. Status (including
 // pending approval) is carried by each card's edge strip, not by position.
+// The one status that does move a row is environment availability: threads
+// on an unreachable environment sink below reachable ones, since nothing on
+// them can progress or be acted on until it reconnects.
 export function sortThreadsForSidebar<
   T extends {
     readonly id: string;
     readonly createdAt: string;
     readonly unsettledAt?: string | null | undefined;
+    readonly environmentUnavailable?: boolean;
   },
 >(threads: readonly T[]): T[] {
   return [...threads].toSorted(
     (left, right) =>
+      environmentUnavailableRank(left) - environmentUnavailableRank(right) ||
       activeThreadAnchorTimestampMs(right) - activeThreadAnchorTimestampMs(left) ||
       left.id.localeCompare(right.id),
   );
@@ -680,11 +711,26 @@ export function formatWorkingDurationLabel(elapsedMs: number): string {
   return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
 }
 
+const OFFLINE_STATUS_PILL: ThreadStatusPill = {
+  label: "Offline",
+  colorClass: "text-zinc-500 dark:text-zinc-400",
+  dotClass: "bg-zinc-500 dark:bg-zinc-400",
+  pulse: false,
+};
+
 export function resolveThreadStatusPill(input: {
   thread: ThreadStatusInput;
 }): ThreadStatusPill | null {
-  const { thread } = input;
+  const pill = resolveConnectedThreadStatusPill(input.thread);
+  // Same stale-claim rule as resolveSidebarThreadStatus; Completed is a
+  // historical fact and stays.
+  if (input.thread.environmentUnavailable && pill !== null && pill.label !== "Completed") {
+    return OFFLINE_STATUS_PILL;
+  }
+  return pill;
+}
 
+function resolveConnectedThreadStatusPill(thread: ThreadStatusInput): ThreadStatusPill | null {
   if (thread.hasPendingApprovals) {
     return {
       label: "Pending Approval",

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -853,8 +853,14 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // stands out.
   const isInFlight =
     status === "working" || status === "monitoring" || status === "approval" || status === "input";
+  // Offline rows recede like resting ones: nothing can happen there until the
+  // environment reconnects, so they must not compete for attention.
   const shouldRecede =
-    (status === "ready" || isInFlight) && !isUnread && !isWoke && !props.isActive && !isSelected;
+    (status === "ready" || status === "offline" || isInFlight) &&
+    !isUnread &&
+    !isWoke &&
+    !props.isActive &&
+    !isSelected;
   // Status hues follow the system-wide convention set by sidebar v1 and the
   // mobile Live Activity/widgets (amber approval, indigo input, sky working)
   // so a thread reads the same color everywhere it surfaces.
@@ -890,25 +896,31 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 icon: null,
                 className: "text-indigo-600 dark:text-indigo-300",
               }
-            : status === "failed"
+            : status === "offline"
               ? {
-                  label: "Failed",
+                  label: "Offline",
                   icon: null,
-                  className: "text-red-700 dark:text-red-300",
+                  className: "text-zinc-500 dark:text-zinc-400",
                 }
-              : isWoke
+              : status === "failed"
                 ? {
-                    label: "Woke",
-                    icon: "woke" as const,
-                    className: "text-amber-700 dark:text-amber-300",
+                    label: "Failed",
+                    icon: null,
+                    className: "text-red-700 dark:text-red-300",
                   }
-                : isUnread
+                : isWoke
                   ? {
-                      label: "Done",
-                      icon: "done" as const,
-                      className: "text-emerald-700 dark:text-emerald-300",
+                      label: "Woke",
+                      icon: "woke" as const,
+                      className: "text-amber-700 dark:text-amber-300",
                     }
-                  : null;
+                  : isUnread
+                    ? {
+                        label: "Done",
+                        icon: "done" as const,
+                        className: "text-emerald-700 dark:text-emerald-300",
+                      }
+                    : null;
   const isWokeStatus = topStatus?.icon === "woke";
 
   const branchMismatch = resolveLocalCheckoutBranchMismatch({

--- a/apps/web/src/lib/threadSort.ts
+++ b/apps/web/src/lib/threadSort.ts
@@ -1,5 +1,6 @@
 export {
   activeThreadAnchorTimestampMs,
+  environmentUnavailableRank,
   getLatestThreadForProject,
   getThreadSortTimestamp,
   sortThreads,

--- a/apps/web/src/state/threads.ts
+++ b/apps/web/src/state/threads.ts
@@ -22,6 +22,7 @@ export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
 );
 export const environmentThreadShells = createEnvironmentThreadShellAtoms({
   catalogValueAtom: environmentCatalog.catalogValueAtom,
+  connectionStateAtom: environmentCatalog.stateAtom,
   snapshotAtom: environmentSnapshotAtom,
 });
 

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -13,6 +13,13 @@ request merges if **Auto-settle merged threads** is enabled.
 When you un-settle a thread, it returns to the top of the active list so you can find it right
 away. Its timestamps do not change. Other threads keep their positions.
 
+When a remote environment cannot be reached, its threads stay in the sidebar but show **Offline**
+instead of live states like Working or Pending Approval: those come from the last data the
+environment sent and cannot update or be acted on until it reconnects. Actions that need the
+environment, such as Stop or Settle, fail with a message naming the disconnected environment. To
+clear the threads entirely, remove the environment in **Settings → Connections**; they return when
+you pair it again.
+
 Right-click a pull request link in a thread and choose **Link to thread** to show that pull request
 in the sidebar. The thread settles when the linked pull request merges if **Auto-settle merged
 threads** is enabled. Right-click the same link and choose **Unlink from thread** to remove it.

--- a/packages/client-runtime/src/state/entities.test.ts
+++ b/packages/client-runtime/src/state/entities.test.ts
@@ -10,7 +10,12 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
-import { PrimaryConnectionTarget } from "../connection/model.ts";
+import {
+  AVAILABLE_CONNECTION_STATE,
+  ConnectionTransientError,
+  PrimaryConnectionTarget,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
 import {
   InvalidScopedProjectKeyError,
   InvalidScopedProjectRefCollectionKeyError,
@@ -174,12 +179,16 @@ function makeHarness() {
     ]),
   });
   const snapshotAtom = createEnvironmentSnapshotAtom(shellStateAtoms);
+  const connectionStateAtoms = Atom.family((_environmentId: EnvironmentId) =>
+    Atom.make(AsyncResult.success<SupervisorConnectionState>(AVAILABLE_CONNECTION_STATE)),
+  );
   const projects = createEnvironmentProjectAtoms({
     catalogValueAtom,
     snapshotAtom,
   });
   const threadShells = createEnvironmentThreadShellAtoms({
     catalogValueAtom,
+    connectionStateAtom: connectionStateAtoms,
     snapshotAtom,
   });
   const threadDetails = createEnvironmentThreadDetailAtoms((environmentId, threadId) =>
@@ -189,6 +198,7 @@ function makeHarness() {
   return {
     registry: AtomRegistry.make(),
     shellStateAtom: shellStateAtoms(ENVIRONMENT_ID),
+    connectionStateAtom: connectionStateAtoms,
     threadStateAtom: (threadId: ThreadId) => threadStateAtoms(`${ENVIRONMENT_ID}\u0000${threadId}`),
     projects,
     threadShells,
@@ -197,6 +207,76 @@ function makeHarness() {
 }
 
 describe("environment entity projections", () => {
+  it("marks cached thread shells from unavailable environments without hiding them", () => {
+    const harness = makeHarness();
+    const ref = { environmentId: ENVIRONMENT_ID, threadId: THREAD_ID };
+    const shellUnavailable = () =>
+      harness.registry.get(harness.threadShells.threadShellAtom(ref))?.environmentUnavailable;
+    const setConnection = (state: SupervisorConnectionState) => {
+      harness.registry.set(
+        harness.connectionStateAtom(ENVIRONMENT_ID),
+        AsyncResult.success<SupervisorConnectionState>(state),
+      );
+    };
+    const initialRefs = harness.registry.get(harness.threadShells.threadRefsAtom);
+    expect(initialRefs.length).toBeGreaterThan(0);
+    expect(shellUnavailable()).toBe(false);
+
+    // A first connection attempt carries no failure yet: still available.
+    setConnection({
+      ...AVAILABLE_CONNECTION_STATE,
+      desired: true,
+      network: "online",
+      phase: "connecting",
+      stage: "preparing",
+      attempt: 1,
+    });
+    expect(shellUnavailable()).toBe(false);
+
+    // A failed attempt in backoff marks the shells, but every row stays listed.
+    const backoff: SupervisorConnectionState = {
+      desired: true,
+      network: "online",
+      phase: "backoff",
+      stage: null,
+      attempt: 1,
+      generation: 0,
+      lastFailure: new ConnectionTransientError({
+        reason: "remote-unavailable",
+        detail: "Remote environment is unavailable.",
+      }),
+      retryAt: 1,
+    };
+    setConnection(backoff);
+    expect(shellUnavailable()).toBe(true);
+    expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual(initialRefs);
+
+    // Retry attempts keep the mark rather than flickering back to available.
+    setConnection({
+      ...backoff,
+      phase: "connecting",
+      stage: "preparing",
+      attempt: 2,
+      retryAt: null,
+    });
+    expect(shellUnavailable()).toBe(true);
+
+    // The device going offline reads as plain cached browsing, not unavailability.
+    setConnection({ ...backoff, network: "offline", phase: "offline", retryAt: null });
+    expect(shellUnavailable()).toBe(false);
+
+    // Reconnecting clears the mark.
+    setConnection({
+      ...AVAILABLE_CONNECTION_STATE,
+      desired: true,
+      network: "online",
+      phase: "connected",
+      attempt: 2,
+      generation: 1,
+    });
+    expect(shellUnavailable()).toBe(false);
+  });
+
   it("composes detail collections with authoritative shell workspace metadata", () => {
     const messages: OrchestrationThread["messages"] = [];
     const detail = {

--- a/packages/client-runtime/src/state/models.ts
+++ b/packages/client-runtime/src/state/models.ts
@@ -14,6 +14,10 @@ export interface EnvironmentProject extends OrchestrationProjectShell {
 
 export interface EnvironmentThreadShell extends OrchestrationThreadShell {
   readonly environmentId: EnvironmentId;
+  /** True while the owning environment's connection is failing: the shell is
+      a cache that cannot receive updates or accept commands right now.
+      Absent/false wherever availability is unknown or not tracked. */
+  readonly environmentUnavailable?: boolean;
 }
 
 export type EnvironmentMessage = OrchestrationMessage;
@@ -32,8 +36,9 @@ export function scopeProject(
 export function scopeThreadShell(
   environmentId: EnvironmentId,
   thread: OrchestrationThreadShell,
+  environmentUnavailable = false,
 ): EnvironmentThreadShell {
-  return { ...thread, environmentId };
+  return { ...thread, environmentId, environmentUnavailable };
 }
 
 export function scopeThread(

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -7,8 +7,11 @@ import type {
   ScopedThreadRef,
   ThreadId,
 } from "@t3tools/contracts";
-import { Atom } from "effect/unstable/reactivity";
+import * as Option from "effect/Option";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
+import { AVAILABLE_CONNECTION_STATE, type SupervisorConnectionState } from "../connection/model.ts";
+import { presentConnectionState } from "../connection/presentation.ts";
 import type { EnvironmentThreadShell } from "./models.ts";
 import { scopeThreadShell } from "./models.ts";
 import type { EnvironmentCatalogState } from "./connections.ts";
@@ -29,12 +32,34 @@ const EMPTY_THREAD_REFS_BY_PROJECT: ReadonlyMap<
   ReadonlyArray<ScopedThreadRef>
 > = new Map();
 
-export function createEnvironmentThreadShellAtoms(input: {
+export function createEnvironmentThreadShellAtoms<E>(input: {
   readonly catalogValueAtom: Atom.Atom<EnvironmentCatalogState>;
+  readonly connectionStateAtom: (
+    environmentId: EnvironmentId,
+  ) => Atom.Atom<AsyncResult.AsyncResult<SupervisorConnectionState, E>>;
   readonly snapshotAtom: (
     environmentId: EnvironmentId,
   ) => Atom.Atom<OrchestrationShellSnapshot | null>;
 }) {
+  // Unavailability requires evidence of trouble while this device is online:
+  // the presented phase is reconnecting (a lost or failed connection) or
+  // error (blocked). Idle catalogs, first connection attempts, and offline
+  // browsing all read as available so cached rows keep their normal
+  // presentation there.
+  const environmentUnavailableAtom = Atom.family((environmentId: EnvironmentId) =>
+    Atom.make((get) => {
+      const connection = Option.getOrElse(
+        AsyncResult.value(get(input.connectionStateAtom(environmentId))),
+        () => AVAILABLE_CONNECTION_STATE,
+      );
+      if (connection.network !== "online") {
+        return false;
+      }
+      const phase = presentConnectionState(connection).phase;
+      return phase === "reconnecting" || phase === "error";
+    }).pipe(Atom.withLabel(`environment-unavailable:${environmentId}`)),
+  );
+
   const environmentThreadsAtom = Atom.family((environmentId: EnvironmentId) =>
     Atom.make(
       (get): ReadonlyArray<OrchestrationThreadShell> =>
@@ -103,14 +128,18 @@ export function createEnvironmentThreadShellAtoms(input: {
   const threadShellAtomFamily = Atom.family((key: string) => {
     const ref = parseThreadKey(key);
     let previousSource: OrchestrationThreadShell | null = null;
+    let previousUnavailable = false;
     let previousValue: EnvironmentThreadShell | null = null;
     return Atom.make((get) => {
       const source = get(environmentThreadIndexAtom(ref.environmentId)).get(ref.threadId) ?? null;
-      if (source === previousSource) {
+      const unavailable = get(environmentUnavailableAtom(ref.environmentId));
+      if (source === previousSource && unavailable === previousUnavailable) {
         return previousValue;
       }
       previousSource = source;
-      previousValue = source === null ? null : scopeThreadShell(ref.environmentId, source);
+      previousUnavailable = unavailable;
+      previousValue =
+        source === null ? null : scopeThreadShell(ref.environmentId, source, unavailable);
       return previousValue;
     }).pipe(Atom.withLabel(`environment-thread-shell:${key}`));
   });

--- a/packages/client-runtime/src/state/threadSort.ts
+++ b/packages/client-runtime/src/state/threadSort.ts
@@ -87,6 +87,19 @@ export function activeThreadAnchorTimestampMs(thread: {
   );
 }
 
+/**
+ * Sort tier for the active thread list: threads on reachable environments
+ * come first, threads whose environment is unavailable sink below them. An
+ * availability flip is a lifecycle transition, so this is the only signal
+ * besides settle/un-settle that may move a row. Shared by web and mobile so
+ * both render the same order.
+ */
+export function environmentUnavailableRank(thread: {
+  readonly environmentUnavailable?: boolean;
+}): number {
+  return thread.environmentUnavailable ? 1 : 0;
+}
+
 export function sortThreads<T extends { readonly id: string } & ThreadSortInput>(
   threads: readonly T[],
   sortOrder: SidebarThreadSortOrder,


### PR DESCRIPTION
When a T3 Connect environment goes offline (a power loss on the remote machine, a dead tunnel), its cached threads kept showing live states like Working or Monitoring indefinitely, sat above current work, and gave no local hint that nothing on them could progress. Fixes #8924.

The shared client runtime now derives an `environmentUnavailable` flag on each thread shell from the environment's presented connection phase (`reconnecting` or `error` while this device is online). On top of that one flag:

- Web and mobile thread lists read live and actionable states (Working, Monitoring, Connecting, Pending Approval, Awaiting Input, Plan Ready) from unreachable environments as a gray **Offline**. Historical facts stay: Failed stays Failed, Completed stays Completed, quiet rows stay quiet.
- The active-list sort sinks offline threads below reachable ones; within each tier the static order is untouched. Reconnecting restores live states and order in place.
- Offline browsing of this device and first connection attempts are unaffected, so cached rows never flicker at startup or while the client itself is offline.

Threads are deliberately marked rather than hidden: settle and stop are server-owned and already fail fast with a toast naming the disconnected environment, server-side auto-settle sweeps stale threads shortly after the machine returns, and Settings → Connections → Remove clears a permanently dead environment. Possible follow-ups, left out on purpose: a collapsed "Offline" shelf per environment if gray rows still feel noisy, and the silent background-work Stop button, which belongs to #8618. Supersedes #8414.

Tests:

- `vp test run packages/client-runtime/src/state/entities.test.ts apps/web/src/components/Sidebar.logic.test.ts apps/mobile/src/features/threads/threadListV2.test.ts`
- Package-scoped typecheck for client-runtime, web, and mobile; changed-file lint and formatting.

Screenshots are dark mode against two live environments with the remote one killed mid-turn. They are hosted on a fork branch and not part of the commit.

Current behavior on `main` while the environment has been dead for over a minute — the row still claims live work:

![Main: dead environment still shows a live Monitoring state](https://raw.githubusercontent.com/Gigioxx/t3code/d9f2167634fcf21e653a7f8cee5c2451e76a5e9a/before-main-stale-live-state.png)

With this change, before and after the remote environment goes down, and after it reconnects:

| Both environments online | Remote environment offline | Reconnected |
| --- | --- | --- |
| ![Online: remote threads show live states above the local one](https://raw.githubusercontent.com/Gigioxx/t3code/d9f2167634fcf21e653a7f8cee5c2451e76a5e9a/pr-1-before-outage.png) | ![Offline: remote threads read Offline and sink below the local thread](https://raw.githubusercontent.com/Gigioxx/t3code/d9f2167634fcf21e653a7f8cee5c2451e76a5e9a/pr-2-after-outage.png) | ![Reconnected: live presentation and order restored](https://raw.githubusercontent.com/Gigioxx/t3code/d9f2167634fcf21e653a7f8cee5c2451e76a5e9a/pr-3-reconnected.png) |

Made with Claude Fable 5 through the Claude Code harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared thread-shell projection and list status/sort logic used across web and mobile; behavior is well-tested but wrong availability rules would mislabel or reorder threads globally.
> 
> **Overview**
> When a remote environment’s connection is failing while the device is online, cached thread shells now get **`environmentUnavailable`** from supervisor connection phase (`reconnecting` / `error`). Web and mobile thread lists use that flag so stale **live** snapshots (Working, Monitoring, approval, input, plan-ready pills, etc.) read as gray **Offline** instead of actionable work; **Failed**, **Completed**, and quiet rows stay as-is.
> 
> **Sorting** on web sidebar and mobile thread list v2 now sinks offline-environment threads below reachable ones via shared `environmentUnavailableRank`, without changing static order within each tier. Sidebar rows treat offline like resting (receded prominence).
> 
> Shell atoms on web/mobile take **`connectionStateAtom`** so availability tracks connection without hiding threads. User docs describe offline labeling and that environment-dependent actions still fail until reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1deee04f4ee03887cef80b553d382cda72bf36cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show threads from unreachable environments as `offline` on mobile and web
> - `createEnvironmentThreadShellAtoms` in [threadShell.ts](https://github.com/pingdotgg/t3code/pull/8935/files#diff-e49ef617e91bb0815a2056981dd21ded980875b9367bfad26d6f2cc019e2ef06) computes the `environmentUnavailable` flag when the device is online and the supervisor connection phase is `reconnecting` or `error`
> - Status resolvers in [threadListV2.ts](https://github.com/pingdotgg/t3code/pull/8935/files#diff-d629687d2b79a927cf01be39191d0e3fc66435674cd6f8a588469b55c70210ed) and [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/8935/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) map live thread states to `'offline'` when this flag is true
> - `sortThreadsForListV2` and `sortThreadsForSidebar` use the new `environmentUnavailableRank` helper to place offline threads below reachable ones
> - Behavioral Change: `resolveThreadStatus` and `resolveSidebarThreadStatus` return `'offline'` instead of live states (like `working` or `input`) when `environmentUnavailable` is true; `failed` and `ready` states remain unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1deee04. 12 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Threads from unreachable environments now display an **Offline** status in web and mobile.
  - Offline threads are visually dimmed and sorted below reachable threads.
  - Actions requiring an unavailable environment show an appropriate failure message.
  - Offline status clears when the environment reconnects.

- **Documentation**
  - Added guidance for managing offline threads through connection settings.

- **Tests**
  - Added coverage for offline status handling, sorting, reconnection, and cached thread behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->