### PR TITLE
feat(desktop): support custom update release sources

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -184,7 +184,10 @@ const bootstrap = Effect.gen(function* () {
     ? Option.getOrThrow(environment.devServerUrl)
     : backendConfig.httpBaseUrl;
   yield* electronProtocol.registerDesktopProtocol({
-    scheme: ElectronProtocol.getDesktopScheme(environment.isDevelopment),
+    scheme: ElectronProtocol.getDesktopScheme(
+      environment.isDevelopment,
+      environment.distributionId,
+    ),
     targetOrigin: rendererTarget,
     backendOrigin: backendConfig.httpBaseUrl,
     clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,

--- a/apps/desktop/src/app/DesktopAppIdentity.test.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.test.ts
@@ -111,7 +111,8 @@ const withIdentity = <A, E, R>(
     readonly calls?: ElectronAppCalls;
     readonly environment?: TestEnvironmentInput;
     readonly legacyPathExists?: boolean;
-    readonly legacyPathProbeError?: PlatformError.PlatformError;
+    readonly existingUserDataDirName?: string;
+    readonly pathProbeError?: PlatformError.PlatformError;
     readonly packageJson?: string;
     readonly pngIconPath?: Option.Option<string>;
   } = {},
@@ -128,10 +129,11 @@ const withIdentity = <A, E, R>(
         Layer.provideMerge(
           FileSystem.layerNoop({
             exists: (path) =>
-              input.legacyPathProbeError
-                ? Effect.fail(input.legacyPathProbeError)
+              input.pathProbeError
+                ? Effect.fail(input.pathProbeError)
                 : Effect.succeed(
-                    input.legacyPathExists === true && path.includes("T3 Code (Alpha)"),
+                    input.legacyPathExists === true &&
+                      path.endsWith(input.existingUserDataDirName ?? "T3 Code (Alpha)"),
                   ),
             readFileString: () =>
               Effect.succeed(input.packageJson ?? '{"t3codeCommitHash":"abcdef1234567890"}'),
@@ -174,16 +176,87 @@ describe("DesktopAppIdentity", () => {
         const error = yield* identity.resolveUserDataPath.pipe(Effect.flip);
 
         assert.instanceOf(error, DesktopAppIdentity.DesktopUserDataPathResolutionError);
-        assert.equal(error.legacyPath, legacyPath);
+        assert.equal(error.candidatePath, legacyPath);
         assert.strictEqual(error.cause, cause);
         assert.equal(
           error.message,
-          `Failed to inspect legacy desktop user-data path at "${legacyPath}".`,
+          `Failed to inspect the desktop user-data path at "${legacyPath}".`,
         );
       }),
-      { legacyPathProbeError: cause },
+      { pathProbeError: cause },
     );
   });
+
+  it.effect("identifies a failed downstream stable-path probe", () => {
+    const stablePath = "/Users/alice/Library/Application Support/T3 Code (Fork)";
+    const cause = PlatformError.systemError({
+      _tag: "PermissionDenied",
+      module: "FileSystem",
+      method: "exists",
+      description: "permission denied",
+      pathOrDescriptor: stablePath,
+    });
+
+    return withIdentity(
+      Effect.gen(function* () {
+        const identity = yield* DesktopAppIdentity.DesktopAppIdentity;
+        const error = yield* identity.resolveUserDataPath.pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopAppIdentity.DesktopUserDataPathResolutionError);
+        assert.equal(error.candidatePath, stablePath);
+        assert.strictEqual(error.cause, cause);
+        assert.equal(
+          error.message,
+          `Failed to inspect the desktop user-data path at "${stablePath}".`,
+        );
+      }),
+      {
+        pathProbeError: cause,
+        environment: {
+          appName: "T3 Code (Fork Nightly)",
+          appVersion: "0.0.38-nightly.20260901.1243",
+        },
+      },
+    );
+  });
+
+  it.effect("keeps a downstream profile separate from an existing official profile", () =>
+    withIdentity(
+      Effect.gen(function* () {
+        const identity = yield* DesktopAppIdentity.DesktopAppIdentity;
+        const userDataPath = yield* identity.resolveUserDataPath;
+
+        assert.equal(userDataPath, "/Users/alice/Library/Application Support/T3 Code (Fork)");
+      }),
+      {
+        legacyPathExists: true,
+        environment: {
+          appName: "T3 Code (Fork Nightly)",
+          appVersion: "0.0.38-nightly.20260901.1243",
+        },
+      },
+    ),
+  );
+
+  it.effect("uses an existing stage-named downstream profile during identity migration", () =>
+    withIdentity(
+      Effect.gen(function* () {
+        const identity = yield* DesktopAppIdentity.DesktopAppIdentity;
+        assert.equal(
+          yield* identity.resolveUserDataPath,
+          "/Users/alice/Library/Application Support/T3 Code (Fork Alpha)",
+        );
+      }),
+      {
+        legacyPathExists: true,
+        existingUserDataDirName: "T3 Code (Fork Alpha)",
+        environment: {
+          appName: "T3 Code (Fork Nightly)",
+          appVersion: "0.0.38-nightly.20260901.1243",
+        },
+      },
+    ),
+  );
 
   it.effect("configures app identity from the environment commit override", () => {
     const calls: ElectronAppCalls = {
@@ -197,7 +270,7 @@ describe("DesktopAppIdentity", () => {
         const identity = yield* DesktopAppIdentity.DesktopAppIdentity;
         yield* identity.configure;
 
-        assert.deepEqual(calls.setName, ["T3 Code (Alpha)"]);
+        assert.deepEqual(calls.setName, []);
         assert.equal(calls.setAboutPanelOptions[0]?.applicationName, "T3 Code (Alpha)");
         assert.equal(calls.setAboutPanelOptions[0]?.applicationVersion, "1.2.3");
         assert.equal(calls.setAboutPanelOptions[0]?.version, "0123456789ab");
@@ -213,6 +286,31 @@ describe("DesktopAppIdentity", () => {
           },
         },
         pngIconPath: Option.some("/icon.png"),
+      },
+    );
+  });
+
+  it.effect("keeps downstream display branding without mutating Electron's locked app name", () => {
+    const calls: ElectronAppCalls = {
+      setAboutPanelOptions: [],
+      setDockIcon: [],
+      setName: [],
+    };
+
+    return withIdentity(
+      Effect.gen(function* () {
+        const identity = yield* DesktopAppIdentity.DesktopAppIdentity;
+        yield* identity.configure;
+
+        assert.deepEqual(calls.setName, []);
+        assert.equal(calls.setAboutPanelOptions[0]?.applicationName, "T3 Code (Fork Nightly)");
+      }),
+      {
+        calls,
+        environment: {
+          appName: "T3 Code (Fork Nightly)",
+          appVersion: "0.0.38-nightly.20260901.1243",
+        },
       },
     );
   });

--- a/apps/desktop/src/app/DesktopAppIdentity.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.ts
@@ -21,12 +21,12 @@ const decodeAppPackageMetadata = Schema.decodeEffect(Schema.fromJsonString(AppPa
 export class DesktopUserDataPathResolutionError extends Schema.TaggedError<DesktopUserDataPathResolutionError>()(
   "DesktopUserDataPathResolutionError",
   {
-    legacyPath: Schema.String,
+    candidatePath: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to inspect legacy desktop user-data path at "${this.legacyPath}".`;
+    return `Failed to inspect the desktop user-data path at "${this.candidatePath}".`;
   }
 }
 
@@ -45,26 +45,50 @@ const normalizeCommitHash = (value: string): Option.Option<string> => {
     : Option.none();
 };
 
-export const resolveUserDataPath = Effect.gen(function* () {
-  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+/** Shared path selection for synchronous pre-ready and ordinary filesystem adapters. */
+export const resolveUserDataPathWith = (
+  inspectPath: (candidate: string) => Effect.Effect<boolean, DesktopUserDataPathResolutionError>,
+) =>
+  Effect.gen(function* () {
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    if (environment.isDownstreamDistribution) {
+      const stablePath = environment.path.join(
+        environment.appDataDirectory,
+        environment.userDataDirName,
+      );
+      if (yield* inspectPath(stablePath)) {
+        return stablePath;
+      }
+      for (const legacyDirName of environment.legacyDownstreamUserDataDirNames) {
+        const legacyPath = environment.path.join(environment.appDataDirectory, legacyDirName);
+        if (yield* inspectPath(legacyPath)) {
+          return legacyPath;
+        }
+      }
+      return stablePath;
+    }
+    const legacyPath = environment.path.join(
+      environment.appDataDirectory,
+      environment.legacyUserDataDirName,
+    );
+    const legacyPathExists = yield* inspectPath(legacyPath);
+    return legacyPathExists
+      ? legacyPath
+      : environment.path.join(environment.appDataDirectory, environment.userDataDirName);
+  }).pipe(Effect.withSpan("desktop.appIdentity.resolveUserDataPath"));
+
+const resolveUserDataPath = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
-  const legacyPath = environment.path.join(
-    environment.appDataDirectory,
-    environment.legacyUserDataDirName,
+  return yield* resolveUserDataPathWith((candidate) =>
+    fileSystem
+      .exists(candidate)
+      .pipe(
+        Effect.mapError(
+          (cause) => new DesktopUserDataPathResolutionError({ candidatePath: candidate, cause }),
+        ),
+      ),
   );
-  const legacyPathExists = yield* fileSystem.exists(legacyPath).pipe(
-    Effect.mapError(
-      (cause) =>
-        new DesktopUserDataPathResolutionError({
-          legacyPath,
-          cause,
-        }),
-    ),
-  );
-  return legacyPathExists
-    ? legacyPath
-    : environment.path.join(environment.appDataDirectory, environment.userDataDirName);
-}).pipe(Effect.withSpan("desktop.appIdentity.resolveUserDataPath"));
+});
 
 /** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
@@ -120,7 +144,6 @@ export const make = Effect.gen(function* () {
 
   const configure = Effect.gen(function* () {
     const commitHash = yield* resolveAboutCommitHash;
-    yield* electronApp.setName(environment.displayName);
     yield* electronApp.setAboutPanelOptions({
       applicationName: environment.displayName,
       applicationVersion: environment.appVersion,

--- a/apps/desktop/src/app/DesktopClerk.test.ts
+++ b/apps/desktop/src/app/DesktopClerk.test.ts
@@ -29,10 +29,15 @@ import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
-const makeDesktopClerkLayer = (isDevelopment = true, events: string[] = []) => {
+const makeDesktopClerkLayer = (
+  isDevelopment = true,
+  events: string[] = [],
+  distributionId: string | null = null,
+) => {
   const environment = DesktopEnvironment.DesktopEnvironment.of({
     stateDir: "/tmp/t3-state",
     isDevelopment,
+    distributionId,
     appDataDirectory: "/tmp/app-data",
     userDataDirName: isDevelopment ? "t3code-dev" : "t3code",
     legacyUserDataDirName: isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)",
@@ -51,7 +56,7 @@ const makeDesktopClerkLayer = (isDevelopment = true, events: string[] = []) => {
       Layer.mergeAll(
         Layer.succeed(DesktopEnvironment.DesktopEnvironment, environment),
         Layer.succeed(ElectronApp.ElectronApp, electronApp),
-        FileSystem.layerNoop({ exists: () => Effect.succeed(false) }),
+        FileSystem.layerNoop({ exists: () => Effect.promise(async () => false) }),
       ),
     ),
   );
@@ -61,6 +66,14 @@ describe("DesktopClerk", () => {
   beforeEach(() => {
     createClerkBridgeMock.mockReset();
     storageMock.mockReset();
+  });
+
+  it("acquires the bridge synchronously before Electron ready", () => {
+    storageMock.mockReturnValue(storageAdapter);
+    createClerkBridgeMock.mockReturnValue({ cleanup: vi.fn(), isPrimaryInstance: true });
+    // oxlint-disable-next-line t3code/no-manual-effect-runtime-in-tests -- This regression must reject asynchronous pre-ready initialization; it.effect would hide the Electron startup race.
+    Effect.runSync(Effect.scoped(Layer.build(makeDesktopClerkLayer(false))));
+    assert.equal(createClerkBridgeMock.mock.calls.length, 1);
   });
 
   it.effect("acquires and releases the SDK bridge with the layer", () => {
@@ -196,5 +209,23 @@ describe("DesktopClerk", () => {
       Effect.provideService(ElectronApp.ElectronApp, electronApp),
       Effect.provideService(ElectronWindow.ElectronWindow, electronWindow),
     );
+  });
+
+  it.effect("uses the distribution renderer origin when acquiring the bridge", () => {
+    storageMock.mockReturnValue(storageAdapter);
+    createClerkBridgeMock.mockReturnValue({ cleanup: vi.fn(), isPrimaryInstance: true });
+    return Effect.gen(function* () {
+      yield* Effect.scoped(Layer.build(makeDesktopClerkLayer(false, [], "fork-abc")));
+      assert.deepEqual(storageMock.mock.calls, [[{ path: "/tmp/t3-state" }]]);
+      assert.deepEqual(createClerkBridgeMock.mock.calls, [
+        [
+          {
+            storage: storageAdapter,
+            passkeys: true,
+            renderer: { scheme: "t3code-fork-abc", host: "app" },
+          },
+        ],
+      ]);
+    });
   });
 });

--- a/apps/desktop/src/app/DesktopClerk.ts
+++ b/apps/desktop/src/app/DesktopClerk.ts
@@ -1,3 +1,5 @@
+// @effect-diagnostics nodeBuiltinImport:off - Clerk must select its profile and register its scheme without yielding before Electron ready.
+import * as NodeFS from "node:fs";
 import { createClerkBridge } from "@clerk/electron";
 import { storage } from "@clerk/electron/storage";
 import * as Context from "effect/Context";
@@ -72,12 +74,16 @@ export const desktopClerkFrontendApiHostname = resolveDesktopClerkFrontendApiHos
     : __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__,
 );
 
-function createDesktopClerkBridge(stateDir: string, isDevelopment: boolean) {
+function createDesktopClerkBridge(
+  stateDir: string,
+  isDevelopment: boolean,
+  distributionId: string | null,
+) {
   return createClerkBridge({
     storage: storage({ path: stateDir }),
     passkeys: true,
     renderer: {
-      scheme: ElectronProtocol.getDesktopScheme(isDevelopment),
+      scheme: ElectronProtocol.getDesktopScheme(isDevelopment, distributionId),
       host: ElectronProtocol.DESKTOP_HOST,
     },
   });
@@ -94,12 +100,26 @@ export const make = Effect.gen(function* () {
   // directory here — under the default productName-derived path, acquiring
   // the lock would create "T3 Code (Alpha)" and make the legacy-install
   // detection in resolveUserDataPath match on fresh installs.
-  const userDataPath = yield* DesktopAppIdentity.resolveUserDataPath;
+  const userDataPath = yield* DesktopAppIdentity.resolveUserDataPathWith((candidate) =>
+    Effect.try({
+      try: () => NodeFS.existsSync(candidate),
+      catch: (cause) =>
+        new DesktopAppIdentity.DesktopUserDataPathResolutionError({
+          candidatePath: candidate,
+          cause,
+        }),
+    }),
+  );
   yield* electronApp.setPath("userData", userDataPath);
 
   const bridge = yield* Effect.acquireRelease(
     Effect.try({
-      try: () => createDesktopClerkBridge(environment.stateDir, environment.isDevelopment),
+      try: () =>
+        createDesktopClerkBridge(
+          environment.stateDir,
+          environment.isDevelopment,
+          environment.distributionId,
+        ),
       catch: (cause) =>
         new DesktopClerkBridgeInitializationError({
           stateDir: environment.stateDir,

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
@@ -1,8 +1,16 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
+import {
+  RelayConnectionTarget,
+  BearerConnectionTarget,
+  BearerConnectionProfile,
+  BearerConnectionCredential,
+} from "@t3tools/client-runtime/connection";
 import { ConnectionCatalogDocument } from "@t3tools/client-runtime/platform";
 import { EnvironmentId, type PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Layer from "effect/Layer";
@@ -19,13 +27,33 @@ import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
+const encodeEncryptedCatalogFixture = Schema.encodeEffect(
+  Schema.fromJsonString(
+    Schema.Struct({ version: Schema.Literal(1), encryptedCatalog: Schema.String }),
+  ),
+);
+const encodeConnectionCatalog = Schema.encodeEffect(
+  Schema.fromJsonString(ConnectionCatalogDocument),
+);
 const decodeConnectionCatalog = Schema.decodeEffect(
   Schema.fromJsonString(ConnectionCatalogDocument),
 );
-function makeSafeStorageLayer(available: boolean, failDecrypt: Ref.Ref<boolean> | null = null) {
+function makeSafeStorageLayer(
+  available: boolean,
+  failDecrypt: Ref.Ref<boolean> | null = null,
+  failEncrypt: Ref.Ref<boolean> | null = null,
+) {
   return Layer.succeed(ElectronSafeStorage.ElectronSafeStorage, {
     isEncryptionAvailable: Effect.succeed(available),
-    encryptString: (value) => Effect.succeed(textEncoder.encode(`encrypted:${value}`)),
+    encryptString: (value) =>
+      Effect.gen(function* () {
+        if (failEncrypt !== null && (yield* Ref.get(failEncrypt))) {
+          return yield* new ElectronSafeStorage.ElectronSafeStorageEncryptError({
+            cause: new Error("could not encrypt promoted catalog"),
+          });
+        }
+        return textEncoder.encode(`encrypted:${value}`);
+      }),
     decryptString: (value) => {
       return Effect.gen(function* () {
         const decoded = textDecoder.decode(value);
@@ -49,6 +77,8 @@ function makeLayer(
   encryptionAvailable = true,
   failDecrypt: Ref.Ref<boolean> | null = null,
   fileSystemLayer: Layer.Layer<FileSystem.FileSystem> = NodeServices.layer,
+  appName?: string,
+  failEncrypt: Ref.Ref<boolean> | null = null,
 ) {
   const environmentLayer = DesktopEnvironment.layer({
     dirname: "/repo/apps/desktop/src",
@@ -56,6 +86,7 @@ function makeLayer(
     platform: "darwin",
     processArch: "arm64",
     appVersion: "1.2.3",
+    ...(appName === undefined ? {} : { appName }),
     appPath: "/repo",
     isPackaged: true,
     resourcesPath: "/missing/resources",
@@ -65,7 +96,7 @@ function makeLayer(
       Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({ T3CODE_HOME: baseDir })),
     ),
   );
-  const safeStorageLayer = makeSafeStorageLayer(encryptionAvailable, failDecrypt);
+  const safeStorageLayer = makeSafeStorageLayer(encryptionAvailable, failDecrypt, failEncrypt);
   const dependencies = Layer.mergeAll(
     environmentLayer,
     safeStorageLayer,
@@ -119,6 +150,440 @@ describe("DesktopConnectionCatalogStore", () => {
       }),
       false,
     ),
+  );
+
+  it.effect("isolates a downstream distribution from the official encrypted catalog", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-desktop-connection-catalog-test-",
+        });
+        const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore.pipe(
+          Effect.provide(
+            makeLayer(baseDir, true, null, NodeServices.layer, "T3 Code (Fork Alpha)"),
+          ),
+        );
+        const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments.pipe(
+          Effect.provide(
+            makeLayer(baseDir, true, null, NodeServices.layer, "T3 Code (Fork Alpha)"),
+          ),
+        );
+        const officialCatalogPath = `${baseDir}/userdata/connection-catalog.json`;
+        const downstreamCatalogPath = `${baseDir}/userdata/connection-catalog.fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45.json`;
+
+        yield* fileSystem.makeDirectory(`${baseDir}/userdata`, { recursive: true });
+        yield* fileSystem.writeFileString(officialCatalogPath, "official-ciphertext");
+        yield* savedEnvironments.setRegistry([
+          {
+            environmentId: EnvironmentId.make("legacy-bearer-environment"),
+            label: "Legacy bearer",
+            httpBaseUrl: "https://legacy.example.com/",
+            wsBaseUrl: "wss://legacy.example.com/",
+            createdAt: "2026-06-01T00:00:00.000Z",
+            lastConnectedAt: null,
+          },
+        ]);
+        assert.deepStrictEqual(yield* store.get, Option.none());
+        assert.isFalse(yield* fileSystem.exists(downstreamCatalogPath));
+        assert.isTrue(yield* store.set('{"schemaVersion":1,"targets":[]}'));
+        assert.equal(yield* fileSystem.readFileString(officialCatalogPath), "official-ciphertext");
+        assert.isTrue(yield* fileSystem.exists(downstreamCatalogPath));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
+  for (const corruptOuterDocument of [false, true]) {
+    it.effect(
+      `preserves the current catalog when a legacy ${corruptOuterDocument ? "document" : "payload"} is corrupt`,
+      () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const baseDir = yield* fs.makeTempDirectoryScoped({
+            prefix: "t3-catalog-corrupt-legacy-",
+          });
+          yield* Effect.gen(function* () {
+            const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore;
+            const environment = yield* DesktopEnvironment.DesktopEnvironment;
+            const current = yield* encodeConnectionCatalog({
+              schemaVersion: 1,
+              targets: [],
+              profiles: [],
+              credentials: [],
+              remoteDpopTokens: [],
+            });
+            yield* store.set(current);
+            const legacyPath = environment.legacyConnectionCatalogPaths[0]!;
+            const legacy = corruptOuterDocument
+              ? "corrupt"
+              : yield* encodeEncryptedCatalogFixture({
+                  version: 1,
+                  encryptedCatalog: Buffer.from("encrypted:corrupt").toString("base64"),
+                });
+            yield* fs.writeFileString(legacyPath, legacy);
+            assert.deepEqual(yield* store.get, Option.some(current));
+            assert.equal(yield* fs.readFileString(legacyPath), legacy);
+          }).pipe(
+            Effect.provide(
+              makeLayer(baseDir, true, null, NodeServices.layer, "T3 Code (Fork Nightly)"),
+            ),
+          );
+        }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+    );
+  }
+
+  for (const hasSharedCatalog of [false, true]) {
+    it.effect(`imports both legacy channels with shared catalog ${hasSharedCatalog}`, () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-catalog-channels-" });
+        yield* Effect.gen(function* () {
+          const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore;
+          const environment = yield* DesktopEnvironment.DesktopEnvironment;
+          yield* fs.makeDirectory(environment.stateDir, { recursive: true });
+          for (const [index, path] of environment.legacyConnectionCatalogPaths.entries()) {
+            const catalog = yield* encodeConnectionCatalog({
+              schemaVersion: 1,
+              targets: [
+                new RelayConnectionTarget({
+                  environmentId: EnvironmentId.make(`channel-${index}`),
+                  label: `Channel ${index}`,
+                }),
+              ],
+              profiles: [],
+              credentials: [],
+              remoteDpopTokens: [],
+            });
+            yield* fs.writeFileString(
+              path,
+              yield* encodeEncryptedCatalogFixture({
+                version: 1,
+                encryptedCatalog: Buffer.from(`encrypted:${catalog}`).toString("base64"),
+              }),
+            );
+          }
+          if (hasSharedCatalog)
+            yield* store.set(
+              yield* encodeConnectionCatalog({
+                schemaVersion: 1,
+                targets: [
+                  new RelayConnectionTarget({
+                    environmentId: EnvironmentId.make("channel-0"),
+                    label: "Current edit",
+                  }),
+                ],
+                profiles: [],
+                credentials: [],
+                remoteDpopTokens: [],
+              }),
+            );
+          const imported = Option.getOrThrow(yield* store.get);
+          const catalog = yield* decodeConnectionCatalog(imported);
+          assert.deepEqual(
+            catalog.targets.map((target) => target.environmentId),
+            ["channel-0", "channel-1"],
+          );
+          if (hasSharedCatalog) assert.equal(catalog.targets[0]!.label, "Current edit");
+          for (const path of environment.legacyConnectionCatalogPaths)
+            assert.isFalse(yield* fs.exists(path));
+          assert.deepEqual(yield* store.get, Option.some(imported));
+        }).pipe(
+          Effect.provide(
+            makeLayer(baseDir, true, null, NodeServices.layer, "T3 Code (Fork Nightly)"),
+          ),
+        );
+      }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+    );
+  }
+
+  it.effect("drops profiles and credentials for superseded connection targets", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-catalog-dedup-" });
+      yield* Effect.gen(function* () {
+        const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore;
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
+        const environmentId = EnvironmentId.make("same-environment");
+        const catalogFor = (connectionId: string) =>
+          encodeConnectionCatalog({
+            schemaVersion: 1,
+            targets: [
+              new BearerConnectionTarget({ environmentId, label: connectionId, connectionId }),
+            ],
+            profiles: [
+              new BearerConnectionProfile({
+                environmentId,
+                label: connectionId,
+                connectionId,
+                httpBaseUrl: "https://example.test/",
+                wsBaseUrl: "wss://example.test/",
+              }),
+            ],
+            credentials: [
+              {
+                connectionId,
+                credential: new BearerConnectionCredential({ token: `test-${connectionId}` }),
+              },
+            ],
+            remoteDpopTokens: [],
+          });
+        yield* store.set(yield* catalogFor("current"));
+        const legacy = yield* catalogFor("superseded");
+        yield* fs.writeFileString(
+          environment.legacyConnectionCatalogPaths[0]!,
+          yield* encodeEncryptedCatalogFixture({
+            version: 1,
+            encryptedCatalog: Buffer.from(`encrypted:${legacy}`).toString("base64"),
+          }),
+        );
+        const merged = yield* decodeConnectionCatalog(Option.getOrThrow(yield* store.get));
+        assert.deepEqual(
+          merged.profiles.map((profile) => profile.connectionId),
+          ["current"],
+        );
+        assert.deepEqual(
+          merged.credentials.map((credential) => credential.connectionId),
+          ["current"],
+        );
+        assert.equal(merged.targets[0]?.label, "current");
+      }).pipe(
+        Effect.provide(
+          makeLayer(baseDir, true, null, NodeServices.layer, "T3 Code (Fork Nightly)"),
+        ),
+      );
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("clearing one channel preserves an unmigrated sibling catalog", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-catalog-clear-" });
+      yield* Effect.gen(function* () {
+        const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore;
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
+        yield* fs.makeDirectory(environment.stateDir, { recursive: true });
+        for (const path of environment.legacyConnectionCatalogPaths)
+          yield* fs.writeFileString(path, "unmigrated");
+        yield* store.clear;
+        assert.isFalse(yield* fs.exists(environment.legacyConnectionCatalogPaths[0]!));
+        assert.equal(
+          yield* fs.readFileString(environment.legacyConnectionCatalogPaths[1]!),
+          "unmigrated",
+        );
+      }).pipe(
+        Effect.provide(
+          makeLayer(baseDir, true, null, NodeServices.layer, "T3 Code (Fork Nightly)"),
+        ),
+      );
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("moves a readable stage-named downstream catalog to its stable identity", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-desktop-connection-catalog-test-",
+        });
+        const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore.pipe(
+          Effect.provide(
+            makeLayer(baseDir, true, null, NodeServices.layer, "T3 Code (Fork Nightly)"),
+          ),
+        );
+        const catalog = '{"schemaVersion":1,"targets":[]}';
+        const legacyPath = `${baseDir}/userdata/connection-catalog.0054003300200043006f00640065002000280046006f0072006b0020004e0069006700680074006c00790029.json`;
+        const stablePath = `${baseDir}/userdata/connection-catalog.fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45.json`;
+        const encryptedCatalog = Buffer.from(`encrypted:${catalog}`, "utf8").toString("base64");
+
+        yield* fileSystem.makeDirectory(`${baseDir}/userdata`, { recursive: true });
+        yield* fileSystem.writeFileString(
+          legacyPath,
+          `{"version":1,"encryptedCatalog":"${encryptedCatalog}"}`,
+        );
+
+        assert.deepStrictEqual(yield* store.get, Option.some(catalog));
+        assert.isTrue(yield* fileSystem.exists(stablePath));
+        assert.isFalse(yield* fileSystem.exists(legacyPath));
+
+        yield* store.clear;
+        assert.deepStrictEqual(yield* store.get, Option.none());
+        assert.isFalse(yield* fileSystem.exists(stablePath));
+        assert.isFalse(yield* fileSystem.exists(legacyPath));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
+  it.effect("preserves encryption failures while promoting a stage-named catalog", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-desktop-connection-catalog-test-",
+        });
+        const failEncrypt = yield* Ref.make(true);
+        const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore.pipe(
+          Effect.provide(
+            makeLayer(
+              baseDir,
+              true,
+              null,
+              NodeServices.layer,
+              "T3 Code (Fork Nightly)",
+              failEncrypt,
+            ),
+          ),
+        );
+        const catalog = '{"schemaVersion":1,"targets":[]}';
+        const legacyPath = `${baseDir}/userdata/connection-catalog.0054003300200043006f00640065002000280046006f0072006b0020004e0069006700680074006c00790029.json`;
+        const stablePath = `${baseDir}/userdata/connection-catalog.fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45.json`;
+        const encryptedCatalog = Buffer.from(`encrypted:${catalog}`, "utf8").toString("base64");
+
+        yield* fileSystem.makeDirectory(`${baseDir}/userdata`, { recursive: true });
+        yield* fileSystem.writeFileString(
+          legacyPath,
+          `{"version":1,"encryptedCatalog":"${encryptedCatalog}"}`,
+        );
+
+        const error = yield* store.get.pipe(Effect.flip);
+        assert.instanceOf(
+          error,
+          DesktopConnectionCatalogStore.DesktopConnectionCatalogStoreProtectionError,
+        );
+        assert.equal(error.operation, "encrypt-catalog");
+        assert.equal(error.catalogPath, stablePath);
+        assert.instanceOf(error.cause, ElectronSafeStorage.ElectronSafeStorageEncryptError);
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
+  it.effect("identifies both catalog paths when promotion cannot persist", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-desktop-connection-catalog-test-",
+        });
+        const legacyPath = `${baseDir}/userdata/connection-catalog.0054003300200043006f00640065002000280046006f0072006b0020004e0069006700680074006c00790029.json`;
+        const stablePath = `${baseDir}/userdata/connection-catalog.fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45.json`;
+        const catalog = '{"schemaVersion":1,"targets":[]}';
+        const encryptedCatalog = Buffer.from(`encrypted:${catalog}`, "utf8").toString("base64");
+        const permissionError = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "makeDirectory",
+          pathOrDescriptor: `${baseDir}/userdata`,
+        });
+
+        yield* fileSystem.makeDirectory(`${baseDir}/userdata`, { recursive: true });
+        yield* fileSystem.writeFileString(
+          legacyPath,
+          `{"version":1,"encryptedCatalog":"${encryptedCatalog}"}`,
+        );
+        const fileSystemLayer = Layer.succeed(
+          FileSystem.FileSystem,
+          FileSystem.makeNoop({
+            exists: fileSystem.exists,
+            readFileString: fileSystem.readFileString,
+            makeDirectory: () => Effect.fail(permissionError),
+          }),
+        );
+        const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore.pipe(
+          Effect.provide(makeLayer(baseDir, true, null, fileSystemLayer, "T3 Code (Fork Nightly)")),
+        );
+
+        const error = yield* store.get.pipe(Effect.flip);
+        assert.instanceOf(
+          error,
+          DesktopConnectionCatalogStore.DesktopConnectionCatalogStorePromotionError,
+        );
+        assert.equal(error.operation, "promote-legacy-catalog");
+        assert.equal(error.catalogPath, stablePath);
+        assert.equal(error.sourceCatalogPath, legacyPath);
+        assert.isTrue(yield* fileSystem.exists(legacyPath));
+        assert.instanceOf(
+          error.cause,
+          DesktopConnectionCatalogStore.DesktopConnectionCatalogStoreWriteError,
+        );
+        assert.equal(
+          error.message,
+          `Desktop connection catalog promotion failed from ${legacyPath} to ${stablePath}.`,
+        );
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
+  it.effect("serializes legacy migration with a concurrent catalog save", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-catalog-race-" });
+      const decryptStarted = yield* Deferred.make<void>();
+      const releaseDecrypt = yield* Deferred.make<void>();
+      const saveStarted = yield* Deferred.make<void>();
+      const operations: string[] = [];
+      const oldCatalog = '{"schemaVersion":1,"targets":[]}';
+      const newCatalog = '{"schemaVersion":1,"targets":[],"profiles":[]}';
+      const safeStorageLayer = Layer.succeed(ElectronSafeStorage.ElectronSafeStorage, {
+        isEncryptionAvailable: Effect.succeed(true),
+        selectedStorageBackend: Effect.succeed(Option.none()),
+        encryptString: (value) =>
+          Effect.sync(() => {
+            operations.push(value === oldCatalog ? "migrate" : "save");
+            return textEncoder.encode(`encrypted:${value}`);
+          }),
+        decryptString: (value) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(decryptStarted, undefined);
+            yield* Deferred.await(releaseDecrypt);
+            return textDecoder.decode(value).slice("encrypted:".length);
+          }),
+      });
+      const environmentLayer = DesktopEnvironment.layer({
+        dirname: "/repo/apps/desktop/src",
+        homeDirectory: baseDir,
+        platform: "darwin",
+        processArch: "arm64",
+        appVersion: "1.2.3",
+        appName: "T3 Code (Fork Nightly)",
+        appPath: "/repo",
+        isPackaged: true,
+        resourcesPath: "/missing/resources",
+        runningUnderArm64Translation: false,
+      }).pipe(
+        Layer.provide(
+          Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({ T3CODE_HOME: baseDir })),
+        ),
+      );
+      const dependencies = Layer.mergeAll(environmentLayer, safeStorageLayer, NodeServices.layer);
+      const saved = DesktopSavedEnvironments.layer.pipe(Layer.provideMerge(dependencies));
+      const store = yield* DesktopConnectionCatalogStore.DesktopConnectionCatalogStore.pipe(
+        Effect.provide(DesktopConnectionCatalogStore.layer.pipe(Layer.provide(saved))),
+      );
+      const environment = yield* DesktopEnvironment.DesktopEnvironment.pipe(
+        Effect.provide(environmentLayer),
+      );
+      const legacyPath = environment.legacyConnectionCatalogPaths[0]!;
+      yield* fileSystem.makeDirectory(`${baseDir}/userdata`, { recursive: true });
+      yield* fileSystem.writeFileString(
+        legacyPath,
+        yield* encodeEncryptedCatalogFixture({
+          version: 1,
+          encryptedCatalog: Buffer.from(`encrypted:${oldCatalog}`).toString("base64"),
+        }),
+      );
+      const reading = yield* Effect.forkChild(store.get);
+      yield* Deferred.await(decryptStarted);
+      const saving = yield* Effect.forkChild(
+        Deferred.succeed(saveStarted, undefined).pipe(Effect.andThen(store.set(newCatalog))),
+      );
+      yield* Deferred.await(saveStarted);
+      yield* Effect.yieldNow;
+      assert.deepEqual(operations, []);
+      yield* Deferred.succeed(releaseDecrypt, undefined);
+      yield* Fiber.join(reading);
+      yield* Fiber.join(saving);
+      assert.deepEqual(operations, ["migrate", "save"]);
+      assert.deepEqual(yield* store.get, Option.some(newCatalog));
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
 
   it.effect("migrates legacy relay, SSH, bearer profile, and credential data", () =>

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -46,6 +46,9 @@ const RuntimeConnectionCatalogDocumentJson = Schema.fromJsonString(
 const encodeRuntimeConnectionCatalogDocumentJson = Schema.encodeEffect(
   RuntimeConnectionCatalogDocumentJson,
 );
+const decodeRuntimeConnectionCatalogDocumentJson = Schema.decodeUnknownEffect(
+  RuntimeConnectionCatalogDocumentJson,
+);
 
 const DesktopConnectionCatalogStoreWriteOperation = Schema.Literals([
   "create-temporary-file-name",
@@ -522,7 +525,7 @@ export const make = Effect.gen(function* () {
             candidate !== catalogPath &&
             catalogs.some((catalog) => catalog.path === catalogPath)
           ) {
-            yield* Schema.decodeUnknownEffect(RuntimeConnectionCatalogDocumentJson)(decrypted).pipe(
+            yield* decodeRuntimeConnectionCatalogDocumentJson(decrypted).pipe(
               Effect.mapError(
                 (cause) =>
                   new DesktopConnectionCatalogStoreDocumentDecodeError({
@@ -554,7 +557,7 @@ export const make = Effect.gen(function* () {
       let decrypted = first.value;
       if (catalogs.length > 1) {
         const documents = yield* Effect.forEach(catalogs, (catalog) =>
-          Schema.decodeUnknownEffect(RuntimeConnectionCatalogDocumentJson)(catalog.value).pipe(
+          decodeRuntimeConnectionCatalogDocumentJson(catalog.value).pipe(
             Effect.mapError(
               (cause) =>
                 new DesktopConnectionCatalogStoreDocumentDecodeError({

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -21,6 +21,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 
 import * as ElectronSafeStorage from "../electron/ElectronSafeStorage.ts";
 import * as DesktopSavedEnvironments from "../settings/DesktopSavedEnvironments.ts";
@@ -33,7 +34,7 @@ const EncryptedConnectionCatalogDocument = Schema.Struct({
 type EncryptedConnectionCatalogDocument = typeof EncryptedConnectionCatalogDocument.Type;
 
 const EncryptedConnectionCatalogDocumentJson = fromLenientJson(EncryptedConnectionCatalogDocument);
-const decodeEncryptedConnectionCatalogDocumentJson = Schema.decodeEffect(
+const decodeEncryptedConnectionCatalogDocumentJson = Schema.decodeUnknownEffect(
   EncryptedConnectionCatalogDocumentJson,
 );
 const encodeEncryptedConnectionCatalogDocumentJson = Schema.encodeEffect(
@@ -133,6 +134,20 @@ export class DesktopConnectionCatalogStoreMigrationError extends Schema.TaggedEr
   }
 }
 
+export class DesktopConnectionCatalogStorePromotionError extends Schema.TaggedError<DesktopConnectionCatalogStorePromotionError>()(
+  "DesktopConnectionCatalogStorePromotionError",
+  {
+    operation: Schema.Literal("promote-legacy-catalog"),
+    sourceCatalogPath: Schema.String,
+    catalogPath: Schema.String,
+    cause: Schema.instanceOf(DesktopConnectionCatalogStoreWriteError),
+  },
+) {
+  override get message(): string {
+    return `Desktop connection catalog promotion failed from ${this.sourceCatalogPath} to ${this.catalogPath}.`;
+  }
+}
+
 export class DesktopConnectionCatalogStoreProtectionError extends Schema.TaggedError<DesktopConnectionCatalogStoreProtectionError>()(
   "DesktopConnectionCatalogStoreProtectionError",
   {
@@ -155,6 +170,7 @@ export class DesktopConnectionCatalogStore extends Context.Service<
       | DesktopConnectionCatalogStoreDocumentDecodeError
       | DesktopConnectionCatalogStoreDecodeError
       | DesktopConnectionCatalogStoreMigrationError
+      | DesktopConnectionCatalogStorePromotionError
       | DesktopConnectionCatalogStoreProtectionError
     >;
     readonly set: (
@@ -383,7 +399,8 @@ export const make = Effect.gen(function* () {
   const safeStorage = yield* ElectronSafeStorage.ElectronSafeStorage;
   const crypto = yield* Crypto.Crypto;
   const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
-  const catalogPath = path.join(environment.stateDir, "connection-catalog.json");
+  const catalogPath = environment.connectionCatalogPath;
+  const mutex = yield* Semaphore.make(1);
   const encryptionAvailable = safeStorage.isEncryptionAvailable.pipe(
     Effect.mapError(
       (cause) =>
@@ -430,6 +447,12 @@ export const make = Effect.gen(function* () {
   });
 
   const migrateLegacyCatalog = Effect.gen(function* () {
+    // Legacy saved-environment secrets belong to the official app's safeStorage
+    // identity. A downstream app cannot decrypt them without a macOS Keychain
+    // prompt, so it must begin with its own empty catalog instead.
+    if (environment.isDownstreamDistribution) {
+      return Option.none<string>();
+    }
     if (!(yield* encryptionAvailable)) {
       return Option.none<string>();
     }
@@ -472,45 +495,164 @@ export const make = Effect.gen(function* () {
 
   return DesktopConnectionCatalogStore.of({
     get: Effect.gen(function* () {
-      const document = yield* readDocument(fileSystem, catalogPath);
-      if (Option.isNone(document)) {
-        return yield* migrateLegacyCatalog;
+      const catalogs: Array<{ path: string; value: string }> = [];
+      for (const candidate of [catalogPath, ...environment.legacyConnectionCatalogPaths]) {
+        const recovered = yield* Effect.gen(function* () {
+          const document = yield* readDocument(fileSystem, candidate);
+          if (Option.isNone(document)) return Option.none<string>();
+          if (!(yield* encryptionAvailable)) return Option.none<string>();
+          const decrypted = yield* decodeSecretBytes(
+            candidate,
+            document.value.encryptedCatalog,
+          ).pipe(
+            Effect.flatMap((encrypted) =>
+              safeStorage.decryptString(encrypted).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new DesktopConnectionCatalogStoreProtectionError({
+                      operation: "decrypt-catalog",
+                      catalogPath: candidate,
+                      cause,
+                    }),
+                ),
+              ),
+            ),
+          );
+          if (
+            candidate !== catalogPath &&
+            catalogs.some((catalog) => catalog.path === catalogPath)
+          ) {
+            yield* Schema.decodeUnknownEffect(RuntimeConnectionCatalogDocumentJson)(decrypted).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new DesktopConnectionCatalogStoreDocumentDecodeError({
+                    catalogPath: candidate,
+                    cause,
+                  }),
+              ),
+            );
+          }
+          return Option.some(decrypted);
+        }).pipe(
+          Effect.catch((cause) => {
+            if (
+              candidate === catalogPath ||
+              !catalogs.some((catalog) => catalog.path === catalogPath)
+            )
+              return Effect.fail(cause);
+            return Effect.logWarning(
+              "Skipped unreadable legacy catalog; current saved connections remain available.",
+              { catalogPath: candidate },
+            ).pipe(Effect.as(Option.none<string>()));
+          }),
+        );
+        if (Option.isSome(recovered)) catalogs.push({ path: candidate, value: recovered.value });
       }
-      if (!(yield* encryptionAvailable)) {
-        return Option.none<string>();
-      }
-      const decrypted = yield* decodeSecretBytes(catalogPath, document.value.encryptedCatalog).pipe(
-        Effect.flatMap((encryptedCatalog) =>
-          safeStorage.decryptString(encryptedCatalog).pipe(
+      const first = catalogs[0];
+      if (first === undefined) return yield* migrateLegacyCatalog;
+      const legacyCatalogs = catalogs.filter((catalog) => catalog.path !== catalogPath);
+      let decrypted = first.value;
+      if (catalogs.length > 1) {
+        const documents = yield* Effect.forEach(catalogs, (catalog) =>
+          Schema.decodeUnknownEffect(RuntimeConnectionCatalogDocumentJson)(catalog.value).pipe(
             Effect.mapError(
               (cause) =>
-                new DesktopConnectionCatalogStoreProtectionError({
-                  operation: "decrypt-catalog",
-                  catalogPath,
+                new DesktopConnectionCatalogStoreDocumentDecodeError({
+                  catalogPath: catalog.path,
                   cause,
                 }),
             ),
           ),
-        ),
-      );
+        );
+        // Current state wins duplicate identities; import every other channel's unique records.
+        const unique = <A>(values: readonly A[], key: (value: A) => string): A[] => {
+          const seen = new Set<string>();
+          return values.filter((value) => {
+            const id = key(value);
+            if (seen.has(id)) return false;
+            seen.add(id);
+            return true;
+          });
+        };
+        const targets = unique(
+          documents.flatMap((document) => document.targets),
+          (target) => target.environmentId,
+        );
+        const connectionIds = new Set(
+          targets.flatMap((target) => ("connectionId" in target ? [target.connectionId] : [])),
+        );
+        decrypted = yield* encodeRuntimeConnectionCatalogDocumentJson({
+          schemaVersion: 1,
+          targets,
+          profiles: unique(
+            documents
+              .flatMap((d) => d.profiles)
+              .filter((profile) => connectionIds.has(profile.connectionId)),
+            (v) => v.connectionId,
+          ),
+          credentials: unique(
+            documents
+              .flatMap((d) => d.credentials)
+              .filter((credential) => connectionIds.has(credential.connectionId)),
+            (v) => v.connectionId,
+          ),
+          remoteDpopTokens: unique(
+            documents.flatMap((d) => d.remoteDpopTokens),
+            (v) => v.environmentId,
+          ),
+        }).pipe(
+          Effect.mapError(
+            (cause) => new DesktopConnectionCatalogStoreDocumentDecodeError({ catalogPath, cause }),
+          ),
+        );
+      }
+      if (legacyCatalogs.length > 0) {
+        yield* writeCatalog(decrypted).pipe(
+          Effect.catchTags({
+            DesktopConnectionCatalogStoreWriteError: (cause) =>
+              Effect.fail(
+                new DesktopConnectionCatalogStorePromotionError({
+                  operation: "promote-legacy-catalog",
+                  sourceCatalogPath: legacyCatalogs[0]!.path,
+                  catalogPath,
+                  cause,
+                }),
+              ),
+          }),
+        );
+        for (const catalog of legacyCatalogs) {
+          yield* fileSystem.remove(catalog.path, { force: true }).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("Could not clear the promoted desktop connection catalog.", {
+                catalogPath: catalog.path,
+                error,
+              }),
+            ),
+          );
+        }
+      }
       return Option.some(decrypted);
-    }).pipe(Effect.withSpan("desktop.connectionCatalogStore.get")),
-    set: Effect.fn("desktop.connectionCatalogStore.set")(function* (catalog) {
+    }).pipe(mutex.withPermits(1), Effect.withSpan("desktop.connectionCatalogStore.get")),
+    set: Effect.fn("desktop.connectionCatalogStore.set")(function* (catalog: string) {
       if (!(yield* encryptionAvailable)) {
         return false;
       }
       yield* writeCatalog(catalog);
       return true;
-    }),
-    clear: fileSystem.remove(catalogPath, { force: true }).pipe(
-      Effect.catch((error) =>
-        Effect.logWarning("Could not clear the desktop connection catalog.", {
-          catalogPath,
-          error,
-        }),
-      ),
-      Effect.withSpan("desktop.connectionCatalogStore.clear"),
-    ),
+    }, mutex.withPermits(1)),
+    clear: Effect.forEach(
+      [catalogPath, ...environment.legacyConnectionCatalogPaths.slice(0, 1)],
+      (candidate) =>
+        fileSystem.remove(candidate, { force: true }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("Could not clear the desktop connection catalog.", {
+              catalogPath: candidate,
+              error,
+            }),
+          ),
+        ),
+      { discard: true },
+    ).pipe(mutex.withPermits(1), Effect.withSpan("desktop.connectionCatalogStore.clear")),
   });
 });
 

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -40,6 +40,119 @@ const makeEnvironment = (
   DesktopEnvironment.DesktopEnvironment.pipe(Effect.provide(makeEnvironmentLayer(overrides, env)));
 
 describe("DesktopEnvironment", () => {
+  it.effect("separates downstream display branding from its stable runtime identity", () =>
+    Effect.gen(function* () {
+      const environment = yield* makeEnvironment({
+        isPackaged: true,
+        appVersion: "0.0.38-nightly.20260901.1",
+        appName: "T3 Code (Fork Nightly)",
+        appPath: "/Applications/T3 Code (Fork Nightly).app/Contents/Resources/app.asar",
+        resourcesPath: "/Applications/T3 Code (Fork Nightly).app/Contents/Resources",
+      });
+
+      assert.equal(environment.displayName, "T3 Code (Fork Nightly)");
+      assert.equal(environment.branding.displayName, "T3 Code (Fork Nightly)");
+      assert.equal(environment.branding.stageLabel, "Nightly");
+      assert.isTrue(environment.isDownstreamDistribution);
+      assert.equal(environment.productName, "T3 Code (Fork)");
+      assert.equal(environment.userDataDirName, "T3 Code (Fork)");
+      assert.deepEqual(environment.legacyDownstreamUserDataDirNames, [
+        "T3 Code (Fork Nightly)",
+        "T3 Code (Fork Alpha)",
+      ]);
+      assert.equal(
+        environment.connectionCatalogPath,
+        "/Users/alice/.t3/userdata/connection-catalog.fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45.json",
+      );
+    }),
+  );
+
+  it.effect("keeps legacy downstream identifiers inside a single path segment", () =>
+    Effect.gen(function* () {
+      const environment = yield* makeEnvironment({
+        isPackaged: true,
+        appName: "T3 Code (x/../../outside Nightly)",
+      });
+      assert.match(environment.distributionId!, /^[a-z0-9-]+$/);
+      assert.notInclude(environment.linuxDesktopEntryName, "../");
+    }),
+  );
+
+  it.effect("preserves the identity of legacy official stable packages", () =>
+    Effect.gen(function* () {
+      const environment = yield* makeEnvironment({
+        isPackaged: true,
+        appVersion: "0.0.38",
+        appName: "T3 Code",
+      });
+      assert.isFalse(environment.isDownstreamDistribution);
+      assert.equal(environment.userDataDirName, "t3code");
+      assert.equal(environment.productName, "T3 Code");
+      assert.equal(
+        environment.connectionCatalogPath,
+        "/Users/alice/.t3/userdata/connection-catalog.json",
+      );
+    }),
+  );
+
+  it.effect("keeps official packaged builds on the shared connection catalog", () =>
+    Effect.gen(function* () {
+      const environment = yield* makeEnvironment({
+        isPackaged: true,
+        appVersion: "0.0.38-nightly.20260901.1",
+        appName: "T3 Code (Nightly)",
+      });
+
+      assert.equal(
+        environment.connectionCatalogPath,
+        "/Users/alice/.t3/userdata/connection-catalog.json",
+      );
+      assert.isFalse(environment.isDownstreamDistribution);
+      assert.equal(environment.userDataDirName, "t3code");
+      assert.equal(environment.productName, "T3 Code (Nightly)");
+    }),
+  );
+
+  it.effect("keeps downstream profile and catalog identity stable across update channels", () =>
+    Effect.gen(function* () {
+      const alpha = yield* makeEnvironment({
+        isPackaged: true,
+        appVersion: "0.0.38",
+        appName: "T3 Code (Fork)",
+      });
+      const nightly = yield* makeEnvironment({
+        isPackaged: true,
+        appVersion: "0.0.38-nightly.20260901.1",
+        appName: "T3 Code (Fork)",
+      });
+
+      assert.equal(alpha.userDataDirName, nightly.userDataDirName);
+      assert.equal(alpha.connectionCatalogPath, nightly.connectionCatalogPath);
+      assert.equal(alpha.productName, nightly.productName);
+      assert.notEqual(alpha.displayName, nightly.displayName);
+      assert.deepEqual(alpha.legacyDownstreamUserDataDirNames, [
+        "T3 Code (Fork Alpha)",
+        "T3 Code (Fork Nightly)",
+      ]);
+      assert.deepEqual(nightly.legacyDownstreamUserDataDirNames, [
+        "T3 Code (Fork Nightly)",
+        "T3 Code (Fork Alpha)",
+      ]);
+    }),
+  );
+
+  it("preserves an unrecognized packaged app name as its display name", () => {
+    const identity = DesktopEnvironment.currentDesktopAppIdentity({
+      isDevelopment: false,
+      isPackaged: true,
+      appVersion: "0.0.38-nightly.20260901.1",
+      appName: "Acme Code",
+    });
+
+    assert.equal(identity.productName, "Acme Code");
+    assert.equal(identity.displayName, "Acme Code");
+  });
+
   it.effect("derives state paths and development identity inside Effect", () =>
     Effect.gen(function* () {
       const environment = yield* makeEnvironment(
@@ -61,6 +174,7 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.stateDir, "/tmp/t3/userdata");
       assert.equal(environment.desktopSettingsPath, "/tmp/t3/userdata/desktop-settings.json");
       assert.equal(environment.clientSettingsPath, "/tmp/t3/userdata/client-settings.json");
+      assert.equal(environment.connectionCatalogPath, "/tmp/t3/userdata/connection-catalog.json");
       assert.equal(
         environment.savedEnvironmentRegistryPath,
         "/tmp/t3/userdata/saved-environments.json",

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -4,6 +4,10 @@ import type {
   DesktopRuntimeArch,
   DesktopRuntimeInfo,
 } from "@t3tools/contracts";
+import {
+  resolveDesktopRuntimeIdentity,
+  type DesktopPackagedAppIdentity,
+} from "@t3tools/shared/desktopBuild";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -23,6 +27,8 @@ export interface MakeDesktopEnvironmentInput {
   readonly platform: NodeJS.Platform;
   readonly processArch: string;
   readonly appVersion: string;
+  readonly appName?: string;
+  readonly packagedIdentity?: DesktopPackagedAppIdentity;
   readonly appPath: string;
   readonly isPackaged: boolean;
   readonly resourcesPath: string;
@@ -47,6 +53,8 @@ export class DesktopEnvironment extends Context.Service<
     readonly stateDir: string;
     readonly desktopSettingsPath: string;
     readonly clientSettingsPath: string;
+    readonly connectionCatalogPath: string;
+    readonly legacyConnectionCatalogPaths: readonly string[];
     readonly savedEnvironmentRegistryPath: string;
     readonly serverSettingsPath: string;
     readonly logDir: string;
@@ -72,12 +80,16 @@ export class DesktopEnvironment extends Context.Service<
     readonly otlpExportIntervalMs: number;
     readonly branding: DesktopAppBranding;
     readonly displayName: string;
+    readonly productName: string;
+    readonly distributionId: string | null;
     readonly appUserModelId: string;
     readonly linuxDesktopEntryName: string;
     readonly linuxWmClass: string;
     readonly linuxApplicationsDir: string;
     readonly appImagePath: Option.Option<string>;
+    readonly isDownstreamDistribution: boolean;
     readonly userDataDirName: string;
+    readonly legacyDownstreamUserDataDirNames: readonly string[];
     readonly legacyUserDataDirName: string;
     readonly defaultDesktopSettings: DesktopAppSettings.DesktopSettings;
     readonly runtimeInfo: DesktopRuntimeInfo;
@@ -87,6 +99,27 @@ export class DesktopEnvironment extends Context.Service<
 >()("@t3tools/desktop/app/DesktopEnvironment") {}
 
 const APP_BASE_NAME = "T3 Code";
+
+function resolveConnectionCatalogFileName(input: {
+  readonly distributionId: string | null;
+}): string {
+  if (input.distributionId === null) {
+    return "connection-catalog.json";
+  }
+
+  // A downstream distribution has its own Electron safeStorage key on macOS.
+  // Keep its encrypted catalog separate from the official app's catalog so
+  // both applications can use the shared T3 backend state without attempting
+  // to decrypt or overwrite each other's credentials.
+  return `connection-catalog.${input.distributionId}.json`;
+}
+
+function legacyConnectionCatalogFileName(displayName: string): string {
+  const scope = Array.from(displayName, (character) =>
+    character.codePointAt(0)!.toString(16).padStart(4, "0"),
+  ).join("");
+  return `connection-catalog.${scope}.json`;
+}
 
 function resolveDesktopAppStageLabel(input: {
   readonly isDevelopment: boolean;
@@ -109,6 +142,17 @@ export function resolveDesktopAppBranding(input: {
     stageLabel,
     displayName: `${APP_BASE_NAME} (${stageLabel})`,
   };
+}
+
+export function currentDesktopAppIdentity(input: {
+  readonly isDevelopment: boolean;
+  readonly isPackaged: boolean;
+  readonly appVersion: string;
+  readonly appName?: string;
+  readonly packagedIdentity?: DesktopPackagedAppIdentity;
+}) {
+  const stageLabel = resolveDesktopAppStageLabel(input);
+  return resolveDesktopRuntimeIdentity({ ...input, stageLabel });
 }
 
 function normalizeDesktopArch(arch: string): DesktopRuntimeArch {
@@ -168,18 +212,52 @@ const make = Effect.fn("desktop.environment.make")(function* (
     input.isPackaged && input.platform === "win32"
       ? path.join(input.resourcesPath, "server.asar")
       : appRoot;
-  const branding = resolveDesktopAppBranding({
+  const fallbackBranding = resolveDesktopAppBranding({
     isDevelopment,
     appVersion: input.appVersion,
   });
-  const displayName = branding.displayName;
+  const resolvedIdentity = currentDesktopAppIdentity({
+    isDevelopment,
+    isPackaged: input.isPackaged,
+    appVersion: input.appVersion,
+    ...(input.appName === undefined ? {} : { appName: input.appName }),
+    ...(input.packagedIdentity === undefined ? {} : { packagedIdentity: input.packagedIdentity }),
+  });
+  const branding = { ...fallbackBranding, displayName: resolvedIdentity.displayName };
+  const displayName = resolvedIdentity.displayName;
+  const productName = resolvedIdentity.productName;
+  const distributionId = resolvedIdentity.distributionId;
+  const isDownstreamDistribution = input.isPackaged && distributionId !== null;
   const stateDir = resolveDesktopStateDir({
     baseDir,
     isDevelopment,
     joinPath: path.join,
     t3Home: config.t3Home,
   });
-  const userDataDirName = isDevelopment ? "t3code-dev" : "t3code";
+  const connectionCatalogPath = path.join(
+    stateDir,
+    resolveConnectionCatalogFileName({
+      distributionId,
+    }),
+  );
+  const legacyDownstreamStages =
+    branding.stageLabel === "Nightly"
+      ? (["Nightly", "Alpha"] as const)
+      : (["Alpha", "Nightly"] as const);
+  const legacyDownstreamUserDataDirNames =
+    isDownstreamDistribution && resolvedIdentity.distributionName
+      ? legacyDownstreamStages.map(
+          (stage) => `T3 Code (${resolvedIdentity.distributionName} ${stage})`,
+        )
+      : [];
+  const legacyConnectionCatalogPaths = legacyDownstreamUserDataDirNames.map((legacyDisplayName) =>
+    path.join(stateDir, legacyConnectionCatalogFileName(legacyDisplayName)),
+  );
+  const userDataDirName = isDevelopment
+    ? "t3code-dev"
+    : isDownstreamDistribution
+      ? productName
+      : "t3code";
   const legacyUserDataDirName = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
   const linuxApplicationsDir = path.join(
     Option.getOrElse(config.xdgDataHome, () => path.join(homeDirectory, ".local", "share")),
@@ -203,6 +281,8 @@ const make = Effect.fn("desktop.environment.make")(function* (
     stateDir,
     desktopSettingsPath: path.join(stateDir, "desktop-settings.json"),
     clientSettingsPath: path.join(stateDir, "client-settings.json"),
+    connectionCatalogPath,
+    legacyConnectionCatalogPaths,
     savedEnvironmentRegistryPath: path.join(stateDir, "saved-environments.json"),
     serverSettingsPath: path.join(stateDir, "settings.json"),
     logDir: path.join(stateDir, "logs"),
@@ -224,14 +304,24 @@ const make = Effect.fn("desktop.environment.make")(function* (
     otlpExportIntervalMs: config.otlpExportIntervalMs,
     branding,
     displayName,
+    productName,
+    distributionId,
     appUserModelId: Option.getOrElse(config.appUserModelIdOverride, () =>
-      isDevelopment ? "com.t3tools.t3code.dev" : "com.t3tools.t3code",
+      isDevelopment ? "com.t3tools.t3code.dev" : resolvedIdentity.appId,
     ),
-    linuxDesktopEntryName: resolveLinuxDesktopEntryName(isDevelopment),
-    linuxWmClass: isDevelopment ? "t3code-dev" : "t3code",
+    linuxDesktopEntryName: isDownstreamDistribution
+      ? `${resolvedIdentity.packageName}.desktop`
+      : resolveLinuxDesktopEntryName(isDevelopment),
+    linuxWmClass: isDownstreamDistribution
+      ? resolvedIdentity.packageName
+      : isDevelopment
+        ? "t3code-dev"
+        : "t3code",
     linuxApplicationsDir,
     appImagePath: config.appImagePath,
+    isDownstreamDistribution,
     userDataDirName,
+    legacyDownstreamUserDataDirNames,
     legacyUserDataDirName,
     defaultDesktopSettings: DesktopAppSettings.resolveDefaultDesktopSettings(input.appVersion),
     runtimeInfo: resolveDesktopRuntimeInfo({

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -180,6 +180,30 @@ describe("DesktopLinuxUrlHandler", () => {
     });
   });
 
+  it.effect("registers a fork without replacing the official URL handler", () => {
+    const recorded = emptyRecording();
+    return Effect.gen(function* () {
+      yield* runRegister(recorded, {
+        environment: {
+          distributionId: "fork-abc",
+          displayName: "T3 Code (Fork)",
+          linuxDesktopEntryName: "t3code-fork-abc.desktop",
+        },
+      });
+      assert.equal(
+        recorded.files[0]?.path,
+        "/home/alice/.local/share/applications/t3code-fork-abc.desktop",
+      );
+      assert.include(recorded.files[0]?.content, "MimeType=x-scheme-handler/t3code-fork-abc;");
+      assert.deepEqual(recorded.commands, [
+        {
+          command: "xdg-mime",
+          args: ["default", "t3code-fork-abc.desktop", "x-scheme-handler/t3code-fork-abc"],
+        },
+      ]);
+    });
+  });
+
   it.effect("falls back to the process executable outside an AppImage", () => {
     const recorded = emptyRecording();
 

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -96,7 +96,10 @@ export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
 
-  const scheme = ElectronProtocol.getDesktopScheme(environment.isDevelopment);
+  const scheme = ElectronProtocol.getDesktopScheme(
+    environment.isDevelopment,
+    environment.distributionId,
+  );
   const desktopEntryPath = environment.path.join(
     environment.linuxApplicationsDir,
     environment.linuxDesktopEntryName,

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
@@ -10,6 +10,8 @@ const {
   getSwitchValueMock,
   hasSwitchMock,
   registerSchemesMock,
+  packagedState,
+  readFileMock,
   setDesktopNameMock,
   mkdirSyncMock,
   writeFileSyncMock,
@@ -18,15 +20,29 @@ const {
   getSwitchValueMock: vi.fn(),
   hasSwitchMock: vi.fn(),
   registerSchemesMock: vi.fn(),
+  readFileMock: vi.fn(),
+  packagedState: { value: false },
   setDesktopNameMock: vi.fn(),
   mkdirSyncMock: vi.fn(),
   writeFileSyncMock: vi.fn(),
 }));
 
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
+  readFileSync: readFileMock,
+  mkdirSync: mkdirSyncMock,
+  writeFileSync: writeFileSyncMock,
+}));
+
 vi.mock("electron", () => ({
   app: {
+    get isPackaged() {
+      return packagedState.value;
+    },
+    getAppPath: () => "/packaged-app",
+    getVersion: () => "1.2.3",
+    getName: () => "T3 Code (Fork)",
     setDesktopName: setDesktopNameMock,
-    getVersion: () => "0.0.37",
     commandLine: {
       appendSwitch: appendSwitchMock,
       getSwitchValue: getSwitchValueMock,
@@ -38,12 +54,6 @@ vi.mock("electron", () => ({
   },
 }));
 
-vi.mock("node:fs", () => ({
-  readFileSync: () => "{}",
-  mkdirSync: mkdirSyncMock,
-  writeFileSync: writeFileSyncMock,
-}));
-
 import * as DesktopPreReadyPlatform from "./DesktopPreReadyPlatform.ts";
 
 describe("DesktopPreReadyPlatform", () => {
@@ -52,6 +62,8 @@ describe("DesktopPreReadyPlatform", () => {
     getSwitchValueMock.mockReset();
     hasSwitchMock.mockReset();
     registerSchemesMock.mockReset();
+    readFileMock.mockReset();
+    packagedState.value = false;
     setDesktopNameMock.mockReset();
     mkdirSyncMock.mockReset();
     writeFileSyncMock.mockReset();
@@ -74,6 +86,65 @@ describe("DesktopPreReadyPlatform", () => {
       ),
     );
   });
+
+  it("retains legacy packaged identity and rejects malformed metadata", () => {
+    packagedState.value = true;
+    readFileMock.mockReturnValue("{}");
+    assert.equal(
+      DesktopPreReadyPlatform.resolveEarlyDesktopSchemeFromProcess(),
+      "t3code-fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45",
+    );
+    readFileMock.mockReturnValue('{"t3codeDesktopIdentity": {"distributionId": 42}}');
+    assert.throws(() => DesktopPreReadyPlatform.resolveEarlyDesktopSchemeFromProcess());
+    assert.equal(registerSchemesMock.mock.calls.length, 0);
+  });
+
+  it.effect("registers the packaged fork scheme during synchronous pre-ready setup", () =>
+    Effect.gen(function* () {
+      packagedState.value = true;
+      readFileMock.mockReturnValue(
+        '{"t3codeDesktopIdentity":{"appId":"com.t3tools.t3code.fork-abc","packageName":"t3code-fork-abc","productName":"T3 Code (Fork)","displayName":"T3 Code (Fork Alpha)","distributionName":"Fork","distributionId":"fork-abc"}}',
+      );
+      yield* DesktopPreReadyPlatform.DesktopPreReadyElectronOptions.pipe(
+        Effect.provide(DesktopPreReadyPlatform.layer),
+        Effect.provideService(HostProcessPlatform, "darwin"),
+      );
+      assert.deepEqual(readFileMock.mock.calls, [["/packaged-app/package.json", "utf8"]]);
+      assert.equal(registerSchemesMock.mock.calls.length, 1);
+      assert.deepInclude(registerSchemesMock.mock.calls[0]![0], {
+        scheme: "t3code-fork-abc",
+        privileges: {
+          standard: true,
+          secure: true,
+          supportFetchAPI: true,
+          corsEnabled: true,
+          stream: true,
+        },
+      });
+    }),
+  );
+
+  it.effect("uses the packaged distribution name for the Linux window class", () =>
+    Effect.gen(function* () {
+      packagedState.value = true;
+      readFileMock.mockReturnValue(
+        '{"t3codeDesktopIdentity":{"appId":"com.t3tools.t3code.fork-abc","packageName":"t3code-fork-abc","productName":"T3 Code (Fork)","displayName":"T3 Code (Fork Alpha)","distributionName":"Fork","distributionId":"fork-abc"}}',
+      );
+
+      yield* DesktopPreReadyPlatform.DesktopPreReadyElectronOptions.pipe(
+        Effect.provide(DesktopPreReadyPlatform.layer),
+        Effect.provideService(HostProcessPlatform, "linux"),
+      );
+
+      assert.deepEqual(appendSwitchMock.mock.calls[0], ["class", "t3code-fork-abc"]);
+      assert.deepEqual(setDesktopNameMock.mock.calls, [["t3code-fork-abc.desktop"]]);
+      assert.include(writeFileSyncMock.mock.calls[0]![0], "/t3code-fork-abc.desktop");
+      assert.include(
+        writeFileSyncMock.mock.calls[0]![1],
+        "MimeType=x-scheme-handler/t3code-fork-abc;",
+      );
+    }),
+  );
 
   for (const previousEntry of [undefined, 'Exec="/Applications/deleted-previous.AppImage" %U']) {
     it.effect(

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.ts
@@ -5,6 +5,13 @@ import * as NodePath from "node:path";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import {
+  DesktopPackageMetadata,
+  resolveDesktopRuntimeIdentity,
+  resolveDesktopUrlScheme,
+} from "@t3tools/shared/desktopBuild";
+import { isNightlyDesktopVersion } from "../updates/updateChannels.ts";
 
 import * as Electron from "electron";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
@@ -48,15 +55,59 @@ export class DesktopPreReadyElectronOptions extends Context.Service<
   }
 >()("@t3tools/desktop/app/DesktopPreReadyPlatform/DesktopPreReadyElectronOptions") {}
 
+const decodeEarlyDesktopPackageMetadata = Schema.decodeUnknownSync(
+  Schema.fromJsonString(DesktopPackageMetadata),
+);
+
+/** Reads packaged identity synchronously before Electron can emit ready. */
+function resolveEarlyDesktopIdentityFromProcess() {
+  // Identity must be known before any asynchronous runtime layer can let
+  // Electron become ready. Clerk later registers the same renderer scheme.
+  const packagedIdentity = Electron.app.isPackaged
+    ? decodeEarlyDesktopPackageMetadata(
+        NodeFS.readFileSync(NodePath.join(Electron.app.getAppPath(), "package.json"), "utf8"),
+      ).t3codeDesktopIdentity
+    : undefined;
+  return Electron.app.isPackaged
+    ? resolveDesktopRuntimeIdentity({
+        isDevelopment: false,
+        isPackaged: true,
+        stageLabel: isNightlyDesktopVersion(Electron.app.getVersion()) ? "Nightly" : "Alpha",
+        appName: Electron.app.getName(),
+        ...(packagedIdentity === undefined ? {} : { packagedIdentity }),
+      })
+    : null;
+}
+
+export function resolveEarlyDesktopSchemeFromProcess(): string | null {
+  const identity = resolveEarlyDesktopIdentityFromProcess();
+  return identity === null ? null : resolveDesktopUrlScheme(false, identity.distributionId);
+}
+
 /** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const platform = yield* HostProcessPlatform;
   return yield* Effect.sync((): DesktopPreReadyElectronOptions["Service"] => {
+    const identity = resolveEarlyDesktopIdentityFromProcess();
+    const distributionScheme =
+      identity === null ? null : resolveDesktopUrlScheme(false, identity.distributionId);
+    ElectronProtocol.registerDesktopSchemePrivilegesSync(
+      distributionScheme === null ? [] : [distributionScheme],
+    );
+
     const linuxPasswordStoreCommandLine =
       platform === "linux"
         ? readCommandLineSwitchValue(Electron.app.commandLine, "password-store")
         : null;
-    const linux = platform === "linux" ? resolveEarlyLinuxElectronOptionsFromProcess() : null;
+    const earlyLinux = platform === "linux" ? resolveEarlyLinuxElectronOptionsFromProcess() : null;
+    const linux =
+      earlyLinux !== null && identity?.distributionId != null
+        ? {
+            ...earlyLinux,
+            linuxDesktopEntryName: `${identity.packageName}.desktop`,
+            linuxWmClass: identity.packageName,
+          }
+        : earlyLinux;
 
     if (linux !== null) {
       // The portal also requires a valid desktop entry. An AppImage update may
@@ -71,12 +122,17 @@ export const make = Effect.gen(function* () {
         NodeFS.writeFileSync(
           NodePath.posix.join(applicationsDir, linux.linuxDesktopEntryName),
           renderUrlHandlerDesktopEntry({
-            displayName: resolveDesktopAppBranding({
-              isDevelopment: linux.isDevelopment,
-              appVersion: Electron.app.getVersion(),
-            }).displayName,
+            displayName:
+              identity?.displayName ??
+              resolveDesktopAppBranding({
+                isDevelopment: linux.isDevelopment,
+                appVersion: Electron.app.getVersion(),
+              }).displayName,
             execTarget: process.env.APPIMAGE?.trim() || process.execPath,
-            scheme: ElectronProtocol.getDesktopScheme(linux.isDevelopment),
+            scheme: ElectronProtocol.getDesktopScheme(
+              linux.isDevelopment,
+              identity?.distributionId ?? null,
+            ),
           }),
           "utf8",
         );
@@ -98,7 +154,4 @@ export const make = Effect.gen(function* () {
 
 // Keep Electron's strict pre-ready setup isolated so later runtime layers cannot
 // observe app readiness before scheme privileges and command-line switches exist.
-export const layer = Layer.mergeAll(
-  ElectronProtocol.layerSchemePrivileges,
-  Layer.effect(DesktopPreReadyElectronOptions, make),
-);
+export const layer = Layer.effect(DesktopPreReadyElectronOptions, make);

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -254,6 +254,7 @@ describe("DesktopServerExposure", () => {
       setServerExposureMode: () => Effect.fail(settingsFailure),
       setTailscaleServe: () => Effect.fail(settingsFailure),
       setUpdateChannel: () => Effect.die("unexpected update channel change"),
+      setUpdateRepository: () => Effect.die("unexpected update repository change"),
       setWslBackendEnabled: () => Effect.die("unexpected WSL backend toggle"),
       setWslDistro: () => Effect.die("unexpected WSL distro change"),
       setWslOnly: () => Effect.die("unexpected WSL-only toggle"),

--- a/apps/desktop/src/electron/ElectronApp.test.ts
+++ b/apps/desktop/src/electron/ElectronApp.test.ts
@@ -13,6 +13,7 @@ const {
   isDefaultProtocolClientMock,
   onMock,
   quitMock,
+  readFileMock,
   relaunchMock,
   removeListenerMock,
   removeSwitchMock,
@@ -35,6 +36,7 @@ const {
   isDefaultProtocolClientMock: vi.fn(() => false),
   onMock: vi.fn(),
   quitMock: vi.fn(),
+  readFileMock: vi.fn(() => '{"name":"t3code"}'),
   relaunchMock: vi.fn(),
   removeListenerMock: vi.fn(),
   removeSwitchMock: vi.fn(),
@@ -46,6 +48,10 @@ const {
   setNameMock: vi.fn(),
   setPathMock: vi.fn(),
   whenReadyMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: readFileMock,
 }));
 
 vi.mock("electron", () => ({
@@ -93,10 +99,18 @@ describe("ElectronApp", () => {
     exitMock.mockClear();
     onMock.mockClear();
     quitMock.mockClear();
+    readFileMock.mockClear();
+    readFileMock.mockReturnValue('{"name":"t3code"}');
     relaunchMock.mockClear();
     removeListenerMock.mockClear();
     removeSwitchMock.mockClear();
     setPathMock.mockClear();
+  });
+
+  it("resolves packaged metadata without yielding before Electron ready", () => {
+    // oxlint-disable-next-line t3code/no-manual-effect-runtime-in-tests -- This regression must reject asynchronous pre-ready initialization; it.effect would hide the Electron startup race.
+    const metadata = Effect.runSync(ElectronApp.make.metadata);
+    assert.equal(metadata.isPackaged, true);
   });
 
   it.effect("reads app metadata through the service", () =>
@@ -113,6 +127,63 @@ describe("ElectronApp", () => {
       });
     }).pipe(Effect.provide(ElectronApp.layer)),
   );
+
+  it.effect("reads the packaged desktop identity from package metadata", () => {
+    readFileMock.mockReturnValueOnce(
+      JSON.stringify({
+        t3codeDesktopIdentity: {
+          appId: "com.t3tools.t3code.fork",
+          packageName: "t3code-fork",
+          productName: "T3 Code (Fork Nightly)",
+          displayName: "T3 Code (Fork Nightly Nightly)",
+          distributionName: "Fork Nightly",
+          distributionId: "fork-nightly",
+        },
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const metadata = yield* electronApp.metadata;
+
+      assert.equal(metadata.packagedIdentity?.distributionName, "Fork Nightly");
+      assert.equal(metadata.packagedIdentity?.displayName, "T3 Code (Fork Nightly Nightly)");
+    }).pipe(Effect.provide(ElectronApp.layer));
+  });
+
+  it.effect("preserves the underlying package metadata read failure", () => {
+    const cause = new Error("manifest unavailable");
+    readFileMock.mockImplementationOnce(() => {
+      throw cause;
+    });
+
+    return Effect.gen(function* () {
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const error = yield* electronApp.metadata.pipe(Effect.flip);
+
+      assert.instanceOf(error, ElectronApp.ElectronAppMetadataReadError);
+      assert.equal(error.property, "package-metadata");
+      assert.strictEqual(error.cause, cause);
+    }).pipe(Effect.provide(ElectronApp.layer));
+  });
+
+  it.effect("rejects malformed packaged desktop identity metadata", () => {
+    readFileMock.mockReturnValueOnce(
+      JSON.stringify({
+        t3codeDesktopIdentity: {
+          appId: "",
+        },
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const error = yield* electronApp.metadata.pipe(Effect.flip);
+
+      assert.instanceOf(error, ElectronApp.ElectronAppMetadataReadError);
+      assert.equal(error.property, "package-metadata");
+    }).pipe(Effect.provide(ElectronApp.layer));
+  });
 
   it.effect("reads the OS locale through the service", () =>
     Effect.gen(function* () {

--- a/apps/desktop/src/electron/ElectronApp.ts
+++ b/apps/desktop/src/electron/ElectronApp.ts
@@ -1,8 +1,15 @@
+// @effect-diagnostics nodeBuiltinImport:off - This Electron adapter reads the packaged manifest before platform layers are available.
+import {
+  DesktopPackageMetadata,
+  type DesktopPackagedAppIdentity,
+} from "@t3tools/shared/desktopBuild";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
 
 import * as Electron from "electron";
 
@@ -12,12 +19,17 @@ export interface ElectronAppMetadata {
   readonly isPackaged: boolean;
   readonly resourcesPath: string;
   readonly runningUnderArm64Translation: boolean;
+  readonly packagedIdentity?: DesktopPackagedAppIdentity;
 }
+
+const decodeDesktopPackageMetadata = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(DesktopPackageMetadata),
+);
 
 export class ElectronAppMetadataReadError extends Schema.TaggedError<ElectronAppMetadataReadError>()(
   "ElectronAppMetadataReadError",
   {
-    property: Schema.Literals(["app-version", "app-path"]),
+    property: Schema.Literals(["app-version", "app-path", "package-metadata"]),
     cause: Schema.Defect(),
   },
 ) {
@@ -117,13 +129,36 @@ export const make = ElectronApp.of({
           cause,
         }),
     });
-
+    const packageMetadata = Electron.app.isPackaged
+      ? yield* Effect.try({
+          try: () => NodeFS.readFileSync(NodePath.join(appPath, "package.json"), "utf8"),
+          catch: (cause) =>
+            new ElectronAppMetadataReadError({
+              property: "package-metadata",
+              cause,
+            }),
+        })
+      : undefined;
+    const packagedIdentity =
+      packageMetadata === undefined
+        ? undefined
+        : yield* decodeDesktopPackageMetadata(packageMetadata).pipe(
+            Effect.map((metadata) => metadata.t3codeDesktopIdentity),
+            Effect.mapError(
+              (cause) =>
+                new ElectronAppMetadataReadError({
+                  property: "package-metadata",
+                  cause,
+                }),
+            ),
+          );
     return {
       appVersion,
       appPath,
       isPackaged: Electron.app.isPackaged,
       resourcesPath: process.resourcesPath,
       runningUnderArm64Translation: Electron.app.runningUnderARM64Translation === true,
+      ...(packagedIdentity === undefined ? {} : { packagedIdentity }),
     };
   }),
   name: Effect.sync(() => Electron.app.name),

--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -23,6 +23,13 @@ describe("ElectronProtocol", () => {
     unhandleMock.mockReset();
   });
 
+  it("derives renderer URLs from the explicit distribution identity", () => {
+    assert.equal(ElectronProtocol.getDesktopScheme(false, null), "t3code");
+    assert.equal(ElectronProtocol.getDesktopScheme(true, null), "t3code-dev");
+    assert.equal(ElectronProtocol.getDesktopScheme(false, "fork-abc"), "t3code-fork-abc");
+    assert.equal(ElectronProtocol.getDesktopUrl(false, "fork-abc"), "t3code-fork-abc://app/");
+  });
+
   it.effect("proxies the stable renderer origin to the current app server", () =>
     Effect.gen(function* () {
       let handler: ((request: Request) => Promise<Response>) | undefined;

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -1,3 +1,4 @@
+import { resolveDesktopUrlScheme } from "@t3tools/shared/desktopBuild";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -12,16 +13,16 @@ export const DESKTOP_HOST = "app";
 const DESKTOP_PRODUCTION_SCHEME = "t3code";
 const DESKTOP_DEVELOPMENT_SCHEME = "t3code-dev";
 
-export function getDesktopScheme(isDevelopment: boolean): string {
-  return isDevelopment ? DESKTOP_DEVELOPMENT_SCHEME : DESKTOP_PRODUCTION_SCHEME;
+export function getDesktopScheme(isDevelopment: boolean, distributionId: string | null): string {
+  return resolveDesktopUrlScheme(isDevelopment, distributionId);
 }
 
-function getDesktopOrigin(isDevelopment: boolean): string {
-  return `${getDesktopScheme(isDevelopment)}://${DESKTOP_HOST}`;
+function getDesktopOrigin(isDevelopment: boolean, distributionId: string | null): string {
+  return `${getDesktopScheme(isDevelopment, distributionId)}://${DESKTOP_HOST}`;
 }
 
-export function getDesktopUrl(isDevelopment: boolean): string {
-  return `${getDesktopOrigin(isDevelopment)}/`;
+export function getDesktopUrl(isDevelopment: boolean, distributionId: string | null): string {
+  return `${getDesktopOrigin(isDevelopment, distributionId)}/`;
 }
 
 export class ElectronProtocolRegistrationError extends Schema.TaggedError<ElectronProtocolRegistrationError>()(
@@ -109,36 +110,24 @@ function withContentSecurityPolicy(response: Response, policy: string): Response
 /**
  * Must run synchronously during process bootstrap, before Electron emits `ready`.
  */
-function registerDesktopSchemePrivilegesSync(): void {
-  Electron.protocol.registerSchemesAsPrivileged([
-    {
-      scheme: DESKTOP_PRODUCTION_SCHEME,
-      privileges: {
-        standard: true,
-        secure: true,
-        supportFetchAPI: true,
-        corsEnabled: true,
-        stream: true,
-      },
-    },
-    {
-      scheme: DESKTOP_DEVELOPMENT_SCHEME,
-      privileges: {
-        standard: true,
-        secure: true,
-        supportFetchAPI: true,
-        corsEnabled: true,
-        stream: true,
-      },
-    },
-  ]);
+export function registerDesktopSchemePrivilegesSync(
+  additionalSchemes: readonly string[] = [],
+): void {
+  Electron.protocol.registerSchemesAsPrivileged(
+    [...new Set([DESKTOP_PRODUCTION_SCHEME, DESKTOP_DEVELOPMENT_SCHEME, ...additionalSchemes])].map(
+      (scheme) => ({
+        scheme,
+        privileges: {
+          standard: true,
+          secure: true,
+          supportFetchAPI: true,
+          corsEnabled: true,
+          stream: true,
+        },
+      }),
+    ),
+  );
 }
-
-const registerDesktopSchemePrivileges = Effect.sync(registerDesktopSchemePrivilegesSync).pipe(
-  Effect.withSpan("desktop.electron.protocol.registerSchemePrivileges"),
-);
-
-export const layerSchemePrivileges = Layer.effectDiscard(registerDesktopSchemePrivileges);
 
 async function proxyRequest(
   request: Request,

--- a/apps/desktop/src/electron/ElectronUpdater.ts
+++ b/apps/desktop/src/electron/ElectronUpdater.ts
@@ -58,6 +58,7 @@ export type ElectronUpdaterError = typeof ElectronUpdaterError.Type;
 export class ElectronUpdater extends Context.Service<
   ElectronUpdater,
   {
+    readonly resetFeed: Effect.Effect<void>;
     readonly setFeedURL: (options: ElectronUpdaterFeedUrl) => Effect.Effect<void>;
     readonly setAutoDownload: (value: boolean) => Effect.Effect<void>;
     readonly setAutoInstallOnAppQuit: (value: boolean) => Effect.Effect<void>;
@@ -82,6 +83,9 @@ export class ElectronUpdater extends Context.Service<
 
 /** @public Service construction is part of the canonical Effect module API. */
 export const make = ElectronUpdater.of({
+  resetFeed: Effect.sync(() => {
+    autoUpdater.updateConfigPath = null;
+  }),
   setFeedURL: (options) =>
     Effect.suspend(() => {
       autoUpdater.setFeedURL(options);

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -30,6 +30,7 @@ import {
   getUpdateState,
   installUpdate,
   setUpdateChannel,
+  setUpdateRepository,
 } from "./methods/updates.ts";
 import {
   getAppBranding,
@@ -125,6 +126,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(probeRemoteEditors);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);
+  yield* ipc.handle(setUpdateRepository);
   yield* ipc.handle(downloadUpdate);
   yield* ipc.handle(installUpdate);
   yield* ipc.handle(checkForUpdate);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -17,6 +17,7 @@ export const DESKTOP_APP_ACTIVATION_REQUEST_CHANNEL = "desktop:app-activation-re
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 export const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";
+export const UPDATE_SET_REPOSITORY_CHANNEL = "desktop:update-set-repository";
 export const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 export const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 export const UPDATE_CHECK_CHANNEL = "desktop:update-check";

--- a/apps/desktop/src/ipc/methods/updates.ts
+++ b/apps/desktop/src/ipc/methods/updates.ts
@@ -2,6 +2,7 @@ import {
   DesktopUpdateActionResultSchema,
   DesktopUpdateChannelSchema,
   DesktopUpdateCheckResultSchema,
+  DesktopUpdateRepositorySchema,
   DesktopUpdateStateSchema,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
@@ -28,6 +29,16 @@ export const setUpdateChannel = DesktopIpc.makeIpcMethod({
   handler: Effect.fn("desktop.ipc.updates.setChannel")(function* (channel) {
     const updates = yield* DesktopUpdates.DesktopUpdates;
     return yield* updates.setChannel(channel);
+  }),
+});
+
+export const setUpdateRepository = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.UPDATE_SET_REPOSITORY_CHANNEL,
+  payload: DesktopUpdateRepositorySchema,
+  result: DesktopUpdateStateSchema,
+  handler: Effect.fn("desktop.ipc.updates.setRepository")(function* (repository) {
+    const updates = yield* DesktopUpdates.DesktopUpdates;
+    return yield* updates.setRepository(repository);
   }),
 });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -70,9 +70,9 @@ import * as DesktopWslServerTree from "./wsl/DesktopWslServerTree.ts";
 
 const desktopEnvironmentLayer = Layer.unwrap(
   Effect.gen(function* () {
-    const metadata = yield* Effect.service(ElectronApp.ElectronApp).pipe(
-      Effect.flatMap((app) => app.metadata),
-    );
+    const electronApp = yield* ElectronApp.ElectronApp;
+    const metadata = yield* electronApp.metadata;
+    const appName = yield* electronApp.name;
     const platform = yield* HostProcessPlatform;
     const processArch = yield* HostProcessArchitecture;
     return DesktopEnvironment.layer({
@@ -80,6 +80,7 @@ const desktopEnvironmentLayer = Layer.unwrap(
       homeDirectory: NodeOS.homedir(),
       platform,
       processArch,
+      appName,
       ...metadata,
     });
   }),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -214,6 +214,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   getUpdateState: () => ipcRenderer.invoke(IpcChannels.UPDATE_GET_STATE_CHANNEL),
   setUpdateChannel: (channel) =>
     ipcRenderer.invoke(IpcChannels.UPDATE_SET_CHANNEL_CHANNEL, channel),
+  setUpdateRepository: (repository) =>
+    ipcRenderer.invoke(IpcChannels.UPDATE_SET_REPOSITORY_CHANNEL, repository),
   checkForUpdate: () => ipcRenderer.invoke(IpcChannels.UPDATE_CHECK_CHANNEL),
   downloadUpdate: () => ipcRenderer.invoke(IpcChannels.UPDATE_DOWNLOAD_CHANNEL),
   installUpdate: () => ipcRenderer.invoke(IpcChannels.UPDATE_INSTALL_CHANNEL),

--- a/apps/desktop/src/settings/DesktopAppSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.test.ts
@@ -30,6 +30,7 @@ const DesktopSettingsPatch = Schema.Struct({
   tailscaleServePort: Schema.optionalKey(Schema.Number),
   updateChannel: Schema.optionalKey(Schema.Literals(["latest", "nightly"])),
   updateChannelConfiguredByUser: Schema.optionalKey(Schema.Boolean),
+  updateRepository: Schema.optionalKey(Schema.NullOr(Schema.String)),
   wslBackendEnabled: Schema.optionalKey(Schema.Boolean),
   wslMode: Schema.optionalKey(Schema.Literals(["local", "wsl"])),
   wslDistro: Schema.optionalKey(Schema.NullOr(Schema.String)),
@@ -113,6 +114,7 @@ describe("DesktopSettings", () => {
         tailscaleServePort: 443,
         updateChannel: "nightly",
         updateChannelConfiguredByUser: false,
+        updateRepository: null,
         wslBackendEnabled: false,
         wslOnly: false,
         wslDistro: null,
@@ -131,6 +133,7 @@ describe("DesktopSettings", () => {
           tailscaleServePort: 8443,
           updateChannel: "latest",
           updateChannelConfiguredByUser: true,
+          updateRepository: null,
         });
 
         assert.deepEqual(yield* settings.load, {
@@ -142,6 +145,7 @@ describe("DesktopSettings", () => {
           tailscaleServePort: 8443,
           updateChannel: "latest",
           updateChannelConfiguredByUser: true,
+          updateRepository: null,
           wslBackendEnabled: false,
           wslOnly: false,
           wslDistro: null,
@@ -208,6 +212,46 @@ describe("DesktopSettings", () => {
     ),
   );
 
+  it.effect("persists and normalizes a custom GitHub update repository", () =>
+    withSettings(
+      Effect.gen(function* () {
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+        yield* settings.setUpdateRepository("https://github.com/acme/t3code.git");
+
+        assert.equal((yield* settings.get).updateRepository, "acme/t3code");
+        assert.equal((yield* settings.get).updateChannel, "nightly");
+        assert.isTrue((yield* settings.get).updateChannelConfiguredByUser);
+        assert.equal((yield* settings.load).updateRepository, "acme/t3code");
+
+        yield* settings.setUpdateChannel("latest");
+        assert.equal((yield* settings.get).updateChannel, "latest");
+        assert.isNull((yield* settings.get).updateRepository);
+
+        yield* settings.setUpdateRepository("acme/t3code");
+        yield* settings.setUpdateRepository(null);
+        assert.isNull((yield* settings.get).updateRepository);
+      }),
+    ),
+  );
+
+  it.effect("migrates a persisted custom source to the Nightly release channel", () =>
+    withSettings(
+      Effect.gen(function* () {
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+        yield* writeSettingsPatch({
+          updateChannel: "latest",
+          updateChannelConfiguredByUser: true,
+          updateRepository: "acme/t3code",
+        });
+
+        const loaded = yield* settings.load;
+        assert.equal(loaded.updateRepository, "acme/t3code");
+        assert.equal(loaded.updateChannel, "nightly");
+        assert.isTrue(loaded.updateChannelConfiguredByUser);
+      }),
+    ),
+  );
+
   it.effect("falls back to defaults when the settings file is malformed", () =>
     withSettings(
       Effect.gen(function* () {
@@ -249,6 +293,7 @@ describe("DesktopSettings", () => {
           tailscaleServePort: 8443,
           updateChannel: "latest",
           updateChannelConfiguredByUser: false,
+          updateRepository: null,
           wslBackendEnabled: false,
           wslOnly: false,
           wslDistro: null,
@@ -305,6 +350,7 @@ describe("DesktopSettings", () => {
             tailscaleServePort: 8443,
             updateChannel: "nightly",
             updateChannelConfiguredByUser: true,
+            updateRepository: null,
             wslBackendEnabled: false,
             wslOnly: false,
             wslDistro: null,
@@ -353,6 +399,7 @@ describe("DesktopSettings", () => {
           tailscaleServePort: 443,
           updateChannel: "nightly",
           updateChannelConfiguredByUser: false,
+          updateRepository: null,
           wslBackendEnabled: false,
           wslOnly: false,
           wslDistro: null,
@@ -370,6 +417,7 @@ describe("DesktopSettings", () => {
           serverExposureMode: "local-only",
           updateChannel: "latest",
           updateChannelConfiguredByUser: true,
+          updateRepository: null,
         });
 
         assert.deepEqual(yield* settings.load, {
@@ -381,6 +429,7 @@ describe("DesktopSettings", () => {
           tailscaleServePort: 443,
           updateChannel: "latest",
           updateChannelConfiguredByUser: true,
+          updateRepository: null,
           wslBackendEnabled: false,
           wslOnly: false,
           wslDistro: null,
@@ -408,6 +457,7 @@ describe("DesktopSettings", () => {
           tailscaleServePort: 443,
           updateChannel: "latest",
           updateChannelConfiguredByUser: false,
+          updateRepository: null,
           wslBackendEnabled: false,
           wslOnly: false,
           wslDistro: null,

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -1,6 +1,8 @@
 import {
   DesktopServerExposureModeSchema,
   DesktopUpdateChannelSchema,
+  normalizeDesktopUpdateRepository,
+  type DesktopUpdateRepository,
   type DesktopServerExposureMode,
   type DesktopUpdateChannel,
 } from "@t3tools/contracts";
@@ -33,6 +35,7 @@ export interface DesktopSettings {
   readonly tailscaleServePort: number;
   readonly updateChannel: DesktopUpdateChannel;
   readonly updateChannelConfiguredByUser: boolean;
+  readonly updateRepository: DesktopUpdateRepository;
   // Was a "local" | "wsl" swap mode in an earlier iteration of the WSL
   // integration. We now run Windows and WSL backends side by side, so the
   // setting is just whether the WSL backend should be running alongside the
@@ -81,6 +84,7 @@ export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   tailscaleServePort: DEFAULT_TAILSCALE_SERVE_PORT,
   updateChannel: "latest",
   updateChannelConfiguredByUser: false,
+  updateRepository: null,
   wslBackendEnabled: false,
   wslDistro: null,
   wslOnly: false,
@@ -102,6 +106,7 @@ const DesktopSettingsDocument = Schema.Struct({
   tailscaleServePort: Schema.optionalKey(Schema.Number),
   updateChannel: Schema.optionalKey(DesktopUpdateChannelSchema),
   updateChannelConfiguredByUser: Schema.optionalKey(Schema.Boolean),
+  updateRepository: Schema.optionalKey(Schema.NullOr(Schema.String)),
   // Newer form of the WSL toggle. `wslMode` is still accepted on load so
   // existing on-disk settings keep working; on the next persist we write the
   // new boolean and the legacy key drops out.
@@ -166,6 +171,9 @@ export class DesktopAppSettings extends Context.Service<
     readonly setUpdateChannel: (
       channel: DesktopUpdateChannel,
     ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
+    readonly setUpdateRepository: (
+      repository: DesktopUpdateRepository,
+    ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
     readonly setWslBackendEnabled: (
       enabled: boolean,
     ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
@@ -211,8 +219,10 @@ function normalizeDesktopSettingsDocument(
   const defaultSettings = resolveDefaultDesktopSettings(appVersion);
   const mainWindowBounds = normalizeMainWindowBounds(parsed.mainWindowBounds);
   const parsedUpdateChannel = Option.fromNullishOr(parsed.updateChannel);
+  const updateRepository = normalizeDesktopUpdateRepository(parsed.updateRepository);
   const isLegacySettings = parsed.updateChannelConfiguredByUser === undefined;
   const updateChannelConfiguredByUser =
+    updateRepository !== null ||
     parsed.updateChannelConfiguredByUser === true ||
     (isLegacySettings && Option.contains(parsedUpdateChannel, "nightly"));
 
@@ -231,10 +241,14 @@ function normalizeDesktopSettingsDocument(
       parsed.serverExposureMode === "network-accessible" ? "network-accessible" : "local-only",
     tailscaleServeEnabled: parsed.tailscaleServeEnabled === true,
     tailscaleServePort: normalizeTailscaleServePort(parsed.tailscaleServePort),
-    updateChannel: updateChannelConfiguredByUser
-      ? Option.getOrElse(parsedUpdateChannel, () => defaultSettings.updateChannel)
-      : defaultSettings.updateChannel,
+    updateChannel:
+      updateRepository !== null
+        ? "nightly"
+        : updateChannelConfiguredByUser
+          ? Option.getOrElse(parsedUpdateChannel, () => defaultSettings.updateChannel)
+          : defaultSettings.updateChannel,
     updateChannelConfiguredByUser,
+    updateRepository,
     wslBackendEnabled,
     wslDistro: normalizeWslDistro(parsed.wslDistro),
     wslOnly: parsed.wslOnly === true,
@@ -270,6 +284,9 @@ function toDesktopSettingsDocument(
   }
   if (settings.updateChannelConfiguredByUser !== defaults.updateChannelConfiguredByUser) {
     document.updateChannelConfiguredByUser = settings.updateChannelConfiguredByUser;
+  }
+  if (settings.updateRepository !== defaults.updateRepository) {
+    document.updateRepository = settings.updateRepository;
   }
   if (settings.wslBackendEnabled !== defaults.wslBackendEnabled) {
     document.wslBackendEnabled = settings.wslBackendEnabled;
@@ -333,12 +350,33 @@ function setUpdateChannel(
   settings: DesktopSettings,
   requestedChannel: DesktopUpdateChannel,
 ): DesktopSettings {
-  return settings.updateChannel === requestedChannel
+  return settings.updateChannel === requestedChannel && settings.updateRepository === null
     ? settings
     : {
         ...settings,
         updateChannel: requestedChannel,
         updateChannelConfiguredByUser: true,
+        updateRepository: null,
+      };
+}
+
+function setUpdateRepository(
+  settings: DesktopSettings,
+  requestedRepository: DesktopUpdateRepository,
+): DesktopSettings {
+  const repository = normalizeDesktopUpdateRepository(requestedRepository);
+  const updateChannel = repository === null ? settings.updateChannel : "nightly";
+  const updateChannelConfiguredByUser =
+    repository === null ? settings.updateChannelConfiguredByUser : true;
+  return settings.updateRepository === repository &&
+    settings.updateChannel === updateChannel &&
+    settings.updateChannelConfiguredByUser === updateChannelConfiguredByUser
+    ? settings
+    : {
+        ...settings,
+        updateRepository: repository,
+        updateChannel,
+        updateChannelConfiguredByUser,
       };
 }
 
@@ -531,6 +569,12 @@ export const make = Effect.gen(function* () {
       persist((settings) => setUpdateChannel(settings, channel)).pipe(
         Effect.withSpan("desktop.settings.setUpdateChannel", { attributes: { channel } }),
       ),
+    setUpdateRepository: (repository) =>
+      persist((settings) => setUpdateRepository(settings, repository)).pipe(
+        Effect.withSpan("desktop.settings.setUpdateRepository", {
+          attributes: { repository: repository ?? "bundled" },
+        }),
+      ),
     setWslBackendEnabled: (enabled) =>
       persist((settings) => setWslBackendEnabled(settings, enabled)).pipe(
         Effect.withSpan("desktop.settings.setWslBackendEnabled", { attributes: { enabled } }),
@@ -582,6 +626,8 @@ export const layerTest = (initialSettings: DesktopSettings = DEFAULT_DESKTOP_SET
           update((settings) => setServerExposureMode(settings, mode)),
         setTailscaleServe: (input) => update((settings) => setTailscaleServe(settings, input)),
         setUpdateChannel: (channel) => update((settings) => setUpdateChannel(settings, channel)),
+        setUpdateRepository: (repository) =>
+          update((settings) => setUpdateRepository(settings, repository)),
         setWslBackendEnabled: (enabled) =>
           update((settings) => setWslBackendEnabled(settings, enabled)),
         setWslDistro: (distro) => update((settings) => setWslDistro(settings, distro)),

--- a/apps/desktop/src/telemetry/DesktopTelemetryPublisher.test.ts
+++ b/apps/desktop/src/telemetry/DesktopTelemetryPublisher.test.ts
@@ -429,6 +429,7 @@ describe("DesktopTelemetryPublisher", () => {
             enabled: true,
             status: "up-to-date",
             channel: "latest",
+            repository: null,
             currentVersion: "1.2.3",
             hostArch: "arm64",
             appArch: "arm64",

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -18,6 +18,15 @@ import * as DesktopState from "../app/DesktopState.ts";
 import * as DesktopUpdates from "./DesktopUpdates.ts";
 import { flushCallbacks, makeHarness } from "./updatesTestHarness.ts";
 
+const forkNightlyIdentity = {
+  appId: "com.t3tools.t3code.fork-nightly",
+  packageName: "t3code-fork-nightly",
+  productName: "T3 Code (Fork Nightly)",
+  displayName: "T3 Code (Fork Nightly Nightly)",
+  distributionName: "Fork Nightly",
+  distributionId: "fork-nightly",
+} as const;
+
 describe("DesktopUpdates", () => {
   it("preserves complete causes for update poller and event failures", () => {
     const cause = Cause.combine(
@@ -83,6 +92,89 @@ describe("DesktopUpdates", () => {
 
       assert.equal(harness.listenerCount(), 0);
     }).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("uses the Nightly release channel for a custom GitHub repository", () => {
+    const harness = makeHarness({
+      env: { T3CODE_DESKTOP_MOCK_UPDATES: "false" },
+      updateRepository: "acme/t3code",
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+
+        assert.deepEqual(harness.feedUrls(), [
+          {
+            provider: "github",
+            owner: "acme",
+            repo: "t3code",
+            releaseType: "prerelease",
+            channel: "nightly",
+          },
+        ]);
+        const state = yield* updates.getState;
+        assert.equal(state.repository, "acme/t3code");
+        assert.equal(state.channel, "nightly");
+
+        const bundled = yield* updates.setChannel("nightly");
+        assert.isNull(bundled.repository);
+        assert.isFalse(bundled.enabled);
+        assert.equal(harness.feedResets(), 1);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("enables a custom repository after starting without an update feed", () => {
+    const harness = makeHarness({
+      env: { T3CODE_DESKTOP_MOCK_UPDATES: "false" },
+      updateRepository: null,
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+
+        assert.isFalse((yield* updates.getState).enabled);
+        assert.equal(harness.listenerCount(), 6);
+
+        const enabled = yield* updates.setRepository("acme/t3code");
+        assert.isTrue(enabled.enabled);
+        assert.equal(enabled.repository, "acme/t3code");
+        assert.equal(enabled.channel, "nightly");
+        assert.equal(harness.listenerCount(), 6);
+        assert.equal(harness.checkCount(), 1);
+
+        const disabled = yield* updates.setRepository(null);
+        assert.isFalse(disabled.enabled);
+
+        yield* updates.setRepository("acme/other");
+        assert.equal(harness.listenerCount(), 6);
+        assert.equal(harness.checkCount(), 2);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("rejects malformed custom repositories without changing the source", () => {
+    const harness = makeHarness({
+      env: { T3CODE_DESKTOP_MOCK_UPDATES: "false" },
+      updateRepository: "acme/t3code",
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+
+        const error = yield* updates
+          .setRepository("https://example.com/releases")
+          .pipe(Effect.flip);
+        assert.instanceOf(error, DesktopUpdates.DesktopUpdateRepositoryError);
+        assert.equal((yield* updates.getState).repository, "acme/t3code");
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });
 
   it.effect("subscribe delivers the latest state plus subsequent changes", () => {
@@ -362,6 +454,154 @@ describe("DesktopUpdates", () => {
       ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
     }),
   );
+
+  it.effect("leaves window closure to the updater after shutdown is ready", () => {
+    const harness = makeHarness();
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+
+        assert.isTrue(result.accepted);
+        assert.equal(harness.stopBackendCount(), 1);
+        assert.equal(harness.destroyWindowCount(), 0);
+        assert.equal(harness.quitAndInstallCount(), 1);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("keeps the app open when its macOS bundle was renamed", () => {
+    const harness = makeHarness({
+      appPath: "/Applications/T3 Code (Fork Nightly).app/Contents/Resources/app.asar",
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const desktopState = yield* DesktopState.DesktopState;
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+
+        assert.isTrue(result.accepted);
+        assert.isFalse(result.completed);
+        assert.isFalse(yield* Ref.get(desktopState.quitting));
+        assert.equal(harness.stopBackendCount(), 0);
+        assert.equal(harness.destroyWindowCount(), 0);
+        assert.equal(harness.quitAndInstallCount(), 0);
+
+        const state = yield* updates.getState;
+        assert.equal(state.status, "downloaded");
+        assert.equal(state.errorContext, "install");
+        assert.equal(
+          state.message,
+          "This copy of T3 Code (Alpha) was renamed after installation. Reinstall it using the app name provided by its disk image before updating.",
+        );
+
+        const changedState = yield* updates.setChannel("nightly");
+        assert.equal(changedState.channel, "nightly");
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("allows a macOS update after switching packaged channels", () => {
+    const harness = makeHarness({
+      appName: "T3 Code (Nightly)",
+      appPath: "/Applications/T3 Code (Alpha).app/Contents/Resources/app.asar",
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+
+        assert.isTrue(result.accepted);
+        assert.equal(harness.stopBackendCount(), 1);
+        assert.equal(harness.quitAndInstallCount(), 1);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("does not strip a stage word from an explicit distribution name", () => {
+    const harness = makeHarness({
+      appName: "T3 Code (Fork Nightly Nightly)",
+      appPath: "/Applications/T3 Code (Fork Alpha).app/Contents/Resources/app.asar",
+      packagedIdentity: forkNightlyIdentity,
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const desktopState = yield* DesktopState.DesktopState;
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+
+        assert.isTrue(result.accepted);
+        assert.isFalse(yield* Ref.get(desktopState.quitting));
+        assert.equal(harness.stopBackendCount(), 0);
+        assert.equal(harness.quitAndInstallCount(), 0);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("allows staged bundles for an explicit distribution ending in a stage word", () => {
+    const harness = makeHarness({
+      appName: "T3 Code (Fork Nightly Nightly)",
+      appPath: "/Applications/T3 Code (Fork Nightly Alpha).app/Contents/Resources/app.asar",
+      packagedIdentity: forkNightlyIdentity,
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+
+        assert.isTrue(result.accepted);
+        assert.equal(harness.stopBackendCount(), 1);
+        assert.equal(harness.quitAndInstallCount(), 1);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("allows a downstream macOS update after switching packaged channels", () => {
+    const harness = makeHarness({
+      appName: "T3 Code (Fork Nightly)",
+      appPath: "/Applications/T3 Code (Fork Alpha).app/Contents/Resources/app.asar",
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+
+        assert.isTrue(result.accepted);
+        assert.equal(harness.stopBackendCount(), 1);
+        assert.equal(harness.quitAndInstallCount(), 1);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
 
   it.effect("keeps raw updater event failures out of update state", () => {
     const harness = makeHarness();
@@ -737,6 +977,40 @@ describe("DesktopUpdates", () => {
             assert.equal(error.action, "check");
             assert.equal(error.requestedChannel, "nightly");
           }
+
+          yield* Deferred.succeed(releaseCheck, undefined);
+          yield* Fiber.join(checkFiber);
+        }),
+      ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+    }),
+  );
+
+  it.effect("fails repository changes with repository context while a check is in progress", () =>
+    Effect.gen(function* () {
+      const checkStarted = yield* Deferred.make<void>();
+      const releaseCheck = yield* Deferred.make<void>();
+      const harness = makeHarness({
+        checkForUpdates: Deferred.succeed(checkStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseCheck)),
+        ),
+      });
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const updates = yield* DesktopUpdates.DesktopUpdates;
+          yield* updates.configure;
+
+          const checkFiber = yield* updates.check("manual").pipe(Effect.forkScoped);
+          yield* Deferred.await(checkStarted);
+
+          const error = yield* updates.setRepository("acme/t3code").pipe(Effect.flip);
+          assert.instanceOf(error, DesktopUpdates.DesktopUpdateRepositoryChangeInProgressError);
+          assert.equal(error.action, "check");
+          assert.equal(error.requestedRepository, "acme/t3code");
+          assert.equal(
+            error.message,
+            "Cannot change the desktop update source to acme/t3code while an update check action is in progress.",
+          );
 
           yield* Deferred.succeed(releaseCheck, undefined);
           yield* Fiber.join(checkFiber);

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -1,9 +1,11 @@
 import {
   DesktopUpdateChannelSchema,
+  normalizeDesktopUpdateRepository,
   type DesktopRuntimeInfo,
   type DesktopUpdateActionResult,
   type DesktopUpdateChannel,
   type DesktopUpdateCheckResult,
+  type DesktopUpdateRepository,
   type DesktopUpdateState,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -50,7 +52,13 @@ const AUTO_UPDATE_STARTUP_DELAY = "15 seconds";
 const AUTO_UPDATE_POLL_INTERVAL = "4 minutes";
 const PREPARED_INSTALL_CHECK_WAIT = Duration.seconds(90);
 
-type UpdateAction = "check" | "download" | "install" | "install-recovery" | "channel";
+type UpdateAction =
+  | "check"
+  | "download"
+  | "install"
+  | "install-recovery"
+  | "channel"
+  | "repository";
 
 interface DesktopPreparedUpdateInstallResult extends DesktopUpdateActionResult {
   readonly failed: boolean;
@@ -79,12 +87,25 @@ const currentIsoTimestamp = DateTime.now.pipe(Effect.map(DateTime.formatIso));
 export class DesktopUpdateActionInProgressError extends Schema.TaggedError<DesktopUpdateActionInProgressError>()(
   "DesktopUpdateActionInProgressError",
   {
-    action: Schema.Literals(["check", "download", "install", "channel"]),
+    action: Schema.Literals(["check", "download", "install", "channel", "repository"]),
     requestedChannel: DesktopUpdateChannelSchema,
   },
 ) {
   override get message(): string {
     return `Cannot change the desktop update channel to ${this.requestedChannel} while an update ${this.action} action is in progress.`;
+  }
+}
+
+export class DesktopUpdateRepositoryChangeInProgressError extends Schema.TaggedError<DesktopUpdateRepositoryChangeInProgressError>()(
+  "DesktopUpdateRepositoryChangeInProgressError",
+  {
+    action: Schema.Literals(["check", "download", "install", "channel", "repository"]),
+    requestedRepository: Schema.NullOr(Schema.String),
+  },
+) {
+  override get message(): string {
+    const repository = this.requestedRepository ?? "the bundled release source";
+    return `Cannot change the desktop update source to ${repository} while an update ${this.action} action is in progress.`;
   }
 }
 
@@ -97,6 +118,29 @@ export class DesktopUpdateChannelPersistenceError extends Schema.TaggedError<Des
 ) {
   override get message(): string {
     return `Failed to persist the ${this.channel} desktop update channel.`;
+  }
+}
+
+export class DesktopUpdateRepositoryError extends Schema.TaggedError<DesktopUpdateRepositoryError>()(
+  "DesktopUpdateRepositoryError",
+  {
+    repository: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Custom update repositories must use the GitHub owner/repository format: ${this.repository}.`;
+  }
+}
+
+export class DesktopUpdateRepositoryPersistenceError extends Schema.TaggedError<DesktopUpdateRepositoryPersistenceError>()(
+  "DesktopUpdateRepositoryPersistenceError",
+  {
+    repository: Schema.NullOr(Schema.String),
+    cause: Schema.instanceOf(DesktopAppSettings.DesktopSettingsWriteError),
+  },
+) {
+  override get message(): string {
+    return "Failed to persist the custom desktop update source.";
   }
 }
 
@@ -127,7 +171,14 @@ export class DesktopUpdateEventHandlingError extends Schema.TaggedError<DesktopU
 export class DesktopUpdaterReportedError extends Schema.TaggedError<DesktopUpdaterReportedError>()(
   "DesktopUpdaterReportedError",
   {
-    operation: Schema.Literals(["check", "download", "install", "channel", "background"]),
+    operation: Schema.Literals([
+      "check",
+      "download",
+      "install",
+      "channel",
+      "repository",
+      "background",
+    ]),
     cause: Schema.Defect(),
   },
 ) {
@@ -146,6 +197,44 @@ export class DesktopUpdateUnexpectedActionError extends Schema.TaggedError<Deskt
   override get message(): string {
     return `Desktop update ${this.action} action failed unexpectedly.`;
   }
+}
+
+export class DesktopUpdateRenamedMacAppError extends Schema.TaggedError<DesktopUpdateRenamedMacAppError>()(
+  "DesktopUpdateRenamedMacAppError",
+  {
+    expectedBundleName: Schema.String,
+    actualBundleName: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `This copy of ${this.expectedBundleName} was renamed after installation. Reinstall it using the app name provided by its disk image before updating.`;
+  }
+}
+
+function resolveMacAppBundleName(appPath: string): string | null {
+  const marker = ".app/Contents/";
+  const markerIndex = appPath.lastIndexOf(marker);
+  if (markerIndex < 0) return null;
+  const bundlePath = appPath.slice(0, markerIndex + ".app".length);
+  const separatorIndex = Math.max(bundlePath.lastIndexOf("/"), bundlePath.lastIndexOf("\\"));
+  return bundlePath.slice(separatorIndex + 1, -".app".length);
+}
+
+function isCompatibleMacAppBundleName(actualBundleName: string, expectedBundleName: string) {
+  if (actualBundleName === expectedBundleName) return true;
+  if (expectedBundleName === "T3 Code (Alpha)" || expectedBundleName === "T3 Code (Nightly)") {
+    return actualBundleName === "T3 Code (Alpha)" || actualBundleName === "T3 Code (Nightly)";
+  }
+
+  // Runtime identity normalizes legacy downstream names to their stable
+  // product name. Append a stage to that exact name instead of stripping a
+  // trailing word that may belong to the distribution itself.
+  const match = /^T3 Code \((.+)\)$/u.exec(expectedBundleName);
+  if (!match) return false;
+  return (
+    actualBundleName === `T3 Code (${match[1]} Alpha)` ||
+    actualBundleName === `T3 Code (${match[1]} Nightly)`
+  );
 }
 
 export type DesktopUpdateConfigureError = never;
@@ -180,6 +269,14 @@ export class DesktopUpdates extends Context.Service<
     readonly setChannel: (
       channel: DesktopUpdateChannel,
     ) => Effect.Effect<DesktopUpdateState, DesktopUpdateSetChannelError>;
+    readonly setRepository: (
+      repository: DesktopUpdateRepository,
+    ) => Effect.Effect<
+      DesktopUpdateState,
+      | DesktopUpdateRepositoryError
+      | DesktopUpdateRepositoryPersistenceError
+      | DesktopUpdateRepositoryChangeInProgressError
+    >;
     readonly check: (reason: string) => Effect.Effect<DesktopUpdateCheckResult>;
     readonly download: Effect.Effect<DesktopUpdateActionResult>;
     readonly install: Effect.Effect<DesktopUpdateActionResult>;
@@ -214,9 +311,15 @@ function createBaseUpdateState(
   channel: DesktopUpdateChannel,
   enabled: boolean,
   environment: DesktopEnvironment.DesktopEnvironment["Service"],
+  repository: DesktopUpdateRepository,
 ): DesktopUpdateState {
   return {
-    ...createInitialDesktopUpdateState(environment.appVersion, environment.runtimeInfo, channel),
+    ...createInitialDesktopUpdateState(
+      environment.appVersion,
+      environment.runtimeInfo,
+      channel,
+      repository,
+    ),
     enabled,
     status: enabled ? "idle" : "disabled",
   };
@@ -286,12 +389,14 @@ export const make = Effect.gen(function* () {
   const activeUpdateActionRef = yield* Ref.make<Option.Option<UpdateAction>>(Option.none());
   const finishedUpdateActions = yield* PubSub.unbounded<UpdateAction>();
   const updaterConfiguredRef = yield* Ref.make(false);
+  const updaterRuntimeInitializedRef = yield* Ref.make(false);
   const lastLoggedDownloadMilestoneRef = yield* Ref.make(-1);
   const updateStateRef = yield* Ref.make<DesktopUpdateState>(
     createInitialDesktopUpdateState(
       environment.appVersion,
       environment.runtimeInfo,
       environment.defaultDesktopSettings.updateChannel,
+      environment.defaultDesktopSettings.updateRepository,
     ),
   );
 
@@ -332,7 +437,16 @@ export const make = Effect.gen(function* () {
   );
 
   const hasUpdateFeedConfig = Ref.get(appUpdateYmlConfigRef).pipe(
-    Effect.map((appUpdateYmlConfig) => Option.isSome(appUpdateYmlConfig) || config.mockUpdates),
+    Effect.flatMap((appUpdateYmlConfig) =>
+      desktopSettings.get.pipe(
+        Effect.map(
+          (settings) =>
+            Option.isSome(appUpdateYmlConfig) ||
+            settings.updateRepository !== null ||
+            config.mockUpdates,
+        ),
+      ),
+    ),
   );
 
   const resolveDisabledReason = Effect.gen(function* () {
@@ -356,11 +470,12 @@ export const make = Effect.gen(function* () {
       Option.isSome(activeAction) ? [false, activeAction] : [true, Option.some(action)],
     );
 
-  const tryStartChannelChange = Ref.modify(activeUpdateActionRef, (activeAction) =>
-    Option.isSome(activeAction)
-      ? [activeAction, activeAction]
-      : [Option.none<UpdateAction>(), Option.some<UpdateAction>("channel")],
-  );
+  const tryStartSettingsChange = (action: "channel" | "repository") =>
+    Ref.modify(activeUpdateActionRef, (activeAction) =>
+      Option.isSome(activeAction)
+        ? [activeAction, activeAction]
+        : [Option.none<UpdateAction>(), Option.some<UpdateAction>(action)],
+    );
 
   const finishUpdateAction = (action: UpdateAction): Effect.Effect<void> =>
     Ref.modify(activeUpdateActionRef, (activeAction) => {
@@ -386,6 +501,27 @@ export const make = Effect.gen(function* () {
       allowPrerelease: allowsPrerelease,
       allowDowngrade: allowsPrerelease,
       fullChangelog: allowsPrerelease,
+    });
+  });
+
+  const applyAutoUpdaterFeed = Effect.fn("desktop.updates.applyAutoUpdaterFeed")(function* (
+    repository: DesktopUpdateRepository,
+    channel: DesktopUpdateChannel,
+  ) {
+    if (repository === null) {
+      yield* electronUpdater.resetFeed;
+    } else {
+      const [owner, repo] = repository.split("/");
+      yield* electronUpdater.setFeedURL({
+        provider: "github",
+        owner,
+        repo,
+        releaseType: channel === "nightly" ? "prerelease" : "release",
+        ...(channel === "nightly" ? { channel: "nightly" } : {}),
+      });
+    }
+    yield* logUpdaterInfo("using update repository", {
+      repository: repository ?? "bundled",
     });
   });
 
@@ -581,6 +717,29 @@ export const make = Effect.gen(function* () {
         }
         if (admission === "refused") {
           return { accepted: false, completed: false, failed: false };
+        }
+
+        if (environment.platform === "darwin" && environment.isPackaged) {
+          const actualBundleName = resolveMacAppBundleName(environment.appPath);
+          if (
+            actualBundleName !== null &&
+            !isCompatibleMacAppBundleName(actualBundleName, environment.productName)
+          ) {
+            const error = new DesktopUpdateRenamedMacAppError({
+              expectedBundleName: environment.productName,
+              actualBundleName,
+            });
+            yield* finishUpdateAction("install");
+            yield* updateState((current) =>
+              reduceDesktopUpdateStateOnInstallFailure(current, error.message),
+            );
+            yield* logUpdaterError(error.message, {
+              errorTag: error._tag,
+              expectedBundleName: error.expectedBundleName,
+              actualBundleName: error.actualBundleName,
+            });
+            return { accepted: true, completed: false, failed: true };
+          }
         }
 
         yield* Ref.set(desktopState.quitting, true);
@@ -845,57 +1004,15 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  return DesktopUpdates.of({
-    getState: Ref.get(updateStateRef),
-    isActionActive: activeUpdateAction.pipe(Effect.map(Option.isSome)),
-    isInstallActive: activeUpdateAction.pipe(
-      Effect.map((action) => Option.isSome(action) && action.value === "install"),
-    ),
-    subscribe: stateMutex.withPermits(1)(
-      Effect.gen(function* () {
-        const subscription = yield* PubSub.subscribe(stateChanges);
-        const latest = yield* Ref.get(updateStateRef);
-        return { latest, changes: Stream.fromSubscription(subscription) };
-      }),
-    ),
-    emitState,
-    disabledReason: resolveDisabledReason,
-    configure: Effect.gen(function* () {
+  const initializeAutoUpdaterRuntime = Effect.fn("desktop.updates.initializeAutoUpdaterRuntime")(
+    function* () {
+      if (yield* Ref.get(updaterRuntimeInitializedRef)) {
+        return;
+      }
       const context = yield* Effect.context<never>();
       const runEffect = (effect: Effect.Effect<void>) => {
         void Effect.runPromiseWith(context)(effect);
       };
-
-      const appUpdateYmlConfig = yield* readAppUpdateYml;
-      yield* Ref.set(appUpdateYmlConfigRef, appUpdateYmlConfig);
-
-      if (config.mockUpdates) {
-        yield* electronUpdater.setFeedURL({
-          provider: "generic",
-          url: `http://localhost:${config.mockUpdateServerPort}`,
-        } as ElectronUpdater.ElectronUpdaterFeedUrl);
-      }
-
-      const settings = yield* desktopSettings.get;
-      const enabled = yield* shouldEnableAutoUpdates;
-      yield* setState(createBaseUpdateState(settings.updateChannel, enabled, environment));
-      if (!enabled) {
-        return;
-      }
-      yield* Ref.set(updaterConfiguredRef, true);
-
-      yield* electronUpdater.setAutoDownload(false);
-      yield* electronUpdater.setAutoInstallOnAppQuit(false);
-      yield* applyAutoUpdaterChannel(settings.updateChannel);
-      yield* electronUpdater.setDisableDifferentialDownload(
-        isArm64HostRunningIntelBuild(environment.runtimeInfo),
-      );
-
-      if (isArm64HostRunningIntelBuild(environment.runtimeInfo)) {
-        yield* logUpdaterInfo(
-          "Apple Silicon host detected while running Intel build; updates will switch to arm64 packages",
-        );
-      }
 
       yield* electronUpdater.on("checking-for-update", () => {
         runEffect(
@@ -920,13 +1037,80 @@ export const make = Effect.gen(function* () {
         runEffect(handleUpdateDownloaded(info));
       });
 
+      yield* Ref.set(updaterRuntimeInitializedRef, true);
       yield* startUpdatePollers;
+    },
+  );
+
+  const enableAutoUpdater = Effect.fn("desktop.updates.enableAutoUpdater")(function* (
+    repository: DesktopUpdateRepository,
+    channel: DesktopUpdateChannel,
+  ) {
+    if (config.mockUpdates) {
+      yield* electronUpdater.setFeedURL({
+        provider: "generic",
+        url: `http://localhost:${config.mockUpdateServerPort}`,
+      } as ElectronUpdater.ElectronUpdaterFeedUrl);
+    }
+
+    yield* electronUpdater.setAutoDownload(false);
+    yield* electronUpdater.setAutoInstallOnAppQuit(false);
+    if (!config.mockUpdates) {
+      yield* applyAutoUpdaterFeed(repository, channel);
+    }
+    yield* applyAutoUpdaterChannel(channel);
+    yield* electronUpdater.setDisableDifferentialDownload(
+      isArm64HostRunningIntelBuild(environment.runtimeInfo),
+    );
+    yield* Ref.set(updaterConfiguredRef, true);
+
+    if (isArm64HostRunningIntelBuild(environment.runtimeInfo)) {
+      yield* logUpdaterInfo(
+        "Apple Silicon host detected while running Intel build; updates will switch to arm64 packages",
+      );
+    }
+  });
+
+  return DesktopUpdates.of({
+    getState: Ref.get(updateStateRef),
+    isActionActive: activeUpdateAction.pipe(Effect.map(Option.isSome)),
+    isInstallActive: activeUpdateAction.pipe(
+      Effect.map((action) => Option.isSome(action) && action.value === "install"),
+    ),
+    subscribe: stateMutex.withPermits(1)(
+      Effect.gen(function* () {
+        const subscription = yield* PubSub.subscribe(stateChanges);
+        const latest = yield* Ref.get(updateStateRef);
+        return { latest, changes: Stream.fromSubscription(subscription) };
+      }),
+    ),
+    emitState,
+    disabledReason: resolveDisabledReason,
+    configure: Effect.gen(function* () {
+      const appUpdateYmlConfig = yield* readAppUpdateYml;
+      yield* Ref.set(appUpdateYmlConfigRef, appUpdateYmlConfig);
+
+      const settings = yield* desktopSettings.get;
+      const enabled = yield* shouldEnableAutoUpdates;
+      yield* setState(
+        createBaseUpdateState(
+          settings.updateChannel,
+          enabled,
+          environment,
+          settings.updateRepository,
+        ),
+      );
+      yield* initializeAutoUpdaterRuntime();
+      if (!enabled) {
+        return;
+      }
+      yield* enableAutoUpdater(settings.updateRepository, settings.updateChannel);
     }).pipe(Effect.withSpan("desktop.updates.configure")),
     setChannel: Effect.fn("desktop.updates.setChannel")(function* (
       nextChannel: DesktopUpdateChannel,
     ) {
       yield* Effect.annotateCurrentSpan({ channel: nextChannel });
-      const activeAction = yield* tryStartChannelChange;
+      const activeAction = yield* tryStartSettingsChange("channel");
       if (Option.isSome(activeAction)) {
         return yield* new DesktopUpdateActionInProgressError({
           action: activeAction.value === "install-recovery" ? "install" : activeAction.value,
@@ -936,7 +1120,7 @@ export const make = Effect.gen(function* () {
 
       return yield* Effect.gen(function* () {
         const state = yield* Ref.get(updateStateRef);
-        if (nextChannel === state.channel) {
+        if (nextChannel === state.channel && state.repository === null) {
           return state;
         }
 
@@ -949,12 +1133,24 @@ export const make = Effect.gen(function* () {
           );
 
         const enabled = yield* shouldEnableAutoUpdates;
-        yield* setState(createBaseUpdateState(nextChannel, enabled, environment));
+        const settings = yield* desktopSettings.get;
+        yield* setState(
+          createBaseUpdateState(nextChannel, enabled, environment, settings.updateRepository),
+        );
 
-        if (!enabled || !(yield* Ref.get(updaterConfiguredRef))) {
+        if (!enabled) {
+          if (!config.mockUpdates) yield* electronUpdater.resetFeed;
+          yield* Ref.set(updaterConfiguredRef, false);
           return yield* Ref.get(updateStateRef);
         }
 
+        if (!(yield* Ref.get(updaterConfiguredRef))) {
+          return yield* Ref.get(updateStateRef);
+        }
+
+        if (!config.mockUpdates) {
+          yield* applyAutoUpdaterFeed(settings.updateRepository, nextChannel);
+        }
         yield* applyAutoUpdaterChannel(nextChannel);
         const allowDowngrade = yield* electronUpdater.allowDowngrade;
         yield* electronUpdater.setAllowDowngrade(true);
@@ -963,6 +1159,64 @@ export const make = Effect.gen(function* () {
         );
         return yield* Ref.get(updateStateRef);
       }).pipe(Effect.ensuring(finishUpdateAction("channel")));
+    }),
+    setRepository: Effect.fn("desktop.updates.setRepository")(function* (
+      nextRepository: DesktopUpdateRepository,
+    ) {
+      const normalizedRepository =
+        nextRepository === null ? null : normalizeDesktopUpdateRepository(nextRepository);
+      if (nextRepository !== null && normalizedRepository === null) {
+        return yield* new DesktopUpdateRepositoryError({ repository: nextRepository });
+      }
+
+      const activeAction = yield* tryStartSettingsChange("repository");
+      if (Option.isSome(activeAction)) {
+        return yield* new DesktopUpdateRepositoryChangeInProgressError({
+          action: activeAction.value === "install-recovery" ? "install" : activeAction.value,
+          requestedRepository: normalizedRepository,
+        });
+      }
+
+      return yield* Effect.gen(function* () {
+        const state = yield* Ref.get(updateStateRef);
+        if (state.repository === normalizedRepository) {
+          return state;
+        }
+
+        const settingsChange = yield* desktopSettings
+          .setUpdateRepository(normalizedRepository)
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new DesktopUpdateRepositoryPersistenceError({
+                  repository: normalizedRepository,
+                  cause,
+                }),
+            ),
+          );
+        const enabled = yield* shouldEnableAutoUpdates;
+        yield* setState(
+          createBaseUpdateState(
+            settingsChange.settings.updateChannel,
+            enabled,
+            environment,
+            settingsChange.settings.updateRepository,
+          ),
+        );
+
+        if (!enabled) {
+          if (!config.mockUpdates) yield* electronUpdater.resetFeed;
+          yield* Ref.set(updaterConfiguredRef, false);
+          return yield* Ref.get(updateStateRef);
+        }
+
+        yield* enableAutoUpdater(
+          settingsChange.settings.updateRepository,
+          settingsChange.settings.updateChannel,
+        );
+        yield* checkForUpdates("repository-change", "held");
+        return yield* Ref.get(updateStateRef);
+      }).pipe(Effect.ensuring(finishUpdateAction("repository")));
     }),
     check: Effect.fn("desktop.updates.check")(function* (reason: string) {
       yield* Effect.annotateCurrentSpan({ reason });

--- a/apps/desktop/src/updates/remoteUpdateFlow.test.ts
+++ b/apps/desktop/src/updates/remoteUpdateFlow.test.ts
@@ -16,6 +16,7 @@ function makeState(overrides: Partial<DesktopUpdateState> = {}): DesktopUpdateSt
     enabled: true,
     status: "idle",
     channel: "latest",
+    repository: null,
     currentVersion: "1.2.3",
     hostArch: "arm64",
     appArch: "arm64",

--- a/apps/desktop/src/updates/updateMachine.ts
+++ b/apps/desktop/src/updates/updateMachine.ts
@@ -1,6 +1,7 @@
 import type {
   DesktopRuntimeInfo,
   DesktopUpdateChannel,
+  DesktopUpdateRepository,
   DesktopUpdateReleaseNote,
   DesktopUpdateState,
 } from "@t3tools/contracts";
@@ -19,11 +20,13 @@ export function createInitialDesktopUpdateState(
   currentVersion: string,
   runtimeInfo: DesktopRuntimeInfo,
   channel: DesktopUpdateChannel,
+  repository: DesktopUpdateRepository = null,
 ): DesktopUpdateState {
   return {
     enabled: false,
     status: "disabled",
     channel,
+    repository,
     currentVersion,
     hostArch: runtimeInfo.hostArch,
     appArch: runtimeInfo.appArch,

--- a/apps/desktop/src/updates/updatesTestHarness.ts
+++ b/apps/desktop/src/updates/updatesTestHarness.ts
@@ -1,5 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { DesktopUpdateState } from "@t3tools/contracts";
+import type { DesktopPackagedAppIdentity } from "@t3tools/shared/desktopBuild";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -32,14 +33,21 @@ export interface UpdatesHarnessOptions {
   readonly stopBackend?: Effect.Effect<void>;
   readonly startBackend?: Effect.Effect<void>;
   readonly env?: Record<string, string | undefined>;
+  readonly updateRepository?: string | null;
+  readonly appPath?: string;
+  readonly appName?: string;
+  readonly packagedIdentity?: DesktopPackagedAppIdentity;
 }
 
 export function makeHarness(options: UpdatesHarnessOptions = {}) {
   let checkCount = 0;
   let quitAndInstallCount = 0;
   let downloadCount = 0;
+  let destroyWindowCount = 0;
+  let stopBackendCount = 0;
   let allowDowngrade = false;
   let fullChangelog = false;
+  let feedResets = 0;
   const feedUrls: ElectronUpdater.ElectronUpdaterFeedUrl[] = [];
   const listeners = new Map<string, Set<(...args: readonly unknown[]) => void>>();
   const sentStates: DesktopUpdateState[] = [];
@@ -63,6 +71,9 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
   };
 
   const updaterLayer = Layer.succeed(ElectronUpdater.ElectronUpdater, {
+    resetFeed: Effect.sync(() => {
+      feedResets += 1;
+    }),
     setFeedURL: (options) =>
       Effect.sync(() => {
         feedUrls.push(options);
@@ -118,6 +129,7 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
         sentStates.push(state as DesktopUpdateState);
       }),
     destroyAll: Effect.sync(() => {
+      destroyWindowCount += 1;
       installSteps.push("destroyAll");
     }),
     syncAllAppearance: () => Effect.void,
@@ -129,7 +141,10 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
     start: Effect.sync(() => {
       installSteps.push("startBackend");
     }).pipe(Effect.andThen(options.startBackend ?? Effect.void)),
-    stop: () => options.stopBackend ?? Effect.void,
+    stop: () =>
+      Effect.sync(() => {
+        stopBackendCount += 1;
+      }).pipe(Effect.andThen(options.stopBackend ?? Effect.void)),
     currentConfig: Effect.succeed(Option.none()),
     snapshot: Effect.succeed({
       desiredRunning: false,
@@ -148,7 +163,11 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
     platform: "darwin",
     processArch: "x64",
     appVersion: "1.2.3",
-    appPath: "/repo",
+    appName: options.appName ?? "T3 Code (Alpha)",
+    ...(options.packagedIdentity === undefined
+      ? {}
+      : { packagedIdentity: options.packagedIdentity }),
+    appPath: options.appPath ?? "/repo",
     isPackaged: true,
     resourcesPath: "/missing/resources",
     runningUnderArm64Translation: false,
@@ -168,10 +187,14 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
 
   let testSettings: DesktopAppSettings.DesktopSettings = {
     ...DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS,
+    updateRepository: options.updateRepository ?? null,
+    ...(options.updateRepository ? { updateChannel: "nightly" } : {}),
   };
   const setUpdateChannelError = options.setUpdateChannelError;
   const settingsLayer =
-    setUpdateChannelError || options.beforeSetUpdateChannel
+    setUpdateChannelError ||
+    options.beforeSetUpdateChannel ||
+    options.updateRepository !== undefined
       ? Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
           get: Effect.sync(() => testSettings),
           load: Effect.sync(() => testSettings),
@@ -184,16 +207,31 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
               : (options.beforeSetUpdateChannel ?? Effect.void).pipe(
                   Effect.andThen(
                     Effect.sync(() => {
-                      const changed = testSettings.updateChannel !== channel;
+                      const changed =
+                        testSettings.updateChannel !== channel ||
+                        testSettings.updateRepository !== null;
                       testSettings = {
                         ...testSettings,
                         updateChannel: channel,
                         updateChannelConfiguredByUser: true,
+                        updateRepository: null,
                       };
                       return { settings: testSettings, changed };
                     }),
                   ),
                 ),
+          setUpdateRepository: (repository) =>
+            Effect.sync(() => {
+              const changed = testSettings.updateRepository !== repository;
+              testSettings = {
+                ...testSettings,
+                updateChannel: repository === null ? testSettings.updateChannel : "nightly",
+                updateChannelConfiguredByUser:
+                  repository === null ? testSettings.updateChannelConfiguredByUser : true,
+                updateRepository: repository,
+              };
+              return { settings: testSettings, changed };
+            }),
           setWslBackendEnabled: () => Effect.die("unexpected WSL backend toggle"),
           setWslDistro: () => Effect.die("unexpected WSL distro change"),
           setWslOnly: () => Effect.die("unexpected WSL-only toggle"),
@@ -224,9 +262,13 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
     layer,
     checkCount: () => checkCount,
     quitAndInstalls: () => quitAndInstallCount,
+    quitAndInstallCount: () => quitAndInstallCount,
+    destroyWindowCount: () => destroyWindowCount,
+    stopBackendCount: () => stopBackendCount,
     installSteps,
     downloadCount: () => downloadCount,
     feedUrls: () => feedUrls,
+    feedResets: () => feedResets,
     fullChangelog: () => fullChangelog,
     listenerCount: () =>
       Array.from(listeners.values()).reduce(

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -67,6 +67,7 @@ const desktopUpdatesLayer = Layer.succeed(DesktopUpdates.DesktopUpdates, {
   disabledReason: Effect.succeed(Option.none()),
   configure: Effect.void,
   setChannel: () => Effect.die("unexpected setChannel"),
+  setRepository: () => Effect.die("unexpected setRepository"),
   check: () => Effect.die("unexpected check"),
   download: Effect.die("unexpected download"),
   install: Effect.die("unexpected install"),

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -250,6 +250,7 @@ function makeTestLayer(input: {
     setServerExposureMode: () => Effect.die("unexpected server exposure update"),
     setTailscaleServe: () => Effect.die("unexpected Tailscale Serve update"),
     setUpdateChannel: () => Effect.die("unexpected update channel change"),
+    setUpdateRepository: () => Effect.die("unexpected update repository change"),
     setWslBackendEnabled: () => Effect.die("unexpected WSL backend toggle"),
     setWslDistro: () => Effect.die("unexpected WSL distro change"),
     setWslOnly: () => Effect.die("unexpected WSL-only toggle"),

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -347,7 +347,7 @@ export const make = Effect.gen(function* () {
     DesktopWindowError
   > {
     yield* previewManager.getBrowserSession();
-    const applicationUrl = getDesktopUrl(environment.isDevelopment);
+    const applicationUrl = getDesktopUrl(environment.isDevelopment, environment.distributionId);
     const iconPaths = yield* assets.iconPaths;
     const iconOption = getIconOption(iconPaths, environment.platform);
     const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;

--- a/apps/server/src/desktopUpdate/DesktopAppUpdate.test.ts
+++ b/apps/server/src/desktopUpdate/DesktopAppUpdate.test.ts
@@ -18,6 +18,7 @@ function makeState(overrides: Partial<DesktopUpdateState> = {}): DesktopUpdateSt
     enabled: true,
     status: "idle",
     channel: "latest",
+    repository: null,
     currentVersion: "1.2.3",
     hostArch: "arm64",
     appArch: "arm64",

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -19,6 +19,7 @@ const baseState: DesktopUpdateState = {
   enabled: true,
   status: "idle",
   channel: "latest",
+  repository: null,
   currentVersion: "1.0.0",
   hostArch: "x64",
   appArch: "x64",
@@ -192,6 +193,12 @@ describe("desktop update UI helpers", () => {
     );
   });
 
+  it("uses a custom repository for release notes", () => {
+    expect(getDesktopUpdateReleaseUrl("0.0.30-nightly.20260728.931", "acme/t3code")).toBe(
+      "https://github.com/acme/t3code/releases/tag/v0.0.30-nightly.20260728.931",
+    );
+  });
+
   it("omits the release URL when the updater does not report a version", () => {
     expect(getDesktopUpdateReleaseUrl(null)).toBeNull();
     expect(getDesktopUpdateReleaseUrl("  ")).toBeNull();
@@ -200,6 +207,9 @@ describe("desktop update UI helpers", () => {
   it("builds the release history URL", () => {
     expect(getDesktopUpdateReleaseHistoryUrl()).toBe(
       "https://github.com/pingdotgg/t3code/releases",
+    );
+    expect(getDesktopUpdateReleaseHistoryUrl("acme/t3code")).toBe(
+      "https://github.com/acme/t3code/releases",
     );
   });
 

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -2,8 +2,8 @@ import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/con
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
+const DEFAULT_DESKTOP_RELEASE_REPOSITORY = "pingdotgg/t3code";
 const DESKTOP_RELEASE_HISTORY_URL = "https://github.com/pingdotgg/t3code/releases";
-const DESKTOP_RELEASE_TAG_URL = `${DESKTOP_RELEASE_HISTORY_URL}/tag`;
 
 /**
  * The main process fills `downloadedVersion` from the updater's `update-downloaded`
@@ -15,14 +15,21 @@ export function getDesktopUpdateDownloadedVersion(state: DesktopUpdateState): st
 }
 
 /** Release notes for an exact downloaded build; nightly suffixes are part of the tag. */
-export function getDesktopUpdateReleaseUrl(version: string | null): string | null {
+export function getDesktopUpdateReleaseUrl(
+  version: string | null,
+  repository: string | null = null,
+): string | null {
   const normalizedVersion = version?.trim();
   if (!normalizedVersion) return null;
-  return `${DESKTOP_RELEASE_TAG_URL}/v${encodeURIComponent(normalizedVersion)}`;
+  const releaseRepository = repository?.trim() || DEFAULT_DESKTOP_RELEASE_REPOSITORY;
+  return `https://github.com/${releaseRepository}/releases/tag/v${encodeURIComponent(normalizedVersion)}`;
 }
 
-export function getDesktopUpdateReleaseHistoryUrl(): string {
-  return DESKTOP_RELEASE_HISTORY_URL;
+export function getDesktopUpdateReleaseHistoryUrl(repository: string | null = null): string {
+  const releaseRepository = repository?.trim();
+  return releaseRepository
+    ? `https://github.com/${releaseRepository}/releases`
+    : DESKTOP_RELEASE_HISTORY_URL;
 }
 
 export function resolveDesktopUpdateButtonAction(

--- a/apps/web/src/components/desktopUpdate.toast.test.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.test.tsx
@@ -43,6 +43,7 @@ function downloadedState(overrides: Partial<DesktopUpdateState> = {}): DesktopUp
     enabled: true,
     status: "downloaded",
     channel: "latest",
+    repository: null,
     currentVersion: "0.0.29",
     hostArch: "arm64",
     appArch: "arm64",

--- a/apps/web/src/components/desktopUpdate.toast.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.tsx
@@ -50,7 +50,10 @@ export function showDesktopUpdateDownloadedToast(
   shell: DesktopUpdateShell,
   state: DesktopUpdateState,
 ): void {
-  const releaseUrl = getDesktopUpdateReleaseUrl(getDesktopUpdateDownloadedVersion(state));
+  const releaseUrl = getDesktopUpdateReleaseUrl(
+    getDesktopUpdateDownloadedVersion(state),
+    state.repository,
+  );
   toastManager.add({
     type: "success",
     title: "Update downloaded",

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -38,7 +38,7 @@ describe("desktop update repository input", () => {
 
 describe("desktop update track", () => {
   it("shows Custom for persisted and in-progress custom source selection", () => {
-    expect(resolveDesktopUpdateTrack("nightly", "saphid/t3code")).toBe("custom");
+    expect(resolveDesktopUpdateTrack("nightly", "example/t3code")).toBe("custom");
     expect(resolveDesktopUpdateTrack("latest", null, true)).toBe("custom");
   });
 

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -17,8 +17,70 @@ import {
   hasChangedBackgroundActivitySettings,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
+  parseDesktopUpdateRepositoryInput,
   resolveBackgroundActivityProfileOption,
+  resolveDesktopUpdateTrack,
+  setDesktopUpdateChannelAfterPendingRepositoryChange,
 } from "./SettingsPanels.logic";
+
+describe("desktop update repository input", () => {
+  it("uses an empty value to restore the bundled release source", () => {
+    expect(parseDesktopUpdateRepositoryInput("   ")).toBeNull();
+  });
+
+  it("normalizes valid repositories and rejects malformed non-empty values", () => {
+    expect(parseDesktopUpdateRepositoryInput(" https://github.com/acme/t3code.git ")).toBe(
+      "acme/t3code",
+    );
+    expect(parseDesktopUpdateRepositoryInput("not a repository")).toBeUndefined();
+  });
+});
+
+describe("desktop update track", () => {
+  it("shows Custom for persisted and in-progress custom source selection", () => {
+    expect(resolveDesktopUpdateTrack("nightly", "saphid/t3code")).toBe("custom");
+    expect(resolveDesktopUpdateTrack("latest", null, true)).toBe("custom");
+  });
+
+  it("shows the release channel when no custom source is selected", () => {
+    expect(resolveDesktopUpdateTrack("latest", null)).toBe("latest");
+    expect(resolveDesktopUpdateTrack("nightly", null)).toBe("nightly");
+  });
+
+  it("waits for a source-field blur commit before changing tracks", async () => {
+    let resolveRepositoryChange: (() => void) | undefined;
+    const pendingRepositoryChange = new Promise<void>((resolve) => {
+      resolveRepositoryChange = resolve;
+    });
+    const calls: string[] = [];
+
+    const change = setDesktopUpdateChannelAfterPendingRepositoryChange({
+      channel: "latest",
+      pendingRepositoryChange,
+      setUpdateChannel: async (channel) => {
+        calls.push(channel);
+      },
+    });
+
+    await Promise.resolve();
+    expect(calls).toEqual([]);
+    resolveRepositoryChange?.();
+    await change;
+    expect(calls).toEqual(["latest"]);
+  });
+
+  it("still changes tracks when the pending source commit fails", async () => {
+    const calls: string[] = [];
+    await setDesktopUpdateChannelAfterPendingRepositoryChange({
+      channel: "nightly",
+      pendingRepositoryChange: Promise.reject(new Error("invalid source")),
+      setUpdateChannel: async (channel) => {
+        calls.push(channel);
+      },
+    });
+    expect(calls).toEqual(["nightly"]);
+  });
+});
 
 describe("typography settings restore", () => {
   it("detects family and size changes by font row", () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,6 +1,9 @@
+import { normalizeDesktopUpdateRepository } from "@t3tools/contracts";
 import type {
   BackgroundActivityProfile,
   BackgroundActivitySettings,
+  DesktopUpdateChannel,
+  DesktopUpdateRepository,
   ProviderDriverKind,
   ProviderInstanceConfig,
   PreviewViewportSetting,
@@ -18,6 +21,33 @@ import {
 } from "@t3tools/shared/backgroundActivitySettings";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
+
+export type DesktopUpdateTrack = DesktopUpdateChannel | "custom";
+
+/** Empty restores the bundled source; malformed non-empty values stay invalid. */
+export function parseDesktopUpdateRepositoryInput(
+  value: string,
+): DesktopUpdateRepository | undefined {
+  if (value.trim().length === 0) return null;
+  return normalizeDesktopUpdateRepository(value) ?? undefined;
+}
+
+export function resolveDesktopUpdateTrack(
+  channel: DesktopUpdateChannel,
+  repository: DesktopUpdateRepository,
+  isCustomDraftSelected = false,
+): DesktopUpdateTrack {
+  return repository !== null || isCustomDraftSelected ? "custom" : channel;
+}
+
+export async function setDesktopUpdateChannelAfterPendingRepositoryChange(input: {
+  readonly channel: DesktopUpdateChannel;
+  readonly pendingRepositoryChange: Promise<unknown> | null;
+  readonly setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<unknown>;
+}): Promise<void> {
+  await input.pendingRepositoryChange?.catch(() => undefined);
+  await input.setUpdateChannel(input.channel);
+}
 
 export function isProjectGroupingEnabled(mode: SidebarProjectGroupingMode): boolean {
   return mode !== "separate";

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import {
   type BackgroundActivityProfile,
-  type DesktopUpdateChannel,
   ProviderDriverKind,
   type ProviderInstanceId,
   type ScopedThreadRef,
@@ -133,6 +132,7 @@ import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ThemeLibrary } from "./ThemeSettings";
 import {
+  type DesktopUpdateTrack,
   backgroundActivityOverrideSettings,
   backgroundActivitySharedPolicySettings,
   durationToSeconds,
@@ -147,6 +147,9 @@ import {
   readLastEnabledProjectGroupingMode,
   rememberEnabledProjectGroupingMode,
   resolveBackgroundActivityProfileOption,
+  resolveDesktopUpdateTrack,
+  parseDesktopUpdateRepositoryInput,
+  setDesktopUpdateChannelAfterPendingRepositoryChange,
 } from "./SettingsPanels.logic";
 import {
   PolicyTooltip,
@@ -249,26 +252,50 @@ function AboutVersionTitle() {
 function AboutVersionSection() {
   const updateState = useDesktopUpdateState();
   const [isChangingUpdateChannel, setIsChangingUpdateChannel] = useState(false);
+  const [isChangingUpdateRepository, setIsChangingUpdateRepository] = useState(false);
+  const [draftUpdateTrack, setDraftUpdateTrack] = useState<DesktopUpdateTrack | null>(null);
   const [isUpdateActionPending, setIsUpdateActionPending] = useState(false);
+  // Clicking the selector blurs the source input first. Keep those updater IPC calls ordered.
+  const pendingRepositoryChangeRef = useRef<Promise<unknown> | null>(null);
+  const queuedUpdateTrackRef = useRef<DesktopUpdateTrack | null>(null);
 
   const hasDesktopBridge = typeof window !== "undefined" && Boolean(window.desktopBridge);
   const selectedUpdateChannel = updateState?.channel ?? "latest";
+  const selectedUpdateRepository = updateState?.repository ?? null;
+  const selectedUpdateTrack =
+    draftUpdateTrack ?? resolveDesktopUpdateTrack(selectedUpdateChannel, selectedUpdateRepository);
   const selectedHostedAppChannel = hasDesktopBridge ? null : HOSTED_APP_CHANNEL;
 
-  const handleUpdateChannelChange = useCallback(
-    (channel: DesktopUpdateChannel) => {
-      const bridge = window.desktopBridge;
-      if (
-        !bridge ||
-        typeof bridge.setUpdateChannel !== "function" ||
-        channel === selectedUpdateChannel
-      ) {
+  const handleUpdateTrackChange = useCallback(
+    (track: DesktopUpdateTrack) => {
+      if (track === "custom") {
+        queuedUpdateTrackRef.current = null;
+        setDraftUpdateTrack("custom");
         return;
       }
 
+      const bridge = window.desktopBridge;
+      if (!bridge || typeof bridge.setUpdateChannel !== "function") {
+        return;
+      }
+      const pendingRepositoryChange = pendingRepositoryChangeRef.current;
+      if (
+        track === selectedUpdateChannel &&
+        selectedUpdateRepository === null &&
+        pendingRepositoryChange === null
+      ) {
+        setDraftUpdateTrack(null);
+        return;
+      }
+
+      queuedUpdateTrackRef.current = track;
+      setDraftUpdateTrack(track);
       setIsChangingUpdateChannel(true);
-      void bridge
-        .setUpdateChannel(channel)
+      void setDesktopUpdateChannelAfterPendingRepositoryChange({
+        channel: track,
+        pendingRepositoryChange,
+        setUpdateChannel: bridge.setUpdateChannel,
+      })
         .catch((error: unknown) => {
           toastManager.add(
             stackedThreadToast({
@@ -279,10 +306,58 @@ function AboutVersionSection() {
           );
         })
         .finally(() => {
+          queuedUpdateTrackRef.current = null;
           setIsChangingUpdateChannel(false);
+          setDraftUpdateTrack(null);
         });
     },
-    [selectedUpdateChannel],
+    [selectedUpdateChannel, selectedUpdateRepository],
+  );
+
+  const handleUpdateRepositoryChange = useCallback(
+    (value: string) => {
+      const bridge = window.desktopBridge;
+      if (!bridge || typeof bridge.setUpdateRepository !== "function") return;
+
+      const repository = parseDesktopUpdateRepositoryInput(value);
+      if (repository === undefined) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Enter a GitHub release source",
+            description: "Use a public GitHub repository URL or owner/repository.",
+          }),
+        );
+        return;
+      }
+      if (repository === selectedUpdateRepository) return;
+
+      setIsChangingUpdateRepository(true);
+      const repositoryChange = bridge.setUpdateRepository(repository);
+      pendingRepositoryChangeRef.current = repositoryChange;
+      void repositoryChange
+        .then(() => {
+          if (queuedUpdateTrackRef.current === null) {
+            setDraftUpdateTrack(null);
+          }
+        })
+        .catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not change update source",
+              description: error instanceof Error ? error.message : "Update source change failed.",
+            }),
+          );
+        })
+        .finally(() => {
+          if (pendingRepositoryChangeRef.current === repositoryChange) {
+            pendingRepositoryChangeRef.current = null;
+          }
+          setIsChangingUpdateRepository(false);
+        });
+    },
+    [selectedUpdateRepository],
   );
 
   const handleButtonClick = useCallback(async () => {
@@ -414,37 +489,65 @@ function AboutVersionSection() {
         }
       />
       {hasDesktopBridge ? (
-        <SettingsRow
-          title="Update track"
-          description="Use stable releases or nightly builds. Switch back anytime."
-          control={
-            <Select
-              value={selectedUpdateChannel}
-              onValueChange={(value) => {
-                handleUpdateChannelChange(value as DesktopUpdateChannel);
-              }}
-            >
-              <SelectTrigger
-                size="sm"
-                className="w-full sm:w-40"
-                aria-label="Update track"
-                disabled={isChangingUpdateChannel}
+        <>
+          <SettingsRow
+            title="Update track"
+            description="Stable follows full releases. Nightly follows T3 Code prereleases. Custom follows Nightly releases from another public GitHub repository."
+            control={
+              <Select
+                value={selectedUpdateTrack}
+                onValueChange={(value) => {
+                  handleUpdateTrackChange(value as DesktopUpdateTrack);
+                }}
               >
-                <SelectValue>
-                  {selectedUpdateChannel === "nightly" ? "Nightly" : "Stable"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value="latest">
-                  Stable
-                </SelectItem>
-                <SelectItem hideIndicator value="nightly">
-                  Nightly
-                </SelectItem>
-              </SelectPopup>
-            </Select>
-          }
-        />
+                <SelectTrigger
+                  size="sm"
+                  className="w-full sm:w-40"
+                  aria-label="Update track"
+                  disabled={isChangingUpdateChannel || isChangingUpdateRepository}
+                >
+                  <SelectValue>
+                    {selectedUpdateTrack === "custom"
+                      ? "Custom"
+                      : selectedUpdateTrack === "nightly"
+                        ? "Nightly"
+                        : "Stable"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="latest">
+                    Stable
+                  </SelectItem>
+                  <SelectItem hideIndicator value="nightly">
+                    Nightly
+                  </SelectItem>
+                  <SelectItem hideIndicator value="custom">
+                    Custom
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            }
+          />
+          {selectedUpdateTrack === "custom" ? (
+            <SettingsRow
+              title="Release source"
+              description="Required for Custom. Paste a public GitHub repository URL or owner/repository."
+              control={
+                <DraftInput
+                  size="sm"
+                  autoFocus={draftUpdateTrack === "custom"}
+                  className="w-full sm:w-72"
+                  aria-label="Custom release source"
+                  placeholder="https://github.com/owner/repository"
+                  spellCheck={false}
+                  value={selectedUpdateRepository ?? ""}
+                  disabled={isChangingUpdateRepository || isChangingUpdateChannel}
+                  onCommit={handleUpdateRepositoryChange}
+                />
+              }
+            />
+          ) : null}
+        </>
       ) : selectedHostedAppChannel ? (
         <SettingsRow
           title="Update track"

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
@@ -11,6 +11,7 @@ const nightlyState: DesktopUpdateState = {
   enabled: true,
   status: "available",
   channel: "nightly",
+  repository: null,
   currentVersion: "0.0.35",
   hostArch: "arm64",
   appArch: "arm64",

--- a/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.test.tsx
@@ -22,6 +22,7 @@ const baseState: DesktopUpdateState = {
   enabled: true,
   status: "available",
   channel: "nightly",
+  repository: null,
   currentVersion: "0.0.35",
   hostArch: "arm64",
   appArch: "arm64",

--- a/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
@@ -76,7 +76,7 @@ export function SidebarUpdateReleaseNotes({
       </div>
       <div className="min-h-0 max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
         {state.releaseNotes.map((releaseNote, index) => {
-          const releaseUrl = getDesktopUpdateReleaseUrl(releaseNote.version);
+          const releaseUrl = getDesktopUpdateReleaseUrl(releaseNote.version, state.repository);
           const omittedItemCount = Math.max(0, releaseNote.totalItems - releaseNote.items.length);
           const linkLabel =
             omittedItemCount === 0
@@ -109,7 +109,10 @@ export function SidebarUpdateReleaseNotes({
         {state.omittedReleaseCount > 0 ? (
           <div>
             <Separator className="my-3 bg-border/60" />
-            <ReleaseLink releaseUrl={getDesktopUpdateReleaseHistoryUrl()} shell={shell}>
+            <ReleaseLink
+              releaseUrl={getDesktopUpdateReleaseHistoryUrl(state.repository)}
+              shell={shell}
+            >
               {`${state.omittedReleaseCount} older ${state.omittedReleaseCount === 1 ? "release" : "releases"} on GitHub`}
             </ReleaseLink>
           </div>

--- a/apps/web/src/state/desktopUpdate.test.ts
+++ b/apps/web/src/state/desktopUpdate.test.ts
@@ -9,6 +9,7 @@ const baseState: DesktopUpdateState = {
   enabled: true,
   status: "idle",
   channel: "latest",
+  repository: null,
   currentVersion: "1.0.0",
   hostArch: "x64",
   appArch: "x64",

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -230,6 +230,41 @@ available.
 - Repository slug source:
   - `T3CODE_DESKTOP_UPDATE_REPOSITORY` (format `owner/repo`), if set.
   - otherwise `GITHUB_REPOSITORY` from GitHub Actions.
+
+### Custom desktop release sources
+
+Packaged desktop builds can use a custom GitHub repository as their update source. In the About
+panel, select the desired update track and enter the repository as `owner/repository` in
+**Release source**. Leaving the field empty restores the repository bundled into the build.
+
+Custom is a Nightly-only source: setting a custom repository switches the update channel to
+Nightly and reads its prereleases. Stable uses the bundled official source. A downstream Nightly
+builder can therefore merge selected
+pull requests onto upstream `main`, publish compatible Nightly artifacts in its own repository,
+and have installed clients follow that repository without changing the upstream release channel.
+
+The custom source is persisted in the shared `~/.t3/userdata` state directory, so side-by-side
+installations can affect one another; it is restricted to GitHub repositories.
+The custom repository must publish the same platform artifact names and updater metadata as the
+standard release workflow. The updater does not verify that a custom repository is maintained by
+T3 Tools, so this setting should only be used with a release source you control.
+
+Downstream builds that coexist with an upstream installation must set
+`T3CODE_DESKTOP_DISTRIBUTION` while building every artifact. For example, `Fork` produces the
+stable product name `T3 Code (Fork)`, the stage-aware About label `T3 Code (Fork Nightly)`, and
+bundle/package identities with a bounded `fork-<sha256>` suffix. The digest keeps distinct labels
+from sharing an update identity without expanding filesystem names. Keep the distribution value
+stable across releases and install the first downstream build manually. Do not rename the `.app`
+bundle after installing it. The desktop checks that its bundle path is canonical for the same
+distribution and either packaged channel before it stops backends or asks the native updater to
+quit.
+
+Downstream branding also isolates Electron's browser profile and encrypted connection catalog. The
+downstream app still shares `~/.t3` projects, threads, settings, and backend data with the upstream
+app, but it does not open the upstream app's live Chromium profile or attempt to decrypt its saved
+remote-environment credentials with a different macOS safe-storage key. Remote environments must
+therefore be added separately in each distribution.
+
 - Required release assets for updater:
   - platform installers (`.exe`, `.dmg`, `.AppImage`, plus macOS `.zip` for Squirrel.Mac update payloads)
   - channel metadata: `latest*.yml` for stable releases, `nightly*.yml` for nightly releases

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -21,6 +21,23 @@ interrupted, and threads without saved provider resume state need a new message.
 If you previously enabled continuation for updates, enable this setting once
 to allow recovery without a connected client.
 
+## Choose a desktop update track
+
+In the desktop app, open **Settings** → **General** and find **Update track** in the About section.
+
+- **Stable** follows full T3 Code releases.
+- **Nightly** follows T3 Code prereleases.
+- **Custom** follows Nightly prereleases from another public GitHub repository. Paste the
+  repository URL or its `owner/repository` name in **Release source**.
+
+Selecting Stable or Nightly clears the custom source. A source-code branch is not an installable
+update feed by itself. Its automation must publish the desktop manifests and installers as GitHub
+Release assets, then Custom can follow that repository.
+
+On macOS, keep the application name supplied by its disk image. Renaming the `.app` bundle breaks
+the native updater's replacement target. T3 Code detects that mismatch before shutdown and keeps
+the app open with recovery instructions.
+
 ## Update a connected server
 
 The offered action depends on how the server runs:

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -1,7 +1,12 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { DesktopEnvironmentBootstrapSchema } from "./ipc.ts";
+import {
+  DesktopEnvironmentBootstrapSchema,
+  DesktopUpdateStateSchema,
+  isValidDesktopUpdateRepository,
+  normalizeDesktopUpdateRepository,
+} from "./ipc.ts";
 
 describe("DesktopEnvironmentBootstrapSchema", () => {
   const decode = Schema.decodeUnknownSync(DesktopEnvironmentBootstrapSchema);
@@ -34,5 +39,51 @@ describe("DesktopEnvironmentBootstrapSchema", () => {
         wsBaseUrl: null,
       }).runningDistro,
     ).toBeNull();
+  });
+});
+
+describe("desktop update repository", () => {
+  it("normalizes GitHub URLs to owner/repository", () => {
+    expect(normalizeDesktopUpdateRepository("HTTPS://GITHUB.COM/acme/t3code")).toBe("acme/t3code");
+    expect(normalizeDesktopUpdateRepository(" https://github.com/acme/t3code.git ")).toBe(
+      "acme/t3code",
+    );
+  });
+
+  it.each(["", "acme", "acme/t3code/releases", "https://example.com/acme/t3code"])(
+    "rejects non-GitHub repository %j",
+    (repository) => {
+      expect(normalizeDesktopUpdateRepository(repository)).toBeNull();
+      expect(isValidDesktopUpdateRepository(repository)).toBe(false);
+    },
+  );
+});
+
+const decodeDesktopUpdateState = Schema.decodeUnknownSync(DesktopUpdateStateSchema);
+
+describe("desktop update status compatibility", () => {
+  it("accepts protocol-v1 update state without a repository", () => {
+    const state = decodeDesktopUpdateState({
+      enabled: true,
+      status: "idle",
+      channel: "latest",
+      currentVersion: "1.2.3",
+      hostArch: "arm64",
+      appArch: "arm64",
+      runningUnderArm64Translation: false,
+      availableVersion: null,
+      downloadedVersion: null,
+      releaseNotes: [],
+      omittedReleaseCount: 0,
+      downloadPercent: null,
+      checkedAt: null,
+      message: null,
+      errorContext: null,
+      canRetry: false,
+    });
+    expect(state.repository).toBeNull();
+    expect(decodeDesktopUpdateState({ ...state, repository: "fork/releases" }).repository).toBe(
+      "fork/releases",
+    );
   });
 });

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -49,6 +49,7 @@ import type {
   TerminalWriteInput,
 } from "./terminal.ts";
 import * as Schema from "effect/Schema";
+import * as Effect from "effect/Effect";
 import type {
   DiscoveredLocalServerList,
   PreviewCloseInput,
@@ -170,6 +171,7 @@ export type DesktopUpdateStatus =
 export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
 export type DesktopUpdateChannel = "latest" | "nightly";
+export type DesktopUpdateRepository = string | null;
 export type DesktopAppStageLabel = "Alpha" | "Dev" | "Nightly";
 
 export const DesktopUpdateStatusSchema = Schema.Literals([
@@ -185,7 +187,39 @@ export const DesktopUpdateStatusSchema = Schema.Literals([
 export const DesktopRuntimeArchSchema = Schema.Literals(["arm64", "x64", "other"]);
 export const DesktopThemeSchema = Schema.Literals(["light", "dark", "system"]);
 export const DesktopUpdateChannelSchema = Schema.Literals(["latest", "nightly"]);
+export const DesktopUpdateRepositorySchema = Schema.NullOr(Schema.String);
 export const DesktopAppStageLabelSchema = Schema.Literals(["Alpha", "Dev", "Nightly"]);
+
+const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+$/;
+
+/**
+ * Normalize the GitHub repository accepted by the desktop update feed.
+ * Custom update sources intentionally stay on GitHub so electron-updater can
+ * retain its release and artifact handling without accepting arbitrary URLs.
+ */
+export function normalizeDesktopUpdateRepository(value: unknown): DesktopUpdateRepository {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  let repository = trimmed;
+  if (/^https:\/\/github\.com\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      if (url.hostname !== "github.com" || url.search || url.hash) return null;
+      repository = url.pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/, "");
+    } catch {
+      return null;
+    }
+  }
+
+  return GITHUB_REPOSITORY_PATTERN.test(repository) ? repository : null;
+}
+
+export function isValidDesktopUpdateRepository(value: unknown): value is string {
+  return normalizeDesktopUpdateRepository(value) !== null;
+}
 
 export interface DesktopAppBranding {
   baseName: string;
@@ -360,6 +394,7 @@ export interface DesktopUpdateState {
   enabled: boolean;
   status: DesktopUpdateStatus;
   channel: DesktopUpdateChannel;
+  repository: DesktopUpdateRepository;
   currentVersion: string;
   hostArch: DesktopRuntimeArch;
   appArch: DesktopRuntimeArch;
@@ -391,6 +426,7 @@ export const DesktopUpdateStateSchema = Schema.Struct({
   enabled: Schema.Boolean,
   status: DesktopUpdateStatusSchema,
   channel: DesktopUpdateChannelSchema,
+  repository: DesktopUpdateRepositorySchema.pipe(Schema.withDecodingDefault(Effect.succeed(null))),
   currentVersion: Schema.String,
   hostArch: DesktopRuntimeArchSchema,
   appArch: DesktopRuntimeArchSchema,
@@ -1318,6 +1354,7 @@ export interface DesktopBridge {
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
+  setUpdateRepository: (repository: DesktopUpdateRepository) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;
   downloadUpdate: () => Promise<DesktopUpdateActionResult>;
   installUpdate: () => Promise<DesktopUpdateActionResult>;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -271,6 +271,10 @@
       "types": "./src/desktopAppControl.ts",
       "import": "./src/desktopAppControl.ts"
     },
+    "./desktopBuild": {
+      "types": "./src/desktopBuild.ts",
+      "import": "./src/desktopBuild.ts"
+    },
     "./claudeCompaction": {
       "types": "./src/claudeCompaction.ts",
       "import": "./src/claudeCompaction.ts"

--- a/packages/shared/src/desktopBuild.ts
+++ b/packages/shared/src/desktopBuild.ts
@@ -1,0 +1,87 @@
+import type { DesktopAppStageLabel } from "@t3tools/contracts";
+import { TrimmedNonEmptyString } from "@t3tools/contracts";
+import { sha256 } from "@noble/hashes/sha2.js";
+import * as Schema from "effect/Schema";
+
+const APP_BASE_NAME = "T3 Code";
+
+/** Identity embedded in a packaged desktop app by the artifact builder. */
+export const DesktopPackagedAppIdentity = Schema.Struct({
+  appId: TrimmedNonEmptyString,
+  packageName: TrimmedNonEmptyString,
+  productName: TrimmedNonEmptyString,
+  displayName: TrimmedNonEmptyString,
+  distributionName: Schema.NullOr(TrimmedNonEmptyString),
+  distributionId: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type DesktopPackagedAppIdentity = typeof DesktopPackagedAppIdentity.Type;
+
+/** Build metadata read by Electron before desktop runtime layers are created. */
+export const DesktopPackageMetadata = Schema.Struct({
+  t3codeDesktopIdentity: Schema.optional(DesktopPackagedAppIdentity),
+});
+
+function distributionIdFromName(name: string): string {
+  const readable = name
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9-]/gu, "-")
+    .slice(0, 24);
+  const digest = Array.from(sha256(new TextEncoder().encode(name)), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return `${readable}-${digest}`;
+}
+
+/** Resolve runtime identity, preferring the exact identity embedded by new builds. */
+export function resolveDesktopRuntimeIdentity(input: {
+  readonly isDevelopment: boolean;
+  readonly isPackaged: boolean;
+  readonly stageLabel: DesktopAppStageLabel;
+  readonly appName?: string;
+  readonly packagedIdentity?: DesktopPackagedAppIdentity;
+}): DesktopPackagedAppIdentity {
+  const officialDisplayName = `${APP_BASE_NAME} (${input.stageLabel})`;
+  const runtimeName =
+    input.isPackaged && input.appName?.trim() ? input.appName.trim() : officialDisplayName;
+  if (input.isPackaged && input.packagedIdentity !== undefined) {
+    return input.packagedIdentity;
+  }
+  if (!input.isPackaged || runtimeName === APP_BASE_NAME || runtimeName === officialDisplayName) {
+    return {
+      appId: input.isDevelopment ? "com.t3tools.t3code.dev" : "com.t3tools.t3code",
+      packageName: input.isDevelopment ? "t3code-dev" : "t3code",
+      productName: runtimeName,
+      displayName: runtimeName,
+      distributionName: null,
+      distributionId: null,
+    };
+  }
+
+  // Compatibility for packages produced before the embedded identity existed.
+  const legacyMatch = /^T3 Code \((.+) (?:Alpha|Nightly)\)$/u.exec(runtimeName);
+  const stableMatch = /^T3 Code \((.+)\)$/u.exec(runtimeName);
+  const distributionName = legacyMatch?.[1] ?? stableMatch?.[1] ?? runtimeName;
+  const distributionId = distributionIdFromName(distributionName);
+  const productName = legacyMatch || stableMatch ? `T3 Code (${distributionName})` : runtimeName;
+  return {
+    appId: `com.t3tools.t3code.${distributionId}`,
+    packageName: `t3code-${distributionId}`,
+    productName,
+    displayName: legacyMatch
+      ? runtimeName
+      : stableMatch
+        ? `T3 Code (${distributionName} ${input.stageLabel})`
+        : runtimeName,
+    distributionName,
+    distributionId,
+  };
+}
+
+/** URL scheme owned by one desktop distribution across release tracks. */
+export function resolveDesktopUrlScheme(
+  isDevelopment: boolean,
+  distributionId: string | null,
+): string {
+  if (distributionId) return `t3code-${distributionId}`;
+  return isDevelopment ? "t3code-dev" : "t3code";
+}

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -14,6 +14,8 @@ import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
+import { resolveDesktopRuntimeIdentity } from "@t3tools/shared/desktopBuild";
+
 import {
   BundleNotSelfContainedError,
   BuildCommandFailedError,
@@ -31,6 +33,7 @@ import {
   MAC_FILE_EXCLUSIONS,
   InvalidMacPasskeyRpDomainError,
   InvalidMacPasskeyPublishableKeyError,
+  InvalidDesktopDistributionError,
   InvalidMockUpdateServerPortError,
   UnsupportedDesktopBuildArchitectureError,
   isMacPasskeySigningConfigurationError,
@@ -51,6 +54,7 @@ import {
   resolveFffNativeDependencies,
   resolveBuildOptions,
   resolveDesktopBuildIconAssets,
+  resolveDesktopBuildIdentity,
   resolveDesktopProductName,
   resolveDesktopUpdateChannel,
   resolveDesktopWebAssetBrand,
@@ -267,6 +271,161 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     assert.equal(resolveDesktopProductName("0.0.17"), "T3 Code (Alpha)");
     assert.equal(resolveDesktopProductName("0.0.17-nightly.20260413.42"), "T3 Code (Nightly)");
   });
+
+  it.effect("derives an isolated identity for a downstream Nightly distribution", () =>
+    Effect.gen(function* () {
+      assert.deepStrictEqual(
+        yield* resolveDesktopBuildIdentity("0.0.17-nightly.20260413.42", " Fork "),
+        {
+          appId:
+            "com.t3tools.t3code.fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45",
+          packageName:
+            "t3code-fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45",
+          productName: "T3 Code (Fork)",
+          displayName: "T3 Code (Fork Nightly)",
+          distributionName: "Fork",
+          distributionId: "fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45",
+        },
+      );
+    }),
+  );
+
+  it.effect("carries suffix-bearing distribution identities into the desktop runtime", () =>
+    Effect.gen(function* () {
+      for (const distributionName of ["Fork Alpha", "Fork Nightly"] as const) {
+        const buildIdentity = yield* resolveDesktopBuildIdentity(
+          "0.0.17-nightly.20260413.42",
+          distributionName,
+        );
+        const runtimeIdentity = resolveDesktopRuntimeIdentity({
+          isDevelopment: false,
+          isPackaged: true,
+          stageLabel: "Nightly",
+          appName: buildIdentity.productName,
+          packagedIdentity: buildIdentity,
+        });
+
+        assert.deepStrictEqual(runtimeIdentity, buildIdentity);
+        assert.equal(runtimeIdentity.distributionName, distributionName);
+        assert.equal(runtimeIdentity.productName, `T3 Code (${distributionName})`);
+        assert.equal(runtimeIdentity.displayName, `T3 Code (${distributionName} Nightly)`);
+      }
+    }),
+  );
+
+  it.effect("keeps distinct downstream distribution identities isolated", () =>
+    Effect.gen(function* () {
+      const spaced = yield* resolveDesktopBuildIdentity("0.0.17-nightly.20260413.42", "Foo Bar");
+      const hyphenated = yield* resolveDesktopBuildIdentity(
+        "0.0.17-nightly.20260413.42",
+        "Foo-Bar",
+      );
+      const uppercase = yield* resolveDesktopBuildIdentity("0.0.17-nightly.20260413.42", "Fork");
+      const lowercase = yield* resolveDesktopBuildIdentity("0.0.17-nightly.20260413.42", "fork");
+
+      assert.notEqual(spaced.appId, hyphenated.appId);
+      assert.notEqual(spaced.packageName, hyphenated.packageName);
+      assert.notEqual(uppercase.appId, lowercase.appId);
+      assert.notEqual(uppercase.packageName, lowercase.packageName);
+    }),
+  );
+
+  it.effect("rejects unsafe downstream distribution names", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveDesktopBuildIdentity(
+        "0.0.17-nightly.20260413.42",
+        "Fork/Nightly",
+      ).pipe(Effect.flip);
+
+      assert.instanceOf(error, InvalidDesktopDistributionError);
+    }),
+  );
+
+  it.effect("rejects downstream display names that exceed filesystem-safe bounds", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveDesktopBuildIdentity(
+        "0.0.17-nightly.20260413.42",
+        `F${"o".repeat(64)}`,
+      ).pipe(Effect.flip);
+
+      assert.instanceOf(error, InvalidDesktopDistributionError);
+    }),
+  );
+
+  it.effect("applies a downstream identity to macOS packaging metadata", () =>
+    Effect.gen(function* () {
+      const identity = yield* resolveDesktopBuildIdentity("0.0.17-nightly.20260413.42", "Fork");
+      const config = yield* createBuildConfig(
+        "mac",
+        "dmg",
+        "0.0.17-nightly.20260413.42",
+        false,
+        false,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        identity,
+      );
+
+      assert.equal(
+        config.appId,
+        "com.t3tools.t3code.fork-8e5b1a73152cf01c1ce614f31711fc4159e8ecc177cd4c02975ed0145b3d3d45",
+      );
+      assert.equal(config.productName, "T3 Code (Fork)");
+      assert.deepEqual((config.mac as Record<string, unknown>).protocols, [
+        { name: "T3 Code", schemes: [`t3code-${identity.distributionId}`] },
+      ]);
+      assert.equal(
+        (config.dmg as { readonly title: string }).title,
+        "T3 Code (Fork) 0.0.17-nightly.20260413.42 Installer",
+      );
+    }),
+  );
+
+  it.effect("keeps fork Linux URL schemes separate from the official installation", () =>
+    Effect.gen(function* () {
+      const identity = yield* resolveDesktopBuildIdentity("1.2.3", "Fork");
+      const config = yield* createBuildConfig(
+        "linux",
+        "AppImage",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        identity,
+      );
+      assert.deepEqual((config.linux as Record<string, unknown>).protocols, [
+        { name: "T3 Code", schemes: [`t3code-${identity.distributionId}`] },
+      ]);
+    }),
+  );
+
+  it.effect("enables stable ad hoc update signing for downstream macOS builds", () =>
+    Effect.gen(function* () {
+      const identity = yield* resolveDesktopBuildIdentity("0.0.17-nightly.20260413.42", "Fork");
+      const config = yield* createBuildConfig(
+        "mac",
+        "dmg",
+        "0.0.17-nightly.20260413.42",
+        false,
+        false,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        identity,
+        true,
+      );
+
+      const mac = config.mac as Record<string, unknown>;
+      assert.equal(mac.identity, "-");
+      assert.match(String(mac.sign), /\/scripts\/sign-macos\.ts$/);
+    }),
+  );
 
   it("switches desktop packaging icons to the nightly artwork for nightly versions", () => {
     assert.deepStrictEqual(resolveDesktopBuildIconAssets("0.0.17"), {
@@ -1413,6 +1572,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
 
     return Effect.scoped(
       Effect.gen(function* () {
+        const path = yield* Path.Path;
         const fixture = yield* makeWindowsPayloadFixture({ copyUnpackedNatives: true });
         yield* validateWindowsPackagedPayload({
           stageDistDir: fixture.stageDistDir,
@@ -1421,7 +1581,11 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         });
 
         assert.isFalse(
-          commands.some((command) => command.options.env?.ELECTRON_RUN_AS_NODE === "1"),
+          commands.some(
+            (command) =>
+              command.command === path.join(fixture.packagedAppDir, fixture.appExecutableName) &&
+              command.options.env?.ELECTRON_RUN_AS_NODE === "1",
+          ),
         );
         assert.isTrue(
           commands.some(
@@ -2177,6 +2341,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         skipBuild: Option.none(),
         keepStage: Option.none(),
         signed: Option.none(),
+        stableMacAdhocSignature: Option.none(),
         verbose: Option.none(),
         mockUpdates: Option.none(),
         mockUpdateServerPort: Option.none(),
@@ -2217,6 +2382,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
             skipBuild: Option.none(),
             keepStage: Option.none(),
             signed: Option.none(),
+            stableMacAdhocSignature: Option.none(),
             verbose: Option.none(),
             mockUpdates: Option.none(),
             mockUpdateServerPort: Option.none(),
@@ -2241,6 +2407,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         skipBuild: Option.some(false),
         keepStage: Option.some(false),
         signed: Option.some(false),
+        stableMacAdhocSignature: Option.some(false),
         verbose: Option.some(false),
         mockUpdates: Option.some(false),
         mockUpdateServerPort: Option.none(),

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { resolveDesktopUrlScheme } from "@t3tools/shared/desktopBuild";
 // @effect-diagnostics nodeBuiltinImport:off - Node's typed junction API avoids Windows symlink privileges while keeping the probe isolated.
 
 import * as NodeFSP from "node:fs/promises";
@@ -14,6 +15,7 @@ import {
 } from "@electron/asar";
 
 import { fromYaml } from "@t3tools/shared/schemaYaml";
+import type { DesktopPackagedAppIdentity } from "@t3tools/shared/desktopBuild";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { clerkFrontendApiHostnameFromPublishableKey } from "@t3tools/shared/relayAuth";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
@@ -87,7 +89,7 @@ const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("..", import.meta.url))),
 );
 const encodeJsonString = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
-const decodeWorkspaceConfig = Schema.decodeEffect(fromYaml(WorkspaceConfig));
+const decodeWorkspaceConfig = Schema.decodeUnknownEffect(fromYaml(WorkspaceConfig));
 const decodeNodePtyManifest = Schema.decodeUnknownEffect(
   Schema.fromJsonString(Schema.Struct({ version: Schema.String })),
 );
@@ -160,6 +162,7 @@ interface BuildCliInput {
   readonly skipBuild: Option.Option<boolean>;
   readonly keepStage: Option.Option<boolean>;
   readonly signed: Option.Option<boolean>;
+  readonly stableMacAdhocSignature: Option.Option<boolean>;
   readonly verbose: Option.Option<boolean>;
   readonly mockUpdates: Option.Option<boolean>;
   readonly mockUpdateServerPort: Option.Option<number>;
@@ -281,6 +284,17 @@ export class InvalidMockUpdateServerPortError extends Schema.TaggedError<Invalid
       inputLength: configuredPort.length,
       cause,
     });
+  }
+}
+
+export class InvalidDesktopDistributionError extends Schema.TaggedError<InvalidDesktopDistributionError>()(
+  "InvalidDesktopDistributionError",
+  {
+    distribution: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "Desktop distribution names must be at most 64 characters, start with a letter, and contain only letters, numbers, spaces, or hyphens.";
   }
 }
 
@@ -929,17 +943,21 @@ interface ResolvedBuildOptions {
   readonly skipBuild: boolean;
   readonly keepStage: boolean;
   readonly signed: boolean;
+  readonly stableMacAdhocSignature: boolean;
   readonly verbose: boolean;
   readonly mockUpdates: boolean;
   readonly mockUpdateServerPort: number | undefined;
   readonly wslPrebuild: string | undefined;
+  readonly buildIdentity: DesktopBuildIdentity;
 }
 
 interface StagePackageJson {
   readonly name: string;
+  readonly productName: string;
   readonly version: string;
   readonly buildVersion: string;
   readonly t3codeCommitHash: string;
+  readonly t3codeDesktopIdentity: DesktopPackagedAppIdentity;
   readonly private: true;
   readonly packageManager: string;
   readonly description: string;
@@ -1250,6 +1268,7 @@ function normalizePasskeyRpDomain(value: string): string {
 
 export function resolveMacPasskeySigningConfiguration(
   env: Readonly<Record<string, string | undefined>>,
+  appId = DESKTOP_APP_ID,
 ): MacPasskeySigningConfiguration {
   const teamId = env.T3CODE_APPLE_TEAM_ID?.trim().toUpperCase() ?? "";
   if (!APPLE_TEAM_ID_PATTERN.test(teamId)) {
@@ -1285,7 +1304,7 @@ export function resolveMacPasskeySigningConfiguration(
   }
 
   return {
-    appId: DESKTOP_APP_ID,
+    appId,
     teamId,
     rpDomains: uniqueRpDomains,
     provisioningProfilePath,
@@ -1582,6 +1601,9 @@ const BuildEnvConfig = Config.all({
   skipBuild: Config.boolean("T3CODE_DESKTOP_SKIP_BUILD").pipe(Config.withDefault(false)),
   keepStage: Config.boolean("T3CODE_DESKTOP_KEEP_STAGE").pipe(Config.withDefault(false)),
   signed: Config.boolean("T3CODE_DESKTOP_SIGNED").pipe(Config.withDefault(false)),
+  stableMacAdhocSignature: Config.boolean("T3CODE_DESKTOP_STABLE_MAC_ADHOC_SIGNATURE").pipe(
+    Config.withDefault(false),
+  ),
   verbose: Config.boolean("T3CODE_DESKTOP_VERBOSE").pipe(Config.withDefault(false)),
   mockUpdates: Config.boolean("T3CODE_DESKTOP_MOCK_UPDATES").pipe(Config.withDefault(false)),
   mockUpdateServerPort: Config.string("T3CODE_DESKTOP_MOCK_UPDATE_SERVER_PORT").pipe(Config.option),
@@ -1590,6 +1612,7 @@ const BuildEnvConfig = Config.all({
   // into the staged node-pty so the WSL backend ships a ready binary and never
   // compiles on the user's machine.
   wslPrebuild: Config.string("T3CODE_DESKTOP_WSL_PREBUILD").pipe(Config.option),
+  distribution: Config.string("T3CODE_DESKTOP_DISTRIBUTION").pipe(Config.option),
 });
 
 const MockUpdateServerPortSchema = Schema.NumberFromString.check(
@@ -1667,6 +1690,10 @@ export const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (
   const skipBuild = resolveBooleanFlag(input.skipBuild, env.skipBuild);
   const keepStage = resolveBooleanFlag(input.keepStage, env.keepStage);
   const signed = resolveBooleanFlag(input.signed, env.signed);
+  const stableMacAdhocSignature =
+    platform === "mac" &&
+    !signed &&
+    resolveBooleanFlag(input.stableMacAdhocSignature, env.stableMacAdhocSignature);
   const verbose = resolveBooleanFlag(input.verbose, env.verbose);
 
   const mockUpdates = resolveBooleanFlag(input.mockUpdates, env.mockUpdates);
@@ -1683,6 +1710,10 @@ export const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (
 
   const wslPrebuild =
     Option.getOrUndefined(input.wslPrebuild) ?? Option.getOrUndefined(env.wslPrebuild);
+  const buildIdentity = yield* resolveDesktopBuildIdentity(
+    version ?? serverPackageJson.version,
+    Option.getOrUndefined(env.distribution),
+  );
 
   return {
     platform,
@@ -1693,10 +1724,12 @@ export const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (
     skipBuild,
     keepStage,
     signed,
+    stableMacAdhocSignature,
     verbose,
     mockUpdates,
     mockUpdateServerPort,
     wslPrebuild,
+    buildIdentity,
   } satisfies ResolvedBuildOptions;
 });
 
@@ -2646,6 +2679,54 @@ export function resolveDesktopProductName(version: string): string {
     : (desktopPackageJson.productName ?? "T3 Code");
 }
 
+export type DesktopBuildIdentity = DesktopPackagedAppIdentity;
+
+const DESKTOP_DISTRIBUTION_PATTERN = /^[A-Za-z][A-Za-z0-9]*(?:[ -][A-Za-z0-9]+)*$/u;
+const DESKTOP_DISTRIBUTION_MAX_LENGTH = 64;
+
+export const resolveDesktopBuildIdentity = Effect.fn("resolveDesktopBuildIdentity")(function* (
+  version: string,
+  distribution: string | undefined,
+) {
+  const normalizedDistribution = distribution?.trim();
+  if (!normalizedDistribution) {
+    return {
+      appId: DESKTOP_APP_ID,
+      packageName: "t3code",
+      productName: resolveDesktopProductName(version),
+      displayName: resolveDesktopProductName(version),
+      distributionName: null,
+      distributionId: null,
+    } satisfies DesktopBuildIdentity;
+  }
+  if (
+    normalizedDistribution.length > DESKTOP_DISTRIBUTION_MAX_LENGTH ||
+    !DESKTOP_DISTRIBUTION_PATTERN.test(normalizedDistribution)
+  ) {
+    return yield* new InvalidDesktopDistributionError({
+      distribution: normalizedDistribution,
+    });
+  }
+
+  const readableDistributionSlug = normalizedDistribution
+    .toLowerCase()
+    .replaceAll(" ", "-")
+    .slice(0, 24);
+  const distributionDigest = NodeCrypto.createHash("sha256")
+    .update(normalizedDistribution, "utf8")
+    .digest("hex");
+  const distributionId = `${readableDistributionSlug}-${distributionDigest}`;
+  const stageLabel = resolveDesktopUpdateChannel(version) === "nightly" ? "Nightly" : "Alpha";
+  return {
+    appId: `${DESKTOP_APP_ID}.${distributionId}`,
+    packageName: `t3code-${distributionId}`,
+    productName: `T3 Code (${normalizedDistribution})`,
+    displayName: `T3 Code (${normalizedDistribution} ${stageLabel})`,
+    distributionName: normalizedDistribution,
+    distributionId,
+  } satisfies DesktopBuildIdentity;
+});
+
 export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   platform: typeof BuildPlatform.Type,
   target: string,
@@ -2664,10 +2745,14 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   // whose source file was never written fails the electron-builder step.
   wslRuntimeBundled = false,
   arch?: typeof BuildArch.Type,
+  configuredBuildIdentity?: DesktopBuildIdentity,
+  stableMacAdhocSignature = false,
 ) {
+  const buildIdentity =
+    configuredBuildIdentity ?? (yield* resolveDesktopBuildIdentity(version, undefined));
   const buildConfig: Record<string, unknown> = {
-    appId: DESKTOP_APP_ID,
-    productName: resolveDesktopProductName(version),
+    appId: buildIdentity.appId,
+    productName: buildIdentity.productName,
     artifactName: "T3-Code-${version}-${arch}.${ext}",
     electronLanguages: [...DESKTOP_ELECTRON_LANGUAGES],
     files: [
@@ -2720,10 +2805,15 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       protocols: [
         {
           name: "T3 Code",
-          schemes: ["t3code", "t3code-dev"],
+          schemes: buildIdentity.distributionId
+            ? [resolveDesktopUrlScheme(false, buildIdentity.distributionId)]
+            : ["t3code", "t3code-dev"],
         },
       ],
-      ...(signed ? { sign: path.join(repoRoot, "scripts/sign-macos.ts") } : {}),
+      ...(stableMacAdhocSignature ? { identity: "-" } : {}),
+      ...(signed || stableMacAdhocSignature
+        ? { sign: path.join(repoRoot, "scripts/sign-macos.ts") }
+        : {}),
       ...(macPasskeySigning
         ? {
             entitlements: macPasskeySigning.entitlementsPath,
@@ -2738,7 +2828,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       // Give the themed installer its own Finder volume name. Finder caches
       // DMG window backgrounds by volume name, so reusing a generic name can
       // make a newly built background look unchanged during testing.
-      title: `${resolveDesktopProductName(version)} ${version} Installer`,
+      title: `${buildIdentity.productName} ${version} Installer`,
       background: `dmg/dmg-background-${updateChannel}.png`,
       window: {
         width: 640,
@@ -2758,7 +2848,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   if (platform === "linux") {
     buildConfig.linux = {
       target: [target],
-      executableName: "t3code",
+      executableName: buildIdentity.packageName,
       icon: "icons",
       category: "Development",
       // electron-builder turns these into MimeType=x-scheme-handler/<scheme>;
@@ -2767,12 +2857,14 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       protocols: [
         {
           name: "T3 Code",
-          schemes: ["t3code", "t3code-dev"],
+          schemes: buildIdentity.distributionId
+            ? [resolveDesktopUrlScheme(false, buildIdentity.distributionId)]
+            : ["t3code", "t3code-dev"],
         },
       ],
       desktop: {
         entry: {
-          StartupWMClass: "t3code",
+          StartupWMClass: buildIdentity.packageName,
         },
       },
     };
@@ -3709,7 +3801,11 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const configuredMacPasskeySigning =
     options.platform === "mac" && options.signed
       ? yield* Effect.try({
-          try: () => resolveMacPasskeySigningConfiguration(loadRepoEnv({ repoRoot })),
+          try: () =>
+            resolveMacPasskeySigningConfiguration(
+              loadRepoEnv({ repoRoot }),
+              options.buildIdentity.appId,
+            ),
           catch: MacPasskeySigningConfigurationResolutionError.fromCause,
         })
       : undefined;
@@ -3767,10 +3863,12 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       ? path.join(stageAppDir, WINDOWS_SERVER_RESOURCE_SOURCE_DIR, WINDOWS_SERVER_ASAR_RESOURCE)
       : undefined;
   const stagePackageJson: StagePackageJson = {
-    name: "t3code",
+    name: options.buildIdentity.packageName,
+    productName: options.buildIdentity.productName,
     version: appVersion,
     buildVersion: appVersion,
     t3codeCommitHash: commitHash,
+    t3codeDesktopIdentity: options.buildIdentity,
     private: true,
     packageManager: rootPackageJson.packageManager,
     description: "T3 Code desktop build",
@@ -3791,6 +3889,8 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
         : undefined,
       bundlesWslRuntime({ arch: options.arch, prebuildPath: options.wslPrebuild }),
       options.arch,
+      options.buildIdentity,
+      options.stableMacAdhocSignature,
     ),
     dependencies: stageDependencies,
     devDependencies: {
@@ -3876,6 +3976,11 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     delete buildEnv.APPLE_API_KEY_ID;
     delete buildEnv.APPLE_API_ISSUER;
   }
+  if (options.stableMacAdhocSignature) {
+    buildEnv.T3CODE_MACOS_STABLE_ADHOC_BUNDLE_ID = options.buildIdentity.appId;
+  } else {
+    delete buildEnv.T3CODE_MACOS_STABLE_ADHOC_BUNDLE_ID;
+  }
 
   if (hostPlatform === "win32") {
     const python = yield* resolvePythonForNodeGyp();
@@ -3948,7 +4053,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   if (options.platform === "win") {
     yield* validateWindowsPackagedPayload({
       stageDistDir,
-      appExecutableName: `${resolveDesktopProductName(appVersion)}.exe`,
+      appExecutableName: `${options.buildIdentity.productName}.exe`,
       targetArch: options.arch,
       expectWslRuntime: bundlesWslRuntime({
         arch: options.arch,
@@ -4021,6 +4126,12 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
   signed: Flag.boolean("signed").pipe(
     Flag.withDescription(
       "Enable signing/notarization discovery; Windows uses Azure Trusted Signing (env: T3CODE_DESKTOP_SIGNED).",
+    ),
+    Flag.optional,
+  ),
+  stableMacAdhocSignature: Flag.boolean("stable-mac-adhoc-signature").pipe(
+    Flag.withDescription(
+      "Use a stable credential-free macOS update requirement (env: T3CODE_DESKTOP_STABLE_MAC_ADHOC_SIGNATURE).",
     ),
     Flag.optional,
   ),

--- a/scripts/sign-macos.test.ts
+++ b/scripts/sign-macos.test.ts
@@ -1,9 +1,14 @@
 import { sign as signApplication, type SignOptions } from "@electron/osx-sign";
-import { expect, it, vi } from "vite-plus/test";
+import { afterEach, expect, it, vi } from "vite-plus/test";
 
 import sign from "./sign-macos.ts";
 
 vi.mock("@electron/osx-sign", () => ({ sign: vi.fn() }));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
 
 it("batches codesign calls without changing existing signing options", async () => {
   const options = {
@@ -23,4 +28,43 @@ it("batches codesign calls without changing existing signing options", async () 
     ...options,
     batchCodesignCalls: true,
   });
+});
+
+it("gives credential-free fork builds a stable top-level update requirement", async () => {
+  vi.stubEnv("T3CODE_MACOS_STABLE_ADHOC_BUNDLE_ID", "com.t3tools.t3code.fork-466f726b");
+  const options = {
+    app: "/tmp/T3 Code (Fork Nightly).app",
+    optionsForFile: () => ({ hardenedRuntime: true }),
+  } satisfies SignOptions;
+
+  await sign(options);
+
+  expect(signApplication).toHaveBeenCalledExactlyOnceWith({
+    ...options,
+    identity: "-",
+    identityValidation: false,
+    batchCodesignCalls: true,
+    optionsForFile: expect.any(Function),
+  });
+  const signedOptions = vi.mocked(signApplication).mock.calls[0]?.[0];
+  const optionsForFile = signedOptions?.optionsForFile;
+  expect(
+    optionsForFile?.("/tmp/T3 Code (Fork Nightly).app/Contents/MacOS/helper", {
+      platform: "darwin",
+    }),
+  ).toEqual({ hardenedRuntime: true, timestamp: "none" });
+  expect(optionsForFile?.(options.app, { platform: "darwin" })).toEqual({
+    hardenedRuntime: true,
+    timestamp: "none",
+    requirements: '=designated => identifier "com.t3tools.t3code.fork-466f726b"',
+  });
+});
+
+it("rejects an unsafe stable ad hoc bundle identifier", async () => {
+  vi.stubEnv("T3CODE_MACOS_STABLE_ADHOC_BUNDLE_ID", 'bad" requirement');
+
+  await expect(sign({ app: "/tmp/T3 Code.app" })).rejects.toThrow(
+    "T3CODE_MACOS_STABLE_ADHOC_BUNDLE_ID must be a bundle identifier.",
+  );
+  expect(signApplication).not.toHaveBeenCalled();
 });

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -1,6 +1,32 @@
 import { sign as signApplication, type SignOptions } from "@electron/osx-sign";
 
+const STABLE_ADHOC_BUNDLE_ID_ENV = "T3CODE_MACOS_STABLE_ADHOC_BUNDLE_ID";
+
 /** Sign files with matching options together instead of spawning codesign for each file. */
 export default async function sign(options: SignOptions): Promise<void> {
-  await signApplication({ ...options, batchCodesignCalls: true });
+  const stableAdhocBundleId = process.env[STABLE_ADHOC_BUNDLE_ID_ENV]?.trim();
+  if (!stableAdhocBundleId) {
+    await signApplication({ ...options, batchCodesignCalls: true });
+    return;
+  }
+  if (!/^[A-Za-z0-9.-]+$/u.test(stableAdhocBundleId)) {
+    throw new Error(`${STABLE_ADHOC_BUNDLE_ID_ENV} must be a bundle identifier.`);
+  }
+
+  const existingOptionsForFile = options.optionsForFile;
+  await signApplication({
+    ...options,
+    identity: "-",
+    identityValidation: false,
+    batchCodesignCalls: true,
+    optionsForFile: (filePath, context) => ({
+      ...existingOptionsForFile?.(filePath, context),
+      timestamp: "none",
+      ...(filePath === options.app
+        ? {
+            requirements: `=designated => identifier "${stableAdhocBundleId}"`,
+          }
+        : {}),
+    }),
+  });
 }


### PR DESCRIPTION
Forks and downstream builds of T3 Code can't point Desktop updates at their own releases. Desktop only follows T3 Code's Stable or Nightly feeds, so a fork build either updates back to upstream or doesn't update at all.

## Fix

- **Settings → Updates** gains a **Custom** track next to Stable and Nightly. It takes a public GitHub repository (a URL or `owner/repo`), normalizes and saves it, and follows that repository's Nightly releases. Choosing Stable or Nightly again restores the full bundled update configuration.
- Update checks, downloads, install status, release links and sidebar release notes all follow the selected source (contracts in `packages/contracts/src/ipc.ts`).
- Distribution identity (branding, URL scheme, profile and connection-catalog paths) is kept across source changes, so switching feeds doesn't orphan saved connections. Legacy Alpha/Nightly catalogs merge in without overwriting current edits. A corrupt legacy catalog is skipped and kept on disk. Profiles and credentials whose targets are dropped by environment deduplication are pruned. Linux scheme registration still happens before Electron is ready.
- A renamed macOS app bundle is detected before installing an update. The app stays open and shows recovery guidance instead.
- User and release docs updated (`docs/user/updating.md`, `docs/operations/release.md`).

The branch is rebased onto current `main` as one squashed feature commit, plus a small follow-up that hoists a schema decoder to module scope (`no-inline-schema-compile`) and replaces a personal repository in a test fixture.

## Verification (head `d3b8eb36a`)

- Focused tests: desktop 192/192 (15 files), web 81, server 6, contracts 70, scripts 140 — all pass.
- Typecheck: `apps/desktop`, `apps/web`, `apps/server`, `packages/contracts`, `packages/shared` — all clean.
- Scoped lint on changed files: no errors. The remaining warnings in `SettingsPanels.tsx` are the same 8 found on `main`.
- Not done: no real native update was installed, and no fresh integrated UI capture was made. The Settings UI hasn't changed since the recordings below.
- Independent cross-provider review was skipped for this revision because Codex weekly quota was at 9%.

<details>
<summary>UI evidence (Settings → Updates; simulated Electron bridge, 390×600, dark)</summary>

These captures show the visible controls and interaction, not native IPC or update installation.

**Before — Stable and Nightly only.**

![Before](https://github.com/saphid/t3code/releases/download/pr-evidence-custom-update-source-20260906/8976-fe57cf6-before.gif)

**After — Custom shows the repository field and normalizes a GitHub URL to `owner/repo`.**

![After](https://github.com/saphid/t3code/releases/download/pr-evidence-custom-update-source-20260906/8976-fe57cf6-after.gif)

**Return — choosing Stable clears the custom source.**

![Return to Stable](https://github.com/saphid/t3code/releases/download/pr-evidence-custom-update-source-20260906/8976-fe57cf6-return-stable.gif)

[Before PNG](https://github.com/saphid/t3code/releases/download/pr-evidence-custom-update-source-20260906/8976-fe57cf6-before.png) · [After PNG](https://github.com/saphid/t3code/releases/download/pr-evidence-custom-update-source-20260906/8976-fe57cf6-after.png) · [Interaction MP4](https://github.com/saphid/t3code/releases/download/pr-evidence-custom-update-source-20260906/8976-fe57cf6-custom-source.mp4)

</details>

Coordination trace: T3 thread 8d629a6b-c61a-4ae7-8500-d1eb965fe46d

Rebased and updated with Claude Opus 5 in the Claude Code harness (earlier revisions: GPT-6 in the Codex harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
