### PR TITLE
fix(codex): keep foreign memory out of chats

### DIFF
--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -62,6 +62,30 @@ function buildScript() {
         },
       },
     },
+    // A real memory leak began at these item notifications without any
+    // thread/started lifecycle notification for the memory thread.
+    {
+      method: "item/agentMessage/delta",
+      params: {
+        delta: "internal memory update",
+        itemId: "memory-message",
+        threadId: MEMORY,
+        turnId: "memory-turn",
+      },
+    },
+    {
+      method: "item/completed",
+      params: {
+        completedAtMs: 0,
+        item: {
+          id: "memory-message",
+          text: "internal memory update",
+          type: "agentMessage",
+        },
+        threadId: MEMORY,
+        turnId: "memory-turn",
+      },
+    },
     // Child terminal lifecycle AFTER the receiver map knows the children —
     // pre-fix, the legacy suppressor dropped these before interception saw
     // them, so no synthetic agent events were emitted.
@@ -467,6 +491,16 @@ describe("CodexSessionRuntime collab integration", () => {
         leaked.map((event) => event.method),
         [],
         "child thread/* lifecycle must not appear as parent events",
+      );
+
+      const leakedMemory = events.filter((event) => {
+        const payload = event.payload as { threadId?: string } | undefined;
+        return payload?.threadId === MEMORY;
+      });
+      assert.deepEqual(
+        leakedMemory.map((event) => event.method),
+        [],
+        "memory output must not appear without a preceding thread/started notification",
       );
 
       yield* runtime.close;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -20,6 +20,7 @@ import {
   openCodexThread,
   readCodexThread,
   rollbackCodexThread,
+  shouldSuppressForeignConversationNotification,
   toMcpElicitationResponse,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
@@ -780,6 +781,61 @@ describe("makeMemoryConsolidationNotificationFilter", () => {
           turnId: "later-turn",
         },
       }),
+      false,
+    );
+  });
+});
+
+describe("shouldSuppressForeignConversationNotification", () => {
+  it("suppresses background memory output without waiting for thread/started", () => {
+    const leakedDelta = {
+      method: "item/agentMessage/delta" as const,
+      params: {
+        delta: "internal memory update",
+        itemId: "memory-message",
+        threadId: "memory-thread",
+        turnId: "memory-turn",
+      },
+    };
+
+    NodeAssert.equal(
+      shouldSuppressForeignConversationNotification(leakedDelta, "root-thread"),
+      true,
+    );
+    NodeAssert.equal(
+      shouldSuppressForeignConversationNotification(
+        {
+          method: "item/completed",
+          params: {
+            completedAtMs: 0,
+            item: {
+              id: "memory-message",
+              text: "internal memory update",
+              type: "agentMessage",
+            },
+            threadId: "memory-thread",
+            turnId: "memory-turn",
+          },
+        },
+        "root-thread",
+      ),
+      true,
+    );
+    NodeAssert.equal(
+      shouldSuppressForeignConversationNotification(
+        { ...leakedDelta, params: { ...leakedDelta.params, threadId: "root-thread" } },
+        "root-thread",
+      ),
+      false,
+    );
+    NodeAssert.equal(
+      shouldSuppressForeignConversationNotification(
+        {
+          method: "serverRequest/resolved",
+          params: { requestId: "memory-approval", threadId: "memory-thread" },
+        },
+        "root-thread",
+      ),
       false,
     );
   });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -820,6 +820,28 @@ function readNotificationThreadId(notification: CodexServerNotification): string
   }
 }
 
+/**
+ * A notification addressed to another provider thread cannot belong in this
+ * session's chat. This does not depend on seeing that thread's lifecycle
+ * start first: background Codex threads can already be running when a session
+ * subscribes and begin with item deltas.
+ *
+ * `serverRequest/resolved` is the one cross-thread notification the parent
+ * owns because it clears approval correlation state.
+ */
+export function shouldSuppressForeignConversationNotification(
+  notification: CodexServerNotification,
+  rootThreadId: string | undefined,
+): boolean {
+  const notificationThreadId = readNotificationThreadId(notification);
+  return (
+    notificationThreadId !== undefined &&
+    rootThreadId !== undefined &&
+    notificationThreadId !== rootThreadId &&
+    notification.method !== "serverRequest/resolved"
+  );
+}
+
 export function makeMemoryConsolidationNotificationFilter(): (
   notification: CodexServerNotification,
 ) => boolean {
@@ -1882,25 +1904,21 @@ export const makeCodexSessionRuntime = (
           return;
         }
 
-        // Suppression applies to receiver-map children (v1) AND to any
-        // conversation that is not the root thread. The live capture
-        // (codexMultiAgentWire.json) shows a child's thread/status/changed
-        // arriving BEFORE anything registers the child — pre-registration
-        // lifecycle must not reach the parent path, where the adapter maps
-        // thread/* onto parent session state. Root-id-known guard keeps the
-        // root's own early notifications flowing during session open.
+        // Receiver-map children (v1) retain their existing lifecycle routing.
+        // Any known notification addressed to a different provider thread is
+        // wholly foreign to the parent chat. This identity boundary also
+        // covers background memory work that begins emitting item deltas
+        // without a thread/started notification on this subscription.
+        // Registered v2 children were intercepted above, and unknown methods
+        // still fall through because readNotificationThreadId only recognizes
+        // protocol methods whose ownership shape we know.
         const suppressRootId = currentProviderThreadId(yield* Ref.get(sessionRef));
-        const foreignConversation = (() => {
-          const providerConversationId = readNotificationThreadId(notification);
-          return (
-            providerConversationId !== undefined &&
-            suppressRootId !== undefined &&
-            providerConversationId !== suppressRootId
-          );
-        })();
+        const suppressForeignConversationNotification =
+          shouldSuppressForeignConversationNotification(notification, suppressRootId);
         if (
-          (childParentTurnId !== undefined || foreignConversation) &&
-          shouldSuppressChildConversationNotification(notification.method)
+          (childParentTurnId !== undefined &&
+            shouldSuppressChildConversationNotification(notification.method)) ||
+          suppressForeignConversationNotification
         ) {
           // Stop-everything must not depend on registration timing: a
           // child's turn/started can arrive before the subAgentActivity that


### PR DESCRIPTION
Codex background memory work can begin emitting item notifications on an existing app-server subscription without sending a new thread/started notification. The stateful memory filter never learns that provider thread ID, so its assistant text can be projected into the active T3 chat.

This treats the active Codex provider thread ID as the chat ownership boundary. Known notifications addressed to another thread are suppressed even when their lifecycle start was missed. Registered multi-agent children still use their dedicated routing, and serverRequest/resolved still passes through for approval correlation cleanup.

The regression replay matches the observed ordering: agent message delta and item completion for a memory thread with no preceding thread/started.

Verification:
- vp test run apps/server/src/provider/Layers/CodexSessionRuntime.test.ts apps/server/src/provider/Layers/CodexCollabWire.test.ts apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
- vp lint --type-aware --type-check --report-unused-disable-directives apps/server/src/provider/Layers/CodexSessionRuntime.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
- vp fmt --check apps/server/src/provider/Layers/CodexSessionRuntime.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
- git diff --check upstream/main...HEAD

Generated with GPT-5.6 Sol in T3 Code via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex notification routing for all non-root threads; incorrect suppression could hide legitimate cross-thread traffic, though collab interception and serverRequest/resolved exceptions limit blast radius.
> 
> **Overview**
> Fixes **background Codex memory work** showing up in the active T3 chat when item deltas arrive on an existing app-server subscription **without** a preceding `thread/started`, so the stateful memory filter never learns that thread id.
> 
> The runtime now treats the **active provider thread id** as the chat boundary: exported `shouldSuppressForeignConversationNotification` drops any known notification whose `threadId` differs from the root, including `item/agentMessage/delta` and `item/completed`, independent of lifecycle registration. **Registered collab children** still go through interception first; **`serverRequest/resolved`** still passes through for approval correlation.
> 
> Suppression logic is split so v1 receiver-map children keep lifecycle-only routing via `shouldSuppressChildConversationNotification`, while the new helper handles the broader foreign-thread case (including the memory leak ordering).
> 
> Tests cover the helper directly and extend the collab integration replay to assert no events leak for the memory thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 509d07f2575741c971de245c0fbba691ad346184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress foreign memory-thread notifications in `makeCodexSessionRuntime`
> - Adds `shouldSuppressForeignConversationNotification` to classify non-root-thread notifications as suppressible, except `serverRequest/resolved`.
> - The notification loop now suppresses all notifications addressed to non-root provider threads (item deltas, completions) instead of only selected lifecycle events, preventing background memory output from appearing in the parent session.
> - Adds unit tests for the new predicate and an integration assertion that no events from the background memory thread leak without a prior `thread/started`.
> - Risk: `makeCodexSessionRuntime` now drops all non-root-thread `item/*` notifications; any consumer relying on foreign thread deltas appearing in the session stream will no longer receive them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 509d07f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented background memory-thread messages from appearing in the parent conversation stream before the thread is initialized.
  - Improved filtering of notifications from unrelated conversation threads while preserving valid root-thread updates and resolved server requests.
  - Added coverage for memory output and cross-thread notification handling to ensure these events remain isolated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->