### PR TITLE
fix(ci): format CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
 reviews:
-    review_status: false
-    auto_review:
-      enabled: false
+  review_status: false
+  auto_review:
+    enabled: false


### PR DESCRIPTION
The latest main commit added CodeRabbit configuration with indentation that fails the repository formatter. As a result, the full `vp check` job fails for every pull request based on that commit.

This applies the repository formatter to `.coderabbit.yaml` without changing its configuration semantics.

Verification:
- `vp fmt .coderabbit.yaml --check`
- `git diff --check`

Built with GPT-5 via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only change to CI config with no runtime or security impact.
> 
> **Overview**
> **Fixes CI failures** caused by `.coderabbit.yaml` indentation not matching the repo formatter after CodeRabbit config was added on main.
> 
> The change only **re-indents** the `reviews`, `review_status`, and `auto_review` keys (2-space YAML style). **No behavior change**—CodeRabbit still has `review_status: false` and `auto_review.enabled: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4e75bbda792667fede1f8a0c4465b70bed5d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix indentation in `.coderabbit.yaml` `reviews` section
> Reduces the indent of child keys under `reviews` (such as `review_status` and `auto_review.enabled`) by two spaces. No keys, values, or names are added, removed, or changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f4e75b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->