### PR TITLE
fix(web): preserve panel state across workspace refreshes

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -30,7 +30,8 @@ import { cn } from "~/lib/utils";
 import { selectThreadDiffPanelSelection, useDiffPanelStore } from "../diffPanelStore";
 import { useTheme } from "../hooks/useTheme";
 import {
-  buildFileDiffRenderKey,
+  buildFileDiffContentVersion,
+  buildFileDiffIdentityKey,
   getDiffCollapseIconClassName,
   getDiffLineStat,
   getRenderablePatch,
@@ -299,7 +300,7 @@ export default function DiffPanel({
   const selectedGitSource = branchDiffPreview.data?.sources.find(
     (source) => source.kind === (selectedGitScope === "unstaged" ? "working-tree" : "branch-range"),
   );
-  const loadDiffFiles = useMemo<FileDiffContentsLoader | undefined>(() => {
+  const currentLoadDiffFiles = useMemo<FileDiffContentsLoader | undefined>(() => {
     const preview = branchDiffPreview.data;
     if (selectedTurnId !== null || !activeThread || !preview || !selectedGitSource) {
       return undefined;
@@ -320,6 +321,13 @@ export default function DiffPanel({
     selectedGitSource,
     selectedTurnId,
   ]);
+  const loadDiffFilesRef = useRef(currentLoadDiffFiles);
+  loadDiffFilesRef.current = currentLoadDiffFiles;
+  const loadDiffFiles = useCallback<FileDiffContentsLoader>(async (fileDiff) => {
+    const loader = loadDiffFilesRef.current;
+    if (!loader) throw new Error("Diff file contents are unavailable for this selection.");
+    return loader(fileDiff);
+  }, []);
   const localBranchRefs = useEnvironmentQuery(
     selectedTurnId === null &&
       selectedGitScope === "branch" &&
@@ -400,17 +408,19 @@ export default function DiffPanel({
     () =>
       renderableFiles.map((fileDiff) => ({
         fileDiff,
-        fileKey: buildFileDiffRenderKey(fileDiff),
+        fileKey: buildFileDiffIdentityKey(fileDiff),
+        fileVersion: buildFileDiffContentVersion(fileDiff),
       })),
     [renderableFiles],
   );
   const codeViewFiles = useMemo(
     () =>
-      renderableFileEntries.map(({ fileDiff, fileKey }) => {
+      renderableFileEntries.map(({ fileDiff, fileKey, fileVersion }) => {
         return {
           fileDiff,
           filePath: resolveFileDiffPath(fileDiff),
           fileKey,
+          fileVersion,
           collapsed: collapsedDiffFileKeys.has(fileKey),
         };
       }),
@@ -950,7 +960,7 @@ export default function DiffPanel({
                     theme: resolveDiffThemeName(resolvedTheme),
                     themeType: resolvedTheme as DiffThemeType,
                     stickyHeaders: true,
-                    ...(loadDiffFiles ? { loadDiffFiles } : {}),
+                    ...(currentLoadDiffFiles ? { loadDiffFiles } : {}),
                   }}
                 />
               </div>

--- a/apps/web/src/components/diffs/AnnotatableCodeView.tsx
+++ b/apps/web/src/components/diffs/AnnotatableCodeView.tsx
@@ -77,6 +77,7 @@ interface AnnotatableCodeViewProps {
     fileDiff: FileDiffMetadata;
     filePath: string;
     fileKey: string;
+    fileVersion: number;
     collapsed: boolean;
   }>;
   sectionId: string;
@@ -125,7 +126,7 @@ export function AnnotatableCodeView({
   const filesByKey = useMemo(() => new Map(files.map((file) => [file.fileKey, file])), [files]);
   const items = useMemo<CodeViewDiffItem<DiffCommentAnnotationGroup>[]>(
     () =>
-      files.map(({ fileDiff, filePath, fileKey, collapsed }) => {
+      files.map(({ fileDiff, filePath, fileKey, fileVersion, collapsed }) => {
         const persisted = reviewComments
           .filter(
             (comment) =>
@@ -153,7 +154,7 @@ export function AnnotatableCodeView({
           annotations,
           collapsed,
           version: fnv1a32(
-            `${collapsed ? "1" : "0"}:${annotations
+            `${fileVersion}:${collapsed ? "1" : "0"}:${annotations
               .flatMap((annotation) =>
                 annotation.metadata.entries.map(
                   (entry) => `${entry.id}:${entry.rangeLabel}:${entry.text}`,

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -22,6 +22,7 @@ import { T3_PIERRE_ICONS } from "~/pierre-icons";
 
 import { createFileTreeDragMentionController } from "./fileTreeDragMention";
 import { areAllDirectoriesExpanded, setAllDirectoriesExpanded } from "./fileTreeExpansion";
+import { buildFileTreePathUpdates } from "./fileTreePathReconciliation";
 import { useProjectEntriesQuery } from "./projectFilesQueryState";
 
 interface FileBrowserPanelProps {
@@ -126,7 +127,7 @@ export default function FileBrowserPanel({
     () => entries.filter((entry) => entry.kind === "directory").map(treePath),
     [entries],
   );
-  const previousTreePathsRef = useRef<readonly string[]>([]);
+  const previousTreePathsRef = useRef<readonly string[] | null>(null);
   const syncingSelectionRef = useRef(false);
   const treeSelectionPathRef = useRef<string | null>(null);
   const handledRevealRef = useRef<{ path: string; revealId: number } | null>(null);
@@ -281,11 +282,18 @@ export default function FileBrowserPanel({
   });
 
   useEffect(() => {
+    if (entriesQuery.data === null) return;
     if (previousTreePathsRef.current === treePaths) return;
     entryKindsRef.current = entryKinds;
+    const previousTreePaths = previousTreePathsRef.current;
     previousTreePathsRef.current = treePaths;
-    model.resetPaths(treePaths);
-  }, [entryKinds, model, treePaths]);
+    if (previousTreePaths === null) {
+      model.resetPaths(treePaths);
+      return;
+    }
+    const updates = buildFileTreePathUpdates(previousTreePaths, treePaths);
+    if (updates.length > 0) model.batch(updates);
+  }, [entriesQuery.data, entryKinds, model, treePaths]);
 
   useEffect(() => {
     if (!selectedPath) {

--- a/apps/web/src/components/files/fileTreePathReconciliation.test.ts
+++ b/apps/web/src/components/files/fileTreePathReconciliation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildFileTreePathUpdates } from "./fileTreePathReconciliation";
+
+describe("buildFileTreePathUpdates", () => {
+  it("updates only paths that changed", () => {
+    expect(
+      buildFileTreePathUpdates(
+        ["src/", "src/kept.ts", "src/removed.ts"],
+        ["src/", "src/kept.ts", "src/added.ts"],
+      ),
+    ).toEqual([
+      { type: "remove", path: "src/removed.ts" },
+      { type: "add", path: "src/added.ts" },
+    ]);
+  });
+
+  it("removes a missing subtree with one recursive update", () => {
+    expect(
+      buildFileTreePathUpdates(
+        ["src/", "src/feature/", "src/feature/index.ts", "src/kept.ts"],
+        ["src/", "src/kept.ts"],
+      ),
+    ).toEqual([{ type: "remove", path: "src/feature/", recursive: true }]);
+  });
+
+  it("does nothing when a refresh returns the same tree", () => {
+    const paths = ["src/", "src/index.ts"];
+    expect(buildFileTreePathUpdates(paths, [...paths])).toEqual([]);
+  });
+});

--- a/apps/web/src/components/files/fileTreePathReconciliation.ts
+++ b/apps/web/src/components/files/fileTreePathReconciliation.ts
@@ -1,0 +1,32 @@
+import type { FileTreeBatchOperation } from "@pierre/trees";
+
+function pathDepth(path: string): number {
+  return path.split("/").filter(Boolean).length;
+}
+
+export function buildFileTreePathUpdates(
+  previousPaths: readonly string[],
+  nextPaths: readonly string[],
+): FileTreeBatchOperation[] {
+  const previous = new Set(previousPaths);
+  const next = new Set(nextPaths);
+  const removedDirectoryRoots: string[] = [];
+  const updates: FileTreeBatchOperation[] = [];
+
+  const removedPaths = previousPaths
+    .filter((path) => !next.has(path))
+    .toSorted((left, right) => pathDepth(left) - pathDepth(right));
+  for (const path of removedPaths) {
+    if (removedDirectoryRoots.some((directory) => path.startsWith(directory))) continue;
+    const recursive = path.endsWith("/");
+    updates.push({ type: "remove", path, ...(recursive ? { recursive: true } : {}) });
+    if (recursive) removedDirectoryRoots.push(path);
+  }
+
+  const addedPaths = nextPaths
+    .filter((path) => !previous.has(path))
+    .toSorted((left, right) => pathDepth(left) - pathDepth(right));
+  for (const path of addedPaths) updates.push({ type: "add", path });
+
+  return updates;
+}

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildFileDiffContentVersion,
+  buildFileDiffIdentityKey,
   buildFileDiffRenderKey,
   buildPatchCacheKey,
   getDiffLineStat,
@@ -82,8 +84,8 @@ describe("getRenderablePatch", () => {
   });
 });
 
-describe("buildFileDiffRenderKey", () => {
-  it("keeps file identity stable when Pierre hydrates a partial diff", () => {
+describe("diff file reconciliation", () => {
+  it("keeps Pierre's render key stable when a partial diff hydrates", () => {
     const patch = [
       "diff --git a/example.ts b/example.ts",
       "--- a/example.ts",
@@ -103,6 +105,48 @@ describe("buildFileDiffRenderKey", () => {
     file.cacheKey = `${file.cacheKey}:hydrated`;
 
     expect(buildFileDiffRenderKey(file)).toBe(key);
+  });
+
+  it("keeps identities stable and versions local to the changed file", () => {
+    const patch = (secondLine: string) =>
+      [
+        "diff --git a/unchanged.ts b/unchanged.ts",
+        "--- a/unchanged.ts",
+        "+++ b/unchanged.ts",
+        "@@ -1 +1 @@",
+        "-before",
+        "+after",
+        "diff --git a/changed.ts b/changed.ts",
+        "--- a/changed.ts",
+        "+++ b/changed.ts",
+        "@@ -1 +1 @@",
+        "-old",
+        `+${secondLine}`,
+      ].join("\n");
+    const before = getRenderablePatch(patch("new"), "before");
+    const after = getRenderablePatch(patch("newer"), "after");
+    expect(before?.kind).toBe("files");
+    expect(after?.kind).toBe("files");
+    if (before?.kind !== "files" || after?.kind !== "files") return;
+
+    const [beforeUnchanged, beforeChanged] = before.files;
+    const [afterUnchanged, afterChanged] = after.files;
+    expect(beforeUnchanged).toBeDefined();
+    expect(beforeChanged).toBeDefined();
+    expect(afterUnchanged).toBeDefined();
+    expect(afterChanged).toBeDefined();
+    if (!beforeUnchanged || !beforeChanged || !afterUnchanged || !afterChanged) return;
+
+    expect(buildFileDiffIdentityKey(afterUnchanged)).toBe(
+      buildFileDiffIdentityKey(beforeUnchanged),
+    );
+    expect(buildFileDiffIdentityKey(afterChanged)).toBe(buildFileDiffIdentityKey(beforeChanged));
+    expect(buildFileDiffContentVersion(afterUnchanged)).toBe(
+      buildFileDiffContentVersion(beforeUnchanged),
+    );
+    expect(buildFileDiffContentVersion(afterChanged)).not.toBe(
+      buildFileDiffContentVersion(beforeChanged),
+    );
   });
 });
 

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -163,11 +163,75 @@ export function resolveFileDiffPreviousPath(fileDiff: FileDiffMetadata): string 
   return raw;
 }
 
+export function buildFileDiffIdentityKey(fileDiff: FileDiffMetadata): string {
+  return `${resolveFileDiffPreviousPath(fileDiff)}\u0000${resolveFileDiffPath(fileDiff)}`;
+}
+
 export function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
   const cacheKey = fileDiff.cacheKey;
   if (!cacheKey) return `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;
 
   return cacheKey.endsWith(":hydrated") ? cacheKey.slice(0, -":hydrated".length) : cacheKey;
+}
+
+function hashFileDiffPart(hash: number, value: string | number | boolean | undefined): number {
+  const serialized = value === undefined ? "undefined" : String(value);
+  const withLength = fnv1a32(`${typeof value}:${serialized.length}:`, hash);
+  return fnv1a32(serialized, withLength);
+}
+
+/**
+ * Content-only version for CodeView reconciliation. Pierre's cache key includes
+ * the whole patch, so using it here would repaint every file when one changes.
+ */
+export function buildFileDiffContentVersion(fileDiff: FileDiffMetadata): number {
+  let hash = FNV_OFFSET_BASIS_32;
+  const append = (value: string | number | boolean | undefined) => {
+    hash = hashFileDiffPart(hash, value);
+  };
+
+  append(fileDiff.name);
+  append(fileDiff.prevName);
+  append(fileDiff.lang);
+  append(fileDiff.newObjectId);
+  append(fileDiff.prevObjectId);
+  append(fileDiff.mode);
+  append(fileDiff.prevMode);
+  append(fileDiff.type);
+  append(fileDiff.isPartial);
+  append(fileDiff.splitLineCount);
+  append(fileDiff.unifiedLineCount);
+
+  for (const line of fileDiff.additionLines) append(line);
+  for (const line of fileDiff.deletionLines) append(line);
+  for (const hunk of fileDiff.hunks) {
+    append(hunk.collapsedBefore);
+    append(hunk.additionStart);
+    append(hunk.additionCount);
+    append(hunk.additionLines);
+    append(hunk.additionLineIndex);
+    append(hunk.deletionStart);
+    append(hunk.deletionCount);
+    append(hunk.deletionLines);
+    append(hunk.deletionLineIndex);
+    append(hunk.hunkContext);
+    append(hunk.hunkSpecs);
+    append(hunk.splitLineStart);
+    append(hunk.splitLineCount);
+    append(hunk.unifiedLineStart);
+    append(hunk.unifiedLineCount);
+    append(hunk.noEOFCRAdditions);
+    append(hunk.noEOFCRDeletions);
+    for (const content of hunk.hunkContent) {
+      append(content.type);
+      append(content.additionLineIndex);
+      append(content.deletionLineIndex);
+      append(content.type === "change" ? content.additions : content.lines);
+      append(content.type === "change" ? content.deletions : undefined);
+    }
+  }
+
+  return hash;
 }
 
 export function getDiffCollapseIconClassName(fileDiff: FileDiffMetadata): string {


### PR DESCRIPTION
Workspace refreshes no longer reset collapsed diff files or rebuild the file tree. The diff now separates stable file identity from per-file content versions, while the file browser applies incremental path changes so unchanged elements stay mounted.

Verified with 12 focused tests, targeted lint and formatting, web typecheck, and the matched UI evidence below.

### Evidence

| Base: state lost after refresh | Branch: state preserved after refresh |
| --- | --- |
| ![Base after refresh expands both files](https://uploads-production-47e4.up.railway.app/files/fbf410c4-c8bc-428a-b85e-fc90cfc4a15f/base-after-refresh.png) | [![Branch after refresh keeps five files collapsed](https://uploads-production-47e4.up.railway.app/files/84c727b6-67a4-44cf-991e-dda0b270b61a/diff-refresh-state-persistence.png)](https://uploads-production-47e4.up.railway.app/files/da4fe247-42b7-4293-a905-31c92c318ac8/pr-8968-real-agent-diff-refresh.mp4) |

[Watch the real-app agent edit test](https://uploads-production-47e4.up.railway.app/files/da4fe247-42b7-4293-a905-31c92c318ac8/pr-8968-real-agent-diff-refresh.mp4)

Real app flow: the branch diff stays open while GPT-5.6-Sol edits the expanded file; the other files remain collapsed through the live refresh.

Written with gpt-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI state and reconciliation logic only; no auth, data persistence, or API contract changes. Risk is mainly regressions in diff rendering or file tree sync after refresh.
> 
> **Overview**
> Workspace refreshes no longer wipe **collapsed diff files** or **rebuild the entire file tree** from scratch. The diff panel now tracks each file with a **stable identity key** (previous + current paths) separate from a **per-file content version**, so unchanged files keep collapse state and only edited files get a new render version in `AnnotatableCodeView`.
> 
> `DiffPanel` also exposes **`loadDiffFiles`** through a stable ref-backed callback so CodeView options do not churn when the git loader is recreated on refresh.
> 
> The file browser applies **incremental path add/remove batches** via `buildFileTreePathUpdates` instead of `resetPaths` on every entry refresh; the first successful load still resets the tree. It skips reconciliation until entries have loaded (`entriesQuery.data !== null`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ead33dc78da67c8c81b74f01eb0e1435b14e100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve diff panel and file tree state across workspace refreshes
> - `DiffPanel` now identifies diff files by previous/current path via `buildFileDiffIdentityKey` instead of the cache key, and computes a per-file content version with `buildFileDiffContentVersion` so only changed files re-render.
> - `AnnotatableCodeView` prepends `fileVersion` into its item version hash, limiting reconciliation to files whose diff content actually changed.
> - `FileBrowserPanel` replaces full tree resets with incremental batched updates: new `buildFileTreePathUpdates` computes a minimal set of add/remove operations, collapsing deleted subtrees into a single recursive remove.
> - Risk: `previousTreePathsRef` in [FileBrowserPanel.tsx](https://github.com/pingdotgg/t3code/pull/8968/files#diff-aeb8bbbac738f422eace5ad6cee4745362f7559fdd5668df4eb1be558f4b5fb3) now starts as `null`; first population calls `model.resetPaths` while subsequent updates rely on `buildFileTreePathUpdates` correctness — any path-order mismatch could produce stale tree nodes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ead33d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diff rendering so file identity remains stable while content updates refresh correctly.
  * Preserved code annotations and view state more reliably when file contents change.
  * Improved file browser synchronization by applying only incremental path changes.
  * Correctly handles deleted folders and unchanged file trees.

* **Tests**
  * Added coverage for diff versioning and file tree path reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->