### PR TITLE
fix(server): cache the resolved git top level per workspace root

### DIFF
--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -25,6 +25,8 @@ const git = (cwd: string, args: ReadonlyArray<string>) =>
 const makeRepositoryIdentityResolverTestLayer = (options: {
   readonly positiveCacheTtl?: Duration.Input;
   readonly negativeCacheTtl?: Duration.Input;
+  readonly repositoryRootCacheTtl?: Duration.Input;
+  readonly repositoryRootNegativeCacheTtl?: Duration.Input;
 }) =>
   Layer.effect(
     RepositoryIdentityResolver.RepositoryIdentityResolver,
@@ -227,6 +229,58 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
           makeRepositoryIdentityResolverTestLayer({
             negativeCacheTtl: Duration.millis(50),
             positiveCacheTtl: Duration.millis(100),
+          }),
+        ),
+      ),
+    ),
+  );
+
+  it.effect("reuses the cached git top level instead of re-running rev-parse per resolve", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const repoRoot = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-repository-identity-root-cache-test-",
+      });
+      const nestedWorkspace = path.join(repoRoot, "packages", "web");
+
+      yield* fileSystem.makeDirectory(nestedWorkspace, { recursive: true });
+      yield* git(repoRoot, ["init"]);
+      yield* git(repoRoot, ["remote", "add", "origin", "git@github.com:T3Tools/t3code.git"]);
+
+      const resolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
+      const initialIdentity = yield* resolver.resolve(nestedWorkspace);
+      expect(initialIdentity?.canonicalKey).toBe("github.com/t3tools/t3code");
+
+      // Turning the nested workspace into its own repository changes what
+      // `git rev-parse --show-toplevel` reports. While the root stays cached the
+      // resolver must keep answering from the outer repository, which proves it
+      // did not spawn git again.
+      yield* git(nestedWorkspace, ["init"]);
+      yield* git(nestedWorkspace, [
+        "remote",
+        "add",
+        "origin",
+        "git@github.com:T3Tools/t3code-nested.git",
+      ]);
+
+      for (const _attempt of [1, 2, 3]) {
+        const cachedIdentity = yield* resolver.resolve(nestedWorkspace);
+        expect(cachedIdentity?.canonicalKey).toBe("github.com/t3tools/t3code");
+      }
+
+      yield* TestClock.adjust(Duration.millis(120));
+
+      const refreshedIdentity = yield* resolver.resolve(nestedWorkspace);
+      expect(refreshedIdentity?.canonicalKey).toBe("github.com/t3tools/t3code-nested");
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          TestClock.layer(),
+          makeRepositoryIdentityResolverTestLayer({
+            negativeCacheTtl: Duration.millis(50),
+            positiveCacheTtl: Duration.seconds(30),
+            repositoryRootCacheTtl: Duration.millis(50),
           }),
         ),
       ),

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -13,13 +13,17 @@ import * as Layer from "effect/Layer";
 import * as ProcessRunner from "../processRunner.ts";
 
 const DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY = 512;
-const DEFAULT_POSITIVE_CACHE_TTL = Duration.minutes(1);
+const DEFAULT_POSITIVE_CACHE_TTL = Duration.minutes(10);
 const DEFAULT_NEGATIVE_CACHE_TTL = Duration.minutes(1);
+const DEFAULT_REPOSITORY_ROOT_CACHE_TTL = Duration.minutes(10);
+const DEFAULT_REPOSITORY_ROOT_NEGATIVE_CACHE_TTL = Duration.minutes(1);
 
 export interface RepositoryIdentityResolverOptions {
   readonly cacheCapacity?: number;
   readonly positiveCacheTtl?: Duration.Input;
   readonly negativeCacheTtl?: Duration.Input;
+  readonly repositoryRootCacheTtl?: Duration.Input;
+  readonly repositoryRootNegativeCacheTtl?: Duration.Input;
 }
 
 export class RepositoryIdentityResolver extends Context.Service<
@@ -87,10 +91,9 @@ function buildRepositoryIdentity(input: {
   };
 }
 
-const resolveRepositoryIdentityCacheKey = Effect.fn("RepositoryIdentityResolver.resolveCacheKey")(
+const resolveRepositoryRoot = Effect.fn("RepositoryIdentityResolver.resolveRepositoryRoot")(
   function* (cwd: string) {
     const processRunner = yield* ProcessRunner.ProcessRunner;
-    let cacheKey = cwd;
 
     // git is a real executable on every platform — no cmd.exe shell mode, which
     // would split paths containing spaces during cmd's re-tokenization.
@@ -102,15 +105,11 @@ const resolveRepositoryIdentityCacheKey = Effect.fn("RepositoryIdentityResolver.
       })
       .pipe(Effect.option);
     if (topLevelResult._tag === "None" || topLevelResult.value.code !== 0) {
-      return cacheKey;
+      return null;
     }
 
     const candidate = topLevelResult.value.stdout.trim();
-    if (candidate.length > 0) {
-      cacheKey = candidate;
-    }
-
-    return cacheKey;
+    return candidate.length > 0 ? candidate : null;
   },
 );
 
@@ -140,6 +139,28 @@ export const make = Effect.fn("RepositoryIdentityResolver.make")(function* (
 ) {
   const processRunner = yield* ProcessRunner.ProcessRunner;
 
+  // Every workspace root maps to the same git top level for the life of the
+  // checkout, but resolving it costs one `git rev-parse` process. Snapshot
+  // reads resolve every project on each call, so an uncached lookup spawns one
+  // process per project per read and dominates snapshot latency on a busy
+  // machine. Cache the mapping alongside the identity it keys.
+  const repositoryRootCache = yield* Cache.makeWith<string, string | null>(
+    (cwd) =>
+      resolveRepositoryRoot(cwd).pipe(
+        Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+      ),
+    {
+      capacity: options.cacheCapacity ?? DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY,
+      timeToLive: Exit.match({
+        onSuccess: (value) =>
+          value === null
+            ? (options.repositoryRootNegativeCacheTtl ?? DEFAULT_REPOSITORY_ROOT_NEGATIVE_CACHE_TTL)
+            : (options.repositoryRootCacheTtl ?? DEFAULT_REPOSITORY_ROOT_CACHE_TTL),
+        onFailure: () => Duration.zero,
+      }),
+    },
+  );
+
   const repositoryIdentityCache = yield* Cache.makeWith<string, RepositoryIdentity | null>(
     (cacheKey) =>
       resolveRepositoryIdentityFromCacheKey(cacheKey).pipe(
@@ -160,10 +181,8 @@ export const make = Effect.fn("RepositoryIdentityResolver.make")(function* (
   const resolve: RepositoryIdentityResolver["Service"]["resolve"] = Effect.fn(
     "RepositoryIdentityResolver.resolve",
   )(function* (cwd) {
-    const cacheKey = yield* resolveRepositoryIdentityCacheKey(cwd).pipe(
-      Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
-    );
-    return yield* Cache.get(repositoryIdentityCache, cacheKey);
+    const repositoryRoot = yield* Cache.get(repositoryRootCache, cwd);
+    return yield* Cache.get(repositoryIdentityCache, repositoryRoot ?? cwd);
   });
 
   return RepositoryIdentityResolver.of({ resolve });


### PR DESCRIPTION
Fixes #8949.

## Problem

`RepositoryIdentityResolver.resolve(cwd)` has two steps. Step two, `git remote -v`, is cached behind `repositoryIdentityCache`. Step one, `resolveRepositoryIdentityCacheKey`, runs `git rev-parse --show-toplevel` to derive that cache's key, and is not cached at all.

`ProjectionSnapshotQuery.resolveRepositoryIdentitiesForProjects` resolves every active project on every call, at concurrency 4. So the cache never prevents a spawn. On an install with 34 projects, each snapshot read spawns 34 `git` processes no matter how warm the cache is, and `getShellSnapshot` runs on every client bootstrap and reconnect.

A traced `shellSnapshot` on that install took 32.9 s, of which 32.5 s was inside `resolveRepositoryIdentitiesForProjects`, split across 34 `resolve` calls of 4 to 6.5 s each. SQL was not involved: across 117,031 `sql.execute` spans in the same window, p99 was 16 ms and nothing exceeded 1 s.

`DEFAULT_POSITIVE_CACHE_TTL` was also `Duration.minutes(1)`, so step two re-spawned for every root at least once a minute.

## Fix

Cache the workspace-root-to-top-level mapping in its own `repositoryRootCache`, alongside the identity it keys. `resolveRepositoryRoot` now returns `string | null` rather than falling back to `cwd`, so the null case can carry its own TTL.

Raise `DEFAULT_POSITIVE_CACHE_TTL` to 10 minutes. A remote URL change now surfaces in up to 10 minutes instead of 1. The negative TTL stays at 1 minute, so a fresh `git init` is still picked up quickly.

Measured on the install above, restarting the server with this change:

| | before | after |
|---|---|---|
| `environment.orchestration.shellSnapshot` | 32,954 ms | 1,744 ms |
| `resolveRepositoryIdentitiesForProjects` | 32,499 ms | 1,638 ms |

Both after-figures are the cold startup run. Seven minutes in, 63 `resolve` calls had produced exactly 34 `resolveRepositoryRoot` spans, one per distinct root, and no more.

The added test turns a nested workspace into its own repository after the first resolve. While the root stays cached the resolver keeps answering from the outer repository, which is only possible if it did not spawn git again; past the TTL it picks up the inner one.

## Verification

- `vp test run apps/server/src/project/RepositoryIdentityResolver.test.ts` — 8 passed
- `vp test run apps/server/src/project` — 35 passed
- `vp test run apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts` — 21 passed
- `tsgo --noEmit` in `apps/server` — clean

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-oriented caching in repository metadata resolution; remote or root changes may be stale until TTL expiry, with no auth or data-mutation impact.
> 
> **Overview**
> **Fixes snapshot/shell bootstrap slowness** by caching `git rev-parse --show-toplevel` per workspace cwd instead of spawning git on every `resolve`, which previously happened even when remote identity was already cached.
> 
> `RepositoryIdentityResolver` now uses a separate **`repositoryRootCache`** (configurable positive/negative TTLs, default 10m / 1m) ahead of the existing identity cache. Root lookup returns **`null`** when rev-parse fails rather than falling back to `cwd`. **`DEFAULT_POSITIVE_CACHE_TTL`** for resolved identities is raised from **1 minute to 10 minutes**.
> 
> A new test proves repeated resolves reuse the cached top level until TTL expiry (nested repo init does not change identity until the root cache refreshes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c71aa17fa131c150d3b5b65c740eaf7c8965dd9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache resolved git top level per workspace root in `RepositoryIdentityResolver`
> - Adds a `repositoryRootCache` keyed by cwd that stores the result of `git rev-parse --show-toplevel`, with separate TTLs for positive hits (`repositoryRootCacheTtl`, 10 min default) and negative results (`repositoryRootNegativeCacheTtl`, 1 min default).
> - `resolveRepositoryRoot` now returns `null` on failure instead of falling back to cwd, enabling distinct negative caching.
> - Increases `DEFAULT_POSITIVE_CACHE_TTL` for the identity cache from 1 minute to 10 minutes.
> - Risk: while the root cache is fresh, `resolve` may return the identity of a previously discovered parent repository even if a nested workspace later becomes its own repository, until the root cache entry expires. Reviewers should check the `repositoryRootCache` TTL configuration in [RepositoryIdentityResolver.ts](https://github.com/pingdotgg/t3code/pull/8950/files#diff-150725a1a7c2fad32a2af878e610161760c1d30b61e1fc4e4aaba35d01587171).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c71aa17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Repository identity resolution now reuses cached repository roots, reducing repeated checks.
  * Positive repository identity results remain cached longer by default.

* **Reliability**
  * Failed repository-root lookups are handled without incorrectly substituting the current directory.
  * Repository-root cache expiration ensures refreshed results when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->