### PR TITLE
feat(web): add reload window command

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -43,6 +43,7 @@ import {
   LinkIcon,
   MessageSquareIcon,
   PaletteIcon,
+  RefreshCwIcon,
   ServerIcon,
   SettingsIcon,
   SquarePenIcon,
@@ -146,7 +147,11 @@ import {
   ThreadCommandSubtitle,
 } from "./ThreadCommandSubtitle";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
-import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
+import {
+  primaryServerKeybindingsAtom,
+  primaryServerProvidersAtom,
+  serverEnvironment,
+} from "../state/server";
 import {
   deriveProviderInstanceEntries,
   resolveDefaultProviderModelSelection,
@@ -167,6 +172,7 @@ import {
   buildSidebarProjectSnapshots,
 } from "../sidebarProjectGrouping";
 import type { Project } from "../types";
+import { refreshProvidersAndReload } from "../reloadWindow";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
 
@@ -405,8 +411,38 @@ export function CommandPalette({ children }: { children: ReactNode }) {
   const openNewThreadIn = useCallback(() => dispatch({ _tag: "OpenNewThreadIn" }), []);
   const clearOpenIntent = useCallback(() => dispatch({ _tag: "ClearOpenIntent" }), []);
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const { environments } = useEnvironments();
+  const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
+    reportFailure: false,
+    reportDefect: false,
+  });
   const { theme, themeHalves, resolvedTheme } = useTheme();
   const composerHandleRef = useRef<ChatComposerHandle | null>(null);
+  const connectedEnvironmentIds = useMemo(
+    () =>
+      environments
+        .filter((environment) => environment.connection.phase === "connected")
+        .map((environment) => environment.environmentId),
+    [environments],
+  );
+  const reloadWindow = useCallback(
+    () =>
+      refreshProvidersAndReload({
+        environmentIds: connectedEnvironmentIds,
+        refreshProviders: (environmentId) =>
+          refreshProviders({ environmentId, input: {} }).then(() => undefined),
+        onRefreshStart: () => {
+          toastManager.add({
+            type: "loading",
+            title: "Reloading window...",
+            description: "Refreshing providers before reload.",
+            timeout: 0,
+          });
+        },
+        reload: () => window.location.reload(),
+      }),
+    [connectedEnvironmentIds, refreshProviders],
+  );
   const routeTarget = useParams({
     strict: false,
     select: (params) => resolveThreadRouteTarget(params),
@@ -448,6 +484,12 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           previewOpen,
         },
       });
+      if (command === "window.reload") {
+        event.preventDefault();
+        event.stopPropagation();
+        void reloadWindow();
+        return;
+      }
       if (command === "themeEditor.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -468,7 +510,16 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keybindings, previewOpen, resolvedTheme, terminalOpen, theme, themeHalves, toggleMode]);
+  }, [
+    keybindings,
+    previewOpen,
+    reloadWindow,
+    resolvedTheme,
+    terminalOpen,
+    theme,
+    themeHalves,
+    toggleMode,
+  ]);
 
   useEffect(
     () =>
@@ -504,6 +555,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           setOpen={setOpen}
           openOverlayMode={toggleMode}
           clearOpenIntent={clearOpenIntent}
+          reloadWindow={reloadWindow}
         />
       </CommandDialog>
     </ComposerHandleContext>
@@ -516,6 +568,7 @@ function CommandPaletteDialog(props: {
   readonly setOpen: (open: boolean) => void;
   readonly openOverlayMode: (mode: SearchOverlayMode) => void;
   readonly clearOpenIntent: () => void;
+  readonly reloadWindow: () => Promise<void>;
 }) {
   const composerHandleRef = useComposerHandleContext();
 
@@ -550,6 +603,7 @@ function CommandPaletteDialog(props: {
           setOpen={props.setOpen}
           openOverlayMode={props.openOverlayMode}
           clearOpenIntent={props.clearOpenIntent}
+          reloadWindow={props.reloadWindow}
         />
       )}
     </CommandDialogPopup>
@@ -561,9 +615,10 @@ function OpenCommandPaletteDialog(props: {
   readonly setOpen: (open: boolean) => void;
   readonly openOverlayMode: (mode: SearchOverlayMode) => void;
   readonly clearOpenIntent: () => void;
+  readonly reloadWindow: () => Promise<void>;
 }) {
   const navigate = useNavigate();
-  const { clearOpenIntent, openIntent, openOverlayMode, setOpen } = props;
+  const { clearOpenIntent, openIntent, openOverlayMode, reloadWindow, setOpen } = props;
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const isActionsOnly = deferredQuery.startsWith(">");
@@ -1610,6 +1665,17 @@ function OpenCommandPaletteDialog(props: {
         initialAppearance: resolvedTheme,
       });
     },
+  });
+
+  actionItems.push({
+    kind: "action",
+    value: "action:reload-window",
+    searchTerms: ["reload window", "refresh", "providers", "plugins", "skills"],
+    title: "Reload Window",
+    description: "Refresh providers and reload the app",
+    icon: <RefreshCwIcon className={ITEM_ICON_CLASS} />,
+    shortcutCommand: "window.reload",
+    run: reloadWindow,
   });
 
   actionItems.push({

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -123,6 +123,7 @@ describe("KeybindingsSettings.logic", () => {
   it("formats static and project script command labels", () => {
     expect(commandLabel("commandPalette.toggle")).toBe("Command Palette: Toggle");
     expect(commandLabel("themeEditor.toggle")).toBe("Theme Editor: Toggle");
+    expect(commandLabel("window.reload")).toBe("Reload Window");
     expect(commandLabel("script.setup-db.run")).toBe("Run Script: Setup Db");
   });
 
@@ -151,7 +152,12 @@ describe("KeybindingsSettings.logic", () => {
     ] satisfies ResolvedKeybindingsConfig);
 
     expect(options).toEqual(
-      expect.arrayContaining(["chat.new", "rightPanel.toggleMaximized", "script.setup-db.run"]),
+      expect.arrayContaining([
+        "chat.new",
+        "rightPanel.toggleMaximized",
+        "script.setup-db.run",
+        "window.reload",
+      ]),
     );
   });
 

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -267,6 +267,9 @@ export function buildKeybindingCommandOptions(
 
 export function commandLabel(command: KeybindingCommand): string {
   const raw = String(command);
+  if (raw === "window.reload") {
+    return "Reload Window";
+  }
   if (raw.startsWith("script.") && raw.endsWith(".run")) {
     return `Run Script: ${titleCaseCommandSegment(raw.slice("script.".length, -".run".length))}`;
   }

--- a/apps/web/src/reloadWindow.test.ts
+++ b/apps/web/src/reloadWindow.test.ts
@@ -1,0 +1,60 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { refreshProvidersAndReload } from "./reloadWindow";
+
+describe("refreshProvidersAndReload", () => {
+  it("waits for every environment refresh before reloading", async () => {
+    const firstEnvironmentId = EnvironmentId.make("environment-first");
+    const secondEnvironmentId = EnvironmentId.make("environment-second");
+    const refreshResolvers = new Map<EnvironmentId, () => void>();
+    const refreshProviders = vi.fn(
+      (environmentId: EnvironmentId) =>
+        new Promise<void>((resolve) => {
+          refreshResolvers.set(environmentId, resolve);
+        }),
+    );
+    const onRefreshStart = vi.fn();
+    const reload = vi.fn();
+
+    const operation = refreshProvidersAndReload({
+      environmentIds: [firstEnvironmentId, secondEnvironmentId],
+      refreshProviders,
+      onRefreshStart,
+      reload,
+    });
+    await Promise.resolve();
+
+    expect(onRefreshStart).toHaveBeenCalledOnce();
+    expect(refreshProviders).toHaveBeenCalledWith(firstEnvironmentId);
+    expect(refreshProviders).toHaveBeenCalledWith(secondEnvironmentId);
+    expect(reload).not.toHaveBeenCalled();
+
+    refreshResolvers.get(firstEnvironmentId)?.();
+    await Promise.resolve();
+    expect(reload).not.toHaveBeenCalled();
+
+    refreshResolvers.get(secondEnvironmentId)?.();
+    await operation;
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("reloads after refresh failures settle", async () => {
+    const reload = vi.fn();
+
+    await refreshProvidersAndReload({
+      environmentIds: [
+        EnvironmentId.make("environment-available"),
+        EnvironmentId.make("environment-unavailable"),
+      ],
+      refreshProviders: (environmentId) =>
+        environmentId === "environment-unavailable"
+          ? Promise.reject(new Error("disconnected"))
+          : Promise.resolve(),
+      onRefreshStart: vi.fn(),
+      reload,
+    });
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/reloadWindow.ts
+++ b/apps/web/src/reloadWindow.ts
@@ -1,0 +1,14 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+export async function refreshProvidersAndReload(input: {
+  readonly environmentIds: ReadonlyArray<EnvironmentId>;
+  readonly refreshProviders: (environmentId: EnvironmentId) => Promise<unknown>;
+  readonly onRefreshStart: () => void;
+  readonly reload: () => void;
+}): Promise<void> {
+  input.onRefreshStart();
+  await Promise.allSettled(
+    input.environmentIds.map((environmentId) => input.refreshProviders(environmentId)),
+  );
+  input.reload();
+}

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -52,6 +52,10 @@ successful pick; its hover glow and badge preview the element and color family t
 `rightPanel.toggleMaximized` maximizes or restores the open right panel. It has no default shortcut,
 so add one in **Settings** → **Keybindings** if you want to use it.
 
+`window.reload` refreshes provider metadata in every connected environment, then reloads the app.
+Use **Reload Window** from the command palette, or assign it a shortcut in **Settings** →
+**Keybindings**. It has no default shortcut.
+
 `thread.settle` settles the active thread or restores it when it is already settled. Its default
 shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
 

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -78,6 +78,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedProjectSearch.command, "projectSearch.toggle");
 
+    const parsedWindowReload = yield* decode(KeybindingRule, {
+      key: "mod+shift+r",
+      command: "window.reload",
+    });
+    assert.strictEqual(parsedWindowReload.command, "window.reload");
+
     const parsedThemeEditor = yield* decode(KeybindingRule, {
       key: "mod+alt+shift+t",
       command: "themeEditor.toggle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -68,6 +68,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "commandPalette.toggle",
   "filePicker.toggle",
   "projectSearch.toggle",
+  "window.reload",
   "themeEditor.toggle",
   "composer.stash",
   "chat.new",


### PR DESCRIPTION
## What Changed

Adds a **Reload Window** command to the command palette and configurable keybindings. It refreshes providers, then reloads the app.

## Why

Provides a simple way to reload after adding provider-side tools such as plugins or skills.

## UI Changes

| Before | After |
| --- | --- |
| ![Before: no Reload Window command](https://gist.githubusercontent.com/darwin-luque/b4c5ad804bebc24fd7aa48c5bd990e40/raw/71061f6055b6f9dca7d99dd44584195f435b00d2/before.svg) | ![After: Reload Window command](https://gist.githubusercontent.com/darwin-luque/b4c5ad804bebc24fd7aa48c5bd990e40/raw/f3a234e2125fa06d30a6c98e94f48ca5ef4894ff/after.svg) |

![Reload Window interaction](https://gist.githubusercontent.com/darwin-luque/b4c5ad804bebc24fd7aa48c5bd990e40/raw/456e31ef4b310402f1c2e8e58d9365c97bac4118/reload-window.svg)

## Test Plan

- [x] Focused web and contracts tests
- [x] Targeted typechecks, lint, and formatting
- [x] Verified the reload flow in the desktop app and web client

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `window.reload` command to command palette for refreshing providers and reloading the window
> - Introduces `refreshProvidersAndReload` in [reloadWindow.ts](https://github.com/pingdotgg/t3code/pull/8977/files#diff-871318ae2cbb17408d35161bcd7d4b0042a5257223a556d247fbee21b453be08), which calls `onRefreshStart`, awaits `Promise.allSettled` over `refreshProviders` for all provided environment IDs, then invokes `reload`.
> - Wires the `window.reload` command through `CommandPalette`, `CommandPaletteDialog`, and `OpenCommandPaletteDialog` so users can trigger provider refresh and window reload from the command palette.
> - Registers `window.reload` in `STATIC_KEYBINDING_COMMANDS` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/8977/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6) and maps it to the label 'Reload Window' in [KeybindingsSettings.logic.ts](https://github.com/pingdotgg/t3code/pull/8977/files#diff-3e063dd9ee56de309e7e9618f62b33b69ff212f57241c19cc7114065efb919dd).
> - Documents the new command in [keybindings.md](https://github.com/pingdotgg/t3code/pull/8977/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4ef77c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Built with GPT-5.6 Sol in Cursor.