### PR TITLE
fix(desktop): keep AppImage launch paths stable

### DIFF
--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -210,6 +210,8 @@ available.
   - otherwise `GITHUB_REPOSITORY` from GitHub Actions.
 - Required release assets for updater:
   - platform installers (`.exe`, `.dmg`, `.AppImage`, plus macOS `.zip` for Squirrel.Mac update payloads)
+  - publish the Linux AppImage as `T3-Code-x86_64.AppImage`; do not add the release version to its filename
+  - users upgrading from a versioned AppImage must update their launcher path once
   - channel metadata: `latest*.yml` for stable releases, `nightly*.yml` for nightly releases
   - `*.blockmap` files (used for differential downloads)
 - macOS metadata note:

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -49,6 +49,12 @@ Nightly:
 yay -S t3code-nightly-bin
 ```
 
+Linux AppImage:
+
+Download `T3-Code-x86_64.AppImage` from GitHub Releases. In-app updates replace that file without
+changing its path. If you installed an older versioned AppImage, update your desktop entry or
+symlink to the stable filename after the first upgrade.
+
 ### Windows Subsystem for Linux
 
 When the desktop app runs a WSL backend, it installs the matching server runtime into

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -11,6 +11,9 @@ the workflow can also be run manually for a specific tag. It selects the stable 
 package, then updates its version and checksums, builds it, regenerates `.SRCINFO`, and pushes it
 to the AUR.
 
+`release.sh` prefers `T3-Code-x86_64.AppImage`. For older tags that lack this asset, it uses the
+versioned AppImage.
+
 To validate a release on Arch Linux:
 
 ```bash

--- a/packaging/aur/scripts/release.sh
+++ b/packaging/aur/scripts/release.sh
@@ -17,14 +17,23 @@ fi
 
 version="${tag#v}"
 pkgver="${version//-/_}"
-asset_name='T3-Code-x86_64.AppImage'
+stable_asset_name='T3-Code-x86_64.AppImage'
+legacy_asset_name="T3-Code-${version}-x86_64.AppImage"
 release_json="$(gh api "repos/$repo/releases/tags/$tag")"
+asset_name="$(jq -r --arg stable "$stable_asset_name" --arg legacy "$legacy_asset_name" '
+  def has_valid_digest: (.digest // "") | test("^sha256:[0-9a-f]{64}$");
+  if any(.assets[]; .name == $stable and has_valid_digest) then $stable
+  elif any(.assets[]; .name == $legacy and has_valid_digest) then $legacy
+  else empty
+  end
+' <<<"$release_json")"
 asset_digest="$(jq -r --arg name "$asset_name" \
   '.assets[] | select(.name == $name) | .digest' <<<"$release_json")"
 appimage_sha256="${asset_digest#sha256:}"
 
 if [[ ! "$appimage_sha256" =~ ^[0-9a-f]{64}$ ]]; then
-  echo "Release $tag is missing $asset_name or its SHA-256 digest." >&2
+  echo "Release $tag has no supported AppImage asset with a SHA-256 digest." >&2
+  echo "Expected $stable_asset_name or $legacy_asset_name." >&2
   exit 1
 fi
 

--- a/packaging/aur/scripts/release.sh
+++ b/packaging/aur/scripts/release.sh
@@ -17,7 +17,7 @@ fi
 
 version="${tag#v}"
 pkgver="${version//-/_}"
-asset_name="T3-Code-${version}-x86_64.AppImage"
+asset_name='T3-Code-x86_64.AppImage'
 release_json="$(gh api "repos/$repo/releases/tags/$tag")"
 asset_digest="$(jq -r --arg name "$asset_name" \
   '.assets[] | select(.name == $name) | .digest' <<<"$release_json")"
@@ -39,6 +39,7 @@ cd "$package_dir"
 sed -Ei \
   -e "s/^pkgver=.*/pkgver=$pkgver/" \
   -e "s/^pkgrel=.*/pkgrel=$pkgrel/" \
+  -e "s/^_appimage_asset=.*/_appimage_asset='$asset_name'/" \
   -e "/# AppImage$/s/'[0-9a-f]{64}'/'$appimage_sha256'/" \
   -e "/# upstream license$/s/'[0-9a-f]{64}'/'$license_sha256'/" \
   PKGBUILD

--- a/packaging/aur/t3code-bin/PKGBUILD
+++ b/packaging/aur/t3code-bin/PKGBUILD
@@ -44,8 +44,9 @@ conflicts=('t3code')
 options=('!debug' '!strip')
 
 _appimage="T3-Code-${pkgver}-x86_64.AppImage"
+_appimage_asset="T3-Code-${pkgver}-x86_64.AppImage"
 source=(
-  "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${pkgver}/$_appimage"
+  "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${pkgver}/$_appimage_asset"
   "${pkgname}-${pkgver}-LICENSE::https://raw.githubusercontent.com/pingdotgg/t3code/v${pkgver}/LICENSE"
 )
 sha256sums=(

--- a/packaging/aur/t3code-nightly-bin/PKGBUILD
+++ b/packaging/aur/t3code-nightly-bin/PKGBUILD
@@ -45,8 +45,9 @@ options=('!debug' '!strip')
 
 _upstream_version="${pkgver/_nightly./-nightly.}"
 _appimage="T3-Code-${_upstream_version}-x86_64.AppImage"
+_appimage_asset="T3-Code-${_upstream_version}-x86_64.AppImage"
 source=(
-  "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${_upstream_version}/$_appimage"
+  "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${_upstream_version}/$_appimage_asset"
   "${pkgname}-${pkgver}-LICENSE::https://raw.githubusercontent.com/pingdotgg/t3code/v${_upstream_version}/LICENSE"
 )
 sha256sums=(

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -653,6 +653,9 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       ]);
       assert.deepStrictEqual(mac.files, [...DESKTOP_FILE_EXCLUSIONS, ...MAC_FILE_EXCLUSIONS]);
       assert.notProperty(mac.mac as Record<string, unknown>, "sign");
+      assert.equal(linux.artifactName, "T3-Code-${arch}.${ext}");
+      assert.equal(mac.artifactName, "T3-Code-${version}-${arch}.${ext}");
+      assert.equal(win.artifactName, "T3-Code-${version}-${arch}.${ext}");
       for (const config of [linux, win]) {
         assert.deepStrictEqual(config.electronLanguages, DESKTOP_ELECTRON_LANGUAGES);
         assert.deepStrictEqual(config.files, DESKTOP_FILE_EXCLUSIONS);

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2143,7 +2143,10 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   const buildConfig: Record<string, unknown> = {
     appId: DESKTOP_APP_ID,
     productName: resolveDesktopProductName(version),
-    artifactName: "T3-Code-${version}-${arch}.${ext}",
+    artifactName:
+      platform === "linux" && target === "AppImage"
+        ? "T3-Code-${arch}.${ext}"
+        : "T3-Code-${version}-${arch}.${ext}",
     electronLanguages: [...DESKTOP_ELECTRON_LANGUAGES],
     files: [...DESKTOP_FILE_EXCLUSIONS, ...(platform === "mac" ? MAC_FILE_EXCLUSIONS : [])],
     directories: {

--- a/scripts/publish-aur.test.ts
+++ b/scripts/publish-aur.test.ts
@@ -1,0 +1,162 @@
+// @effect-diagnostics nodeBuiltinImport:off - exercises the real release script in an isolated filesystem.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import { assert, it } from "@effect/vitest";
+
+const repoRoot = NodePath.resolve(NodePath.dirname(NodeURL.fileURLToPath(import.meta.url)), "..");
+const releaseScriptPath = NodePath.join(repoRoot, "packaging/aur/scripts/release.sh");
+const emptySha256 = "0".repeat(64);
+const appImageSha256 = "a".repeat(64);
+const legacyAppImageSha256 = "b".repeat(64);
+
+function writeExecutable(filePath: string, contents: string) {
+  NodeFS.writeFileSync(filePath, contents, { mode: 0o755 });
+}
+
+function runRelease(assets: ReadonlyArray<{ readonly name: string; readonly digest: string }>) {
+  const fixtureRoot = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "publish-aur-"));
+  const scriptDir = NodePath.join(fixtureRoot, "packaging/aur/scripts");
+  const packageDir = NodePath.join(fixtureRoot, "packaging/aur/t3code-bin");
+  const binDir = NodePath.join(fixtureRoot, "bin");
+
+  try {
+    NodeFS.mkdirSync(scriptDir, { recursive: true });
+    NodeFS.mkdirSync(packageDir, { recursive: true });
+    NodeFS.mkdirSync(binDir);
+    NodeFS.copyFileSync(releaseScriptPath, NodePath.join(scriptDir, "release.sh"));
+    NodeFS.chmodSync(NodePath.join(scriptDir, "release.sh"), 0o755);
+    NodeFS.writeFileSync(
+      NodePath.join(packageDir, "PKGBUILD"),
+      `pkgver=0.0.33
+pkgrel=1
+_appimage_asset="T3-Code-\${pkgver}-x86_64.AppImage"
+sha256sums=(
+  '${emptySha256}' # AppImage
+  '${emptySha256}' # upstream license
+)
+`,
+    );
+
+    writeExecutable(
+      NodePath.join(binDir, "gh"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *'/releases/tags/'* ]]; then
+  printf '%s\n' "$TEST_RELEASE_JSON"
+elif [[ "$*" == *'/contents/LICENSE'* ]]; then
+  printf 'license\n'
+else
+  printf 'Unexpected gh arguments: %s\n' "$*" >&2
+  exit 1
+fi
+`,
+    );
+    writeExecutable(
+      NodePath.join(binDir, "makepkg"),
+      `#!/usr/bin/env bash
+if [[ " $* " == *' --printsrcinfo '* ]]; then
+  printf 'pkgbase = t3code-bin\n'
+elif [[ " $* " == *' --packagelist '* ]]; then
+  printf '%s/fake.pkg.tar.zst\n' "$PWD"
+fi
+`,
+    );
+    writeExecutable(NodePath.join(binDir, "namcap"), "#!/usr/bin/env bash\nexit 0\n");
+    writeExecutable(NodePath.join(binDir, "id"), "#!/usr/bin/env bash\nprintf '1000\\n'\n");
+
+    const result = NodeChildProcess.spawnSync(NodePath.join(scriptDir, "release.sh"), {
+      cwd: fixtureRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AUR_SSH_PRIVATE_KEY: "",
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        RELEASE_TAG: "v1.2.3",
+        TEST_RELEASE_JSON: JSON.stringify({ assets }),
+      },
+    });
+    const pkgbuild = NodeFS.readFileSync(NodePath.join(packageDir, "PKGBUILD"), "utf8");
+
+    return { result, pkgbuild };
+  } finally {
+    NodeFS.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+it("publishes an AUR package from a legacy versioned AppImage asset", () => {
+  const { result, pkgbuild } = runRelease([
+    {
+      name: "T3-Code-1.2.3-x86_64.AppImage",
+      digest: `sha256:${appImageSha256}`,
+    },
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.include(pkgbuild, "_appimage_asset='T3-Code-1.2.3-x86_64.AppImage'");
+  assert.include(pkgbuild, `'${appImageSha256}' # AppImage`);
+});
+
+it("prefers the stable AppImage asset when both filenames are present", () => {
+  const { result, pkgbuild } = runRelease([
+    {
+      name: "T3-Code-1.2.3-x86_64.AppImage",
+      digest: `sha256:${legacyAppImageSha256}`,
+    },
+    {
+      name: "T3-Code-x86_64.AppImage",
+      digest: `sha256:${appImageSha256}`,
+    },
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.include(pkgbuild, "_appimage_asset='T3-Code-x86_64.AppImage'");
+  assert.include(pkgbuild, `'${appImageSha256}' # AppImage`);
+});
+
+it("uses the legacy asset when the stable asset has no valid digest", () => {
+  const { result, pkgbuild } = runRelease([
+    {
+      name: "T3-Code-x86_64.AppImage",
+      digest: "sha256:invalid",
+    },
+    {
+      name: "T3-Code-1.2.3-x86_64.AppImage",
+      digest: `sha256:${legacyAppImageSha256}`,
+    },
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.include(pkgbuild, "_appimage_asset='T3-Code-1.2.3-x86_64.AppImage'");
+  assert.include(pkgbuild, `'${legacyAppImageSha256}' # AppImage`);
+});
+
+it("rejects a release without a supported AppImage asset", () => {
+  const { result } = runRelease([]);
+
+  assert.equal(result.status, 1);
+  assert.include(
+    result.stderr,
+    "Release v1.2.3 has no supported AppImage asset with a SHA-256 digest.\n" +
+      "Expected T3-Code-x86_64.AppImage or T3-Code-1.2.3-x86_64.AppImage.",
+  );
+});
+
+it("rejects supported AppImage filenames without a valid digest", () => {
+  const { result } = runRelease([
+    {
+      name: "T3-Code-x86_64.AppImage",
+      digest: "sha256:invalid",
+    },
+    {
+      name: "T3-Code-1.2.3-x86_64.AppImage",
+      digest: "",
+    },
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.include(result.stderr, "has no supported AppImage asset with a SHA-256 digest");
+});


### PR DESCRIPTION
Versioned Linux AppImage filenames make `electron-updater` move the binary to a new path on every release. Desktop entries, pinned launchers, and symlinks can then point at a deleted file.

This gives Linux AppImage artifacts the stable `T3-Code-${arch}.AppImage` name. macOS and Windows artifacts remain versioned. The AUR release script prefers the stable remote asset and falls back to the versioned asset for older tags. PKGBUILDs keep a versioned local filename, so existing releases remain buildable without makepkg cache collisions.

### Migration limitation

The installed legacy binary performs the first versioned-to-stable update and removes the versioned path before the new binary starts. Code shipped in this PR cannot preserve or restore that path reliably.

Users upgrading from a versioned AppImage must update their launcher path once after the first transition. Later in-app updates replace the stable path in place.

Tests:

- `vp test run scripts/publish-aur.test.ts scripts/build-desktop-artifact.test.ts apps/desktop/src/electron/ElectronUpdater.test.ts`
- `vp run --filter @t3tools/scripts typecheck`
- `vp run --filter @t3tools/desktop typecheck`
- Targeted lint, formatting, and AUR shell syntax checks
- `electron-updater` 6.8.3 fixture covering legacy-to-stable and stable-to-stable installs

Refs #8944

Generated with GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux release artifact naming and updater install paths; existing launchers pinned to versioned AppImage paths break until users update them once.
> 
> **Overview**
> Linux AppImage releases now ship as **`T3-Code-x86_64.AppImage`** (no version in the filename) so `electron-updater` can replace the binary in place instead of moving to a new path each release. **macOS and Windows** artifacts still use versioned names.
> 
> **AUR packaging** (`release.sh`, both PKGBUILDs) picks the stable GitHub asset when present and falls back to the legacy versioned AppImage for older tags; PKGBUILDs keep a versioned local download name via `_appimage_asset` so makepkg caches stay distinct.
> 
> **Docs** (`release.md`, `install.md`, AUR README) describe the stable asset and note that users on an old versioned AppImage must point their desktop entry or symlink at the stable filename **once** after the first upgrade.
> 
> **Tests** lock in per-platform `artifactName` in the desktop build config and add `publish-aur.test.ts` for stable-vs-legacy asset selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7549f9083bc89abdd6017d266ebaa2d8896f8e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use versionless filename for Linux AppImage builds and AUR packaging
> - Changes `createBuildConfig` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/8983/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) so Linux AppImage artifacts are named `T3-Code-${arch}.${ext}` without the version; macOS and Windows stay versioned
> - Updates [release.sh](https://github.com/pingdotgg/t3code/pull/8983/files#diff-95dd0840eed48d9bf92e26e60c9ef91b786639bcce7784b829c13ee36f66d4b3) and both PKGBUILD files to prefer the stable non-versioned AppImage asset, falling back to the legacy versioned filename when the stable one lacks a valid SHA-256 digest
> - Adds docs in [release.md](https://github.com/pingdotgg/t3code/pull/8983/files#diff-a426703c462dd239e12f4c991868c2b2bcc70f5ff28e0b2fed4c76c2b545874b) and [install.md](https://github.com/pingdotgg/t3code/pull/8983/files#diff-5445c9485dbf19d6da7ef0ed9335ef230c4eb448b7a58ebc7810d3f1eca744c2) explaining the stable naming and the one-time launcher path update for users on older versioned AppImages
> - Risk: users upgrading from an older versioned AppImage must update their desktop entry or symlink to `T3-Code-x86_64.AppImage` once; otherwise launchers pointing at the old versioned filename will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7549f90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Linux AppImage releases now use the stable filename `T3-Code-x86_64.AppImage`, improving automatic update handling.
  - Existing users upgrading from versioned AppImages may need to update their desktop launcher or symlink once.
- **Documentation**
  - Added Linux installation guidance covering AppImage setup, in-app updates, and launcher adjustments.
- **Bug Fixes**
  - Improved Linux package publishing to prefer the stable AppImage and fall back to versioned assets when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->