### PR TITLE
feat(projects): seed actions from user config

### DIFF
--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -30,6 +30,7 @@ import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSn
 import { OrchestrationLayerLive } from "../orchestration/runtimeLayer.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "../persistence/Layers/Sqlite.ts";
 import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
+import { loadUserProjectScripts } from "../project/UserProjectScripts.ts";
 import * as ServerRuntimeStartup from "../serverRuntimeStartup.ts";
 import {
   clearPersistedServerRuntimeState,
@@ -425,7 +426,13 @@ const runProjectMutation = Effect.fn("runProjectMutation")(function* (
       const orchestrationEngine = yield* OrchestrationEngine.OrchestrationEngineService;
       const output = yield* run({
         snapshot,
-        dispatch: (command) => orchestrationEngine.dispatch(command),
+        dispatch: (command) =>
+          command.type === "project.create"
+            ? loadUserProjectScripts(config.stateDir).pipe(
+                Effect.flatMap((scripts) => orchestrationEngine.dispatch({ ...command, scripts })),
+                Effect.asVoid,
+              )
+            : orchestrationEngine.dispatch(command).pipe(Effect.asVoid),
         mode: "offline",
       });
       yield* Console.log(output);

--- a/apps/server/src/orchestration/Normalizer.test.ts
+++ b/apps/server/src/orchestration/Normalizer.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vite-plus/test";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
 import {
   CommandId,
   type ClientOrchestrationCommand,
@@ -7,8 +8,13 @@ import {
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 
-import { canonicalizeClientCommandTimestamps } from "./Normalizer.ts";
+import * as ServerConfig from "../config.ts";
+import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import { canonicalizeClientCommandTimestamps, normalizeDispatchCommand } from "./Normalizer.ts";
 
 const clientCreatedAt = "2031-01-01T00:00:00.000Z";
 const serverReceivedAt = "2026-07-18T00:00:00.000Z";
@@ -71,3 +77,62 @@ describe("canonicalizeClientCommandTimestamps", () => {
     expect(result.bootstrap?.createThread?.createdAt).toBe(serverReceivedAt);
   });
 });
+
+it.effect("seeds project.create from the user t3.json instead of client input", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-normalizer-user-actions-",
+      });
+      const workspaceRoot = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-normalizer-project-",
+      });
+      yield* fileSystem.writeFileString(
+        path.join(stateDir, "t3.json"),
+        '{ "scripts": [{ "name": "Handoff", "command": "t3-handoff action" }] }',
+      );
+
+      const command: ClientOrchestrationCommand = {
+        type: "project.create",
+        commandId: CommandId.make("command-user-actions"),
+        projectId: ProjectId.make("project-user-actions"),
+        title: "User actions",
+        workspaceRoot,
+        scripts: [
+          {
+            id: "spoofed",
+            name: "Spoofed",
+            command: "false",
+            icon: "play",
+            runOnWorktreeCreate: false,
+          },
+        ],
+        createdAt: clientCreatedAt,
+      };
+
+      const normalized = yield* normalizeDispatchCommand(command).pipe(
+        Effect.provideService(ServerConfig.ServerConfig, { stateDir } as never),
+        Effect.provideService(WorkspacePaths.WorkspacePaths, {
+          normalizeWorkspaceRoot: (value) => Effect.succeed(value),
+          resolveRelativePathWithinRoot: () => Effect.die("unused"),
+        }),
+      );
+
+      expect(normalized.type).toBe("project.create");
+      if (normalized.type !== "project.create") {
+        throw new Error("Expected project.create");
+      }
+      expect(normalized.scripts).toEqual([
+        {
+          id: "handoff",
+          name: "Handoff",
+          command: "t3-handoff action",
+          icon: "play",
+          runOnWorktreeCreate: false,
+        },
+      ]);
+    }),
+  ).pipe(Effect.provide(NodeServices.layer)),
+);

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -19,6 +19,7 @@ import {
 } from "../attachmentStore.ts";
 import { ServerConfig } from "../config.ts";
 import { parseBase64DataUrl } from "../imageMime.ts";
+import { loadUserProjectScripts } from "../project/UserProjectScripts.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
 export const canonicalizeClientCommandTimestamps = (
@@ -116,6 +117,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
           canonicalCommand.createWorkspaceRootIfMissing,
         ),
         createWorkspaceRootIfMissing: canonicalCommand.createWorkspaceRootIfMissing === true,
+        scripts: yield* loadUserProjectScripts(serverConfig.stateDir),
       } satisfies OrchestrationCommand;
     }
 

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -42,6 +42,38 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
     }),
   );
 
+  it.effect("propagates seeded scripts on project.create", () =>
+    Effect.gen(function* () {
+      const now = "2026-01-01T00:00:00.000Z";
+      const scripts = [
+        {
+          id: "handoff",
+          name: "Handoff",
+          command: "t3-handoff action",
+          icon: "play" as const,
+          runOnWorktreeCreate: false,
+        },
+      ];
+
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "project.create",
+          commandId: CommandId.make("cmd-project-create-seeded-scripts"),
+          projectId: asProjectId("project-seeded-scripts"),
+          title: "Scripts",
+          workspaceRoot: "/tmp/seeded-scripts",
+          scripts,
+          createdAt: now,
+        },
+        readModel: createEmptyReadModel(now),
+      });
+
+      const event = Array.isArray(result) ? result[0] : result;
+      expect(event.type).toBe("project.created");
+      expect((event.payload as { scripts: unknown[] }).scripts).toEqual(scripts);
+    }),
+  );
+
   it.effect("propagates scripts in project.meta.update payload", () =>
     Effect.gen(function* () {
       const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -251,7 +251,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           workspaceRoot: command.workspaceRoot,
           defaultModelSelection: command.defaultModelSelection ?? null,
           faviconPath: null,
-          scripts: [],
+          scripts: command.scripts ?? [],
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },

--- a/apps/server/src/project/UserProjectScripts.test.ts
+++ b/apps/server/src/project/UserProjectScripts.test.ts
@@ -1,0 +1,102 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { loadUserProjectScripts } from "./UserProjectScripts.ts";
+
+it.layer(NodeServices.layer)("loadUserProjectScripts", (it) => {
+  const withStateDir = <A, E, R>(run: (stateDir: string) => Effect.Effect<A, E, R>) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3code-user-project-scripts-",
+        });
+        return yield* run(stateDir);
+      }),
+    );
+
+  describe("user t3.json", () => {
+    it.effect("returns no scripts when the file is missing", () =>
+      withStateDir((stateDir) =>
+        loadUserProjectScripts(stateDir).pipe(
+          Effect.tap((scripts) => Effect.sync(() => expect(scripts).toEqual([]))),
+        ),
+      ),
+    );
+
+    it.effect("loads scripts with stable ids and Action defaults", () =>
+      withStateDir((stateDir) =>
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* fileSystem.writeFileString(
+            path.join(stateDir, "t3.json"),
+            `{
+              "scripts": [
+                { "name": "Handoff", "command": "t3-handoff action" },
+                {
+                  "name": "Handoff",
+                  "command": "t3-handoff action --confirm",
+                  "icon": "configure",
+                  "runOnWorktreeCreate": true,
+                  "previewUrl": "http://localhost:5173",
+                  "autoOpenPreview": true
+                },
+                {
+                  "name": "Setup",
+                  "command": "pnpm install",
+                  "runOnWorktreeCreate": true
+                }
+              ]
+            }`,
+          );
+
+          const scripts = yield* loadUserProjectScripts(stateDir);
+
+          expect(scripts).toEqual([
+            {
+              id: "handoff",
+              name: "Handoff",
+              command: "t3-handoff action",
+              icon: "play",
+              runOnWorktreeCreate: false,
+            },
+            {
+              id: "handoff-2",
+              name: "Handoff",
+              command: "t3-handoff action --confirm",
+              icon: "configure",
+              runOnWorktreeCreate: false,
+              previewUrl: "http://localhost:5173",
+              autoOpenPreview: true,
+            },
+            {
+              id: "setup",
+              name: "Setup",
+              command: "pnpm install",
+              icon: "play",
+              runOnWorktreeCreate: true,
+            },
+          ]);
+        }),
+      ),
+    );
+
+    it.effect("ignores an invalid file", () =>
+      withStateDir((stateDir) =>
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* fileSystem.writeFileString(path.join(stateDir, "t3.json"), "{ not-json");
+
+          const scripts = yield* loadUserProjectScripts(stateDir);
+
+          expect(scripts).toEqual([]);
+        }),
+      ),
+    );
+  });
+});

--- a/apps/server/src/project/UserProjectScripts.ts
+++ b/apps/server/src/project/UserProjectScripts.ts
@@ -1,0 +1,17 @@
+import { projectScriptsFromFileScripts } from "@t3tools/shared/projectScripts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import * as T3ProjectFileLoader from "./T3ProjectFileLoader.ts";
+
+export const loadUserProjectScripts = Effect.fn("loadUserProjectScripts")(function* (
+  stateDir: string,
+) {
+  const loader = yield* T3ProjectFileLoader.make;
+  const projectFile = yield* loader.load(stateDir);
+
+  return Option.match(projectFile, {
+    onNone: () => [],
+    onSome: (file) => projectScriptsFromFileScripts(file.scripts ?? []),
+  });
+});

--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -132,6 +132,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
     const targets = yield* ServerRuntimeStartup.resolveAutoBootstrapWelcomeTargets.pipe(
       Effect.provideService(ServerConfig.ServerConfig, {
         cwd: "/tmp/startup-project",
+        stateDir: "/tmp/t3code-server-startup-user-actions-missing",
         autoBootstrapProjectFromCwd: true,
       } as never),
       Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
@@ -189,6 +190,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
     const targets = yield* ServerRuntimeStartup.resolveAutoBootstrapWelcomeTargets.pipe(
       Effect.provideService(ServerConfig.ServerConfig, {
         cwd: "/tmp/startup-project",
+        stateDir: "/tmp/t3code-server-startup-user-actions-missing",
         autoBootstrapProjectFromCwd: true,
       } as never),
       Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -37,6 +37,7 @@ import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import * as ProviderService from "./provider/Services/ProviderService.ts";
 import * as ProviderSessionDirectory from "./provider/Services/ProviderSessionDirectory.ts";
 import * as ProviderSessionReaper from "./provider/Services/ProviderSessionReaper.ts";
+import { loadUserProjectScripts } from "./project/UserProjectScripts.ts";
 import { forkParked } from "./serverActivation.ts";
 import * as ServiceLauncherClient from "./cloud/serviceLauncherClient.ts";
 import {
@@ -213,6 +214,7 @@ export const resolveAutoBootstrapWelcomeTargets = Effect.gen(function* () {
           title: bootstrapProjectTitle,
           workspaceRoot: serverConfig.cwd,
           defaultModelSelection: nextProjectDefaultModelSelection,
+          scripts: yield* loadUserProjectScripts(serverConfig.stateDir),
           createdAt,
         });
       } else {

--- a/apps/web/src/projectScripts.ts
+++ b/apps/web/src/projectScripts.ts
@@ -1,11 +1,12 @@
 import {
-  MAX_SCRIPT_ID_LENGTH,
   SCRIPT_RUN_COMMAND_PATTERN,
   type KeybindingCommand,
   type ProjectScript,
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 const isScriptRunCommand = Schema.is(SCRIPT_RUN_COMMAND_PATTERN);
+
+export { nextProjectScriptId } from "@t3tools/shared/projectScripts";
 
 export interface ProjectScriptInput {
   readonly name: ProjectScript["name"];
@@ -32,21 +33,6 @@ export function buildProjectScript(id: string, input: ProjectScriptInput): Proje
   };
 }
 
-function normalizeScriptId(value: string): string {
-  const cleaned = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  if (cleaned.length === 0) {
-    return "script";
-  }
-  if (cleaned.length <= MAX_SCRIPT_ID_LENGTH) {
-    return cleaned;
-  }
-  return cleaned.slice(0, MAX_SCRIPT_ID_LENGTH).replace(/-+$/g, "") || "script";
-}
-
 export const commandForProjectScript = (scriptId: string): KeybindingCommand =>
   SCRIPT_RUN_COMMAND_PATTERN.make(`script.${scriptId}.run`);
 
@@ -57,28 +43,6 @@ export function projectScriptIdFromCommand(command: string): string | null {
   }
   const [prefix, , suffix] = SCRIPT_RUN_COMMAND_PATTERN.parts;
   return trimmed.slice(prefix.literal.length, -suffix.literal.length);
-}
-
-export function nextProjectScriptId(name: string, existingIds: Iterable<string>): string {
-  const taken = new Set(Array.from(existingIds));
-  const baseId = normalizeScriptId(name);
-  if (!taken.has(baseId)) return baseId;
-
-  let suffix = 2;
-  while (suffix < 10_000) {
-    const candidate = `${baseId}-${suffix}`;
-    const safeCandidate =
-      candidate.length <= MAX_SCRIPT_ID_LENGTH
-        ? candidate
-        : `${baseId.slice(0, Math.max(1, MAX_SCRIPT_ID_LENGTH - String(suffix).length - 1))}-${suffix}`;
-    if (!taken.has(safeCandidate)) {
-      return safeCandidate;
-    }
-    suffix += 1;
-  }
-
-  // This last-resort fallback only triggers after exhausting thousands of suffixes.
-  return `${baseId}-${Date.now()}`.slice(0, MAX_SCRIPT_ID_LENGTH);
 }
 
 export function primaryProjectScript(scripts: ReadonlyArray<ProjectScript>): ProjectScript | null {

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -151,6 +151,15 @@ it.effect("trims branded ids and command string fields at decode boundaries", ()
         provider: "codex",
         model: " gpt-5.2 ",
       },
+      scripts: [
+        {
+          id: " handoff ",
+          name: " Handoff ",
+          command: " t3-handoff action ",
+          icon: "play",
+          runOnWorktreeCreate: false,
+        },
+      ],
       createdAt: "2026-01-01T00:00:00.000Z",
     });
     assert.strictEqual(parsed.commandId, "cmd-1");
@@ -162,6 +171,15 @@ it.effect("trims branded ids and command string fields at decode boundaries", ()
       instanceId: ProviderInstanceId.make("codex"),
       model: "gpt-5.2",
     });
+    assert.deepStrictEqual(parsed.scripts, [
+      {
+        id: "handoff",
+        name: "Handoff",
+        command: "t3-handoff action",
+        icon: "play",
+        runOnWorktreeCreate: false,
+      },
+    ]);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -709,6 +709,7 @@ export const ProjectCreateCommand = Schema.Struct({
   workspaceRoot: TrimmedNonEmptyString,
   createWorkspaceRootIfMissing: Schema.optional(Schema.Boolean),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
+  scripts: Schema.optional(Schema.Array(ProjectScript)),
   createdAt: IsoDateTime,
 });
 

--- a/packages/shared/src/projectScripts.ts
+++ b/packages/shared/src/projectScripts.ts
@@ -1,4 +1,8 @@
-import type { ProjectScript } from "@t3tools/contracts";
+import {
+  MAX_SCRIPT_ID_LENGTH,
+  type ProjectScript,
+  type T3ProjectFileScript,
+} from "@t3tools/contracts";
 
 interface ProjectScriptRuntimeEnvInput {
   project: {
@@ -34,4 +38,76 @@ export function projectScriptRuntimeEnv(
 
 export function setupProjectScript(scripts: readonly ProjectScript[]): ProjectScript | null {
   return scripts.find((script) => script.runOnWorktreeCreate) ?? null;
+}
+
+function normalizeProjectScriptId(value: string): string {
+  const cleaned = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (cleaned.length === 0) {
+    return "script";
+  }
+  if (cleaned.length <= MAX_SCRIPT_ID_LENGTH) {
+    return cleaned;
+  }
+  return cleaned.slice(0, MAX_SCRIPT_ID_LENGTH).replace(/-+$/g, "") || "script";
+}
+
+export function nextProjectScriptId(name: string, existingIds: Iterable<string>): string {
+  const taken = new Set(Array.from(existingIds));
+  const baseId = normalizeProjectScriptId(name);
+  if (!taken.has(baseId)) return baseId;
+
+  let suffix = 2;
+  while (true) {
+    const candidate = `${baseId}-${suffix}`;
+    const safeCandidate =
+      candidate.length <= MAX_SCRIPT_ID_LENGTH
+        ? candidate
+        : `${baseId.slice(0, Math.max(1, MAX_SCRIPT_ID_LENGTH - String(suffix).length - 1))}-${suffix}`;
+    if (!taken.has(safeCandidate)) {
+      return safeCandidate;
+    }
+    suffix += 1;
+  }
+}
+
+export function projectScriptsFromFileScripts(
+  fileScripts: ReadonlyArray<T3ProjectFileScript>,
+): ReadonlyArray<ProjectScript> {
+  const scripts: ProjectScript[] = [];
+
+  for (const fileScript of fileScripts) {
+    const runOnWorktreeCreate = fileScript.runOnWorktreeCreate ?? false;
+    if (runOnWorktreeCreate) {
+      for (let index = 0; index < scripts.length; index += 1) {
+        const script = scripts[index];
+        if (script?.runOnWorktreeCreate) {
+          scripts[index] = { ...script, runOnWorktreeCreate: false };
+        }
+      }
+    }
+
+    const id = nextProjectScriptId(
+      fileScript.name,
+      scripts.map((script) => script.id),
+    );
+    scripts.push({
+      id,
+      name: fileScript.name,
+      command: fileScript.command,
+      icon: fileScript.icon ?? "play",
+      runOnWorktreeCreate,
+      ...(fileScript.previewUrl === undefined
+        ? {}
+        : {
+            previewUrl: fileScript.previewUrl,
+            autoOpenPreview: fileScript.autoOpenPreview ?? false,
+          }),
+    });
+  }
+
+  return scripts;
 }


### PR DESCRIPTION
## Problem

Project Actions are scoped to one project, so users must recreate the same personal Action every time they add a repository. Discussion #6989 proposes a user-level `t3.json` as the source for defaults.

## Fix

- read `${stateDir}/t3.json` only when a project is created
- convert its scripts with the same IDs and defaults used by the existing Action import UI
- seed WebSocket/HTTP, auto-bootstrap, and offline CLI project creation paths
- treat missing or invalid user config as empty, leaving existing projects untouched

Client-supplied script defaults are replaced at the server normalization boundary.

## Tests

- `pnpm exec vp test run packages/contracts/src/orchestration.test.ts apps/web/src/projectScripts.test.ts apps/server/src/project/UserProjectScripts.test.ts apps/server/src/orchestration/Normalizer.test.ts apps/server/src/orchestration/decider.projectScripts.test.ts apps/server/src/serverRuntimeStartup.test.ts apps/server/src/cli/project.test.ts`
- targeted contracts, shared, web, and server typechecks
- targeted format and lint checks

Built with GPT-5.6 Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration dispatch normalization and project-create payloads; user-config scripts become executable Actions on every new project, though client script spoofing is explicitly blocked.
> 
> **Overview**
> New projects get **Project Actions** from the user-level **`${stateDir}/t3.json`** instead of starting empty or trusting the client. **`loadUserProjectScripts`** reads that file (missing/invalid → no scripts) and **`projectScriptsFromFileScripts`** in shared applies the same ID/default rules as the Action UI.
> 
> **`project.create`** normalization **overwrites** any client `scripts` with the server-loaded list (HTTP/WebSocket path). The decider persists **`command.scripts`** on **`project.created`**. The same seeding runs for **auto-bootstrap** startup and **offline CLI** `project add`.
> 
> **`ProjectCreateCommand`** gains optional **`scripts`**; **`nextProjectScriptId`** moves from web into **`@t3tools/shared/projectScripts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 557b66ec498e5b040432bcfe48c5055e2fea0c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed `project.create` actions from user `t3.json` config
> - Introduces `loadUserProjectScripts` in [UserProjectScripts.ts](https://github.com/pingdotgg/t3code/pull/8947/files#diff-ef3bae755c55438e1ea221bc1581d377ab164f5e52382915059cb007e1f560b1) to load and normalize scripts from `stateDir/t3.json`, returning `[]` when the file is missing
> - Adds `projectScriptsFromFileScripts` in [projectScripts.ts](https://github.com/pingdotgg/t3code/pull/8947/files#diff-bfddd6d50e315fe984b5e730f37beb0cb378cba7b4f505cbb2840dd965af64d5) to convert file script entries into runtime `ProjectScript` objects with default icon/runOnWorktreeCreate, enforced single-setup semantics, and stable non-colliding ids via a rewritten `nextProjectScriptId`
> - `normalizeDispatchCommand` in [Normalizer.ts](https://github.com/pingdotgg/t3code/pull/8947/files#diff-751e99c6b2a5986d684c4717507023bfb24d6250386e071d6b48dd195e10c5ea), the CLI dispatch in [project.ts](https://github.com/pingdotgg/t3code/pull/8947/files#diff-44f1264ca9e5b2f3994c44291b5616390842fc6345021ca54e8447fd8dbbc1cd), and `resolveAutoBootstrapWelcomeTargets` in [serverRuntimeStartup.ts](https://github.com/pingdotgg/t3code/pull/8947/files#diff-1930335d6e319fc5766e0578303e19f9d788e9990f87604b77f9f768e61d7118) all inject server-side scripts into `project.create` commands
> - `decideOrchestrationCommand` in [decider.ts](https://github.com/pingdotgg/t3code/pull/8947/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6) now emits `command.scripts ?? []` on `project.created` instead of an unconditional empty array
> - Risk: `normalizeDispatchCommand` replaces any client-provided scripts on `project.create` with server-loaded ones; verify no callers depend on passing scripts through the normalizer
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 557b66e. 8 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project creation now supports configured project scripts.
  * Scripts are automatically loaded from the project configuration file during project creation and bootstrapping.
  * Script identifiers are normalized and made unique automatically.
  * Project scripts support default icons, worktree startup behavior, preview URLs, and automatic preview opening.
  * Only one script can run automatically when a worktree is created.

* **Bug Fixes**
  * Preserves configured scripts in newly created projects instead of discarding them.
  * Invalid or missing project configuration files are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->