### PR TITLE
feat(claude): profile custom model effort

### DIFF
--- a/apps/server/src/provider/ClaudeModelCatalog.test.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.test.ts
@@ -5,11 +5,15 @@ import { hasValidClaudeManifestAdapters } from "./ClaudeModelManifest.ts";
 import type { ModelManifestData } from "./ModelManifest.ts";
 import {
   formatClaudeVersionUpgradeMessage,
+  getClaudeCatalogModelCapabilities,
+  isClaudeCatalogCustomEffortProfile,
   normalizeClaudeCatalogEffort,
   resolveClaudeCatalogApiModelId,
+  resolveClaudeCatalogEffort,
   resolveClaudeModelCatalog,
   resolveClaudeModelsForVersion,
   resolveClaudeModelSlug,
+  scopeClaudeModelCatalog,
 } from "./ClaudeModelCatalog.ts";
 
 /**
@@ -111,6 +115,73 @@ describe("Claude model catalog", () => {
         model: "synthetic",
       }),
       "claude-synthetic-next[large]",
+    );
+  });
+
+  it("scopes custom aliases and attaches configured effort profiles", () => {
+    const catalog = scopeClaudeModelCatalog(
+      resolveClaudeModelCatalog(manifest()),
+      ["synthetic", "custom-model", "custom-model"],
+      {
+        "custom-model": {
+          capabilities: { reasoning: { levels: ["low", "xhigh"] } },
+        },
+      },
+    );
+
+    assert.strictEqual(resolveClaudeModelSlug(catalog, "synthetic"), "synthetic");
+    assert.isTrue(isClaudeCatalogCustomEffortProfile(catalog, "custom-model"));
+    assert.deepStrictEqual(
+      getClaudeCatalogModelCapabilities(catalog, "custom-model").optionDescriptors?.[0],
+      {
+        id: "effort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "default", label: "Default", isDefault: true },
+          { id: "low", label: "Low" },
+          { id: "xhigh", label: "Extra High" },
+        ],
+        currentValue: "default",
+      },
+    );
+    assert.strictEqual(resolveClaudeCatalogEffort(catalog, "custom-model", undefined), "default");
+    assert.strictEqual(normalizeClaudeCatalogEffort(catalog, "xhigh", "custom-model"), "xhigh");
+    assert.deepStrictEqual(
+      catalog.models.filter((entry) => entry.model.slug === "custom-model").length,
+      1,
+    );
+  });
+
+  it("keeps built-in catalog capabilities when a custom profile uses the same slug", () => {
+    const catalog = scopeClaudeModelCatalog(
+      resolveClaudeModelCatalog(manifest()),
+      ["claude-synthetic-next"],
+      {
+        "claude-synthetic-next": {
+          capabilities: { reasoning: { levels: ["low"] } },
+        },
+      },
+    );
+
+    assert.isFalse(isClaudeCatalogCustomEffortProfile(catalog, "claude-synthetic-next"));
+    assert.strictEqual(
+      resolveClaudeCatalogEffort(catalog, "claude-synthetic-next", undefined),
+      "extreme",
+    );
+  });
+
+  it("does not treat prototype keys as configured profiles", () => {
+    const catalog = scopeClaudeModelCatalog(resolveClaudeModelCatalog(manifest()), ["toString"], {
+      "other-model": {
+        capabilities: { reasoning: { levels: ["high"] } },
+      },
+    });
+
+    assert.isFalse(isClaudeCatalogCustomEffortProfile(catalog, "toString"));
+    assert.deepStrictEqual(
+      getClaudeCatalogModelCapabilities(catalog, "toString").optionDescriptors,
+      [],
     );
   });
 

--- a/apps/server/src/provider/ClaudeModelCatalog.testFixtures.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.testFixtures.ts
@@ -54,6 +54,7 @@ export const SYNTHETIC_CLAUDE_MODEL_CATALOG: ClaudeModelCatalog = {
       },
       runtime,
       compatibility: {},
+      customEffortProfile: false,
     },
     {
       model: {
@@ -66,6 +67,7 @@ export const SYNTHETIC_CLAUDE_MODEL_CATALOG: ClaudeModelCatalog = {
       },
       runtime,
       compatibility: {},
+      customEffortProfile: false,
     },
     {
       model: {
@@ -78,6 +80,7 @@ export const SYNTHETIC_CLAUDE_MODEL_CATALOG: ClaudeModelCatalog = {
       },
       runtime: {},
       compatibility: {},
+      customEffortProfile: false,
     },
   ],
 };

--- a/apps/server/src/provider/ClaudeModelCatalog.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.ts
@@ -1,4 +1,7 @@
 import {
+  CUSTOM_MODEL_REASONING_DEFAULT,
+  type CustomModelProfile,
+  type CustomModelProfiles,
   type ModelCapabilities,
   type ModelSelection,
   ProviderDriverKind,
@@ -32,6 +35,7 @@ export interface ClaudeCatalogModel {
   readonly model: ServerProviderModel;
   readonly runtime: ClaudeCodeProfile;
   readonly compatibility: ClaudeCodeCompatibility;
+  readonly customEffortProfile: boolean;
 }
 
 export interface ClaudeModelCatalog {
@@ -51,6 +55,7 @@ function tryResolveClaudeModelCatalog(manifest: ModelManifestData): ClaudeModelC
       model: entry.model,
       runtime: profile.value.claudeCode ?? {},
       compatibility: adapter.value.claudeCode ?? {},
+      customEffortProfile: false,
     });
   }
 
@@ -70,33 +75,85 @@ export function resolveClaudeModelCatalog(manifest: ModelManifestData): ClaudeMo
 
 export const BUNDLED_CLAUDE_MODEL_CATALOG = resolveClaudeModelCatalog(BUNDLED_MODEL_MANIFEST);
 
-/** Keeps custom model aliases opaque while preserving canonical built-in models and capabilities. */
+const CUSTOM_MODEL_REASONING_LABELS: Readonly<Record<string, string>> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  max: "Max",
+};
+
+function customModelCapabilities(profile: CustomModelProfile | undefined): ModelCapabilities {
+  if (!profile) return EMPTY_CAPABILITIES;
+  return {
+    optionDescriptors: [
+      {
+        id: "effort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: CUSTOM_MODEL_REASONING_DEFAULT, label: "Default", isDefault: true },
+          ...profile.capabilities.reasoning.levels.map((level) => ({
+            id: level,
+            label: CUSTOM_MODEL_REASONING_LABELS[level] ?? level,
+          })),
+        ],
+        currentValue: CUSTOM_MODEL_REASONING_DEFAULT,
+      },
+    ],
+  };
+}
+
+/** Keeps custom model aliases opaque and attaches settings-owned custom model profiles. */
 export function scopeClaudeModelCatalog(
   catalog: ClaudeModelCatalog,
   customModels: ReadonlyArray<string>,
+  customModelProfiles?: CustomModelProfiles,
 ): ClaudeModelCatalog {
-  const customAliases = new Set(
-    customModels.flatMap((model) => {
-      const slug = normalizeCustomModelSlug(model);
-      return slug ? [slug.toLowerCase()] : [];
-    }),
-  );
-  if (customAliases.size === 0) return catalog;
+  const customSlugs = customModels.flatMap((model) => {
+    const slug = normalizeCustomModelSlug(model);
+    return slug ? [slug] : [];
+  });
+  if (customSlugs.length === 0) return catalog;
 
-  return {
-    models: catalog.models.map((entry) => {
-      if (!entry.model.aliases?.some((alias) => customAliases.has(alias.toLowerCase()))) {
-        return entry;
-      }
-      return {
-        ...entry,
+  const customAliases = new Set(customSlugs.map((slug) => slug.toLowerCase()));
+  const builtInSlugs = new Set(catalog.models.map((entry) => entry.model.slug));
+  const seenCustom = new Set<string>();
+  const builtIns = catalog.models.map((entry) => {
+    if (!entry.model.aliases?.some((alias) => customAliases.has(alias.toLowerCase()))) {
+      return entry;
+    }
+    return {
+      ...entry,
+      model: {
+        ...entry.model,
+        aliases: entry.model.aliases.filter((alias) => !customAliases.has(alias.toLowerCase())),
+      },
+    };
+  });
+  const custom = customSlugs.flatMap((slug): ReadonlyArray<ClaudeCatalogModel> => {
+    if (builtInSlugs.has(slug) || seenCustom.has(slug)) return [];
+    seenCustom.add(slug);
+    const profile =
+      customModelProfiles && Object.prototype.hasOwnProperty.call(customModelProfiles, slug)
+        ? customModelProfiles[slug]
+        : undefined;
+    return [
+      {
         model: {
-          ...entry.model,
-          aliases: entry.model.aliases.filter((alias) => !customAliases.has(alias.toLowerCase())),
+          slug,
+          name: slug,
+          isCustom: true,
+          capabilities: customModelCapabilities(profile),
         },
-      };
-    }),
-  };
+        runtime: {},
+        compatibility: {},
+        customEffortProfile: profile !== undefined,
+      },
+    ];
+  });
+
+  return { models: [...builtIns, ...custom] };
 }
 
 export function resolveClaudeCatalogModel(
@@ -115,6 +172,13 @@ export function resolveClaudeCatalogModel(
 
 export function resolveClaudeModelSlug(catalog: ClaudeModelCatalog, slugOrAlias: string): string {
   return resolveClaudeCatalogModel(catalog, slugOrAlias)?.model.slug ?? slugOrAlias;
+}
+
+export function isClaudeCatalogCustomEffortProfile(
+  catalog: ClaudeModelCatalog,
+  slugOrAlias: string | null | undefined,
+): boolean {
+  return resolveClaudeCatalogModel(catalog, slugOrAlias)?.customEffortProfile === true;
 }
 
 export function getClaudeCatalogModelCapabilities(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -489,6 +489,70 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("forwards custom model effort into query options", () => {
+    const harness = makeHarness({
+      claudeConfig: {
+        customModels: ["custom-model"],
+        customModelProfiles: {
+          "custom-model": {
+            capabilities: { reasoning: { levels: ["xhigh", "max"] } },
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "custom-model",
+          [{ id: "effort", value: "max" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(harness.getLastCreateQueryInput()?.options.effort, "max");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("omits effort for custom model Default", () => {
+    const harness = makeHarness({
+      claudeConfig: {
+        customModels: ["custom-model"],
+        customModelProfiles: {
+          "custom-model": {
+            capabilities: { reasoning: { levels: ["low", "xhigh"] } },
+          },
+        },
+      },
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "custom-model",
+          [{ id: "effort", value: "default" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(harness.getLastCreateQueryInput()?.options.effort, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("runs Claude SDK sessions with the configured CLAUDE_CONFIG_DIR", () => {
     const harness = makeHarness({ claudeConfig: { homePath: "~/.claude-work" } });
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -24,6 +24,8 @@ import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 import {
   ApprovalRequestId,
   type CanonicalItemType,
+  CUSTOM_MODEL_REASONING_DEFAULT,
+  CUSTOM_MODEL_REASONING_LEVELS,
   type CanonicalRequestType,
   type ClaudeSettings,
   EventId,
@@ -86,6 +88,7 @@ import {
   BUNDLED_CLAUDE_MODEL_CATALOG,
   type ClaudeModelCatalog,
   getClaudeCatalogModelCapabilities,
+  isClaudeCatalogCustomEffortProfile,
   isClaudeCatalogUltracodeEffort,
   normalizeClaudeCatalogEffort,
   resolveClaudeCatalogApiModelId,
@@ -114,6 +117,7 @@ type ClaudeToolResultStreamKind = Extract<
   "command_output" | "file_change_output"
 >;
 type ClaudeSdkEffort = NonNullable<ClaudeQueryOptions["effort"]>;
+type ClaudeCustomEffort = (typeof CUSTOM_MODEL_REASONING_LEVELS)[number];
 
 function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
   const result = encodeUnknownJsonStringExit(input);
@@ -396,6 +400,12 @@ function getEffectiveClaudeAgentEffort(
 ): ClaudeSdkEffort | null {
   const normalized = normalizeClaudeCatalogEffort(catalog, effort, model);
   return normalized ? (normalized as ClaudeSdkEffort) : null;
+}
+
+const customModelReasoningLevels = new Set<string>(CUSTOM_MODEL_REASONING_LEVELS);
+
+function getCustomClaudeAgentEffort(effort: string | null | undefined): ClaudeCustomEffort | null {
+  return effort && customModelReasoningLevels.has(effort) ? (effort as ClaudeCustomEffort) : null;
 }
 
 function isClaudeInterruptedMessage(message: string): boolean {
@@ -1725,7 +1735,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("claudeAgent");
   const modelCatalogEffect = (
     options?.modelCatalog ?? Effect.succeed(BUNDLED_CLAUDE_MODEL_CATALOG)
-  ).pipe(Effect.map((catalog) => scopeClaudeModelCatalog(catalog, claudeSettings.customModels)));
+  ).pipe(
+    Effect.map((catalog) =>
+      scopeClaudeModelCatalog(
+        catalog,
+        claudeSettings.customModels,
+        claudeSettings.customModelProfiles,
+      ),
+    ),
+  );
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig;
@@ -4310,6 +4328,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const rawEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
       const effort =
         resolveClaudeCatalogEffort(modelCatalog, modelSelection?.model, rawEffort) ?? null;
+      const customProfiled = isClaudeCatalogCustomEffortProfile(
+        modelCatalog,
+        modelSelection?.model,
+      );
       const fastModeSupported = descriptors.some(
         (descriptor) => descriptor.type === "boolean" && descriptor.id === "fastMode",
       );
@@ -4322,12 +4344,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const thinking = thinkingSupported
         ? getModelSelectionBooleanOptionValue(modelSelection, "thinking")
         : undefined;
-      const ultracode = isClaudeCatalogUltracodeEffort(effort);
-      const effectiveEffort = getEffectiveClaudeAgentEffort(
-        modelCatalog,
-        effort,
-        modelSelection?.model,
-      );
+      const ultracode = !customProfiled && isClaudeCatalogUltracodeEffort(effort);
+      const customEffort = customProfiled
+        ? getCustomClaudeAgentEffort(effort === CUSTOM_MODEL_REASONING_DEFAULT ? null : effort)
+        : null;
+      const effectiveEffort = customProfiled
+        ? customEffort
+        : getEffectiveClaudeAgentEffort(modelCatalog, effort, modelSelection?.model);
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
         auto: "auto",
@@ -4596,9 +4619,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         modelSelection.model,
         getModelSelectionStringOptionValue(modelSelection, "effort"),
       );
-      context.currentEffort =
-        getEffectiveClaudeAgentEffort(modelCatalog, turnEffort ?? null, modelSelection.model) ??
-        undefined;
+      const customProfiled = isClaudeCatalogCustomEffortProfile(modelCatalog, modelSelection.model);
+      context.currentEffort = customProfiled
+        ? (getCustomClaudeAgentEffort(
+            turnEffort === CUSTOM_MODEL_REASONING_DEFAULT ? null : turnEffort,
+          ) ?? undefined)
+        : (getEffectiveClaudeAgentEffort(modelCatalog, turnEffort ?? null, modelSelection.model) ??
+          undefined);
     }
 
     // Apply interaction mode by switching the SDK's permission mode.

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -1,8 +1,4 @@
-import {
-  type ClaudeSettings,
-  type ModelCapabilities,
-  type ServerProviderSlashCommand,
-} from "@t3tools/contracts";
+import { type ClaudeSettings, type ServerProviderSlashCommand } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -10,7 +6,6 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import {
   query as claudeQuery,
@@ -25,7 +20,6 @@ import {
   DEFAULT_TIMEOUT_MS,
   isCommandMissingCause,
   parseGenericCliVersion,
-  providerModelsFromSettings,
   spawnAndCollect,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
@@ -37,11 +31,8 @@ import {
   type ClaudeModelCatalog,
   formatClaudeVersionUpgradeMessage,
   resolveClaudeModelsForVersion,
+  scopeClaudeModelCatalog,
 } from "../ClaudeModelCatalog.ts";
-
-const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
-  optionDescriptors: [],
-});
 
 const CLAUDE_PRESENTATION = {
   displayName: "Claude",
@@ -402,11 +393,12 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
 > {
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
-  const allModels = providerModelsFromSettings(
-    modelCatalog.models.map((entry) => entry.model),
+  const scopedModelCatalog = scopeClaudeModelCatalog(
+    modelCatalog,
     claudeSettings.customModels,
-    DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+    claudeSettings.customModelProfiles,
   );
+  const allModels = scopedModelCatalog.models.map((entry) => entry.model);
 
   if (!claudeSettings.enabled) {
     return buildServerProvider({
@@ -492,12 +484,11 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     });
   }
 
-  const models = providerModelsFromSettings(
-    resolveClaudeModelsForVersion(modelCatalog, parsedVersion),
-    claudeSettings.customModels,
-    DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+  const models = resolveClaudeModelsForVersion(scopedModelCatalog, parsedVersion);
+  const versionUpgradeMessage = formatClaudeVersionUpgradeMessage(
+    scopedModelCatalog,
+    parsedVersion,
   );
-  const versionUpgradeMessage = formatClaudeVersionUpgradeMessage(modelCatalog, parsedVersion);
 
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
@@ -564,11 +555,11 @@ export const makePendingClaudeProvider = (
 ): Effect.Effect<ServerProviderDraft> =>
   Effect.gen(function* () {
     const checkedAt = yield* nowIso;
-    const models = providerModelsFromSettings(
-      modelCatalog.models.map((entry) => entry.model),
+    const models = scopeClaudeModelCatalog(
+      modelCatalog,
       claudeSettings.customModels,
-      DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-    );
+      claudeSettings.customModelProfiles,
+    ).models.map((entry) => entry.model);
 
     if (!claudeSettings.enabled) {
       return buildServerProvider({

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -696,6 +696,58 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ]);
       });
 
+      it("treats refreshed custom model capabilities as authoritative", () => {
+        const customModel = {
+          slug: "custom-model",
+          name: "custom-model",
+          isCustom: true,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("effort", "Reasoning", [
+                { id: "high", label: "High", isDefault: true },
+              ]),
+            ],
+          }),
+        } as const;
+        const previousProvider = {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          driver: ProviderDriverKind.make("claudeAgent"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-14T00:00:00.000Z",
+          version: "2.1.0",
+          models: [customModel],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-04-14T00:01:00.000Z",
+          models: [{ ...customModel, capabilities: null }],
+        } satisfies ServerProvider;
+
+        assert.strictEqual(
+          mergeProviderSnapshot(previousProvider, refreshedProvider).models[0]?.capabilities,
+          null,
+        );
+
+        const codexProvider = {
+          ...previousProvider,
+          instanceId: ProviderInstanceId.make("codex"),
+          driver: ProviderDriverKind.make("codex"),
+        } satisfies ServerProvider;
+        const pendingCodexProvider = {
+          ...codexProvider,
+          models: [{ ...customModel, capabilities: null }],
+        } satisfies ServerProvider;
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(codexProvider, pendingCodexProvider).models[0]?.capabilities,
+          customModel.capabilities,
+        );
+      });
+
       it("drops stale OpenCode models missing from a successful refresh", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("opencode"),

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -144,7 +144,12 @@ const mergeProviderModels = (
   const previousBySlug = new Map(previousModels.map((model) => [model.slug, model] as const));
   const mergedModels = nextModels.map((model) => {
     const previousModel = previousBySlug.get(model.slug);
-    if (!previousModel || hasModelCapabilities(model) || !hasModelCapabilities(previousModel)) {
+    if (
+      (provider.driver === ProviderDriverKind.make("claudeAgent") && model.isCustom) ||
+      !previousModel ||
+      hasModelCapabilities(model) ||
+      !hasModelCapabilities(previousModel)
+    ) {
       return model;
     }
     return {

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -309,6 +309,72 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     ),
   );
 
+  it.effect("forwards configured custom model effort", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: { title: "Use custom effort", body: "Body" },
+        }),
+        argsMustContain: "--model custom-model --effort xhigh",
+        claudeConfig: {
+          customModels: ["custom-model"],
+          customModelProfiles: {
+            "custom-model": {
+              capabilities: { reasoning: { levels: ["low", "xhigh"] } },
+            },
+          },
+        },
+      },
+      (textGeneration) =>
+        textGeneration.generatePrContent({
+          cwd: process.cwd(),
+          baseBranch: "main",
+          headBranch: "feature/custom-effort",
+          commitSummary: "Use custom effort",
+          diffSummary: "1 file changed",
+          diffPatch: "diff --git a/README.md b/README.md",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            "custom-model",
+            [{ id: "effort", value: "xhigh" }],
+          ),
+        }),
+    ),
+  );
+
+  it.effect("omits effort for configured custom model Default", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: { title: "Use default effort", body: "Body" },
+        }),
+        argsMustNotContain: "--effort",
+        claudeConfig: {
+          customModels: ["custom-model"],
+          customModelProfiles: {
+            "custom-model": {
+              capabilities: { reasoning: { levels: ["low", "xhigh"] } },
+            },
+          },
+        },
+      },
+      (textGeneration) =>
+        textGeneration.generatePrContent({
+          cwd: process.cwd(),
+          baseBranch: "main",
+          headBranch: "feature/custom-default",
+          commitSummary: "Use default effort",
+          diffSummary: "1 file changed",
+          diffPatch: "diff --git a/README.md b/README.md",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            "custom-model",
+            [{ id: "effort", value: "default" }],
+          ),
+        }),
+    ),
+  );
+
   it.effect(
     "keeps canonical built-in capabilities when a custom model collides with its alias",
     () =>

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -13,7 +13,11 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
-import { type ClaudeSettings, type ModelSelection } from "@t3tools/contracts";
+import {
+  CUSTOM_MODEL_REASONING_DEFAULT,
+  type ClaudeSettings,
+  type ModelSelection,
+} from "@t3tools/contracts";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
@@ -40,6 +44,7 @@ import {
   BUNDLED_CLAUDE_MODEL_CATALOG,
   type ClaudeModelCatalog,
   getClaudeCatalogModelCapabilities,
+  isClaudeCatalogCustomEffortProfile,
   isClaudeCatalogUltracodeEffort,
   normalizeClaudeCatalogEffort,
   resolveClaudeCatalogApiModelId,
@@ -70,7 +75,13 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
   const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
   const scopedModelCatalog = modelCatalog.pipe(
-    Effect.map((catalog) => scopeClaudeModelCatalog(catalog, claudeSettings.customModels)),
+    Effect.map((catalog) =>
+      scopeClaudeModelCatalog(
+        catalog,
+        claudeSettings.customModels,
+        claudeSettings.customModelProfiles,
+      ),
+    ),
   );
 
   const readStreamAsString = <E>(
@@ -151,12 +162,16 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       resolvedModelSelection.model,
       rawEffortSelection,
     );
-    const cliEffort = normalizeClaudeCatalogEffort(
+    const customProfiled = isClaudeCatalogCustomEffortProfile(
       catalog,
-      resolvedEffort,
       resolvedModelSelection.model,
     );
-    const ultracode = isClaudeCatalogUltracodeEffort(resolvedEffort);
+    const cliEffort = customProfiled
+      ? resolvedEffort === CUSTOM_MODEL_REASONING_DEFAULT
+        ? undefined
+        : resolvedEffort
+      : normalizeClaudeCatalogEffort(catalog, resolvedEffort, resolvedModelSelection.model);
+    const ultracode = !customProfiled && isClaudeCatalogUltracodeEffort(resolvedEffort);
     const thinkingDescriptor = findDescriptor("thinking");
     const fastModeDescriptor = findDescriptor("fastMode");
     const thinking =

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -8,7 +8,11 @@ import {
   type ServerProviderModel,
 } from "@t3tools/contracts";
 
-import { deriveProviderModelsForDisplay, ProviderInstanceCard } from "./ProviderInstanceCard";
+import {
+  deriveProviderModelsForDisplay,
+  nextCustomModelsConfig,
+  ProviderInstanceCard,
+} from "./ProviderInstanceCard";
 
 describe("deriveProviderModelsForDisplay", () => {
   it("uses current config custom models instead of stale live custom rows", () => {
@@ -39,6 +43,57 @@ describe("deriveProviderModelsForDisplay", () => {
         customModels: ["kept-custom"],
       }).map((model) => model.slug),
     ).toEqual(["server-model", "kept-custom"]);
+  });
+
+  it("prunes deleted Claude custom model profiles", () => {
+    expect(
+      nextCustomModelsConfig(
+        {
+          customModels: ["kept", "removed"],
+          customModelProfiles: {
+            kept: { capabilities: { reasoning: { levels: ["high"] } } },
+            removed: { capabilities: { reasoning: { levels: ["low"] } } },
+          },
+        },
+        ["kept"],
+        true,
+      ),
+    ).toEqual({
+      customModels: ["kept"],
+      customModelProfiles: {
+        kept: { capabilities: { reasoning: { levels: ["high"] } } },
+      },
+    });
+  });
+
+  it("removes an empty Claude custom model profile map", () => {
+    expect(
+      nextCustomModelsConfig(
+        {
+          customModels: ["removed"],
+          customModelProfiles: {
+            removed: { capabilities: { reasoning: { levels: ["high"] } } },
+          },
+        },
+        [],
+        true,
+      ),
+    ).toEqual({ customModels: [] });
+  });
+
+  it("preserves opaque profiles for non-Claude providers", () => {
+    expect(
+      nextCustomModelsConfig(
+        {
+          customModels: ["removed"],
+          customModelProfiles: { removed: { future: true } },
+        },
+        [],
+      ),
+    ).toEqual({
+      customModels: [],
+      customModelProfiles: { removed: { future: true } },
+    });
   });
 
   it("shows a redacted provider email in the editor header status line", () => {

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -135,6 +135,33 @@ function nextConfigBlobWithValue(
   return base;
 }
 
+export function nextCustomModelsConfig(
+  config: unknown,
+  customModels: ReadonlyArray<string>,
+  pruneCustomModelProfiles = false,
+): Record<string, unknown> {
+  const nextConfig = nextConfigBlobWithValue(config, "customModels", [...customModels]);
+  const profiles = nextConfig.customModelProfiles;
+  if (
+    !pruneCustomModelProfiles ||
+    profiles === null ||
+    typeof profiles !== "object" ||
+    Array.isArray(profiles)
+  ) {
+    return nextConfig;
+  }
+  const retained = new Set(customModels.map((model) => model.trim()));
+  const retainedProfiles = Object.fromEntries(
+    Object.entries(profiles).filter(([slug]) => retained.has(slug)),
+  );
+  if (Object.keys(retainedProfiles).length > 0) {
+    nextConfig.customModelProfiles = retainedProfiles;
+  } else {
+    delete nextConfig.customModelProfiles;
+  }
+  return nextConfig;
+}
+
 export function deriveProviderModelsForDisplay(input: {
   readonly liveModels: ReadonlyArray<ServerProviderModel> | undefined;
   readonly customModels: ReadonlyArray<string>;
@@ -523,7 +550,7 @@ export function ProviderInstanceCard({
   };
 
   const updateCustomModels = (next: ReadonlyArray<string>) => {
-    const nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...next]);
+    const nextConfig = nextCustomModelsConfig(instance.config, next, driverKind === "claudeAgent");
     const { config: _omit, ...rest } = instance;
     onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
   };

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 - [Source control integrations](./user/source-control.md)
 - [Background service (Linux)](./user/background-service.md)
 - Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md) · [OpenCode](./user/providers-opencode.md)
+- [Custom model reasoning profiles](./user/custom-model-reasoning-profiles.md)
 
 Mobile app: [apps/mobile/README.md](../apps/mobile/README.md)
 

--- a/docs/user/custom-model-reasoning-profiles.md
+++ b/docs/user/custom-model-reasoning-profiles.md
@@ -1,0 +1,54 @@
+# Custom model reasoning profiles
+
+T3 Code can add a Reasoning menu to a manually configured Claude custom model. Profiles are supported beside `customModels` in a named entry under `providerInstances.<id>.config`. There is no separate profile file or in-app profile editor.
+
+Profiles do not change built-in Claude models or models from other providers.
+
+## Configure a profile
+
+Edit `~/.t3/userdata/settings.json` on the machine running the T3 Code server. The settings watcher reloads valid changes without a restart.
+
+Do not add profiles under the legacy `providers.claudeAgent` object. If the Claude provider exists only there, edit it once in **Settings → Providers** first; T3 Code migrates it into `providerInstances`.
+
+```json
+{
+  "providerInstances": {
+    "claude_gateway": {
+      "driver": "claudeAgent",
+      "config": {
+        "customModels": ["gpt-5.6-sol"],
+        "customModelProfiles": {
+          "gpt-5.6-sol": {
+            "capabilities": {
+              "reasoning": {
+                "levels": ["low", "medium", "high"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The profile key must match a trimmed entry in `customModels` for the same Claude provider. Each profile chooses an ordered subset of `low`, `medium`, `high`, `xhigh`, and `max`.
+
+## Composer behavior
+
+T3 Code adds **Default** before the configured values and keeps their order. When the Claude runtime starts, Default omits `--effort` so Claude Code uses its configured default. Other choices are passed without built-in model compatibility remapping.
+
+Web, desktop, and mobile use the same provider capability metadata.
+
+## Validation
+
+An invalid profile marks only that named Claude provider instance unavailable. Other settings and providers remain active. Correct the profile to restore the instance.
+
+- `levels` must contain at least one unique value.
+- Each level must be `low`, `medium`, `high`, `xhigh`, or `max`.
+- Every profile key must match a custom model in the same Claude provider.
+- A built-in catalog entry wins when a custom model uses the same slug, so its profile is ignored.
+
+A custom model does not need a profile. Without one, its current behavior remains unchanged.
+
+When a level is removed, a saved selection that used it resolves to Default. When a custom model is removed in Settings, T3 Code removes its matching profile in the same update.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -21,6 +21,78 @@ const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const decodeClaudeSettings = Schema.decodeUnknownSync(ClaudeSettings);
 
+describe("Claude custom model profiles", () => {
+  it("trims supported levels and preserves their order", () => {
+    const settings = decodeClaudeSettings({
+      customModels: ["custom-model"],
+      customModelProfiles: {
+        "custom-model": {
+          capabilities: { reasoning: { levels: ["  low  ", "xhigh"] } },
+        },
+      },
+    });
+
+    expect(settings.customModelProfiles?.["custom-model"]?.capabilities.reasoning.levels).toEqual([
+      "low",
+      "xhigh",
+    ]);
+  });
+
+  it.each([
+    { levels: [] },
+    { levels: [""] },
+    { levels: ["high", " high "] },
+    { levels: ["default"] },
+  ])("rejects invalid reasoning levels: $levels", ({ levels }) => {
+    expect(() =>
+      decodeClaudeSettings({
+        customModels: ["custom-model"],
+        customModelProfiles: {
+          "custom-model": { capabilities: { reasoning: { levels } } },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("requires profiles to match a configured custom model", () => {
+    expect(() =>
+      decodeClaudeSettings({
+        customModels: ["kept-model"],
+        customModelProfiles: {
+          orphan: { capabilities: { reasoning: { levels: ["high"] } } },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("keeps named provider config opaque at the server settings boundary", () => {
+    const instanceId = ProviderInstanceId.make("claude_custom");
+    const decoded = decodeServerSettings({
+      providerInstances: {
+        [instanceId]: {
+          driver: "claudeAgent",
+          config: {
+            customModels: [],
+            customModelProfiles: {
+              orphan: { capabilities: { reasoning: { levels: ["high"] } } },
+            },
+          },
+        },
+      },
+    });
+
+    expect(decoded.providerInstances[instanceId]?.config).toEqual({
+      customModels: [],
+      customModelProfiles: {
+        orphan: { capabilities: { reasoning: { levels: ["high"] } } },
+      },
+    });
+    expect(
+      decodeServerSettingsPatch({ providerInstances: decoded.providerInstances }).providerInstances,
+    ).toEqual(decoded.providerInstances);
+  });
+});
+
 describe("ClaudeSettings auto-compaction", () => {
   it("uses Claude's default threshold when no override is configured", () => {
     expect(decodeClaudeSettings({}).autoCompactWindow).toBe("");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -476,6 +476,51 @@ export type CodexSettings = typeof CodexSettings.Type;
 // the update that introduced it.
 const CLAUDE_AUTO_COMPACT_WINDOW_PATTERN = /^(?:|[1-9]\d{5}|1000000)$/;
 
+export const CUSTOM_MODEL_REASONING_DEFAULT = "default";
+export const CUSTOM_MODEL_REASONING_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+const CustomModelReasoningLevel = TrimmedNonEmptyString.check(
+  Schema.makeFilter(
+    (level) =>
+      CUSTOM_MODEL_REASONING_LEVELS.some((candidate) => candidate === level) ||
+      `Unsupported custom model reasoning level ${JSON.stringify(level)}. Expected one of: ${CUSTOM_MODEL_REASONING_LEVELS.join(", ")}.`,
+  ),
+);
+
+export const CustomModelProfile = Schema.Struct({
+  capabilities: Schema.Struct({
+    reasoning: Schema.Struct({
+      levels: Schema.Array(CustomModelReasoningLevel)
+        .check(Schema.isNonEmpty())
+        .check(
+          Schema.makeFilter(
+            (levels) =>
+              new Set(levels).size === levels.length || "Reasoning levels must be unique.",
+          ),
+        ),
+    }),
+  }),
+});
+export type CustomModelProfile = typeof CustomModelProfile.Type;
+
+export const CustomModelProfiles = Schema.Record(TrimmedNonEmptyString, CustomModelProfile);
+export type CustomModelProfiles = typeof CustomModelProfiles.Type;
+
+const customModelProfilesMatchModels = Schema.makeFilter(
+  (settings: {
+    readonly customModels?: ReadonlyArray<string>;
+    readonly customModelProfiles?: CustomModelProfiles;
+  }) => {
+    const customModels = new Set((settings.customModels ?? []).map((model) => model.trim()));
+    for (const slug of Object.keys(settings.customModelProfiles ?? {})) {
+      if (!customModels.has(slug)) {
+        return `Custom model profile ${JSON.stringify(slug)} has no matching customModels entry.`;
+      }
+    }
+    return true;
+  },
+);
+
 export const ClaudeSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
@@ -501,6 +546,9 @@ export const ClaudeSettings = makeProviderSettingsSchema(
     customModels: Schema.Array(Schema.String).pipe(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    customModelProfiles: Schema.optionalKey(
+      CustomModelProfiles.pipe(Schema.annotateKey({ providerSettingsForm: { hidden: true } })),
     ),
     launchArgs: Schema.String.pipe(
       Schema.withDecodingDefault(Effect.succeed("")),
@@ -531,7 +579,15 @@ export const ClaudeSettings = makeProviderSettingsSchema(
   {
     order: ["binaryPath", "homePath", "autoCompactWindow", "launchArgs"],
   },
-);
+)
+  .check(customModelProfilesMatchModels)
+  .pipe(
+    Schema.annotate({
+      providerSettingsFormSchema: {
+        order: ["binaryPath", "homePath", "autoCompactWindow", "launchArgs"],
+      },
+    }),
+  );
 export type ClaudeSettings = typeof ClaudeSettings.Type;
 
 export const CursorSettings = makeProviderSettingsSchema(


### PR DESCRIPTION
## What Changed

- add `customModelProfiles` to named Claude provider settings so custom models can declare an ordered subset of `low`, `medium`, `high`, `xhigh`, and `max`
- attach settings-owned custom models and capabilities to the current scoped `ClaudeModelCatalog`, preserving remote-manifest built-ins and alias behavior
- expose the existing Reasoning control with a synthetic **Default** choice that inherits Claude Code's configured effort
- pass selected custom effort through the same query-start `--effort` path used by built-in Claude models, while Default omits the override
- keep profile validation scoped to the named Claude provider instance, and remove profiles when their custom model is deleted
- document the supported `settings.json` contract

## Why

Custom models already work through Claude-compatible gateways, but T3 assigns them empty capabilities. Users can select and run those models without controlling Claude Code effort per thread.

This is the orchestration V2 implementation discussed in #4192 and the Ideas discussion it became. It is configuration-first so a future Settings editor can use the same contract without changing runtime behavior.

## UI Changes

A profiled custom model gains the existing Reasoning selector. Without a profile, the composer remains unchanged. Before and after screenshots are attached below.

## Verification

- rebased onto current upstream `main` after the remote Claude model-manifest migration
- 230 focused tests across settings contracts, ClaudeModelCatalog, provider snapshots, Claude runtime, text generation, and settings cleanup
- targeted typechecks passed for `@t3tools/contracts`, `t3`, and `@t3tools/web`
- targeted lint passed with only existing unrelated repository warnings
- isolated browser flow verified Default/Low/Medium/High rendering on the rebased implementation
- independent final review of the current upstream port reported no issues
- `git diff --check` passed

## Risk and rollback

The setting is optional. Existing providers, unprofiled custom models, remote-manifest models, and built-in Claude behavior keep their current paths. Invalid profiles make only the named Claude provider instance unavailable. Roll back by reverting the eventual merge commit.

## Checklist

- [x] This PR is focused on custom Claude model effort profiles
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or timing behavior changed

Review tier: standard.

Implemented with GPT-5.6 Sol in the Claude Code harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add custom model reasoning profiles for Claude with direct effort forwarding
> - Introduces a validated `customModelProfiles` field in `ClaudeSettings` where each profile maps a custom model to a non-empty, unique, ordered list of reasoning levels drawn from `low`, `medium`, `high`, `xhigh`, `max`; every profile key must match a configured `customModels` entry. Schema lives in [settings.ts](https://github.com/pingdotgg/t3code/pull/8964/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c).
> - Reworks `scopeClaudeModelCatalog` to emit a distinct custom catalog row per custom slug with a Reasoning selector built from the profile; built-in slugs still win over same-slug custom profiles and matching aliases are removed from built-in rows.
> - Claude adapter, text-generation, and provider status paths now pass custom profiles into scoping. For profiled custom models, the selected reasoning level is forwarded directly as query/CLI effort and built-in normalization and ultracode handling are skipped; `Default` omits effort.
> - Fixes `mergeProviderModels` so a refreshed Claude custom model replaces stale previous capabilities even when the refreshed row has null capabilities; non-Claude retention is unchanged.
> - Settings UI prunes `customModelProfiles` entries when a Claude custom model is removed, and deletes the map when empty; non-Claude provider profile data is preserved.
> - Risk: `mergeProviderModels` Claude-specific branch in [ProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/8964/files#diff-5c33694fd7889294ecb21a88beafee2debe92f779baab4629651d4c8be8a9a97) returns the refreshed custom row before the previous-capability retention path — non-Claude providers are unaffected, but any out-of-tree consumer relying on capability retention for Claude custom rows with null capabilities will see the new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0c01b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude session/query effort wiring and provider snapshot merging; behavior is gated on optional settings and built-ins are preserved, but incorrect effort forwarding could affect custom-gateway runs.
> 
> **Overview**
> Adds **`customModelProfiles`** on named Claude provider config so manually listed custom models can expose a **Reasoning** selector with **Default** plus an ordered subset of `low` / `medium` / `high` / `xhigh` / `max`. Contracts validate levels and require profile keys to match `customModels`; invalid profiles fail only that Claude instance.
> 
> **`scopeClaudeModelCatalog`** now materializes custom slugs with profile-driven capabilities (built-in catalog slugs still win), tracks **`customEffortProfile`**, and feeds provider snapshots, the Claude adapter, and text generation. **Default** omits `--effort`; other choices pass through without built-in effort remapping or ultracode. Provider registry merge treats refreshed Claude custom model capabilities as authoritative.
> 
> Settings UI **prunes orphaned profiles** when custom models are removed (Claude only). User docs describe the `settings.json` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c01b201f9a35403233ac557b48328cc1b5170f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->