### PR TITLE
fix(web): fold complete response segments

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -337,7 +337,7 @@ describe("deriveMessagesTimelineRows", () => {
           },
         },
       ],
-      expandedTurnIds: new Set(["turn-1" as never]),
+      expandedFoldIds: new Set(["turn-fold:turn-1"]),
       isWorking: false,
       activeTurnStartedAt: null,
       turnDiffSummaryByAssistantMessageId: new Map(),
@@ -552,7 +552,7 @@ describe("deriveMessagesTimelineRows", () => {
 
     const expandedRows = deriveMessagesTimelineRows({
       timelineEntries,
-      expandedTurnIds: new Set(["turn-1" as never]),
+      expandedFoldIds: new Set(["turn-fold:turn-1"]),
       isWorking: false,
       activeTurnStartedAt: null,
       turnDiffSummaryByAssistantMessageId: new Map(),
@@ -626,6 +626,403 @@ describe("deriveMessagesTimelineRows", () => {
     });
 
     expect(rows.map((row) => row.id)).toEqual(["turn-fold:turn-1", "assistant-final-entry"]);
+  });
+
+  it("folds a subagent wake-up continuation into the same user-to-user segment", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "user-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "user-1" as never,
+            role: "user" as const,
+            text: "Delegate this",
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "assistant-handoff-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:05Z",
+          message: {
+            id: "assistant-handoff" as never,
+            role: "assistant" as const,
+            text: "Handing this to a subagent.",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:05Z",
+            updatedAt: "2026-01-01T00:00:06Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "work-entry-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:08Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:08Z",
+            turnId: "turn-1" as never,
+            label: "Ran subagent",
+            tone: "tool" as const,
+          },
+        },
+        {
+          id: "assistant-followup-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:20Z",
+          message: {
+            id: "assistant-followup" as never,
+            role: "assistant" as const,
+            text: "The subagent came back with the answer.",
+            turnId: "turn-2" as never,
+            createdAt: "2026-01-01T00:00:20Z",
+            updatedAt: "2026-01-01T00:00:24Z",
+            streaming: false,
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-2" as never,
+        state: "completed",
+        startedAt: "2026-01-01T00:00:18Z",
+        completedAt: "2026-01-01T00:00:24Z",
+      },
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "user-entry",
+      "turn-fold:turn-1",
+      "assistant-followup-entry",
+    ]);
+    expect(rows.find((row) => row.kind === "turn-fold")?.label).toBe("Worked for 24s");
+  });
+
+  it("folds plan chips, turn-less work, and the spawn CTA of a settled segment", () => {
+    const timelineEntries = [
+      {
+        id: "user-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:00Z",
+        message: {
+          id: "user-1" as never,
+          role: "user" as const,
+          text: "Run the fleet",
+          turnId: null,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "assistant-first-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:05Z",
+        message: {
+          id: "assistant-first" as never,
+          role: "assistant" as const,
+          text: "Planning the run.",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:05Z",
+          updatedAt: "2026-01-01T00:00:06Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "work-entry-1",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:08Z",
+        entry: {
+          id: "work-1",
+          createdAt: "2026-01-01T00:00:08Z",
+          turnId: "turn-1" as never,
+          label: "Ran command",
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "background-work-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:09Z",
+        entry: {
+          id: "background-work-1",
+          createdAt: "2026-01-01T00:00:09Z",
+          turnId: null,
+          label: "Background task output",
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "proposed-plan-entry",
+        kind: "proposed-plan" as const,
+        createdAt: "2026-01-01T00:00:11Z",
+        proposedPlan: {
+          id: "plan-1" as never,
+          createdAt: "2026-01-01T00:00:11Z",
+          updatedAt: "2026-01-01T00:00:11Z",
+          turnId: "turn-1" as never,
+          planMarkdown: "1. Fan out agents\n2. Merge results",
+          implementedAt: null,
+          implementationThreadId: null,
+        },
+      },
+      {
+        id: "agent-spawn-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:12Z",
+        entry: {
+          id: "agent-spawn-1",
+          createdAt: "2026-01-01T00:00:12Z",
+          turnId: "turn-1" as never,
+          label: "Ran 3 subagents",
+          tone: "tool" as const,
+          agentSpawn: { workflowId: null, agentTaskIds: ["task-1", "task-2", "task-3"] },
+        },
+      },
+      {
+        id: "assistant-progress-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:20Z",
+        message: {
+          id: "assistant-progress" as never,
+          role: "assistant" as const,
+          text: "The subagents came back.",
+          turnId: "turn-2" as never,
+          createdAt: "2026-01-01T00:00:20Z",
+          updatedAt: "2026-01-01T00:00:21Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "assistant-final-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:25Z",
+        message: {
+          id: "assistant-final" as never,
+          role: "assistant" as const,
+          text: "Here is the merged result.",
+          turnId: "turn-2" as never,
+          createdAt: "2026-01-01T00:00:25Z",
+          updatedAt: "2026-01-01T00:00:30Z",
+          streaming: false,
+        },
+      },
+    ];
+    const baseInput = {
+      timelineEntries,
+      latestTurn: {
+        turnId: "turn-2" as never,
+        state: "completed" as const,
+        startedAt: "2026-01-01T00:00:18Z",
+        completedAt: "2026-01-01T00:00:30Z",
+      },
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    };
+
+    expect(deriveMessagesTimelineRows(baseInput).map((row) => row.id)).toEqual([
+      "user-entry",
+      "turn-fold:turn-1",
+      "assistant-final-entry",
+    ]);
+    expect(
+      deriveMessagesTimelineRows({
+        ...baseInput,
+        expandedFoldIds: new Set(["turn-fold:turn-1"]),
+      }).map((row) => row.id),
+    ).toEqual([
+      "user-entry",
+      "turn-fold:turn-1",
+      "assistant-first-entry",
+      "work-toggle:work-entry-1",
+      "proposed-plan-entry",
+      "agent-spawn-entry",
+      "assistant-progress-entry",
+      "assistant-final-entry",
+    ]);
+  });
+
+  it("gives separate stable fold ids to segments that share a trailing turn id", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "user-1-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "user-1" as never,
+            role: "user",
+            text: "Start",
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "assistant-1-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:05Z",
+          message: {
+            id: "assistant-1" as never,
+            role: "assistant",
+            text: "First response",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:05Z",
+            updatedAt: "2026-01-01T00:00:06Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "work-1-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:07Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:07Z",
+            turnId: "turn-1" as never,
+            label: "Finished first response",
+            tone: "tool",
+          },
+        },
+        {
+          id: "user-2-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:08Z",
+          message: {
+            id: "user-2" as never,
+            role: "user",
+            text: "Steer",
+            turnId: null,
+            createdAt: "2026-01-01T00:00:08Z",
+            updatedAt: "2026-01-01T00:00:08Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "trailing-work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:09Z",
+          entry: {
+            id: "trailing-work",
+            createdAt: "2026-01-01T00:00:09Z",
+            turnId: "turn-1" as never,
+            label: "Late receipt",
+            tone: "tool",
+          },
+        },
+        {
+          id: "assistant-2-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:10Z",
+          message: {
+            id: "assistant-2" as never,
+            role: "assistant",
+            text: "Second response",
+            turnId: "turn-2" as never,
+            createdAt: "2026-01-01T00:00:10Z",
+            updatedAt: "2026-01-01T00:00:11Z",
+            streaming: false,
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-2" as never,
+        state: "completed",
+        startedAt: "2026-01-01T00:00:10Z",
+        completedAt: "2026-01-01T00:00:11Z",
+      },
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    const foldIds = rows.filter((row) => row.kind === "turn-fold").map((row) => row.id);
+    expect(foldIds).toEqual(["turn-fold:turn-1", "turn-fold:turn-1:user-2-entry"]);
+    expect(new Set(rows.map((row) => row.id)).size).toBe(rows.length);
+  });
+
+  it("keeps the latest segment unfolded while a later turn in it is still running", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "assistant-handoff-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:05Z",
+          message: {
+            id: "assistant-handoff" as never,
+            role: "assistant" as const,
+            text: "Handing this to a subagent.",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:05Z",
+            updatedAt: "2026-01-01T00:00:06Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "work-entry-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:20Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:20Z",
+            turnId: "turn-2" as never,
+            label: "Read files",
+            tone: "tool" as const,
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-2" as never,
+        state: "running",
+        startedAt: "2026-01-01T00:00:18Z",
+        completedAt: null,
+      },
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.some((row) => row.kind === "turn-fold")).toBe(false);
+    expect(rows.map((row) => row.id)).toContain("assistant-handoff-entry");
+  });
+
+  it("leaves a segment with no turn id unfolded", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:05Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:05Z",
+            turnId: null,
+            label: "Background output",
+            tone: "tool" as const,
+          },
+        },
+      ],
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.some((row) => row.kind === "turn-fold")).toBe(false);
+    expect(rows.map((row) => row.id)).toEqual(["work-toggle:work-entry"]);
   });
 
   it("derives a sane duration for a steer-superseded turn with one instant commentary message", () => {
@@ -1326,7 +1723,7 @@ describe("deriveMessagesTimelineRows", () => {
           },
         },
       ],
-      expandedTurnIds: new Set(["turn-1" as never]),
+      expandedFoldIds: new Set(["turn-fold:turn-1"]),
       isWorking: false,
       activeTurnStartedAt: null,
       turnDiffSummaryByAssistantMessageId: new Map(),

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -440,9 +440,16 @@ export function resolveAssistantMessageCopyState({
   };
 }
 
+/**
+ * One user request can be answered across several turn ids: the provider mints
+ * a fresh synthetic turn whenever output resumes with no active turn (a
+ * subagent waking the agent back up, or a stop hook forcing a retry). Keying
+ * the response on the user-to-user segment instead of the turn id keeps that
+ * one logical response as one response.
+ */
 function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<TimelineEntry>) {
-  const lastAssistantMessageIdByResponseKey = new Map<string, string>();
-  let nullTurnResponseIndex = 0;
+  const lastAssistantMessageIdBySegment = new Map<number, string>();
+  let segmentIndex = 0;
 
   for (const timelineEntry of timelineEntries) {
     if (timelineEntry.kind !== "message") {
@@ -450,23 +457,21 @@ function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<Timeli
     }
     const { message } = timelineEntry;
     if (message.role === "user") {
-      nullTurnResponseIndex += 1;
+      segmentIndex += 1;
       continue;
     }
     if (message.role !== "assistant") {
       continue;
     }
 
-    const responseKey = message.turnId
-      ? `turn:${message.turnId}`
-      : `unkeyed:${nullTurnResponseIndex}`;
-    lastAssistantMessageIdByResponseKey.set(responseKey, message.id);
+    lastAssistantMessageIdBySegment.set(segmentIndex, message.id);
   }
 
-  return new Set(lastAssistantMessageIdByResponseKey.values());
+  return new Set(lastAssistantMessageIdBySegment.values());
 }
 
 interface TurnFold {
+  foldId: string;
   turnId: TurnId;
   anchorEntryId: string;
   createdAt: string;
@@ -513,9 +518,10 @@ function timelineEntryTurnId(entry: TimelineEntry): TurnId | null {
 }
 
 /**
- * Settled turns keep only their terminal assistant message visible.
- * Everything before it folds behind a "Worked for ..." row anchored at the
- * first hidden entry, so the duration leads directly into the final response.
+ * A settled user-to-user segment keeps only its last assistant message
+ * visible; everything before it folds behind a "Worked for ..." row anchored
+ * at the first hidden entry. Grouping by segment rather than by turn id keeps
+ * a response the provider split across synthetic turns under one fold.
  */
 function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
@@ -523,50 +529,51 @@ function deriveTurnFolds(input: {
   latestTurn: TimelineLatestTurn | null;
   unsettledTurnId: TurnId | null;
 }): ReadonlyMap<string, TurnFold> {
-  interface TurnGroup {
+  interface SegmentGroup {
     entries: Array<TimelineEntry>;
+    turnIds: Set<TurnId>;
+    firstTurnId: TurnId | null;
+    lastTurnId: TurnId | null;
+    boundaryEntryId: string | null;
     terminalEntry: Extract<TimelineEntry, { kind: "message" }> | null;
     hasStreamingMessage: boolean;
-    /**
-     * The user message that kicked the turn off. Entry timestamps alone
-     * undercount the duration (the first entry appears only once the
-     * provider starts producing output), and a turn cut short by a steer may
-     * hold a single instantaneous commentary message.
-     */
     startBoundary: string | null;
   }
-  const groupsByTurnId = new Map<TurnId, TurnGroup>();
+  const groupsBySegmentIndex = new Map<number, SegmentGroup>();
 
-  let pendingUserBoundary: string | null = null;
+  let segmentIndex = 0;
+  let segmentBoundary: string | null = null;
+  let segmentBoundaryEntryId: string | null = null;
   for (const entry of input.timelineEntries) {
     if (entry.kind === "message" && entry.message.role === "user") {
-      pendingUserBoundary = entry.message.createdAt;
+      segmentIndex += 1;
+      segmentBoundary = entry.message.createdAt;
+      segmentBoundaryEntryId = entry.id;
       continue;
     }
-    const turnId =
-      entry.kind === "message" && entry.message.role === "assistant"
-        ? (entry.message.turnId ?? null)
-        : entry.kind === "work"
-          ? (entry.entry.turnId ?? null)
-          : null;
-    if (!turnId) {
-      continue;
-    }
-    let group = groupsByTurnId.get(turnId);
+    // Membership is positional, not by turn id: plan chips and turn-less work
+    // rows are intermediate output of the same response.
+    const turnId = timelineEntryTurnId(entry);
+    let group = groupsBySegmentIndex.get(segmentIndex);
     if (!group) {
       group = {
         entries: [],
+        turnIds: new Set(),
+        firstTurnId: turnId,
+        lastTurnId: turnId,
+        boundaryEntryId: segmentBoundaryEntryId,
         terminalEntry: null,
         hasStreamingMessage: false,
-        // Each user boundary starts at most one turn; a second turn after the
-        // same user message (e.g. a steer-superseded continuation) falls back
-        // to its own first entry.
-        startBoundary: pendingUserBoundary,
+        startBoundary: segmentBoundary,
       };
-      pendingUserBoundary = null;
-      groupsByTurnId.set(turnId, group);
+      groupsBySegmentIndex.set(segmentIndex, group);
     }
     group.entries.push(entry);
+    if (turnId !== null) {
+      group.turnIds.add(turnId);
+      group.firstTurnId ??= turnId;
+      group.lastTurnId = turnId;
+    }
     if (entry.kind === "message") {
       if (input.terminalAssistantMessageIds.has(entry.message.id)) {
         group.terminalEntry = entry;
@@ -578,26 +585,25 @@ function deriveTurnFolds(input: {
   }
 
   const foldsByAnchorEntryId = new Map<string, TurnFold>();
-  for (const [turnId, group] of groupsByTurnId) {
-    if (turnId === input.unsettledTurnId) {
+  const foldCountByFirstTurnId = new Map<TurnId, number>();
+  for (const group of groupsBySegmentIndex.values()) {
+    const turnId = group.lastTurnId;
+    const firstTurnId = group.firstTurnId;
+    // A turn-less segment has no durable fold identity, so it stays unfolded.
+    if (turnId === null || firstTurnId === null) {
+      continue;
+    }
+    if (input.unsettledTurnId !== null && group.turnIds.has(input.unsettledTurnId)) {
       continue;
     }
     if (group.hasStreamingMessage) {
       continue;
     }
-    const hiddenEntryIds = new Set<string>();
-    for (const entry of group.entries) {
-      if (entry.id === group.terminalEntry?.id) {
-        continue;
-      }
-      // Agent-spawn CTA rows never fold: workflows outlive their launching
-      // turn (dynamic spawns, background execution), and folding the CTA
-      // when the turn settles makes a still-running fleet invisible.
-      if (entry.kind === "work" && entry.entry.agentSpawn !== undefined) {
-        continue;
-      }
-      hiddenEntryIds.add(entry.id);
-    }
+    const hiddenEntryIds = new Set(
+      group.entries
+        .filter((entry) => entry.id !== group.terminalEntry?.id)
+        .map((entry) => entry.id),
+    );
     if (hiddenEntryIds.size === 0) {
       continue;
     }
@@ -610,12 +616,13 @@ function deriveTurnFolds(input: {
     }
 
     const isLatestInterruptedTurn =
-      input.latestTurn?.turnId === turnId && input.latestTurn.state === "interrupted";
-    // A turn cut short by a steer leaves trailing work entries behind its
-    // terminal message — take whichever ended last.
+      input.latestTurn !== null &&
+      group.turnIds.has(input.latestTurn.turnId) &&
+      input.latestTurn.state === "interrupted";
     const lastEntryEnd =
       lastEntry.kind === "message" ? lastEntry.message.updatedAt : lastEntry.createdAt;
     const elapsedMs =
+      group.turnIds.size === 1 &&
       input.latestTurn?.turnId === turnId &&
       input.latestTurn.startedAt &&
       input.latestTurn.completedAt
@@ -634,7 +641,14 @@ function deriveTurnFolds(input: {
         ? `Worked for ${duration}`
         : "Worked";
 
+    const priorFoldCount = foldCountByFirstTurnId.get(firstTurnId) ?? 0;
+    foldCountByFirstTurnId.set(firstTurnId, priorFoldCount + 1);
+    const foldId =
+      priorFoldCount === 0
+        ? `turn-fold:${firstTurnId}`
+        : `turn-fold:${firstTurnId}:${group.boundaryEntryId ?? firstHiddenEntry.id}`;
     foldsByAnchorEntryId.set(firstHiddenEntry.id, {
+      foldId,
       turnId,
       anchorEntryId: firstHiddenEntry.id,
       createdAt: firstHiddenEntry.createdAt,
@@ -649,7 +663,7 @@ export function deriveMessagesTimelineRows(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
   latestTurn?: TimelineLatestTurn | null;
   runningTurnId?: TurnId | null;
-  expandedTurnIds?: ReadonlySet<TurnId>;
+  expandedFoldIds?: ReadonlySet<string>;
   expandedWorkGroupIds?: ReadonlySet<string>;
   isWorking: boolean;
   activeTurnStartedAt: string | null;
@@ -673,7 +687,7 @@ export function deriveMessagesTimelineRows(input: {
   });
   const collapsedEntryIds = new Set<string>();
   for (const fold of foldsByAnchorEntryId.values()) {
-    if (!input.expandedTurnIds?.has(fold.turnId)) {
+    if (!input.expandedFoldIds?.has(fold.foldId)) {
       for (const entryId of fold.hiddenEntryIds) {
         collapsedEntryIds.add(entryId);
       }
@@ -798,11 +812,11 @@ export function deriveMessagesTimelineRows(input: {
     if (anchoredTurnFold) {
       nextRows.push({
         kind: "turn-fold",
-        id: `turn-fold:${anchoredTurnFold.turnId}`,
+        id: anchoredTurnFold.foldId,
         createdAt: anchoredTurnFold.createdAt,
         turnId: anchoredTurnFold.turnId,
         label: anchoredTurnFold.label,
-        expanded: input.expandedTurnIds?.has(anchoredTurnFold.turnId) ?? false,
+        expanded: input.expandedFoldIds?.has(anchoredTurnFold.foldId) ?? false,
       });
     }
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -164,7 +164,7 @@ interface TimelineRowSharedState {
   onFileOpen: (attachment: ChatFileAttachment) => void;
   openingVideoAttachmentId: string | null;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
-  onToggleTurnFold: (turnId: TurnId) => void;
+  onToggleTurnFold: (foldId: string) => void;
   onToggleWorkGroup: (groupId: string, anchorKey: string) => void;
   agentPanelModel: AgentPanelModel;
   onOpenAgents: () => void;
@@ -309,7 +309,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   topFadeEnabled = false,
   loadEarlier = null,
 }: MessagesTimelineProps) {
-  const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
+  const [expandedFoldIds, setExpandedFoldIds] = useState<ReadonlySet<string>>(new Set());
   const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
   const [disclosureToggleSettling, setDisclosureToggleSettling] = useState(false);
   const [minimapStripMap] = useState(() => new Map<string, HTMLSpanElement>());
@@ -373,14 +373,14 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   );
 
   const onToggleTurnFold = useCallback(
-    (turnId: TurnId) => {
-      suspendEndScrollMaintenanceForDisclosure(`turn-fold:${turnId}`);
-      setExpandedTurnIds((existing) => {
+    (foldId: string) => {
+      suspendEndScrollMaintenanceForDisclosure(foldId);
+      setExpandedFoldIds((existing) => {
         const next = new Set(existing);
-        if (next.has(turnId)) {
-          next.delete(turnId);
+        if (next.has(foldId)) {
+          next.delete(foldId);
         } else {
-          next.add(turnId);
+          next.add(foldId);
         }
         return next;
       });
@@ -403,34 +403,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [suspendEndScrollMaintenanceForDisclosure],
   );
 
-  // An in-session interrupt leaves its turn expanded so the user keeps their
-  // place; the next turn (or a reload, since this is local state) folds it.
   const previousLatestTurnRef = useRef(latestTurn);
-  useEffect(() => {
-    const previous = previousLatestTurnRef.current;
-    previousLatestTurnRef.current = latestTurn;
-    if (!latestTurn || previous?.turnId === undefined) {
-      return;
-    }
-    if (latestTurn.turnId === previous.turnId) {
-      if (previous.state === "running" && latestTurn.state === "interrupted") {
-        setExpandedTurnIds((existing) => {
-          const next = new Set(existing);
-          next.add(latestTurn.turnId);
-          return next;
-        });
-      }
-      return;
-    }
-    setExpandedTurnIds((existing) => {
-      if (!existing.has(previous.turnId)) {
-        return existing;
-      }
-      const next = new Set(existing);
-      next.delete(previous.turnId);
-      return next;
-    });
-  }, [latestTurn]);
 
   const rawRows = useMemo(
     () =>
@@ -438,7 +411,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         timelineEntries,
         latestTurn,
         runningTurnId,
-        expandedTurnIds,
+        expandedFoldIds,
         expandedWorkGroupIds,
         isWorking,
         activeTurnStartedAt,
@@ -449,7 +422,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       timelineEntries,
       latestTurn,
       runningTurnId,
-      expandedTurnIds,
+      expandedFoldIds,
       expandedWorkGroupIds,
       isWorking,
       activeTurnStartedAt,
@@ -457,6 +430,35 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       revertTurnCountByUserMessageId,
     ],
   );
+  // An in-session interrupt leaves its fold expanded so the user keeps their
+  // place; a later user-to-user segment folds it again.
+  useEffect(() => {
+    const previous = previousLatestTurnRef.current;
+    previousLatestTurnRef.current = latestTurn;
+    if (!latestTurn || previous?.turnId === undefined) return;
+
+    if (latestTurn.turnId === previous.turnId) {
+      if (previous.state !== "running" || latestTurn.state !== "interrupted") return;
+      const interruptedFoldId = rawRows.find(
+        (row) => row.kind === "turn-fold" && row.turnId === latestTurn.turnId,
+      )?.id;
+      if (!interruptedFoldId) return;
+      setExpandedFoldIds((existing) => new Set(existing).add(interruptedFoldId));
+      return;
+    }
+
+    const previousFoldId = rawRows.find(
+      (row) => row.kind === "turn-fold" && row.turnId === previous.turnId,
+    )?.id;
+    if (!previousFoldId) return;
+    setExpandedFoldIds((existing) => {
+      if (!existing.has(previousFoldId)) return existing;
+      const next = new Set(existing);
+      next.delete(previousFoldId);
+      return next;
+    });
+  }, [latestTurn, rawRows]);
+
   const rows = useStableRows(rawRows);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
@@ -1238,7 +1240,7 @@ function TurnFoldTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
         type="button"
         aria-expanded={row.expanded}
         data-scroll-anchor-ignore
-        onClick={() => ctx.onToggleTurnFold(row.turnId)}
+        onClick={() => ctx.onToggleTurnFold(row.id)}
         className="flex cursor-pointer select-none items-center gap-1 rounded-md px-1 text-sm leading-relaxed text-muted-foreground tabular-nums transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
       >
         <span>{row.label}</span>


### PR DESCRIPTION

## What Changed

Settled chat history now treats everything between two user messages as one response segment, even when the provider resumes that response under additional synthetic turn IDs.

The segment keeps only its terminal assistant message visible. Intermediate assistant messages, tool activity, plans, background receipts, and agent-spawn rows remain available behind one fold.

Fold IDs use the segment's first real turn and, when needed, its user-message boundary. This keeps an expanded segment open when a wake-up turn is appended and prevents duplicate row IDs when a late receipt retains an earlier turn ID after a steer.

## Why

Provider wake-ups from subagents and stop hooks can mint a new turn ID without starting a new user response. Grouping folds directly by turn ID split one logical reply into several visible responses.

The prior last-turn identity also changed as continuation output arrived. That remounted and re-collapsed an expanded fold. Separate user-to-user segments could additionally share the same last turn ID, creating duplicate React keys and row-map collisions.

## Test Coverage

- Multi-turn subagent wake-up responses collapse into one segment.
- Plans, turn-less work, and agent-spawn rows fold with their response.
- Running continuation turns keep the segment unfolded.
- Segments without a real turn ID remain unfolded.
- Expanded folds retain their identity when a continuation turn is appended.
- Separate segments sharing a trailing turn ID receive unique row IDs.
- Complete chat component test suite.
- Web TypeScript typecheck.

Fixes #8945
Fixes #8946

## Checklist

- [x] This PR contains one focused timeline reliability fix
- [x] I explained what changed and why
- [ ] Before/after interaction recording will be attached in a follow-up comment

Work by Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timeline row derivation and expand/collapse state are user-facing; logic is heavily tested but edge cases around multi-turn segments and interrupts could still affect scroll or disclosure behavior.
> 
> **Overview**
> Settled chat history now collapses **everything between two user messages** into one “Worked for …” fold, instead of one fold per provider turn id. Subagent wake-ups and stop-hook retries that mint new turn ids stay a single logical reply with one terminal assistant message visible.
> 
> **Fold identity** moves from `expandedTurnIds` / `turn-fold:${turnId}` to **`expandedFoldIds`** and stable **`foldId`** strings (`turn-fold:${firstTurnId}` or with a user-boundary suffix when segments share a trailing turn id). That fixes duplicate React keys and stops expanded folds from remounting when continuation output arrives.
> 
> **Folding rules** also change: plan chips, turn-less work, and agent-spawn rows fold with their segment (agent-spawn is no longer always left visible), segments with no real turn id stay unfolded, and any segment that still has a running turn in `turnIds` stays unfolded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef68daf1f38661c092d63fe5af584b815cf30fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fold complete response segments in `MessagesTimeline` instead of individual turns
> - Changes fold grouping from per-turn to per user-to-user segment in `deriveTurnFolds`, so a single fold now covers all assistant messages, plan chips, turn-less work, and spawn CTA entries between two user messages.
> - Replaces `expandedTurnIds` (`Set<TurnId>`) with `expandedFoldIds` (`Set<string>`) throughout the component and derivation, using stable fold ids like `turn-fold:<firstTurnId>` (with an anchor entry id suffix when multiple segments share the same first turn id).
> - `deriveTerminalAssistantMessageIds` now returns the last assistant message per user-to-user segment rather than per turn id, collapsing resumed turns into one terminal answer.
> - Segments that contain the currently running turn are left unfolded; segments with no turn id are also left unfolded.
> - Risk: `TurnFold.foldId` and `onToggleTurnFold(foldId: string)` change the public shape of fold row identity and the toggle callback in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/8973/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588); any out-of-tree consumers of these props must update from `TurnId` to `string` fold ids.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ef68daf. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved message timeline folding for multi-step responses and subagent activity.
  - Added folding support for plan items, turn-less work entries, and agent-spawn actions.
  - Fold sections now maintain stable identities and preserve expansion during interruptions.
  - The latest active segment remains expanded while subsequent work is running.

- **Bug Fixes**
  - Corrected folding behavior for split responses and segments sharing turn identifiers.
  - Prevented unintended folding of turn-less segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->