### PR TITLE
fix(web): warn when agent startup stalls

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -35,6 +35,8 @@ import {
   resolveSendEnvMode,
   resolveDraftHeroState,
   scheduleEnvironmentReconnectWarning,
+  shouldShowStartingSessionWarning,
+  STARTING_SESSION_WARNING_AFTER_MS,
   startNewThreadForProject,
   codexArtifactTemplatePromptToAppend,
   shouldDockDraftHeroForSubmission,
@@ -263,6 +265,47 @@ describe("environment reconnect warning grace", () => {
     expect(hasEnvironmentReconnectWarningGraceElapsed(anotherEnvironmentId, environmentId)).toBe(
       false,
     );
+  });
+});
+
+describe("starting session warning", () => {
+  const startingSession = {
+    status: "starting" as const,
+    updatedAt: "2026-03-29T00:00:00.000Z",
+  };
+
+  it("appears after the provider has remained in startup past the grace period", () => {
+    expect(
+      shouldShowStartingSessionWarning({
+        session: startingSession,
+        now: new Date(
+          Date.parse(startingSession.updatedAt) + STARTING_SESSION_WARNING_AFTER_MS - 1,
+        ).toISOString(),
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowStartingSessionWarning({
+        session: startingSession,
+        now: new Date(
+          Date.parse(startingSession.updatedAt) + STARTING_SESSION_WARNING_AFTER_MS,
+        ).toISOString(),
+      }),
+    ).toBe(true);
+  });
+
+  it("stays hidden for healthy session states and malformed timestamps", () => {
+    expect(
+      shouldShowStartingSessionWarning({
+        session: { ...startingSession, status: "running" },
+        now: "2026-03-29T00:10:00.000Z",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowStartingSessionWarning({
+        session: { ...startingSession, updatedAt: "invalid" },
+        now: "2026-03-29T00:10:00.000Z",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -41,6 +41,7 @@ export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by
 export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 export const ENVIRONMENT_RECONNECT_WARNING_GRACE_MS = 2_000;
+export const STARTING_SESSION_WARNING_AFTER_MS = 60_000;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
@@ -135,6 +136,21 @@ export function hasEnvironmentReconnectWarningGraceElapsed(
   elapsedEnvironmentId: EnvironmentId | null,
 ): boolean {
   return activeEnvironmentId !== null && activeEnvironmentId === elapsedEnvironmentId;
+}
+
+export function shouldShowStartingSessionWarning(input: {
+  session: Pick<NonNullable<Thread["session"]>, "status" | "updatedAt"> | null;
+  now: string;
+}): boolean {
+  if (input.session?.status !== "starting") return false;
+
+  const startedAtMs = Date.parse(input.session.updatedAt);
+  const nowMs = Date.parse(input.now);
+  return (
+    Number.isFinite(startedAtMs) &&
+    Number.isFinite(nowMs) &&
+    nowMs - startedAtMs >= STARTING_SESSION_WARNING_AFTER_MS
+  );
 }
 
 export function startNewThreadForProject(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -193,6 +193,7 @@ import {
   GitBranchIcon,
   Minimize2Icon,
   PaperclipIcon,
+  TriangleAlertIcon,
   WifiOffIcon,
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
@@ -358,6 +359,7 @@ import {
   shouldDockDraftHeroForSubmission,
   shouldReleaseTimelineAnchorForToolActivity,
   shouldShowBranchMismatchBanner,
+  shouldShowStartingSessionWarning,
   shouldShowPlanFollowUpPrompt,
   getStartedThreadModelChangeBlockReason,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
@@ -1334,6 +1336,9 @@ function ChatViewContent(props: ChatViewProps) {
     reportFailure: false,
   });
   const interruptThreadTurn = useAtomCommand(threadEnvironment.interruptTurn, {
+    reportFailure: false,
+  });
+  const stopThreadSession = useAtomCommand(threadEnvironment.stopSession, {
     reportFailure: false,
   });
   const respondToThreadApproval = useAtomCommand(threadEnvironment.respondToApproval, {
@@ -4867,6 +4872,61 @@ function ChatViewContent(props: ChatViewProps) {
   // interrupting, and works by session, so no active turn is needed.
   const activeBackgroundLiveness =
     !isWorking && activeThread ? (activeThreadShell?.backgroundLiveness ?? null) : null;
+  const startingSessionWarningVisible = shouldShowStartingSessionWarning({
+    session: activeThread?.session ?? null,
+    now: `${nowMinute}:00.000Z`,
+  });
+  const [isStoppingStartingSession, setIsStoppingStartingSession] = useState(false);
+  useEffect(() => {
+    setIsStoppingStartingSession(false);
+  }, [activeThread?.id, activeThread?.session?.status]);
+  const handleStopStartingSession = useCallback(async () => {
+    if (!activeThread || activeThread.session?.status !== "starting") return;
+
+    setIsStoppingStartingSession(true);
+    const result = await stopThreadSession({
+      environmentId,
+      input: { threadId: activeThread.id },
+    });
+    if (result._tag === "Failure") {
+      setIsStoppingStartingSession(false);
+      if (!isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        setThreadError(
+          activeThread.id,
+          error instanceof Error ? error.message : "Failed to stop the unresponsive agent.",
+        );
+      }
+    }
+  }, [activeThread, environmentId, setThreadError, stopThreadSession]);
+  const startingSessionWarningBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
+    if (!activeThread || !startingSessionWarningVisible) return null;
+
+    return {
+      id: `starting-session-warning:${activeThread.id}:${activeThread.session?.updatedAt ?? "unknown"}`,
+      variant: "warning",
+      priority: "urgent",
+      icon: <TriangleAlertIcon />,
+      title: "Agent may be stuck",
+      description:
+        "It has been connecting longer than expected. Stop it, then resend your message.",
+      actions: (
+        <Button
+          size="xs"
+          variant="ghost"
+          disabled={isStoppingStartingSession}
+          onClick={() => void handleStopStartingSession()}
+        >
+          {isStoppingStartingSession ? "Stopping..." : "Stop agent"}
+        </Button>
+      ),
+    };
+  }, [
+    activeThread,
+    handleStopStartingSession,
+    isStoppingStartingSession,
+    startingSessionWarningVisible,
+  ]);
   const [isStoppingBackgroundWork, setIsStoppingBackgroundWork] = useState(false);
   useEffect(() => {
     // "Stopping..." holds until the liveness clears; the interrupt command
@@ -5109,6 +5169,8 @@ function ChatViewContent(props: ChatViewProps) {
   const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const backgroundLivenessItems =
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
+    const startingSessionWarningItems =
+      startingSessionWarningBannerItem === null ? [] : [startingSessionWarningBannerItem];
     const resumeCompactionItems =
       resumeCompactionBannerItem === null ? [] : [resumeCompactionBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
@@ -5116,6 +5178,7 @@ function ChatViewContent(props: ChatViewProps) {
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
         ...systemComposerBannerItems,
+        ...startingSessionWarningItems,
         ...backgroundLivenessItems,
         ...resumeCompactionItems,
         ...wokeThreadItems,
@@ -5124,6 +5187,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return [
       ...systemComposerBannerItems,
+      ...startingSessionWarningItems,
       ...backgroundLivenessItems,
       ...resumeCompactionItems,
       ...wokeThreadItems,
@@ -5177,6 +5241,7 @@ function ChatViewContent(props: ChatViewProps) {
     parkedThreadBannerItem,
     resumeCompactionBannerItem,
     showBranchMismatchBanner,
+    startingSessionWarningBannerItem,
     systemComposerBannerItems,
     wokeThreadBannerItem,
   ]);


### PR DESCRIPTION
## Problem

A provider can remain in the starting session state without giving the user any indication that startup has stalled. The existing session reaper handles inactive provider bindings on a much longer interval, but it does not give users a timely recovery path in the composer.

## Fix

- Show a persistent warning after a session has remained in starting for 60 seconds.
- Provide a thread-scoped Stop agent action so the user can stop the stuck session and resend.
- Reset the action state when the active thread or session status changes.
- Cover the threshold, healthy-state, and malformed-timestamp behavior with unit tests.

This is scoped to the shared web/desktop chat composer; mobile uses a separate surface.

## Screenshots

| Before | After |
| --- | --- |
| ![Composer before stalled-start warning](https://github.com/user-attachments/assets/44b123e9-e92a-4719-b6e7-bb42d17cb53c) | ![Composer with stalled-start warning](https://github.com/user-attachments/assets/0ff57f84-67c6-4d9c-9d5e-8020b2181bdc) |

## Validation

- pnpm --filter @t3tools/web test -- src/components/ChatView.logic.test.ts (3,054 tests passed)
- pnpm --filter @t3tools/web typecheck
- Targeted vp lint on the three changed files
- Browser verification against an isolated T3 home directory

Built with GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UX around an existing `stopSession` path with pure logic and unit tests; no auth or data-model changes.
> 
> **Overview**
> Adds a **composer warning** when the active thread’s provider session stays in **`starting`** for at least **60 seconds**, so users aren’t left with a silent “connecting” state.
> 
> `ChatView.logic` introduces `STARTING_SESSION_WARNING_AFTER_MS` and `shouldShowStartingSessionWarning` (only `starting`, finite timestamps, elapsed time). **ChatView** wires that into the composer banner stack as an urgent warning (“Agent may be stuck”) with a **Stop agent** action that calls `threadEnvironment.stopSession` for the active thread, shows **Stopping…** while pending, clears stop state on thread/session changes, and surfaces failures via thread error. Unit tests cover the threshold edge, non-starting sessions, and invalid `updatedAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6184793b2e8411265c6a8f47b15c88627a841c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ChatView` warning banner for stalled agent startup
> - Introduces `shouldShowStartingSessionWarning` in [ChatView.logic.ts](apps/web/src/components/ChatView.logic.ts) to show a banner when a session remains `starting` for at least 60 seconds.
> - The banner renders a "Stop agent" button in [ChatView.tsx](apps/web/src/components/ChatView.tsx) that calls `threadEnvironment.stopSession` and tracks pending state via `isStoppingStartingSession`.
> - Adds unit tests in [ChatView.logic.test.ts](apps/web/src/components/ChatView.logic.test.ts) covering the grace period boundary, healthy states, and invalid timestamps.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6184793. 2 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 4877](https://github.com/pingdotgg/t3code/blob/6184793b2e8411265c6a8f47b15c88627a841c9d/apps/web/src/components/ChatView.tsx#L4877): The warning is driven by `nowMinute`, which is truncated to a UTC minute and only publishes on minute boundaries. A session that enters `starting` just after a boundary is still only ~59.999 seconds old at the next tick, so it is not re-evaluated as stalled until the following boundary—nearly 120 seconds after startup—rather than after the intended 60 seconds. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->