### PR TITLE
fix(server): avoid hydrating activities for shell summaries

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -18,8 +18,10 @@ import { OrchestrationEventStore } from "../../persistence/Services/Orchestratio
 import { ProjectionPendingApprovalRepository } from "../../persistence/Services/ProjectionPendingApprovals.ts";
 import { ProjectionProjectRepository } from "../../persistence/Services/ProjectionProjects.ts";
 import { ProjectionStateRepository } from "../../persistence/Services/ProjectionState.ts";
-import { ProjectionThreadActivityRepository } from "../../persistence/Services/ProjectionThreadActivities.ts";
-import { type ProjectionThreadActivity } from "../../persistence/Services/ProjectionThreadActivities.ts";
+import {
+  type ProjectionThreadActivity,
+  ProjectionThreadActivityRepository,
+} from "../../persistence/Services/ProjectionThreadActivities.ts";
 import {
   type ProjectionThreadMessage,
   ProjectionThreadMessageRepository,
@@ -151,52 +153,6 @@ function shouldRefreshThreadShellSummary(event: OrchestrationEvent): boolean {
     default:
       return false;
   }
-}
-
-function derivePendingUserInputCountFromActivities(
-  activities: ReadonlyArray<ProjectionThreadActivity>,
-): number {
-  const openRequestIds = new Set<string>();
-  const ordered = [...activities].toSorted(
-    (left, right) =>
-      left.createdAt.localeCompare(right.createdAt) ||
-      left.activityId.localeCompare(right.activityId),
-  );
-
-  for (const activity of ordered) {
-    const requestId = extractActivityRequestId(activity.payload);
-    if (requestId === null) {
-      continue;
-    }
-    const payload =
-      typeof activity.payload === "object" && activity.payload !== null
-        ? (activity.payload as Record<string, unknown>)
-        : null;
-    const detail = typeof payload?.detail === "string" ? payload.detail.toLowerCase() : null;
-
-    if (activity.kind === "user-input.requested") {
-      openRequestIds.add(requestId);
-      continue;
-    }
-
-    if (activity.kind === "user-input.resolved") {
-      openRequestIds.delete(requestId);
-      continue;
-    }
-
-    if (
-      activity.kind === "provider.user-input.respond.failed" &&
-      detail !== null &&
-      (detail.includes("stale pending user-input request") ||
-        detail.includes("unknown pending user-input request") ||
-        detail.includes("unknown pending user input request") ||
-        detail.includes("unknown pending codex user input request"))
-    ) {
-      openRequestIds.delete(requestId);
-    }
-  }
-
-  return openRequestIds.size;
 }
 
 function deriveHasActionableProposedPlan(input: {
@@ -585,11 +541,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         return;
       }
 
-      const [messages, proposedPlans, activities, pendingApprovals] = yield* Effect.all([
+      const [messages, proposedPlans, pendingApprovals, pendingUserInputCount] = yield* Effect.all([
         projectionThreadMessageRepository.listByThreadId({ threadId }),
         projectionThreadProposedPlanRepository.listByThreadId({ threadId }),
-        projectionThreadActivityRepository.listByThreadId({ threadId }),
         projectionPendingApprovalRepository.listByThreadId({ threadId }),
+        projectionThreadActivityRepository.countPendingUserInputs({ threadId }),
       ]);
 
       let latestUserMessageAt: string | null = null;
@@ -605,7 +561,6 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       const pendingApprovalCount = pendingApprovals.filter(
         (approval) => approval.status === "pending",
       ).length;
-      const pendingUserInputCount = derivePendingUserInputCountFromActivities(activities);
       const hasActionableProposedPlan = deriveHasActionableProposedPlan({
         latestTurnId: existingRow.value.latestTurnId,
         proposedPlans,
@@ -1648,8 +1603,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           // Only approval-requested activities should create pending-approval
           // rows.  Other activity kinds that happen to carry a requestId
           // (e.g. user-input.requested / user-input.resolved) must not
-          // pollute this projection — they have their own accounting via
-          // derivePendingUserInputCountFromActivities.
+          // pollute this projection — they have their own activity lifecycle
+          // accounting in ProjectionThreadActivityRepository.
           if (event.payload.activity.kind !== "approval.requested") {
             return;
           }

--- a/apps/server/src/persistence/Layers/ProjectionThreadActivities.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadActivities.test.ts
@@ -1,0 +1,85 @@
+import { EventId, ThreadId } from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { ProjectionThreadActivityRepository } from "../Services/ProjectionThreadActivities.ts";
+import { ProjectionThreadActivityRepositoryLive } from "./ProjectionThreadActivities.ts";
+import { SqlitePersistenceMemory } from "./Sqlite.ts";
+
+const layer = it.layer(
+  ProjectionThreadActivityRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+);
+
+layer("ProjectionThreadActivityRepository", (it) => {
+  it.effect("counts user-input lifecycle state without hydrating unrelated payloads", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadActivityRepository;
+      const sql = yield* SqlClient.SqlClient;
+      const threadId = ThreadId.make("thread-pending-user-input-count");
+      const createdAt = "2026-03-01T00:00:00.000Z";
+
+      yield* Effect.forEach(
+        [
+          {
+            activityId: EventId.make("activity-input-open"),
+            kind: "user-input.requested",
+            payload: { requestId: "input-open" },
+            createdAt,
+          },
+          {
+            activityId: EventId.make("activity-input-resolved-request"),
+            kind: "user-input.requested",
+            payload: { requestId: "input-resolved" },
+            createdAt: "2026-03-01T00:00:01.000Z",
+          },
+          {
+            activityId: EventId.make("activity-input-resolved"),
+            kind: "user-input.resolved",
+            payload: { requestId: "input-resolved" },
+            createdAt: "2026-03-01T00:00:02.000Z",
+          },
+          {
+            activityId: EventId.make("activity-input-stale-request"),
+            kind: "user-input.requested",
+            payload: { requestId: "input-stale" },
+            createdAt: "2026-03-01T00:00:03.000Z",
+          },
+          {
+            activityId: EventId.make("activity-input-stale-failure"),
+            kind: "provider.user-input.respond.failed",
+            payload: {
+              requestId: "input-stale",
+              detail: "Unknown pending Codex user input request",
+            },
+            createdAt: "2026-03-01T00:00:04.000Z",
+          },
+        ],
+        (activity) =>
+          repository.upsert({
+            ...activity,
+            threadId,
+            turnId: null,
+            tone: "info",
+            summary: activity.kind,
+          }),
+        { discard: true },
+      );
+
+      // A malformed tool payload proves the count query never decodes or
+      // JSON-inspects unrelated activity bodies.
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at
+        )
+        VALUES (
+          'activity-large-tool', ${threadId}, NULL, 'tool', 'tool.completed',
+          'large tool output', 'not-json', NULL, '2026-03-01T00:00:05.000Z'
+        )
+      `;
+
+      assert.equal(yield* repository.countPendingUserInputs({ threadId }), 1);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
@@ -22,6 +22,7 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
     sequence: Schema.NullOr(NonNegativeInt),
   }),
 );
+const PendingUserInputCountRowSchema = Schema.Struct({ count: Schema.Number });
 
 function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: string) {
   return (cause: unknown) =>
@@ -97,6 +98,46 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
       `,
   });
 
+  const countPendingUserInputRows = SqlSchema.findOne({
+    Request: ListProjectionThreadActivitiesInput,
+    Result: PendingUserInputCountRowSchema,
+    execute: ({ threadId }) =>
+      sql`
+        WITH user_input_lifecycle AS (
+          SELECT
+            kind,
+            json_extract(payload_json, '$.requestId') AS request_id,
+            ROW_NUMBER() OVER (
+              PARTITION BY json_extract(payload_json, '$.requestId')
+              ORDER BY created_at DESC, activity_id DESC
+            ) AS request_order
+          FROM projection_thread_activities
+          WHERE thread_id = ${threadId}
+            AND (
+              kind IN ('user-input.requested', 'user-input.resolved')
+              OR (
+                kind = 'provider.user-input.respond.failed'
+                AND (
+                  lower(COALESCE(json_extract(payload_json, '$.detail'), ''))
+                    LIKE '%stale pending user-input request%'
+                  OR lower(COALESCE(json_extract(payload_json, '$.detail'), ''))
+                    LIKE '%unknown pending user-input request%'
+                  OR lower(COALESCE(json_extract(payload_json, '$.detail'), ''))
+                    LIKE '%unknown pending user input request%'
+                  OR lower(COALESCE(json_extract(payload_json, '$.detail'), ''))
+                    LIKE '%unknown pending codex user input request%'
+                )
+              )
+            )
+            AND json_extract(payload_json, '$.requestId') IS NOT NULL
+        )
+        SELECT COUNT(*) AS count
+        FROM user_input_lifecycle
+        WHERE request_order = 1
+          AND kind = 'user-input.requested'
+      `,
+  });
+
   const deleteProjectionThreadActivityRows = SqlSchema.void({
     Request: DeleteProjectionThreadActivitiesInput,
     execute: ({ threadId }) =>
@@ -139,6 +180,18 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
       ),
     );
 
+  const countPendingUserInputs: ProjectionThreadActivityRepositoryShape["countPendingUserInputs"] =
+    (input) =>
+      countPendingUserInputRows(input).pipe(
+        Effect.mapError(
+          toPersistenceSqlOrDecodeError(
+            "ProjectionThreadActivityRepository.countPendingUserInputs:query",
+            "ProjectionThreadActivityRepository.countPendingUserInputs:decodeRow",
+          ),
+        ),
+        Effect.map((row) => row.count),
+      );
+
   const deleteByThreadId: ProjectionThreadActivityRepositoryShape["deleteByThreadId"] = (input) =>
     deleteProjectionThreadActivityRows(input).pipe(
       Effect.mapError(
@@ -149,6 +202,7 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
   return {
     upsert,
     listByThreadId,
+    countPendingUserInputs,
     deleteByThreadId,
   } satisfies ProjectionThreadActivityRepositoryShape;
 });

--- a/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
@@ -68,6 +68,13 @@ export interface ProjectionThreadActivityRepositoryShape {
   ) => Effect.Effect<ReadonlyArray<ProjectionThreadActivity>, ProjectionRepositoryError>;
 
   /**
+   * Count unresolved user-input requests without hydrating activity payloads.
+   */
+  readonly countPendingUserInputs: (
+    input: ListProjectionThreadActivitiesInput,
+  ) => Effect.Effect<number, ProjectionRepositoryError>;
+
+  /**
    * Delete projected thread activity rows by thread.
    */
   readonly deleteByThreadId: (


### PR DESCRIPTION
## What Changed

- Derive the pending user-input count with a focused SQL lifecycle query.
- Stop loading and decoding every thread activity when refreshing shell summary state.
- Preserve requested, resolved, stale, and unknown-request lifecycle semantics.
- Add focused repository and projection-pipeline coverage.

## Why

Severity: **high (regular-use blocker)**.

Every event that refreshed a thread shell summary loaded the thread's complete activity history just to calculate one pending-input count. In tool-heavy conversations that history can be multi-gigabyte. Sending a normal follow-up could therefore spend seconds hydrating unrelated payloads, exhaust V8, restart the backend, and result in a message that never received a response.

The count is relational lifecycle state and can be computed directly from the few relevant activity kinds without materializing tool output.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Source `pendingUserInputCount` from SQL query instead of hydrated activities
> - Adds `ProjectionThreadActivityRepository.countPendingUserInputs`, which counts unresolved user-input requests per thread using a SQL window query that extracts `requestId` via `json_extract` without decoding payloads into application objects
> - Removes `derivePendingUserInputCountFromActivities` and switches `refreshThreadShellSummary` to the repository method, so shell summaries no longer hydrate activity rows
> - Adds a test seeding activities across the user-input lifecycle plus a malformed tool payload, asserting the count returns `1` without hydrating unrelated payloads
> - Behavioral Change: `pendingUserInputCount` is now computed entirely in the database; any out-of-tree code relying on the removed `derivePendingUserInputCountFromActivities` helper or on hydrated activities for this count will break
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c49e861. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->