### PR TITLE
feat(shortcuts): copy active thread reference

### DIFF
--- a/apps/mobile/modules/t3-native-controls/android/src/main/java/expo/modules/t3nativecontrols/T3KeyboardCommandsModule.kt
+++ b/apps/mobile/modules/t3-native-controls/android/src/main/java/expo/modules/t3nativecontrols/T3KeyboardCommandsModule.kt
@@ -23,7 +23,7 @@ class T3KeyboardCommandsModule : Module() {
 
 class T3KeyboardCommandsView(
   context: Context,
-  appContext: AppContext,
+  appContext: AppContext
 ) : ExpoView(context, appContext) {
   private val onCommand by EventDispatcher()
   var enabledCommands = emptySet<String>()

--- a/apps/mobile/modules/t3-native-controls/android/src/main/java/expo/modules/t3nativecontrols/T3KeyboardCommandsModule.kt
+++ b/apps/mobile/modules/t3-native-controls/android/src/main/java/expo/modules/t3nativecontrols/T3KeyboardCommandsModule.kt
@@ -1,0 +1,46 @@
+package expo.modules.t3nativecontrols
+
+import android.content.Context
+import android.view.KeyEvent
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ExpoView
+
+class T3KeyboardCommandsModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("T3KeyboardCommands")
+
+    View(T3KeyboardCommandsView::class) {
+      Prop("enabledCommands") { view: T3KeyboardCommandsView, commands: List<String> ->
+        view.enabledCommands = commands.toSet()
+      }
+      Events("onCommand")
+    }
+  }
+}
+
+class T3KeyboardCommandsView(
+  context: Context,
+  appContext: AppContext,
+) : ExpoView(context, appContext) {
+  private val onCommand by EventDispatcher()
+  var enabledCommands = emptySet<String>()
+
+  override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+    val copiesThreadReference =
+      event.action == KeyEvent.ACTION_DOWN &&
+        event.repeatCount == 0 &&
+        event.keyCode == KeyEvent.KEYCODE_C &&
+        event.isCtrlPressed &&
+        event.isShiftPressed &&
+        !event.isAltPressed &&
+        enabledCommands.contains("copyThreadReference")
+    if (copiesThreadReference) {
+      onCommand(mapOf("command" to "copyThreadReference"))
+      return true
+    }
+    return super.dispatchKeyEvent(event)
+  }
+}

--- a/apps/mobile/modules/t3-native-controls/expo-module.config.json
+++ b/apps/mobile/modules/t3-native-controls/expo-module.config.json
@@ -4,6 +4,9 @@
     "modules": ["T3NativeControlsModule", "T3KeyboardCommandsModule"]
   },
   "android": {
-    "modules": ["expo.modules.t3nativecontrols.T3NativeControlsModule"]
+    "modules": [
+      "expo.modules.t3nativecontrols.T3NativeControlsModule",
+      "expo.modules.t3nativecontrols.T3KeyboardCommandsModule"
+    ]
   }
 }

--- a/apps/mobile/modules/t3-native-controls/ios/T3KeyboardCommandsModule.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/T3KeyboardCommandsModule.swift
@@ -29,6 +29,13 @@ public final class T3KeyboardCommandsView: ExpoView {
       enabledCommand("files", input: "f", modifiers: [.command, .shift], action: #selector(openFiles), title: "Open Files"),
       enabledCommand("terminal", input: "t", modifiers: [.command, .shift], action: #selector(openTerminal), title: "Open Terminal"),
       enabledCommand("review", input: "r", modifiers: [.command, .shift], action: #selector(openReview), title: "Open Review"),
+      enabledCommand(
+        "copyThreadReference",
+        input: "c",
+        modifiers: [.command, .shift],
+        action: #selector(copyThreadReference),
+        title: "Copy PR Link or Thread ID"
+      ),
       enabledCommand("toggleSidebar", input: "\\", modifiers: .command, action: #selector(handleToggleSidebar), title: "Toggle Sidebar"),
     ].compactMap { $0 }
   }
@@ -106,6 +113,7 @@ public final class T3KeyboardCommandsView: ExpoView {
   @objc private func openFiles() { emit("files") }
   @objc private func openTerminal() { emit("terminal") }
   @objc private func openReview() { emit("review") }
+  @objc private func copyThreadReference() { emit("copyThreadReference") }
   @objc private func handleToggleSidebar() { emit("toggleSidebar") }
 
   private func emit(_ command: String) {

--- a/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
+++ b/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
@@ -119,7 +119,7 @@ export function HardwareKeyboardCommandProvider({
       commands.add("files");
       commands.add("terminal");
       commands.add("review");
-      commands.add("copyThreadReference");
+      if (!/\/terminal(?:\/|$)/.test(pathname)) commands.add("copyThreadReference");
     }
     return [...commands];
   }, [pathname, registrationVersion, navigation]);

--- a/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
+++ b/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
@@ -119,7 +119,7 @@ export function HardwareKeyboardCommandProvider({
       commands.add("files");
       commands.add("terminal");
       commands.add("review");
-      if (!/\/terminal(?:\/|$)/.test(pathname)) commands.add("copyThreadReference");
+      if (pathname.split("/")[4] !== "terminal") commands.add("copyThreadReference");
     }
     return [...commands];
   }, [pathname, registrationVersion, navigation]);

--- a/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
+++ b/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
@@ -1,7 +1,22 @@
 import { StackActions, useNavigation } from "@react-navigation/native";
-import { useCallback, useMemo, useSyncExternalStore, type PropsWithChildren } from "react";
+import { resolveThreadReferenceCopyTarget } from "@t3tools/shared/threadReference";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type PropsWithChildren,
+} from "react";
 
+import { tryCopyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import { T3KeyboardCommands } from "../../native/T3KeyboardCommands";
+import { useProject, useThreadShell } from "../../state/entities";
+import { useEnvironmentQuery } from "../../state/query";
+import type { GitActionProgress } from "../../state/use-vcs-action-state";
+import { vcsEnvironment } from "../../state/vcs";
+import { GitActionProgressOverlay } from "../threads/GitActionProgressOverlay";
 import {
   dispatchHardwareKeyboardCommand,
   getHardwareKeyboardCommandRegistrationVersion,
@@ -11,11 +26,85 @@ import {
   type HardwareKeyboardCommand,
 } from "./hardwareKeyboardCommands";
 
+const EMPTY_COPY_FEEDBACK: GitActionProgress = {
+  phase: "idle",
+  label: null,
+  description: null,
+};
+const COPY_FEEDBACK_DISMISS_MS = 3_000;
+
 export function HardwareKeyboardCommandProvider({
   children,
   pathname,
 }: PropsWithChildren<{ readonly pathname: string }>) {
   const navigation = useNavigation();
+  const activeThreadRef = useMemo(() => parseActiveThreadPath(pathname), [pathname]);
+  const activeThread = useThreadShell(activeThreadRef);
+  const activeProjectRef = useMemo(
+    () =>
+      activeThread === null
+        ? null
+        : {
+            environmentId: activeThread.environmentId,
+            projectId: activeThread.projectId,
+          },
+    [activeThread],
+  );
+  const activeProject = useProject(activeProjectRef);
+  const activeThreadCwd = activeThread?.worktreePath ?? activeProject?.workspaceRoot ?? null;
+  const gitStatus = useEnvironmentQuery(
+    activeThread !== null &&
+      activeThread.linkedPullRequest == null &&
+      activeThread.branch !== null &&
+      activeThreadCwd !== null
+      ? vcsEnvironment.status({
+          environmentId: activeThread.environmentId,
+          input: { cwd: activeThreadCwd },
+        })
+      : null,
+  ).data;
+  const detectedPullRequestUrl =
+    activeThread?.branch != null && gitStatus?.refName === activeThread.branch
+      ? (gitStatus.pr?.url ?? null)
+      : null;
+  const copyTarget = useMemo(
+    () =>
+      activeThread === null
+        ? null
+        : resolveThreadReferenceCopyTarget({
+            threadId: activeThread.id,
+            linkedPullRequestUrl: activeThread.linkedPullRequest?.url ?? null,
+            detectedPullRequestUrl,
+          }),
+    [activeThread, detectedPullRequestUrl],
+  );
+  const [copyFeedback, setCopyFeedback] = useState<GitActionProgress>(EMPTY_COPY_FEEDBACK);
+  const copyFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissCopyFeedback = useCallback(() => {
+    if (copyFeedbackTimerRef.current !== null) {
+      clearTimeout(copyFeedbackTimerRef.current);
+      copyFeedbackTimerRef.current = null;
+    }
+    setCopyFeedback(EMPTY_COPY_FEEDBACK);
+  }, []);
+  const showCopyFeedback = useCallback((feedback: GitActionProgress) => {
+    if (copyFeedbackTimerRef.current !== null) {
+      clearTimeout(copyFeedbackTimerRef.current);
+    }
+    setCopyFeedback(feedback);
+    copyFeedbackTimerRef.current = setTimeout(() => {
+      copyFeedbackTimerRef.current = null;
+      setCopyFeedback(EMPTY_COPY_FEEDBACK);
+    }, COPY_FEEDBACK_DISMISS_MS);
+  }, []);
+  useEffect(
+    () => () => {
+      if (copyFeedbackTimerRef.current !== null) {
+        clearTimeout(copyFeedbackTimerRef.current);
+      }
+    },
+    [],
+  );
   const registrationVersion = useSyncExternalStore(
     subscribeToHardwareKeyboardCommandRegistrations,
     getHardwareKeyboardCommandRegistrationVersion,
@@ -25,10 +114,11 @@ export function HardwareKeyboardCommandProvider({
     const commands = new Set<HardwareKeyboardCommand>(getRegisteredHardwareKeyboardCommands());
     commands.add("newTask");
     if (pathname !== "/" || navigation.canGoBack()) commands.add("back");
-    if (parseActiveThreadPath(pathname)) {
+    if (activeThreadRef !== null) {
       commands.add("files");
       commands.add("terminal");
       commands.add("review");
+      commands.add("copyThreadReference");
     }
     return [...commands];
   }, [pathname, registrationVersion, navigation]);
@@ -36,6 +126,31 @@ export function HardwareKeyboardCommandProvider({
   const onCommand = useCallback(
     (command: HardwareKeyboardCommand) => {
       if (dispatchHardwareKeyboardCommand(command)) return;
+
+      if (command === "copyThreadReference") {
+        if (copyTarget === null) return;
+        void tryCopyTextWithHaptic(copyTarget.value, {
+          target: copyTarget.clipboardTarget,
+        }).then((didCopy) => {
+          showCopyFeedback(
+            didCopy
+              ? {
+                  phase: "success",
+                  label: copyTarget.successTitle,
+                  description: copyTarget.value,
+                }
+              : {
+                  phase: "error",
+                  label:
+                    copyTarget.kind === "pull-request"
+                      ? "Could not copy PR link"
+                      : "Could not copy thread ID",
+                  description: "Try again.",
+                },
+          );
+        });
+        return;
+      }
 
       if (command === "newTask") {
         navigation.navigate("NewTaskSheet", { screen: "NewTask" });
@@ -62,12 +177,15 @@ export function HardwareKeyboardCommandProvider({
         navigation.navigate("ThreadReview", thread);
       }
     },
-    [pathname, navigation],
+    [copyTarget, navigation, pathname, showCopyFeedback],
   );
 
   return (
-    <T3KeyboardCommands enabledCommands={enabledCommands} onCommand={onCommand}>
-      {children}
-    </T3KeyboardCommands>
+    <>
+      <T3KeyboardCommands enabledCommands={enabledCommands} onCommand={onCommand}>
+        {children}
+      </T3KeyboardCommands>
+      <GitActionProgressOverlay progress={copyFeedback} onDismiss={dismissCopyFeedback} />
+    </>
   );
 }

--- a/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
+++ b/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
@@ -69,16 +69,17 @@ export function HardwareKeyboardCommandProvider({
       : null;
   const copyTarget = useMemo(
     () =>
-      activeThread === null
+      activeThreadRef === null
         ? null
         : resolveThreadReferenceCopyTarget({
-            threadId: activeThread.id,
-            linkedPullRequestUrl: activeThread.linkedPullRequest?.url ?? null,
+            threadId: activeThread?.id ?? activeThreadRef.threadId,
+            linkedPullRequestUrl: activeThread?.linkedPullRequest?.url ?? null,
             detectedPullRequestUrl,
           }),
-    [activeThread, detectedPullRequestUrl],
+    [activeThread, activeThreadRef, detectedPullRequestUrl],
   );
   const [copyFeedback, setCopyFeedback] = useState<GitActionProgress>(EMPTY_COPY_FEEDBACK);
+  const copyRequestIdRef = useRef(0);
   const copyFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dismissCopyFeedback = useCallback(() => {
     if (copyFeedbackTimerRef.current !== null) {
@@ -129,9 +130,11 @@ export function HardwareKeyboardCommandProvider({
 
       if (command === "copyThreadReference") {
         if (copyTarget === null) return;
+        const requestId = ++copyRequestIdRef.current;
         void tryCopyTextWithHaptic(copyTarget.value, {
           target: copyTarget.clipboardTarget,
         }).then((didCopy) => {
+          if (requestId !== copyRequestIdRef.current) return;
           showCopyFeedback(
             didCopy
               ? {
@@ -141,10 +144,7 @@ export function HardwareKeyboardCommandProvider({
                 }
               : {
                   phase: "error",
-                  label:
-                    copyTarget.kind === "pull-request"
-                      ? "Could not copy PR link"
-                      : "Could not copy thread ID",
+                  label: copyTarget.failureTitle,
                   description: "Try again.",
                 },
           );

--- a/apps/mobile/src/features/keyboard/hardwareKeyboardCommands.ts
+++ b/apps/mobile/src/features/keyboard/hardwareKeyboardCommands.ts
@@ -8,6 +8,7 @@ export type HardwareKeyboardCommand =
   | "files"
   | "terminal"
   | "review"
+  | "copyThreadReference"
   | "toggleSidebar";
 
 type CommandHandler = () => boolean | void;

--- a/apps/mobile/src/lib/copyTextWithHaptic.test.ts
+++ b/apps/mobile/src/lib/copyTextWithHaptic.test.ts
@@ -22,6 +22,7 @@ import {
   CopyTextClipboardWriteError,
   CopyTextHapticFeedbackError,
   copyTextWithHaptic,
+  tryCopyTextWithHaptic,
 } from "./copyTextWithHaptic";
 
 describe("copyTextWithHaptic", () => {
@@ -52,6 +53,19 @@ describe("copyTextWithHaptic", () => {
     expect(mocks.setStringAsync).toHaveBeenCalledWith("work output");
     expect(mocks.selectionAsync).toHaveBeenCalledOnce();
     expect(mocks.impactAsync).not.toHaveBeenCalled();
+  });
+
+  it("reports whether the clipboard write succeeded", async () => {
+    mocks.setStringAsync.mockResolvedValueOnce(undefined);
+
+    await expect(tryCopyTextWithHaptic("thread-123")).resolves.toBe(true);
+  });
+
+  it("returns false when the clipboard write fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.setStringAsync.mockRejectedValueOnce(new Error("native clipboard failure"));
+
+    await expect(tryCopyTextWithHaptic("thread-123")).resolves.toBe(false);
   });
 
   it("reports structured failures without including clipboard contents", async () => {

--- a/apps/mobile/src/lib/copyTextWithHaptic.ts
+++ b/apps/mobile/src/lib/copyTextWithHaptic.ts
@@ -27,19 +27,22 @@ export class CopyTextHapticFeedbackError extends Schema.TaggedErrorClass<CopyTex
   }
 }
 
-export function copyTextWithHaptic(
+interface CopyTextWithHapticOptions {
+  readonly target?: string;
+  readonly feedback?: "light-impact" | "selection";
+}
+
+export async function tryCopyTextWithHaptic(
   value: string,
-  options: {
-    readonly target?: string;
-    readonly feedback?: "light-impact" | "selection";
-  } = {},
-): void {
+  options: CopyTextWithHapticOptions = {},
+): Promise<boolean> {
   const target = options.target ?? "text";
   const feedback = options.feedback ?? "light-impact";
 
-  void (async () => {
+  const clipboardWrite = (async () => {
     try {
       await Clipboard.setStringAsync(value);
+      return true;
     } catch (cause) {
       console.error(
         new CopyTextClipboardWriteError({
@@ -47,6 +50,7 @@ export function copyTextWithHaptic(
           cause,
         }),
       );
+      return false;
     }
   })();
 
@@ -67,4 +71,10 @@ export function copyTextWithHaptic(
       );
     }
   })();
+
+  return await clipboardWrite;
+}
+
+export function copyTextWithHaptic(value: string, options: CopyTextWithHapticOptions = {}): void {
+  void tryCopyTextWithHaptic(value, options);
 }

--- a/apps/mobile/src/native/T3KeyboardCommands.android.tsx
+++ b/apps/mobile/src/native/T3KeyboardCommands.android.tsx
@@ -1,0 +1,31 @@
+import { requireNativeView } from "expo";
+import type { PropsWithChildren } from "react";
+import type { NativeSyntheticEvent, ViewProps } from "react-native";
+
+import type { HardwareKeyboardCommand } from "../features/keyboard/hardwareKeyboardCommands";
+
+interface NativeKeyboardCommandsProps extends ViewProps, PropsWithChildren {
+  readonly enabledCommands: ReadonlyArray<HardwareKeyboardCommand>;
+  readonly onCommand: (
+    event: NativeSyntheticEvent<{ readonly command: HardwareKeyboardCommand }>,
+  ) => void;
+}
+
+const NativeKeyboardCommands = requireNativeView<NativeKeyboardCommandsProps>("T3KeyboardCommands");
+
+export function T3KeyboardCommands(
+  props: PropsWithChildren<{
+    readonly enabledCommands: ReadonlyArray<HardwareKeyboardCommand>;
+    readonly onCommand: (command: HardwareKeyboardCommand) => void;
+  }>,
+) {
+  return (
+    <NativeKeyboardCommands
+      onCommand={(event) => props.onCommand(event.nativeEvent.command)}
+      enabledCommands={props.enabledCommands}
+      style={{ flex: 1 }}
+    >
+      {props.children}
+    </NativeKeyboardCommands>
+  );
+}

--- a/apps/mobile/src/state/use-thread-selection.ts
+++ b/apps/mobile/src/state/use-thread-selection.ts
@@ -54,6 +54,7 @@ function threadDetailToShell(
     interactionMode: thread.interactionMode,
     branch: thread.branch,
     worktreePath: thread.worktreePath,
+    linkedPullRequest: thread.linkedPullRequest ?? null,
     latestTurn: thread.latestTurn,
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -195,6 +195,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
+      assert.equal(defaultsByCommand.get("thread.copyReference"), "mod+shift+c");
       assert.equal(defaultsByCommand.get("thread.settle"), "mod+shift+s");
       assert.equal(defaultsByCommand.get("thread.pin"), "mod+shift+p");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -55,6 +55,7 @@ import {
 } from "@t3tools/shared/model";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
+import { resolveThreadReferenceCopyTarget } from "@t3tools/shared/threadReference";
 import {
   getTerminalLabel,
   nextTerminalId,
@@ -4600,6 +4601,44 @@ function ChatViewContent(props: ChatViewProps) {
     linkedPullRequest: linkedThreadPullRequest,
     linkedPullRequestStatus,
   });
+  const activeThreadReferenceCopyTarget = useMemo(
+    () =>
+      activeThreadId === null
+        ? null
+        : resolveThreadReferenceCopyTarget({
+            threadId: activeThreadId,
+            linkedPullRequestUrl: linkedThreadPullRequest?.url ?? null,
+            detectedPullRequestUrl: activeThreadPr?.url ?? null,
+          }),
+    [activeThreadId, activeThreadPr?.url, linkedThreadPullRequest?.url],
+  );
+  const copyActiveThreadReference = useCallback(() => {
+    const target = activeThreadReferenceCopyTarget;
+    if (target === null) return;
+    void writeTextToClipboard(target.value, target.clipboardTarget).then(
+      (didCopy) => {
+        if (!didCopy) return;
+        toastManager.add({
+          type: "success",
+          title: target.successTitle,
+          description: target.value,
+        });
+      },
+      (error) => {
+        console.error(error);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title:
+              target.kind === "pull-request"
+                ? "Failed to copy PR link"
+                : "Failed to copy thread ID",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      },
+    );
+  }, [activeThreadReferenceCopyTarget]);
   // The right panel offers the thread's own change request, so it can only offer it once the
   // branch has one; until then the picker says so rather than opening an empty panel.
   const addPullRequestSurface = useCallback(() => {
@@ -5301,6 +5340,13 @@ function ChatViewContent(props: ChatViewProps) {
       });
       if (!command) return;
 
+      if (command === "thread.copyReference") {
+        event.preventDefault();
+        event.stopPropagation();
+        copyActiveThreadReference();
+        return;
+      }
+
       if (command === "thread.settle") {
         event.preventDefault();
         event.stopPropagation();
@@ -5470,6 +5516,7 @@ function ChatViewContent(props: ChatViewProps) {
     supportsPinning,
     supportsSettlement,
     confirmAndUnpinThread,
+    copyActiveThreadReference,
     toggleRightPanel,
     toggleRightPanelMaximized,
     toggleTerminalVisibility,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4603,14 +4603,14 @@ function ChatViewContent(props: ChatViewProps) {
   });
   const activeThreadReferenceCopyTarget = useMemo(
     () =>
-      activeThreadId === null
+      activeThreadId === null || !isServerThread
         ? null
         : resolveThreadReferenceCopyTarget({
             threadId: activeThreadId,
             linkedPullRequestUrl: linkedThreadPullRequest?.url ?? null,
             detectedPullRequestUrl: activeThreadPr?.url ?? null,
           }),
-    [activeThreadId, activeThreadPr?.url, linkedThreadPullRequest?.url],
+    [activeThreadId, activeThreadPr?.url, isServerThread, linkedThreadPullRequest?.url],
   );
   const copyActiveThreadReference = useCallback(() => {
     const target = activeThreadReferenceCopyTarget;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5340,7 +5340,7 @@ function ChatViewContent(props: ChatViewProps) {
       if (command === "thread.copyReference") {
         event.preventDefault();
         event.stopPropagation();
-        copyActiveThreadReference();
+        if (!event.repeat) copyActiveThreadReference();
         return;
       }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4629,10 +4629,7 @@ function ChatViewContent(props: ChatViewProps) {
         toastManager.add(
           stackedThreadToast({
             type: "error",
-            title:
-              target.kind === "pull-request"
-                ? "Failed to copy PR link"
-                : "Failed to copy thread ID",
+            title: target.failureTitle,
             description: error instanceof Error ? error.message : "An error occurred.",
           }),
         );

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import {
+  scopedThreadKey,
+  scopeProjectRef,
+  scopeThreadRef,
+} from "@t3tools/client-runtime/environment";
 import {
   canCreateProjectInEnvironment,
   getCloneDestinationBrowsePath,
@@ -79,8 +83,9 @@ import { vcsEnvironment } from "../state/vcs";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import { useProject, useProjects, useThreadShells } from "../state/entities";
 import { useThreadSearch } from "../state/queries";
+import * as ThreadPr from "./ThreadStatusIndicators";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
   appendBrowsePathSegment,
@@ -591,16 +596,11 @@ function OpenCommandPaletteDialog(props: {
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
-  const activeThreadProject = useMemo(
-    () =>
-      activeThread == null
-        ? null
-        : (projects.find(
-            (project) =>
-              project.environmentId === activeThread.environmentId &&
-              project.id === activeThread.projectId,
-          ) ?? null),
-    [activeThread, projects],
+  const changeRequestSnapshotByKey = useAtomValue(ThreadPr.threadChangeRequestSnapshotsAtom);
+  const activeThreadProject = useProject(
+    activeThread === null
+      ? null
+      : scopeProjectRef(activeThread.environmentId, activeThread.projectId),
   );
   const activeThreadCwd = activeThread?.worktreePath ?? activeThreadProject?.workspaceRoot ?? null;
   const activeThreadGitStatus = useEnvironmentQuery(
@@ -615,20 +615,24 @@ function OpenCommandPaletteDialog(props: {
       : null,
   ).data;
   const detectedPullRequestUrl =
-    activeThread?.branch != null && activeThreadGitStatus?.refName === activeThread.branch
-      ? (activeThreadGitStatus.pr?.url ?? null)
-      : null;
-  const activeThreadReferenceCopyTarget = useMemo(
-    () =>
-      activeThread == null
-        ? null
-        : resolveThreadReferenceCopyTarget({
-            threadId: activeThread.id,
-            linkedPullRequestUrl: activeThread.linkedPullRequest?.url ?? null,
-            detectedPullRequestUrl,
-          }),
-    [activeThread, detectedPullRequestUrl],
-  );
+    activeThread == null || activeThread.linkedPullRequest != null
+      ? null
+      : (ThreadPr.resolveDisplayedThreadPr({
+          threadBranch: activeThread.branch,
+          gitStatus: activeThreadGitStatus ?? null,
+          snapshot: changeRequestSnapshotByKey.get(
+            scopedThreadKey(scopeThreadRef(activeThread.environmentId, activeThread.id)),
+          ),
+          retainTerminalOnBranchMismatch: activeThread.worktreePath === null,
+        })?.url ?? null);
+  const activeThreadReferenceCopyTarget =
+    activeThread == null
+      ? null
+      : resolveThreadReferenceCopyTarget({
+          threadId: activeThread.id,
+          linkedPullRequestUrl: activeThread.linkedPullRequest?.url ?? null,
+          detectedPullRequestUrl,
+        });
   const copyActiveThreadReference = useCallback(async () => {
     const target = activeThreadReferenceCopyTarget;
     if (target === null) return;
@@ -2245,16 +2249,12 @@ function OpenCommandPaletteDialog(props: {
         return;
       }
     }
-    if (command === "thread.copyReference") {
-      const matchingItem = displayedGroups
-        .flatMap((group) => group.items)
-        .find((item) => item.shortcutCommand === command);
-      if (matchingItem) {
-        event.preventDefault();
-        event.stopPropagation();
-        executeItem(matchingItem);
-        return;
-      }
+    if (command === "thread.copyReference" && activeThreadReferenceCopyTarget !== null) {
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+      void copyActiveThreadReference();
+      return;
     }
 
     if (addProjectCloneFlow?.step === "repository" && event.key === "Enter") {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -649,8 +649,7 @@ function OpenCommandPaletteDialog(props: {
       toastManager.add(
         stackedThreadToast({
           type: "error",
-          title:
-            target.kind === "pull-request" ? "Failed to copy PR link" : "Failed to copy thread ID",
+          title: target.failureTitle,
           description: error instanceof Error ? error.message : "An error occurred.",
         }),
       );

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -11,6 +11,7 @@ import {
 } from "@t3tools/client-runtime/operations/projects";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
+import { resolveThreadReferenceCopyTarget } from "@t3tools/shared/threadReference";
 import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
@@ -65,6 +66,7 @@ import { useAtomValue } from "@effect/atom-react";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { useClientSettings } from "../hooks/useSettings";
 import { useTheme } from "../hooks/useTheme";
 import { readLocalApi } from "../localApi";
@@ -73,6 +75,7 @@ import { filesystemEnvironment } from "../state/filesystem";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { sourceControlEnvironment } from "../state/sourceControl";
+import { vcsEnvironment } from "../state/vcs";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
@@ -588,6 +591,67 @@ function OpenCommandPaletteDialog(props: {
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
+  const activeThreadProject = useMemo(
+    () =>
+      activeThread == null
+        ? null
+        : (projects.find(
+            (project) =>
+              project.environmentId === activeThread.environmentId &&
+              project.id === activeThread.projectId,
+          ) ?? null),
+    [activeThread, projects],
+  );
+  const activeThreadCwd = activeThread?.worktreePath ?? activeThreadProject?.workspaceRoot ?? null;
+  const activeThreadGitStatus = useEnvironmentQuery(
+    activeThread != null &&
+      activeThread.linkedPullRequest == null &&
+      activeThread.branch !== null &&
+      activeThreadCwd !== null
+      ? vcsEnvironment.status({
+          environmentId: activeThread.environmentId,
+          input: { cwd: activeThreadCwd },
+        })
+      : null,
+  ).data;
+  const detectedPullRequestUrl =
+    activeThread?.branch != null && activeThreadGitStatus?.refName === activeThread.branch
+      ? (activeThreadGitStatus.pr?.url ?? null)
+      : null;
+  const activeThreadReferenceCopyTarget = useMemo(
+    () =>
+      activeThread == null
+        ? null
+        : resolveThreadReferenceCopyTarget({
+            threadId: activeThread.id,
+            linkedPullRequestUrl: activeThread.linkedPullRequest?.url ?? null,
+            detectedPullRequestUrl,
+          }),
+    [activeThread, detectedPullRequestUrl],
+  );
+  const copyActiveThreadReference = useCallback(async () => {
+    const target = activeThreadReferenceCopyTarget;
+    if (target === null) return;
+    try {
+      const didCopy = await writeTextToClipboard(target.value, target.clipboardTarget);
+      if (!didCopy) return;
+      toastManager.add({
+        type: "success",
+        title: target.successTitle,
+        description: target.value,
+      });
+    } catch (error) {
+      console.error(error);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title:
+            target.kind === "pull-request" ? "Failed to copy PR link" : "Failed to copy thread ID",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    }
+  }, [activeThreadReferenceCopyTarget]);
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -1525,6 +1589,20 @@ function OpenCommandPaletteDialog(props: {
     });
   }
 
+  if (activeThreadReferenceCopyTarget !== null) {
+    actionItems.push({
+      kind: "action",
+      value: "action:copy-thread-reference",
+      searchTerms: ["copy", "pull request", "pr link", "thread id", "reference"],
+      title:
+        activeThreadReferenceCopyTarget.kind === "pull-request" ? "Copy PR link" : "Copy thread ID",
+      description: activeThreadReferenceCopyTarget.value,
+      icon: <LinkIcon className={ITEM_ICON_CLASS} />,
+      shortcutCommand: "thread.copyReference",
+      run: copyActiveThreadReference,
+    });
+  }
+
   actionItems.push({
     kind: "action",
     value: "action:open-file-picker",
@@ -2157,6 +2235,17 @@ function OpenCommandPaletteDialog(props: {
       context: { modelPickerOpen: false },
     });
     if (threadJumpIndexFromCommand(command ?? "") !== null) {
+      const matchingItem = displayedGroups
+        .flatMap((group) => group.items)
+        .find((item) => item.shortcutCommand === command);
+      if (matchingItem) {
+        event.preventDefault();
+        event.stopPropagation();
+        executeItem(matchingItem);
+        return;
+      }
+    }
+    if (command === "thread.copyReference") {
       const matchingItem = displayedGroups
         .flatMap((group) => group.items)
         .find((item) => item.shortcutCommand === command);

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -143,6 +143,11 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
   {
+    shortcut: modShortcut("c", { shiftKey: true }),
+    command: "thread.copyReference",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("s", { shiftKey: true }),
     command: "thread.settle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -207,6 +212,32 @@ describe("settle thread shortcut", () => {
     assert.isNull(
       resolveShortcutCommand(event({ key: "s", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
         platform: "Win32",
+        context: { terminalFocus: true },
+      }),
+    );
+  });
+});
+
+describe("copy thread reference shortcut", () => {
+  it("resolves Cmd+Shift+C on macOS and Ctrl+Shift+C elsewhere", () => {
+    assert.equal(
+      resolveShortcutCommand(event({ key: "c", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      "thread.copyReference",
+    );
+    assert.equal(
+      resolveShortcutCommand(event({ key: "c", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+      }),
+      "thread.copyReference",
+    );
+  });
+
+  it("leaves terminal copy untouched", () => {
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "c", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
         context: { terminalFocus: true },
       }),
     );

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -52,6 +52,10 @@ successful pick; its hover glow and badge preview the element and color family t
 `rightPanel.toggleMaximized` maximizes or restores the open right panel. It has no default shortcut,
 so add one in **Settings** → **Keybindings** if you want to use it.
 
+`thread.copyReference` copies the active thread's pull request link, or its thread ID when no pull
+request is available. Its default shortcut is `mod+shift+c`, and it does not replace terminal copy
+while the terminal has focus.
+
 `thread.settle` settles the active thread or restores it when it is already settled. Its default
 shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
 

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -114,6 +114,13 @@ it.effect("parses keybinding rules", () =>
       when: "!terminalFocus",
     });
     assert.strictEqual(parsedThreadSettle.command, "thread.settle");
+
+    const parsedThreadCopyReference = yield* decode(KeybindingRule, {
+      key: "mod+shift+c",
+      command: "thread.copyReference",
+      when: "!terminalFocus",
+    });
+    assert.strictEqual(parsedThreadCopyReference.command, "thread.copyReference");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.copyReference",
   "thread.settle",
   "thread.pin",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -167,6 +167,10 @@
       "types": "./src/keybindings.ts",
       "import": "./src/keybindings.ts"
     },
+    "./threadReference": {
+      "types": "./src/threadReference.ts",
+      "import": "./src/threadReference.ts"
+    },
     "./composerTrigger": {
       "types": "./src/composerTrigger.ts",
       "import": "./src/composerTrigger.ts"

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -46,6 +46,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "mod+shift+c", command: "thread.copyReference", when: "!terminalFocus" },
   { key: "mod+shift+s", command: "thread.settle", when: "!terminalFocus" },
   { key: "mod+shift+p", command: "thread.pin", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({

--- a/packages/shared/src/threadReference.test.ts
+++ b/packages/shared/src/threadReference.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveThreadReferenceCopyTarget } from "./threadReference.ts";
+
+describe("resolveThreadReferenceCopyTarget", () => {
+  it("prefers a durable linked pull request", () => {
+    expect(
+      resolveThreadReferenceCopyTarget({
+        threadId: "thread-1",
+        linkedPullRequestUrl: "https://github.com/t3/pr/12",
+        detectedPullRequestUrl: "https://github.com/t3/pr/13",
+      }),
+    ).toMatchObject({
+      kind: "pull-request",
+      value: "https://github.com/t3/pr/12",
+      successTitle: "PR link copied",
+    });
+  });
+
+  it("uses a pull request detected from the active branch", () => {
+    expect(
+      resolveThreadReferenceCopyTarget({
+        threadId: "thread-1",
+        detectedPullRequestUrl: "https://github.com/t3/pr/13",
+      }),
+    ).toMatchObject({
+      kind: "pull-request",
+      value: "https://github.com/t3/pr/13",
+    });
+  });
+
+  it("falls back to the thread ID", () => {
+    expect(resolveThreadReferenceCopyTarget({ threadId: "thread-1" })).toEqual({
+      kind: "thread",
+      value: "thread-1",
+      clipboardTarget: "thread ID",
+      successTitle: "Thread ID copied",
+    });
+  });
+});

--- a/packages/shared/src/threadReference.test.ts
+++ b/packages/shared/src/threadReference.test.ts
@@ -35,6 +35,7 @@ describe("resolveThreadReferenceCopyTarget", () => {
       value: "thread-1",
       clipboardTarget: "thread ID",
       successTitle: "Thread ID copied",
+      failureTitle: "Failed to copy thread ID",
     });
   });
 });

--- a/packages/shared/src/threadReference.ts
+++ b/packages/shared/src/threadReference.ts
@@ -1,0 +1,27 @@
+export interface ThreadReferenceCopyTarget {
+  readonly kind: "pull-request" | "thread";
+  readonly value: string;
+  readonly clipboardTarget: string;
+  readonly successTitle: string;
+}
+
+export function resolveThreadReferenceCopyTarget(input: {
+  readonly threadId: string;
+  readonly linkedPullRequestUrl?: string | null;
+  readonly detectedPullRequestUrl?: string | null;
+}): ThreadReferenceCopyTarget {
+  const pullRequestUrl = input.linkedPullRequestUrl ?? input.detectedPullRequestUrl;
+  return pullRequestUrl
+    ? {
+        kind: "pull-request",
+        value: pullRequestUrl,
+        clipboardTarget: "pull request link",
+        successTitle: "PR link copied",
+      }
+    : {
+        kind: "thread",
+        value: input.threadId,
+        clipboardTarget: "thread ID",
+        successTitle: "Thread ID copied",
+      };
+}

--- a/packages/shared/src/threadReference.ts
+++ b/packages/shared/src/threadReference.ts
@@ -3,6 +3,7 @@ export interface ThreadReferenceCopyTarget {
   readonly value: string;
   readonly clipboardTarget: string;
   readonly successTitle: string;
+  readonly failureTitle: string;
 }
 
 export function resolveThreadReferenceCopyTarget(input: {
@@ -17,11 +18,13 @@ export function resolveThreadReferenceCopyTarget(input: {
         value: pullRequestUrl,
         clipboardTarget: "pull request link",
         successTitle: "PR link copied",
+        failureTitle: "Failed to copy PR link",
       }
     : {
         kind: "thread",
         value: input.threadId,
         clipboardTarget: "thread ID",
         successTitle: "Thread ID copied",
+        failureTitle: "Failed to copy thread ID",
       };
 }


### PR DESCRIPTION
Cmd/Ctrl+Shift+C now copies the active thread's linked or detected pull request URL, falling back to its thread ID, across web, desktop, iOS, and Android hardware keyboards. Clipboard success or failure is shown in a toast, while terminal focus keeps its existing copy behavior.

Verified with 128 focused tests, affected package typechecks, targeted lint and formatting, Expo native-module resolution, and a live web interaction that confirmed both the copied thread ID and toast.

Built with `gpt-5.6-sol` in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UX and clipboard/keybinding wiring with terminal-focus guards; Android may consume Ctrl+Shift+C when the shortcut is enabled on thread screens.
> 
> **Overview**
> Adds **`thread.copyReference`** (`mod+shift+c`, disabled when the terminal has focus) so users can copy the active thread’s **linked or branch-detected PR URL**, or **thread ID** as a fallback.
> 
> A new shared **`resolveThreadReferenceCopyTarget`** centralizes that precedence and copy/toast messaging. **Web** handles the binding in **`ChatView`** and exposes a matching **command palette** action; **mobile** wires **Cmd/Ctrl+Shift+C** through native **`T3KeyboardCommands`** (new **Android** Expo view/module alongside the existing **iOS** key commands) and **`HardwareKeyboardCommandProvider`**, with **`tryCopyTextWithHaptic`** for awaitable clipboard success and a short overlay for feedback. Thread shells now include **`linkedPullRequest`** for copy resolution on mobile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0877310d319f9ea6f2f7c214660e9b8ef30e3cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `thread.copyReference` shortcut on `mod+shift+c`
> - Adds `thread.copyReference` bound to `mod+shift+c` to copy the active thread's PR URL, falling back to the thread ID.
> - Adds a shared `resolveThreadReferenceCopyTarget` utility used by Web ([ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8994/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/8994/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a)) and Mobile ([HardwareKeyboardCommandProvider.tsx](https://github.com/pingdotgg/t3code/pull/8994/files#diff-7591a0152493fc1dc1b0bf35780f1701e70c7749147ae90236a22d1754feba93)).
> - Adds native Android ([T3KeyboardCommandsModule.kt](https://github.com/pingdotgg/t3code/pull/8994/files#diff-34d2c62295ee3155bca4d33b0d65fe38877a40450e9c3719168f4277bb4dcace)) and iOS ([T3KeyboardCommandsModule.swift](https://github.com/pingdotgg/t3code/pull/8994/files#diff-ff4014b4f64eb29abcea75687ee10e8a5fd00c350a836979d00f90d60adc12dc)) keyboard handlers to detect the shortcut and emit events.
> - Shows success or error feedback via toasts on Web and transient overlays with haptics on Mobile.
> - Risk: Keybinding uses `!terminalFocus` condition to avoid hijacking terminal copy behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e087731.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->