### PR TITLE
fix(preview): restore browser tab recording via display media handler

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -11,7 +11,6 @@ import {
   DesktopPreviewConfigInputSchema,
   DesktopPreviewNavigateInputSchema,
   DesktopPreviewRecordingArtifactSchema,
-  DesktopPreviewRecordingSourceSchema,
   DesktopPreviewRecordingSaveInputSchema,
   DesktopPreviewRegisterWebviewInputSchema,
   DesktopPreviewScreenshotArtifactSchema,
@@ -174,15 +173,11 @@ export const cancelPickElement = tabMethod(
   "desktop.ipc.preview.cancelPickElement",
   (manager, tabId) => manager.cancelPickElement(tabId),
 );
-export const startRecording = DesktopIpc.makeIpcMethod({
-  channel: IpcChannels.PREVIEW_RECORDING_START_CHANNEL,
-  payload: DesktopPreviewTabInputSchema,
-  result: DesktopPreviewRecordingSourceSchema,
-  handler: Effect.fn("desktop.ipc.preview.startRecording")(function* ({ tabId }) {
-    const manager = yield* PreviewManager.PreviewManager;
-    return yield* manager.startRecording(tabId);
-  }),
-});
+export const startRecording = tabMethod(
+  IpcChannels.PREVIEW_RECORDING_START_CHANNEL,
+  "desktop.ipc.preview.startRecording",
+  (manager, tabId) => manager.startRecording(tabId),
+);
 export const stopRecording = tabMethod(
   IpcChannels.PREVIEW_RECORDING_STOP_CHANNEL,
   "desktop.ipc.preview.stopRecording",

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -270,6 +270,40 @@ const makeTestPreviewWebContents = (
     capturePage,
   }) as never;
 
+/** Two ready tabs (41, 42) sharing one window, so they contend for the single display-media slot. */
+const setupRecordingRaceTabs = (manager: PreviewManager.PreviewManager["Service"]) =>
+  Effect.gen(function* () {
+    const capturePage = vi.fn(async () => ({
+      toJPEG: () => Buffer.from("unused-recording-frame"),
+      getSize: () => ({ width: 1280, height: 720 }),
+    }));
+    const host = makeTestHostWebContents();
+    const makeWebContents = (id: number) =>
+      Object.assign(makeTestPreviewWebContents(capturePage, id, host), {
+        executeJavaScript: vi.fn(async () => ({ width: 1280, height: 720 })),
+      });
+    const webContentsById = new Map([
+      [41, makeWebContents(41)],
+      [42, makeWebContents(42)],
+    ]);
+    fromId.mockImplementation((id) =>
+      id === undefined ? null : (webContentsById.get(id) ?? null),
+    );
+    yield* manager.createTab("tab_race_a");
+    yield* manager.createTab("tab_race_b");
+    yield* manager.registerWebview("tab_race_a", 41);
+    yield* manager.registerWebview("tab_race_b", 42);
+    const grants: Array<{ video?: unknown }> = [];
+    return {
+      host,
+      grants,
+      takeGrant: () =>
+        host.displayMediaHandler()?.({}, (value) => {
+          grants.push(value);
+        }),
+    };
+  });
+
 const TEST_FAVICON = "data:image/png;base64,cG5n";
 
 const makeSourcePng = (width = 1, height = 1): Buffer => {
@@ -1900,9 +1934,10 @@ describe("PreviewManager", () => {
           toJPEG: () => Buffer.from("recording-frame"),
           getSize: () => ({ width: 1280, height: 720 }),
         }));
+        const host = makeTestHostWebContents();
         const webContentsById = new Map([
-          [41, makeTestPreviewWebContents(capturePage, 41)],
-          [42, makeTestPreviewWebContents(capturePage, 42)],
+          [41, makeTestPreviewWebContents(capturePage, 41, host)],
+          [42, makeTestPreviewWebContents(capturePage, 42, host)],
         ]);
         fromId.mockImplementation((id) =>
           id === undefined ? null : (webContentsById.get(id) ?? null),
@@ -1919,6 +1954,8 @@ describe("PreviewManager", () => {
         } as never);
 
         yield* manager.startRecording("tab_capture_throttling_1");
+        // The first renderer takes its grant, freeing the arm slot for the second tab.
+        host.displayMediaHandler()?.({}, () => {});
         yield* manager.startRecording("tab_capture_throttling_2");
         expect(setBackgroundThrottling.mock.calls).toEqual([[false]]);
 
@@ -2102,7 +2139,7 @@ describe("PreviewManager", () => {
     ),
   );
 
-  effectIt.effect("returns native media sources for concurrent preview recordings", () =>
+  effectIt.effect("grants each concurrent preview recording its own tab frame", () =>
     withManager((manager) =>
       Effect.gen(function* () {
         const firstJpeg = Buffer.from("first-recording-frame");
@@ -2117,6 +2154,8 @@ describe("PreviewManager", () => {
         }));
         const firstSendCommand = vi.fn(async () => undefined);
         const secondSendCommand = vi.fn(async () => undefined);
+        // Both webviews live in the same window, so they share one display-media handler.
+        const host = makeTestHostWebContents();
         const makeWebContents = (
           id: number,
           capturePage: typeof firstCapturePage,
@@ -2125,7 +2164,7 @@ describe("PreviewManager", () => {
           ({
             id,
             mainFrame: { routingId: id },
-            hostWebContents: makeTestHostWebContents(),
+            hostWebContents: host,
             executeJavaScript: vi.fn(async () =>
               id === 41 ? { width: 800, height: 600 } : { width: 390, height: 844 },
             ),
@@ -2164,10 +2203,18 @@ describe("PreviewManager", () => {
         yield* manager.createTab("tab_2");
         yield* manager.registerWebview("tab_1", 41);
         yield* manager.registerWebview("tab_2", 42);
-        yield* Effect.all([manager.startRecording("tab_1"), manager.startRecording("tab_2")], {
-          concurrency: 2,
-          discard: true,
-        });
+
+        const grants: Array<{ video?: unknown }> = [];
+        const takeGrant = () =>
+          host.displayMediaHandler()?.({}, (value) => {
+            grants.push(value);
+          });
+
+        yield* manager.startRecording("tab_1");
+        takeGrant();
+        yield* manager.startRecording("tab_2");
+        takeGrant();
+        expect(grants).toEqual([{ video: { routingId: 41 } }, { video: { routingId: 42 } }]);
 
         expect(firstCapturePage).toHaveBeenCalledOnce();
         expect(secondCapturePage).toHaveBeenCalledOnce();
@@ -2184,6 +2231,64 @@ describe("PreviewManager", () => {
           concurrency: 2,
           discard: true,
         });
+      }),
+    ),
+  );
+
+  // Runs on the real clock: an earlier queueing design only settled under TestClock and stalled the
+  // losing start forever in the desktop app.
+  effectIt.live("settles both starts when two tabs race for the capture stream", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const { host, grants, takeGrant } = yield* setupRecordingRaceTabs(manager);
+
+        const exits = yield* Effect.all(
+          [
+            Effect.exit(manager.startRecording("tab_race_a")),
+            Effect.exit(manager.startRecording("tab_race_b")),
+          ],
+          { concurrency: 2 },
+        );
+
+        const [exitA, exitB] = exits;
+        // Exactly one start owns the stream; the other fails fast instead of hanging.
+        expect(exits.filter(Exit.isSuccess)).toHaveLength(1);
+        const loserExit = Exit.isSuccess(exitA) ? exitB : exitA;
+        if (Exit.isSuccess(loserExit)) return;
+        expect(Option.getOrThrow(Cause.findErrorOption(loserExit.cause))).toMatchObject({
+          _tag: "PreviewRecordingArmConflictError",
+        });
+
+        // The single grant goes to the tab that actually won the slot, never the other one.
+        takeGrant();
+        expect(grants).toEqual([{ video: { routingId: Exit.isSuccess(exitA) ? 41 : 42 } }]);
+        expect(host.session.setDisplayMediaRequestHandler).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect("releases an armed slot that the renderer never redeemed", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const { grants, takeGrant } = yield* setupRecordingRaceTabs(manager);
+
+        yield* manager.startRecording("tab_race_a");
+        const blocked = yield* Effect.exit(manager.startRecording("tab_race_b"));
+        if (Exit.isSuccess(blocked)) throw new Error("expected the second tab to be refused");
+        expect(Option.getOrThrow(Cause.findErrorOption(blocked.cause))).toMatchObject({
+          _tag: "PreviewRecordingArmConflictError",
+          tabId: "tab_race_b",
+          armedTabId: "tab_race_a",
+        });
+
+        // Nothing ever captured the armed tab, so the slot goes stale and stops blocking starts.
+        yield* TestClock.adjust(10_000);
+        yield* manager.startRecording("tab_race_b");
+        takeGrant();
+        expect(grants).toEqual([{ video: { routingId: 42 } }]);
+
+        yield* manager.stopRecording("tab_race_a");
+        yield* manager.stopRecording("tab_race_b");
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -209,14 +209,41 @@ interface TestCapturedPreviewImage {
   readonly getSize: () => { readonly width: number; readonly height: number };
 }
 
+type TestDisplayMediaHandler = (
+  request: unknown,
+  callback: (streams: { video?: unknown }) => void,
+) => void;
+
+interface TestHostWebContents {
+  readonly id: number;
+  readonly session: {
+    readonly setDisplayMediaRequestHandler: ReturnType<typeof vi.fn>;
+  };
+  readonly displayMediaHandler: () => TestDisplayMediaHandler | undefined;
+}
+
+const makeTestHostWebContents = (): TestHostWebContents => {
+  let handler: TestDisplayMediaHandler | undefined;
+  return {
+    id: 7,
+    session: {
+      setDisplayMediaRequestHandler: vi.fn((next: TestDisplayMediaHandler) => {
+        handler = next;
+      }),
+    },
+    displayMediaHandler: () => handler,
+  };
+};
+
 const makeTestPreviewWebContents = (
   capturePage: () => Promise<TestCapturedPreviewImage>,
   id = 42,
+  hostWebContents: TestHostWebContents = makeTestHostWebContents(),
 ) =>
   ({
     id,
-    hostWebContents: { id: 7 },
-    getMediaSourceId: vi.fn(() => `tab:${id}`),
+    mainFrame: { routingId: id },
+    hostWebContents,
     executeJavaScript: vi.fn(async () => ({ width: 1280, height: 720 })),
     isDestroyed: () => false,
     getType: () => "webview",
@@ -2097,8 +2124,8 @@ describe("PreviewManager", () => {
         ) =>
           ({
             id,
-            hostWebContents: { id: 7 },
-            getMediaSourceId: vi.fn(() => `tab:${id}`),
+            mainFrame: { routingId: id },
+            hostWebContents: makeTestHostWebContents(),
             executeJavaScript: vi.fn(async () =>
               id === 41 ? { width: 800, height: 600 } : { width: 390, height: 844 },
             ),
@@ -2137,15 +2164,11 @@ describe("PreviewManager", () => {
         yield* manager.createTab("tab_2");
         yield* manager.registerWebview("tab_1", 41);
         yield* manager.registerWebview("tab_2", 42);
-        const sources = yield* Effect.all(
-          [manager.startRecording("tab_1"), manager.startRecording("tab_2")],
-          { concurrency: 2 },
-        );
+        yield* Effect.all([manager.startRecording("tab_1"), manager.startRecording("tab_2")], {
+          concurrency: 2,
+          discard: true,
+        });
 
-        expect(sources).toEqual([
-          { sourceId: "tab:41", width: 800, height: 600 },
-          { sourceId: "tab:42", width: 390, height: 844 },
-        ]);
         expect(firstCapturePage).toHaveBeenCalledOnce();
         expect(secondCapturePage).toHaveBeenCalledOnce();
         expect(firstSendCommand).not.toHaveBeenCalledWith(
@@ -2171,23 +2194,24 @@ describe("PreviewManager", () => {
         const capturePage = vi.fn(async () => {
           throw new Error("source is not ready");
         });
-        const getMediaSourceId = vi.fn(() => "tab:42");
-        const webContents = Object.assign(makeTestPreviewWebContents(capturePage), {
+        const host = makeTestHostWebContents();
+        const webContents = Object.assign(makeTestPreviewWebContents(capturePage, 42, host), {
           executeJavaScript: vi.fn(async () => ({ width: 1280, height: 720 })),
-          getMediaSourceId,
         });
         fromId.mockReturnValue(webContents);
 
         yield* manager.createTab("tab_recording_warmup_failure");
         yield* manager.registerWebview("tab_recording_warmup_failure", 42);
 
-        expect(yield* manager.startRecording("tab_recording_warmup_failure")).toEqual({
-          sourceId: "tab:42",
-          width: 1280,
-          height: 720,
-        });
+        yield* manager.startRecording("tab_recording_warmup_failure");
         expect(capturePage).toHaveBeenCalledTimes(2);
-        expect(getMediaSourceId).toHaveBeenCalledOnce();
+
+        // The armed tab answers exactly one display-media request, then further requests are denied.
+        const handler = host.displayMediaHandler();
+        const streams: Array<{ video?: unknown }> = [];
+        handler?.({}, (value) => streams.push(value));
+        handler?.({}, (value) => streams.push(value));
+        expect(streams).toEqual([{ video: { routingId: 42 } }, {}]);
 
         yield* manager.stopRecording("tab_recording_warmup_failure");
       }),
@@ -2201,10 +2225,9 @@ describe("PreviewManager", () => {
           toJPEG: () => Buffer.from("unused-recording-frame"),
           getSize: () => ({ width: 1280, height: 720 }),
         }));
-        const getMediaSourceId = vi.fn(() => "tab:42");
-        const webContents = Object.assign(makeTestPreviewWebContents(capturePage), {
+        const host = makeTestHostWebContents();
+        const webContents = Object.assign(makeTestPreviewWebContents(capturePage, 42, host), {
           executeJavaScript: vi.fn(async () => ({ width: 0, height: 720 })),
-          getMediaSourceId,
         });
         fromId.mockReturnValue(webContents);
 
@@ -2219,7 +2242,7 @@ describe("PreviewManager", () => {
           tabId: "tab_invalid_recording_size",
           webContentsId: 42,
         });
-        expect(getMediaSourceId).not.toHaveBeenCalled();
+        expect(host.session.setDisplayMediaRequestHandler).not.toHaveBeenCalled();
       }),
     ),
   );
@@ -2272,11 +2295,7 @@ describe("PreviewManager", () => {
         rejectFirstMeasurement(new Error("first measurement failed"));
         const firstExit = yield* Fiber.await(firstStart);
         expect(Exit.isFailure(firstExit)).toBe(true);
-        expect(yield* Fiber.join(secondStart)).toEqual({
-          sourceId: "tab:42",
-          width: 1280,
-          height: 720,
-        });
+        yield* Fiber.join(secondStart);
 
         yield* manager.stopRecording("tab_recording_start_race");
         expect(setBackgroundThrottling.mock.calls).toEqual([[false], [true], [false], [true]]);
@@ -2329,11 +2348,7 @@ describe("PreviewManager", () => {
         expect(replacementOn).not.toHaveBeenCalled();
 
         finishMeasurement({ width: 1280, height: 720 });
-        expect(yield* Fiber.join(start)).toEqual({
-          sourceId: "tab:42",
-          width: 1280,
-          height: 720,
-        });
+        yield* Fiber.join(start);
         yield* Fiber.join(replacement);
         expect(replacementOn).toHaveBeenCalled();
         yield* manager.stopRecording("tab_recording_replacement_race");
@@ -2345,7 +2360,9 @@ describe("PreviewManager", () => {
     withManager((manager) =>
       Effect.gen(function* () {
         const setBackgroundThrottling = vi.fn();
-        const mainWindowWebContents = { setBackgroundThrottling };
+        const mainWindowWebContents = Object.assign(makeTestHostWebContents(), {
+          setBackgroundThrottling,
+        });
         const jpeg = Buffer.from("shared-preview-frame");
         const capturePage = vi.fn(async () => ({
           toJPEG: () => jpeg,
@@ -2353,8 +2370,8 @@ describe("PreviewManager", () => {
         }));
         fromId.mockReturnValue({
           id: 42,
+          mainFrame: { routingId: 42 },
           hostWebContents: mainWindowWebContents,
-          getMediaSourceId: vi.fn(() => "tab:42"),
           executeJavaScript: vi.fn(async () => ({ width: 1280, height: 720 })),
           isDestroyed: () => false,
           getType: () => "webview",

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -278,9 +278,11 @@ const setupRecordingRaceTabs = (manager: PreviewManager.PreviewManager["Service"
       getSize: () => ({ width: 1280, height: 720 }),
     }));
     const host = makeTestHostWebContents();
+    const destroyedIds = new Set<number>();
     const makeWebContents = (id: number) =>
       Object.assign(makeTestPreviewWebContents(capturePage, id, host), {
         executeJavaScript: vi.fn(async () => ({ width: 1280, height: 720 })),
+        isDestroyed: () => destroyedIds.has(id),
       });
     const webContentsById = new Map([
       [41, makeWebContents(41)],
@@ -297,6 +299,7 @@ const setupRecordingRaceTabs = (manager: PreviewManager.PreviewManager["Service"
     return {
       host,
       grants,
+      destroy: (id: number) => destroyedIds.add(id),
       takeGrant: () =>
         host.displayMediaHandler()?.({}, (value) => {
           grants.push(value);
@@ -2288,6 +2291,38 @@ describe("PreviewManager", () => {
         expect(grants).toEqual([{ video: { routingId: 42 } }]);
 
         yield* manager.stopRecording("tab_race_a");
+        yield* manager.stopRecording("tab_race_b");
+      }),
+    ),
+  );
+
+  effectIt.effect("denies a display-media request that arrives after the arm went stale", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const { grants, takeGrant } = yield* setupRecordingRaceTabs(manager);
+
+        yield* manager.startRecording("tab_race_a");
+        yield* TestClock.adjust(10_000);
+        // The handler cannot read a clock, so the expiry fiber must have dropped the frame.
+        takeGrant();
+        expect(grants).toEqual([{}]);
+
+        yield* manager.stopRecording("tab_race_a");
+      }),
+    ),
+  );
+
+  effectIt.effect("reclaims the arm slot from a destroyed webContents", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const { grants, takeGrant, destroy } = yield* setupRecordingRaceTabs(manager);
+
+        yield* manager.startRecording("tab_race_a");
+        destroy(41);
+        yield* manager.startRecording("tab_race_b");
+        takeGrant();
+        expect(grants).toEqual([{ video: { routingId: 42 } }]);
+
         yield* manager.stopRecording("tab_race_b");
       }),
     ),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3135,6 +3135,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (
       previous !== null &&
       previous.tabId !== tabId &&
+      !previous.webContents.isDestroyed() &&
       now - previous.armedAtMillis < RECORDING_ARM_GRACE_MS
     ) {
       return yield* new PreviewRecordingArmConflictError({
@@ -3143,7 +3144,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         armedTabId: previous.tabId,
       });
     }
-    pendingRecording = { tabId, webContents: wc, armedAtMillis: now };
+    const armed: PendingRecording = { tabId, webContents: wc, armedAtMillis: now };
+    pendingRecording = armed;
+    // The handler callback is sync and cannot read a clock, so expiry is driven from here.
+    // Identity compare: a re-arm replaces the object, and this fiber must not clobber it.
+    yield* Effect.forkIn(
+      Effect.sleep(RECORDING_ARM_GRACE_MS).pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            if (pendingRecording === armed) pendingRecording = null;
+          }),
+        ),
+      ),
+      parentScope,
+    );
   });
 
   // Installed once per session: answers the renderer's `getDisplayMedia()` with the tab that

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -111,6 +111,8 @@ const MAX_SCREENSHOT_WIDTH = 1280;
 /** Readiness probe: a tab that reports a positive viewport is scriptable and ready to capture. */
 const RECORDING_SOURCE_SIZE_EXPRESSION =
   "({ width: Math.round(globalThis.innerWidth), height: Math.round(globalThis.innerHeight) })";
+/** How long an armed tab keeps the exclusive display-media slot before another tab may take it. */
+const RECORDING_ARM_GRACE_MS = 10_000;
 const PICTURE_IN_PICTURE_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
 const PICTURE_IN_PICTURE_JPEG_QUALITY = 80;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
@@ -400,6 +402,13 @@ interface PictureInPictureSession {
   readonly initializationScope: Scope.Closeable;
 }
 
+/** The tab whose frame the next `getDisplayMedia()` request is allowed to capture. */
+interface PendingRecording {
+  readonly tabId: string;
+  readonly webContents: Electron.WebContents;
+  readonly armedAtMillis: number;
+}
+
 interface PickSession {
   readonly cancel: Effect.Effect<void>;
 }
@@ -594,10 +603,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   // Tab recording uses `setDisplayMediaRequestHandler` because Electron's legacy
   // `getMediaSourceId` + `chromeMediaSource: "tab"` capture path was removed upstream
   // (electron#44618) and now always rejects with NotAllowedError.
-  let pendingRecording: {
-    readonly tabId: string;
-    readonly webContents: Electron.WebContents;
-  } | null = null;
+  let pendingRecording: PendingRecording | null = null;
   const displayMediaHandlerSessions = new WeakSet<Session>();
   let frameCaptureWindowOpen = true;
   let currentMainWindow: BrowserWindow | undefined;
@@ -1897,6 +1903,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
 
   const closeTabUnlocked = Effect.fn("PreviewManager.closeTabUnlocked")(function* (tabId: string) {
     if (!(yield* SynchronizedRef.get(tabsRef)).has(tabId)) return;
+    clearPendingRecording(tabId);
     yield* Effect.all(
       [
         cancelPickElement(tabId),
@@ -3112,6 +3119,33 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (pendingRecording?.tabId === tabId) pendingRecording = null;
   };
 
+  /**
+   * Claims the single arm slot for `tabId`. A display-media request carries no tab identity, so the
+   * slot is exclusive: a second tab arming before the first request lands would redirect the first
+   * renderer's stream. Rather than queue (which can only ever stall a start), a colliding start
+   * fails fast and the renderer can retry. An arm the renderer never redeemed goes stale after
+   * `RECORDING_ARM_GRACE_MS` so it cannot hold the slot forever.
+   */
+  const armPendingRecording = Effect.fn("PreviewManager.armPendingRecording")(function* (
+    tabId: string,
+    wc: Electron.WebContents,
+  ) {
+    const now = yield* Clock.currentTimeMillis;
+    const previous = pendingRecording;
+    if (
+      previous !== null &&
+      previous.tabId !== tabId &&
+      now - previous.armedAtMillis < RECORDING_ARM_GRACE_MS
+    ) {
+      return yield* new PreviewRecordingArmConflictError({
+        tabId,
+        webContentsId: wc.id,
+        armedTabId: previous.tabId,
+      });
+    }
+    pendingRecording = { tabId, webContents: wc, armedAtMillis: now };
+  });
+
   // Installed once per session: answers the renderer's `getDisplayMedia()` with the tab that
   // `startRecording` armed, and denies anything else so pages cannot capture on their own.
   const installDisplayMediaRequestHandler = (session: Session) => {
@@ -3182,7 +3216,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           });
         }
         installDisplayMediaRequestHandler(requestWebContents.session);
-        pendingRecording = { tabId, webContents: wc };
+        yield* armPendingRecording(tabId, wc);
       }).pipe(
         Effect.onError(() => {
           clearPendingRecording(tabId);
@@ -3193,8 +3227,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   });
 
   const stopRecording = Effect.fn("PreviewManager.stopRecording")(function* (tabId: string) {
-    clearPendingRecording(tabId);
-    yield* withTabLifecycleLock(tabId, stopFrameCapture(tabId, "recording"));
+    // Clearing runs under the tab lock so it cannot land before an in-flight start arms.
+    yield* withTabLifecycleLock(
+      tabId,
+      Effect.suspend(() => {
+        clearPendingRecording(tabId);
+        return stopFrameCapture(tabId, "recording");
+      }),
+    );
   });
 
   const saveRecording = Effect.fn("PreviewManager.saveRecording")(function* (
@@ -4013,6 +4053,19 @@ export class PreviewRecordingSourceSizeUnavailableError extends Schema.TaggedErr
   }
 }
 
+export class PreviewRecordingArmConflictError extends Schema.TaggedErrorClass<PreviewRecordingArmConflictError>()(
+  "PreviewRecordingArmConflictError",
+  {
+    tabId: Schema.String,
+    webContentsId: Schema.Number,
+    armedTabId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Preview tab ${this.armedTabId} is still claiming the capture stream, so recording could not start for tab ${this.tabId}`;
+  }
+}
+
 export class PreviewOperationError extends Schema.TaggedErrorClass<PreviewOperationError>()(
   "PreviewOperationError",
   {
@@ -4221,6 +4274,7 @@ export const PreviewManagerError = Schema.Union([
   PreviewWebviewNotInitializedError,
   PreviewMainWindowClosedError,
   PreviewRecordingSourceSizeUnavailableError,
+  PreviewRecordingArmConflictError,
   PreviewOperationError,
   PreviewArtifactPathOutsideDirectoryError,
   PreviewArtifactImageLoadError,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -16,7 +16,6 @@ import type {
   PreviewAnnotationSubmissionResult,
   DesktopPreviewRecordingArtifact,
   DesktopPreviewRecordingFrame,
-  DesktopPreviewRecordingSource,
   DesktopPreviewScreenshotArtifact,
   DesktopPreviewTabDefaults,
   PreviewAutomationClickInput,
@@ -109,6 +108,7 @@ const MAX_EVALUATION_BYTES = 64_000;
 const MAX_VISIBLE_TEXT_LENGTH = 20_000;
 const MAX_INTERACTIVE_ELEMENTS = 200;
 const MAX_SCREENSHOT_WIDTH = 1280;
+/** Readiness probe: a tab that reports a positive viewport is scriptable and ready to capture. */
 const RECORDING_SOURCE_SIZE_EXPRESSION =
   "({ width: Math.round(globalThis.innerWidth), height: Math.round(globalThis.innerHeight) })";
 const PICTURE_IN_PICTURE_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
@@ -591,6 +591,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const pictureInPictureAspectRatiosRef = yield* Ref.make<ReadonlyMap<string, number>>(new Map());
   const pictureInPictureMutationSemaphore = yield* Semaphore.make(1);
   const closingTabIdsRef = yield* Ref.make<ReadonlySet<string>>(new Set());
+  // Tab recording uses `setDisplayMediaRequestHandler` because Electron's legacy
+  // `getMediaSourceId` + `chromeMediaSource: "tab"` capture path was removed upstream
+  // (electron#44618) and now always rejects with NotAllowedError.
+  let pendingRecording: {
+    readonly tabId: string;
+    readonly webContents: Electron.WebContents;
+  } | null = null;
+  const displayMediaHandlerSessions = new WeakSet<Session>();
   let frameCaptureWindowOpen = true;
   let currentMainWindow: BrowserWindow | undefined;
   let mainWindowCleanupFiber: Fiber.Fiber<void, never> | undefined;
@@ -3099,6 +3107,27 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     return yield* Effect.failCause(initializationExit.cause);
   });
 
+  /** Only drops the armed target when it still belongs to `tabId`, so tabs cannot clobber each other. */
+  const clearPendingRecording = (tabId: string) => {
+    if (pendingRecording?.tabId === tabId) pendingRecording = null;
+  };
+
+  // Installed once per session: answers the renderer's `getDisplayMedia()` with the tab that
+  // `startRecording` armed, and denies anything else so pages cannot capture on their own.
+  const installDisplayMediaRequestHandler = (session: Session) => {
+    if (displayMediaHandlerSessions.has(session)) return;
+    displayMediaHandlerSessions.add(session);
+    session.setDisplayMediaRequestHandler((_request, callback) => {
+      const target = pendingRecording?.webContents;
+      pendingRecording = null;
+      if (!target || target.isDestroyed()) {
+        callback({});
+        return;
+      }
+      callback({ video: target.mainFrame });
+    });
+  };
+
   const startRecording = Effect.fn("PreviewManager.startRecording")(function* (tabId: string) {
     if ((yield* Ref.get(closingTabIdsRef)).has(tabId)) {
       return yield* new PreviewTabNotFoundError({ tabId });
@@ -3152,24 +3181,19 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             webContentsId: wc.id,
           });
         }
-        const sourceId = yield* attempt(
-          {
-            operation: "recording.getMediaSourceId",
-            tabId,
-            webContentsId: wc.id,
-          },
-          () => wc.getMediaSourceId(requestWebContents),
-        );
-        return {
-          sourceId,
-          width: measuredSize.width,
-          height: measuredSize.height,
-        } satisfies DesktopPreviewRecordingSource;
-      }).pipe(Effect.onError(() => stopFrameCapture(tabId, "recording").pipe(Effect.ignore))),
+        installDisplayMediaRequestHandler(requestWebContents.session);
+        pendingRecording = { tabId, webContents: wc };
+      }).pipe(
+        Effect.onError(() => {
+          clearPendingRecording(tabId);
+          return stopFrameCapture(tabId, "recording").pipe(Effect.ignore);
+        }),
+      ),
     );
   });
 
   const stopRecording = Effect.fn("PreviewManager.stopRecording")(function* (tabId: string) {
+    clearPendingRecording(tabId);
     yield* withTabLifecycleLock(tabId, stopFrameCapture(tabId, "recording"));
   });
 
@@ -4274,9 +4298,7 @@ export class PreviewManager extends Context.Service<
     readonly copyArtifactToClipboard: (path: string) => Effect.Effect<void, PreviewManagerError>;
     readonly openPictureInPicture: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly closePictureInPicture: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-    readonly startRecording: (
-      tabId: string,
-    ) => Effect.Effect<DesktopPreviewRecordingSource, PreviewManagerError>;
+    readonly startRecording: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly stopRecording: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly saveRecording: (
       tabId: string,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -2011,6 +2011,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         ? tab.webContentsId
         : null;
     if (replacedWebContentsId !== null) {
+      // The replaced guest can no longer redeem a display-media grant.
+      clearPendingRecording(tabId);
       yield* Effect.all(
         [
           detachControlSession(replacedWebContentsId),

--- a/apps/web/src/browser/browserRecording.test.ts
+++ b/apps/web/src/browser/browserRecording.test.ts
@@ -1,33 +1,39 @@
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { clientSettings, events, getUserMedia, registrySet, save, startScreencast, stopScreencast } =
-  vi.hoisted(() => {
-    const events: string[] = [];
-    return {
-      clientSettings: { browserRecordingFrameRate: 30 as 30 | 60 },
-      events,
-      getUserMedia: vi.fn(),
-      registrySet: vi.fn((_atom: unknown, value: { readonly tabIds: ReadonlySet<string> }) => {
-        events.push(
-          value.tabIds.size === 0 ? "clear" : `publish:${Array.from(value.tabIds).join(",")}`,
-        );
-      }),
-      save: vi.fn(async (tabId: string) => ({
-        id: "recording-test",
-        tabId,
-        path: "/tmp/recording-test.webm",
-        mimeType: "video/webm" as const,
-        sizeBytes: 0,
-        createdAt: "2026-06-26T00:00:00.000Z",
-      })),
-      startScreencast: vi.fn(async (tabId: string) => {
-        events.push("start-screencast");
-        return { sourceId: `source:${tabId}`, width: 1000, height: 620 };
-      }),
-      stopScreencast: vi.fn(async () => undefined),
-    };
-  });
+const {
+  clientSettings,
+  events,
+  getDisplayMedia,
+  registrySet,
+  save,
+  startScreencast,
+  stopScreencast,
+} = vi.hoisted(() => {
+  const events: string[] = [];
+  return {
+    clientSettings: { browserRecordingFrameRate: 30 as 30 | 60 },
+    events,
+    getDisplayMedia: vi.fn(),
+    registrySet: vi.fn((_atom: unknown, value: { readonly tabIds: ReadonlySet<string> }) => {
+      events.push(
+        value.tabIds.size === 0 ? "clear" : `publish:${Array.from(value.tabIds).join(",")}`,
+      );
+    }),
+    save: vi.fn(async (tabId: string) => ({
+      id: "recording-test",
+      tabId,
+      path: "/tmp/recording-test.webm",
+      mimeType: "video/webm" as const,
+      sizeBytes: 0,
+      createdAt: "2026-06-26T00:00:00.000Z",
+    })),
+    startScreencast: vi.fn(async (_tabId: string) => {
+      events.push("start-screencast");
+    }),
+    stopScreencast: vi.fn(async () => undefined),
+  };
+});
 
 vi.mock("~/components/preview/previewBridge", () => ({
   previewBridge: {
@@ -122,10 +128,10 @@ describe("browser recording", () => {
     });
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal("MediaRecorder", FakeMediaRecorder as unknown as typeof MediaRecorder);
-    getUserMedia.mockResolvedValue({
+    getDisplayMedia.mockResolvedValue({
       getTracks: () => [{ stop: vi.fn() }],
     });
-    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    vi.stubGlobal("navigator", { mediaDevices: { getDisplayMedia } });
     useBrowserSurfaceStore.setState({ activityByTabId: {}, byTabId: {} });
   });
 
@@ -146,9 +152,8 @@ describe("browser recording", () => {
     startScreencast.mockImplementationOnce(async (tabId: string) => {
       expect(animationFrameCount).toBe(2);
       expect(useBrowserSurfaceStore.getState().activityByTabId[tabId]).toBe(1);
-      return { sourceId: `source:${tabId}`, width: 1000, height: 620 };
     });
-    getUserMedia.mockImplementationOnce(async () => {
+    getDisplayMedia.mockImplementationOnce(async () => {
       expect(animationFrameCount).toBe(2);
       expect(useBrowserSurfaceStore.getState().activityByTabId["background-tab"]).toBe(1);
       return { getTracks: () => [{ stop: vi.fn() }] };
@@ -178,26 +183,16 @@ describe("browser recording", () => {
     await stopBrowserRecording("hidden-window-tab");
   });
 
-  it("records the native tab stream at the preview's current dimensions", async () => {
+  it("records the native tab stream armed by the main process", async () => {
     const stopTrack = vi.fn();
     const stream = { getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream;
-    getUserMedia.mockResolvedValueOnce(stream);
+    getDisplayMedia.mockResolvedValueOnce(stream);
 
     await startBrowserRecording("recording-tab");
 
-    expect(getUserMedia).toHaveBeenCalledWith({
+    expect(getDisplayMedia).toHaveBeenCalledWith({
       audio: false,
-      video: {
-        mandatory: {
-          chromeMediaSource: "tab",
-          chromeMediaSourceId: "source:recording-tab",
-          minWidth: 1000,
-          maxWidth: 1000,
-          minHeight: 620,
-          maxHeight: 620,
-          maxFrameRate: 30,
-        },
-      },
+      video: { frameRate: { max: 30 } },
     });
     expect(FakeMediaRecorder.instances[0]?.stream).toBe(stream);
 
@@ -210,18 +205,16 @@ describe("browser recording", () => {
 
     await startBrowserRecording("recording-tab");
 
-    expect(getUserMedia).toHaveBeenCalledWith({
+    expect(getDisplayMedia).toHaveBeenCalledWith({
       audio: false,
-      video: {
-        mandatory: expect.objectContaining({ maxFrameRate: 60 }),
-      },
+      video: { frameRate: { max: 60 } },
     });
     await stopBrowserRecording("recording-tab");
   });
 
   it("stops the native stream when MediaRecorder cleanup fails", async () => {
     const stopTrack = vi.fn();
-    getUserMedia.mockResolvedValueOnce({
+    getDisplayMedia.mockResolvedValueOnce({
       getTracks: () => [{ stop: stopTrack }],
     });
 
@@ -285,7 +278,7 @@ describe("browser recording", () => {
   });
 
   it("releases the native capture lease when stream acquisition fails", async () => {
-    getUserMedia.mockRejectedValueOnce(new Error("capture failed"));
+    getDisplayMedia.mockRejectedValueOnce(new Error("capture failed"));
 
     await expect(startBrowserRecording("recording-tab")).rejects.toMatchObject({
       operation: "capture-media-stream",
@@ -300,7 +293,7 @@ describe("browser recording", () => {
     vi.useFakeTimers();
     let finishCapture!: (stream: MediaStream) => void;
     const stopTrack = vi.fn();
-    getUserMedia.mockImplementationOnce(
+    getDisplayMedia.mockImplementationOnce(
       () =>
         new Promise<MediaStream>((resolve) => {
           finishCapture = resolve;
@@ -308,7 +301,7 @@ describe("browser recording", () => {
     );
 
     const startPromise = startBrowserRecording("recording-tab");
-    await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(getDisplayMedia).toHaveBeenCalledOnce());
     const rejection = expect(startPromise).rejects.toMatchObject({
       _tag: "BrowserRecordingCaptureTimeoutError",
       tabId: "recording-tab",
@@ -387,7 +380,6 @@ describe("browser recording", () => {
       await new Promise<void>((resolve) => {
         finishStartingScreencast = resolve;
       });
-      return { sourceId: "source:recording-tab", width: 1000, height: 620 };
     });
 
     const firstStart = startBrowserRecording("recording-tab");
@@ -452,7 +444,6 @@ describe("browser recording", () => {
       await new Promise<void>((resolve) => {
         finishStartingScreencast = resolve;
       });
-      return { sourceId: "source:recording-tab", width: 1000, height: 620 };
     });
 
     const startPromise = startBrowserRecording("recording-tab");
@@ -476,7 +467,6 @@ describe("browser recording", () => {
       await new Promise<void>((resolve) => {
         finishStartingScreencast = resolve;
       });
-      return { sourceId: "source:recording-tab", width: 1000, height: 620 };
     });
 
     const firstStart = startBrowserRecording("recording-tab");
@@ -503,7 +493,6 @@ describe("browser recording", () => {
       await new Promise<void>((resolve) => {
         finishStartingScreencast = resolve;
       });
-      return { sourceId: "source:recording-tab", width: 1000, height: 620 };
     });
     stopScreencast.mockRejectedValueOnce(new Error("initial stop failed"));
 
@@ -537,7 +526,6 @@ describe("browser recording", () => {
       await new Promise<void>((resolve) => {
         finishStartingScreencast = resolve;
       });
-      return { sourceId: "source:recording-tab", width: 1000, height: 620 };
     });
 
     const startPromise = startBrowserRecording("recording-tab");

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -1,8 +1,4 @@
-import type {
-  DesktopPreviewRecordingArtifact,
-  DesktopPreviewRecordingSource,
-  ScopedThreadRef,
-} from "@t3tools/contracts";
+import type { DesktopPreviewRecordingArtifact, ScopedThreadRef } from "@t3tools/contracts";
 import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import { Atom } from "effect/unstable/reactivity";
@@ -184,23 +180,12 @@ const createMediaRecorder = (stream: MediaStream): MediaRecorder => {
   return mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
 };
 
-const captureTabMediaStream = (
-  source: DesktopPreviewRecordingSource,
-  frameRate: number,
-): Promise<MediaStream> =>
-  navigator.mediaDevices.getUserMedia({
+const captureTabMediaStream = (frameRate: number): Promise<MediaStream> =>
+  // The desktop main process routes this request to the tab that `startScreencast` armed, so the
+  // stream already arrives at that tab's native size and needs no source or dimension constraints.
+  navigator.mediaDevices.getDisplayMedia({
     audio: false,
-    video: {
-      mandatory: {
-        chromeMediaSource: "tab",
-        chromeMediaSourceId: source.sourceId,
-        minWidth: source.width,
-        maxWidth: source.width,
-        minHeight: source.height,
-        maxHeight: source.height,
-        maxFrameRate: frameRate,
-      },
-    } as unknown as MediaTrackConstraints,
+    video: { frameRate: { max: frameRate } },
   });
 
 const stopMediaRecorder = async (recorder: MediaRecorder | null): Promise<void> => {
@@ -218,12 +203,11 @@ const stopMediaStream = (stream: MediaStream | null): void => {
 
 const captureTabMediaStreamWithTimeout = async (
   tabId: string,
-  source: DesktopPreviewRecordingSource,
   frameRate: number,
 ): Promise<MediaStream> => {
   let acceptStream = true;
   let timeoutId: number | null = null;
-  const streamPromise = captureTabMediaStream(source, frameRate).then((stream) => {
+  const streamPromise = captureTabMediaStream(frameRate).then((stream) => {
     if (!acceptStream) stopMediaStream(stream);
     return stream;
   });
@@ -402,9 +386,8 @@ export async function startBrowserRecording(
       () => getClientSettings().browserRecordingFrameRate,
     );
     const [frameRate] = await Promise.all([frameRatePromise, waitForBrowserRecordingPaint()]);
-    let source: DesktopPreviewRecordingSource;
     try {
-      source = await bridge.recording.startScreencast(tabId);
+      await bridge.recording.startScreencast(tabId);
     } catch (cause) {
       if (!isRecordingStarting(recording)) {
         throw recordingStartupCancelledError(recording, cause);
@@ -436,7 +419,7 @@ export async function startBrowserRecording(
     };
     await throwIfStartupCancelled();
     try {
-      recording.stream = await captureTabMediaStreamWithTimeout(tabId, source, frameRate);
+      recording.stream = await captureTabMediaStreamWithTimeout(tabId, frameRate);
     } catch (cause) {
       const cleanupCause = await cleanupFailedRecordingStart(bridge, recording);
       if (isBrowserRecordingCaptureTimeoutError(cause) && cleanupCause === undefined) throw cause;

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -1,0 +1,52 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  PreviewAutomationOperationError,
+  PreviewAutomationRecordingNotActiveError,
+  serializePreviewAutomationHostError,
+} from "./previewAutomationErrors";
+
+const operationError = (cause: unknown) =>
+  new PreviewAutomationOperationError({
+    requestId: "request-1",
+    operation: "recordingStart",
+    environmentId: EnvironmentId.make("env-1"),
+    threadId: ThreadId.make("thread-1"),
+    tabId: null,
+    cause,
+  });
+
+describe("serializePreviewAutomationHostError", () => {
+  it("keeps the underlying failure reason as a flat cause summary", () => {
+    const serialized = serializePreviewAutomationHostError(
+      operationError(
+        Object.assign(new Error("Cannot satisfy constraints"), { name: "OverconstrainedError" }),
+      ),
+    );
+
+    expect(serialized.detail).toMatchObject({
+      cause: "OverconstrainedError: Cannot satisfy constraints",
+      operation: "recordingStart",
+    });
+  });
+
+  it("renders non-error causes without losing them", () => {
+    expect(serializePreviewAutomationHostError(operationError("boom")).detail).toMatchObject({
+      cause: "boom",
+    });
+  });
+
+  it("omits cause for errors that carry none", () => {
+    const serialized = serializePreviewAutomationHostError(
+      new PreviewAutomationRecordingNotActiveError({
+        requestId: "request-1",
+        environmentId: EnvironmentId.make("env-1"),
+        threadId: ThreadId.make("thread-1"),
+        tabId: null,
+      }),
+    );
+
+    expect(serialized.detail).not.toHaveProperty("cause");
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -37,6 +37,21 @@ describe("serializePreviewAutomationHostError", () => {
     });
   });
 
+  it("omits causes that render to nothing", () => {
+    expect(
+      serializePreviewAutomationHostError(operationError({ message: "" })).detail,
+    ).not.toHaveProperty("cause");
+    expect(serializePreviewAutomationHostError(operationError("")).detail).not.toHaveProperty(
+      "cause",
+    );
+  });
+
+  it("survives causes that cannot be stringified", () => {
+    expect(
+      serializePreviewAutomationHostError(operationError(Object.create(null))).detail,
+    ).toMatchObject({ cause: "[unserializable cause]" });
+  });
+
   it("omits cause for errors that carry none", () => {
     const serialized = serializePreviewAutomationHostError(
       new PreviewAutomationRecordingNotActiveError({

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -18,38 +18,15 @@ const operationError = (cause: unknown) =>
   });
 
 describe("serializePreviewAutomationHostError", () => {
-  it("keeps the underlying failure reason as a flat cause summary", () => {
+  it("keeps operation context without leaking the cause", () => {
     const serialized = serializePreviewAutomationHostError(
       operationError(
         Object.assign(new Error("Cannot satisfy constraints"), { name: "OverconstrainedError" }),
       ),
     );
 
-    expect(serialized.detail).toMatchObject({
-      cause: "OverconstrainedError: Cannot satisfy constraints",
-      operation: "recordingStart",
-    });
-  });
-
-  it("renders non-error causes without losing them", () => {
-    expect(serializePreviewAutomationHostError(operationError("boom")).detail).toMatchObject({
-      cause: "boom",
-    });
-  });
-
-  it("omits causes that render to nothing", () => {
-    expect(
-      serializePreviewAutomationHostError(operationError({ message: "" })).detail,
-    ).not.toHaveProperty("cause");
-    expect(serializePreviewAutomationHostError(operationError("")).detail).not.toHaveProperty(
-      "cause",
-    );
-  });
-
-  it("survives causes that cannot be stringified", () => {
-    expect(
-      serializePreviewAutomationHostError(operationError(Object.create(null))).detail,
-    ).toMatchObject({ cause: "[unserializable cause]" });
+    expect(serialized.detail).toMatchObject({ operation: "recordingStart" });
+    expect(serialized.detail).not.toHaveProperty("cause");
   });
 
   it("omits cause for errors that carry none", () => {

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -218,15 +218,31 @@ export type PreviewAutomationHostError = typeof PreviewAutomationHostError.Type;
 
 export const isPreviewAutomationHostError = Schema.is(PreviewAutomationHostError);
 
+/** Compact, stack-free rendering of a failure cause so the server log keeps the real reason. */
+const summarizeCause = (cause: unknown): string | null => {
+  if (cause === undefined || cause === null) return null;
+  if (typeof cause === "object" && "message" in cause && typeof cause.message === "string") {
+    const name =
+      "name" in cause && typeof cause.name === "string" && cause.name.length > 0
+        ? cause.name
+        : null;
+    return name ? `${name}: ${cause.message}` : cause.message;
+  }
+  const rendered = String(cause);
+  return rendered.length === 0 ? null : rendered;
+};
+
 export function serializePreviewAutomationHostError(
   error: PreviewAutomationHostError,
 ): NonNullable<PreviewAutomationResponse["error"]> {
-  const detail = Object.fromEntries(
+  const detail: Record<string, unknown> = Object.fromEntries(
     Object.entries(error).filter(
       ([key]) =>
         key !== "_tag" && key !== "cause" && key !== "name" && key !== "message" && key !== "stack",
     ),
   );
+  const causeSummary = "cause" in error ? summarizeCause(error.cause) : null;
+  if (causeSummary !== null) detail.cause = causeSummary;
   return {
     _tag: error.responseTag,
     message: error.message,

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -218,17 +218,31 @@ export type PreviewAutomationHostError = typeof PreviewAutomationHostError.Type;
 
 export const isPreviewAutomationHostError = Schema.is(PreviewAutomationHostError);
 
-/** Compact, stack-free rendering of a failure cause so the server log keeps the real reason. */
-const summarizeCause = (cause: unknown): string | null => {
-  if (cause === undefined || cause === null) return null;
-  if (typeof cause === "object" && "message" in cause && typeof cause.message === "string") {
+const renderCause = (cause: unknown): string => {
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string"
+  ) {
     const name =
       "name" in cause && typeof cause.name === "string" && cause.name.length > 0
         ? cause.name
         : null;
     return name ? `${name}: ${cause.message}` : cause.message;
   }
-  const rendered = String(cause);
+  try {
+    // Null-prototype objects and hostile `toString` implementations both throw here.
+    return String(cause);
+  } catch {
+    return "[unserializable cause]";
+  }
+};
+
+/** Compact, stack-free rendering of a failure cause so the server log keeps the real reason. */
+const summarizeCause = (cause: unknown): string | null => {
+  if (cause === undefined || cause === null) return null;
+  const rendered = renderCause(cause);
   return rendered.length === 0 ? null : rendered;
 };
 

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -218,34 +218,6 @@ export type PreviewAutomationHostError = typeof PreviewAutomationHostError.Type;
 
 export const isPreviewAutomationHostError = Schema.is(PreviewAutomationHostError);
 
-const renderCause = (cause: unknown): string => {
-  if (
-    typeof cause === "object" &&
-    cause !== null &&
-    "message" in cause &&
-    typeof cause.message === "string"
-  ) {
-    const name =
-      "name" in cause && typeof cause.name === "string" && cause.name.length > 0
-        ? cause.name
-        : null;
-    return name ? `${name}: ${cause.message}` : cause.message;
-  }
-  try {
-    // Null-prototype objects and hostile `toString` implementations both throw here.
-    return String(cause);
-  } catch {
-    return "[unserializable cause]";
-  }
-};
-
-/** Compact, stack-free rendering of a failure cause so the server log keeps the real reason. */
-const summarizeCause = (cause: unknown): string | null => {
-  if (cause === undefined || cause === null) return null;
-  const rendered = renderCause(cause);
-  return rendered.length === 0 ? null : rendered;
-};
-
 export function serializePreviewAutomationHostError(
   error: PreviewAutomationHostError,
 ): NonNullable<PreviewAutomationResponse["error"]> {
@@ -255,8 +227,6 @@ export function serializePreviewAutomationHostError(
         key !== "_tag" && key !== "cause" && key !== "name" && key !== "message" && key !== "stack",
     ),
   );
-  const causeSummary = "cause" in error ? summarizeCause(error.cause) : null;
-  if (causeSummary !== null) detail.cause = causeSummary;
   return {
     _tag: error.responseTag,
     message: error.message,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -734,19 +734,6 @@ export const DesktopPreviewRecordingFrameSchema: Schema.Codec<DesktopPreviewReco
     receivedAt: Schema.String,
   });
 
-export interface DesktopPreviewRecordingSource {
-  sourceId: string;
-  width: number;
-  height: number;
-}
-
-export const DesktopPreviewRecordingSourceSchema: Schema.Codec<DesktopPreviewRecordingSource> =
-  Schema.Struct({
-    sourceId: Schema.String,
-    width: Schema.Int.check(Schema.isGreaterThan(0)),
-    height: Schema.Int.check(Schema.isGreaterThan(0)),
-  });
-
 export interface DesktopPreviewRecordingArtifact {
   id: string;
   tabId: string;
@@ -1228,7 +1215,7 @@ export interface DesktopPreviewBridge {
     close: (tabId: string) => Promise<void>;
   };
   recording: {
-    startScreencast: (tabId: string) => Promise<DesktopPreviewRecordingSource>;
+    startScreencast: (tabId: string) => Promise<void>;
     stopScreencast: (tabId: string) => Promise<void>;
     save: (
       tabId: string,


### PR DESCRIPTION
browser tab recording has been failing to start since the electron 43 bump: the renderer acquired the stream with the legacy `getUserMedia` + `chromeMediaSource: "tab"` + `wc.getMediaSourceId(...)` path, which chromium removed upstream (electron/electron#44618) and which now always rejects with `NotAllowedError: Permission denied`. on retina displays the exact `min == max` css-pixel constraints were additionally unsatisfiable against device-pixel frames.

this switches capture to electron's supported path: `startRecording` in the main process arms the target tab and installs a per-session `setDisplayMediaRequestHandler` that answers the renderer's `getDisplayMedia()` with that tab's `WebFrameMain`, one grant per arm, denying anything unarmed so preview pages cannot capture on their own. the renderer now requests only `frameRate: { max }` — the handler already picks the exact tab, so the stream arrives at native device-pixel size and the `DesktopPreviewRecordingSource` sourceId/width/height plumbing is deleted (the viewport measurement stays as a readiness probe).

concurrent starts on different tabs cannot cross-capture: a second tab arming while another arm is outstanding fails fast with a tagged conflict error, an unredeemed arm is actively expired after a short grace (a scoped fiber clears the slot, so a stale grant can never be redeemed by a later request), and an arm whose webview was destroyed is reclaimed immediately. covered by real-clock race, stale-expiry, and destroyed-webview tests.

verified live in the dev desktop app on a retina mac (dpr 2): record from the preview toolbar and from the gesture-less bridge path both produce av1 webm artifacts at full native resolution (966x1376 for a 483x688 panel) with the "Recording saved" toast; before the change both paths failed instantly. focused tests and typechecks for contracts, desktop, and web pass.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Gigioxx/t3code/assets/preview-recording-evidence/before-error.png) | ![after](https://raw.githubusercontent.com/Gigioxx/t3code/assets/preview-recording-evidence/after-saved.png) |

sample artifact recorded by the fixed pipeline: [demo-recording.webm](https://github.com/Gigioxx/t3code/raw/assets/preview-recording-evidence/demo-recording.webm)

Built with Claude Fable 5 in the Claude Code harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop capture permissions, concurrent recording semantics, and a cross-process IPC contract; mistakes could deny capture, mis-route streams, or leave stale arms blocking recording.
> 
> **Overview**
> **Restores broken preview tab recording** after Chromium removed the legacy `getUserMedia` + `chromeMediaSource: "tab"` + `getMediaSourceId` path. Capture now uses Electron’s **`setDisplayMediaRequestHandler`**: `startRecording` arms one tab, the renderer calls **`getDisplayMedia()`** with only a max frame rate, and the main process grants that tab’s **`mainFrame`** once per arm.
> 
> **API and behavior changes:** `DesktopPreviewRecordingSource` and the `startScreencast` / IPC return payload are removed; arming is **`void`**. A single exclusive **arm slot** per window session rejects overlapping starts with **`PreviewRecordingArmConflictError`**, expires unredeemed arms after **10s**, and clears on stop, tab close, or destroyed webview. Viewport measurement remains as a readiness probe only.
> 
> **Web and contracts** drop chrome tab constraints and dimension locking (which broke on retina). Tests cover display-media grants, races (including real-clock), stale arms, and automation error serialization without leaking causes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4a2c4f959c57425d5a40517c54701640551e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore browser tab recording via `getDisplayMedia` handler in `PreviewManager`
> - Replaces the native `getMediaSourceId` flow with a display-media arming model: `startRecording` installs a session `setDisplayMediaRequestHandler` and exclusively arms the requested tab to answer one `getDisplayMedia` call, instead of returning a `DesktopPreviewRecordingSource`.
> - Adds a 10s grace window (`RECORDING_ARM_GRACE_MS`) so an unredeemed or destroyed arm auto-expires; a second arm within that window fails fast with `PreviewRecordingArmConflictError`.
> - Web side switches from `getUserMedia` with chrome-specific constraints to `navigator.mediaDevices.getDisplayMedia` with only a max `frameRate` constraint.
> - Removes `DesktopPreviewRecordingSource` from contracts, IPC, and all consumers; `startScreencast` now returns `Promise<void>`.
> - Risk: `startRecording` signature changed from `Effect<DesktopPreviewRecordingSource, ...>` to `Effect<void, PreviewManagerError>` and `PreviewRecordingArmConflictError` is added to the error union — any out-of-tree consumer expecting a source descriptor or unaware of the conflict error will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b4a2c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated tab recording to use the modern display-capture flow for improved compatibility.
  - Simplified recording startup so source details are no longer required.
  - Added safeguards against conflicting recording sessions and abandoned capture attempts.

- **Bug Fixes**
  - Improved cleanup when recording cannot start or a tab is closed.
  - Automation errors now provide clearer, more concise details.

- **Tests**
  - Expanded coverage for recording conflicts, timeouts, cleanup, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
