### PR TITLE
fix(web): keep sidebar timer on the response

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1072,44 +1072,50 @@ describe("resolveWorkingStartedAt", () => {
     updatedAt: "2026-03-09T10:02:00.000Z",
   };
 
-  it("uses the running turn's start time", () => {
+  it("uses the latest user message across synthetic turns", () => {
     expect(
       resolveWorkingStartedAt({
+        latestUserMessageAt: "2026-03-09T09:55:00.000Z",
         latestTurn: makeLatestTurn({ completedAt: null }),
         session,
       }),
-    ).toBe("2026-03-09T10:00:00.000Z");
+    ).toBe("2026-03-09T09:55:00.000Z");
   });
 
-  it("uses the request time while a turn awaits adoption", () => {
+  it("uses the request time while a turn awaits adoption without a user message projection", () => {
     expect(
       resolveWorkingStartedAt({
+        latestUserMessageAt: null,
         latestTurn: makeLatestTurn({ startedAt: null, completedAt: null }),
         session,
       }),
     ).toBe("2026-03-09T10:00:00.000Z");
   });
 
-  it("falls back to the session transition when the latest turn already completed", () => {
+  it("keeps using the user message when the latest synthetic turn already completed", () => {
     expect(
       resolveWorkingStartedAt({
+        latestUserMessageAt: "2026-03-09T09:55:00.000Z",
         latestTurn: makeLatestTurn(),
         session,
       }),
-    ).toBe("2026-03-09T10:02:00.000Z");
+    ).toBe("2026-03-09T09:55:00.000Z");
   });
 
-  it("skips a malformed startedAt instead of returning it", () => {
+  it("skips malformed timestamps and falls back through turn and session candidates", () => {
     expect(
       resolveWorkingStartedAt({
-        latestTurn: makeLatestTurn({ startedAt: "not-a-date", completedAt: null }),
+        latestUserMessageAt: "not-a-date",
+        latestTurn: makeLatestTurn({ startedAt: "also-not-a-date", completedAt: null }),
         session,
       }),
     ).toBe("2026-03-09T10:00:00.000Z");
   });
 
-  it("returns null with neither a running turn nor a session", () => {
-    expect(resolveWorkingStartedAt({ latestTurn: null, session: null })).toBeNull();
+  it("returns null without a message, turn, or session", () => {
+    expect(
+      resolveWorkingStartedAt({ latestUserMessageAt: null, latestTurn: null, session: null }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -658,18 +658,20 @@ export function sortSettledThreadsForSidebar<
   );
 }
 
-/** The timestamp a working thread's elapsed label counts from: the running
-    turn's start (request time until adoption), falling back to the session's
-    last transition when the turn projection lags behind. Malformed
-    timestamps fall through to the next candidate, not just missing ones. */
+/** The timestamp a working thread's elapsed label counts from: the user
+    message that started the current response segment. Turn ids may change
+    while that response is still running, so turn and session timestamps are
+    only fallbacks when the message projection is missing or malformed. */
 export function resolveWorkingStartedAt(
-  thread: Pick<SidebarThreadSummary, "latestTurn" | "session">,
+  thread: Pick<SidebarThreadSummary, "latestUserMessageAt" | "latestTurn" | "session">,
 ): string | null {
   const turn = thread.latestTurn;
-  if (turn && turn.completedAt === null) {
-    return firstValidTimestamp(turn.startedAt, turn.requestedAt, thread.session?.updatedAt);
-  }
-  return firstValidTimestamp(thread.session?.updatedAt);
+  return firstValidTimestamp(
+    thread.latestUserMessageAt,
+    turn?.completedAt === null ? turn.startedAt : null,
+    turn?.completedAt === null ? turn.requestedAt : null,
+    thread.session?.updatedAt,
+  );
 }
 
 export function formatWorkingDurationLabel(elapsedMs: number): string {


### PR DESCRIPTION

## What Changed

The sidebar's `Working Ns` label now starts from the latest user message that began the current response. Active-turn request/start timestamps and the session update remain fallbacks when that projection is unavailable or malformed.

## Why

A provider may resume one response under a newly generated synthetic turn after a subagent or stop hook wakes it. The sidebar previously used the latest turn's start time, so each continuation reset the visible elapsed duration even though the user was still waiting on the same response.

Using the user-message boundary keeps the timer stable across those continuation turns. The synthetic-turn behavior that triggers this reset is also described in #8945; this PR only corrects the sidebar duration and does not claim to close that issue.

The current sidebar summary does not expose a reliable signal that distinguishes a synthetic continuation from a later agent-initiated background burst. This change intentionally follows the response-boundary projection rather than introducing an arbitrary time threshold.

## Test Coverage

- Latest user message wins across running synthetic turns.
- A completed latest synthetic turn does not reset the response timer.
- Turn request time remains the fallback before a user-message projection is available.
- Malformed timestamps fall through to valid turn or session values.
- Missing message, turn, and session data returns no timer start.
- Web TypeScript typecheck.

## Checklist

- [x] This PR contains one focused timer correction
- [x] I explained what changed and why
- [ ] Before/after interaction recording will be attached in a follow-up comment

Work by Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only sidebar timer logic with focused unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> The sidebar **Working** elapsed label now anchors on **`latestUserMessageAt`** (the user message that started the current response) instead of the active turn’s start/request time.
> 
> **`resolveWorkingStartedAt`** still falls back to incomplete-turn `startedAt` / `requestedAt`, then `session.updatedAt`, when that projection is missing or invalid—so synthetic continuation turns no longer reset the visible duration while the same response is still in flight.
> 
> Unit tests for **`resolveWorkingStartedAt`** were updated to cover user-message priority, adoption without a message projection, completed synthetic turns, malformed timestamps, and empty inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab34e1e741f1f598518b5905f5ec47de6cecb401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use latest user message timestamp for sidebar `resolveWorkingStartedAt` timer
> Changes `resolveWorkingStartedAt` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/8974/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to accept `latestUserMessageAt` and prefer it as the working start time, falling back to `turn.startedAt`, `turn.requestedAt`, then `session.updatedAt` via a unified `firstValidTimestamp` call. Malformed timestamps are skipped across all candidates. Tests in [Sidebar.logic.test.ts](https://github.com/pingdotgg/t3code/pull/8974/files#diff-32549f6f09ae3a1d9d846a62727c17b9f9ec246030982995fd972b497a87335a) are updated to assert the new precedence and null/malformed fallbacks.
> - Behavioral Change: the sidebar elapsed label now primarily counts from the initiating user message instead of the running turn's start; callers of `resolveWorkingStartedAt` must pass the new `latestUserMessageAt` argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab34e1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved elapsed-time labels in the sidebar by prioritizing the latest user message timestamp.
  * Added more reliable fallback behavior for active and completed turns.
  * Improved handling of malformed or missing timestamps to prevent incorrect labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->