### PR TITLE
feat(server): expose thread ID to terminal sessions

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1578,9 +1578,11 @@ it.layer(
       const { manager, ptyAdapter } = yield* createManager();
       yield* manager.open(
         openInput({
+          threadId: "thread-canonical",
           env: {
             T3CODE_PROJECT_ROOT: "/repo",
             T3CODE_WORKTREE_PATH: "/repo/worktree-a",
+            T3CODE_THREAD_ID: "thread-spoofed",
             CUSTOM_FLAG: "1",
           },
         }),
@@ -1591,6 +1593,7 @@ it.layer(
 
       assert.equal(spawnInput.env.T3CODE_PROJECT_ROOT, "/repo");
       assert.equal(spawnInput.env.T3CODE_WORKTREE_PATH, "/repo/worktree-a");
+      assert.equal(spawnInput.env.T3CODE_THREAD_ID, "thread-canonical");
       assert.equal(spawnInput.env.CUSTOM_FLAG, "1");
     }),
   );

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1869,6 +1869,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           Effect.gen(function* () {
             const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
             const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
+            terminalEnv.T3CODE_THREAD_ID = session.threadId;
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;
             startedShell = spawnResult.shellLabel;


### PR DESCRIPTION
## Problem

Project Actions and terminal-driven tools receive project and worktree context, but not the exact thread they were launched from. Worktree inference becomes ambiguous when several threads share one checkout. This is the smallest useful slice from Ideas discussion #6781.

## Change

Inject `T3CODE_THREAD_ID` at the server's terminal spawn boundary. The server assigns the canonical session thread ID after merging runtime environment values, so a client-supplied value cannot spoof it. Because every terminal starts through this boundary, Actions can consume the variable without separate web, desktop, or mobile plumbing.

## Verification

- `pnpm exec vp test run apps/server/src/terminal/Manager.test.ts` (54 tests passed)
- `pnpm --filter t3 typecheck`
- `pnpm exec vp fmt --check apps/server/src/terminal/Manager.ts apps/server/src/terminal/Manager.test.ts`
- `pnpm exec vp lint apps/server/src/terminal/Manager.ts apps/server/src/terminal/Manager.test.ts`

Built with GPT-5.6 Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change at terminal spawn with a regression test for env spoofing; no auth or data-model changes.
> 
> **Overview**
> Terminal PTY processes now receive **`T3CODE_THREAD_ID`** set from the server session’s **`threadId`**, applied in **`startSession`** immediately after **`createTerminalSpawnEnv`** merges host and runtime env. That ordering lets Project Actions and shell tools read the launching thread even when several threads share one worktree, without extra client plumbing.
> 
> A client-supplied **`T3CODE_THREAD_ID`** in open **`env`** cannot override the value: the server assigns the canonical ID on every spawn (and restart) path that goes through this boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4857f02d8b25dd90601ce1909ba5d50125d885a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `T3CODE_THREAD_ID` env var for terminal sessions from `session.threadId`
> In `TerminalManager.makeWithOptions`, the terminal spawn environment now gets `T3CODE_THREAD_ID` set to `session.threadId` after `createTerminalSpawnEnv`. This overrides any value from `baseEnv` or `session.runtimeEnv`.
>
> Tests confirm the session thread ID takes precedence over a spoofed env value.
>
> Risk: spawned terminal processes that previously relied on a caller-supplied `T3CODE_THREAD_ID` will now have it replaced with the session's thread ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4857f02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal sessions now consistently receive the correct thread identifier, preventing conflicting or spoofed environment values from affecting spawned processes.
* **Tests**
  * Added coverage to verify that the canonical thread identifier is used when starting terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->