### PR TITLE
fix(server): keep Claude CLI alive across Stop

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -54,11 +54,16 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   private done = false;
   private failure: unknown | undefined;
 
+  public readonly interruptCalls: Array<void> = [];
+  public readonly stopTaskCalls: Array<string> = [];
   public readonly setModelCalls: Array<string | undefined> = [];
   public readonly setPermissionModeCalls: Array<string> = [];
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
   public closeCalls = 0;
   public closeError: unknown | undefined;
+  public stopTask: ((taskId: string) => Promise<void>) | undefined = async (taskId: string) => {
+    this.stopTaskCalls.push(taskId);
+  };
 
   emit(message: SDKMessage): void {
     if (this.done) {
@@ -93,6 +98,10 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
       waiter.resolve({ done: true, value: undefined });
     }
   }
+
+  readonly interrupt = async (): Promise<void> => {
+    this.interruptCalls.push(undefined);
+  };
 
   readonly setModel = async (model?: string): Promise<void> => {
     this.setModelCalls.push(model);
@@ -157,6 +166,7 @@ function makeHarness(config?: {
   readonly instanceId?: ProviderInstanceId;
 }) {
   const query = new FakeClaudeQuery();
+  let createQueryCalls = 0;
   let createInput:
     | {
         readonly prompt: AsyncIterable<SDKUserMessage>;
@@ -167,6 +177,7 @@ function makeHarness(config?: {
   const adapterOptions: ClaudeAdapterLiveOptions = {
     ...(config?.instanceId ? { instanceId: config.instanceId } : {}),
     createQuery: (input) => {
+      createQueryCalls += 1;
       createInput = input;
       return query;
     },
@@ -201,6 +212,7 @@ function makeHarness(config?: {
     ),
     query,
     getLastCreateQueryInput: () => createInput,
+    getCreateQueryCalls: () => createQueryCalls,
   };
 }
 
@@ -1626,7 +1638,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("interruptTurn settles live tasks and closes the provider session", () => {
+  it.effect("interruptTurn settles live tasks and keeps the provider session", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
@@ -1691,12 +1703,12 @@ describe("ClaudeAdapterLive", () => {
       );
       yield* adapter.interruptTurn(session.threadId);
 
-      // Closing the session is the hard stop because SDK interrupt can leave
-      // resumed background work alive.
-      assert.equal(harness.query.closeCalls, 1);
-
-      const sessions = yield* adapter.listSessions();
-      assert.equal(sessions.length, 0);
+      // Cooperative stop: kill live tasks, interrupt the parent turn, keep
+      // the CLI so the next prompt does not --resume and rewrite the cache.
+      assert.deepEqual(harness.query.stopTaskCalls, ["task-live"]);
+      assert.equal(harness.query.interruptCalls.length, 1);
+      assert.equal(harness.query.closeCalls, 0);
+      assert.equal(yield* adapter.hasSession(session.threadId), true);
 
       const stoppedTaskEvents = Array.from(yield* Fiber.join(stoppedTaskEventFiber));
       assert.equal(stoppedTaskEvents.length, 1);
@@ -1714,6 +1726,98 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("interruptTurn reuses the live query for the next sendTurn", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const turnEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "turn.started" || event.type === "turn.completed"),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const firstTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "first",
+        attachments: [],
+      });
+      assert.equal(harness.getCreateQueryCalls(), 1);
+
+      yield* adapter.interruptTurn(session.threadId);
+
+      const followUp = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "second",
+        attachments: [],
+      });
+
+      const turnEvents = Array.from(yield* Fiber.join(turnEventsFiber));
+      assert.deepEqual(
+        turnEvents.map((event) => event.type),
+        ["turn.started", "turn.completed", "turn.started"],
+      );
+      assert.equal(harness.query.interruptCalls.length, 1);
+      assert.equal(harness.query.closeCalls, 0);
+      assert.equal(harness.getCreateQueryCalls(), 1);
+      assert.equal(yield* adapter.hasSession(session.threadId), true);
+      assert.equal(String(followUp.threadId), String(session.threadId));
+      assert.notEqual(String(followUp.turnId), String(firstTurn.turnId));
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("interruptTurn closes when live tasks remain without stopTask", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      harness.query.stopTask = undefined;
+
+      const taskStartedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.started"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "spawn agents",
+        attachments: [],
+      });
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-runaway",
+        description: "Agent A",
+        task_type: "local_agent",
+        uuid: "task-runaway-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(taskStartedFiber);
+
+      yield* adapter.interruptTurn(session.threadId);
+
+      assert.equal(harness.query.interruptCalls.length, 0);
+      assert.equal(harness.query.closeCalls, 1);
+      assert.equal(yield* adapter.hasSession(session.threadId), false);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("keeps the session available when process close fails", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -1725,7 +1829,7 @@ describe("ClaudeAdapterLive", () => {
       });
       harness.query.closeError = new Error("close failed");
 
-      const result = yield* adapter.interruptTurn(session.threadId).pipe(Effect.result);
+      const result = yield* adapter.stopSession(session.threadId).pipe(Effect.result);
 
       assert.equal(result._tag, "Failure");
       if (result._tag === "Failure") {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -318,6 +318,9 @@ interface ClaudeSessionContext {
 }
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
+  readonly interrupt: () => Promise<void>;
+  /** SDK Query.stopTask — present on real queries; optional for test doubles. */
+  readonly stopTask?: (taskId: string) => Promise<void>;
   readonly setModel: (model?: string) => Promise<void>;
   readonly setPermissionMode: (mode: PermissionMode) => Promise<void>;
   readonly setMaxThinkingTokens: (maxThinkingTokens: number | null) => Promise<void>;
@@ -4608,10 +4611,70 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   const interruptTurn: ClaudeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
     function* (threadId, _turnId) {
       const context = yield* requireSession(threadId);
-      // interrupt() can acknowledge while resumed background tasks keep the
-      // CLI alive. Stop is a hard session boundary for Claude, so close the
-      // query and let the SDK escalate to SIGKILL when graceful exit fails.
-      yield* stopSessionInternal(context);
+      // Esc should cancel the in-flight turn without tearing down the CLI.
+      // Closing forces the next prompt through --resume; Claude Code puts
+      // `git status` in the cached prefix, so a dirty tree re-bills the
+      // whole conversation as cache writes (anthropics/claude-code#78720,
+      // pingdotgg/t3code#7338). interrupt() alone can leave subagents
+      // running, so stop live tasks first. If any remain, fall back to
+      // close — that is the hard stop from #5891 for runaway fleets.
+      if (context.query.stopTask && context.liveTaskIds.size > 0) {
+        const liveIds = Array.from(context.liveTaskIds);
+        yield* Effect.forEach(
+          liveIds,
+          (taskId) =>
+            Effect.gen(function* () {
+              const stopAcknowledged = yield* Effect.tryPromise({
+                // Invoke through the query object: SDK methods rely on `this`.
+                try: () => context.query.stopTask!(taskId),
+                catch: () => undefined,
+              }).pipe(
+                Effect.timeout("3 seconds"),
+                Effect.as(true),
+                Effect.catch(() => Effect.succeed(false)),
+              );
+              if (!stopAcknowledged || !context.liveTaskIds.delete(taskId)) {
+                return;
+              }
+
+              // stopTask only acknowledges the control request. Its separate
+              // task_notification can lose the race with interrupt(), so make
+              // the acknowledged stop authoritative for the durable UI state.
+              const stamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "task.completed",
+                eventId: stamp.eventId,
+                provider: PROVIDER,
+                createdAt: stamp.createdAt,
+                threadId: context.session.threadId,
+                ...(context.turnState
+                  ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
+                  : {}),
+                payload: {
+                  taskId: RuntimeTaskId.make(taskId),
+                  status: "stopped",
+                  ...taskLinkageFor(context.taskAgents, taskId),
+                },
+                providerRefs: nativeProviderRefs(context),
+              });
+            }).pipe(Effect.ignore),
+          { concurrency: 8, discard: true },
+        ).pipe(Effect.timeout("10 seconds"), Effect.ignore);
+      }
+
+      if (context.liveTaskIds.size > 0) {
+        yield* stopSessionInternal(context);
+        return;
+      }
+
+      yield* Effect.tryPromise({
+        try: () => context.query.interrupt(),
+        catch: (cause) => toRequestError(threadId, "turn/interrupt", cause),
+      });
+
+      if (context.turnState) {
+        yield* completeTurn(context, "interrupted");
+      }
     },
   );
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -132,6 +132,11 @@ Clients never call a provider directly. They dispatch orchestration commands ove
 `thread.user-input.respond`, `thread.checkpoint.revert`, and `thread.session.stop`, plus the mode
 setters `thread.runtime-mode.set` and `thread.interaction-mode.set`.
 
+Claude Stop is `thread.turn.interrupt`, not `thread.session.stop`. The Claude adapter interrupts the
+in-flight turn and stops live subagent tasks, then keeps the CLI process so the next prompt is not a
+`--resume`. Closing on Esc was re-billing prompt cache on every stop. `thread.session.stop` and the
+idle reaper still close the process.
+
 The engine persists an event for the command, and a server-side reactor performs the provider call.
 Provider output comes back as internal commands such as `thread.message.assistant.delta` and
 `thread.session.set`, which clients observe through `orchestration.subscribeThread`. See


### PR DESCRIPTION
## What Changed

Claude Stop (`interruptTurn`) no longer closes the provider query. It now:

1. Stops live subagent tasks via `Query.stopTask`
2. Calls `Query.interrupt()` and completes the local turn
3. Keeps the CLI process so the next prompt is queued into the same session
4. Falls back to `close()` only when live tasks remain (the #5891 runaway-fleet case)

`thread.session.stop` and the 30-minute idle reaper still tear the process down.

## Why

[#7338](https://github.com/pingdotgg/t3code/issues/7338) reports ~2× Claude usage in T3 vs native Claude Code. After [#5891](https://github.com/pingdotgg/t3code/pull/5891), Esc killed the CLI. The next message `--resume`s a new process.

A cheap local check (Haiku, `--max-turns 1`, prompt `reply with just the word ok`, 5h usage 0% → 1%):

| turn | cache_write | cache_read |
| --- | --- | --- |
| 1 cold | 24,538 | 13,694 |
| 2 `--resume`, git unchanged | 26,841 | 13,694 |
| 3 `--resume` after one untracked file | 26,944 | 13,694 |

Each resume rewrote ~27k cache tokens even when git status did not change. On a 300k thread that is the cache-write spike reported in #7338. Native Claude Code keeps one process alive across Esc.

This does not claim to erase the whole gap. Claude effort/fast-mode changes still restart the session, idle reaping still stops it after 30 minutes, and app restart still `--resume`s. Those are separate.

## Test plan

- [x] `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` (81 passed)
- [ ] Esc mid-turn, send a follow-up: session stays, usage should not jump as a full resume
- [ ] Esc while subagents are running: live tasks stop; if they cannot, process still closes
- [ ] Changing Claude effort still restarts (unchanged)


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep Claude CLI alive across Stop by interrupting turn and stopping live tasks
> - Reworks `interruptTurn` in `ClaudeAdapter` to cooperatively stop live subagent tasks via `query.stopTask` and cancel the in-flight turn via `query.interrupt`, instead of unconditionally closing the CLI session.
> - Emits `task.completed` events with status `'stopped'` for acknowledged task stops, and completes the open turn as `'interrupted'`.
> - Falls back to `stopSessionInternal` (closing the CLI) only when live tasks remain and `stopTask` is unavailable or ineffective.
> - Extends the `ClaudeQueryRuntime` interface to require `interrupt()` and optionally support `stopTask(taskId)`.
> - Updates tests in [ClaudeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/8997/files#diff-1657a55ebc1e3682293aa20a7f71a55adf8de546f36af50f289dca9da45b0b6f) and documents the new Stop semantics in [providers.md](https://github.com/pingdotgg/t3code/pull/8997/files#diff-3d909027abc31a863f0c0e5ecef5aa50ac285620ad827db723eb0a4ac46d3f85).
> - Risk: any out-of-tree implementation of `ClaudeQueryRuntime` must now provide `interrupt()`; without it, type checking and runtime calls will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4b1c76f. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->