### PR TITLE
fix(server): stop a busy terminal from starving other terminals' persistence

### DIFF
--- a/packages/shared/src/KeyedCoalescingWorker.test.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.test.ts
@@ -94,4 +94,97 @@ describe("makeKeyedCoalescingWorker", () => {
       }),
     ),
   );
+
+  it.live("lets other keys progress while one key stays continuously dirty", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const processed: string[] = [];
+        const busyStarted = yield* Deferred.make<void>();
+        const releaseBusy = yield* Deferred.make<void>();
+        const quietProcessed = yield* Deferred.make<void>();
+
+        const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+          merge: (_current, next) => next,
+          process: (key, value) =>
+            Effect.gen(function* () {
+              processed.push(`${key}:${value}`);
+
+              if (value === "busy-1") {
+                yield* Deferred.succeed(busyStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseBusy);
+              }
+
+              if (key === "quiet") {
+                yield* Deferred.succeed(quietProcessed, undefined).pipe(Effect.orDie);
+              }
+            }),
+        });
+
+        yield* worker.enqueue("busy", "busy-1");
+        yield* Deferred.await(busyStarted);
+
+        // While the busy key is mid-batch, it becomes dirty again and another
+        // key arrives. The dirty key must go to the queue tail, not back into
+        // the worker, or the quiet key's flush never runs.
+        yield* worker.enqueue("busy", "busy-2");
+        yield* worker.enqueue("quiet", "quiet-1");
+        yield* Deferred.succeed(releaseBusy, undefined);
+
+        yield* Deferred.await(quietProcessed);
+        yield* worker.drainKey("quiet");
+        yield* worker.drainKey("busy");
+
+        expect(processed).toEqual(["busy:busy-1", "quiet:quiet-1", "busy:busy-2"]);
+      }),
+    ),
+  );
+
+  it.live("still coalesces updates that land while their key waits at the queue tail", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const processed: string[] = [];
+        const firstStarted = yield* Deferred.make<void>();
+        const releaseFirst = yield* Deferred.make<void>();
+        const otherStarted = yield* Deferred.make<void>();
+        const releaseOther = yield* Deferred.make<void>();
+
+        const worker = yield* makeKeyedCoalescingWorker<string, string, never, never>({
+          merge: (current, next) => `${current}+${next}`,
+          process: (key, value) =>
+            Effect.gen(function* () {
+              processed.push(`${key}:${value}`);
+
+              if (value === "first") {
+                yield* Deferred.succeed(firstStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseFirst);
+              }
+
+              if (key === "other") {
+                yield* Deferred.succeed(otherStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseOther);
+              }
+            }),
+        });
+
+        yield* worker.enqueue("busy", "first");
+        yield* Deferred.await(firstStarted);
+
+        // Dirty the busy key mid-batch so it gets requeued behind "other",
+        // then keep writing to it while it waits at the tail. Every write must
+        // fold into one merged batch, not extra queue entries.
+        yield* worker.enqueue("busy", "a");
+        yield* worker.enqueue("other", "other-1");
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* Deferred.await(otherStarted);
+        yield* worker.enqueue("busy", "b");
+        yield* worker.enqueue("busy", "c");
+        yield* Deferred.succeed(releaseOther, undefined);
+
+        yield* worker.drainKey("busy");
+        yield* worker.drainKey("other");
+
+        expect(processed).toEqual(["busy:first", "other:other-1", "busy:a+b+c"]);
+      }),
+    ),
+  );
 });

--- a/packages/shared/src/KeyedCoalescingWorker.ts
+++ b/packages/shared/src/KeyedCoalescingWorker.ts
@@ -39,20 +39,26 @@ export const makeKeyedCoalescingWorker = <K, V, E, R>(options: {
       options.process(key, value).pipe(
         Effect.flatMap(() =>
           TxRef.modify(stateRef, (state) => {
-            const nextValue = state.latestByKey.get(key);
-            if (nextValue === undefined) {
-              const activeKeys = new Set(state.activeKeys);
-              activeKeys.delete(key);
-              return [null, { ...state, activeKeys }] as const;
+            const activeKeys = new Set(state.activeKeys);
+            activeKeys.delete(key);
+
+            if (!state.latestByKey.has(key)) {
+              return [false, { ...state, activeKeys }] as const;
             }
 
-            const latestByKey = new Map(state.latestByKey);
-            latestByKey.delete(key);
-            return [nextValue, { ...state, latestByKey }] as const;
-          }).pipe(Effect.tx),
-        ),
-        Effect.flatMap((nextValue) =>
-          nextValue === null ? Effect.void : processKey(key, nextValue),
+            // Work arrived while this batch ran. Requeue the key at the tail
+            // instead of processing it again here, so a continuously dirty
+            // key (a terminal in a redraw loop) cannot monopolize the worker
+            // and starve every other key's flush.
+            const queuedKeys = new Set(state.queuedKeys);
+            queuedKeys.add(key);
+            return [true, { ...state, activeKeys, queuedKeys }] as const;
+          }).pipe(
+            Effect.flatMap((shouldRequeue) =>
+              shouldRequeue ? TxQueue.offer(queue, key) : Effect.void,
+            ),
+            Effect.tx,
+          ),
         ),
       );
 


### PR DESCRIPTION
When a key in `KeyedCoalescingWorker` became dirty again while its batch was processing, `processKey` recursed on that same key. A terminal running a redraw-heavy loop keeps its key permanently dirty, so the single worker fiber never returned to the queue: every other key's persistence stalled, `drainKey` never resolved, and `terminal.close` hung holding the thread lock, blocking new terminals in that thread until a reconnect interrupted it.

Instead of recursing, a batch that completes with newer data pending now atomically moves its key from active back to queued and offers it at the queue tail, in the same transaction. Other keys interleave fairly, and updates that land while the key waits at the tail still coalesce into one merged batch.

The two new tests fail against the previous implementation (starved quiet key processed out of order) and pass with the change; the existing coalescing and failure-requeue tests are unchanged and stay green, as do the terminal manager's tests.

Fixes #8872

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core scheduling in a shared worker used for terminal persistence; behavior is well-tested but affects concurrency and shutdown/drain timing across terminals.
> 
> **Overview**
> **Fixes worker starvation when one key stays dirty during processing** (e.g. a terminal in a redraw loop blocking other terminals’ persistence and `drainKey` / `terminal.close`).
> 
> In `KeyedCoalescingWorker`, when a batch finishes but `latestByKey` still has that key, the worker **no longer recurses** into `processKey` on the same fiber. It clears the key from `activeKeys`, adds it to `queuedKeys`, and **`TxQueue.offer`s it at the queue tail** in the same transaction so other keys can run in between.
> 
> Adds two live tests: one asserts `quiet` runs before a requeued `busy` key (`busy:busy-1`, `quiet:quiet-1`, `busy:busy-2`); one asserts merges while waiting at the tail still coalesce (`busy:a+b+c`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0427b5fbaa8ca4b0e76c9fdba47a135b6d00c982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop busy terminal starvation by requeuing keys in `KeyedCoalescingWorker`
> - Changes `processKey` in `makeKeyedCoalescingWorker` to requeue dirty keys to the queue tail instead of recursively processing them immediately.
> - Prevents persistence starvation by allowing other terminal keys to run between batches when one key is continuously dirty.
> - Adds tests for cross-key fairness and tail-queue coalescing in [KeyedCoalescingWorker.test.ts](https://github.com/pingdotgg/t3code/pull/8966/files#diff-e37473be9d14a5defd2de2e8e427bbe001b7eba520360ec9fee6154e042dc632).
> - Behavioral Change: `processKey` no longer extracts pending values and recurses; it removes the key from `activeKeys` and offers it to the queue if `latestByKey` has pending work.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0427b5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background processing so continuously updated items no longer monopolize the queue.
  * Ensured work for other items can continue while one item is busy.
  * Combined updates that arrive while an item is waiting into a single processing batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->