### PR TITLE
feat(client): render viewed images in work logs

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1545,6 +1545,7 @@ function renderFeedEntry(
       iconSubtleColor={iconSubtleColor}
       onCopyRow={props.onCopyWorkRow}
       onToggleRow={props.onToggleWorkRow}
+      renderImage={props.renderMarkdownImage}
     />
   );
 }

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -2,6 +2,7 @@ import * as Haptics from "expo-haptics";
 import { KeyboardAwareLegendList } from "@legendapp/list/keyboard";
 import { type LegendListRef } from "@legendapp/list/react-native";
 import type {
+  AssetResource,
   ChatAttachment,
   ChatFileAttachment,
   ChatImageAttachment,
@@ -17,7 +18,11 @@ import {
 import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
 import { formatAttachmentSize } from "@t3tools/client-runtime/state/attachments";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
-import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
+import {
+  classifyMarkdownImageSource,
+  markdownImageSourceFragment,
+} from "@t3tools/client-runtime/markdown-images";
+import { resolveViewedImageAsset } from "@t3tools/client-runtime/work-log/presentation";
 import {
   renderCodexFileCitationsAsMarkdown,
   splitCodexArtifactTemplateMarkdown,
@@ -565,24 +570,24 @@ function ThreadMarkdownImageRequest(props: {
   );
 }
 
-/** Markdown image whose src is a workspace file — loads through a signed asset URL. */
+/** Environment-hosted image that loads through a signed asset URL. */
 function ThreadMarkdownImage(props: {
   readonly environmentId: EnvironmentId;
-  readonly threadId: ThreadId;
-  readonly path: string;
+  readonly resource: Extract<AssetResource, { readonly _tag: "attachment" | "workspace-file" }>;
   readonly alt: string | null;
+  readonly srcFragment?: string;
   readonly onPressPreview: (source: FilePreviewSource) => void;
 }) {
-  const assetUrl = useAssetUrlState(props.environmentId, {
-    _tag: "workspace-file",
-    threadId: props.threadId,
-    path: props.path,
-  });
+  const assetUrl = useAssetUrlState(props.environmentId, props.resource);
 
   return (
     <ThreadMarkdownImageView
-      uri={assetUrl._tag === "Success" ? assetUrl.url : null}
-      sourceKey={props.path}
+      uri={assetUrl._tag === "Success" ? assetUrl.url + (props.srcFragment ?? "") : null}
+      sourceKey={
+        props.resource._tag === "attachment"
+          ? `attachment:${props.resource.attachmentId}`
+          : `workspace:${props.resource.path}`
+      }
       unavailable={assetUrl._tag === "Failure"}
       alt={props.alt}
       onPressPreview={props.onPressPreview}
@@ -1333,6 +1338,7 @@ function renderFeedEntry(
     readonly onPressVideo: (attachment: ChatFileAttachment, sourceIdentifier: string) => void;
     readonly onMarkdownLinkPress: (href: string) => void;
     readonly renderMarkdownImage: MarkdownImageRenderer;
+    readonly renderViewedImage: MarkdownImageRenderer;
     readonly iconSubtleColor: string | import("react-native").ColorValue;
     readonly userBubbleColor: string | import("react-native").ColorValue;
     readonly markdownStyles: MarkdownStyleSets;
@@ -1545,7 +1551,7 @@ function renderFeedEntry(
       iconSubtleColor={iconSubtleColor}
       onCopyRow={props.onCopyWorkRow}
       onToggleRow={props.onToggleWorkRow}
-      renderImage={props.renderMarkdownImage}
+      renderImage={props.renderViewedImage}
     />
   );
 }
@@ -1984,12 +1990,34 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       return (
         <ThreadMarkdownImage
           environmentId={props.environmentId}
-          threadId={props.threadId}
-          path={imageSource.path}
+          resource={{
+            _tag: "workspace-file",
+            threadId: props.threadId,
+            path: imageSource.path,
+          }}
           alt={image.alt}
+          srcFragment={markdownImageSourceFragment(image.href)}
           onPressPreview={(source) => setExpandedFile((current) => current ?? source)}
         />
       );
+    },
+    [props.environmentId, props.threadId, props.workspaceRoot],
+  );
+  const renderViewedImage = useCallback<MarkdownImageRenderer>(
+    (image) => {
+      const viewedImage = resolveViewedImageAsset(image.href, {
+        threadId: props.threadId,
+        workspaceRoot: props.workspaceRoot,
+      });
+      return viewedImage ? (
+        <ThreadMarkdownImage
+          environmentId={props.environmentId}
+          resource={viewedImage.resource}
+          alt={viewedImage.alt}
+          srcFragment={viewedImage.srcFragment}
+          onPressPreview={(source) => setExpandedFile((current) => current ?? source)}
+        />
+      ) : null;
     },
     [props.environmentId, props.threadId, props.workspaceRoot],
   );
@@ -2444,6 +2472,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
           onPressVideo,
           onMarkdownLinkPress,
           renderMarkdownImage,
+          renderViewedImage,
           iconSubtleColor,
           userBubbleColor,
           markdownStyles,
@@ -2478,6 +2507,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       props.onUseArtifactTemplate,
       props.skills,
       renderMarkdownImage,
+      renderViewedImage,
     ],
   );
 

--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -17,7 +17,11 @@ import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 import { AppText as Text } from "../../components/AppText";
 import { cn } from "../../lib/cn";
 import type { ThreadFeedActivity } from "../../lib/threadActivity";
-import type { ToolGroupSummaryKind } from "@t3tools/client-runtime/work-log/presentation";
+import {
+  type ToolGroupSummaryKind,
+  workEntryViewedImagePath,
+} from "@t3tools/client-runtime/work-log/presentation";
+import type { MarkdownImageRenderer } from "../../native/SelectableMarkdownText";
 import Animated, {
   cancelAnimation,
   Easing,
@@ -277,6 +281,7 @@ export function ThreadWorkLog(props: {
   readonly iconSubtleColor: import("react-native").ColorValue;
   readonly onCopyRow: (rowId: string, value: string) => void;
   readonly onToggleRow: (rowId: string) => void;
+  readonly renderImage: MarkdownImageRenderer;
 }) {
   const rows = props.activities.map((activity) => ({
     ...activity,
@@ -294,6 +299,7 @@ export function ThreadWorkLog(props: {
           const expanded = props.expandedRows[row.id] ?? false;
           const canExpand = row.canExpand;
           const fullDetail = expanded ? row.getFullDetail() : null;
+          const viewedImagePath = workEntryViewedImagePath(row.workEntry);
           const displayText = row.detail ?? row.summary;
           const iconIsDestructive = row.icon === "alert" || row.icon === "warning";
           const failed = row.status === "failure";
@@ -393,6 +399,11 @@ export function ThreadWorkLog(props: {
                   layout={WORK_LOG_LAYOUT_TRANSITION}
                   className="ml-7 border-l border-adaptive-neutral-300-a60-white-a12 pb-1 pl-3 pt-0.5"
                 >
+                  {viewedImagePath ? (
+                    <View className="pb-1.5">
+                      {props.renderImage({ href: viewedImagePath, alt: null, title: null })}
+                    </View>
+                  ) : null}
                   <ScrollView
                     nestedScrollEnabled
                     directionalLockEnabled

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1216,12 +1216,12 @@ function ChatMarkdownImageFallback(props: {
 }
 
 /** Markdown images whose src is a workspace file path load through a signed asset URL. */
-const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(props: {
+export const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(props: {
   readonly threadRef: ScopedThreadRef;
   readonly path: string;
   readonly alt: string;
-  readonly copyMarkdown: string;
-  readonly srcFragment: string;
+  readonly copyMarkdown?: string;
+  readonly srcFragment?: string;
   readonly style?: CSSProperties | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
@@ -1250,7 +1250,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
       />
     );
   }
-  const src = assetUrl.url + props.srcFragment;
+  const src = assetUrl.url + (props.srcFragment ?? "");
   return (
     <img
       src={src}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -22,6 +22,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type {
+  AssetResource,
   EnvironmentId,
   ScopedThreadRef,
   ServerProviderSkill,
@@ -1215,21 +1216,17 @@ function ChatMarkdownImageFallback(props: {
   );
 }
 
-/** Markdown images whose src is a workspace file path load through a signed asset URL. */
-export const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(props: {
-  readonly threadRef: ScopedThreadRef;
-  readonly path: string;
+/** Environment-hosted images load through a signed asset URL. */
+export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props: {
+  readonly environmentId: EnvironmentId;
+  readonly resource: Extract<AssetResource, { readonly _tag: "attachment" | "workspace-file" }>;
   readonly alt: string;
   readonly copyMarkdown?: string;
   readonly srcFragment?: string;
   readonly style?: CSSProperties | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
-  const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
-    _tag: "workspace-file",
-    threadId: props.threadRef.threadId,
-    path: props.path,
-  });
+  const assetUrl = useAssetUrlState(props.environmentId, props.resource);
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
 
   if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
@@ -2361,9 +2358,13 @@ function ChatMarkdown({
         }
         if (imageSource._tag === "WorkspaceFile" && threadRef) {
           return (
-            <ChatMarkdownWorkspaceImage
-              threadRef={threadRef}
-              path={imageSource.path}
+            <ChatMarkdownAssetImage
+              environmentId={threadRef.environmentId}
+              resource={{
+                _tag: "workspace-file",
+                threadId: threadRef.threadId,
+                path: imageSource.path,
+              }}
               alt={altText}
               copyMarkdown={copyMarkdown}
               srcFragment={markdownImageSourceFragment(classifiedSrc)}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -1,6 +1,18 @@
 import * as Equal from "effect/Equal";
 import { renderCodexDirectivesForCopy } from "@t3tools/client-runtime/codex-markdown-directives";
 import {
+  omitSupersededLifecycleMarkers,
+  summarizeToolGroup,
+  toolGroupSummaryKind,
+  type ToolGroupSummaryKind,
+} from "@t3tools/client-runtime/work-log/presentation";
+export {
+  normalizeCompactToolLabel,
+  summarizeToolGroup,
+  toolGroupAction,
+  workLogEntryIsLocalCodeSearch,
+} from "@t3tools/client-runtime/work-log/presentation";
+import {
   formatDuration,
   workEntryDisplayIndicatesToolFailure,
   workEntryIndicatesToolNeutralStatus,
@@ -260,157 +272,6 @@ export function computeMessageDurationStart(
   }
 
   return result;
-}
-
-export function normalizeCompactToolLabel(value: string): string {
-  return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
-}
-
-type ToolGroupAction = "read" | "edit" | "command" | "code-search" | "search" | "other" | "update";
-type ToolGroupSummaryKind = ToolGroupAction | "dynamic-tool" | "agent-tool" | "tone-tool" | "mixed";
-
-export function workLogEntryIsLocalCodeSearch(entry: WorkLogEntry): boolean {
-  return (
-    entry.itemType === "web_search" &&
-    /\bgrep\b/i.test(normalizeCompactToolLabel(entry.toolTitle ?? entry.label))
-  );
-}
-
-export function toolGroupAction(entry: WorkLogEntry): ToolGroupAction {
-  if (
-    entry.requestKind === "file-read" ||
-    entry.itemType === "image_view" ||
-    (entry.itemType === "dynamic_tool_call" && entry.toolTitle === "Read File")
-  ) {
-    return "read";
-  }
-  if (
-    entry.requestKind === "file-change" ||
-    entry.itemType === "file_change" ||
-    (entry.changedFiles?.length ?? 0) > 0
-  ) {
-    return "edit";
-  }
-  if (entry.requestKind === "command" || entry.itemType === "command_execution" || entry.command) {
-    return "command";
-  }
-  if (workLogEntryIsLocalCodeSearch(entry)) return "code-search";
-  if (entry.itemType === "web_search") return "search";
-  return workLogEntryIsToolLike(entry) ? "other" : "update";
-}
-
-function toolGroupActionCount(
-  action: ToolGroupAction,
-  entries: ReadonlyArray<WorkLogEntry>,
-): number {
-  if (action !== "edit") return entries.length;
-
-  const changedFiles = new Set<string>();
-  let editsWithoutFileDetails = 0;
-  for (const entry of entries) {
-    if (!entry.changedFiles || entry.changedFiles.length === 0) {
-      editsWithoutFileDetails += 1;
-      continue;
-    }
-    for (const file of entry.changedFiles) changedFiles.add(file);
-  }
-  return changedFiles.size + editsWithoutFileDetails;
-}
-
-function toolGroupActionLabel(action: ToolGroupAction, count: number): string {
-  switch (action) {
-    case "read":
-      return `Read ${count} ${count === 1 ? "file" : "files"}`;
-    case "edit":
-      return `Changed ${count} ${count === 1 ? "file" : "files"}`;
-    case "command":
-      return `Ran ${count} ${count === 1 ? "command" : "commands"}`;
-    case "search":
-      return `Searched the web ${count} ${count === 1 ? "time" : "times"}`;
-    case "code-search":
-      return `Searched code ${count} ${count === 1 ? "time" : "times"}`;
-    case "other":
-      return `Used ${count} ${count === 1 ? "tool" : "tools"}`;
-    case "update":
-      return `Received ${count} ${count === 1 ? "update" : "updates"}`;
-  }
-}
-
-/** Immediate, provider-neutral fallback while generated tool summaries are disabled or unavailable. */
-export function summarizeToolGroup(entries: ReadonlyArray<WorkLogEntry>): string {
-  const summaryEntries = omitSupersededLifecycleMarkers(entries, (entry) => entry);
-  const groupedEntries = new Map<ToolGroupAction, WorkLogEntry[]>();
-  for (const entry of summaryEntries) {
-    const action = toolGroupAction(entry);
-    const group = groupedEntries.get(action);
-    if (group) group.push(entry);
-    else groupedEntries.set(action, [entry]);
-  }
-  const labels = [...groupedEntries].map(([action, actionEntries]) =>
-    toolGroupActionLabel(action, toolGroupActionCount(action, actionEntries)),
-  );
-  const sentenceLabels = labels.map((label, index) =>
-    index === 0 ? label : label.charAt(0).toLowerCase() + label.slice(1),
-  );
-  if (sentenceLabels.length < 2) return sentenceLabels[0] ?? "";
-  if (sentenceLabels.length === 2) return sentenceLabels.join(" and ");
-  return `${sentenceLabels.slice(0, -1).join(", ")}, and ${sentenceLabels.at(-1)}`;
-}
-
-function omitSupersededLifecycleMarkers<T>(
-  entries: readonly T[],
-  workEntryFor: (entry: T) => WorkLogEntry,
-): T[] {
-  const laterTerminalIdentities = new Set<string>();
-  const reversedEntries: T[] = [];
-
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const entry = entries[index]!;
-    const workEntry = workEntryFor(entry);
-    const normalizedLabel = normalizeCompactToolLabel(workEntry.toolTitle ?? workEntry.label);
-    const identity = [
-      workEntry.turnId ?? "no-turn",
-      workEntry.itemType ?? "",
-      normalizedLabel,
-    ].join("\u001f");
-    const isStatuslessIdlessMarker =
-      workEntry.toolCallId === undefined &&
-      workEntry.toolLifecycleStatus === undefined &&
-      (workEntry.sourceActivityKind === "tool.started" ||
-        workEntry.sourceActivityKind === "tool.updated");
-    if (isStatuslessIdlessMarker && laterTerminalIdentities.has(identity)) continue;
-
-    reversedEntries.push(entry);
-    if (
-      workEntry.sourceActivityKind === "tool.completed" ||
-      (workEntry.toolLifecycleStatus !== undefined &&
-        workEntry.toolLifecycleStatus !== "inProgress")
-    ) {
-      laterTerminalIdentities.add(identity);
-    }
-  }
-
-  return reversedEntries.toReversed();
-}
-
-function toolGroupSummaryKind(entries: ReadonlyArray<WorkLogEntry>): ToolGroupSummaryKind {
-  const actions = new Set(entries.map(toolGroupAction));
-  if (actions.size !== 1) return "mixed";
-
-  const action = actions.values().next().value!;
-  if (action !== "other") return action;
-
-  const fallbackKinds = new Set(
-    entries.map((entry): ToolGroupSummaryKind => {
-      if (entry.itemType === "mcp_tool_call") return "other";
-      if (entry.itemType === "dynamic_tool_call") return "dynamic-tool";
-      if (entry.itemType === "collab_agent_tool_call" || entry.taskId) return "agent-tool";
-      if (entry.tone === "thinking") return "agent-tool";
-      if (entry.tone === "tool") return "tone-tool";
-      return "other";
-    }),
-  );
-  return fallbackKinds.size === 1 ? fallbackKinds.values().next().value! : "mixed";
 }
 
 function workGroupIdentity(timelineEntryId: string, entry: WorkLogEntry): string {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -9,7 +9,10 @@ import {
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import { commandProgramName } from "@t3tools/client-runtime/work-log/command-label";
-import { workEntryViewedImagePath } from "@t3tools/client-runtime/work-log/presentation";
+import {
+  resolveViewedImageAsset,
+  workEntryViewedImagePath,
+} from "@t3tools/client-runtime/work-log/presentation";
 import type { AgentPanelModel } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
   emptyAgentPanelModel,
@@ -56,7 +59,7 @@ import {
   resolveDiffThemeName,
   resolveFileDiffPath,
 } from "../../lib/diffRendering";
-import ChatMarkdown, { ChatMarkdownWorkspaceImage } from "../ChatMarkdown";
+import ChatMarkdown, { ChatMarkdownAssetImage } from "../ChatMarkdown";
 import {
   BotIcon,
   CheckIcon,
@@ -2423,6 +2426,13 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const displayText = workEntryPreview(workEntry, workspaceRoot) ?? toolWorkEntryHeading(workEntry);
   const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
   const viewedImagePath = workEntryViewedImagePath(workEntry);
+  const viewedImage =
+    viewedImagePath && threadRef
+      ? resolveViewedImageAsset(viewedImagePath, {
+          threadId: threadRef.threadId,
+          workspaceRoot,
+        })
+      : null;
   const canExpand = expandedBody !== null;
   const showDestructiveRowStyle =
     showFailedIndicator &&
@@ -2516,12 +2526,13 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          {viewedImagePath && threadRef ? (
+          {viewedImage && threadRef ? (
             <div className="mb-1.5">
-              <ChatMarkdownWorkspaceImage
-                threadRef={threadRef}
-                path={viewedImagePath}
-                alt={viewedImagePath.split(/[\\/]/).at(-1) ?? "image"}
+              <ChatMarkdownAssetImage
+                environmentId={threadRef.environmentId}
+                resource={viewedImage.resource}
+                alt={viewedImage.alt}
+                srcFragment={viewedImage.srcFragment}
                 style={{ maxHeight: "16rem" }}
                 onImageExpand={onImageExpand}
               />

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -9,6 +9,7 @@ import {
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import { commandProgramName } from "@t3tools/client-runtime/work-log/command-label";
+import { workEntryViewedImagePath } from "@t3tools/client-runtime/work-log/presentation";
 import type { AgentPanelModel } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
   emptyAgentPanelModel,
@@ -55,7 +56,7 @@ import {
   resolveDiffThemeName,
   resolveFileDiffPath,
 } from "../../lib/diffRendering";
-import ChatMarkdown from "../ChatMarkdown";
+import ChatMarkdown, { ChatMarkdownWorkspaceImage } from "../ChatMarkdown";
 import {
   BotIcon,
   CheckIcon,
@@ -2412,6 +2413,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   isExpandedToolGroupEntry: boolean;
 }) {
   const { workEntry, workspaceRoot, isExpandedToolGroupEntry } = props;
+  const { threadRef, onImageExpand } = use(TimelineRowCtx);
   const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
@@ -2420,6 +2422,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
     showWarningIndicator || showFailedIndicator ? "circle-alert" : workEntryIconName(workEntry);
   const displayText = workEntryPreview(workEntry, workspaceRoot) ?? toolWorkEntryHeading(workEntry);
   const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
+  const viewedImagePath = workEntryViewedImagePath(workEntry);
   const canExpand = expandedBody !== null;
   const showDestructiveRowStyle =
     showFailedIndicator &&
@@ -2513,6 +2516,17 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
+          {viewedImagePath && threadRef ? (
+            <div className="mb-1.5">
+              <ChatMarkdownWorkspaceImage
+                threadRef={threadRef}
+                path={viewedImagePath}
+                alt={viewedImagePath.split(/[\\/]/).at(-1) ?? "image"}
+                style={{ maxHeight: "16rem" }}
+                onImageExpand={onImageExpand}
+              />
+            </div>
+          ) : null}
           <pre className={toolCallExpandedBodyClassName}>{expandedBody}</pre>
         </div>
       ) : null}

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { workEntryViewedImagePath } from "./presentation.js";
+import { ThreadId } from "@t3tools/contracts";
+
+import { resolveViewedImageAsset, workEntryViewedImagePath } from "./presentation.js";
 
 describe("workEntryViewedImagePath", () => {
   const entry = { label: "Read", tone: "tool" } as const;
@@ -27,5 +29,42 @@ describe("workEntryViewedImagePath", () => {
       workEntryViewedImagePath({ ...entry, itemType: "image_view", detail: "a.png\nb.png" }),
     ).toBeNull();
     expect(workEntryViewedImagePath({ ...entry, detail: "a.png" })).toBeNull();
+  });
+});
+
+describe("resolveViewedImageAsset", () => {
+  const threadId = ThreadId.make("thread-1");
+
+  it("loads t3 attachment paths as attachments", () => {
+    const attachmentId =
+      "11111111-1111-4111-8111-111111111111-22222222-2222-4222-8222-222222222222";
+    expect(
+      resolveViewedImageAsset(`/Users/demo/.t3/dev/attachments/${attachmentId}.png`, {
+        threadId,
+        workspaceRoot: "/workspace",
+      }),
+    ).toEqual({
+      resource: { _tag: "attachment", attachmentId },
+      alt: `${attachmentId}.png`,
+      srcFragment: "",
+    });
+  });
+
+  it("normalizes workspace image sources", () => {
+    expect(
+      resolveViewedImageAsset("screens/logo.svg?v=2#mark", {
+        threadId,
+        workspaceRoot: "/workspace",
+      }),
+    ).toEqual({
+      resource: {
+        _tag: "workspace-file",
+        threadId,
+        path: "/workspace/screens/logo.svg",
+      },
+      alt: "logo.svg",
+      srcFragment: "#mark",
+    });
+    expect(resolveViewedImageAsset("https://example.com/logo.png", { threadId })).toBeNull();
   });
 });

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { workEntryViewedImagePath } from "./presentation.js";
+
+describe("workEntryViewedImagePath", () => {
+  const entry = { label: "Read", tone: "tool" } as const;
+
+  it("returns a single image path from supported read entries", () => {
+    expect(
+      workEntryViewedImagePath({ ...entry, requestKind: "file-read", detail: " assets/a.png " }),
+    ).toBe("assets/a.png");
+    expect(
+      workEntryViewedImagePath({
+        ...entry,
+        itemType: "dynamic_tool_call",
+        toolTitle: "Read file",
+        detail: "C:\\workspace\\a.webp",
+      }),
+    ).toBe("C:\\workspace\\a.webp");
+  });
+
+  it("rejects non-image, multi-line, and non-read details", () => {
+    expect(
+      workEntryViewedImagePath({ ...entry, itemType: "image_view", detail: "a.txt" }),
+    ).toBeNull();
+    expect(
+      workEntryViewedImagePath({ ...entry, itemType: "image_view", detail: "a.png\nb.png" }),
+    ).toBeNull();
+    expect(workEntryViewedImagePath({ ...entry, detail: "a.png" })).toBeNull();
+  });
+});

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -1,4 +1,5 @@
 import { isToolLifecycleItemType, type ToolLifecycleItemType } from "@t3tools/contracts";
+import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 
 export function isWorktreeSetupActivity(kind: string): boolean {
   return kind === "setup-script.requested" || kind === "setup-script.started";
@@ -9,6 +10,7 @@ export interface WorkLogPresentationEntry {
   readonly toolTitle?: string;
   readonly tone: "thinking" | "tool" | "info" | "error";
   readonly command?: string;
+  readonly detail?: string;
   readonly changedFiles?: ReadonlyArray<string>;
   readonly itemType?: ToolLifecycleItemType;
   readonly requestKind?: string;
@@ -57,7 +59,8 @@ export function toolGroupAction(entry: WorkLogPresentationEntry): ToolGroupActio
   if (
     entry.requestKind === "file-read" ||
     entry.itemType === "image_view" ||
-    (entry.itemType === "dynamic_tool_call" && entry.toolTitle === "Read File")
+    (entry.itemType === "dynamic_tool_call" &&
+      entry.toolTitle?.trim().toLowerCase() === "read file")
   ) {
     return "read";
   }
@@ -74,6 +77,16 @@ export function toolGroupAction(entry: WorkLogPresentationEntry): ToolGroupActio
   if (workLogEntryIsLocalCodeSearch(entry)) return "code-search";
   if (entry.itemType === "web_search") return "search";
   return workLogEntryIsToolLike(entry) ? "other" : "update";
+}
+
+export function workEntryViewedImagePath(entry: WorkLogPresentationEntry): string | null {
+  const detail = entry.detail?.trim();
+  return toolGroupAction(entry) === "read" &&
+    detail !== undefined &&
+    !/[\r\n]/.test(detail) &&
+    isWorkspaceImagePreviewPath(detail)
+    ? detail
+    : null;
 }
 
 function toolGroupActionCount(

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -1,5 +1,12 @@
-import { isToolLifecycleItemType, type ToolLifecycleItemType } from "@t3tools/contracts";
+import {
+  isToolLifecycleItemType,
+  type AssetResource,
+  type ThreadId,
+  type ToolLifecycleItemType,
+} from "@t3tools/contracts";
 import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
+
+import { classifyMarkdownImageSource, markdownImageSourceFragment } from "../markdownImages.js";
 
 export function isWorktreeSetupActivity(kind: string): boolean {
   return kind === "setup-script.requested" || kind === "setup-script.started";
@@ -87,6 +94,43 @@ export function workEntryViewedImagePath(entry: WorkLogPresentationEntry): strin
     isWorkspaceImagePreviewPath(detail)
     ? detail
     : null;
+}
+
+export interface ViewedImageAsset {
+  readonly resource: Extract<AssetResource, { readonly _tag: "attachment" | "workspace-file" }>;
+  readonly alt: string;
+  readonly srcFragment: string;
+}
+
+const ABSOLUTE_IMAGE_SOURCE_PATTERN = /^(?:file:|[\\/]|[a-z]:[\\/])/i;
+const T3_ATTACHMENT_IMAGE_PATH_PATTERN =
+  /(?:^|[\\/])(?:dev|userdata)[\\/]attachments[\\/]([a-z0-9_-]{1,128})\.[a-z0-9]{1,10}$/i;
+
+export function resolveViewedImageAsset(
+  source: string,
+  input: {
+    readonly threadId: ThreadId;
+    readonly workspaceRoot?: string | null | undefined;
+  },
+): ViewedImageAsset | null {
+  const imageSource = classifyMarkdownImageSource(source, input.workspaceRoot ?? ".");
+  if (imageSource._tag !== "WorkspaceFile") return null;
+
+  const path =
+    input.workspaceRoot == null && imageSource.path.startsWith("./")
+      ? imageSource.path.slice(2)
+      : imageSource.path;
+  const attachmentId = ABSOLUTE_IMAGE_SOURCE_PATTERN.test(source)
+    ? (T3_ATTACHMENT_IMAGE_PATH_PATTERN.exec(path)?.[1] ?? null)
+    : null;
+
+  return {
+    resource: attachmentId
+      ? { _tag: "attachment", attachmentId }
+      : { _tag: "workspace-file", threadId: input.threadId, path },
+    alt: path.split(/[\\/]/).at(-1) ?? "image",
+    srcFragment: markdownImageSourceFragment(source),
+  };
 }
 
 function toolGroupActionCount(


### PR DESCRIPTION
Expanded image-read work-log rows currently show only file paths, and persisted T3 attachment paths fail when treated as workspace files. This keeps the shared work-log selector, resolves each viewed image to either a workspace-file or attachment asset, reuses the signed asset renderers on web and mobile, and removes duplicate web grouping code.

### Evidence

Before: an expanded `Read 1 file` row falls back to `Image unavailable` for a persisted T3 attachment.

![Before: persisted attachment image is unavailable](https://uploads-production-47e4.up.railway.app/files/fb5148b1-66b8-481b-bda9-233ea1a31c17/18137064-25f2-4172-ad28-4878bfa6763c-a07523ff-c0bc-49df-acd8-1622015c897f.png)

After: the isolated T3 preview resolved the same path shape as an `attachment` asset, returned the SVG with HTTP 200, and rendered it without the unavailable fallback. The T3 snapshot and recording endpoints timed out, so the after screenshot is still unverified.

### Checks

- `vp run --filter @t3tools/client-runtime typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/mobile typecheck`
- targeted Vite+ formatting and lint
- bundled runtime assertions for persisted attachment paths and workspace paths with query/fragment suffixes
- focused Vite+ test collection is currently blocked before collection by `TypeError: Cannot read properties of undefined (reading 'config')`

Built with `gpt-5.6-sol` in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes asset resolution and signed URL loading for work-log previews across web and mobile; incorrect path classification could still show unavailable images but does not touch auth or data persistence.
> 
> **Overview**
> Expanded **read** work-log rows can now show an inline image preview instead of only a path string. Shared logic in `client-runtime` picks eligible image paths from entry detail (`workEntryViewedImagePath`) and resolves them to signed **attachment** or **workspace-file** assets (`resolveViewedImageAsset`), including persisted T3 attachment paths that previously broke when treated as workspace files.
> 
> **Web** and **mobile** reuse the same asset image components (`ChatMarkdownAssetImage` / generalized `ThreadMarkdownImage`) inside expanded work-log detail, with URL fragments preserved for markdown-style sources. Web **MessagesTimeline.logic** drops duplicated tool-group summarization and re-exports it from `work-log/presentation`; dynamic “Read file” tool rows are matched case-insensitively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b61074954a052164e5237ff2aa95c3518b419e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render viewed images in work-log entries on mobile and web
> - Generalizes `ThreadMarkdownImage` (mobile) and `ChatMarkdownAssetImage` (web) to accept either an attachment or a workspace-file resource, and to append optional `srcFragment` (hash/query) to the resolved asset URL.
> - Adds `workEntryViewedImagePath` and `resolveViewedImageAsset` in [presentation.ts](https://github.com/pingdotgg/t3code/pull/8936/files#diff-b6852793cd3916fd7bb7704e9bfe1391f7ca44403063a0502eb92d59f5060972) to detect when a work-log entry reflects an image read and to classify the source into an `AssetResource`.
> - Expanded work-log rows on both platforms now render the resolved image above the detail text via the pluggable `renderImage` (mobile) or `ChatMarkdownAssetImage` (web) callbacks.
> - Replaces local tool/action normalization utilities in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/8936/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) with re-exports from `@t3tools/client-runtime/work-log/presentation`.
> - Fixes `toolGroupAction` to classify dynamic tool calls named "Read File" (case-insensitive, whitespace-trimmed) as a `read` action.
> - Risk: `ThreadMarkdownImage` props changed from `threadId`/`path` to a `resource` prop; any out-of-tree callers of the old signature will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22b6107.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
