### PR TITLE
fix(server): keep git repository detection cached for minutes

### DIFF
--- a/apps/server/src/vcs/VcsDriverRegistry.test.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.test.ts
@@ -1,7 +1,9 @@
 import { assert, it, describe } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import { TestClock } from "effect/testing";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as VcsProcess from "./VcsProcess.ts";
@@ -91,6 +93,54 @@ describe("VcsDriverRegistry", () => {
         ],
       );
     }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("keeps repository detection cached for minutes, not seconds", () => {
+    const calls: VcsProcess.VcsProcessInput[] = [];
+    const layer = Layer.effect(VcsDriverRegistry.VcsDriverRegistry, VcsDriverRegistry.make).pipe(
+      Layer.provide(NodeServices.layer),
+      Layer.provide(
+        Layer.mock(VcsProjectConfig.VcsProjectConfig)({
+          resolveKind: (input) => Effect.succeed(input.requestedKind ?? "auto"),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              calls.push(input);
+              const command = normalizeGitArgs(input.args).join(" ");
+              if (command === "rev-parse --is-inside-work-tree") {
+                return processOutput("true\n");
+              }
+              if (command === "rev-parse --show-toplevel") {
+                return processOutput("/repo\n");
+              }
+              if (command === "rev-parse --git-common-dir") {
+                return processOutput("/repo/.git\n");
+              }
+              return processOutput("");
+            }),
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+      yield* registry.resolve({ cwd: "/repo", requestedKind: "git" });
+      const callsAfterFirstResolve = calls.length;
+      assert.isAbove(callsAfterFirstResolve, 0);
+
+      // Detection used to expire after two seconds, so every later VCS call
+      // spawned git again for the same checkout.
+      yield* TestClock.adjust(Duration.minutes(1));
+      yield* registry.resolve({ cwd: "/repo", requestedKind: "git" });
+      assert.strictEqual(calls.length, callsAfterFirstResolve);
+
+      yield* TestClock.adjust(Duration.minutes(6));
+      yield* registry.resolve({ cwd: "/repo", requestedKind: "git" });
+      assert.isAbove(calls.length, callsAfterFirstResolve);
+    }).pipe(Effect.provide(Layer.merge(TestClock.layer(), layer)));
   });
 
   it.effect("detects a repository created after a negative lookup", () => {

--- a/apps/server/src/vcs/VcsDriverRegistry.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.ts
@@ -12,7 +12,12 @@ import * as VcsProjectConfig from "./VcsProjectConfig.ts";
 import * as VcsDriver from "./VcsDriver.ts";
 
 const DETECTION_CACHE_CAPACITY = 2_048;
-const DETECTION_CACHE_TTL = Duration.seconds(2);
+// Detection spawns three git processes per cwd. A two second window meant
+// every VCS call past that re-ran them, which dominates latency when many
+// projects refresh at once. Whether a directory is a git repository is stable,
+// and a negative result is still never cached, so `git init` is picked up at
+// once.
+const DETECTION_CACHE_TTL = Duration.minutes(5);
 
 export interface VcsDriverResolveInput {
   readonly cwd: string;


### PR DESCRIPTION
Refs #8949.

## Problem

`VcsDriverRegistry` caches repository detection for `Duration.seconds(2)`. `GitVcsDriver.detectRepository` spawns three git processes per cwd: `rev-parse --is-inside-work-tree`, `rev-parse --show-toplevel`, and `rev-parse --git-common-dir`. Any VCS call more than two seconds after the previous one re-runs all three for the same checkout, and nothing about a checkout's git-ness changes that fast.

Two seconds is an outlier in this layer. Every neighbouring cache in `GitVcsDriverCore.ts` is measured in minutes:

```
REPOSITORY_PATHS_CACHE_TTL      = Duration.minutes(10)
LIST_REFS_SNAPSHOT_CACHE_TTL    = Duration.minutes(2)
STATUS_DEFAULT_BRANCH_CACHE_TTL = Duration.minutes(5)
STATUS_ORIGIN_EXISTS_CACHE_TTL  = Duration.minutes(5)
```

On an install with 34 projects refreshing together, `VcsDriverRegistry.detect` was traced at 4.8 to 5.9 s while the spawns queued behind other git work.

## Fix

Raise `DETECTION_CACHE_TTL` to 5 minutes, matching the status caches next to it.

A negative result still gets `Duration.zero`, so it is never cached and a fresh `git init` is picked up on the very next call. The longer TTL only delays noticing that an existing repository changed kind or root, which is rare.

Measured after the change, 291 `detect` calls were served by 160 actual `detectRepository` runs. Before, each of the 291 would have re-run three git processes.

The added test asserts no new git process after one minute and re-detection after six, using `TestClock` and the call-counting `VcsProcess` mock already in that file.

## Verification

- `vp test run apps/server/src/vcs/VcsDriverRegistry.test.ts` — 4 passed
- `vp test run apps/server/src/vcs` — 102 passed
- `tsgo --noEmit` in `apps/server` — clean

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance tuning with bounded staleness (up to 5 minutes for positive detections); negative lookups and cache failure paths are unchanged.
> 
> **Overview**
> **Extends repository detection cache TTL** in `VcsDriverRegistry` from **2 seconds to 5 minutes**, so repeated `resolve`/`detect` for the same cwd does not keep spawning three `git rev-parse` processes. Comments in `VcsDriverRegistry.ts` document the latency motivation and that **failed (non-repo) lookups are still uncached** (`Duration.zero`), so new `git init` is detected on the next call.
> 
> Adds **`TestClock` coverage** in `VcsDriverRegistry.test.ts`: after the first resolve, advancing **1 minute** must not increase mocked git calls; advancing **6 more minutes** must trigger re-detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2523d1dfe2ce7f15d2eb77a9db849df446759cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `VcsDriverRegistry` repository detection cache TTL from 2s to 5m
> Changes `DETECTION_CACHE_TTL` in [VcsDriverRegistry.ts](https://github.com/pingdotgg/t3code/pull/8951/files#diff-e0c0a0d3c1b8820cd3f921f4ab4a39bc4d709d265ee76ac53b0380ff8f88b5f4) from `Duration.seconds(2)` to `Duration.minutes(5)` to reduce redundant git process spawning. Adds a `TestClock`-based test in [VcsDriverRegistry.test.ts](https://github.com/pingdotgg/t3code/pull/8951/files#diff-6800374e0ad08ac06f233cf660cdc696b7fd268f0f53858c96147dcd98a92993) that verifies detection results stay cached for at least 1 minute and expire by ~7 minutes of simulated time. Behavioral Change: stale repository detection results may persist up to 5 minutes instead of 2 seconds before re-detection runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2523d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Repository detection results are now cached for up to five minutes, reducing repeated detection operations.
  - Cached results remain available during normal short-term use and refresh automatically after the cache expires.
  - This reduces unnecessary repeated repository checks while ensuring detection information is refreshed periodically.

- **Tests**
  - Added coverage verifying that cached detection results remain valid during the cache window and that detection runs again after expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->