### PR TITLE
feat(mobile): add native image and PDF previews

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -206,6 +206,7 @@ const config: ExpoConfig = {
       },
       NSLocalNetworkUsageDescription:
         "Allow T3 Code to connect to T3 Code servers on your local network or tailnet.",
+      NSPhotoLibraryAddUsageDescription: "Allow T3 Code to save images to your photo library.",
       ITSAppUsesNonExemptEncryption: false,
       // The App Store screenshot harness rotates the iPad interface from
       // inside the app (CI denies osascript the Accessibility access that

--- a/apps/mobile/modules/t3-native-controls/ios/T3NativeControlsModule.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/T3NativeControlsModule.swift
@@ -5,6 +5,7 @@ import UIKit
 public final class T3NativeControlsModule: Module {
   private let presentationSources = T3PresentationSources()
   private var videoPresentation: T3NativeVideoPresentation?
+  private var filePresentation: T3NativeFilePresentation?
 
   public func definition() -> ModuleDefinition {
     Name("T3NativeControls")
@@ -23,9 +24,22 @@ public final class T3NativeControlsModule: Module {
       self.dismissVideo(identifier: identifier)
     }.runOnQueue(.main)
 
+    AsyncFunction("presentFile") { (url: URL, title: String, sourceIdentifier: String, identifier: String, promise: Promise) in
+      try self.presentFile(url: url, title: title, sourceIdentifier: sourceIdentifier,
+                           identifier: identifier, promise: promise)
+    }.runOnQueue(.main)
+
+    AsyncFunction("dismissFile") { (identifier: String) in
+      self.dismissFile(identifier: identifier)
+    }.runOnQueue(.main)
+
     OnDestroy {
       let presentation = self.videoPresentation
-      DispatchQueue.main.async { presentation?.dismiss() }
+      let file = self.filePresentation
+      DispatchQueue.main.async {
+        presentation?.dismiss()
+        file?.dismiss()
+      }
     }
 
     View(T3PresentationSourceView.self) {
@@ -140,7 +154,7 @@ public final class T3NativeControlsModule: Module {
     let isPlayableURL = url.isFileURL
       ? FileManager.default.isReadableFile(atPath: url.path)
       : (["https", "http"].contains(url.scheme?.lowercased() ?? "") && url.host != nil)
-    guard videoPresentation == nil,
+    guard videoPresentation == nil, filePresentation == nil,
       let presenter = appContext?.utilities?.currentViewController(),
       isPlayableURL
     else {
@@ -160,6 +174,24 @@ public final class T3NativeControlsModule: Module {
 
   private func dismissVideo(identifier: String) {
     if videoPresentation?.identifier == identifier { videoPresentation?.dismiss() }
+  }
+
+  private func presentFile(url: URL, title: String, sourceIdentifier: String,
+                           identifier: String, promise: Promise) throws {
+    guard filePresentation == nil, videoPresentation == nil,
+      let presenter = appContext?.utilities?.currentViewController()
+    else { throw URLError(.cannotLoadFromNetwork) }
+    let file = T3NativeFilePresentation(identifier: identifier, sources: presentationSources,
+                                        sourceIdentifier: sourceIdentifier) { [weak self] error in
+      self?.filePresentation = nil
+      if let error { promise.reject(error) } else { promise.resolve(nil) }
+    }
+    filePresentation = file
+    file.present(url: url, title: title, from: presenter)
+  }
+
+  private func dismissFile(identifier: String) {
+    if filePresentation?.identifier == identifier { filePresentation?.dismiss() }
   }
 
   private func shareFile(url: URL, title: String, sourceIdentifier: String, promise: Promise) throws {

--- a/apps/mobile/modules/t3-native-controls/ios/T3NativeFilePresentation.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/T3NativeFilePresentation.swift
@@ -1,0 +1,298 @@
+import AVFoundation
+import ImageIO
+import QuickLook
+import UIKit
+import UniformTypeIdentifiers
+
+private final class FilePreviewItem: NSObject, QLPreviewItem {
+  var previewItemURL: URL?
+  var previewItemTitle: String?
+}
+
+private struct PreparedPreviewFile {
+  let url: URL
+  let image: UIImage?
+}
+
+/// UIKit supplies pinch/pan physics, header controls, sharing, and interactive zoom dismissal.
+private final class NativeImagePreviewController: UIViewController, UIScrollViewDelegate {
+  var usesZoomTransition = false
+  private let imageView: UIImageView
+  private let scrollView = UIScrollView()
+  private let url: URL
+  private let onClose: () -> Void
+  private let onDismiss: () -> Void
+  private var viewportSize = CGSize.zero
+
+  init(image: UIImage, url: URL, title: String, onClose: @escaping () -> Void, onDismiss: @escaping () -> Void) {
+    self.imageView = UIImageView(image: image)
+    self.url = url
+    self.onClose = onClose
+    self.onDismiss = onDismiss
+    super.init(nibName: nil, bundle: nil)
+    self.title = title
+  }
+
+  required init?(coder: NSCoder) { nil }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .black
+    scrollView.frame = view.bounds
+    scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    scrollView.contentInsetAdjustmentBehavior = .never
+    scrollView.showsHorizontalScrollIndicator = false
+    scrollView.showsVerticalScrollIndicator = false
+    scrollView.delegate = self
+    scrollView.accessibilityIdentifier = "ImagePreviewScrollView"
+    imageView.isAccessibilityElement = true
+    imageView.accessibilityLabel = title
+    imageView.accessibilityIdentifier = "ImagePreviewImage"
+    scrollView.addSubview(imageView)
+    view.addSubview(scrollView)
+
+    navigationItem.leftBarButtonItem = UIBarButtonItem(systemItem: .close, primaryAction: UIAction { [weak self] _ in
+      self?.onClose()
+    })
+    navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share))
+    navigationItem.rightBarButtonItem?.accessibilityLabel = "Share"
+    let appearance = UINavigationBarAppearance()
+    appearance.configureWithTransparentBackground()
+    appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+    navigationItem.standardAppearance = appearance
+    navigationItem.scrollEdgeAppearance = appearance
+    navigationItem.compactAppearance = appearance
+    navigationController?.navigationBar.tintColor = .white
+
+    let doubleTap = UITapGestureRecognizer(target: self, action: #selector(zoom))
+    doubleTap.numberOfTapsRequired = 2
+    let singleTap = UITapGestureRecognizer(target: self, action: #selector(toggleControls))
+    singleTap.require(toFail: doubleTap)
+    scrollView.addGestureRecognizer(singleTap)
+    scrollView.addGestureRecognizer(doubleTap)
+    if !usesZoomTransition {
+      let swipe = UISwipeGestureRecognizer(target: self, action: #selector(closeIfNotZoomed))
+      swipe.direction = .down
+      scrollView.addGestureRecognizer(swipe)
+    }
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    let size = scrollView.bounds.size
+    guard size != viewportSize, let image = imageView.image, size.width > 0, size.height > 0 else { return }
+    viewportSize = size
+    scrollView.minimumZoomScale = 1
+    scrollView.zoomScale = 1
+    imageView.frame = CGRect(origin: .zero, size: image.size)
+    scrollView.contentSize = image.size
+    let fit = min(size.width / image.size.width, size.height / image.size.height)
+    scrollView.maximumZoomScale = max(fit * 4, 1)
+    scrollView.minimumZoomScale = fit
+    scrollView.zoomScale = fit
+    centerImage()
+  }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    if isBeingDismissed || navigationController?.isBeingDismissed == true || navigationController?.presentingViewController == nil {
+      onDismiss()
+    }
+  }
+
+  func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
+  func scrollViewDidZoom(_ scrollView: UIScrollView) { centerImage() }
+
+  private func centerImage() {
+    let horizontal = max(0, (scrollView.bounds.width - scrollView.contentSize.width) / 2)
+    let vertical = max(0, (scrollView.bounds.height - scrollView.contentSize.height) / 2)
+    scrollView.contentInset = UIEdgeInsets(top: vertical, left: horizontal, bottom: vertical, right: horizontal)
+  }
+
+  @objc private func zoom(_ recognizer: UITapGestureRecognizer) {
+    if scrollView.zoomScale > scrollView.minimumZoomScale * 1.01 {
+      scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+    } else {
+      let scale = min(scrollView.minimumZoomScale * 3, scrollView.maximumZoomScale)
+      let point = recognizer.location(in: imageView)
+      let size = CGSize(width: scrollView.bounds.width / scale, height: scrollView.bounds.height / scale)
+      let rect = CGRect(x: point.x - size.width / 2, y: point.y - size.height / 2, width: size.width, height: size.height)
+      scrollView.zoom(to: rect, animated: true)
+    }
+  }
+
+  @objc private func toggleControls() {
+    guard let navigationController else { return }
+    navigationController.setNavigationBarHidden(!navigationController.isNavigationBarHidden, animated: true)
+  }
+
+  @objc private func closeIfNotZoomed() {
+    if scrollView.zoomScale <= scrollView.minimumZoomScale * 1.01 { onClose() }
+  }
+
+  @objc private func share(_ sender: UIBarButtonItem) {
+    let sheet = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    sheet.popoverPresentationController?.barButtonItem = sender
+    present(sheet, animated: true)
+  }
+}
+
+/// Shares file preparation and lifecycle between the image viewer and Quick Look documents.
+final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
+  QLPreviewControllerDelegate, UIAdaptivePresentationControllerDelegate {
+  let identifier: String
+  private var controller: UIViewController?
+  private let completion: (Error?) -> Void
+  private weak var sources: T3PresentationSources?
+  private let sourceIdentifier: String
+  private let item = FilePreviewItem()
+  private var loading: Task<Void, Never>?
+  private var presented = false
+  private var dismissRequested = false
+  private var finished = false
+
+  init(identifier: String, sources: T3PresentationSources, sourceIdentifier: String, completion: @escaping (Error?) -> Void) {
+    self.identifier = identifier
+    self.sources = sources
+    self.sourceIdentifier = sourceIdentifier
+    self.completion = completion
+    super.init()
+  }
+
+  func present(url: URL, title: String, from presenter: UIViewController) {
+    loading = Task { @MainActor [self] in
+      do {
+        let file = try await Self.prepareFile(url: url, title: title)
+        guard !finished, !Task.isCancelled else {
+          try? FileManager.default.removeItem(at: file.url.deletingLastPathComponent())
+          return
+        }
+        item.previewItemURL = file.url
+        item.previewItemTitle = title
+        let preview: UIViewController
+        if let image = file.image {
+          let viewer = NativeImagePreviewController(
+            image: image, url: file.url, title: title,
+            onClose: { [weak self] in self?.dismiss() }, onDismiss: { [weak self] in self?.finish() }
+          )
+          let navigation = UINavigationController(rootViewController: viewer)
+          navigation.modalPresentationStyle = .fullScreen
+          navigation.overrideUserInterfaceStyle = .dark
+          preview = navigation
+          if #available(iOS 18.0, *), !UIAccessibility.isReduceMotionEnabled,
+            sources?.view(for: sourceIdentifier)?.window != nil {
+            viewer.usesZoomTransition = true
+            let options = UIViewController.Transition.ZoomOptions()
+            options.alignmentRectProvider = { context in
+              AVMakeRect(aspectRatio: image.size, insideRect: context.zoomedViewController.view.bounds)
+            }
+            preview.preferredTransition = .zoom(options: options) { [weak self] _ in
+              guard let self, let source = sources?.view(for: sourceIdentifier), source.window != nil else { return nil }
+              return source
+            }
+          }
+          navigation.view.backgroundColor = .black
+        } else {
+          let quickLook = QLPreviewController()
+          quickLook.delegate = self
+          quickLook.dataSource = self
+          preview = quickLook
+        }
+        controller = preview
+        presenter.present(preview, animated: !UIAccessibility.isReduceMotionEnabled) { [self] in
+          presented = true
+          if dismissRequested { dismiss() }
+        }
+        preview.presentationController?.delegate = self
+      } catch {
+        finish(error: error)
+      }
+    }
+  }
+
+  func dismiss() {
+    dismissRequested = true
+    loading?.cancel()
+    guard !finished else { return }
+    guard presented else {
+      if controller?.presentingViewController == nil { finish() }
+      return
+    }
+    controller?.dismiss(animated: !UIAccessibility.isReduceMotionEnabled) { [self] in finish() }
+  }
+
+  func numberOfPreviewItems(in controller: QLPreviewController) -> Int { item.previewItemURL == nil ? 0 : 1 }
+
+  func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+    item
+  }
+
+  func previewControllerDidDismiss(_ controller: QLPreviewController) { finish() }
+
+  func presentationControllerDidDismiss(_ presentationController: UIPresentationController) { finish() }
+
+  private func finish(error: Error? = nil) {
+    guard !finished else { return }
+    finished = true
+    loading?.cancel()
+    loading = nil
+    if let file = item.previewItemURL {
+      try? FileManager.default.removeItem(at: file.deletingLastPathComponent())
+    }
+    item.previewItemURL = nil
+    completion(error)
+  }
+
+  /// Copy original bytes so preview and sharing do not mutate a draft or workspace file.
+  nonisolated private static func prepareFile(url: URL, title: String) async throws -> PreparedPreviewFile {
+    try Task.checkCancellation()
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent("t3-preview-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    do {
+      let download = directory.appendingPathComponent("original")
+      if url.isFileURL {
+        try FileManager.default.copyItem(at: url, to: download)
+      } else if url.scheme == "data" {
+        try Data(contentsOf: url).write(to: download, options: .atomic)
+      } else {
+        guard ["https", "http"].contains(url.scheme?.lowercased() ?? "") else {
+          throw URLError(.unsupportedURL)
+        }
+        let (temporaryFile, response) = try await URLSession.shared.download(from: url)
+        guard let response = response as? HTTPURLResponse, (200..<300).contains(response.statusCode) else {
+          throw URLError(.badServerResponse)
+        }
+        try FileManager.default.moveItem(at: temporaryFile, to: download)
+      }
+      try Task.checkCancellation()
+      let type: UTType
+      var previewImage: UIImage?
+      if let image = CGImageSourceCreateWithURL(download as CFURL, nil),
+        CGImageSourceGetCount(image) > 0, let imageType = CGImageSourceGetType(image),
+        let detectedType = UTType(imageType as String) {
+        type = detectedType
+        // Animated images stay in Quick Look; static images are decoded before the zoom starts.
+        if CGImageSourceGetCount(image) == 1 {
+          previewImage = UIImage(contentsOfFile: download.path)?.preparingForDisplay()
+        }
+      } else if CGPDFDocument(download as CFURL) != nil {
+        type = .pdf
+      } else {
+        throw URLError(.cannotDecodeContentData)
+      }
+      let filename = URL(fileURLWithPath: title).lastPathComponent as NSString
+      let originalExtension = filename.pathExtension
+      let fileExtension = UTType(filenameExtension: originalExtension) == type
+        ? originalExtension : type.preferredFilenameExtension ?? "png"
+      let stem = filename.deletingPathExtension
+      var name = String(stem.prefix(60)).components(separatedBy: .controlCharacters).joined(separator: "_")
+      while name.utf8.count > 200 { name.removeLast() }
+      let file = directory.appendingPathComponent("\(name.isEmpty ? "Preview" : name).\(fileExtension)")
+      try FileManager.default.moveItem(at: download, to: file)
+      return PreparedPreviewFile(url: file, image: previewImage)
+    } catch {
+      try? FileManager.default.removeItem(at: directory)
+      throw error
+    }
+  }
+}

--- a/apps/mobile/modules/t3-native-controls/ios/T3NativeFilePresentation.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/T3NativeFilePresentation.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import ImageIO
 import QuickLook
 import UIKit
@@ -9,135 +8,16 @@ private final class FilePreviewItem: NSObject, QLPreviewItem {
   var previewItemTitle: String?
 }
 
-private struct PreparedPreviewFile {
-  let url: URL
-  let image: UIImage?
-}
+private final class FilePreviewController: QLPreviewController {
+  var onAppear: (() -> Void)?
 
-/// UIKit supplies pinch/pan physics, header controls, sharing, and interactive zoom dismissal.
-private final class NativeImagePreviewController: UIViewController, UIScrollViewDelegate {
-  var usesZoomTransition = false
-  private let imageView: UIImageView
-  private let scrollView = UIScrollView()
-  private let url: URL
-  private let onClose: () -> Void
-  private let onDismiss: () -> Void
-  private var viewportSize = CGSize.zero
-
-  init(image: UIImage, url: URL, title: String, onClose: @escaping () -> Void, onDismiss: @escaping () -> Void) {
-    self.imageView = UIImageView(image: image)
-    self.url = url
-    self.onClose = onClose
-    self.onDismiss = onDismiss
-    super.init(nibName: nil, bundle: nil)
-    self.title = title
-  }
-
-  required init?(coder: NSCoder) { nil }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = .black
-    scrollView.frame = view.bounds
-    scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    scrollView.contentInsetAdjustmentBehavior = .never
-    scrollView.showsHorizontalScrollIndicator = false
-    scrollView.showsVerticalScrollIndicator = false
-    scrollView.delegate = self
-    scrollView.accessibilityIdentifier = "ImagePreviewScrollView"
-    imageView.isAccessibilityElement = true
-    imageView.accessibilityLabel = title
-    imageView.accessibilityIdentifier = "ImagePreviewImage"
-    scrollView.addSubview(imageView)
-    view.addSubview(scrollView)
-
-    navigationItem.leftBarButtonItem = UIBarButtonItem(systemItem: .close, primaryAction: UIAction { [weak self] _ in
-      self?.onClose()
-    })
-    navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share))
-    navigationItem.rightBarButtonItem?.accessibilityLabel = "Share"
-    let appearance = UINavigationBarAppearance()
-    appearance.configureWithTransparentBackground()
-    appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
-    navigationItem.standardAppearance = appearance
-    navigationItem.scrollEdgeAppearance = appearance
-    navigationItem.compactAppearance = appearance
-    navigationController?.navigationBar.tintColor = .white
-
-    let doubleTap = UITapGestureRecognizer(target: self, action: #selector(zoom))
-    doubleTap.numberOfTapsRequired = 2
-    let singleTap = UITapGestureRecognizer(target: self, action: #selector(toggleControls))
-    singleTap.require(toFail: doubleTap)
-    scrollView.addGestureRecognizer(singleTap)
-    scrollView.addGestureRecognizer(doubleTap)
-    if !usesZoomTransition {
-      let swipe = UISwipeGestureRecognizer(target: self, action: #selector(closeIfNotZoomed))
-      swipe.direction = .down
-      scrollView.addGestureRecognizer(swipe)
-    }
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    let size = scrollView.bounds.size
-    guard size != viewportSize, let image = imageView.image, size.width > 0, size.height > 0 else { return }
-    viewportSize = size
-    scrollView.minimumZoomScale = 1
-    scrollView.zoomScale = 1
-    imageView.frame = CGRect(origin: .zero, size: image.size)
-    scrollView.contentSize = image.size
-    let fit = min(size.width / image.size.width, size.height / image.size.height)
-    scrollView.maximumZoomScale = max(fit * 4, 1)
-    scrollView.minimumZoomScale = fit
-    scrollView.zoomScale = fit
-    centerImage()
-  }
-
-  override func viewDidDisappear(_ animated: Bool) {
-    super.viewDidDisappear(animated)
-    if isBeingDismissed || navigationController?.isBeingDismissed == true || navigationController?.presentingViewController == nil {
-      onDismiss()
-    }
-  }
-
-  func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
-  func scrollViewDidZoom(_ scrollView: UIScrollView) { centerImage() }
-
-  private func centerImage() {
-    let horizontal = max(0, (scrollView.bounds.width - scrollView.contentSize.width) / 2)
-    let vertical = max(0, (scrollView.bounds.height - scrollView.contentSize.height) / 2)
-    scrollView.contentInset = UIEdgeInsets(top: vertical, left: horizontal, bottom: vertical, right: horizontal)
-  }
-
-  @objc private func zoom(_ recognizer: UITapGestureRecognizer) {
-    if scrollView.zoomScale > scrollView.minimumZoomScale * 1.01 {
-      scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
-    } else {
-      let scale = min(scrollView.minimumZoomScale * 3, scrollView.maximumZoomScale)
-      let point = recognizer.location(in: imageView)
-      let size = CGSize(width: scrollView.bounds.width / scale, height: scrollView.bounds.height / scale)
-      let rect = CGRect(x: point.x - size.width / 2, y: point.y - size.height / 2, width: size.width, height: size.height)
-      scrollView.zoom(to: rect, animated: true)
-    }
-  }
-
-  @objc private func toggleControls() {
-    guard let navigationController else { return }
-    navigationController.setNavigationBarHidden(!navigationController.isNavigationBarHidden, animated: true)
-  }
-
-  @objc private func closeIfNotZoomed() {
-    if scrollView.zoomScale <= scrollView.minimumZoomScale * 1.01 { onClose() }
-  }
-
-  @objc private func share(_ sender: UIBarButtonItem) {
-    let sheet = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-    sheet.popoverPresentationController?.barButtonItem = sender
-    present(sheet, animated: true)
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    onAppear?()
   }
 }
 
-/// Shares file preparation and lifecycle between the image viewer and Quick Look documents.
+/// Quick Look owns image and document controls, zooming, and source-view transitions.
 final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
   QLPreviewControllerDelegate, UIAdaptivePresentationControllerDelegate {
   let identifier: String
@@ -147,7 +27,6 @@ final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
   private let sourceIdentifier: String
   private let item = FilePreviewItem()
   private var loading: Task<Void, Never>?
-  private var presented = false
   private var dismissRequested = false
   private var finished = false
 
@@ -164,44 +43,18 @@ final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
       do {
         let file = try await Self.prepareFile(url: url, title: title)
         guard !finished, !Task.isCancelled else {
-          try? FileManager.default.removeItem(at: file.url.deletingLastPathComponent())
+          try? FileManager.default.removeItem(at: file.deletingLastPathComponent())
           return
         }
-        item.previewItemURL = file.url
+        item.previewItemURL = file
         item.previewItemTitle = title
-        let preview: UIViewController
-        if let image = file.image {
-          let viewer = NativeImagePreviewController(
-            image: image, url: file.url, title: title,
-            onClose: { [weak self] in self?.dismiss() }, onDismiss: { [weak self] in self?.finish() }
-          )
-          let navigation = UINavigationController(rootViewController: viewer)
-          navigation.modalPresentationStyle = .fullScreen
-          navigation.overrideUserInterfaceStyle = .dark
-          preview = navigation
-          if #available(iOS 18.0, *), !UIAccessibility.isReduceMotionEnabled,
-            sources?.view(for: sourceIdentifier)?.window != nil {
-            viewer.usesZoomTransition = true
-            let options = UIViewController.Transition.ZoomOptions()
-            options.alignmentRectProvider = { context in
-              AVMakeRect(aspectRatio: image.size, insideRect: context.zoomedViewController.view.bounds)
-            }
-            preview.preferredTransition = .zoom(options: options) { [weak self] _ in
-              guard let self, let source = sources?.view(for: sourceIdentifier), source.window != nil else { return nil }
-              return source
-            }
-          }
-          navigation.view.backgroundColor = .black
-        } else {
-          let quickLook = QLPreviewController()
-          quickLook.delegate = self
-          quickLook.dataSource = self
-          preview = quickLook
-        }
+        let preview = FilePreviewController()
+        preview.delegate = self
+        preview.dataSource = self
+        preview.onAppear = { [weak self] in self?.resumePendingDismissal() }
         controller = preview
         presenter.present(preview, animated: !UIAccessibility.isReduceMotionEnabled) { [self] in
-          presented = true
-          if dismissRequested { dismiss() }
+          resumePendingDismissal()
         }
         preview.presentationController?.delegate = self
       } catch {
@@ -214,17 +67,36 @@ final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
     dismissRequested = true
     loading?.cancel()
     guard !finished else { return }
-    guard presented else {
-      if controller?.presentingViewController == nil { finish() }
-      return
+    guard let controller else { finish(); return }
+    // Drain Close from viewDidAppear after opening or cancelling an interactive dismissal.
+    // Starting a second modal transition while UIKit is settling the first can strand it.
+    guard !controller.isBeingPresented, !controller.isBeingDismissed else { return }
+    controller.dismiss(animated: !UIAccessibility.isReduceMotionEnabled) { [self] in finish() }
+  }
+
+  private func resumePendingDismissal() {
+    // Appearance callbacks run before UIKit has cleared the current transition.
+    DispatchQueue.main.async { [weak self] in
+      if self?.dismissRequested == true { self?.dismiss() }
     }
-    controller?.dismiss(animated: !UIAccessibility.isReduceMotionEnabled) { [self] in finish() }
   }
 
   func numberOfPreviewItems(in controller: QLPreviewController) -> Int { item.previewItemURL == nil ? 0 : 1 }
 
   func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
     item
+  }
+
+  func previewController(_ controller: QLPreviewController, transitionViewFor item: QLPreviewItem) -> UIView? {
+    guard !UIAccessibility.isReduceMotionEnabled else { return nil }
+    return sources?.view(for: sourceIdentifier)
+  }
+
+  func previewController(_ controller: QLPreviewController, frameFor item: QLPreviewItem,
+                         inSourceView view: AutoreleasingUnsafeMutablePointer<UIView?>) -> CGRect {
+    guard !UIAccessibility.isReduceMotionEnabled, let source = sources?.view(for: sourceIdentifier) else { return .zero }
+    view.pointee = source
+    return source.bounds
   }
 
   func previewControllerDidDismiss(_ controller: QLPreviewController) { finish() }
@@ -240,11 +112,11 @@ final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
       try? FileManager.default.removeItem(at: file.deletingLastPathComponent())
     }
     item.previewItemURL = nil
-    completion(error)
+    DispatchQueue.main.async { [completion] in completion(error) }
   }
 
   /// Copy original bytes so preview and sharing do not mutate a draft or workspace file.
-  nonisolated private static func prepareFile(url: URL, title: String) async throws -> PreparedPreviewFile {
+  nonisolated private static func prepareFile(url: URL, title: String) async throws -> URL {
     try Task.checkCancellation()
     let directory = FileManager.default.temporaryDirectory.appendingPathComponent("t3-preview-\(UUID().uuidString)")
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -266,15 +138,10 @@ final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
       }
       try Task.checkCancellation()
       let type: UTType
-      var previewImage: UIImage?
       if let image = CGImageSourceCreateWithURL(download as CFURL, nil),
         CGImageSourceGetCount(image) > 0, let imageType = CGImageSourceGetType(image),
         let detectedType = UTType(imageType as String) {
         type = detectedType
-        // Animated images stay in Quick Look; static images are decoded before the zoom starts.
-        if CGImageSourceGetCount(image) == 1 {
-          previewImage = UIImage(contentsOfFile: download.path)?.preparingForDisplay()
-        }
       } else if CGPDFDocument(download as CFURL) != nil {
         type = .pdf
       } else {
@@ -289,7 +156,7 @@ final class T3NativeFilePresentation: NSObject, QLPreviewControllerDataSource,
       while name.utf8.count > 200 { name.removeLast() }
       let file = directory.appendingPathComponent("\(name.isEmpty ? "Preview" : name).\(fileExtension)")
       try FileManager.default.moveItem(at: download, to: file)
-      return PreparedPreviewFile(url: file, image: previewImage)
+      return file
     } catch {
       try? FileManager.default.removeItem(at: directory)
       throw error

--- a/apps/mobile/src/components/ComposerAttachmentStrip.tsx
+++ b/apps/mobile/src/components/ComposerAttachmentStrip.tsx
@@ -6,15 +6,18 @@ import { Alert, Image, Pressable, ScrollView, View } from "react-native";
 import { AppText as Text } from "./AppText";
 import type { DraftComposerAttachment, DraftComposerFileAttachment } from "../lib/composerImages";
 import { VideoAttachmentTile } from "./VideoAttachmentTile";
-import { loadLocalVideoPreview } from "../lib/localVideoPreview";
+import { loadLocalAttachmentPreview } from "../lib/localAttachmentPreview";
+import { PresentationSource } from "./NativePresentation";
+import type { FilePreviewSource } from "./FilePreviewModal";
+import { isPdfFile } from "../lib/filePreview";
 
 export interface ComposerAttachmentStripProps {
   /** Attachments to display. */
   readonly attachments: ReadonlyArray<DraftComposerAttachment>;
   /** Called when the user removes an attachment. */
   readonly onRemove: (imageId: string) => void;
-  /** Called when the user taps on an image thumbnail to preview it. */
-  readonly onPressImage?: (previewUri: string) => void;
+  /** Called when the user taps an image or PDF to preview it. */
+  readonly onPressPreview?: (source: FilePreviewSource) => void;
   readonly onPressVideo?: (
     attachment: DraftComposerFileAttachment,
     sourceIdentifier: string,
@@ -32,7 +35,7 @@ export function ComposerAttachmentThumbnail(props: {
   readonly size: number;
   readonly borderRadius: number;
   readonly compact?: boolean;
-  readonly onPressImage?: (previewUri: string) => void;
+  readonly onPressPreview?: (source: FilePreviewSource) => void;
   readonly onPressVideo?: (
     attachment: DraftComposerFileAttachment,
     sourceIdentifier: string,
@@ -41,17 +44,30 @@ export function ComposerAttachmentThumbnail(props: {
   const { attachment } = props;
   const style = { width: props.size, height: props.size, borderRadius: props.borderRadius };
   if (attachment.type === "image") {
+    const sourceIdentifier = `draft-image:${attachment.id}`;
     return (
-      <Pressable
-        onPress={props.onPressImage ? () => props.onPressImage?.(attachment.previewUri) : undefined}
-      >
-        <Image
-          source={{ uri: attachment.previewUri }}
-          style={style}
-          className="bg-subtle"
-          resizeMode="cover"
-        />
-      </Pressable>
+      <PresentationSource identifier={sourceIdentifier}>
+        <Pressable
+          accessibilityRole="imagebutton"
+          accessibilityLabel={`Open ${attachment.name}`}
+          disabled={!props.onPressPreview}
+          onPress={() =>
+            props.onPressPreview?.({
+              kind: "image",
+              uri: attachment.dataUrl,
+              name: attachment.name,
+              sourceIdentifier,
+            })
+          }
+        >
+          <Image
+            source={{ uri: attachment.previewUri }}
+            style={style}
+            className="bg-subtle"
+            resizeMode="cover"
+          />
+        </Pressable>
+      </PresentationSource>
     );
   }
   const onPressVideo = props.onPressVideo;
@@ -60,27 +76,42 @@ export function ComposerAttachmentThumbnail(props: {
       <ComposerVideoAttachment {...props} attachment={attachment} onPressVideo={onPressVideo} />
     );
   }
+  const canPreview = isPdfFile(attachment) && props.onPressPreview !== undefined;
+  const sourceIdentifier = `draft-file:${attachment.id}`;
   return (
-    <View
-      className={
-        props.compact
-          ? "items-center justify-center bg-subtle"
-          : "items-center justify-center gap-1 bg-subtle px-2"
-      }
-      style={style}
-    >
-      <SymbolView
-        name="doc.text"
-        size={props.compact ? 15 : 22}
-        tintColor="#a3a3a3"
-        type="monochrome"
-      />
-      {!props.compact ? (
-        <Text className="w-full text-center text-2xs text-foreground" numberOfLines={1}>
-          {attachment.name}
-        </Text>
-      ) : null}
-    </View>
+    <PresentationSource identifier={sourceIdentifier}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${attachment.name}`}
+        disabled={!canPreview}
+        onPress={() =>
+          props.onPressPreview?.({
+            kind: "pdf",
+            name: attachment.name,
+            attachment,
+            sourceIdentifier,
+          })
+        }
+        className={
+          props.compact
+            ? "items-center justify-center bg-subtle"
+            : "items-center justify-center gap-1 bg-subtle px-2"
+        }
+        style={style}
+      >
+        <SymbolView
+          name="doc.text"
+          size={props.compact ? 15 : 22}
+          tintColor="#a3a3a3"
+          type="monochrome"
+        />
+        {!props.compact ? (
+          <Text className="w-full text-center text-2xs text-foreground" numberOfLines={1}>
+            {attachment.name}
+          </Text>
+        ) : null}
+      </Pressable>
+    </PresentationSource>
   );
 }
 
@@ -113,7 +144,7 @@ function ComposerVideoAttachment(props: {
     shareRef.current = controller;
     setSharing(true);
     void (async () => {
-      const preview = await loadLocalVideoPreview(attachment, controller.signal);
+      const preview = await loadLocalAttachmentPreview(attachment, controller.signal);
       if (!preview) return;
       try {
         await preview.share(controller.signal, sourceIdentifier);
@@ -185,7 +216,7 @@ export function ComposerAttachmentStrip(props: ComposerAttachmentStripProps) {
               attachment={attachment}
               size={size}
               borderRadius={radius}
-              onPressImage={props.onPressImage}
+              onPressPreview={props.onPressPreview}
               onPressVideo={props.onPressVideo}
             />
             <Pressable

--- a/apps/mobile/src/components/FilePreview.ios.tsx
+++ b/apps/mobile/src/components/FilePreview.ios.tsx
@@ -1,0 +1,43 @@
+import { requireNativeModule } from "expo";
+import { useEffect, useEffectEvent, useId } from "react";
+import { Alert } from "react-native";
+
+import type { ResolvedFilePreviewSource } from "./FilePreviewModal";
+
+const NativeControls = requireNativeModule<{
+  presentFile(
+    uri: string,
+    name: string,
+    sourceIdentifier: string,
+    identifier: string,
+  ): Promise<void>;
+  dismissFile(identifier: string): Promise<void>;
+}>("T3NativeControls");
+
+export function FilePreview(props: {
+  readonly source: ResolvedFilePreviewSource;
+  readonly onRequestClose: () => void;
+}) {
+  const { uri, name, sourceIdentifier } = props.source;
+  const identifier = useId();
+  const onRequestClose = useEffectEvent(props.onRequestClose);
+
+  useEffect(() => {
+    let canceled = false;
+    void NativeControls.presentFile(uri, name ?? "Preview", sourceIdentifier ?? "", identifier)
+      .catch(() => {
+        if (!canceled) {
+          Alert.alert("Could not open preview", "The file could not be loaded. Please try again.");
+        }
+      })
+      .finally(() => {
+        if (!canceled) onRequestClose();
+      });
+    return () => {
+      canceled = true;
+      void NativeControls.dismissFile(identifier).catch(() => undefined);
+    };
+  }, [uri, name, sourceIdentifier, identifier]);
+
+  return null;
+}

--- a/apps/mobile/src/components/FilePreview.tsx
+++ b/apps/mobile/src/components/FilePreview.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useEffectEvent } from "react";
+import { Alert } from "react-native";
+import ImageViewing from "react-native-image-viewing";
+
+import { downloadAndShareAttachment, shareLocalAttachment } from "../lib/attachmentDownload";
+import type { ResolvedFilePreviewSource } from "./FilePreviewModal";
+
+function PdfPreview(props: {
+  readonly source: ResolvedFilePreviewSource;
+  readonly onRequestClose: () => void;
+}) {
+  const { uri, name } = props.source;
+  const onRequestClose = useEffectEvent(props.onRequestClose);
+  useEffect(() => {
+    const controller = new AbortController();
+    const input = {
+      attachment: { name: name ?? "Document.pdf", mimeType: "application/pdf" },
+      signal: controller.signal,
+    };
+    // Android's system chooser supplies the installed PDF apps.
+    const opened =
+      uri.startsWith("file:") || uri.startsWith("content:")
+        ? shareLocalAttachment({ ...input, uri })
+        : downloadAndShareAttachment({ ...input, url: uri });
+    void opened
+      .catch(() => {
+        if (!controller.signal.aborted) Alert.alert("Could not open PDF", "Please try again.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) onRequestClose();
+      });
+    return () => controller.abort();
+  }, [uri, name]);
+  return null;
+}
+
+export function FilePreview(props: {
+  readonly source: ResolvedFilePreviewSource;
+  readonly onRequestClose: () => void;
+}) {
+  if (props.source.kind === "pdf") return <PdfPreview {...props} />;
+  return (
+    <ImageViewing
+      images={[{ uri: props.source.uri }]}
+      imageIndex={0}
+      visible
+      onRequestClose={props.onRequestClose}
+      swipeToCloseEnabled
+      doubleTapToZoomEnabled
+    />
+  );
+}

--- a/apps/mobile/src/components/FilePreviewModal.tsx
+++ b/apps/mobile/src/components/FilePreviewModal.tsx
@@ -1,0 +1,93 @@
+import { useIsFocused } from "@react-navigation/native";
+import type { AssetResource, EnvironmentId } from "@t3tools/contracts";
+import { useEffect, useEffectEvent, useState } from "react";
+import { Alert, Keyboard } from "react-native";
+
+import type { DraftComposerFileAttachment } from "../lib/composerImages";
+import { loadLocalAttachmentPreview } from "../lib/localAttachmentPreview";
+import { useAssetUrlState } from "../state/assets";
+import { usePreparedConnection } from "../state/session";
+import { FilePreview } from "./FilePreview";
+
+export interface ResolvedFilePreviewSource {
+  readonly kind: "image" | "pdf";
+  readonly uri: string;
+  readonly name?: string;
+  readonly sourceIdentifier?: string;
+}
+
+export type FilePreviewSource = Omit<ResolvedFilePreviewSource, "uri"> &
+  (
+    | { readonly uri: string }
+    | { readonly attachment: DraftComposerFileAttachment }
+    | { readonly environmentId: EnvironmentId; readonly resource: AssetResource }
+  );
+
+function ResolvedFilePreview(props: {
+  readonly source: FilePreviewSource;
+  readonly onRequestClose: () => void;
+}) {
+  const { source } = props;
+  const environmentId = "environmentId" in source ? source.environmentId : null;
+  const connection = usePreparedConnection(environmentId);
+  const asset = useAssetUrlState(environmentId, "resource" in source ? source.resource : null);
+  // Keep the original URL through dismissal; a refreshed signature must not reopen the viewer.
+  const [uri, setUri] = useState<string | null>("uri" in source ? source.uri : null);
+  const onRequestClose = useEffectEvent(props.onRequestClose);
+  const failed =
+    environmentId !== null &&
+    uri === null &&
+    (connection._tag === "None" || asset._tag === "Failure");
+  useEffect(() => Keyboard.dismiss(), []);
+  useEffect(() => {
+    if (uri === null && asset._tag === "Success") setUri(asset.url);
+  }, [uri, asset]);
+  useEffect(() => {
+    if (!failed) return;
+    Alert.alert("Could not open preview", "Reconnect to this environment and try again.");
+    onRequestClose();
+  }, [failed]);
+  useEffect(() => {
+    if (!("attachment" in source)) return;
+    const controller = new AbortController();
+    let release: (() => void) | undefined;
+    void loadLocalAttachmentPreview(source.attachment, controller.signal)
+      .then((file) => {
+        if (!file) return;
+        if (controller.signal.aborted) {
+          file.dispose();
+          return;
+        }
+        release = file.dispose;
+        setUri(file.uri);
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        Alert.alert("Could not open preview", "Attach the file again and retry.");
+        onRequestClose();
+      });
+    return () => {
+      controller.abort();
+      release?.();
+    };
+  }, [source]);
+
+  return uri === null ? null : (
+    <FilePreview source={{ ...source, uri }} onRequestClose={props.onRequestClose} />
+  );
+}
+
+export function FilePreviewModal(props: {
+  readonly source: FilePreviewSource | null;
+  readonly onRequestClose: () => void;
+}) {
+  const isFocused = useIsFocused();
+  const hasSource = props.source !== null;
+  const onRequestClose = useEffectEvent(props.onRequestClose);
+  useEffect(() => {
+    if (!isFocused && hasSource) onRequestClose();
+  }, [isFocused, hasSource]);
+
+  if (!props.source || !isFocused) return null;
+  return <ResolvedFilePreview source={props.source} onRequestClose={props.onRequestClose} />;
+}

--- a/apps/mobile/src/components/VideoPreviewModal.ios.tsx
+++ b/apps/mobile/src/components/VideoPreviewModal.ios.tsx
@@ -4,7 +4,7 @@ import { requireNativeModule } from "expo";
 import { useEffect, useEffectEvent, useId, useState } from "react";
 import { Alert, Keyboard } from "react-native";
 
-import { loadLocalVideoPreview } from "../lib/localVideoPreview";
+import { loadLocalAttachmentPreview } from "../lib/localAttachmentPreview";
 import { useAssetUrlState } from "../state/assets";
 import { usePreparedConnection } from "../state/session";
 import type { VideoPreviewSource } from "./VideoPreviewModal";
@@ -67,7 +67,7 @@ function NativeVideoPreview(props: {
     void (async () => {
       const file =
         source.type === "local"
-          ? await loadLocalVideoPreview(source.attachment, controller.signal)
+          ? await loadLocalAttachmentPreview(source.attachment, controller.signal)
           : null;
       if (source.type === "local" && !file) return;
       try {

--- a/apps/mobile/src/components/VideoPreviewModal.tsx
+++ b/apps/mobile/src/components/VideoPreviewModal.tsx
@@ -20,7 +20,7 @@ import {
   type AttachmentPreviewFile,
 } from "../lib/attachmentDownload";
 import type { DraftComposerFileAttachment } from "../lib/composerImages";
-import { loadLocalVideoPreview } from "../lib/localVideoPreview";
+import { loadLocalAttachmentPreview } from "../lib/localAttachmentPreview";
 import { useAssetUrlState } from "../state/assets";
 import { usePreparedConnection } from "../state/session";
 import { SymbolView } from "./AppSymbol";
@@ -155,7 +155,7 @@ function OpenVideoPreviewModal(props: {
     setFailure(null);
     const loading =
       source.type === "local"
-        ? loadLocalVideoPreview(source.attachment, controller.signal)
+        ? loadLocalAttachmentPreview(source.attachment, controller.signal)
         : downloadAttachmentForPreview({
             url: downloadUrl!,
             attachment: { name: attachment.name, mimeType },

--- a/apps/mobile/src/components/VideoThumbnailImage.tsx
+++ b/apps/mobile/src/components/VideoThumbnailImage.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { StyleSheet } from "react-native";
 
 import type { DraftComposerFileAttachment } from "../lib/composerImages";
-import { loadLocalVideoPreview } from "../lib/localVideoPreview";
+import { loadLocalAttachmentPreview } from "../lib/localAttachmentPreview";
 import { cachedVideoThumbnail, loadVideoThumbnail } from "../lib/videoThumbnails";
 
 export function VideoThumbnailImage(props: {
@@ -25,7 +25,7 @@ export function VideoThumbnailImage(props: {
       async (signal) =>
         typeof source === "string"
           ? { uri: source, dispose: () => undefined }
-          : loadLocalVideoPreview(source, signal),
+          : loadLocalAttachmentPreview(source, signal),
       controller.signal,
     ).then((thumbnail) => {
       if (thumbnail && !controller.signal.aborted) setLoaded({ key: cacheKey, thumbnail });

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -17,9 +17,11 @@ import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { EmptyState } from "../../components/EmptyState";
+import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { resolveFileSelectionNavigationAction } from "../../lib/adaptive-navigation";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
+import { isPdfFile } from "../../lib/filePreview";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
 import { useThreadSelection } from "../../state/use-thread-selection";
@@ -487,6 +489,7 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
     readonly mode: FileViewMode;
   } | null>(null);
   const [previewRevision, setPreviewRevision] = useState(0);
+  const [fullScreenPreview, setFullScreenPreview] = useState<FilePreviewSource | null>(null);
   const isBrowserFile = relativePath !== null && isBrowserPreviewFile(relativePath);
   const isImageFile = relativePath !== null && isImagePreviewFile(relativePath);
   const canPreview =
@@ -586,6 +589,20 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
         inline: false,
         onPress: () => copyTextWithHaptic(relativePath),
       } as const,
+      isPdfFile({ name: relativePath }) && previewUri !== null
+        ? ({
+            id: "open-pdf",
+            title: "Open PDF",
+            icon: "arrow.up.left.and.arrow.down.right",
+            inline: false,
+            onPress: () =>
+              setFullScreenPreview({
+                kind: "pdf",
+                uri: previewUri,
+                name: basename(relativePath),
+              }),
+          } as const)
+        : null,
       isBrowserFile && typeof assetPreviewUri === "string"
         ? ({
             id: "open-browser",
@@ -605,7 +622,15 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
           } as const)
         : null,
     ].filter((action) => action !== null);
-  }, [assetPreviewUri, canPreview, isBrowserFile, isImageFile, relativePath, resolvedActiveMode]);
+  }, [
+    assetPreviewUri,
+    previewUri,
+    canPreview,
+    isBrowserFile,
+    isImageFile,
+    relativePath,
+    resolvedActiveMode,
+  ]);
 
   const androidFileMenuActions = useMemo<MenuAction[]>(
     () =>
@@ -765,6 +790,10 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
           relativePath={relativePath}
           truncated={fileData?.truncated ?? false}
           onRefresh={() => fileQuery.refresh()}
+        />
+        <FilePreviewModal
+          source={fullScreenPreview}
+          onRequestClose={() => setFullScreenPreview(null)}
         />
       </View>
     </ReviewHighlighterProvider>

--- a/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
@@ -1,24 +1,25 @@
 import { useAtomValue } from "@effect/atom-react";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { ActivityIndicator, Image, Pressable, View } from "react-native";
-import ImageViewing from "react-native-image-viewing";
 import { AsyncResult } from "effect/unstable/reactivity";
 
 import { AppText as Text } from "../../components/AppText";
 import { EmptyState } from "../../components/EmptyState";
 import { workspaceFileImageAtom } from "./workspace-file-image-cache";
+import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
+import { PresentationSource } from "../../components/NativePresentation";
 
 function ResolvedWorkspaceFileImagePreview(props: {
   readonly accessibilityLabel: string;
   readonly uri: string;
 }) {
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [fullScreenVisible, setFullScreenVisible] = useState(false);
+  const [preview, setPreview] = useState<FilePreviewSource | null>(null);
+  const sourceIdentifier = useId();
   const imageSource = useMemo(
     () => ({ uri: props.uri, cache: "force-cache" as const }),
     [props.uri],
   );
-  const fullScreenImages = useMemo(() => [imageSource], [imageSource]);
 
   return (
     <View className="relative flex-1 bg-subtle">
@@ -27,18 +28,27 @@ function ResolvedWorkspaceFileImagePreview(props: {
         accessibilityLabel={`Open full-screen preview of ${props.accessibilityLabel}`}
         disabled={loadError !== null}
         className="flex-1 p-4 active:bg-subtle-strong"
-        onPress={() => setFullScreenVisible(true)}
+        onPress={() =>
+          setPreview({
+            kind: "image",
+            uri: props.uri,
+            name: props.accessibilityLabel,
+            sourceIdentifier,
+          })
+        }
       >
-        <Image
-          accessible={false}
-          source={imageSource}
-          className="h-full w-full"
-          resizeMode="contain"
-          onLoadStart={() => setLoadError(null)}
-          onError={(event) => {
-            setLoadError(event.nativeEvent.error || "The image could not be rendered.");
-          }}
-        />
+        <PresentationSource identifier={sourceIdentifier} style={{ flex: 1 }}>
+          <Image
+            accessible={false}
+            source={imageSource}
+            className="h-full w-full"
+            resizeMode="contain"
+            onLoadStart={() => setLoadError(null)}
+            onError={(event) => {
+              setLoadError(event.nativeEvent.error || "The image could not be rendered.");
+            }}
+          />
+        </PresentationSource>
       </Pressable>
 
       {loadError !== null ? (
@@ -47,14 +57,7 @@ function ResolvedWorkspaceFileImagePreview(props: {
         </View>
       ) : null}
 
-      <ImageViewing
-        images={fullScreenImages}
-        imageIndex={0}
-        visible={fullScreenVisible}
-        onRequestClose={() => setFullScreenVisible(false)}
-        swipeToCloseEnabled
-        doubleTapToZoomEnabled
-      />
+      <FilePreviewModal source={preview} onRequestClose={() => setPreview(null)} />
     </View>
   );
 }

--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Platform, Pressable, ScrollView, View, useWindowDimensions } from "react-native";
 import { KeyboardAvoidingView, KeyboardStickyView } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import ImageViewing from "react-native-image-viewing";
+import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { SymbolView } from "../../components/AppSymbol";
@@ -53,7 +53,7 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
     Record<string, ReadonlyArray<ReviewHighlightedToken>>
   >({});
   const [attachments, setAttachments] = useState<ReadonlyArray<DraftComposerImageAttachment>>([]);
-  const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
+  const [previewFile, setPreviewFile] = useState<FilePreviewSource | null>(null);
 
   const selectedLines = useMemo(
     () => (target ? getSelectedReviewCommentLines(target) : []),
@@ -272,7 +272,7 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
                         attachments={attachments}
                         imageBorderRadius={16}
                         imageSize={60}
-                        onPressImage={setPreviewImageUri}
+                        onPressPreview={setPreviewFile}
                         removeButtonPlacement="gutter"
                         onRemove={(imageId) => {
                           setAttachments((current) =>
@@ -332,14 +332,7 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
           </View>
         </KeyboardStickyView>
       ) : null}
-      <ImageViewing
-        images={previewImageUri ? [{ uri: previewImageUri }] : []}
-        imageIndex={0}
-        visible={previewImageUri !== null}
-        onRequestClose={() => setPreviewImageUri(null)}
-        swipeToCloseEnabled
-        doubleTapToZoomEnabled
-      />
+      <FilePreviewModal source={previewFile} onRequestClose={() => setPreviewFile(null)} />
     </View>
   );
 }

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -35,6 +35,7 @@ import {
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { ComposerAttachmentButton } from "../../components/ComposerAttachmentButton";
 import { ComposerAttachmentStrip } from "../../components/ComposerAttachmentStrip";
+import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
 import { VideoPreviewModal, type VideoPreviewSource } from "../../components/VideoPreviewModal";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import { SymbolView } from "../../components/AppSymbol";
@@ -167,17 +168,28 @@ export function NewTaskDraftScreen(props: {
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [previewVideo, setPreviewVideo] = useState<VideoPreviewSource | null>(null);
-  const wasFocusedBeforeVideoRef = useRef(false);
+  const [previewFile, setPreviewFile] = useState<FilePreviewSource | null>(null);
+  const wasFocusedBeforePreviewRef = useRef(false);
   const openVideoPreview = useCallback(
     (attachment: DraftComposerFileAttachment, sourceIdentifier: string) => {
-      wasFocusedBeforeVideoRef.current = isComposerFocused;
+      wasFocusedBeforePreviewRef.current = isComposerFocused;
+      setPreviewFile(null);
       setPreviewVideo((current) => current ?? { type: "local", attachment, sourceIdentifier });
     },
     [isComposerFocused],
   );
-  const closeVideoPreview = useCallback(() => {
+  const openFilePreview = useCallback(
+    (source: FilePreviewSource) => {
+      wasFocusedBeforePreviewRef.current = isComposerFocused;
+      setPreviewVideo(null);
+      setPreviewFile((current) => current ?? source);
+    },
+    [isComposerFocused],
+  );
+  const closeMediaPreview = useCallback(() => {
     setPreviewVideo(null);
-    if (wasFocusedBeforeVideoRef.current) {
+    setPreviewFile(null);
+    if (wasFocusedBeforePreviewRef.current) {
       setTimeout(() => {
         if (navigation.isFocused()) promptInputRef.current?.focus();
       }, 100);
@@ -1212,6 +1224,9 @@ export function NewTaskDraftScreen(props: {
                   ? () => undefined
                   : flow.removeAttachment
               }
+              onPressPreview={
+                isComposerInteractionLocked || voiceInput.isBusy ? undefined : openFilePreview
+              }
               onPressVideo={
                 isComposerInteractionLocked || voiceInput.isBusy ? undefined : openVideoPreview
               }
@@ -1318,7 +1333,8 @@ export function NewTaskDraftScreen(props: {
           </ComposerDictationToolbar>
         </Animated.View>
       </ComposerSurface>
-      <VideoPreviewModal source={previewVideo} onRequestClose={closeVideoPreview} />
+      <VideoPreviewModal source={previewVideo} onRequestClose={closeMediaPreview} />
+      <FilePreviewModal source={previewFile} onRequestClose={closeMediaPreview} />
     </View>
   );
 

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -20,7 +20,7 @@ import {
   type RefObject,
 } from "react";
 import { ActivityIndicator, Platform, Pressable, View, type ViewStyle } from "react-native";
-import ImageViewing from "react-native-image-viewing";
+import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
 import Animated, {
   FadeIn,
   FadeInDown,
@@ -311,7 +311,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const inFlightThreadIdsRef = useRef(new Set<string>());
   const { onExpandedChange } = props;
 
-  const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
+  const [previewFile, setPreviewFile] = useState<FilePreviewSource | null>(null);
   const [previewVideo, setPreviewVideo] = useState<VideoPreviewSource | null>(null);
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
   const showStopAction =
@@ -372,17 +372,17 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     onExpandedChange?.(isExpanded);
   }, [isExpanded, onExpandedChange]);
 
-  const onPressImage = useCallback(
-    (uri: string) => {
+  const onPressPreview = useCallback(
+    (source: FilePreviewSource) => {
       wasExpandedBeforePreviewRef.current = isFocused;
       setPreviewVideo(null);
-      setPreviewImageUri(uri);
+      setPreviewFile((current) => current ?? source);
     },
     [isFocused],
   );
 
   const closePreview = useCallback(() => {
-    setPreviewImageUri(null);
+    setPreviewFile(null);
     setPreviewVideo(null);
     if (wasExpandedBeforePreviewRef.current) {
       setTimeout(() => {
@@ -394,7 +394,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const onPressVideo = useCallback(
     (attachment: DraftComposerFileAttachment, sourceIdentifier: string) => {
       wasExpandedBeforePreviewRef.current = isFocused;
-      setPreviewImageUri(null);
+      setPreviewFile(null);
       setPreviewVideo((current) => current ?? { type: "local", attachment, sourceIdentifier });
     },
     [isFocused],
@@ -619,7 +619,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                 <ComposerAttachmentStrip
                   attachments={props.draftAttachments}
                   onRemove={voiceInput.isBusy ? () => undefined : props.onRemoveDraftImage}
-                  onPressImage={voiceInput.isBusy ? undefined : onPressImage}
+                  onPressPreview={voiceInput.isBusy ? undefined : onPressPreview}
                   onPressVideo={voiceInput.isBusy ? undefined : onPressVideo}
                 />
               </Animated.View>
@@ -673,7 +673,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                     size={30}
                     borderRadius={8}
                     compact
-                    onPressImage={onPressImage}
+                    onPressPreview={onPressPreview}
                     onPressVideo={onPressVideo}
                   />
                 ))}
@@ -819,14 +819,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       </Animated.View>
 
       <VideoPreviewModal source={previewVideo} onRequestClose={closePreview} />
-      <ImageViewing
-        images={previewImageUri ? [{ uri: previewImageUri }] : []}
-        imageIndex={0}
-        visible={previewImageUri !== null}
-        onRequestClose={closePreview}
-        swipeToCloseEnabled
-        doubleTapToZoomEnabled
-      />
+      <FilePreviewModal source={previewFile} onRequestClose={closePreview} />
     </Animated.View>
   );
 });

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -36,6 +36,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useId,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -62,8 +63,9 @@ import {
   View,
   type ViewStyle,
 } from "react-native";
-import { TouchableOpacity } from "react-native-gesture-handler";
-import ImageViewing from "react-native-image-viewing";
+import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
+import { isPdfFile } from "../../lib/filePreview";
+import { PresentationSource } from "../../components/NativePresentation";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Animated, {
   FadeIn,
@@ -212,9 +214,11 @@ export interface ThreadFeedProps {
 function MessageAttachmentImage(props: {
   readonly environmentId: EnvironmentId;
   readonly attachmentId: string;
+  readonly name: string;
   readonly className: string;
-  readonly onPressImage: (uri: string, headers?: Record<string, string>) => void;
+  readonly onPressPreview: (source: FilePreviewSource) => void;
 }) {
+  const sourceIdentifier = useId();
   const uri = useAssetUrl(props.environmentId, {
     _tag: "attachment",
     attachmentId: props.attachmentId,
@@ -229,9 +233,17 @@ function MessageAttachmentImage(props: {
   }
 
   return (
-    <TouchableOpacity activeOpacity={0.7} onPress={() => props.onPressImage(uri)}>
-      <Image source={{ uri }} className={props.className} resizeMode="cover" />
-    </TouchableOpacity>
+    <PresentationSource identifier={sourceIdentifier}>
+      <Pressable
+        accessibilityRole="imagebutton"
+        accessibilityLabel={`Open ${props.name}`}
+        onPress={() =>
+          props.onPressPreview({ kind: "image", uri, name: props.name, sourceIdentifier })
+        }
+      >
+        <Image source={{ uri }} className={props.className} resizeMode="cover" />
+      </Pressable>
+    </PresentationSource>
   );
 }
 
@@ -249,14 +261,21 @@ function isFileAttachment(attachment: ChatAttachment): attachment is ChatFileAtt
 function MessageAttachmentFile(props: {
   readonly environmentId: EnvironmentId;
   readonly attachment: ChatFileAttachment;
+  readonly onPressPreview: (source: FilePreviewSource) => void;
   readonly onPressVideo: (attachment: ChatFileAttachment, sourceIdentifier: string) => void;
 }) {
+  const sourceIdentifier = useId();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
     reportFailure: false,
   });
   const preparedConnection = usePreparedConnection(props.environmentId);
   const { attachment } = props;
   const videoType = videoMimeType(attachment);
+  const isPdf = isPdfFile(attachment);
+  const fileTypeLabel = isPdf
+    ? "PDF"
+    : (attachment.name.match(/\.([a-z0-9]{1,8})$/i)?.[1]?.toUpperCase() ?? "File");
+  const sizeLabel = formatAttachmentSize(attachment.sizeBytes);
   const thumbnailUrl = useAssetUrl(
     props.environmentId,
     videoType === null
@@ -348,26 +367,63 @@ function MessageAttachmentFile(props: {
   }
 
   return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={`Open ${attachment.name}`}
-      accessibilityState={{ disabled: opening || httpBaseUrl === null, busy: opening }}
-      disabled={opening || httpBaseUrl === null}
-      className="flex-row items-center gap-2 py-1"
-      onPress={() => shareFile()}
+    <PresentationSource
+      identifier={sourceIdentifier}
+      className="my-1"
+      style={{ width: 280, maxWidth: "100%" }}
     >
-      {opening ? (
-        <ActivityIndicator size="small" />
-      ) : (
-        <SymbolView name="doc.text" size={16} tintColor="#a3a3a3" type="monochrome" />
-      )}
-      <Text className="min-w-0 flex-1 text-sm text-foreground" numberOfLines={1}>
-        {attachment.name}
-      </Text>
-      <Text className="text-xs text-foreground-muted">
-        {formatAttachmentSize(attachment.sizeBytes)}
-      </Text>
-    </Pressable>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${attachment.name}`}
+        accessibilityValue={{ text: `${fileTypeLabel}, ${sizeLabel}` }}
+        accessibilityState={{ disabled: opening || httpBaseUrl === null, busy: opening }}
+        disabled={opening || httpBaseUrl === null}
+        className="min-w-0 flex-row items-center gap-3 rounded-xl border border-border bg-card p-3 active:bg-subtle"
+        onPress={() =>
+          isPdf
+            ? props.onPressPreview({
+                kind: "pdf",
+                name: attachment.name,
+                environmentId: props.environmentId,
+                resource: {
+                  _tag: "attachment",
+                  attachmentId: attachment.id,
+                  fileName: attachment.name,
+                  mimeType: "application/pdf",
+                },
+                sourceIdentifier,
+              })
+            : shareFile(sourceIdentifier)
+        }
+      >
+        <View className="h-12 w-10 shrink-0 items-center justify-center rounded-lg bg-subtle">
+          {opening ? (
+            <ActivityIndicator size="small" />
+          ) : (
+            <SymbolView
+              name="doc.text"
+              size={26}
+              tintColorClassName={isPdf ? "accent-red-500" : "accent-foreground-muted"}
+              type="monochrome"
+            />
+          )}
+        </View>
+        <View className="min-w-0 flex-1 gap-1">
+          <Text className="font-t3-medium text-sm text-foreground" numberOfLines={2}>
+            {attachment.name}
+          </Text>
+          <Text className="text-xs text-foreground-muted" numberOfLines={1}>
+            {fileTypeLabel} · {sizeLabel}
+          </Text>
+        </View>
+        <SymbolView
+          name="chevron.right"
+          size={12}
+          tintColorClassName="accent-foreground-muted"
+          type="monochrome"
+        />
+      </Pressable>
+    </PresentationSource>
   );
 }
 
@@ -391,8 +447,9 @@ function ThreadMarkdownImageView(props: {
   readonly sourceKey: string;
   readonly unavailable: boolean;
   readonly alt: string | null;
-  readonly onPressImage: (uri: string) => void;
+  readonly onPressPreview: (source: FilePreviewSource) => void;
 }) {
+  const sourceIdentifier = useId();
   const [availableWidth, setAvailableWidth] = useState(0);
   const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
   const [failedUri, setFailedUri] = useState<string | null>(null);
@@ -437,27 +494,35 @@ function ThreadMarkdownImageView(props: {
           )}
         </View>
       ) : (
-        <TouchableOpacity
-          accessibilityRole="imagebutton"
-          accessibilityLabel={props.alt ?? "Markdown image"}
-          activeOpacity={0.7}
-          onPress={() => props.onPressImage(props.uri!)}
-          style={{ alignSelf: "flex-start" }}
-        >
-          <View
-            className="items-center justify-center overflow-hidden rounded-[10px] bg-md-code-bg"
-            style={{
-              ...frameStyle,
-            }}
+        <PresentationSource identifier={sourceIdentifier} style={{ alignSelf: "flex-start" }}>
+          <Pressable
+            accessibilityRole="imagebutton"
+            accessibilityLabel={props.alt ?? "Markdown image"}
+            onPress={() =>
+              props.onPressPreview({
+                kind: "image",
+                uri: props.uri!,
+                name: props.alt ?? "Image",
+                sourceIdentifier,
+              })
+            }
+            style={{ alignSelf: "flex-start" }}
           >
-            <ThreadMarkdownImageRequest
-              key={props.uri}
-              uri={props.uri}
-              onLoad={setSourceSize}
-              onError={() => setFailedUri(props.uri)}
-            />
-          </View>
-        </TouchableOpacity>
+            <View
+              className="items-center justify-center overflow-hidden rounded-[10px] bg-md-code-bg"
+              style={{
+                ...frameStyle,
+              }}
+            >
+              <ThreadMarkdownImageRequest
+                key={props.uri}
+                uri={props.uri}
+                onLoad={setSourceSize}
+                onError={() => setFailedUri(props.uri)}
+              />
+            </View>
+          </Pressable>
+        </PresentationSource>
       )}
       {props.alt ? (
         <Text selectable className="text-xs text-foreground-muted">
@@ -506,7 +571,7 @@ function ThreadMarkdownImage(props: {
   readonly threadId: ThreadId;
   readonly path: string;
   readonly alt: string | null;
-  readonly onPressImage: (uri: string) => void;
+  readonly onPressPreview: (source: FilePreviewSource) => void;
 }) {
   const assetUrl = useAssetUrlState(props.environmentId, {
     _tag: "workspace-file",
@@ -520,7 +585,7 @@ function ThreadMarkdownImage(props: {
       sourceKey={props.path}
       unavailable={assetUrl._tag === "Failure"}
       alt={props.alt}
-      onPressImage={props.onPressImage}
+      onPressPreview={props.onPressPreview}
     />
   );
 }
@@ -532,7 +597,7 @@ function ThreadMarkdownImageUnavailable(props: { readonly alt: string | null }) 
       sourceKey="unavailable"
       unavailable
       alt={props.alt}
-      onPressImage={() => undefined}
+      onPressPreview={() => undefined}
     />
   );
 }
@@ -1264,7 +1329,7 @@ function renderFeedEntry(
     readonly onToggleWorkGroup: (groupId: string) => void;
     readonly onToggleWorkRow: (rowId: string) => void;
     readonly onToggleTurnFold: (turnId: TurnId) => void;
-    readonly onPressImage: (uri: string, headers?: Record<string, string>) => void;
+    readonly onPressPreview: (source: FilePreviewSource) => void;
     readonly onPressVideo: (attachment: ChatFileAttachment, sourceIdentifier: string) => void;
     readonly onMarkdownLinkPress: (href: string) => void;
     readonly renderMarkdownImage: MarkdownImageRenderer;
@@ -1375,14 +1440,16 @@ function renderFeedEntry(
                   key={attachment.id}
                   environmentId={props.environmentId}
                   attachmentId={attachment.id}
+                  name={attachment.name}
                   className="aspect-[1.3] w-full rounded-[14px] bg-white/15"
-                  onPressImage={props.onPressImage}
+                  onPressPreview={props.onPressPreview}
                 />
               ) : isFileAttachment(attachment) ? (
                 <MessageAttachmentFile
                   key={attachment.id}
                   environmentId={props.environmentId}
                   attachment={attachment}
+                  onPressPreview={props.onPressPreview}
                   onPressVideo={props.onPressVideo}
                 />
               ) : (
@@ -1436,14 +1503,16 @@ function renderFeedEntry(
               key={attachment.id}
               environmentId={props.environmentId}
               attachmentId={attachment.id}
+              name={attachment.name}
               className="mt-1.5 aspect-[1.3] w-full rounded-[18px] bg-adaptive-neutral-200-800"
-              onPressImage={props.onPressImage}
+              onPressPreview={props.onPressPreview}
             />
           ) : isFileAttachment(attachment) ? (
             <MessageAttachmentFile
               key={attachment.id}
               environmentId={props.environmentId}
               attachment={attachment}
+              onPressPreview={props.onPressPreview}
               onPressVideo={props.onPressVideo}
             />
           ) : (
@@ -1806,13 +1875,11 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     expandedTurnIds: new Set(),
   });
   const { copiedRowId, expandedWorkGroups, expandedWorkRows, expandedTurnIds } = interactionState;
-  const [expandedImage, setExpandedImage] = useState<{
-    uri: string;
-    headers?: Record<string, string>;
-  } | null>(null);
+  const [expandedFile, setExpandedFile] = useState<FilePreviewSource | null>(null);
   const [expandedVideo, setExpandedVideo] = useState<VideoPreviewSource | null>(null);
   useEffect(() => {
     setExpandedVideo(null);
+    setExpandedFile(null);
   }, [props.environmentId, props.threadId, props.contentPresentation.kind]);
   const horizontalPadding = props.layoutVariant === "split" ? 20 : 16;
   const contentHorizontalPadding = deriveCenteredContentHorizontalPadding({
@@ -1858,6 +1925,22 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         );
         if (relativePath) {
           void Haptics.selectionAsync();
+          if (isPdfFile({ name: relativePath })) {
+            setExpandedFile(
+              (current) =>
+                current ?? {
+                  kind: "pdf",
+                  name: relativePath.split("/").at(-1),
+                  environmentId: props.environmentId,
+                  resource: {
+                    _tag: "workspace-file",
+                    threadId: props.threadId,
+                    path: relativePath,
+                  },
+                },
+            );
+            return;
+          }
           navigation.navigate("ThreadFile", {
             environmentId: String(props.environmentId),
             threadId: String(props.threadId),
@@ -1869,6 +1952,12 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       }
 
       if (presentation.href) {
+        if (/^https?:\/\//i.test(presentation.href) && isPdfFile({ name: presentation.href })) {
+          setExpandedFile(
+            (current) => current ?? { kind: "pdf", uri: presentation.href!, name: "Document.pdf" },
+          );
+          return;
+        }
         void tryOpenExternalUrl(presentation.href, "markdown-link");
       }
     },
@@ -1884,7 +1973,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             sourceKey={imageSource.uri}
             unavailable={false}
             alt={image.alt}
-            onPressImage={(uri) => setExpandedImage({ uri })}
+            onPressPreview={(source) => setExpandedFile((current) => current ?? source)}
           />
         );
       }
@@ -1897,7 +1986,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
           threadId={props.threadId}
           path={imageSource.path}
           alt={image.alt}
-          onPressImage={(uri) => setExpandedImage({ uri })}
+          onPressPreview={(source) => setExpandedFile((current) => current ?? source)}
         />
       );
     },
@@ -2285,8 +2374,8 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     [suspendEndScrollMaintenanceForDisclosure],
   );
 
-  const onPressImage = useCallback((uri: string, headers?: Record<string, string>) => {
-    setExpandedImage({ uri, headers });
+  const onPressPreview = useCallback((source: FilePreviewSource) => {
+    setExpandedFile((current) => current ?? source);
   }, []);
   const onPressVideo = useCallback(
     (attachment: ChatFileAttachment, sourceIdentifier: string) => {
@@ -2350,7 +2439,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
           onToggleWorkGroup,
           onToggleWorkRow,
           onToggleTurnFold,
-          onPressImage,
+          onPressPreview,
           onPressVideo,
           onMarkdownLinkPress,
           renderMarkdownImage,
@@ -2379,7 +2468,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       userBubbleMaxWidth,
       onCopyWorkRow,
       onMarkdownLinkPress,
-      onPressImage,
+      onPressPreview,
       onPressVideo,
       onToggleTurnFold,
       onToggleWorkGroup,
@@ -2565,23 +2654,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       </View>
 
       <VideoPreviewModal source={expandedVideo} onRequestClose={() => setExpandedVideo(null)} />
-      <ImageViewing
-        images={
-          expandedImage
-            ? [
-                {
-                  uri: expandedImage.uri,
-                  headers: expandedImage.headers,
-                },
-              ]
-            : []
-        }
-        imageIndex={0}
-        visible={expandedImage !== null}
-        onRequestClose={() => setExpandedImage(null)}
-        swipeToCloseEnabled
-        doubleTapToZoomEnabled
-      />
+      <FilePreviewModal source={expandedFile} onRequestClose={() => setExpandedFile(null)} />
     </>
   );
 });

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { PROVIDER_SEND_TURN_MAX_IMAGE_BYTES } from "@t3tools/contracts";
 import type { ImagePickerAsset } from "expo-image-picker";
 
 const mocks = vi.hoisted(() => ({
@@ -9,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   delete: vi.fn(),
   open: vi.fn(),
   size: vi.fn(),
+  readBase64: vi.fn(),
 }));
 
 vi.mock("expo-file-system", () => {
@@ -55,6 +57,10 @@ vi.mock("expo-file-system", () => {
       mocks.copy(this.uri, destination.uri);
     }
 
+    async base64(): Promise<string> {
+      return mocks.readBase64(this.uri);
+    }
+
     delete(): void {
       mocks.delete(this.uri);
     }
@@ -95,7 +101,113 @@ describe("composer file attachments", () => {
     mocks.delete.mockReset();
     mocks.open.mockReset();
     mocks.size.mockReset();
+    mocks.readBase64.mockReset();
     mocks.size.mockImplementation((uri: string) => (uri.startsWith("content:") ? null : 42));
+  });
+
+  describe("photo library image conversion", () => {
+    const jpeg = "/9j/2Q==";
+    const photo: ImagePickerAsset = {
+      uri: "file:///picker/photo.heic",
+      type: "image",
+      fileName: "photo.HEIC",
+      mimeType: "image/heic",
+      fileSize: 20 * 1024 * 1024,
+      base64: jpeg,
+      width: 1,
+      height: 1,
+    };
+
+    it.each(["image/heic", "image/heif", undefined])(
+      "attaches the native JPEG conversion with matching metadata when the source MIME is %s",
+      async (mimeType) => {
+        mocks.pickMedia.mockResolvedValue({
+          canceled: false,
+          assets: [{ ...photo, mimeType }],
+        });
+
+        const result = await pickComposerImages({ existingCount: 0 });
+
+        expect(result).toEqual({
+          images: [
+            {
+              id: "attachment-id",
+              type: "image",
+              name: "photo.jpg",
+              mimeType: "image/jpeg",
+              sizeBytes: 4,
+              dataUrl: `data:image/jpeg;base64,${jpeg}`,
+              previewUri: `data:image/jpeg;base64,${jpeg}`,
+            },
+          ],
+          error: null,
+        });
+      },
+    );
+
+    it.each([
+      { extension: "png", mimeType: "image/png", base64: "iVBORw0KGgo=" },
+      { extension: "gif", mimeType: "image/gif", base64: "R0lGODlh" },
+      { extension: "webp", mimeType: "image/webp", base64: "UklGRgQAAABXRUJQ" },
+    ])("preserves original $extension bytes instead of the picker's JPEG", async (original) => {
+      const name = `photo.${original.extension}`;
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [{ ...photo, fileName: name, mimeType: original.mimeType }],
+      });
+      mocks.readBase64.mockResolvedValue(original.base64);
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      expect(result.error).toBeNull();
+      expect(result.images).toEqual([
+        expect.objectContaining({
+          name,
+          mimeType: original.mimeType,
+          dataUrl: `data:${original.mimeType};base64,${original.base64}`,
+          sizeBytes: Buffer.from(original.base64, "base64").byteLength,
+        }),
+      ]);
+    });
+
+    it("checks the converted JPEG size even when the HEIC source was smaller", async () => {
+      const oversized =
+        jpeg.slice(0, 4) + "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4);
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [{ ...photo, fileSize: 42, base64: oversized }],
+      });
+
+      await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
+        images: [],
+        error: "'photo.HEIC' exceeds the 10 MB attachment limit.",
+      });
+    });
+
+    it("does not relabel unconverted HEIC bytes as JPEG", async () => {
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [{ ...photo, base64: "AAAAGGZ0eXBoZWlj" }],
+      });
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      expect(result.images).toEqual([]);
+      expect(result.error).toContain("not a supported image type");
+    });
+
+    it("retains a converted photo when another original cannot be read", async () => {
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [{ ...photo, fileName: "missing.gif", mimeType: "image/gif" }, photo],
+      });
+      mocks.readBase64.mockRejectedValue(new Error("missing file"));
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      expect(result.images).toEqual([expect.objectContaining({ name: "photo.jpg" })]);
+      expect(result.error).toBe("Failed to read 'missing.gif'.");
+    });
   });
 
   describe("photo library videos", () => {

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -351,7 +351,7 @@ export async function pickComposerMedia(input: {
       error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} attachments per message.`;
       break;
     }
-    const mimeType = asset.mimeType?.toLowerCase();
+    let mimeType = asset.mimeType?.toLowerCase();
     if (asset.type === "video" || mimeType?.startsWith("video/")) {
       if (input.maxVideoBytes === undefined) {
         error = "Video attachments are unavailable here.";
@@ -375,35 +375,61 @@ export async function pickComposerMedia(input: {
       }
       continue;
     }
-    if (!mimeType?.startsWith("image/")) {
+    if (asset.type !== "image" && !mimeType?.startsWith("image/")) {
       error = `Unsupported file type for '${asset.fileName ?? "image"}'.`;
       continue;
     }
-    if (!isProviderSendTurnSupportedImageMimeType(mimeType)) {
-      error = `'${asset.fileName ?? "image"}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
-      continue;
-    }
 
-    const base64 = asset.base64;
+    let base64 = asset.base64;
     if (!base64) {
       error = `Failed to read '${asset.fileName ?? "image"}'.`;
       continue;
     }
 
-    const sizeBytes = asset.fileSize ?? estimateBase64ByteSize(base64);
+    let name = asset.fileName?.trim() || "image";
+    // The iOS picker returns JPEG base64 even when its metadata describes HEIC,
+    // PNG, or GIF. Keep supported originals so transparency and animation survive;
+    // use the native JPEG conversion for formats providers cannot accept.
+    if (base64.startsWith("/9j/")) {
+      if (
+        mimeType &&
+        mimeType !== "image/jpeg" &&
+        isProviderSendTurnSupportedImageMimeType(mimeType)
+      ) {
+        try {
+          const { File } = await import("expo-file-system");
+          base64 = await new File(asset.uri).base64();
+        } catch {
+          error = `Failed to read '${name}'.`;
+          continue;
+        }
+      } else {
+        mimeType = "image/jpeg";
+        if (!/\.jpe?g$/i.test(name)) {
+          name = `${name.replace(/\.[^.]+$/, "")}.jpg`;
+        }
+      }
+    }
+    if (!mimeType || !isProviderSendTurnSupportedImageMimeType(mimeType)) {
+      error = `'${name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+      continue;
+    }
+
+    const sizeBytes = estimateBase64ByteSize(base64);
     if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
       error = `'${asset.fileName ?? "image"}' exceeds the 10 MB attachment limit.`;
       continue;
     }
 
+    const dataUrl = `data:${mimeType};base64,${base64}`;
     attachments.push({
       id: uuidv4(),
       type: "image",
-      name: asset.fileName ?? "image",
+      name,
       mimeType,
       sizeBytes,
-      dataUrl: `data:${mimeType};base64,${base64}`,
-      previewUri: asset.uri,
+      dataUrl,
+      previewUri: mimeType === asset.mimeType?.toLowerCase() ? asset.uri : dataUrl,
     });
   }
 

--- a/apps/mobile/src/lib/filePreview.test.ts
+++ b/apps/mobile/src/lib/filePreview.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { isPdfFile } from "./filePreview";
+
+describe("PDF preview detection", () => {
+  it.each([
+    [{ name: "download", mimeType: "application/pdf" }, true],
+    [{ name: "download", mimeType: "APPLICATION/PDF; charset=binary" }, true],
+    [{ name: "Report.PDF", mimeType: "application/octet-stream" }, true],
+    [{ name: "https://example.com/report.pdf?signature=abc#page=2" }, true],
+    [{ name: "report.pdf", mimeType: "text/plain" }, false],
+    [{ name: "report.pdf.exe" }, false],
+    [{ name: "https://example.com/page?download=report.pdf" }, false],
+  ])("classifies %j as %s", (file, expected) => {
+    expect(isPdfFile(file)).toBe(expected);
+  });
+});

--- a/apps/mobile/src/lib/filePreview.ts
+++ b/apps/mobile/src/lib/filePreview.ts
@@ -1,0 +1,6 @@
+/** MIME metadata wins; use the extension for files reported without a specific type. */
+export function isPdfFile(file: { readonly name: string; readonly mimeType?: string }): boolean {
+  const mimeType = file.mimeType?.split(";", 1)[0]?.trim().toLowerCase();
+  if (mimeType && mimeType !== "application/octet-stream") return mimeType === "application/pdf";
+  return /\.pdf$/i.test(file.name.split(/[?#]/, 1)[0] ?? "");
+}

--- a/apps/mobile/src/lib/localAttachmentPreview.test.ts
+++ b/apps/mobile/src/lib/localAttachmentPreview.test.ts
@@ -24,7 +24,7 @@ vi.mock("expo-file-system", () => ({
   },
 }));
 
-import { loadLocalVideoPreview } from "./localVideoPreview";
+import { loadLocalAttachmentPreview } from "./localAttachmentPreview";
 
 const attachment = {
   type: "file" as const,
@@ -45,9 +45,22 @@ beforeEach(() => {
   mocks.share.mockResolvedValue(undefined);
 });
 
-describe("loadLocalVideoPreview", () => {
+describe("loadLocalAttachmentPreview", () => {
+  it("retains and shares a PDF with its original filename and type", async () => {
+    const pdf = { ...attachment, name: "report.pdf", mimeType: "application/pdf" };
+    const preview = await loadLocalAttachmentPreview(pdf, new AbortController().signal);
+    await preview!.share(new AbortController().signal);
+    expect(mocks.share).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachment: { name: "report.pdf", mimeType: "application/pdf" },
+      }),
+    );
+    expect(mocks.retain.mock.results[0]!.value).not.toHaveBeenCalled();
+    preview!.dispose();
+    expect(mocks.retain.mock.results[0]!.value).toHaveBeenCalledTimes(1);
+  });
   it("resolves the current iOS container and releases its playback lease once", async () => {
-    const preview = await loadLocalVideoPreview(attachment, new AbortController().signal);
+    const preview = await loadLocalAttachmentPreview(attachment, new AbortController().signal);
     expect(preview?.uri).toContain("/22222222-2222-4222-8222-222222222222/Documents/");
     expect(mocks.retain).toHaveBeenCalledWith(attachment);
     const release = mocks.retain.mock.results[0]!.value;
@@ -62,7 +75,7 @@ describe("loadLocalVideoPreview", () => {
     async (sourceIdentifier) => {
       const shared = Promise.withResolvers<void>();
       mocks.share.mockReturnValue(shared.promise);
-      const preview = await loadLocalVideoPreview(attachment, new AbortController().signal);
+      const preview = await loadLocalAttachmentPreview(attachment, new AbortController().signal);
       const share = preview!.share(new AbortController().signal, sourceIdentifier);
       expect(mocks.retain).toHaveBeenCalledTimes(2);
       const releasePlayback = mocks.retain.mock.results[0]!.value;
@@ -78,7 +91,7 @@ describe("loadLocalVideoPreview", () => {
 
   it("releases a failed share while keeping playback retained", async () => {
     mocks.share.mockRejectedValue(new Error("Sharing unavailable"));
-    const preview = await loadLocalVideoPreview(attachment, new AbortController().signal);
+    const preview = await loadLocalAttachmentPreview(attachment, new AbortController().signal);
     await expect(preview!.share(new AbortController().signal)).rejects.toThrow(
       "Sharing unavailable",
     );
@@ -89,7 +102,7 @@ describe("loadLocalVideoPreview", () => {
 
   it("releases a load canceled during native module loading", async () => {
     const controller = new AbortController();
-    const loading = loadLocalVideoPreview(attachment, controller.signal);
+    const loading = loadLocalAttachmentPreview(attachment, controller.signal);
     controller.abort();
     await expect(loading).resolves.toBeNull();
     expect(mocks.retain.mock.results[0]!.value).toHaveBeenCalledTimes(1);
@@ -98,14 +111,14 @@ describe("loadLocalVideoPreview", () => {
 
   it("reports missing files and releases their lease", async () => {
     mocks.exists.mockReturnValue(false);
-    await expect(loadLocalVideoPreview(attachment, new AbortController().signal)).rejects.toThrow(
-      "This video is no longer available. Attach the file again.",
-    );
+    await expect(
+      loadLocalAttachmentPreview(attachment, new AbortController().signal),
+    ).rejects.toThrow("This attachment is no longer available. Attach the file again.");
     expect(mocks.retain.mock.results[0]!.value).toHaveBeenCalledTimes(1);
   });
 
   it("does not start sharing a disposed preview", async () => {
-    const preview = await loadLocalVideoPreview(attachment, new AbortController().signal);
+    const preview = await loadLocalAttachmentPreview(attachment, new AbortController().signal);
     preview!.dispose();
     await preview!.share(new AbortController().signal);
     expect(mocks.share).not.toHaveBeenCalled();

--- a/apps/mobile/src/lib/localAttachmentPreview.ts
+++ b/apps/mobile/src/lib/localAttachmentPreview.ts
@@ -5,8 +5,8 @@ import { resolveOwnedComposerAttachmentFileUri } from "./composerAttachmentFiles
 import { shareLocalAttachment, type AttachmentPreviewFile } from "./attachmentDownload";
 import { retainComposerAttachmentFileForPreview } from "../state/use-composer-drafts";
 
-/** Retains the draft original for playback and gives each outgoing share its own lease. */
-export async function loadLocalVideoPreview(
+/** Retains the draft original for preview and gives each outgoing share its own lease. */
+export async function loadLocalAttachmentPreview(
   attachment: DraftComposerFileAttachment,
   signal: AbortSignal,
 ): Promise<AttachmentPreviewFile | null> {
@@ -54,6 +54,6 @@ export async function loadLocalVideoPreview(
   } catch (cause) {
     release();
     if (signal.aborted) return null;
-    throw new Error("This video is no longer available. Attach the file again.", { cause });
+    throw new Error("This attachment is no longer available. Attach the file again.", { cause });
   }
 }

--- a/docs/internals/mobile-navigation.md
+++ b/docs/internals/mobile-navigation.md
@@ -51,13 +51,12 @@ use a separate implementation and do not need this workaround.
 
 ## Native media presentations
 
-`PresentationSource` in `NativePresentation` registers a thumbnail for AVKit's
-full-screen entry and UIKit's share sheet. Wrap the thumbnail as its single child
+`PresentationSource` in `NativePresentation` registers a thumbnail for AVKit,
+image zoom transitions, and UIKit's share sheet. Wrap the thumbnail as its single child
 and pass the stable identifier to the presentation. The registry keeps weak
 references to source views; recycled or compact composer thumbnails can register
 the same identifier. Identifiers must distinguish simultaneously visible attachments.
-This source registration does not own playback and can be reused by a future image
-viewer. Android uses a regular view.
+The source registration does not own the preview. Android uses a regular view.
 
 On iOS, video previews mount `AVPlayerViewController` temporarily inside the
 registered source and enter full screen through AVKit. AVKit
@@ -67,7 +66,24 @@ simulator, that leaves native Close unable to exit full screen. When the source 
 the player uses a standard modal presentation. Programmatic entry uses the same
 guarded `enterFullScreenAnimated:completionHandler:` selector as Expo Video;
 if that selector is unavailable, the player also falls back to a standard modal.
-Images retain their existing viewer.
+
+`FilePreviewModal` resolves image and PDF sources from a URI, a signed environment asset,
+or a retained composer file. On iOS, static images use `UIImageView` inside `UIScrollView`,
+with standard navigation-bar Close and Share items. The image is decoded before presentation
+so UIKit's iOS 18+ `preferredTransition` can zoom from the thumbnail into visible content.
+Quick Look delays image rendering until after presentation, leaving a blank zoom destination.
+It remains the viewer for PDFs and animated images, providing document search and sharing.
+Missing sources, older systems, and Reduce Motion use a standard presentation.
+
+The shared native presenter copies original bytes into its own temporary directory and
+removes that copy after dismissal. Network downloads write to disk, and sharing never edits
+the source attachment. Draft images use their stored upload data rather than a potentially
+expired picker URI. No React Navigation route or custom transition animator is needed.
+
+The same viewer handles message images, markdown images, PDF attachments and links,
+composer thumbnails, and workspace image previews. The workspace PDF web preview has an
+Open PDF action for the native viewer. Android retains its image viewer and uses the
+system chooser for PDFs. Saving images on iOS uses the add-only photo-library permission.
 
 Received videos open directly from their signed asset URL. AVKit handles buffering;
 the client does not download the entire file or show a separate opening overlay before

--- a/docs/internals/mobile-navigation.md
+++ b/docs/internals/mobile-navigation.md
@@ -68,12 +68,13 @@ guarded `enterFullScreenAnimated:completionHandler:` selector as Expo Video;
 if that selector is unavailable, the player also falls back to a standard modal.
 
 `FilePreviewModal` resolves image and PDF sources from a URI, a signed environment asset,
-or a retained composer file. On iOS, static images use `UIImageView` inside `UIScrollView`,
-with standard navigation-bar Close and Share items. The image is decoded before presentation
-so UIKit's iOS 18+ `preferredTransition` can zoom from the thumbnail into visible content.
-Quick Look delays image rendering until after presentation, leaving a blank zoom destination.
-It remains the viewer for PDFs and animated images, providing document search and sharing.
-Missing sources, older systems, and Reduce Motion use a standard presentation.
+or a retained composer file. On iOS, Quick Look owns image and document layout, controls,
+zooming, sharing, and interactive dismissal. Its delegate supplies the registered thumbnail
+and its bounds for Quick Look's source-view zoom. Do not layer `preferredTransition` or
+another image scroll view over that presentation: Quick Look coordinates its image gestures
+with the return to the thumbnail. Missing sources use the standard transition, and Reduce
+Motion disables animation. A pending programmatic Close waits until the current presentation
+or cancelled dismissal has settled before starting another transition.
 
 The shared native presenter copies original bytes into its own temporary directory and
 removes that copy after dismissal. Network downloads write to disk, and sharing never edits

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -20,7 +20,13 @@ file uploads, **+** opens a menu beside the button with **Photo Library** and **
 Videos use the server's file upload limit. You can also share photos, videos, and files into
 T3 Code from other apps through the system share sheet. Mobile uploads happen when the message
 sends, so queued messages keep their files until they deliver. Select a received file on mobile
-to save it or open it in another app through the system share sheet.
+to preview it or open the system share options.
+
+Tap an image or PDF before or after sending to open it. On iOS, images zoom from their thumbnail
+into the native viewer. Pinch or double-tap to zoom, and swipe down or tap Close to return.
+Use Share to save a copy or send it to another app. PDFs support page navigation and search.
+PDF links in assistant responses open the same preview. On Android, images open in the image
+viewer and PDFs open the system chooser.
 
 Select a video attachment before or after sending to play it. Web and desktop use the browser's
 built-in controls. On mobile, videos open in a full-screen player with native playback controls.

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -42,7 +42,8 @@ On web and desktop, if you reload before a file finishes uploading, the draft ke
 and shows **Attach again** next to it. Attach the file again or remove it, then send.
 
 On web and desktop, HEIC and HEIF photos are automatically converted to JPEG when you drag them into
-the composer or paste them into a message.
+the composer or paste them into a message. On iOS, selecting them from **Photo Library** also
+converts them to JPEG. The 10 MB image limit applies to the converted photo.
 
 On mobile, the model picker shows each OpenCode model's upstream provider, such as Anthropic,
 GitHub Copilot, or OpenCode Zen, beneath its name. Search by that provider name to narrow the list


### PR DESCRIPTION
## What changed

Images and PDFs open in iOS Quick Look from messages, assistant links, drafts, and the Files page. Quick Look owns the native controls, image zooming, interactive dismissal, and transition back to the thumbnail. File attachments now have readable cards in light and dark mode.

HEIC and HEIF photos selected from the iOS photo library use Expo's existing native JPEG conversion. The attachment name, MIME type, preview, and size match the converted bytes. PNG, GIF, and WebP selections retain their original bytes. No new dependency or native build change is required.

The previews reuse the existing transition sources and temporary-file handling. Previewing and sharing use a copy, leaving the original attachment unchanged. Android retains its image viewer and opens PDFs through the system chooser.

## Why

Image previews should match native video playback. PDFs should be readable from the conversation, and attachment filenames need sufficient contrast inside blue user bubbles.

## UI changes

Native image controls, pinch zoom, cancelled swipe, and dismissal back to message and composer thumbnails:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/50f53329cfa66a90/image-interactive-dismissal.mp4

PDF cards, user attachments, assistant workspace links, and assistant attachments:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/290e705944b93d7e/pdf-message-preview.mp4

| | Before | After |
| --- | --- | --- |
| Image viewer | <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/350ad25b4049a50a/before-image-viewer.png" width="250" alt="Previous image viewer"> | <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/73b4132132181a37/native-image-controls-updated.png" width="250" alt="Native image controls"> |
| File attachments | <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/92e538eacdf639a5/before-file-cards.png" width="250" alt="Previous file attachment rows"> | <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7548b9ba1fe9c7a5/file-cards-light.png" width="250" alt="File attachment cards"> |

<details>
<summary>File cards in dark mode</summary>

<img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2959a20a0eb5641c/file-cards-dark.png" width="300" alt="File attachment cards in dark mode">

</details>

## Validation

- 42 preview/download tests and 44 composer attachment tests passed, plus mobile typecheck and targeted TypeScript and Swift lint.
- Verified on iPhone 17 Pro Simulator with iOS 27: image and PDF entry points, native sharing, pinch and double-tap zoom, interactive drag cancellation, and return to message and composer thumbnails. Closing during presentation passed at 0, 80, 150, 250, and 400 ms.
- HEIC fixture converted to a 900 × 1400 JPEG with UIKit on iOS Simulator. The iOS 27 Photos sheet did not expose selectable controls to UI automation, so the complete picker interaction remains unverified.
- Latest Simulator and device builds passed. The updated device build is ready; installation is pending because the phone is currently unavailable to Xcode. Phone runtime, Android, and older iOS versions were not exercised.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native Quick Look presentation, modal dismissal timing, and many attachment entry points; incorrect lifecycle or URL handling could strand modals or show wrong preview bytes, but scope is mobile media UX rather than auth or data persistence.
> 
> **Overview**
> Adds a shared **`FilePreviewModal`** flow so images and PDFs open from the composer, thread feed, review composer, workspace image preview, and thread files screen, replacing scattered **`react-native-image-viewing`** usage with **`onPressPreview`** / **`FilePreviewSource`**.
> 
> On **iOS**, **`T3NativeFilePresentation`** presents images and PDFs through **Quick Look** with thumbnail zoom via **`PresentationSource`**, copies bytes to a temp file for safe preview/share, and **`T3NativeControls`** gains **`presentFile`** / **`dismissFile`** (mutually exclusive with video). **Android** keeps **`react-native-image-viewing`** for images and routes PDFs through the system share/chooser.
> 
> **PDFs** are detected with **`isPdfFile`**, shown as tappable cards in messages, and open from markdown/workspace links and an **Open PDF** action on the files route. **`loadLocalVideoPreview`** is generalized to **`loadLocalAttachmentPreview`** for draft file preview and sharing.
> 
> **Photo library** picking now reconciles iOS returning JPEG base64 for HEIC while preserving original **PNG/GIF/WebP** bytes when supported, with size checks on converted JPEG. **`NSPhotoLibraryAddUsageDescription`** is added for saving images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f95459e20f7cc170bf2d0cc39c21e0e3460cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native image and PDF previews via `FilePreviewModal` across mobile
> - Introduces `FilePreviewModal` and `FilePreviewSource` to replace `react-native-image-viewing` for image and PDF previews in the composer, feed, and file screens.
> - iOS presents PDFs via Quick Look and images via a custom zoomable viewer using `T3NativeControlsModule`; Android uses `react-native-image-viewing` for images and the system chooser for PDFs.
> - Improves the composer image picker to convert HEIC/HEIF to JPEG and preserve original PNG/GIF/WebP bytes when the iOS picker returns JPEG base64.
> - Risk: Renames `onPressImage` to `onPressPreview` in `ComposerAttachmentStripProps` and `loadLocalVideoPreview` to `loadLocalAttachmentPreview`, requiring callers to update references.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dcd586.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image and PDF previews across mobile attachments, threads, comments, workspaces, and file screens.
  * Added zooming, sharing, navigation, and full-screen viewing for supported previews.
  * Added PDF detection and an “Open PDF” action for thread files.
  * Improved video and attachment preview handling.

* **Bug Fixes**
  * Improved preview loading, cleanup, cancellation, and error handling.
  * Improved HEIC/HEIF conversion and image size validation.
  * Added iOS photo-library permission messaging.

* **Documentation**
  * Updated mobile navigation and composer documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->