### PR TITLE
feat(appearance): add high-contrast user messages

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -14,6 +14,7 @@ import * as DesktopClientSettings from "./DesktopClientSettings.ts";
 
 const clientSettings: ClientSettings = {
   appearanceContrast: 100,
+  userMessagePresentation: "high-contrast",
   browserDefaultViewport: { _tag: "preset", width: 1024, height: 600, presetId: "nest-hub" },
   browserDefaultZoomFactor: 1.25,
   browserDefaultAppearance: "dark",

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -828,7 +828,26 @@ describe("MessagesTimeline", () => {
 
     expect(markup).not.toContain("Show full message");
     expect(markup).toContain('data-user-message-collapsible="false"');
+    expect(markup).toContain('data-user-message-bubble="true"');
     expect(markup).toContain("rounded-2xl bg-message p-3");
+  });
+
+  it("keeps user message actions and focus indicators on semantic colors", () => {
+    const entry = buildUserTimelineEntry("Review [the change](https://example.com) and `ship` it.");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        revertTurnCountByUserMessageId={new Map([[entry.message.id, 1]])}
+        timelineEntries={[entry]}
+      />,
+    );
+
+    expect(markup).toContain('data-user-message-bubble="true"');
+    expect(markup).toContain('aria-label="Revert to this message"');
+    expect(markup).toContain('aria-label="Copy link"');
+    expect(markup).toContain("focus-visible:ring-2");
+    expect(markup).toContain('href="https://example.com"');
+    expect(markup).toContain('<code data-inline-code="">ship</code>');
   });
 
   it("preserves arbitrary XML-like tags and comparisons in rendered user messages", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1049,7 +1049,10 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
 
   return (
     <div className="group flex flex-col items-end gap-1">
-      <div className="relative max-w-[80%] rounded-2xl bg-message p-3 text-message-foreground">
+      <div
+        className="relative max-w-[80%] rounded-2xl bg-message p-3 text-message-foreground"
+        data-user-message-bubble
+      >
         {(regularImages.length > 0 || userVideos.length > 0) && (
           <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
             {regularImages.map((image) => (

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -12,6 +12,7 @@ import {
   backgroundActivitySharedPolicySettings,
   buildProviderInstanceUpdatePatch,
   formatDiagnosticsDescription,
+  getAppearanceSettingsRestorePatch,
   getChangedBrowserSettingLabels,
   getChangedTypographySettingLabels,
   isSamePreviewViewport,
@@ -20,6 +21,16 @@ import {
   projectGroupingModeFromToggle,
   resolveBackgroundActivityProfileOption,
 } from "./SettingsPanels.logic";
+
+describe("appearance settings restore", () => {
+  it("restores subtle user messages with the neighboring appearance defaults", () => {
+    expect(getAppearanceSettingsRestorePatch()).toEqual({
+      appearanceContrast: 100,
+      userMessagePresentation: "subtle",
+      glassOpacity: 80,
+    });
+  });
+});
 
 describe("typography settings restore", () => {
   it("detects family and size changes by font row", () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -7,6 +7,7 @@ import type {
   ProviderInstanceId,
   ServerSettings,
   SidebarProjectGroupingMode,
+  ClientSettingsPatch,
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
@@ -29,6 +30,17 @@ export function projectGroupingModeFromToggle(
 ): SidebarProjectGroupingMode {
   if (!enabled) return "separate";
   return lastEnabledMode === "repository_path" ? "repository_path" : "repository";
+}
+
+export function getAppearanceSettingsRestorePatch(): Pick<
+  ClientSettingsPatch,
+  "appearanceContrast" | "userMessagePresentation" | "glassOpacity"
+> {
+  return {
+    appearanceContrast: DEFAULT_UNIFIED_SETTINGS.appearanceContrast,
+    userMessagePresentation: DEFAULT_UNIFIED_SETTINGS.userMessagePresentation,
+    glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+  };
 }
 
 const LAST_ENABLED_PROJECT_GROUPING_MODE_KEY = "t3code:last-enabled-project-grouping-mode";

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
   DEFAULT_UNIFIED_SETTINGS,
   type EnvironmentIdentificationMode,
+  type UserMessagePresentation,
   MAX_APPEARANCE_CONTRAST,
   MAX_CODE_FONT_SIZE,
   MAX_GLASS_OPACITY,
@@ -126,6 +127,7 @@ import {
   durationToSeconds,
   formatDiagnosticsDescription,
   getChangedBrowserSettingLabels,
+  getAppearanceSettingsRestorePatch,
   getChangedTypographySettingLabels,
   normalizeIntervalSeconds,
   PROVIDER_HEALTH_INTERVAL_STEP_SECONDS,
@@ -151,6 +153,11 @@ const ENVIRONMENT_IDENTIFICATION_LABELS: Record<EnvironmentIdentificationMode, s
   artwork: "Artwork",
   pill: "Version pill",
   none: "None",
+};
+
+const USER_MESSAGE_PRESENTATION_LABELS: Record<UserMessagePresentation, string> = {
+  subtle: "Subtle",
+  "high-contrast": "High contrast",
 };
 
 const TIMESTAMP_FORMAT_LABELS = {
@@ -480,6 +487,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.appearanceContrast !== DEFAULT_UNIFIED_SETTINGS.appearanceContrast
         ? ["Contrast"]
         : []),
+      ...(settings.userMessagePresentation !== DEFAULT_UNIFIED_SETTINGS.userMessagePresentation
+        ? ["User messages"]
+        : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
       ...(settings.environmentIdentificationMode !==
       DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode
@@ -556,6 +566,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.browserRecordingFrameRate,
       settings.browserAutoShowFloatingPreview,
       settings.appearanceContrast,
+      settings.userMessagePresentation,
       settings.enableAgentBrowserAccess,
       settings.confirmQuit,
       settings.confirmThreadArchive,
@@ -653,13 +664,12 @@ export function useSettingsRestore(onRestored?: () => void) {
       return;
     }
     updateSettings({
-      appearanceContrast: DEFAULT_UNIFIED_SETTINGS.appearanceContrast,
+      ...getAppearanceSettingsRestorePatch(),
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
-      glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
@@ -1077,6 +1087,47 @@ export function AppearanceSettingsPanel() {
                 value={settings.appearanceContrast}
               />
             </div>
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("user-message-presentation")}
+          description="Choose the visual separation of user-authored messages."
+          resetAction={
+            settings.userMessagePresentation !==
+            DEFAULT_UNIFIED_SETTINGS.userMessagePresentation ? (
+              <SettingResetButton
+                label="user messages"
+                onClick={() =>
+                  updateSettings({
+                    userMessagePresentation: DEFAULT_UNIFIED_SETTINGS.userMessagePresentation,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.userMessagePresentation}
+              onValueChange={(value) => {
+                if (value === "subtle" || value === "high-contrast") {
+                  updateSettings({ userMessagePresentation: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="User messages">
+                <SelectValue>
+                  {USER_MESSAGE_PRESENTATION_LABELS[settings.userMessagePresentation]}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                {Object.entries(USER_MESSAGE_PRESENTATION_LABELS).map(([value, label]) => (
+                  <SelectItem hideIndicator key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -92,6 +92,10 @@ describe("searchSettings", () => {
       id: "word-wrap",
       to: "/settings/appearance",
     });
+    expect(searchSettings("user messages")[0]).toMatchObject({
+      id: "user-message-presentation",
+      to: "/settings/appearance",
+    });
     expect(searchSettings("environment identification")[0]).toMatchObject({
       id: "environment-identification",
       to: "/settings/appearance",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -64,6 +64,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/appearance",
   },
   {
+    id: "user-message-presentation",
+    title: "User messages",
+    to: "/settings/appearance",
+  },
+  {
     // Prefixed because the slider control already owns the `glass-opacity` id.
     id: "setting-glass-opacity",
     title: "Glass opacity",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1180,7 +1180,7 @@ html[data-user-message-presentation="high-contrast"] [data-user-message-bubble] 
 html[data-user-message-presentation="high-contrast"]
   [data-user-message-bubble]
   .chat-markdown
-  a:not(.chat-markdown-file-link) {
+  a:not(.chat-markdown-file-link, [data-footnote-ref], [data-footnote-backref]) {
   color: var(--message-foreground);
   text-decoration-line: underline;
   text-decoration-color: color-mix(in srgb, currentcolor 65%, transparent);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1179,6 +1179,16 @@ html[data-user-message-presentation="high-contrast"] [data-user-message-bubble] 
 
 html[data-user-message-presentation="high-contrast"]
   [data-user-message-bubble]
+  .chat-markdown
+  a:not(.chat-markdown-file-link) {
+  color: var(--message-foreground);
+  text-decoration-line: underline;
+  text-decoration-color: color-mix(in srgb, currentcolor 65%, transparent);
+  text-underline-offset: 0.16em;
+}
+
+html[data-user-message-presentation="high-contrast"]
+  [data-user-message-bubble]
   .chat-markdown-codeblock {
   --contrast-foreground: var(--code-foreground);
   --contrast-muted-foreground: color-mix(

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1180,6 +1180,14 @@ html[data-user-message-presentation="high-contrast"] [data-user-message-bubble] 
 html[data-user-message-presentation="high-contrast"]
   [data-user-message-bubble]
   .chat-markdown-codeblock {
+  --contrast-foreground: var(--code-foreground);
+  --contrast-muted-foreground: color-mix(
+    in oklab,
+    var(--code-foreground) 78%,
+    var(--code-background)
+  );
+  --accent: color-mix(in oklab, var(--code-background) 82%, var(--code-foreground));
+  --ring: var(--code-foreground);
   border-color: var(--contrast-border);
   background-color: var(--code-background);
   color: var(--code-foreground);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1139,6 +1139,61 @@ html[data-theme-id]:not([data-theme-id=""]) {
   --terminal-selection-background: var(--app-theme-terminal-selection-background);
 }
 
+html[data-user-message-presentation="high-contrast"]:not([data-user-message-presentation=""]) {
+  --message-surface: var(--user-message-high-contrast-surface);
+  --message-foreground: var(--user-message-high-contrast-foreground);
+}
+
+html[data-user-message-presentation="high-contrast"] [data-user-message-bubble] {
+  --background: color-mix(in oklab, var(--message-surface) 94%, var(--message-foreground));
+  --foreground: var(--message-foreground);
+  --card: var(--background);
+  --card-foreground: var(--message-foreground);
+  --popover: var(--background);
+  --popover-foreground: var(--message-foreground);
+  --primary: var(--message-foreground);
+  --primary-foreground: var(--message-surface);
+  --secondary: color-mix(in oklab, var(--message-surface) 88%, var(--message-foreground));
+  --secondary-foreground: var(--message-foreground);
+  --muted: color-mix(in oklab, var(--message-surface) 88%, var(--message-foreground));
+  --muted-foreground: color-mix(in oklab, var(--message-foreground) 78%, var(--message-surface));
+  --placeholder: var(--muted-foreground);
+  --secondary-label: var(--muted-foreground);
+  --icon-muted: var(--muted-foreground);
+  --accent: color-mix(in oklab, var(--message-surface) 82%, var(--message-foreground));
+  --accent-foreground: var(--message-foreground);
+  --border: color-mix(in oklab, var(--message-surface) 72%, var(--message-foreground));
+  --input: var(--border);
+  --ring: var(--message-foreground);
+  --info-foreground: var(--message-foreground);
+  --contrast-foreground: var(--message-foreground);
+  --contrast-muted-foreground: var(--muted-foreground);
+  --contrast-placeholder: var(--placeholder);
+  --contrast-secondary-label: var(--secondary-label);
+  --contrast-icon-muted: var(--icon-muted);
+  --contrast-card-foreground: var(--card-foreground);
+  --contrast-popover-foreground: var(--popover-foreground);
+  --contrast-accent-foreground: var(--accent-foreground);
+  --contrast-secondary-foreground: var(--secondary-foreground);
+  --contrast-border: var(--border);
+  --contrast-input: var(--input);
+}
+
+html[data-user-message-presentation="high-contrast"]
+  [data-user-message-bubble]
+  .chat-markdown-codeblock {
+  border-color: var(--contrast-border);
+  background-color: var(--code-background);
+  color: var(--code-foreground);
+}
+
+html[data-user-message-presentation="high-contrast"]
+  [data-user-message-bubble]
+  .chat-markdown-codeblock
+  pre {
+  color: var(--code-foreground);
+}
+
 /* Theme-token dependency probes are restored synchronously, before paint. Keep
    transitions from observing the temporary sentinel color in between. */
 html[data-theme-token-probe],

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1139,12 +1139,9 @@ html[data-theme-id]:not([data-theme-id=""]) {
   --terminal-selection-background: var(--app-theme-terminal-selection-background);
 }
 
-html[data-user-message-presentation="high-contrast"]:not([data-user-message-presentation=""]) {
+html[data-user-message-presentation="high-contrast"] [data-user-message-bubble] {
   --message-surface: var(--user-message-high-contrast-surface);
   --message-foreground: var(--user-message-high-contrast-foreground);
-}
-
-html[data-user-message-presentation="high-contrast"] [data-user-message-bubble] {
   --background: color-mix(in oklab, var(--message-surface) 94%, var(--message-foreground));
   --foreground: var(--message-foreground);
   --card: var(--background);
@@ -1175,6 +1172,7 @@ html[data-user-message-presentation="high-contrast"] [data-user-message-bubble] 
   --contrast-popover-foreground: var(--popover-foreground);
   --contrast-accent-foreground: var(--accent-foreground);
   --contrast-secondary-foreground: var(--secondary-foreground);
+  --contrast-message-foreground: var(--message-foreground);
   --contrast-border: var(--border);
   --contrast-input: var(--input);
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -33,6 +33,7 @@ import {
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { applyAppearanceFontVariables } from "~/appearanceFonts";
 import { applyAppearanceContrast } from "~/appearanceContrast";
+import { applyUserMessagePresentation } from "~/userMessagePresentation";
 import { useClientSettings } from "../hooks/useSettings";
 import { PlanAgentSelectionHeal } from "../planAgentSelectionHeal";
 import {
@@ -41,7 +42,8 @@ import {
   selectProjectGroupingSettings,
 } from "../logicalProject";
 import { useUiStateStore } from "../uiStateStore";
-import { syncBrowserChromeTheme } from "../hooks/useTheme";
+import { syncBrowserChromeTheme, useTheme } from "../hooks/useTheme";
+import { getResolvedThemeColors, resolveThemeHalf } from "../themePalette";
 import { configureClientTracing } from "../observability/clientTracing";
 import { resolveInitialServerAuthGateState } from "../environments/primary";
 import { hasHostedPairingRequest, isHostedStaticApp } from "../hostedPairing";
@@ -134,6 +136,7 @@ function RootRouteView() {
     <ToastProvider>
       <AnchoredToastProvider>
         <DocumentTitleSync />
+        <UserMessagePresentationSync />
         <ContrastAppearanceSync />
         <EnvironmentThemeSync />
         <GlassAppearanceSync />
@@ -172,6 +175,22 @@ function ContrastAppearanceSync() {
   useEffect(() => {
     applyAppearanceContrast(document.documentElement, appearanceContrast);
   }, [appearanceContrast]);
+
+  return null;
+}
+
+function UserMessagePresentationSync() {
+  const presentation = useClientSettings((settings) => settings.userMessagePresentation);
+  const { resolvedTheme, theme, themeHalves } = useTheme();
+  const activeTheme = resolveThemeHalf(theme, themeHalves, resolvedTheme);
+
+  useEffect(() => {
+    applyUserMessagePresentation(
+      document.documentElement,
+      presentation,
+      getResolvedThemeColors(activeTheme, resolvedTheme),
+    );
+  }, [activeTheme, presentation, resolvedTheme]);
 
   return null;
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -42,8 +42,7 @@ import {
   selectProjectGroupingSettings,
 } from "../logicalProject";
 import { useUiStateStore } from "../uiStateStore";
-import { syncBrowserChromeTheme, useTheme } from "../hooks/useTheme";
-import { getResolvedThemeColors, resolveThemeHalf } from "../themePalette";
+import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import { configureClientTracing } from "../observability/clientTracing";
 import { resolveInitialServerAuthGateState } from "../environments/primary";
 import { hasHostedPairingRequest, isHostedStaticApp } from "../hostedPairing";
@@ -181,16 +180,10 @@ function ContrastAppearanceSync() {
 
 function UserMessagePresentationSync() {
   const presentation = useClientSettings((settings) => settings.userMessagePresentation);
-  const { resolvedTheme, theme, themeHalves } = useTheme();
-  const activeTheme = resolveThemeHalf(theme, themeHalves, resolvedTheme);
 
   useEffect(() => {
-    applyUserMessagePresentation(
-      document.documentElement,
-      presentation,
-      getResolvedThemeColors(activeTheme, resolvedTheme),
-    );
-  }, [activeTheme, presentation, resolvedTheme]);
+    applyUserMessagePresentation(document.documentElement, presentation);
+  }, [presentation]);
 
   return null;
 }

--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -461,6 +461,33 @@ describe("theme files", () => {
     vi.unstubAllGlobals();
   });
 
+  it("uses the live system appearance when no explicit palette mode is supplied", () => {
+    const setProperty = vi.fn();
+    vi.stubGlobal("document", {
+      documentElement: {
+        classList: { contains: vi.fn(() => false) },
+        dataset: {},
+        style: { removeProperty: vi.fn(), setProperty },
+      },
+    });
+    vi.stubGlobal("window", {
+      matchMedia: vi.fn(() => ({ matches: true })),
+    });
+
+    applyThemePalette("system");
+
+    const surface = setProperty.mock.calls.findLast(
+      ([variable]) => variable === "--user-message-high-contrast-surface",
+    )?.[1];
+    const foreground = setProperty.mock.calls.findLast(
+      ([variable]) => variable === "--user-message-high-contrast-foreground",
+    )?.[1];
+    expect(asHex(surface)).toBe("#f5f5f5");
+    expect(asHex(foreground)).toBe("#0a0a0a");
+
+    vi.unstubAllGlobals();
+  });
+
   it("keeps optional light and dark palettes under one theme id", () => {
     const theme = parseThemeFile({
       version: THEME_FILE_VERSION,

--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -81,10 +81,26 @@ function contrastRatio(first: string, second: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+function compositeForTest(foreground: string, backdrop: string): string {
+  const foregroundHex = themeColorToHex(foreground);
+  const backdropHex = asHex(backdrop);
+  if (!foregroundHex) throw new Error(`Expected a theme color, received ${foreground}`);
+  const alpha =
+    foregroundHex.length === 9 ? Number.parseInt(foregroundHex.slice(7, 9), 16) / 255 : 1;
+  const channel = (hex: string, index: number) => Number.parseInt(hex.slice(index, index + 2), 16);
+  return `#${[1, 3, 5]
+    .map((index) =>
+      Math.round(channel(backdropHex, index) * (1 - alpha) + channel(foregroundHex, index) * alpha)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
 describe("high-contrast user message colors", () => {
   it("inverts the stock light and dark palettes through their own colors", () => {
-    const light = resolveHighContrastUserMessageColors(getStandardThemeColors("light"));
-    const dark = resolveHighContrastUserMessageColors(getStandardThemeColors("dark"));
+    const light = resolveHighContrastUserMessageColors(getStandardThemeColors("light"), "light");
+    const dark = resolveHighContrastUserMessageColors(getStandardThemeColors("dark"), "dark");
 
     expect(asHex(light.messageSurface)).toBe("#27272a");
     expect(asHex(light.messageForeground)).toBe("#fcfcfc");
@@ -93,10 +109,10 @@ describe("high-contrast user message colors", () => {
   });
 
   it.each([
-    ["stock light", getStandardThemeColors("light")],
-    ["stock dark", getStandardThemeColors("dark")],
-    ["custom light", createManagedThemeColors("light", "#f7f1e8", "#7c3aed")],
-    ["custom dark", createManagedThemeColors("dark", "#102a2a", "#2dd4bf")],
+    ["stock light", getStandardThemeColors("light"), "light"],
+    ["stock dark", getStandardThemeColors("dark"), "dark"],
+    ["custom light", createManagedThemeColors("light", "#f7f1e8", "#7c3aed"), "light"],
+    ["custom dark", createManagedThemeColors("dark", "#102a2a", "#2dd4bf"), "dark"],
     [
       "low-contrast custom",
       {
@@ -104,9 +120,10 @@ describe("high-contrast user message colors", () => {
         canvas: canonical("#777777"),
         text: canonical("#888888"),
       },
+      "light",
     ],
-  ] as const)("meets both contrast floors for %s", (_name, colors) => {
-    const resolved = resolveHighContrastUserMessageColors(colors);
+  ] as const)("meets both contrast floors for %s", (_name, colors, appearance) => {
+    const resolved = resolveHighContrastUserMessageColors(colors, appearance);
 
     expect(contrastRatio(resolved.messageSurface, colors.canvas)).toBeGreaterThanOrEqual(3);
     expect(
@@ -116,8 +133,15 @@ describe("high-contrast user message colors", () => {
 
   it("meets both contrast floors for every built-in appearance", () => {
     for (const theme of BUILT_IN_THEMES) {
-      for (const colors of [theme.colors, ...Object.values(theme.variants ?? {})]) {
-        const resolved = resolveHighContrastUserMessageColors(colors);
+      const appearances = [
+        { appearance: theme.appearance, colors: theme.colors },
+        ...Object.entries(theme.variants ?? {}).map(([appearance, colors]) => ({
+          appearance: appearance as "light" | "dark",
+          colors,
+        })),
+      ];
+      for (const { appearance, colors } of appearances) {
+        const resolved = resolveHighContrastUserMessageColors(colors, appearance);
 
         expect(contrastRatio(resolved.messageSurface, colors.canvas)).toBeGreaterThanOrEqual(3);
         expect(
@@ -125,6 +149,22 @@ describe("high-contrast user message colors", () => {
         ).toBeGreaterThanOrEqual(4.5);
       }
     }
+  });
+
+  it("solves alpha-bearing custom colors against the appearance backdrop", () => {
+    const standard = getStandardThemeColors("light");
+    const colors = {
+      ...standard,
+      canvas: canonical("#11111133"),
+      text: canonical("#00000080"),
+    };
+    const effectiveCanvas = compositeForTest(colors.canvas, standard.canvas);
+    const resolved = resolveHighContrastUserMessageColors(colors, "light");
+
+    expect(contrastRatio(resolved.messageSurface, effectiveCanvas)).toBeGreaterThanOrEqual(3);
+    expect(
+      contrastRatio(resolved.messageForeground, resolved.messageSurface),
+    ).toBeGreaterThanOrEqual(4.5);
   });
 });
 
@@ -390,18 +430,28 @@ describe("theme files", () => {
 
   it("suppresses sidebar artwork during a live custom-theme preview", () => {
     const listener = vi.fn();
+    const setProperty = vi.fn();
     const unsubscribe = subscribeToThemePreview(listener);
     vi.stubGlobal("document", {
       documentElement: {
         classList: { toggle: vi.fn() },
         dataset: {},
-        style: { removeProperty: vi.fn(), setProperty: vi.fn() },
+        style: { removeProperty: vi.fn(), setProperty },
       },
     });
 
     applyThemeColorPreview(T3_CHAT_THEME.colors, "light");
     expect(getThemePreviewSidebarArtwork()).toBe(false);
     expect(listener).toHaveBeenCalledTimes(1);
+    const lightMessageSurface = setProperty.mock.calls.findLast(
+      ([variable]) => variable === "--user-message-high-contrast-surface",
+    )?.[1];
+
+    applyThemeColorPreview(T3_CHAT_THEME.variants!.dark!, "dark");
+    const darkMessageSurface = setProperty.mock.calls.findLast(
+      ([variable]) => variable === "--user-message-high-contrast-surface",
+    )?.[1];
+    expect(darkMessageSurface).not.toBe(lightMessageSurface);
 
     applyThemePalette("system");
     expect(getThemePreviewSidebarArtwork()).toBeNull();

--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -36,6 +36,8 @@ import {
   createManagedThemeColors,
   createVividThemeColors,
   getDefaultThemeColors,
+  getStandardThemeColors,
+  resolveHighContrastUserMessageColors,
   themeColorToHex,
   toCanonicalThemeColor,
   THEME_FILE_VERSION,
@@ -78,6 +80,53 @@ function contrastRatio(first: string, second: string): number {
   const darker = Math.min(luminance(first), luminance(second));
   return (lighter + 0.05) / (darker + 0.05);
 }
+
+describe("high-contrast user message colors", () => {
+  it("inverts the stock light and dark palettes through their own colors", () => {
+    const light = resolveHighContrastUserMessageColors(getStandardThemeColors("light"));
+    const dark = resolveHighContrastUserMessageColors(getStandardThemeColors("dark"));
+
+    expect(asHex(light.messageSurface)).toBe("#27272a");
+    expect(asHex(light.messageForeground)).toBe("#fcfcfc");
+    expect(asHex(dark.messageSurface)).toBe("#f5f5f5");
+    expect(asHex(dark.messageForeground)).toBe("#0a0a0a");
+  });
+
+  it.each([
+    ["stock light", getStandardThemeColors("light")],
+    ["stock dark", getStandardThemeColors("dark")],
+    ["custom light", createManagedThemeColors("light", "#f7f1e8", "#7c3aed")],
+    ["custom dark", createManagedThemeColors("dark", "#102a2a", "#2dd4bf")],
+    [
+      "low-contrast custom",
+      {
+        ...getStandardThemeColors("light"),
+        canvas: canonical("#777777"),
+        text: canonical("#888888"),
+      },
+    ],
+  ] as const)("meets both contrast floors for %s", (_name, colors) => {
+    const resolved = resolveHighContrastUserMessageColors(colors);
+
+    expect(contrastRatio(resolved.messageSurface, colors.canvas)).toBeGreaterThanOrEqual(3);
+    expect(
+      contrastRatio(resolved.messageForeground, resolved.messageSurface),
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("meets both contrast floors for every built-in appearance", () => {
+    for (const theme of BUILT_IN_THEMES) {
+      for (const colors of [theme.colors, ...Object.values(theme.variants ?? {})]) {
+        const resolved = resolveHighContrastUserMessageColors(colors);
+
+        expect(contrastRatio(resolved.messageSurface, colors.canvas)).toBeGreaterThanOrEqual(3);
+        expect(
+          contrastRatio(resolved.messageForeground, resolved.messageSurface),
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+});
 
 describe("theme files", () => {
   it("keeps every built-in palette value in canonical OKLCH form", () => {

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -556,6 +556,17 @@ function parseThemeRgbColor(value: string, fallback: ThemeRgbColor): ThemeRgbCol
   return parsed ? themeOklchToRgb(parsed.color) : fallback;
 }
 
+function compositeThemeColor(
+  value: string,
+  backdrop: ThemeRgbColor,
+  fallback: ThemeRgbColor,
+): ThemeRgbColor {
+  const parsed = parseThemeColor(value);
+  return parsed
+    ? mixThemeRgbColors(backdrop, themeOklchToRgb(parsed.color), parsed.alpha)
+    : fallback;
+}
+
 function themeRgbToHexColor(color: ThemeRgbColor): string {
   return `#${[color.r, color.g, color.b]
     .map((channel) =>
@@ -1011,9 +1022,16 @@ export type UserMessageColors = Readonly<{
  * the canvas seeds its foreground, so custom hue choices survive whenever
  * they already satisfy the contrast floors.
  */
-export function resolveHighContrastUserMessageColors(colors: ThemeColors): UserMessageColors {
-  const canvas = parseThemeRgbColor(colors.canvas, { r: 252, g: 252, b: 252 });
-  const surfaceSeed = parseThemeRgbColor(colors.text, readableThemeForeground(canvas));
+export function resolveHighContrastUserMessageColors(
+  colors: ThemeColors,
+  appearance: ThemeAppearance,
+): UserMessageColors {
+  const standardCanvas = parseThemeRgbColor(
+    getStandardThemeColors(appearance).canvas,
+    appearance === "dark" ? { r: 10, g: 10, b: 10 } : { r: 252, g: 252, b: 252 },
+  );
+  const canvas = compositeThemeColor(colors.canvas, standardCanvas, standardCanvas);
+  const surfaceSeed = compositeThemeColor(colors.text, canvas, readableThemeForeground(canvas));
   const surfaceDirection =
     themeContrastRatio(canvas, THEME_WHITE_FOREGROUND) >=
     themeContrastRatio(canvas, THEME_BLACK_FOREGROUND)
@@ -1046,6 +1064,22 @@ export function resolveHighContrastUserMessageColors(colors: ThemeColors): UserM
     messageSurface: themeOklchToThemeColor(messageSurface),
     messageForeground: themeOklchToThemeColor(messageForeground),
   };
+}
+
+const HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE = "--user-message-high-contrast-surface";
+const HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE = "--user-message-high-contrast-foreground";
+
+function applyHighContrastUserMessageColors(
+  root: HTMLElement,
+  colors: ThemeColors,
+  appearance: ThemeAppearance,
+): void {
+  const resolved = resolveHighContrastUserMessageColors(colors, appearance);
+  root.style.setProperty(HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE, resolved.messageSurface);
+  root.style.setProperty(
+    HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE,
+    resolved.messageForeground,
+  );
 }
 
 function readableThemeText(
@@ -1533,16 +1567,6 @@ export function getThemeColorsForMode(
 }
 
 /** Resolve the complete palette that the selected theme paints for one appearance. */
-export function getResolvedThemeColors(
-  theme: ThemePreference,
-  appearance: ThemeAppearance,
-): ThemeColors {
-  const definition = getThemeDefinition(theme);
-  return definition
-    ? (getThemeColorsForMode(definition, appearance) ?? definition.colors)
-    : getStandardThemeColors(appearance);
-}
-
 export function getThemeModes(theme: ThemeDefinition): ReadonlyArray<ThemeAppearance> {
   return (["light", "dark"] as const).filter((mode) => getThemeColorsForMode(theme, mode) !== null);
 }
@@ -1947,6 +1971,7 @@ export function applyThemeColorPreview(colors: ThemeColors, appearance: ThemeApp
     // A half-typed hex keeps the last good value instead of blanking the role.
     if (isThemeColor(value)) root.style.setProperty(APP_THEME_VARIABLES[role], value);
   }
+  applyHighContrastUserMessageColors(root, colors, appearance);
 }
 
 export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppearance): void {
@@ -1965,6 +1990,7 @@ export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppe
     for (const [role, value] of Object.entries(colors) as Array<[ThemeColorRole, string]>) {
       root.style.setProperty(APP_THEME_VARIABLES[role], value);
     }
+    applyHighContrastUserMessageColors(root, colors, mode);
     return;
   }
 
@@ -1972,6 +1998,8 @@ export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppe
   for (const variable of Object.values(APP_THEME_VARIABLES)) {
     root.style.removeProperty(variable);
   }
+  const mode = appearance ?? legacyThemeMode(theme) ?? "light";
+  applyHighContrastUserMessageColors(root, getStandardThemeColors(mode), mode);
 }
 
 export function resolveThemeAppearance(

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -1974,6 +1974,13 @@ export function applyThemeColorPreview(colors: ThemeColors, appearance: ThemeApp
   applyHighContrastUserMessageColors(root, colors, appearance);
 }
 
+function currentSystemAppearance(root: HTMLElement): ThemeAppearance {
+  if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  return root.classList?.contains?.("dark") ? "dark" : "light";
+}
+
 export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppearance): void {
   if (typeof document === "undefined") return;
 
@@ -1998,7 +2005,10 @@ export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppe
   for (const variable of Object.values(APP_THEME_VARIABLES)) {
     root.style.removeProperty(variable);
   }
-  const mode = appearance ?? legacyThemeMode(theme) ?? "light";
+  const mode =
+    appearance ??
+    legacyThemeMode(theme) ??
+    (theme === "system" ? currentSystemAppearance(root) : "light");
   applyHighContrastUserMessageColors(root, getStandardThemeColors(mode), mode);
 }
 

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -1000,6 +1000,54 @@ function readableThemeForeground(background: ThemeRgbColor): ThemeRgbColor {
     : THEME_BLACK_FOREGROUND;
 }
 
+export type UserMessageColors = Readonly<{
+  messageSurface: string;
+  messageForeground: string;
+}>;
+
+/**
+ * Invert user messages through the active palette while keeping enough
+ * headroom for browser color conversion. Theme text seeds the bubble, and
+ * the canvas seeds its foreground, so custom hue choices survive whenever
+ * they already satisfy the contrast floors.
+ */
+export function resolveHighContrastUserMessageColors(colors: ThemeColors): UserMessageColors {
+  const canvas = parseThemeRgbColor(colors.canvas, { r: 252, g: 252, b: 252 });
+  const surfaceSeed = parseThemeRgbColor(colors.text, readableThemeForeground(canvas));
+  const surfaceDirection =
+    themeContrastRatio(canvas, THEME_WHITE_FOREGROUND) >=
+    themeContrastRatio(canvas, THEME_BLACK_FOREGROUND)
+      ? "lighter"
+      : "darker";
+  const messageSurface = solveOklchLightness(
+    themeRgbToOklch(surfaceSeed),
+    canvas,
+    3.1,
+    surfaceDirection,
+  );
+  const messageSurfaceRgb = themeOklchToRgb(messageSurface);
+  const foregroundSeed = parseThemeRgbColor(
+    colors.canvas,
+    readableThemeForeground(messageSurfaceRgb),
+  );
+  const foregroundDirection =
+    themeContrastRatio(messageSurfaceRgb, THEME_WHITE_FOREGROUND) >=
+    themeContrastRatio(messageSurfaceRgb, THEME_BLACK_FOREGROUND)
+      ? "lighter"
+      : "darker";
+  const messageForeground = solveOklchLightness(
+    themeRgbToOklch(foregroundSeed),
+    messageSurfaceRgb,
+    4.6,
+    foregroundDirection,
+  );
+
+  return {
+    messageSurface: themeOklchToThemeColor(messageSurface),
+    messageForeground: themeOklchToThemeColor(messageForeground),
+  };
+}
+
 function readableThemeText(
   background: ThemeRgbColor,
   foreground: ThemeRgbColor,
@@ -1482,6 +1530,17 @@ export function getThemeColorsForMode(
 ): ThemeColors | null {
   if (mode === theme.appearance) return theme.colors;
   return theme.variants?.[mode] ?? null;
+}
+
+/** Resolve the complete palette that the selected theme paints for one appearance. */
+export function getResolvedThemeColors(
+  theme: ThemePreference,
+  appearance: ThemeAppearance,
+): ThemeColors {
+  const definition = getThemeDefinition(theme);
+  return definition
+    ? (getThemeColorsForMode(definition, appearance) ?? definition.colors)
+    : getStandardThemeColors(appearance);
 }
 
 export function getThemeModes(theme: ThemeDefinition): ReadonlyArray<ThemeAppearance> {

--- a/apps/web/src/userMessagePresentation.test.ts
+++ b/apps/web/src/userMessagePresentation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { getStandardThemeColors } from "./themePalette";
+import {
+  applyUserMessagePresentation,
+  HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE,
+  HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE,
+} from "./userMessagePresentation";
+
+function makeRoot() {
+  const setProperty = vi.fn();
+  const dataset: DOMStringMap = {};
+  return {
+    root: { dataset, style: { setProperty } } as unknown as HTMLElement,
+    dataset,
+    setProperty,
+  };
+}
+
+describe("applyUserMessagePresentation", () => {
+  it("applies preference changes immediately without replacing subtle semantic colors", () => {
+    const { root, dataset, setProperty } = makeRoot();
+    const colors = getStandardThemeColors("light");
+
+    applyUserMessagePresentation(root, "high-contrast", colors);
+    expect(dataset.userMessagePresentation).toBe("high-contrast");
+
+    applyUserMessagePresentation(root, "subtle", colors);
+    expect(dataset.userMessagePresentation).toBe("subtle");
+    expect(setProperty).toHaveBeenCalledWith(
+      HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE,
+      expect.stringMatching(/^oklch\(/),
+    );
+    expect(setProperty).toHaveBeenCalledWith(
+      HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE,
+      expect.stringMatching(/^oklch\(/),
+    );
+    expect(setProperty).not.toHaveBeenCalledWith("--message-surface", expect.anything());
+    expect(setProperty).not.toHaveBeenCalledWith("--message-foreground", expect.anything());
+  });
+});

--- a/apps/web/src/userMessagePresentation.test.ts
+++ b/apps/web/src/userMessagePresentation.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { getStandardThemeColors } from "./themePalette";
-import {
-  applyUserMessagePresentation,
-  HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE,
-  HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE,
-} from "./userMessagePresentation";
+import { applyUserMessagePresentation } from "./userMessagePresentation";
 
 function makeRoot() {
   const setProperty = vi.fn();
@@ -20,21 +15,12 @@ function makeRoot() {
 describe("applyUserMessagePresentation", () => {
   it("applies preference changes immediately without replacing subtle semantic colors", () => {
     const { root, dataset, setProperty } = makeRoot();
-    const colors = getStandardThemeColors("light");
-
-    applyUserMessagePresentation(root, "high-contrast", colors);
+    applyUserMessagePresentation(root, "high-contrast");
     expect(dataset.userMessagePresentation).toBe("high-contrast");
 
-    applyUserMessagePresentation(root, "subtle", colors);
+    applyUserMessagePresentation(root, "subtle");
     expect(dataset.userMessagePresentation).toBe("subtle");
-    expect(setProperty).toHaveBeenCalledWith(
-      HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE,
-      expect.stringMatching(/^oklch\(/),
-    );
-    expect(setProperty).toHaveBeenCalledWith(
-      HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE,
-      expect.stringMatching(/^oklch\(/),
-    );
+    expect(setProperty).not.toHaveBeenCalled();
     expect(setProperty).not.toHaveBeenCalledWith("--message-surface", expect.anything());
     expect(setProperty).not.toHaveBeenCalledWith("--message-foreground", expect.anything());
   });

--- a/apps/web/src/userMessagePresentation.ts
+++ b/apps/web/src/userMessagePresentation.ts
@@ -1,21 +1,8 @@
 import type { UserMessagePresentation } from "@t3tools/contracts/settings";
 
-import { resolveHighContrastUserMessageColors, type ThemeColors } from "./themePalette";
-
-export const HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE = "--user-message-high-contrast-surface";
-export const HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE =
-  "--user-message-high-contrast-foreground";
-
 export function applyUserMessagePresentation(
   root: HTMLElement,
   presentation: UserMessagePresentation,
-  colors: ThemeColors,
 ): void {
-  const highContrast = resolveHighContrastUserMessageColors(colors);
-  root.style.setProperty(HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE, highContrast.messageSurface);
-  root.style.setProperty(
-    HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE,
-    highContrast.messageForeground,
-  );
   root.dataset.userMessagePresentation = presentation;
 }

--- a/apps/web/src/userMessagePresentation.ts
+++ b/apps/web/src/userMessagePresentation.ts
@@ -1,0 +1,21 @@
+import type { UserMessagePresentation } from "@t3tools/contracts/settings";
+
+import { resolveHighContrastUserMessageColors, type ThemeColors } from "./themePalette";
+
+export const HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE = "--user-message-high-contrast-surface";
+export const HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE =
+  "--user-message-high-contrast-foreground";
+
+export function applyUserMessagePresentation(
+  root: HTMLElement,
+  presentation: UserMessagePresentation,
+  colors: ThemeColors,
+): void {
+  const highContrast = resolveHighContrastUserMessageColors(colors);
+  root.style.setProperty(HIGH_CONTRAST_USER_MESSAGE_SURFACE_VARIABLE, highContrast.messageSurface);
+  root.style.setProperty(
+    HIGH_CONTRAST_USER_MESSAGE_FOREGROUND_VARIABLE,
+    highContrast.messageForeground,
+  );
+  root.dataset.userMessagePresentation = presentation;
+}

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -118,6 +118,29 @@ describe("ClientSettings appearance contrast", () => {
   });
 });
 
+describe("ClientSettings user message presentation", () => {
+  it("defaults older settings to the subtle treatment", () => {
+    expect(decodeClientSettings({}).userMessagePresentation).toBe("subtle");
+  });
+
+  it.each(["subtle", "high-contrast"] as const)(
+    "accepts the %s treatment in settings and patches",
+    (userMessagePresentation) => {
+      expect(decodeClientSettings({ userMessagePresentation }).userMessagePresentation).toBe(
+        userMessagePresentation,
+      );
+      expect(decodeClientSettingsPatch({ userMessagePresentation }).userMessagePresentation).toBe(
+        userMessagePresentation,
+      );
+    },
+  );
+
+  it("rejects unsupported treatments", () => {
+    expect(() => decodeClientSettings({ userMessagePresentation: "inverted" })).toThrow();
+    expect(() => decodeClientSettingsPatch({ userMessagePresentation: "inverted" })).toThrow();
+  });
+});
+
 describe("ClientSettings environment identification", () => {
   it("defaults to artwork and accepts each presentation mode", () => {
     expect(decodeClientSettings({}).environmentIdentificationMode).toBe("artwork");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -83,6 +83,10 @@ export const AppearanceContrast = Schema.Int.check(
 );
 export type AppearanceContrast = typeof AppearanceContrast.Type;
 export const DEFAULT_APPEARANCE_CONTRAST: AppearanceContrast = 100;
+
+export const UserMessagePresentation = Schema.Literals(["subtle", "high-contrast"]);
+export type UserMessagePresentation = typeof UserMessagePresentation.Type;
+export const DEFAULT_USER_MESSAGE_PRESENTATION: UserMessagePresentation = "subtle";
 /**
  * Font size preferences, in CSS pixels. The ranges are deliberately narrow:
  * the interface size scales every rem-based dimension in the app, so the
@@ -161,6 +165,9 @@ export const DEFAULT_BROWSER_RECORDING_FRAME_RATE: BrowserRecordingFrameRate = 3
 export const ClientSettingsSchema = Schema.Struct({
   appearanceContrast: AppearanceContrast.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_APPEARANCE_CONTRAST)),
+  ),
+  userMessagePresentation: UserMessagePresentation.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_USER_MESSAGE_PRESENTATION)),
   ),
   browserDefaultViewport: PreviewViewportSetting.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_BROWSER_VIEWPORT)),
@@ -931,6 +938,7 @@ export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;
 
 export const ClientSettingsPatch = Schema.Struct({
   appearanceContrast: Schema.optionalKey(AppearanceContrast),
+  userMessagePresentation: Schema.optionalKey(UserMessagePresentation),
   browserDefaultViewport: Schema.optionalKey(PreviewViewportSetting),
   browserDefaultZoomFactor: Schema.optionalKey(PreviewZoomFactor),
   browserDefaultAppearance: Schema.optionalKey(PreviewAppearancePreference),


### PR DESCRIPTION
User messages can blend into the conversation canvas, especially in light themes, which makes the instructions that start each turn harder to scan.

This adds a `User messages` preference in Settings > Appearance. `Subtle` preserves the existing message surface and foreground and remains the default. `High contrast` derives an inverted surface and foreground from the active theme, with a 3:1 bubble-to-canvas floor and a 4.5:1 foreground-to-bubble floor. The preference applies to existing messages immediately and uses the existing client-settings persistence path.

Closes #8927

## Behavior

- Keeps the current semantic message colors untouched when `Subtle` is selected.
- Resolves high-contrast colors from every built-in appearance and from custom palettes instead of using a fixed black/white pair.
- Recomputes on preference, theme, appearance mode, and system color-scheme changes.
- Keeps links, inline and fenced code, lists, attachments, context content, long-message controls, timestamps, copy and revert actions, hover states, and focus indicators readable.
- Restores `Subtle` through the existing Restore defaults flow and decodes older saved settings without a migration.

## Multi-surface audit

- Web uses the new typed `ClientSettings` field, Appearance control, root synchronizer, and semantic message tokens.
- Desktop wraps the web client and persists the same field through `client-settings.json`; the desktop persistence test covers the new value.
- Remote web use follows the existing client-settings API. No standalone browser-storage key was added.
- Mobile is unchanged. It has a separate React Native preferences store and theme runtime, so parity would require a second preference, UI, and persistence path rather than a small shared change.

## Visual evidence

Settings at the tested stock T3 Code light appearance, 100% contrast:

<img width="900" alt="Settings showing the High contrast user messages preference" src="https://github.com/user-attachments/assets/5fcf3e65-1cf6-4ec6-aa6d-a54d41a94e22" />

### Light appearance

| Before | High contrast |
| --- | --- |
| <img width="720" alt="Subtle user message bubbles in the T3 Code light appearance" src="https://github.com/user-attachments/assets/cb66bee5-246a-46ad-8b7d-4e66f4b7e080" /> | <img width="720" alt="High-contrast user message bubbles in the T3 Code light appearance" src="https://github.com/user-attachments/assets/e4773588-60a6-40f2-83f1-f76abe684a42" /> |

### Dark appearance

| Before | High contrast |
| --- | --- |
| <img width="720" alt="Subtle user message bubbles in the T3 Code dark appearance" src="https://github.com/user-attachments/assets/5a06612b-3207-43d9-ad9c-d10e21b65333" /> | <img width="720" alt="High-contrast user message bubbles in the T3 Code dark appearance" src="https://github.com/user-attachments/assets/df2c9eeb-4ab5-4dcd-bfec-50e1533f085c" /> |

All four thread images use the same 1440 x 900 viewport, thread, collapsed message state, and bubble positions. The after images were recaptured on commit `1f411615c3df70a4bea3b02872d767936a1e99a9` after rebasing onto current `origin/main`.

## Verification

- `vp install --frozen-lockfile` completed with the current lockfile and supply-chain policy check.
- Focused tests: 11 files passed, 306 tests passed. These cover schema decode and patch behavior, older settings, desktop persistence, reset defaults, immediate application, every built-in appearance, representative custom and alpha-bearing palettes, explicit and system-derived appearance fallbacks, contrast thresholds, settings search, semantic message rendering, attachments, actions, focus classes, timeline logic, and the rebased chat integration.

```sh
vp test run packages/contracts/src/settings.test.ts apps/desktop/src/settings/DesktopClientSettings.test.ts apps/web/src/localApi.test.ts apps/web/src/hooks/useSettings.test.ts apps/web/src/themePalette.test.ts apps/web/src/userMessagePresentation.test.ts apps/web/src/components/settings/settingsSearch.test.ts apps/web/src/components/settings/SettingsPanels.logic.test.ts apps/web/src/components/chat/MessagesTimeline.logic.test.ts apps/web/src/components/chat/MessagesTimeline.test.tsx apps/web/src/components/ChatView.logic.test.ts
```

- `vp run --filter @t3tools/contracts typecheck` passed.
- `vp run --filter @t3tools/web typecheck` passed.
- `vp run --filter @t3tools/desktop typecheck` passed.
- Changed-file `vp lint --report-unused-disable-directives` passed.
- Changed-file `vp fmt --check` passed.
- `git diff --check` passed.
- AutoReview loops 1 through 6 used `gpt-5.6-luna` with `max` thinking. Loop 3 found a dark-system fallback regression, loop 4 cleared it, and loops 5 and 6 reported no actionable P0 or P1 findings on the subsequent link-affordance and footnote-selector changes.

## Real-client matrix

| Scenario | Result |
| --- | --- |
| Default `Subtle` | Matched the recorded baseline surface and foreground values exactly. |
| Select `High contrast` | Existing user bubbles updated immediately without a reload. |
| Stock light | Dark theme-derived bubbles and light content rendered clearly. |
| Stock dark | Light theme-derived bubbles and dark content rendered clearly. |
| Theme switch | Grove recomputed its own high-contrast pair and returning to T3 Code preserved the preference. |
| System color scheme | Live light to dark to light emulation recomputed existing bubbles each time. |
| Persistence | Full navigation/reload preserved `High contrast` through client settings. |
| Reset | Restore defaults changed the control and applied root state back to `Subtle`. |
| Content | Plain text, multiline Markdown, links, inline code, fenced code, lists, an image attachment fallback, timestamps, copy actions, and the long-message expander remained readable. |
| Interaction | Hover and keyboard focus exposed message actions with a visible focus indicator. Revert rendering and focus classes also pass focused coverage. |

## Model and harness

Built with `gpt-5.6-sol` at high reasoning through the Codex harness in T3 Code.
