### PR TITLE
fix(desktop): check artifact build prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing
 
+## Developer Setup
+
+See the [maintainer scripts guide](docs/internals/scripts.md#first-checkout) for the initial checkout,
+development commands, tests, and platform-specific desktop packaging prerequisites.
+
 ## Read This First
 
 We are not actively accepting contributions right now.

--- a/docs/internals/scripts.md
+++ b/docs/internals/scripts.md
@@ -84,19 +84,19 @@ Ubuntu and Debian:
 
 ```bash
 sudo apt-get update
-sudo apt-get install cargo rustc build-essential libx11-dev libxrandr-dev libxtst-dev libxt-dev
+sudo apt-get install cargo rustc build-essential imagemagick libx11-dev libxrandr-dev libxtst-dev libxt-dev
 ```
 
 Fedora:
 
 ```bash
-sudo dnf install rust cargo gcc gcc-c++ make libX11-devel libXrandr-devel libXtst-devel libXt-devel
+sudo dnf install rust cargo gcc gcc-c++ make ImageMagick libX11-devel libXrandr-devel libXtst-devel libXt-devel
 ```
 
 Arch Linux:
 
 ```bash
-sudo pacman -S rust base-devel libx11 libxrandr libxtst libxt
+sudo pacman -S rust base-devel imagemagick libx11 libxrandr libxtst libxt
 ```
 
 The artifact script checks these capabilities before starting the web and desktop builds. If
@@ -131,6 +131,9 @@ Visual Studio Installer, select **Desktop development with C++** and include:
 - MSVC x64/x86 build tools
 - A Windows 10 or Windows 11 SDK
 - MSVC Spectre-mitigated libraries
+
+ARM64 installers require the corresponding MSVC ARM64 build tools and Spectre-mitigated libraries
+instead of the x64/x86 components.
 
 Add the Rust target matching the installer architecture:
 

--- a/docs/internals/scripts.md
+++ b/docs/internals/scripts.md
@@ -74,6 +74,77 @@ authenticated.
 - `vp run dist:desktop:win`: Builds a Windows NSIS installer into `./release`. `:arm64` and `:x64`
   variants exist.
 
+### Linux AppImage prerequisites
+
+Linux AppImage packaging compiles the Rust resource monitor and rebuilds the `uiohook-napi` native
+addon. Install a Rust toolchain, the standard C/C++ build tools, and the X11 development headers
+before running `vp run dist:desktop:linux`.
+
+Ubuntu and Debian:
+
+```bash
+sudo apt-get update
+sudo apt-get install cargo rustc build-essential libx11-dev libxrandr-dev libxtst-dev libxt-dev
+```
+
+Fedora:
+
+```bash
+sudo dnf install rust cargo gcc gcc-c++ make libX11-devel libXrandr-devel libXtst-devel libXt-devel
+```
+
+Arch Linux:
+
+```bash
+sudo pacman -S rust base-devel libx11 libxrandr libxtst libxt
+```
+
+The artifact script checks these capabilities before starting the web and desktop builds. If
+anything is unavailable, it reports every failed check together and prints the Ubuntu/Debian
+installation command. The check compiles and links tiny temporary programs, so it also catches
+installed runtime X11 libraries that are missing their development headers or linker symlinks.
+
+### macOS DMG prerequisites
+
+Install the Xcode Command Line Tools and Rust before building a DMG:
+
+```bash
+xcode-select --install
+```
+
+Install Rust from [rustup.rs](https://rustup.rs). The artifact script checks Cargo, Clang, Make,
+`sips`, and `iconutil`. Universal builds additionally require `lipo`. It also verifies that Rust
+has every requested target; add missing targets with:
+
+```bash
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+```
+
+Unsigned local builds need no Apple credentials. Builds using `--signed` additionally require the
+certificate, provisioning profile, team ID, and notarization configuration described below.
+
+### Windows installer prerequisites
+
+Install Rust from [rustup.rs](https://rustup.rs), Python 3, and Visual Studio Build Tools. In the
+Visual Studio Installer, select **Desktop development with C++** and include:
+
+- MSVC x64/x86 build tools
+- A Windows 10 or Windows 11 SDK
+- MSVC Spectre-mitigated libraries
+
+Add the Rust target matching the installer architecture:
+
+```powershell
+rustup target add x86_64-pc-windows-msvc
+# For an arm64 installer:
+rustup target add aarch64-pc-windows-msvc
+```
+
+Windows supplies `tar.exe`; it is checked when `--wsl-prebuild` makes the artifact include the WSL
+runtime. NSIS is downloaded by electron-builder and does not need a separate installation.
+Unsigned local builds need no Azure credentials. Builds using `--signed` additionally require the
+Azure Trusted Signing configuration described below.
+
 ### Desktop `.dmg` packaging notes
 
 - Default build is unsigned/not notarized for local sharing.

--- a/docs/internals/scripts.md
+++ b/docs/internals/scripts.md
@@ -76,27 +76,26 @@ authenticated.
 
 ### Linux AppImage prerequisites
 
-Linux AppImage packaging compiles the Rust resource monitor and rebuilds the `uiohook-napi` native
-addon. Install a Rust toolchain, the standard C/C++ build tools, and the X11 development headers
-before running `vp run dist:desktop:linux`.
+Linux AppImage packaging compiles the Rust resource monitor. Install a Rust toolchain, the standard
+C/C++ build tools, and ImageMagick before running `vp run dist:desktop:linux`.
 
 Ubuntu and Debian:
 
 ```bash
 sudo apt-get update
-sudo apt-get install cargo rustc build-essential imagemagick libx11-dev libxrandr-dev libxtst-dev libxt-dev
+sudo apt-get install cargo rustc build-essential imagemagick
 ```
 
 Fedora:
 
 ```bash
-sudo dnf install rust cargo gcc gcc-c++ make ImageMagick libX11-devel libXrandr-devel libXtst-devel libXt-devel
+sudo dnf install rust cargo gcc gcc-c++ make ImageMagick
 ```
 
 Arch Linux:
 
 ```bash
-sudo pacman -S rust base-devel imagemagick libx11 libxrandr libxtst libxt
+sudo pacman -S rust base-devel imagemagick
 ```
 
 The artifact script checks these capabilities before starting the web and desktop builds. If

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -32,9 +32,14 @@ import {
   UnsupportedDesktopBuildArchitectureError,
   isMacPasskeySigningConfigurationError,
   LinuxIconResizeError,
+  LinuxDesktopBuildPrerequisitesMissingError,
+  MacDesktopBuildPrerequisitesMissingError,
   MacPasskeySigningConfigurationResolutionError,
   MissingMacPasskeyProvisioningProfileError,
   packWindowsServerAsar,
+  preflightLinuxDesktopBuild,
+  preflightMacDesktopBuild,
+  preflightWindowsDesktopBuild,
   renderMacPasskeyEntitlements,
   resolveClerkPasskeyNativeArtifacts,
   resolveMacPasskeySigningConfiguration,
@@ -63,6 +68,7 @@ import {
   copyDirectoryPreservingSymlinks,
   validateWindowsPackagedPayload,
   WindowsPrimaryNativeProbeError,
+  WindowsDesktopBuildPrerequisitesMissingError,
   WindowsPackagedPayloadValidationError,
   WINDOWS_PACKAGED_PAYLOAD_FILE_LIMIT,
   WINDOWS_SERVER_ASAR_IGNORE_GLOBS,
@@ -808,6 +814,103 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
           ),
           "cached monitor",
         );
+      }),
+    ),
+  );
+
+  it.effect("reports every missing Linux desktop build prerequisite with an install command", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const spawner = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make((command) => {
+            const childProcess = command as unknown as {
+              readonly command: string;
+              readonly args: ReadonlyArray<string>;
+            };
+            const fails =
+              childProcess.command === "cargo" ||
+              childProcess.args.includes("X11/extensions/Xrandr.h");
+            return Effect.succeed(mockProcess(fails ? 1 : 0));
+          }),
+        );
+
+        const error = yield* preflightLinuxDesktopBuild().pipe(
+          Effect.provide(spawner),
+          Effect.flip,
+        );
+
+        assert.instanceOf(error, LinuxDesktopBuildPrerequisitesMissingError);
+        assert.deepStrictEqual(error.missing, ["cargo", "xrandr"]);
+        assert.include(error.message, "Rust compiler and Cargo (cargo, rustc)");
+        assert.include(error.message, "Xrandr headers and linker library (libxrandr-dev)");
+        assert.include(error.message, "sudo apt-get install cargo rustc libxrandr-dev");
+      }),
+    ),
+  );
+
+  it.effect("reports missing macOS tools and Rust targets before building", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const spawner = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make((command) => {
+            const childProcess = command as unknown as {
+              readonly command: string;
+              readonly args: ReadonlyArray<string>;
+            };
+            const fails = childProcess.command === "iconutil" || childProcess.command === "rustc";
+            return Effect.succeed(mockProcess(fails ? 1 : 0));
+          }),
+        );
+        const error = yield* preflightMacDesktopBuild("universal").pipe(
+          Effect.provide(spawner),
+          Effect.flip,
+        );
+
+        assert.instanceOf(error, MacDesktopBuildPrerequisitesMissingError);
+        assert.deepStrictEqual(error.missing, ["rust", "iconutil"]);
+        assert.deepStrictEqual(error.rustTargets, ["aarch64-apple-darwin", "x86_64-apple-darwin"]);
+        assert.include(error.message, "xcode-select --install");
+        assert.include(error.message, "rustup target add aarch64-apple-darwin x86_64-apple-darwin");
+      }),
+    ),
+  );
+
+  it.effect("reports missing Windows toolchain capabilities before building", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-windows-preflight-" });
+        const pythonPath = path.join(tempDir, "python.exe");
+        yield* fs.writeFileString(pythonPath, "python");
+        const spawner = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make((command) => {
+            const childProcess = command as unknown as { readonly command: string };
+            const fails =
+              childProcess.command === "rustc" || childProcess.command === "powershell.exe";
+            return Effect.succeed(mockProcess(fails ? 1 : 0));
+          }),
+        );
+        const error = yield* preflightWindowsDesktopBuild({
+          arch: "x64",
+          bundlesWslRuntime: true,
+        }).pipe(
+          Effect.provide(spawner),
+          Effect.provide(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({ env: { npm_config_python: pythonPath } }),
+            ),
+          ),
+          Effect.flip,
+        );
+
+        assert.instanceOf(error, WindowsDesktopBuildPrerequisitesMissingError);
+        assert.deepStrictEqual(error.missing, ["rust", "msvc"]);
+        assert.equal(error.rustTarget, "x86_64-pc-windows-msvc");
+        assert.include(error.message, "Visual Studio Build Tools components");
       }),
     ),
   );

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -821,6 +821,8 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
   it.effect("reports every missing Linux desktop build prerequisite with an install command", () =>
     Effect.scoped(
       Effect.gen(function* () {
+        const commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> =
+          [];
         const spawner = Layer.succeed(
           ChildProcessSpawner.ChildProcessSpawner,
           ChildProcessSpawner.make((command) => {
@@ -828,6 +830,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
               readonly command: string;
               readonly args: ReadonlyArray<string>;
             };
+            commands.push(childProcess);
             const fails =
               childProcess.command === "cargo" ||
               childProcess.args.includes("X11/extensions/Xrandr.h");
@@ -835,7 +838,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
           }),
         );
 
-        const error = yield* preflightLinuxDesktopBuild().pipe(
+        const error = yield* preflightLinuxDesktopBuild("arm64").pipe(
           Effect.provide(spawner),
           Effect.flip,
         );
@@ -845,6 +848,12 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         assert.include(error.message, "Rust compiler and Cargo (cargo, rustc)");
         assert.include(error.message, "Xrandr headers and linker library (libxrandr-dev)");
         assert.include(error.message, "sudo apt-get install cargo rustc libxrandr-dev");
+        assert.isTrue(
+          commands.some(
+            (command) =>
+              command.command === "rustc" && command.args.includes("aarch64-unknown-linux-gnu"),
+          ),
+        );
       }),
     ),
   );
@@ -859,7 +868,9 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
               readonly command: string;
               readonly args: ReadonlyArray<string>;
             };
-            const fails = childProcess.command === "iconutil" || childProcess.command === "rustc";
+            const fails =
+              childProcess.command === "rustc" ||
+              (childProcess.command === "xcrun" && childProcess.args.includes("iconutil"));
             return Effect.succeed(mockProcess(fails ? 1 : 0));
           }),
         );

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -901,7 +901,9 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
           ChildProcessSpawner.make((command) => {
             const childProcess = command as unknown as { readonly command: string };
             const fails =
-              childProcess.command === "rustc" || childProcess.command === "powershell.exe";
+              childProcess.command === "rustc" ||
+              childProcess.command === "powershell.exe" ||
+              childProcess.command === pythonPath;
             return Effect.succeed(mockProcess(fails ? 1 : 0));
           }),
         );
@@ -919,7 +921,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         );
 
         assert.instanceOf(error, WindowsDesktopBuildPrerequisitesMissingError);
-        assert.deepStrictEqual(error.missing, ["rust", "msvc"]);
+        assert.deepStrictEqual(error.missing, ["rust", "python", "msvc"]);
         assert.equal(error.rustTarget, "x86_64-pc-windows-msvc");
         assert.include(error.message, "Visual Studio Build Tools components");
       }),

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -831,9 +831,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
               readonly args: ReadonlyArray<string>;
             };
             commands.push(childProcess);
-            const fails =
-              childProcess.command === "cargo" ||
-              childProcess.args.includes("X11/extensions/Xrandr.h");
+            const fails = childProcess.command === "cargo" || childProcess.command === "rustc";
             return Effect.succeed(mockProcess(fails ? 1 : 0));
           }),
         );
@@ -844,10 +842,11 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         );
 
         assert.instanceOf(error, LinuxDesktopBuildPrerequisitesMissingError);
-        assert.deepStrictEqual(error.missing, ["cargo", "xrandr"]);
+        assert.deepStrictEqual(error.missing, ["cargo", "rust-target"]);
         assert.include(error.message, "Rust compiler and Cargo (cargo, rustc)");
-        assert.include(error.message, "Xrandr headers and linker library (libxrandr-dev)");
-        assert.include(error.message, "sudo apt-get install cargo rustc libxrandr-dev");
+        assert.include(error.message, "Requested Rust standard library");
+        assert.include(error.message, "sudo apt-get install cargo rustc");
+        assert.include(error.message, "rustup target add aarch64-unknown-linux-gnu");
         assert.isTrue(
           commands.some(
             (command) =>

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -108,7 +108,8 @@ const stageWslRuntimeTreeFixture = Effect.fn("stageWslRuntimeTreeFixture")(funct
   );
 });
 
-function mockProcess(exitCode: number) {
+function mockProcess(exitCode: number, stdout = "") {
+  const encodedStdout = new TextEncoder().encode(stdout);
   return ChildProcessSpawner.makeHandle({
     pid: ChildProcessSpawner.ProcessId(1),
     exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
@@ -116,7 +117,7 @@ function mockProcess(exitCode: number) {
     kill: () => Effect.void,
     unref: Effect.succeed(Effect.void),
     stdin: Sink.drain,
-    stdout: Stream.empty,
+    stdout: stdout ? Stream.make(encodedStdout) : Stream.empty,
     stderr: Stream.empty,
     all: Stream.empty,
     getInputFd: () => Sink.drain,
@@ -925,6 +926,53 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         assert.deepStrictEqual(error.missing, ["rust", "python", "msvc"]);
         assert.equal(error.rustTarget, "x86_64-pc-windows-msvc");
         assert.include(error.message, "Visual Studio Build Tools components");
+      }),
+    ),
+  );
+
+  it.effect("rejects a PATH-discovered Python executable that is not Python 3", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-python2-preflight-" });
+        const pythonPath = path.join(tempDir, "python");
+        yield* fs.writeFileString(pythonPath, "python2");
+        const spawner = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make((command) => {
+            const childProcess = command as unknown as {
+              readonly command: string;
+              readonly args: ReadonlyArray<string>;
+            };
+            if (childProcess.command === "python") {
+              return Effect.succeed(mockProcess(0, `${pythonPath}\n`));
+            }
+            if (childProcess.command === pythonPath) {
+              return Effect.succeed(mockProcess(1));
+            }
+            return Effect.succeed(mockProcess(0));
+          }),
+        );
+        const error = yield* preflightWindowsDesktopBuild({
+          arch: "x64",
+          bundlesWslRuntime: false,
+        }).pipe(
+          Effect.provide(
+            Layer.merge(
+              spawner,
+              ConfigProvider.layer(
+                ConfigProvider.fromEnv({
+                  env: { T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR: "true" },
+                }),
+              ),
+            ),
+          ),
+          Effect.flip,
+        );
+
+        assert.instanceOf(error, WindowsDesktopBuildPrerequisitesMissingError);
+        assert.deepStrictEqual(error.missing, ["python"]);
       }),
     ),
   );

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -911,10 +911,12 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
           arch: "x64",
           bundlesWslRuntime: true,
         }).pipe(
-          Effect.provide(spawner),
           Effect.provide(
-            ConfigProvider.layer(
-              ConfigProvider.fromEnv({ env: { npm_config_python: pythonPath } }),
+            Layer.merge(
+              spawner,
+              ConfigProvider.layer(
+                ConfigProvider.fromEnv({ env: { npm_config_python: pythonPath } }),
+              ),
             ),
           ),
           Effect.flip,

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -289,23 +289,17 @@ export class BuildCommandFailedError extends Schema.TaggedErrorClass<BuildComman
 
 export const LINUX_DESKTOP_BUILD_PREREQUISITES = [
   { id: "cargo", description: "Rust compiler and Cargo", packages: ["cargo", "rustc"] },
+  { id: "rust-target", description: "Requested Rust standard library", packages: [] },
   { id: "cc", description: "C/C++ build toolchain", packages: ["build-essential"] },
   { id: "make", description: "Make", packages: ["build-essential"] },
   { id: "imagemagick", description: "ImageMagick", packages: ["imagemagick"] },
-  { id: "x11", description: "X11 headers and linker library", packages: ["libx11-dev"] },
-  {
-    id: "xrandr",
-    description: "Xrandr headers and linker library",
-    packages: ["libxrandr-dev"],
-  },
-  { id: "xtst", description: "Xtst headers and linker library", packages: ["libxtst-dev"] },
-  { id: "xt", description: "Xt headers and linker library", packages: ["libxt-dev"] },
 ] as const;
 
 export class LinuxDesktopBuildPrerequisitesMissingError extends Schema.TaggedErrorClass<LinuxDesktopBuildPrerequisitesMissingError>()(
   "LinuxDesktopBuildPrerequisitesMissingError",
   {
     missing: Schema.Array(Schema.String),
+    rustTarget: Schema.String,
   },
 ) {
   override get message(): string {
@@ -313,7 +307,11 @@ export class LinuxDesktopBuildPrerequisitesMissingError extends Schema.TaggedErr
       this.missing.includes(requirement.id),
     );
     const details = missingRequirements
-      .map((requirement) => `  - ${requirement.description} (${requirement.packages.join(", ")})`)
+      .map((requirement) =>
+        requirement.packages.length > 0
+          ? `  - ${requirement.description} (${requirement.packages.join(", ")})`
+          : `  - ${requirement.description}`,
+      )
       .join("\n");
     const packages = [
       ...new Set(missingRequirements.flatMap((requirement) => requirement.packages)),
@@ -322,8 +320,12 @@ export class LinuxDesktopBuildPrerequisitesMissingError extends Schema.TaggedErr
       "Linux desktop build prerequisites are missing:",
       details,
       "",
-      "On Ubuntu/Debian, install them with:",
-      `  sudo apt-get install ${packages.join(" ")}`,
+      ...(packages.length > 0
+        ? ["On Ubuntu/Debian, install them with:", `  sudo apt-get install ${packages.join(" ")}`]
+        : []),
+      ...(this.missing.includes("rust-target")
+        ? ["Add the requested Rust target with:", `  rustup target add ${this.rustTarget}`]
+        : []),
       "",
       "For other distributions, see docs/internals/scripts.md#linux-appimage-prerequisites.",
       "Then rerun `vp run dist:desktop:linux`.",
@@ -1621,25 +1623,19 @@ const rustTargetIsInstalled = Effect.fn("rustTargetIsInstalled")(function* (targ
 export const preflightLinuxDesktopBuild = Effect.fn("preflightLinuxDesktopBuild")(function* (
   arch: typeof BuildArch.Type = "x64",
 ) {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
   const reuseResourceMonitor = yield* Config.boolean("T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR").pipe(
     Config.withDefault(false),
   );
-  const probeDir = yield* fs.makeTempDirectoryScoped({
-    prefix: "t3code-linux-build-preflight-",
-  });
-  const sourcePath = path.join(probeDir, "probe.c");
-  yield* fs.writeFileString(sourcePath, "int main(void) { return 0; }\n");
+  const rustTarget = resolveResourceMonitorRustTargets("linux", arch)[0]!;
 
-  const commandChecks = yield* Effect.all(
+  const checks = yield* Effect.all(
     {
       cargo: reuseResourceMonitor
         ? Effect.succeed(true)
-        : Effect.all([
-            desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
-            rustTargetIsInstalled(resolveResourceMonitorRustTargets("linux", arch)[0]!),
-          ]).pipe(Effect.map(([cargo, target]) => cargo && target)),
+        : desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
+      "rust-target": reuseResourceMonitor
+        ? Effect.succeed(true)
+        : rustTargetIsInstalled(rustTarget),
       cc: desktopBuildProbeSucceeds(ChildProcess.make("cc", ["--version"]), "cc"),
       make: desktopBuildProbeSucceeds(ChildProcess.make("make", ["--version"]), "make"),
       imagemagick: Effect.all([
@@ -1649,69 +1645,12 @@ export const preflightLinuxDesktopBuild = Effect.fn("preflightLinuxDesktopBuild"
     },
     { concurrency: "unbounded" },
   );
-
-  const nativeChecks = commandChecks.cc
-    ? yield* Effect.all(
-        {
-          x11: desktopBuildProbeSucceeds(
-            ChildProcess.make("cc", [
-              sourcePath,
-              "-include",
-              "X11/keysym.h",
-              "-lX11",
-              "-o",
-              path.join(probeDir, "x11"),
-            ]),
-            "X11 build prerequisite probe",
-          ),
-          xrandr: desktopBuildProbeSucceeds(
-            ChildProcess.make("cc", [
-              sourcePath,
-              "-include",
-              "X11/extensions/Xrandr.h",
-              "-lXrandr",
-              "-o",
-              path.join(probeDir, "xrandr"),
-            ]),
-            "Xrandr build prerequisite probe",
-          ),
-          xtst: desktopBuildProbeSucceeds(
-            ChildProcess.make("cc", [
-              sourcePath,
-              "-include",
-              "X11/extensions/XTest.h",
-              "-lXtst",
-              "-o",
-              path.join(probeDir, "xtst"),
-            ]),
-            "Xtst build prerequisite probe",
-          ),
-          xt: desktopBuildProbeSucceeds(
-            ChildProcess.make("cc", [
-              sourcePath,
-              "-include",
-              "X11/Intrinsic.h",
-              "-lXt",
-              "-o",
-              path.join(probeDir, "xt"),
-            ]),
-            "Xt build prerequisite probe",
-          ),
-        },
-        { concurrency: "unbounded" },
-      )
-    : { x11: true, xrandr: true, xtst: true, xt: true };
-
-  const checks = {
-    ...commandChecks,
-    ...nativeChecks,
-  };
   const missing = LINUX_DESKTOP_BUILD_PREREQUISITES.filter(
     (requirement) => !checks[requirement.id],
   ).map((requirement) => requirement.id);
 
   if (missing.length > 0) {
-    return yield* new LinuxDesktopBuildPrerequisitesMissingError({ missing });
+    return yield* new LinuxDesktopBuildPrerequisitesMissingError({ missing, rustTarget });
   }
 });
 

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -882,7 +882,7 @@ const resolvePythonForNodeGyp = Effect.fn("resolvePythonForNodeGyp")(function* (
   }
 
   const executable = probe.stdout.trim();
-  if (!executable || !(yield* fs.exists(executable))) {
+  if (!executable || !(yield* fs.exists(executable)) || !(yield* isPython3(executable))) {
     return undefined;
   }
 

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -287,6 +287,124 @@ export class BuildCommandFailedError extends Schema.TaggedErrorClass<BuildComman
   }
 }
 
+export const LINUX_DESKTOP_BUILD_PREREQUISITES = [
+  { id: "cargo", description: "Rust compiler and Cargo", packages: ["cargo", "rustc"] },
+  { id: "cc", description: "C/C++ build toolchain", packages: ["build-essential"] },
+  { id: "make", description: "Make", packages: ["build-essential"] },
+  { id: "x11", description: "X11 headers and linker library", packages: ["libx11-dev"] },
+  {
+    id: "xrandr",
+    description: "Xrandr headers and linker library",
+    packages: ["libxrandr-dev"],
+  },
+  { id: "xtst", description: "Xtst headers and linker library", packages: ["libxtst-dev"] },
+  { id: "xt", description: "Xt headers and linker library", packages: ["libxt-dev"] },
+] as const;
+
+type LinuxDesktopBuildPrerequisiteId = (typeof LINUX_DESKTOP_BUILD_PREREQUISITES)[number]["id"];
+
+export class LinuxDesktopBuildPrerequisitesMissingError extends Schema.TaggedErrorClass<LinuxDesktopBuildPrerequisitesMissingError>()(
+  "LinuxDesktopBuildPrerequisitesMissingError",
+  {
+    missing: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    const missingRequirements = LINUX_DESKTOP_BUILD_PREREQUISITES.filter((requirement) =>
+      this.missing.includes(requirement.id),
+    );
+    const details = missingRequirements
+      .map((requirement) => `  - ${requirement.description} (${requirement.packages.join(", ")})`)
+      .join("\n");
+    const packages = [
+      ...new Set(missingRequirements.flatMap((requirement) => requirement.packages)),
+    ];
+    return [
+      "Linux desktop build prerequisites are missing:",
+      details,
+      "",
+      "On Ubuntu/Debian, install them with:",
+      `  sudo apt-get install ${packages.join(" ")}`,
+      "",
+      "For other distributions, see docs/internals/scripts.md#linux-appimage-prerequisites.",
+      "Then rerun `vp run dist:desktop:linux`.",
+    ].join("\n");
+  }
+}
+
+const MAC_DESKTOP_BUILD_PREREQUISITES = [
+  { id: "rust", description: "Rust/Cargo and the requested Rust target" },
+  { id: "clang", description: "Xcode Command Line Tools (clang)" },
+  { id: "make", description: "Xcode Command Line Tools (make)" },
+  { id: "sips", description: "macOS image tool (sips)" },
+  { id: "iconutil", description: "macOS icon tool (iconutil)" },
+  { id: "lipo", description: "Xcode universal-binary tool (lipo)" },
+] as const;
+
+export class MacDesktopBuildPrerequisitesMissingError extends Schema.TaggedErrorClass<MacDesktopBuildPrerequisitesMissingError>()(
+  "MacDesktopBuildPrerequisitesMissingError",
+  {
+    missing: Schema.Array(Schema.String),
+    rustTargets: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    const details = MAC_DESKTOP_BUILD_PREREQUISITES.filter((requirement) =>
+      this.missing.includes(requirement.id),
+    )
+      .map((requirement) => `  - ${requirement.description}`)
+      .join("\n");
+    return [
+      "macOS desktop build prerequisites are missing:",
+      details,
+      "",
+      "Install Apple's build tools with:",
+      "  xcode-select --install",
+      "Install Rust from https://rustup.rs, then add the requested target(s):",
+      `  rustup target add ${this.rustTargets.join(" ")}`,
+      "",
+      "Then rerun the desktop artifact command.",
+    ].join("\n");
+  }
+}
+
+const WINDOWS_DESKTOP_BUILD_PREREQUISITES = [
+  { id: "rust", description: "Rust/Cargo and the requested MSVC Rust target" },
+  { id: "python", description: "Python 3 for node-gyp" },
+  {
+    id: "msvc",
+    description: "Visual Studio Build Tools with C++, Windows SDK, and Spectre libraries",
+  },
+  { id: "tar", description: "tar for the bundled WSL runtime" },
+] as const;
+
+export class WindowsDesktopBuildPrerequisitesMissingError extends Schema.TaggedErrorClass<WindowsDesktopBuildPrerequisitesMissingError>()(
+  "WindowsDesktopBuildPrerequisitesMissingError",
+  {
+    missing: Schema.Array(Schema.String),
+    rustTarget: Schema.String,
+  },
+) {
+  override get message(): string {
+    const details = WINDOWS_DESKTOP_BUILD_PREREQUISITES.filter((requirement) =>
+      this.missing.includes(requirement.id),
+    )
+      .map((requirement) => `  - ${requirement.description}`)
+      .join("\n");
+    return [
+      "Windows desktop build prerequisites are missing:",
+      details,
+      "",
+      "Install Rust from https://rustup.rs and add the requested target:",
+      `  rustup target add ${this.rustTarget}`,
+      "Install Python 3 and the Visual Studio Build Tools components listed in",
+      "docs/internals/scripts.md#windows-installer-prerequisites.",
+      "",
+      "Then rerun the desktop artifact command.",
+    ].join("\n");
+  }
+}
+
 export class ResourceMonitorBuildOutputMissingError extends Schema.TaggedErrorClass<ResourceMonitorBuildOutputMissingError>()(
   "ResourceMonitorBuildOutputMissingError",
   {
@@ -1467,6 +1585,196 @@ const runCommand = Effect.fn("runCommand")(function* (
     });
   }
 });
+
+const desktopBuildProbeSucceeds = Effect.fn("desktopBuildProbeSucceeds")(function* (
+  command: ChildProcess.Command,
+  label: string,
+) {
+  return yield* runCommand(command, { label, verbose: false }).pipe(
+    Effect.as(true),
+    Effect.catch(() => Effect.succeed(false)),
+  );
+});
+
+export const preflightLinuxDesktopBuild = Effect.fn("preflightLinuxDesktopBuild")(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const reuseResourceMonitor = yield* Config.boolean("T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR").pipe(
+    Config.withDefault(false),
+  );
+  const probeDir = yield* fs.makeTempDirectoryScoped({
+    prefix: "t3code-linux-build-preflight-",
+  });
+  const sourcePath = path.join(probeDir, "probe.c");
+  yield* fs.writeFileString(sourcePath, "int main(void) { return 0; }\n");
+
+  const commandChecks = yield* Effect.all(
+    {
+      cargo: reuseResourceMonitor
+        ? Effect.succeed(true)
+        : desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
+      cc: desktopBuildProbeSucceeds(ChildProcess.make("cc", ["--version"]), "cc"),
+      make: desktopBuildProbeSucceeds(ChildProcess.make("make", ["--version"]), "make"),
+    },
+    { concurrency: "unbounded" },
+  );
+
+  const nativeChecks = commandChecks.cc
+    ? yield* Effect.all(
+        {
+          x11: desktopBuildProbeSucceeds(
+            ChildProcess.make("cc", [
+              sourcePath,
+              "-include",
+              "X11/keysym.h",
+              "-lX11",
+              "-o",
+              path.join(probeDir, "x11"),
+            ]),
+            "X11 build prerequisite probe",
+          ),
+          xrandr: desktopBuildProbeSucceeds(
+            ChildProcess.make("cc", [
+              sourcePath,
+              "-include",
+              "X11/extensions/Xrandr.h",
+              "-lXrandr",
+              "-o",
+              path.join(probeDir, "xrandr"),
+            ]),
+            "Xrandr build prerequisite probe",
+          ),
+          xtst: desktopBuildProbeSucceeds(
+            ChildProcess.make("cc", [
+              sourcePath,
+              "-include",
+              "X11/extensions/XTest.h",
+              "-lXtst",
+              "-o",
+              path.join(probeDir, "xtst"),
+            ]),
+            "Xtst build prerequisite probe",
+          ),
+          xt: desktopBuildProbeSucceeds(
+            ChildProcess.make("cc", [
+              sourcePath,
+              "-include",
+              "X11/Intrinsic.h",
+              "-lXt",
+              "-o",
+              path.join(probeDir, "xt"),
+            ]),
+            "Xt build prerequisite probe",
+          ),
+        },
+        { concurrency: "unbounded" },
+      )
+    : { x11: true, xrandr: true, xtst: true, xt: true };
+
+  const checks: Record<LinuxDesktopBuildPrerequisiteId, boolean> = {
+    ...commandChecks,
+    ...nativeChecks,
+  };
+  const missing = LINUX_DESKTOP_BUILD_PREREQUISITES.filter(
+    (requirement) => !checks[requirement.id],
+  ).map((requirement) => requirement.id);
+
+  if (missing.length > 0) {
+    return yield* new LinuxDesktopBuildPrerequisitesMissingError({ missing });
+  }
+});
+
+export const preflightMacDesktopBuild = Effect.fn("preflightMacDesktopBuild")(function* (
+  arch: typeof BuildArch.Type,
+) {
+  const rustTargets = resolveResourceMonitorRustTargets("mac", arch);
+  const reuseResourceMonitor = yield* Config.boolean("T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR").pipe(
+    Config.withDefault(false),
+  );
+  const checks = yield* Effect.all(
+    {
+      rust: reuseResourceMonitor
+        ? Effect.succeed(true)
+        : Effect.all([
+            desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
+            Effect.forEach(rustTargets, (target) =>
+              desktopBuildProbeSucceeds(
+                ChildProcess.make("rustc", ["--print", "target-libdir", "--target", target]),
+                `Rust target ${target}`,
+              ),
+            ).pipe(Effect.map((results) => results.every(Boolean))),
+          ]).pipe(Effect.map(([cargo, targets]) => cargo && targets)),
+      clang: desktopBuildProbeSucceeds(ChildProcess.make("clang", ["--version"]), "clang"),
+      make: desktopBuildProbeSucceeds(ChildProcess.make("make", ["--version"]), "make"),
+      sips: desktopBuildProbeSucceeds(ChildProcess.make("sips", ["--help"]), "sips"),
+      iconutil: desktopBuildProbeSucceeds(ChildProcess.make("iconutil", ["--help"]), "iconutil"),
+      lipo:
+        arch === "universal"
+          ? desktopBuildProbeSucceeds(ChildProcess.make("lipo", ["-version"]), "lipo")
+          : Effect.succeed(true),
+    },
+    { concurrency: "unbounded" },
+  );
+  const missing = MAC_DESKTOP_BUILD_PREREQUISITES.filter(
+    (requirement) => !checks[requirement.id],
+  ).map((requirement) => requirement.id);
+  if (missing.length > 0) {
+    return yield* new MacDesktopBuildPrerequisitesMissingError({ missing, rustTargets });
+  }
+});
+
+const WINDOWS_VSWHERE_PREREQUISITE_SCRIPT = [
+  "$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\\Installer\\vswhere.exe'",
+  "if (!(Test-Path $vswhere)) { exit 1 }",
+  "$install = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre -property installationPath",
+  "if (!$install) { exit 1 }",
+  "$kitsRoot = Get-ItemPropertyValue 'HKLM:\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots' -Name KitsRoot10 -ErrorAction SilentlyContinue",
+  "if (!$kitsRoot -or !(Test-Path (Join-Path $kitsRoot 'Lib'))) { exit 1 }",
+].join("; ");
+
+export const preflightWindowsDesktopBuild = Effect.fn("preflightWindowsDesktopBuild")(
+  function* (input: { readonly arch: typeof BuildArch.Type; readonly bundlesWslRuntime: boolean }) {
+    const rustTarget = resolveResourceMonitorRustTargets("win", input.arch)[0]!;
+    const reuseResourceMonitor = yield* Config.boolean(
+      "T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR",
+    ).pipe(Config.withDefault(false));
+    const python = yield* resolvePythonForNodeGyp();
+    const checks = yield* Effect.all(
+      {
+        rust: reuseResourceMonitor
+          ? Effect.succeed(true)
+          : Effect.all([
+              desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
+              desktopBuildProbeSucceeds(
+                ChildProcess.make("rustc", ["--print", "target-libdir", "--target", rustTarget]),
+                `Rust target ${rustTarget}`,
+              ),
+            ]).pipe(Effect.map(([cargo, target]) => cargo && target)),
+        python: Effect.succeed(python !== undefined),
+        msvc: desktopBuildProbeSucceeds(
+          ChildProcess.make("powershell.exe", [
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            WINDOWS_VSWHERE_PREREQUISITE_SCRIPT,
+          ]),
+          "Visual Studio Build Tools",
+        ),
+        tar: input.bundlesWslRuntime
+          ? desktopBuildProbeSucceeds(ChildProcess.make("tar.exe", ["--version"]), "tar")
+          : Effect.succeed(true),
+      },
+      { concurrency: "unbounded" },
+    );
+    const missing = WINDOWS_DESKTOP_BUILD_PREREQUISITES.filter(
+      (requirement) => !checks[requirement.id],
+    ).map((requirement) => requirement.id);
+    if (missing.length > 0) {
+      return yield* new WindowsDesktopBuildPrerequisitesMissingError({ missing, rustTarget });
+    }
+  },
+);
 
 /**
  * Every `node_modules` directory that would be visible from `startDir`.
@@ -2899,6 +3207,21 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const path = yield* Path.Path;
   const fs = yield* FileSystem.FileSystem;
   const hostPlatform = yield* HostProcessPlatform;
+  if (hostPlatform === "linux" && options.platform === "linux") {
+    yield* preflightLinuxDesktopBuild();
+  }
+  if (hostPlatform === "darwin" && options.platform === "mac") {
+    yield* preflightMacDesktopBuild(options.arch);
+  }
+  if (hostPlatform === "win32" && options.platform === "win") {
+    yield* preflightWindowsDesktopBuild({
+      arch: options.arch,
+      bundlesWslRuntime: bundlesWslRuntime({
+        arch: options.arch,
+        prebuildPath: options.wslPrebuild,
+      }),
+    });
+  }
   const workspaceConfig = yield* readWorkspaceConfig();
   const workspaceCatalog = workspaceConfig.catalog ?? {};
   const workspaceOverrides = workspaceConfig.overrides ?? {};

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1601,7 +1601,7 @@ const desktopBuildProbeSucceeds = Effect.fn("desktopBuildProbeSucceeds")(functio
 ) {
   return yield* runCommand(command, { label, verbose: false }).pipe(
     Effect.as(true),
-    Effect.catch(() => Effect.succeed(false)),
+    Effect.orElseSucceed(() => false),
   );
 });
 
@@ -2062,22 +2062,22 @@ const verifyPackagedBundleIsSelfContained = Effect.fn("verifyPackagedBundleIsSel
       // stdin, a port, a lock) would otherwise hang release CI until the job
       // times out with nothing useful in the log.
       Effect.timeout(BUNDLE_SELF_CHECK_TIMEOUT),
-      Effect.catchTag("TimeoutError", () =>
-        Effect.fail(
-          new BundleNotSelfContainedError({
-            exitCode: -1,
-            output: `The packaged bundle did not print its version within ${Duration.toSeconds(BUNDLE_SELF_CHECK_TIMEOUT)}s; it is hanging rather than failing to resolve.`,
-          }),
-        ),
-      ),
-      Effect.catchTag("BuildCommandFailedError", (error) =>
-        Effect.fail(
-          new BundleNotSelfContainedError({
-            exitCode: error.exitCode,
-            output: `${error.stderrTail ?? ""}${error.stdoutTail ?? ""}`.trim(),
-          }),
-        ),
-      ),
+      Effect.catchTags({
+        TimeoutError: () =>
+          Effect.fail(
+            new BundleNotSelfContainedError({
+              exitCode: -1,
+              output: `The packaged bundle did not print its version within ${Duration.toSeconds(BUNDLE_SELF_CHECK_TIMEOUT)}s; it is hanging rather than failing to resolve.`,
+            }),
+          ),
+        BuildCommandFailedError: (error) =>
+          Effect.fail(
+            new BundleNotSelfContainedError({
+              exitCode: error.exitCode,
+              output: `${error.stderrTail ?? ""}${error.stdoutTail ?? ""}`.trim(),
+            }),
+          ),
+      }),
     );
   },
 );

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -291,6 +291,7 @@ export const LINUX_DESKTOP_BUILD_PREREQUISITES = [
   { id: "cargo", description: "Rust compiler and Cargo", packages: ["cargo", "rustc"] },
   { id: "cc", description: "C/C++ build toolchain", packages: ["build-essential"] },
   { id: "make", description: "Make", packages: ["build-essential"] },
+  { id: "imagemagick", description: "ImageMagick", packages: ["imagemagick"] },
   { id: "x11", description: "X11 headers and linker library", packages: ["libx11-dev"] },
   {
     id: "xrandr",
@@ -300,8 +301,6 @@ export const LINUX_DESKTOP_BUILD_PREREQUISITES = [
   { id: "xtst", description: "Xtst headers and linker library", packages: ["libxtst-dev"] },
   { id: "xt", description: "Xt headers and linker library", packages: ["libxt-dev"] },
 ] as const;
-
-type LinuxDesktopBuildPrerequisiteId = (typeof LINUX_DESKTOP_BUILD_PREREQUISITES)[number]["id"];
 
 export class LinuxDesktopBuildPrerequisitesMissingError extends Schema.TaggedErrorClass<LinuxDesktopBuildPrerequisitesMissingError>()(
   "LinuxDesktopBuildPrerequisitesMissingError",
@@ -1596,7 +1595,22 @@ const desktopBuildProbeSucceeds = Effect.fn("desktopBuildProbeSucceeds")(functio
   );
 });
 
-export const preflightLinuxDesktopBuild = Effect.fn("preflightLinuxDesktopBuild")(function* () {
+const rustTargetIsInstalled = Effect.fn("rustTargetIsInstalled")(function* (target: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const result = yield* spawnAndCollectOutput(
+    ChildProcess.make("rustc", ["--print", "target-libdir", "--target", target]),
+  ).pipe(Effect.orElseSucceed(() => null));
+  if (result === null || result.exitCode !== 0) return false;
+
+  const targetLibDir = result.stdout.trim();
+  if (targetLibDir === "") return false;
+  const entries = yield* fs.readDirectory(targetLibDir).pipe(Effect.orElseSucceed(() => []));
+  return entries.some((entry) => entry.startsWith("libstd-") && entry.endsWith(".rlib"));
+});
+
+export const preflightLinuxDesktopBuild = Effect.fn("preflightLinuxDesktopBuild")(function* (
+  arch: typeof BuildArch.Type = "x64",
+) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const reuseResourceMonitor = yield* Config.boolean("T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR").pipe(
@@ -1612,9 +1626,16 @@ export const preflightLinuxDesktopBuild = Effect.fn("preflightLinuxDesktopBuild"
     {
       cargo: reuseResourceMonitor
         ? Effect.succeed(true)
-        : desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
+        : Effect.all([
+            desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
+            rustTargetIsInstalled(resolveResourceMonitorRustTargets("linux", arch)[0]!),
+          ]).pipe(Effect.map(([cargo, target]) => cargo && target)),
       cc: desktopBuildProbeSucceeds(ChildProcess.make("cc", ["--version"]), "cc"),
       make: desktopBuildProbeSucceeds(ChildProcess.make("make", ["--version"]), "make"),
+      imagemagick: Effect.all([
+        desktopBuildProbeSucceeds(ChildProcess.make("magick", ["-version"]), "magick"),
+        desktopBuildProbeSucceeds(ChildProcess.make("convert", ["-version"]), "convert"),
+      ]).pipe(Effect.map(([magick, convert]) => magick || convert)),
     },
     { concurrency: "unbounded" },
   );
@@ -1671,7 +1692,7 @@ export const preflightLinuxDesktopBuild = Effect.fn("preflightLinuxDesktopBuild"
       )
     : { x11: true, xrandr: true, xtst: true, xt: true };
 
-  const checks: Record<LinuxDesktopBuildPrerequisiteId, boolean> = {
+  const checks = {
     ...commandChecks,
     ...nativeChecks,
   };
@@ -1697,17 +1718,17 @@ export const preflightMacDesktopBuild = Effect.fn("preflightMacDesktopBuild")(fu
         ? Effect.succeed(true)
         : Effect.all([
             desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
-            Effect.forEach(rustTargets, (target) =>
-              desktopBuildProbeSucceeds(
-                ChildProcess.make("rustc", ["--print", "target-libdir", "--target", target]),
-                `Rust target ${target}`,
-              ),
-            ).pipe(Effect.map((results) => results.every(Boolean))),
+            Effect.forEach(rustTargets, rustTargetIsInstalled).pipe(
+              Effect.map((results) => results.every(Boolean)),
+            ),
           ]).pipe(Effect.map(([cargo, targets]) => cargo && targets)),
       clang: desktopBuildProbeSucceeds(ChildProcess.make("clang", ["--version"]), "clang"),
       make: desktopBuildProbeSucceeds(ChildProcess.make("make", ["--version"]), "make"),
       sips: desktopBuildProbeSucceeds(ChildProcess.make("sips", ["--help"]), "sips"),
-      iconutil: desktopBuildProbeSucceeds(ChildProcess.make("iconutil", ["--help"]), "iconutil"),
+      iconutil: desktopBuildProbeSucceeds(
+        ChildProcess.make("xcrun", ["--find", "iconutil"]),
+        "iconutil",
+      ),
       lipo:
         arch === "universal"
           ? desktopBuildProbeSucceeds(ChildProcess.make("lipo", ["-version"]), "lipo")
@@ -1723,14 +1744,26 @@ export const preflightMacDesktopBuild = Effect.fn("preflightMacDesktopBuild")(fu
   }
 });
 
-const WINDOWS_VSWHERE_PREREQUISITE_SCRIPT = [
-  "$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\\Installer\\vswhere.exe'",
-  "if (!(Test-Path $vswhere)) { exit 1 }",
-  "$install = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre -property installationPath",
-  "if (!$install) { exit 1 }",
-  "$kitsRoot = Get-ItemPropertyValue 'HKLM:\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots' -Name KitsRoot10 -ErrorAction SilentlyContinue",
-  "if (!$kitsRoot -or !(Test-Path (Join-Path $kitsRoot 'Lib'))) { exit 1 }",
-].join("; ");
+function windowsVswherePrerequisiteScript(arch: typeof BuildArch.Type): string {
+  const components =
+    arch === "arm64"
+      ? [
+          "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
+          "Microsoft.VisualStudio.Component.VC.Tools.ARM64.Spectre",
+        ]
+      : [
+          "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+          "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre",
+        ];
+  return [
+    "$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\\Installer\\vswhere.exe'",
+    "if (!(Test-Path $vswhere)) { exit 1 }",
+    `$install = & $vswhere -latest -products * -requires ${components.join(" ")} -property installationPath`,
+    "if (!$install) { exit 1 }",
+    "$kitsRoot = Get-ItemPropertyValue 'HKLM:\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots' -Name KitsRoot10 -ErrorAction SilentlyContinue",
+    "if (!$kitsRoot -or !(Test-Path (Join-Path $kitsRoot 'Lib'))) { exit 1 }",
+  ].join("; ");
+}
 
 export const preflightWindowsDesktopBuild = Effect.fn("preflightWindowsDesktopBuild")(
   function* (input: { readonly arch: typeof BuildArch.Type; readonly bundlesWslRuntime: boolean }) {
@@ -1745,10 +1778,7 @@ export const preflightWindowsDesktopBuild = Effect.fn("preflightWindowsDesktopBu
           ? Effect.succeed(true)
           : Effect.all([
               desktopBuildProbeSucceeds(ChildProcess.make("cargo", ["--version"]), "cargo"),
-              desktopBuildProbeSucceeds(
-                ChildProcess.make("rustc", ["--print", "target-libdir", "--target", rustTarget]),
-                `Rust target ${rustTarget}`,
-              ),
+              rustTargetIsInstalled(rustTarget),
             ]).pipe(Effect.map(([cargo, target]) => cargo && target)),
         python: Effect.succeed(python !== undefined),
         msvc: desktopBuildProbeSucceeds(
@@ -1757,7 +1787,7 @@ export const preflightWindowsDesktopBuild = Effect.fn("preflightWindowsDesktopBu
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            WINDOWS_VSWHERE_PREREQUISITE_SCRIPT,
+            windowsVswherePrerequisiteScript(input.arch),
           ]),
           "Visual Studio Build Tools",
         ),
@@ -3208,7 +3238,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const fs = yield* FileSystem.FileSystem;
   const hostPlatform = yield* HostProcessPlatform;
   if (hostPlatform === "linux" && options.platform === "linux") {
-    yield* preflightLinuxDesktopBuild();
+    yield* preflightLinuxDesktopBuild(options.arch);
   }
   if (hostPlatform === "darwin" && options.platform === "mac") {
     yield* preflightMacDesktopBuild(options.arch);

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -838,8 +838,18 @@ const resolvePythonForNodeGyp = Effect.fn("resolvePythonForNodeGyp")(function* (
     ),
     localAppData: Config.string("LOCALAPPDATA").pipe(Config.option),
   });
+  const isPython3 = (candidate: string) =>
+    spawnAndCollectOutput(
+      ChildProcess.make(candidate, [
+        "-c",
+        "import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)",
+      ]),
+    ).pipe(
+      Effect.map((result) => result.exitCode === 0),
+      Effect.orElseSucceed(() => false),
+    );
   const configured = Option.getOrUndefined(env.configuredPython);
-  if (configured && (yield* fs.exists(configured))) {
+  if (configured && (yield* fs.exists(configured)) && (yield* isPython3(configured))) {
     return configured;
   }
 
@@ -848,7 +858,7 @@ const resolvePythonForNodeGyp = Effect.fn("resolvePythonForNodeGyp")(function* (
     if (localAppData) {
       for (const version of ["Python313", "Python312", "Python311", "Python310"]) {
         const candidate = path.join(localAppData, "Programs", "Python", version, "python.exe");
-        if (yield* fs.exists(candidate)) {
+        if ((yield* fs.exists(candidate)) && (yield* isPython3(candidate))) {
           return candidate;
         }
       }


### PR DESCRIPTION
Desktop artifact builds currently fail late when a host is missing Rust or native platform tooling, leaving contributors to infer system packages from compiler output. Contributor setup documentation does not describe the full platform requirements.

This adds early capability-based preflights for Linux, macOS, and Windows, with actionable platform guidance and focused coverage. It documents the required Rust targets, native compiler tools, Linux X11 headers, Visual Studio components, and signing boundaries.

Verification:
- `vp test run scripts/build-desktop-artifact.test.ts`
- `vp lint scripts/build-desktop-artifact.ts scripts/build-desktop-artifact.test.ts`
- `vp exec tsc -p scripts/tsconfig.json --noEmit`
- targeted `vp fmt --check`

Built with GPT-5 via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect local/CI desktop packaging ergonomics and docs; behavior is additive early validation with tests, not production runtime paths.
> 
> **Overview**
> Desktop artifact builds now **fail fast** with structured errors when the host is missing required tooling, instead of dying mid-build with opaque compiler output.
> 
> **`buildDesktopArtifact`** runs new **`preflightLinuxDesktopBuild`**, **`preflightMacDesktopBuild`**, and **`preflightWindowsDesktopBuild`** probes when building on the matching host (Rust/Cargo and installed targets, Linux cc/make/ImageMagick, macOS Xcode tools including universal **`lipo`**, Windows Python 3, MSVC/SDK via **`vswhere`**, and **`tar.exe`** when WSL runtime bundling is enabled). Missing pieces surface as tagged errors that list gaps and point at **`rustup target add`**, apt install lines, or the expanded docs.
> 
> **`resolvePythonForNodeGyp`** now verifies candidates actually run as **Python 3**, so PATH shims to Python 2 no longer pass preflight. **`T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR`** still skips Rust checks when reusing a cached monitor binary.
> 
> **CONTRIBUTING.md** links to the maintainer scripts guide; **`docs/internals/scripts.md`** adds per-OS prerequisite sections (Linux distros, macOS DMG, Windows installer). Tests cover aggregated Linux failures, macOS universal targets, Windows MSVC/Python, and non-Python-3 discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d04853a6cccd4b8ecc3e7d6a618eb79360b23d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add preflight checks for desktop artifact build prerequisites
> - Added `preflightLinuxDesktopBuild`, `preflightMacDesktopBuild`, and `preflightWindowsDesktopBuild` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/8975/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to verify tools like Cargo, Rust targets, MSVC, and Python 3 before starting.
> - Missing prerequisites now abort the build early with structured errors containing platform-specific install guidance.
> - Updated `resolvePythonForNodeGyp` to execute a version check and reject non-Python 3 interpreters.
> - Documented the required packaging prerequisites in [CONTRIBUTING.md](https://github.com/pingdotgg/t3code/pull/8975/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) and [docs/internals/scripts.md](https://github.com/pingdotgg/t3code/pull/8975/files#diff-e96bcd8be67e46ebdfbb43cd2996f544400f2c88e1c7c30ab5ee8a05b1ff4cbf).
> - Risk: `resolvePythonForNodeGyp` now rejects Python 2 or non-existent executables, which may cause earlier failures for environments relying on outdated defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98d0485.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-build checks for Linux, macOS, and Windows desktop packages.
  * Build errors now identify missing tools, libraries, architectures, and installation guidance.
  * Checks account for platform-specific packaging and signing requirements.

* **Documentation**
  * Added developer setup guidance for building, testing, and packaging desktop applications.
  * Documented prerequisites for Linux AppImage, macOS DMG, and Windows installer creation.

* **Tests**
  * Added coverage for missing prerequisites, architecture targets, and actionable error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->