### PR TITLE
fix(desktop): keep SSH aliases dynamic across reconnects

### DIFF
--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -132,6 +132,10 @@ Use this when you want the desktop app to start or reuse T3 Code on another mach
 4. Enter the SSH target, such as `user@example.com`.
 5. Confirm the launch. The desktop app probes the host, starts or reuses a remote T3 server, opens a local port forward, and saves the environment.
 
+When the target is an alias from `~/.ssh/config`, T3 Code resolves `HostName`, `User`, and `Port` again on each connection. A username or port entered in T3 Code remains an explicit override. This allows an alias to keep working when its configured address or port changes.
+
+Connections saved by an earlier version may contain the address, username, and port that the alias resolved to at setup time. Remove and add such a connection once to restore alias-based resolution.
+
 After setup, the renderer connects to a local forwarded HTTP/WebSocket endpoint. The remote host still owns the actual T3 server, projects, files, git state, terminals, and provider sessions.
 
 SSH launch is a desktop feature because it needs local process and SSH access. Once the environment is paired and saved, it uses the same environment list and connection model as direct LAN, Tailscale, HTTPS, or future tunnel-backed environments.

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -206,16 +206,22 @@ describe("connection onboarding", () => {
     }),
   );
 
-  it.effect("prepares an SSH registration from the provisioned platform environment", () =>
+  it.effect("prepares an SSH registration without persisting resolved connection details", () =>
     Effect.gen(function* () {
-      const target = {
+      const requestedTarget = {
+        alias: "devbox",
+        hostname: "devbox",
+        username: "developer",
+        port: null,
+      };
+      const resolvedTarget = {
         alias: "devbox",
         hostname: "devbox.example.test",
         username: "developer",
         port: 22,
       };
       const registration = yield* prepareSshRegistration({
-        target,
+        target: requestedTarget,
       }).pipe(
         Effect.provideService(
           SshEnvironmentGateway,
@@ -225,7 +231,7 @@ describe("connection onboarding", () => {
                 environmentId: EnvironmentId.make("environment-ssh"),
                 label: "Remote development box",
                 bootstrap: {
-                  target,
+                  target: resolvedTarget,
                   httpBaseUrl: "http://127.0.0.1:3201",
                   wsBaseUrl: "ws://127.0.0.1:3201",
                   pairingToken: "pairing-token",
@@ -249,7 +255,7 @@ describe("connection onboarding", () => {
           environmentId: "environment-ssh",
           label: "Remote development box",
           connectionId: "ssh:environment-ssh",
-          target,
+          target: requestedTarget,
         },
       });
     }),

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -228,7 +228,7 @@ export const prepareSshRegistration = Effect.fn(
       connectionId,
       environmentId: provisioned.environmentId,
       label,
-      target: provisioned.bootstrap.target,
+      target: input.target,
     }),
   });
 });

--- a/packages/client-runtime/src/connection/resolver.test.ts
+++ b/packages/client-runtime/src/connection/resolver.test.ts
@@ -486,7 +486,7 @@ describe("ConnectionResolver", () => {
         port: 2222,
       } as const;
       const preparedTargets = yield* Ref.make<ReadonlyArray<DesktopSshEnvironmentTarget>>([]);
-      const persistedProfiles = yield* Ref.make<ReadonlyArray<ConnectionProfile>>([]);
+      const profileWrites = yield* Ref.make<ReadonlyArray<ConnectionProfile>>([]);
       const target = new SshConnectionTarget({
         environmentId: ENVIRONMENT_ID,
         label: "SSH",
@@ -500,7 +500,7 @@ describe("ConnectionResolver", () => {
       });
       const brokerLayer = yield* makeDependencies({
         onProfilePut: (nextProfile) =>
-          Ref.update(persistedProfiles, (profiles) => [...profiles, nextProfile]),
+          Ref.update(profileWrites, (profiles) => [...profiles, nextProfile]),
         prepareSsh: (input) =>
           Ref.update(preparedTargets, (targets) => [...targets, input.target]).pipe(
             Effect.as({
@@ -517,8 +517,8 @@ describe("ConnectionResolver", () => {
       const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
 
       yield* broker.prepare(catalogEntry(target, Option.some(profile)));
-      const savedProfile = (yield* Ref.get(persistedProfiles)).at(-1) ?? profile;
-      yield* broker.prepare(catalogEntry(target, Option.some(savedProfile)));
+      expect(yield* Ref.get(profileWrites)).toEqual([]);
+      yield* broker.prepare(catalogEntry(target, Option.some(profile)));
 
       expect(yield* Ref.get(preparedTargets)).toEqual([requestedTarget, requestedTarget]);
     }),

--- a/packages/client-runtime/src/connection/resolver.test.ts
+++ b/packages/client-runtime/src/connection/resolver.test.ts
@@ -97,6 +97,7 @@ const makeDependencies = Effect.fn("TestConnectionResolver.makeDependencies")((o
   readonly authorizeDpop?: RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization["Service"]["authorizeDpop"];
   readonly primaryBearerToken?: string;
   readonly prepareSsh?: ClientCapabilities.SshEnvironmentGateway["Service"]["prepare"];
+  readonly onProfilePut?: (profile: ConnectionProfile) => Effect.Effect<void>;
 }) => {
   const profiles = new Map(
     (options?.profiles ?? []).map((profile) => [profile.connectionId, profile]),
@@ -105,7 +106,10 @@ const makeDependencies = Effect.fn("TestConnectionResolver.makeDependencies")((o
 
   const profileStore = ConnectionProfileStore.ConnectionProfileStore.of({
     get: (connectionId) => Effect.succeed(Option.fromNullishOr(profiles.get(connectionId))),
-    put: (profile) => Effect.sync(() => void profiles.set(profile.connectionId, profile)),
+    put: (profile) =>
+      Effect.sync(() => void profiles.set(profile.connectionId, profile)).pipe(
+        Effect.andThen(options?.onProfilePut?.(profile) ?? Effect.void),
+      ),
     remove: (connectionId) => Effect.sync(() => void profiles.delete(connectionId)),
   });
   const credentialStore = ConnectionCredentialStore.ConnectionCredentialStore.of({
@@ -464,6 +468,59 @@ describe("ConnectionResolver", () => {
       ).toContain("wsTicket=bearer");
       expect(yield* Ref.get(preparedTargets)).toEqual([SSH_TARGET]);
       expect(yield* Ref.get(connectionMethods)).toEqual(["ssh"]);
+    }),
+  );
+
+  it.effect("keeps the requested SSH target across reconnects", () =>
+    Effect.gen(function* () {
+      const requestedTarget = {
+        alias: "development",
+        hostname: "development",
+        username: "developer",
+        port: null,
+      } as const;
+      const resolvedTarget = {
+        alias: "development",
+        hostname: "development.example.test",
+        username: "developer",
+        port: 2222,
+      } as const;
+      const preparedTargets = yield* Ref.make<ReadonlyArray<DesktopSshEnvironmentTarget>>([]);
+      const persistedProfiles = yield* Ref.make<ReadonlyArray<ConnectionProfile>>([]);
+      const target = new SshConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "SSH",
+        connectionId: "ssh-1",
+      });
+      const profile = new SshConnectionProfile({
+        connectionId: "ssh-1",
+        environmentId: ENVIRONMENT_ID,
+        label: "SSH",
+        target: requestedTarget,
+      });
+      const brokerLayer = yield* makeDependencies({
+        onProfilePut: (nextProfile) =>
+          Ref.update(persistedProfiles, (profiles) => [...profiles, nextProfile]),
+        prepareSsh: (input) =>
+          Ref.update(preparedTargets, (targets) => [...targets, input.target]).pipe(
+            Effect.as({
+              bootstrap: {
+                target: resolvedTarget,
+                httpBaseUrl: "http://127.0.0.1:4010",
+                wsBaseUrl: "ws://127.0.0.1:4010",
+                pairingToken: null,
+              },
+              bearerToken: "ssh-bearer",
+            }),
+          ),
+      });
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      yield* broker.prepare(catalogEntry(target, Option.some(profile)));
+      const savedProfile = (yield* Ref.get(persistedProfiles)).at(-1) ?? profile;
+      yield* broker.prepare(catalogEntry(target, Option.some(savedProfile)));
+
+      expect(yield* Ref.get(preparedTargets)).toEqual([requestedTarget, requestedTarget]);
     }),
   );
 

--- a/packages/client-runtime/src/connection/resolver.ts
+++ b/packages/client-runtime/src/connection/resolver.ts
@@ -33,7 +33,6 @@ import type {
   SshConnectionTarget,
 } from "./model.ts";
 import { ConnectionBlockedError, type ConnectionAttemptError } from "./model.ts";
-import * as ConnectionProfileStore from "./profileStore.ts";
 
 export class ConnectionResolver extends Context.Service<
   ConnectionResolver,
@@ -196,7 +195,6 @@ const makeRelayBroker = Effect.fn("clientRuntime.connection.broker.makeRelay")(f
 });
 
 const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(function* () {
-  const profiles = yield* ConnectionProfileStore.ConnectionProfileStore;
   const ssh = yield* ClientCapabilities.SshEnvironmentGateway;
   const remote = yield* RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization;
 
@@ -225,14 +223,6 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
       expectedEnvironmentId: target.environmentId,
       target: profile.target,
     });
-    yield* profiles.put(
-      new SshConnectionProfile({
-        connectionId: profile.connectionId,
-        environmentId: profile.environmentId,
-        label: profile.label,
-        target: prepared.bootstrap.target,
-      }),
-    );
     const authorized = yield* remote.authorizeBearer({
       expectedEnvironmentId: target.environmentId,
       httpBaseUrl: prepared.bootstrap.httpBaseUrl,

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -15,6 +15,7 @@ import {
   getLastNonEmptyOutputLine,
   parseSshResolveOutput,
   resolveRemoteT3CliPackageSpec,
+  resolveSshTarget,
   runSshCommand,
 } from "./command.ts";
 import { SshCommandError } from "./errors.ts";
@@ -98,6 +99,45 @@ describe("ssh command", () => {
       );
     }),
   );
+
+  it.effect("resolves ssh config with the explicit username", () => {
+    let spawnedArgs: ReadonlyArray<string> = [];
+    const spawner = ChildProcessSpawner.make((command) => {
+      spawnedArgs = command._tag === "StandardCommand" ? command.args : [];
+      return Effect.succeed(
+        ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(123),
+          stdout: Stream.make(
+            encoder.encode(
+              ["hostname devbox.example.com", "user chosen-user", "port 3333", ""].join("\n"),
+            ),
+          ),
+          stderr: Stream.empty,
+          all: Stream.empty,
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: Sink.drain,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        }),
+      );
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const target = yield* resolveSshTarget("devbox", { username: "chosen-user" });
+
+      assert.include(spawnedArgs, "-G");
+      assert.include(spawnedArgs, "chosen-user@devbox");
+      assert.equal(target.username, "chosen-user");
+      assert.equal(target.port, 3333);
+    }).pipe(Effect.provide(processLayer));
+  });
 
   it.effect("resolves the remote t3 package spec from the desktop release channel", () =>
     Effect.sync(() => {

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -327,6 +327,7 @@ export const runSshCommand = Effect.fn("ssh/command.runSshCommand")(function* (
 
 export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(function* (
   alias: string,
+  input?: { readonly username?: string | null },
 ): Effect.fn.Return<
   DesktopSshEnvironmentTarget,
   SshCommandError | SshInvalidTargetError,
@@ -336,13 +337,14 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
   if (trimmedAlias.length === 0) {
     return yield* new SshInvalidTargetError({ message: "SSH host alias is required." });
   }
+  const username = input?.username?.trim() || null;
 
-  yield* Effect.logDebug("ssh.target.resolve.start", { alias: trimmedAlias });
+  yield* Effect.logDebug("ssh.target.resolve.start", { alias: trimmedAlias, username });
   return yield* runSshCommand(
     {
       alias: trimmedAlias,
       hostname: trimmedAlias,
-      username: null,
+      username,
       port: null,
     },
     { preHostArgs: ["-G"] },
@@ -356,7 +358,7 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
         Effect.as({
           alias: trimmedAlias,
           hostname: trimmedAlias,
-          username: null,
+          username,
           port: null,
         }),
       ),

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -400,6 +400,7 @@ describe("ssh tunnel scripts", () => {
     const resolutions = [
       { hostname: "first.example.test", port: 2222 },
       { hostname: "second.example.test", port: 3333 },
+      { hostname: "third.example.test", port: 4444 },
     ] as const;
     const spawnedCommands: Array<ReadonlyArray<string>> = [];
     let resolutionIndex = 0;
@@ -469,6 +470,12 @@ describe("ssh tunnel scripts", () => {
       assert.equal(stopCommandCount, 0);
 
       yield* manager.disconnectEnvironment(requestedTarget);
+      const stopCommand = spawnedCommands.findLast(
+        (args) => args.includes("sh") && !args.includes("--"),
+      );
+      assert.isDefined(stopCommand);
+      assert.include(stopCommand, "HostName=second.example.test");
+      assert.include(stopCommand, "chosen-user@devbox");
       assert.equal(tunnelKillCount, 2);
       assert.equal(stopCommandCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -387,6 +387,65 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(processLayer));
   });
 
+  it.effect("keeps remote state identity stable when an alias resolution changes", () => {
+    const requestedTarget = {
+      alias: "devbox",
+      hostname: "devbox",
+      username: "chosen-user",
+      port: null,
+    } as const;
+    const connectAfterResolution = (resolvedHostname: string, resolvedPort: number) => {
+      const spawnedCommands: Array<ReadonlyArray<string>> = [];
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.sync(() => {
+          const args = commandArgs(command);
+          spawnedCommands.push(args);
+          if (args.includes("-G")) {
+            return makeSuccessfulProcess(
+              [`hostname ${resolvedHostname}`, "user config-user", `port ${resolvedPort}`, ""].join(
+                "\n",
+              ),
+            );
+          }
+          if (args.includes("-N")) {
+            return makeRunningProcess(() => undefined);
+          }
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+
+      return Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        const environment = yield* manager.ensureEnvironment(requestedTarget);
+        const launchArgs = spawnedCommands.find(
+          (args) => args.includes("sh") && args.includes("--"),
+        );
+        assert.isDefined(launchArgs);
+        assert.equal(environment.target.hostname, resolvedHostname);
+        assert.equal(environment.target.port, resolvedPort);
+        assert.include(launchArgs, String(resolvedPort));
+        assert.include(launchArgs, "chosen-user@devbox");
+        return launchArgs.at(-1);
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    };
+
+    return Effect.gen(function* () {
+      const firstStateKey = yield* connectAfterResolution("first.example.test", 2222);
+      const secondStateKey = yield* connectAfterResolution("second.example.test", 3333);
+
+      assert.isDefined(firstStateKey);
+      assert.equal(secondStateKey, firstStateKey);
+    });
+  });
+
   it.effect("closes the tunnel scope and starts fresh after disconnect", () => {
     const spawnedCommands: Array<ReadonlyArray<string>> = [];
     let tunnelKillCount = 0;

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -84,6 +84,15 @@ const makeRunningProcess = (onKill: () => void) => {
   });
 };
 
+const makeDelayedKillRunningProcess = (beforeKill: Effect.Effect<void>, onKill: () => void) => {
+  const process = makeRunningProcess(onKill);
+  return {
+    ...process,
+    kill: (options: Parameters<typeof process.kill>[0]) =>
+      beforeKill.pipe(Effect.andThen(process.kill(options))),
+  };
+};
+
 const testHttpClient = HttpClient.make((request) =>
   Effect.succeed(HttpClientResponse.fromWeb(request, new Response("", { status: 200 }))),
 );
@@ -390,7 +399,7 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(processLayer));
   });
 
-  it.effect("keeps remote state identity stable when an alias resolution changes", () => {
+  it.effect("keeps the remote server when an alias port changes", () => {
     const requestedTarget = {
       alias: "devbox",
       hostname: "devbox",
@@ -398,9 +407,9 @@ describe("ssh tunnel scripts", () => {
       port: null,
     } as const;
     const resolutions = [
-      { hostname: "first.example.test", port: 2222 },
-      { hostname: "second.example.test", port: 3333 },
-      { hostname: "third.example.test", port: 4444 },
+      { hostname: "devbox.example.test", port: 2222 },
+      { hostname: "devbox.example.test", port: 3333 },
+      { hostname: "devbox.example.test", port: 4444 },
     ] as const;
     const spawnedCommands: Array<ReadonlyArray<string>> = [];
     let resolutionIndex = 0;
@@ -456,9 +465,9 @@ describe("ssh tunnel scripts", () => {
       const firstLaunch = launchCommands[0];
       const secondLaunch = launchCommands[1];
 
-      assert.equal(first.target.hostname, "first.example.test");
+      assert.equal(first.target.hostname, "devbox.example.test");
       assert.equal(first.target.port, 2222);
-      assert.equal(second.target.hostname, "second.example.test");
+      assert.equal(second.target.hostname, "devbox.example.test");
       assert.equal(second.target.port, 3333);
       assert.isDefined(firstLaunch);
       assert.isDefined(secondLaunch);
@@ -474,12 +483,176 @@ describe("ssh tunnel scripts", () => {
         (args) => args.includes("sh") && !args.includes("--"),
       );
       assert.isDefined(stopCommand);
-      assert.include(stopCommand, "HostName=second.example.test");
+      assert.include(stopCommand, "HostName=devbox.example.test");
       assert.include(stopCommand, "chosen-user@devbox");
       assert.equal(tunnelKillCount, 2);
       assert.equal(stopCommandCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
+
+  it.effect("stops the previous remote server when an alias changes host or user", () => {
+    const requestedTarget = {
+      alias: "devbox",
+      hostname: "devbox",
+      username: null,
+      port: null,
+    } as const;
+    const resolutions = [
+      { hostname: "first.example.test", username: "first-user" },
+      { hostname: "first.example.test", username: "second-user" },
+      { hostname: "second.example.test", username: "second-user" },
+      { hostname: "third.example.test", username: "third-user" },
+    ] as const;
+    const spawnedCommands: Array<ReadonlyArray<string>> = [];
+    let resolutionIndex = 0;
+    let tunnelKillCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        spawnedCommands.push(args);
+        if (args.includes("-G")) {
+          const resolution = resolutions[Math.min(resolutionIndex, resolutions.length - 1)];
+          resolutionIndex += 1;
+          assert.isDefined(resolution);
+          return makeSuccessfulProcess(
+            [
+              `hostname ${resolution.hostname}`,
+              `user ${resolution.username}`,
+              "port 2222",
+              "",
+            ].join("\n"),
+          );
+        }
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        return makeSuccessfulProcess('{"stopped":true}\n');
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.ensureEnvironment(requestedTarget);
+      yield* manager.ensureEnvironment(requestedTarget);
+      yield* manager.ensureEnvironment(requestedTarget);
+      yield* manager.disconnectEnvironment(requestedTarget);
+
+      const stopCommands = spawnedCommands.filter(
+        (args) => args.includes("sh") && !args.includes("--"),
+      );
+      const firstStop = stopCommands[0];
+      const secondStop = stopCommands[1];
+      const finalStop = stopCommands[2];
+      assert.isDefined(firstStop);
+      assert.isDefined(secondStop);
+      assert.isDefined(finalStop);
+      assert.include(firstStop, "HostName=first.example.test");
+      assert.include(firstStop, "first-user@devbox");
+      assert.include(secondStop, "HostName=first.example.test");
+      assert.include(secondStop, "second-user@devbox");
+      assert.include(finalStop, "HostName=second.example.test");
+      assert.include(finalStop, "second-user@devbox");
+      assert.equal(tunnelKillCount, 3);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("finishes local tunnel cleanup when replacement is interrupted", () =>
+    Effect.gen(function* () {
+      const killStarted = yield* Deferred.make<void>();
+      const allowKill = yield* Deferred.make<void>();
+      const requestedTarget = {
+        alias: "devbox",
+        hostname: "devbox",
+        username: "chosen-user",
+        port: null,
+      } as const;
+      const resolutions = [
+        { hostname: "devbox.example.test", port: 2222 },
+        { hostname: "devbox.example.test", port: 3333 },
+      ] as const;
+      let resolutionIndex = 0;
+      let tunnelCount = 0;
+      let tunnelKillCount = 0;
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.sync(() => {
+          const args = commandArgs(command);
+          if (args.includes("-G")) {
+            const resolution = resolutions[Math.min(resolutionIndex, resolutions.length - 1)];
+            resolutionIndex += 1;
+            assert.isDefined(resolution);
+            return makeSuccessfulProcess(
+              [
+                `hostname ${resolution.hostname}`,
+                "user config-user",
+                `port ${resolution.port}`,
+                "",
+              ].join("\n"),
+            );
+          }
+          if (args.includes("-N")) {
+            tunnelCount += 1;
+            return tunnelCount === 1
+              ? makeDelayedKillRunningProcess(
+                  Deferred.succeed(killStarted, undefined).pipe(
+                    Effect.andThen(Deferred.await(allowKill)),
+                  ),
+                  () => {
+                    tunnelKillCount += 1;
+                  },
+                )
+              : makeRunningProcess(() => {
+                  tunnelKillCount += 1;
+                });
+          }
+          if (args.includes("sh") && args.includes("--")) {
+            return makeSuccessfulProcess('{"remotePort":3773}\n');
+          }
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+
+      yield* Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        yield* manager.ensureEnvironment(requestedTarget);
+        const replacement = yield* manager
+          .ensureEnvironment(requestedTarget)
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(killStarted);
+        const interrupt = yield* Fiber.interrupt(replacement).pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+
+        assert.equal(tunnelKillCount, 0);
+
+        yield* Deferred.succeed(allowKill, undefined);
+        yield* Fiber.join(interrupt);
+        const replacementExit = yield* Fiber.await(replacement);
+
+        assert.isTrue(Exit.isFailure(replacementExit));
+        assert.equal(tunnelKillCount, 1);
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    }),
+  );
 
   it.effect("interrupts tunnel creation superseded by a new alias resolution", () =>
     Effect.gen(function* () {
@@ -580,7 +753,7 @@ describe("ssh tunnel scripts", () => {
         assert.equal(interruptedLaunchCount, 2);
         assert.equal(launchCount, 3);
         assert.equal(tunnelKillCount, 1);
-        assert.equal(stopCommandCount, 1);
+        assert.equal(stopCommandCount, 2);
         const thirdExit = yield* Fiber.await(third);
         assert.isTrue(Exit.isFailure(thirdExit));
       }).pipe(Effect.provide(layer), Effect.scoped);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -2,7 +2,9 @@ import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
 import * as Duration from "effect/Duration";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
@@ -471,6 +473,112 @@ describe("ssh tunnel scripts", () => {
       assert.equal(stopCommandCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
+
+  it.effect("interrupts tunnel creation superseded by a new alias resolution", () =>
+    Effect.gen(function* () {
+      const firstLaunchStarted = yield* Deferred.make<void>();
+      const thirdLaunchStarted = yield* Deferred.make<void>();
+      const requestedTarget = {
+        alias: "devbox",
+        hostname: "devbox",
+        username: "chosen-user",
+        port: null,
+      } as const;
+      const resolutions = [
+        { hostname: "first.example.test", port: 2222 },
+        { hostname: "second.example.test", port: 3333 },
+        { hostname: "third.example.test", port: 4444 },
+      ] as const;
+      let resolutionIndex = 0;
+      let launchCount = 0;
+      let interruptedLaunchCount = 0;
+      let tunnelKillCount = 0;
+      let stopCommandCount = 0;
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          const args = commandArgs(command);
+          if (args.includes("-G")) {
+            const resolution = resolutions[Math.min(resolutionIndex, resolutions.length - 1)];
+            resolutionIndex += 1;
+            assert.isDefined(resolution);
+            return makeSuccessfulProcess(
+              [
+                `hostname ${resolution.hostname}`,
+                "user config-user",
+                `port ${resolution.port}`,
+                "",
+              ].join("\n"),
+            );
+          }
+          if (args.includes("sh") && args.includes("--")) {
+            launchCount += 1;
+            const launchStarted =
+              launchCount === 1
+                ? firstLaunchStarted
+                : launchCount === 3
+                  ? thirdLaunchStarted
+                  : null;
+            if (launchStarted !== null) {
+              return yield* Deferred.succeed(launchStarted, undefined).pipe(
+                Effect.andThen(Effect.never),
+                Effect.onInterrupt(() =>
+                  Effect.sync(() => {
+                    interruptedLaunchCount += 1;
+                  }),
+                ),
+              );
+            }
+            return makeSuccessfulProcess('{"remotePort":3773}\n');
+          }
+          if (args.includes("-N")) {
+            return makeRunningProcess(() => {
+              tunnelKillCount += 1;
+            });
+          }
+          if (args.includes("sh")) {
+            stopCommandCount += 1;
+          }
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+
+      yield* Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        const first = yield* manager.ensureEnvironment(requestedTarget).pipe(Effect.forkChild);
+        yield* Deferred.await(firstLaunchStarted);
+
+        const second = yield* manager.ensureEnvironment(requestedTarget);
+
+        assert.equal(second.target.hostname, "second.example.test");
+        assert.equal(second.target.port, 3333);
+        assert.equal(interruptedLaunchCount, 1);
+        assert.equal(launchCount, 2);
+        assert.equal(tunnelKillCount, 0);
+
+        const firstExit = yield* Fiber.await(first);
+        assert.isTrue(Exit.isFailure(firstExit));
+
+        const third = yield* manager.ensureEnvironment(requestedTarget).pipe(Effect.forkChild);
+        yield* Deferred.await(thirdLaunchStarted);
+        yield* manager.disconnectEnvironment(requestedTarget);
+
+        assert.equal(interruptedLaunchCount, 2);
+        assert.equal(launchCount, 3);
+        assert.equal(tunnelKillCount, 1);
+        assert.equal(stopCommandCount, 1);
+        const thirdExit = yield* Fiber.await(third);
+        assert.isTrue(Exit.isFailure(thirdExit));
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    }),
+  );
 
   it("rejects invalid remote state key overrides", () => {
     const target = {

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -394,56 +394,95 @@ describe("ssh tunnel scripts", () => {
       username: "chosen-user",
       port: null,
     } as const;
-    const connectAfterResolution = (resolvedHostname: string, resolvedPort: number) => {
-      const spawnedCommands: Array<ReadonlyArray<string>> = [];
-      const spawner = ChildProcessSpawner.make((command) =>
-        Effect.sync(() => {
-          const args = commandArgs(command);
-          spawnedCommands.push(args);
-          if (args.includes("-G")) {
-            return makeSuccessfulProcess(
-              [`hostname ${resolvedHostname}`, "user config-user", `port ${resolvedPort}`, ""].join(
-                "\n",
-              ),
-            );
-          }
-          if (args.includes("-N")) {
-            return makeRunningProcess(() => undefined);
-          }
+    const resolutions = [
+      { hostname: "first.example.test", port: 2222 },
+      { hostname: "second.example.test", port: 3333 },
+    ] as const;
+    const spawnedCommands: Array<ReadonlyArray<string>> = [];
+    let resolutionIndex = 0;
+    let tunnelKillCount = 0;
+    let stopCommandCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        spawnedCommands.push(args);
+        if (args.includes("-G")) {
+          const resolution = resolutions[Math.min(resolutionIndex, resolutions.length - 1)];
+          resolutionIndex += 1;
+          assert.isDefined(resolution);
+          return makeSuccessfulProcess(
+            [
+              `hostname ${resolution.hostname}`,
+              "user config-user",
+              `port ${resolution.port}`,
+              "",
+            ].join("\n"),
+          );
+        }
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
           return makeSuccessfulProcess('{"remotePort":3773}\n');
-        }),
-      );
-      const layer = Layer.mergeAll(
-        NodeServices.layer,
-        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
-        Layer.succeed(HttpClient.HttpClient, testHttpClient),
-        Layer.succeed(NetService.NetService, testNetService),
-        SshPasswordPrompt.disabledLayer,
-        SshEnvironmentManager.layer(),
-      );
-
-      return Effect.gen(function* () {
-        const manager = yield* SshEnvironmentManager;
-        const environment = yield* manager.ensureEnvironment(requestedTarget);
-        const launchArgs = spawnedCommands.find(
-          (args) => args.includes("sh") && args.includes("--"),
-        );
-        assert.isDefined(launchArgs);
-        assert.equal(environment.target.hostname, resolvedHostname);
-        assert.equal(environment.target.port, resolvedPort);
-        assert.include(launchArgs, String(resolvedPort));
-        assert.include(launchArgs, "chosen-user@devbox");
-        return launchArgs.at(-1);
-      }).pipe(Effect.provide(layer), Effect.scoped);
-    };
+        }
+        if (args.includes("sh")) {
+          stopCommandCount += 1;
+        }
+        return makeSuccessfulProcess('{"stopped":true}\n');
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
 
     return Effect.gen(function* () {
-      const firstStateKey = yield* connectAfterResolution("first.example.test", 2222);
-      const secondStateKey = yield* connectAfterResolution("second.example.test", 3333);
+      const manager = yield* SshEnvironmentManager;
+      const first = yield* manager.ensureEnvironment(requestedTarget);
+      const second = yield* manager.ensureEnvironment(requestedTarget);
+      const launchCommands = spawnedCommands.filter(
+        (args) => args.includes("sh") && args.includes("--"),
+      );
+      const firstLaunch = launchCommands[0];
+      const secondLaunch = launchCommands[1];
 
-      assert.isDefined(firstStateKey);
-      assert.equal(secondStateKey, firstStateKey);
-    });
+      assert.equal(first.target.hostname, "first.example.test");
+      assert.equal(first.target.port, 2222);
+      assert.equal(second.target.hostname, "second.example.test");
+      assert.equal(second.target.port, 3333);
+      assert.isDefined(firstLaunch);
+      assert.isDefined(secondLaunch);
+      assert.include(firstLaunch, "chosen-user@devbox");
+      assert.include(secondLaunch, "chosen-user@devbox");
+      assert.equal(secondLaunch.at(-1), firstLaunch.at(-1));
+      assert.equal(spawnedCommands.filter((args) => args.includes("-N")).length, 2);
+      assert.equal(tunnelKillCount, 1);
+      assert.equal(stopCommandCount, 0);
+
+      yield* manager.disconnectEnvironment(requestedTarget);
+      assert.equal(tunnelKillCount, 2);
+      assert.equal(stopCommandCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it("rejects invalid remote state key overrides", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    assert.throws(
+      () => buildRemoteStopScript(target, 'x"; command; #'),
+      /Invalid remote state key/u,
+    );
   });
 
   it.effect("closes the tunnel scope and starts fresh after disconnect", () => {

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -13,6 +13,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { SshPasswordPrompt } from "./auth.ts";
+import { SshInvalidTargetError } from "./errors.ts";
 import {
   buildRemoteLaunchScript,
   buildRemotePairingScript,
@@ -483,6 +484,26 @@ describe("ssh tunnel scripts", () => {
       () => buildRemoteStopScript(target, 'x"; command; #'),
       /Invalid remote state key/u,
     );
+  });
+
+  it.effect("reports invalid remote state key overrides through the typed error channel", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const error = yield* launchOrReuseRemoteServer(
+        target,
+        undefined,
+        undefined,
+        'x"; command; #',
+      ).pipe(Effect.flip);
+
+      assert.instanceOf(error, SshInvalidTargetError);
+    }).pipe(Effect.provide(NodeServices.layer));
   });
 
   it.effect("closes the tunnel scope and starts fresh after disconnect", () => {

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -125,6 +125,13 @@ function sshTargetLogFields(target: DesktopSshEnvironmentTarget) {
   };
 }
 
+function targetsShareRemoteServer(
+  current: DesktopSshEnvironmentTarget,
+  next: DesktopSshEnvironmentTarget,
+): boolean {
+  return current.hostname === next.hostname && current.username === next.username;
+}
+
 function sshRunnerLogFields(runner: RemoteT3RunnerOptions | undefined) {
   if (runner?.nodeScriptPath?.trim()) {
     return { runner: "node-script", nodeScriptPath: runner.nodeScriptPath.trim() };
@@ -1223,46 +1230,50 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const closeTunnelEntry = Effect.fn("ssh/tunnel.closeTunnelEntry")(function* (
     entry: SshTunnelEntry,
   ) {
-    yield* Effect.logDebug("ssh.tunnel.close.start", {
-      ...sshTargetLogFields(entry.target),
-      key: entry.key,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-    });
-    yield* Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
-    yield* Effect.logInfo("ssh.tunnel.close.succeeded", {
-      ...sshTargetLogFields(entry.target),
-      key: entry.key,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-    });
+    yield* Effect.gen(function* () {
+      yield* Effect.logDebug("ssh.tunnel.close.start", {
+        ...sshTargetLogFields(entry.target),
+        key: entry.key,
+        localPort: entry.localPort,
+        remotePort: entry.remotePort,
+      });
+      yield* Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
+      yield* Effect.logInfo("ssh.tunnel.close.succeeded", {
+        ...sshTargetLogFields(entry.target),
+        key: entry.key,
+        localPort: entry.localPort,
+        remotePort: entry.remotePort,
+      });
+    }).pipe(Effect.uninterruptible);
   });
 
   const closeLocalTunnelEntry = Effect.fn("ssh/tunnel.closeLocalTunnelEntry")(function* (
     entry: SshTunnelEntry,
   ) {
-    yield* Effect.logDebug("ssh.tunnel.replace.start", {
-      ...sshTargetLogFields(entry.target),
-      key: entry.key,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-    });
-    if (tunnels.get(entry.remoteStateKey) === entry) {
-      tunnels.delete(entry.remoteStateKey);
-    }
-    yield* entry.process
-      .kill({
-        killSignal: "SIGTERM",
-        forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
-      })
-      .pipe(Effect.ignore);
-    yield* Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
-    yield* Effect.logInfo("ssh.tunnel.replace.succeeded", {
-      ...sshTargetLogFields(entry.target),
-      key: entry.key,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-    });
+    yield* Effect.gen(function* () {
+      yield* Effect.logDebug("ssh.tunnel.replace.start", {
+        ...sshTargetLogFields(entry.target),
+        key: entry.key,
+        localPort: entry.localPort,
+        remotePort: entry.remotePort,
+      });
+      if (tunnels.get(entry.remoteStateKey) === entry) {
+        tunnels.delete(entry.remoteStateKey);
+      }
+      yield* entry.process
+        .kill({
+          killSignal: "SIGTERM",
+          forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+        })
+        .pipe(Effect.ignore);
+      yield* Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
+      yield* Effect.logInfo("ssh.tunnel.replace.succeeded", {
+        ...sshTargetLogFields(entry.target),
+        key: entry.key,
+        localPort: entry.localPort,
+        remotePort: entry.remotePort,
+      });
+    }).pipe(Effect.uninterruptible);
   });
 
   const cancelPendingTunnelEntry = Effect.fn("ssh/tunnel.cancelPendingTunnelEntry")(function* (
@@ -1439,77 +1450,88 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       remotePort,
     });
     const entryScope = yield* Scope.make("sequential");
-    const tunnelEntry = yield* runWithSshAuth({
-      key: input.key,
-      target: input.resolvedTarget,
-      operation: (authOptions) =>
-        startSshTunnel({
-          key: input.key,
-          remoteStateKey: input.remoteStateKey,
-          resolvedTarget: input.resolvedTarget,
-          remotePort,
-          localPort,
-          httpBaseUrl,
-          wsBaseUrl,
-          authOptions,
-          remoteServerKind: remoteLaunch.remoteServerKind,
-        }).pipe(Effect.provideService(Scope.Scope, entryScope)),
-    }).pipe(
-      Effect.onExit((exit) =>
-        Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
-      ),
-    );
     const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
     const fileSystemService = yield* FileSystem.FileSystem;
     const pathService = yield* Path.Path;
-    yield* Scope.addFinalizer(
-      entryScope,
-      Effect.gen(function* () {
-        if (tunnels.get(tunnelEntry.remoteStateKey) !== tunnelEntry) {
-          return;
-        }
-        yield* Effect.logDebug("ssh.environment.tunnel.finalizer.start", {
-          ...sshTargetLogFields(tunnelEntry.target),
-          key: tunnelEntry.key,
-          localPort: tunnelEntry.localPort,
-          remotePort: tunnelEntry.remotePort,
-        });
-        tunnels.delete(tunnelEntry.remoteStateKey);
-        const authSecret = authSecrets.get(tunnelEntry.key) ?? null;
-        yield* Effect.all(
-          [
-            tunnelEntry.process.kill({
-              killSignal: "SIGTERM",
-              forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
-            }),
-            stopRemoteServer(
-              tunnelEntry.target,
-              authSecret === null
-                ? {
-                    batchMode: "yes",
-                    interactiveAuth: false,
-                  }
-                : {
-                    authSecret,
-                    batchMode: "no",
-                    interactiveAuth: true,
-                  },
-              tunnelEntry.remoteStateKey,
-            ).pipe(
-              Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
-              Effect.provideService(FileSystem.FileSystem, fileSystemService),
-              Effect.provideService(Path.Path, pathService),
-            ),
-          ],
-          { concurrency: "unbounded" },
-        ).pipe(Effect.ignore);
-        yield* Effect.logDebug("ssh.environment.tunnel.finalizer.succeeded", {
-          ...sshTargetLogFields(tunnelEntry.target),
-          key: tunnelEntry.key,
-          localPort: tunnelEntry.localPort,
-          remotePort: tunnelEntry.remotePort,
-        });
-      }).pipe(Effect.ignore),
+    const registerTunnelFinalizer = Effect.fn("ssh/tunnel.registerTunnelFinalizer")(function* (
+      tunnelEntry: SshTunnelEntry,
+    ) {
+      yield* Scope.addFinalizer(
+        entryScope,
+        Effect.gen(function* () {
+          if (tunnels.get(tunnelEntry.remoteStateKey) !== tunnelEntry) {
+            return;
+          }
+          yield* Effect.logDebug("ssh.environment.tunnel.finalizer.start", {
+            ...sshTargetLogFields(tunnelEntry.target),
+            key: tunnelEntry.key,
+            localPort: tunnelEntry.localPort,
+            remotePort: tunnelEntry.remotePort,
+          });
+          tunnels.delete(tunnelEntry.remoteStateKey);
+          const authSecret = authSecrets.get(tunnelEntry.key) ?? null;
+          yield* Effect.all(
+            [
+              tunnelEntry.process.kill({
+                killSignal: "SIGTERM",
+                forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+              }),
+              stopRemoteServer(
+                tunnelEntry.target,
+                authSecret === null
+                  ? {
+                      batchMode: "yes",
+                      interactiveAuth: false,
+                    }
+                  : {
+                      authSecret,
+                      batchMode: "no",
+                      interactiveAuth: true,
+                    },
+                tunnelEntry.remoteStateKey,
+              ).pipe(
+                Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
+                Effect.provideService(FileSystem.FileSystem, fileSystemService),
+                Effect.provideService(Path.Path, pathService),
+              ),
+            ],
+            { concurrency: "unbounded" },
+          ).pipe(Effect.ignore);
+          yield* Effect.logDebug("ssh.environment.tunnel.finalizer.succeeded", {
+            ...sshTargetLogFields(tunnelEntry.target),
+            key: tunnelEntry.key,
+            localPort: tunnelEntry.localPort,
+            remotePort: tunnelEntry.remotePort,
+          });
+        }).pipe(Effect.ignore),
+      );
+    });
+    const tunnelEntry = yield* Effect.uninterruptibleMask((restore) =>
+      restore(
+        runWithSshAuth({
+          key: input.key,
+          target: input.resolvedTarget,
+          operation: (authOptions) =>
+            startSshTunnel({
+              key: input.key,
+              remoteStateKey: input.remoteStateKey,
+              resolvedTarget: input.resolvedTarget,
+              remotePort,
+              localPort,
+              httpBaseUrl,
+              wsBaseUrl,
+              authOptions,
+              remoteServerKind: remoteLaunch.remoteServerKind,
+            }).pipe(Effect.provideService(Scope.Scope, entryScope)),
+        }),
+      ).pipe(
+        Effect.onExit((exit) =>
+          Exit.isSuccess(exit)
+            ? Effect.void
+            : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
+        ),
+        Effect.tap(registerTunnelFinalizer),
+      ),
     );
     yield* Effect.logDebug("ssh.environment.tunnel.create.succeeded", {
       ...sshTargetLogFields(input.resolvedTarget),
@@ -1534,7 +1556,9 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         previousKey: entry.key,
         key,
       });
-      yield* closeLocalTunnelEntry(entry);
+      yield* targetsShareRemoteServer(entry.target, resolvedTarget)
+        ? closeLocalTunnelEntry(entry)
+        : closeTunnelEntry(entry);
       entry = null;
     }
 
@@ -1668,7 +1692,9 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...sshTargetLogFields(target),
       issuePairingToken: requestOptions?.issuePairingToken === true,
     });
-    const baseResolved = yield* resolveSshTarget(target.alias || target.hostname);
+    const baseResolved = yield* resolveSshTarget(target.alias || target.hostname, {
+      username: target.username,
+    });
     const resolvedTarget: DesktopSshEnvironmentTarget = {
       ...baseResolved,
       ...(target.username !== null ? { username: target.username } : {}),
@@ -1726,7 +1752,9 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     target: DesktopSshEnvironmentTarget,
   ): Effect.fn.Return<void, SshEnvironmentEffectError, SshEnvironmentEffectContext> {
     yield* Effect.logInfo("ssh.environment.disconnect.start", sshTargetLogFields(target));
-    const baseResolved = yield* resolveSshTarget(target.alias || target.hostname);
+    const baseResolved = yield* resolveSshTarget(target.alias || target.hostname, {
+      username: target.username,
+    });
     const resolvedTarget: DesktopSshEnvironmentTarget = {
       ...baseResolved,
       ...(target.username !== null ? { username: target.username } : {}),

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -33,7 +33,7 @@ import {
   buildSshHostSpecEffect,
   collectProcessOutput,
   getLastNonEmptyOutputLine,
-  remoteStateKey,
+  remoteStateKey as deriveRemoteStateKey,
   resolveSshCommand,
   resolveSshTarget,
   runSshCommand,
@@ -71,6 +71,7 @@ export interface SshEnvironmentManagerOptions {
 
 interface SshTunnelEntry {
   readonly key: string;
+  readonly remoteStateKey: string;
   readonly target: DesktopSshEnvironmentTarget;
   readonly remotePort: number;
   readonly remoteServerKind: "external" | "managed" | null;
@@ -689,22 +690,29 @@ export function buildRemoteLaunchScript(input?: RemoteT3RunnerOptions): string {
 export function buildRemotePairingScript(
   target: DesktopSshEnvironmentTarget,
   input?: RemoteT3RunnerOptions,
+  remoteStateKey = deriveRemoteStateKey(target),
 ): string {
   return applyScriptPlaceholders(REMOTE_PAIRING_SCRIPT, {
-    T3_STATE_KEY: remoteStateKey(target),
+    T3_STATE_KEY: remoteStateKey,
     T3_RUNNER_SCRIPT: stripTrailingNewlines(buildRemoteT3RunnerScript(input)),
   });
 }
 
-export function buildRemoteStopScript(target: DesktopSshEnvironmentTarget): string {
+export function buildRemoteStopScript(
+  target: DesktopSshEnvironmentTarget,
+  remoteStateKey = deriveRemoteStateKey(target),
+): string {
   return applyScriptPlaceholders(REMOTE_STOP_SCRIPT, {
-    T3_STATE_KEY: remoteStateKey(target),
+    T3_STATE_KEY: remoteStateKey,
   });
 }
 
-function buildRemoteLogTailScript(target: DesktopSshEnvironmentTarget): string {
+function buildRemoteLogTailScript(
+  target: DesktopSshEnvironmentTarget,
+  remoteStateKey = deriveRemoteStateKey(target),
+): string {
   return applyScriptPlaceholders(REMOTE_LOG_TAIL_SCRIPT, {
-    T3_STATE_KEY: remoteStateKey(target),
+    T3_STATE_KEY: remoteStateKey,
   });
 }
 
@@ -713,6 +721,7 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
     target: DesktopSshEnvironmentTarget,
     input?: SshAuthOptions,
     runner?: RemoteT3RunnerOptions,
+    remoteStateKey = deriveRemoteStateKey(target),
   ): Effect.fn.Return<
     { readonly remotePort: number; readonly remoteServerKind: "external" | "managed" | null },
     SshCommandError | SshInvalidTargetError | SshLaunchError,
@@ -721,10 +730,10 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
     yield* Effect.logInfo("ssh.remoteServer.launch.start", {
       ...sshTargetLogFields(target),
       ...sshRunnerLogFields(runner),
-      stateKey: remoteStateKey(target),
+      stateKey: remoteStateKey,
     });
     const result = yield* runSshCommand(target, {
-      remoteCommandArgs: ["sh", "-l", "-s", "--", remoteStateKey(target)],
+      remoteCommandArgs: ["sh", "-l", "-s", "--", remoteStateKey],
       stdin: buildRemoteLaunchScript(runner),
       timeoutMs: REMOTE_LAUNCH_TIMEOUT_MS,
       ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
@@ -757,7 +766,7 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
       ...sshTargetLogFields(target),
       remotePort: parsed.remotePort,
       remoteServerKind: parsed.serverKind ?? null,
-      stateKey: remoteStateKey(target),
+      stateKey: remoteStateKey,
     });
     return {
       remotePort: parsed.remotePort,
@@ -770,6 +779,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
   target: DesktopSshEnvironmentTarget,
   input?: SshAuthOptions,
   runner?: RemoteT3RunnerOptions,
+  remoteStateKey = deriveRemoteStateKey(target),
 ): Effect.fn.Return<
   {
     readonly credential: string;
@@ -779,11 +789,11 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
 > {
   yield* Effect.logDebug("ssh.remoteServer.pairingToken.start", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey(target),
+    stateKey: remoteStateKey,
   });
   const result = yield* runSshCommand(target, {
     remoteCommandArgs: ["sh", "-s"],
-    stdin: buildRemotePairingScript(target, runner),
+    stdin: buildRemotePairingScript(target, runner, remoteStateKey),
     ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
     ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),
     ...(input?.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),
@@ -812,7 +822,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
   }
   yield* Effect.logDebug("ssh.remoteServer.pairingToken.created", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey(target),
+    stateKey: remoteStateKey,
   });
   return {
     credential: parsed.credential,
@@ -822,6 +832,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
 export const stopRemoteServer = Effect.fn("ssh/tunnel.stopRemoteServer")(function* (
   target: DesktopSshEnvironmentTarget,
   input?: SshAuthOptions,
+  remoteStateKey = deriveRemoteStateKey(target),
 ): Effect.fn.Return<
   void,
   SshCommandError | SshInvalidTargetError,
@@ -829,24 +840,25 @@ export const stopRemoteServer = Effect.fn("ssh/tunnel.stopRemoteServer")(functio
 > {
   yield* Effect.logInfo("ssh.remoteServer.stop.start", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey(target),
+    stateKey: remoteStateKey,
   });
   yield* runSshCommand(target, {
     remoteCommandArgs: ["sh", "-s"],
-    stdin: buildRemoteStopScript(target),
+    stdin: buildRemoteStopScript(target, remoteStateKey),
     ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
     ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),
     ...(input?.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),
   });
   yield* Effect.logInfo("ssh.remoteServer.stop.succeeded", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey(target),
+    stateKey: remoteStateKey,
   });
 });
 
 const readRemoteServerLogTail = Effect.fn("ssh/tunnel.readRemoteServerLogTail")(function* (
   target: DesktopSshEnvironmentTarget,
   input?: SshAuthOptions,
+  remoteStateKey = deriveRemoteStateKey(target),
 ): Effect.fn.Return<
   string,
   SshCommandError | SshInvalidTargetError,
@@ -854,7 +866,7 @@ const readRemoteServerLogTail = Effect.fn("ssh/tunnel.readRemoteServerLogTail")(
 > {
   const result = yield* runSshCommand(target, {
     remoteCommandArgs: ["sh", "-s"],
-    stdin: buildRemoteLogTailScript(target),
+    stdin: buildRemoteLogTailScript(target, remoteStateKey),
     timeoutMs: 10_000,
     ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
     ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),
@@ -941,6 +953,7 @@ const reserveLocalTunnelPort = Effect.fn("ssh/tunnel.reserveLocalTunnelPort")(fu
 
 const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: {
   readonly key: string;
+  readonly remoteStateKey: string;
   readonly resolvedTarget: DesktopSshEnvironmentTarget;
   readonly remotePort: number;
   readonly localPort: number;
@@ -1048,6 +1061,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
   });
   const tunnelEntry: SshTunnelEntry = {
     key: input.key,
+    remoteStateKey: input.remoteStateKey,
     target: input.resolvedTarget,
     remotePort: input.remotePort,
     remoteServerKind: input.remoteServerKind,
@@ -1121,7 +1135,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
           net.canListenOnHost(input.localPort, "127.0.0.1"),
         );
         const remoteLogTailExit = yield* Effect.exit(
-          readRemoteServerLogTail(input.resolvedTarget, input.authOptions),
+          readRemoteServerLogTail(input.resolvedTarget, input.authOptions, input.remoteStateKey),
         );
         const processRunning = Exit.isSuccess(processRunningExit) ? processRunningExit.value : null;
         const localPortAvailable = Exit.isSuccess(localPortAvailableExit)
@@ -1331,6 +1345,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
 
   const createTunnelEntry = Effect.fn("ssh/tunnel.ensureTunnelEntry.create")(function* (input: {
     readonly key: string;
+    readonly remoteStateKey: string;
     readonly resolvedTarget: DesktopSshEnvironmentTarget;
     readonly runner?: RemoteT3RunnerOptions;
   }): Effect.fn.Return<SshTunnelEntry, SshEnvironmentEffectError, SshEnvironmentEffectContext> {
@@ -1343,7 +1358,12 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       key: input.key,
       target: input.resolvedTarget,
       operation: (authOptions) =>
-        launchOrReuseRemoteServer(input.resolvedTarget, authOptions, input.runner),
+        launchOrReuseRemoteServer(
+          input.resolvedTarget,
+          authOptions,
+          input.runner,
+          input.remoteStateKey,
+        ),
     });
     const remotePort = remoteLaunch.remotePort;
     yield* Effect.logDebug("ssh.environment.remotePort.ready", {
@@ -1368,6 +1388,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       operation: (authOptions) =>
         startSshTunnel({
           key: input.key,
+          remoteStateKey: input.remoteStateKey,
           resolvedTarget: input.resolvedTarget,
           remotePort,
           localPort,
@@ -1417,6 +1438,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
                     batchMode: "no",
                     interactiveAuth: true,
                   },
+              tunnelEntry.remoteStateKey,
             ).pipe(
               Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
               Effect.provideService(FileSystem.FileSystem, fileSystemService),
@@ -1444,6 +1466,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
 
   const ensureTunnelEntry = Effect.fn("ssh/tunnel.ensureTunnelEntry")(function* (
     key: string,
+    remoteStateKey: string,
     resolvedTarget: DesktopSshEnvironmentTarget,
     runner?: RemoteT3RunnerOptions,
   ): Effect.fn.Return<SshTunnelEntry, SshEnvironmentEffectError, SshEnvironmentEffectContext> {
@@ -1494,6 +1517,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
 
     return yield* createTunnelEntry({
       key,
+      remoteStateKey,
       resolvedTarget,
       ...(runner === undefined ? {} : { runner }),
     }).pipe(
@@ -1532,6 +1556,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...(target.username !== null ? { username: target.username } : {}),
       ...(target.port !== null ? { port: target.port } : {}),
     };
+    const remoteStateKey = deriveRemoteStateKey(target);
     const key = targetConnectionKey(resolvedTarget);
     yield* Effect.logDebug("ssh.environment.target.resolved", {
       ...sshTargetLogFields(resolvedTarget),
@@ -1549,13 +1574,14 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...sshRunnerLogFields(runner),
       key,
     });
-    const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
+    const entry = yield* ensureTunnelEntry(key, remoteStateKey, resolvedTarget, runner);
 
     const pairingResult = requestOptions?.issuePairingToken
       ? yield* runWithSshAuth({
           key,
           target: entry.target,
-          operation: (authOptions) => issueRemotePairingToken(entry.target, authOptions, runner),
+          operation: (authOptions) =>
+            issueRemotePairingToken(entry.target, authOptions, runner, entry.remoteStateKey),
         })
       : null;
     const pairingToken = pairingResult?.credential ?? null;
@@ -1588,6 +1614,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...(target.username !== null ? { username: target.username } : {}),
       ...(target.port !== null ? { port: target.port } : {}),
     };
+    const remoteStateKey = deriveRemoteStateKey(target);
     const key = targetConnectionKey(resolvedTarget);
     const entry = tunnels.get(key) ?? null;
     yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
@@ -1604,7 +1631,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       yield* runWithSshAuth({
         key,
         target: resolvedTarget,
-        operation: (authOptions) => stopRemoteServer(resolvedTarget, authOptions),
+        operation: (authOptions) => stopRemoteServer(resolvedTarget, authOptions, remoteStateKey),
       });
     }
     yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -57,6 +57,7 @@ const TUNNEL_SHUTDOWN_TIMEOUT_MS = 2_000;
 const REMOTE_READY_TIMEOUT_MS = 60_000;
 const REMOTE_LAUNCH_TIMEOUT_MS = 90_000;
 const REMOTE_REUSE_READY_TIMEOUT_MS = 2_000;
+const REMOTE_STATE_KEY_PATTERN = /^[0-9a-f]{16}$/u;
 
 export interface RemoteT3RunnerOptions {
   readonly packageSpec?: string;
@@ -80,6 +81,11 @@ interface SshTunnelEntry {
   readonly wsBaseUrl: string;
   readonly process: ChildProcessSpawner.ChildProcessHandle;
   readonly scope: Scope.Scope;
+}
+
+interface PendingSshTunnelEntry {
+  readonly key: string;
+  readonly deferred: Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>;
 }
 
 type SshEnvironmentEffectContext =
@@ -221,6 +227,13 @@ function stripTrailingNewlines(value: string): string {
 
 function shellSingleQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function validateRemoteStateKey(value: string): string {
+  if (!REMOTE_STATE_KEY_PATTERN.test(value)) {
+    throw new Error("Invalid remote state key.");
+  }
+  return value;
 }
 
 function applyScriptPlaceholders(
@@ -693,7 +706,7 @@ export function buildRemotePairingScript(
   remoteStateKey = deriveRemoteStateKey(target),
 ): string {
   return applyScriptPlaceholders(REMOTE_PAIRING_SCRIPT, {
-    T3_STATE_KEY: remoteStateKey,
+    T3_STATE_KEY: validateRemoteStateKey(remoteStateKey),
     T3_RUNNER_SCRIPT: stripTrailingNewlines(buildRemoteT3RunnerScript(input)),
   });
 }
@@ -703,7 +716,7 @@ export function buildRemoteStopScript(
   remoteStateKey = deriveRemoteStateKey(target),
 ): string {
   return applyScriptPlaceholders(REMOTE_STOP_SCRIPT, {
-    T3_STATE_KEY: remoteStateKey,
+    T3_STATE_KEY: validateRemoteStateKey(remoteStateKey),
   });
 }
 
@@ -712,7 +725,7 @@ function buildRemoteLogTailScript(
   remoteStateKey = deriveRemoteStateKey(target),
 ): string {
   return applyScriptPlaceholders(REMOTE_LOG_TAIL_SCRIPT, {
-    T3_STATE_KEY: remoteStateKey,
+    T3_STATE_KEY: validateRemoteStateKey(remoteStateKey),
   });
 }
 
@@ -727,13 +740,14 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
     SshCommandError | SshInvalidTargetError | SshLaunchError,
     ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
   > {
+    const stateKey = validateRemoteStateKey(remoteStateKey);
     yield* Effect.logInfo("ssh.remoteServer.launch.start", {
       ...sshTargetLogFields(target),
       ...sshRunnerLogFields(runner),
-      stateKey: remoteStateKey,
+      stateKey,
     });
     const result = yield* runSshCommand(target, {
-      remoteCommandArgs: ["sh", "-l", "-s", "--", remoteStateKey],
+      remoteCommandArgs: ["sh", "-l", "-s", "--", stateKey],
       stdin: buildRemoteLaunchScript(runner),
       timeoutMs: REMOTE_LAUNCH_TIMEOUT_MS,
       ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
@@ -766,7 +780,7 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
       ...sshTargetLogFields(target),
       remotePort: parsed.remotePort,
       remoteServerKind: parsed.serverKind ?? null,
-      stateKey: remoteStateKey,
+      stateKey,
     });
     return {
       remotePort: parsed.remotePort,
@@ -1186,10 +1200,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
 ): Effect.fn.Return<SshEnvironmentManagerShape, never, Scope.Scope> {
   const managerScope = yield* Scope.Scope;
   const tunnels = new Map<string, SshTunnelEntry>();
-  const pendingTunnelEntries = new Map<
-    string,
-    Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>
-  >();
+  const pendingTunnelEntries = new Map<string, PendingSshTunnelEntry>();
   const authSecrets = new Map<string, string>();
 
   const closeTunnelEntry = Effect.fn("ssh/tunnel.closeTunnelEntry")(function* (
@@ -1210,16 +1221,43 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     });
   });
 
+  const closeLocalTunnelEntry = Effect.fn("ssh/tunnel.closeLocalTunnelEntry")(function* (
+    entry: SshTunnelEntry,
+  ) {
+    yield* Effect.logDebug("ssh.tunnel.replace.start", {
+      ...sshTargetLogFields(entry.target),
+      key: entry.key,
+      localPort: entry.localPort,
+      remotePort: entry.remotePort,
+    });
+    if (tunnels.get(entry.remoteStateKey) === entry) {
+      tunnels.delete(entry.remoteStateKey);
+    }
+    yield* entry.process
+      .kill({
+        killSignal: "SIGTERM",
+        forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+      })
+      .pipe(Effect.ignore);
+    yield* Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
+    yield* Effect.logInfo("ssh.tunnel.replace.succeeded", {
+      ...sshTargetLogFields(entry.target),
+      key: entry.key,
+      localPort: entry.localPort,
+      remotePort: entry.remotePort,
+    });
+  });
+
   const cancelPendingTunnelEntry = Effect.fn("ssh/tunnel.cancelPendingTunnelEntry")(function* (
-    key: string,
+    remoteStateKey: string,
     target: DesktopSshEnvironmentTarget,
   ) {
-    const pending = pendingTunnelEntries.get(key);
+    const pending = pendingTunnelEntries.get(remoteStateKey);
     if (!pending) {
       return;
     }
-    pendingTunnelEntries.delete(key);
-    yield* Deferred.fail(pending, makeSshTunnelCancelledError(target)).pipe(Effect.ignore);
+    pendingTunnelEntries.delete(remoteStateKey);
+    yield* Deferred.fail(pending.deferred, makeSshTunnelCancelledError(target)).pipe(Effect.ignore);
   });
 
   yield* Scope.addFinalizer(
@@ -1402,14 +1440,14 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
       ),
     );
-    tunnels.set(input.key, tunnelEntry);
+    tunnels.set(input.remoteStateKey, tunnelEntry);
     const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
     const fileSystemService = yield* FileSystem.FileSystem;
     const pathService = yield* Path.Path;
     yield* Scope.addFinalizer(
       entryScope,
       Effect.gen(function* () {
-        if (tunnels.get(tunnelEntry.key) !== tunnelEntry) {
+        if (tunnels.get(tunnelEntry.remoteStateKey) !== tunnelEntry) {
           return;
         }
         yield* Effect.logDebug("ssh.environment.tunnel.finalizer.start", {
@@ -1418,7 +1456,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
           localPort: tunnelEntry.localPort,
           remotePort: tunnelEntry.remotePort,
         });
-        tunnels.delete(tunnelEntry.key);
+        tunnels.delete(tunnelEntry.remoteStateKey);
         const authSecret = authSecrets.get(tunnelEntry.key) ?? null;
         yield* Effect.all(
           [
@@ -1470,7 +1508,17 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     resolvedTarget: DesktopSshEnvironmentTarget,
     runner?: RemoteT3RunnerOptions,
   ): Effect.fn.Return<SshTunnelEntry, SshEnvironmentEffectError, SshEnvironmentEffectContext> {
-    let entry = tunnels.get(key) ?? null;
+    let entry = tunnels.get(remoteStateKey) ?? null;
+
+    if (entry !== null && entry.key !== key) {
+      yield* Effect.logInfo("ssh.environment.tunnel.endpointChanged", {
+        ...sshTargetLogFields(resolvedTarget),
+        previousKey: entry.key,
+        key,
+      });
+      yield* closeLocalTunnelEntry(entry);
+      entry = null;
+    }
 
     if (entry !== null) {
       yield* Effect.logDebug("ssh.environment.tunnel.existing.check", {
@@ -1499,21 +1547,24 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         cause: readinessExit.cause,
       });
       yield* closeTunnelEntry(entry);
-      yield* cancelPendingTunnelEntry(key, resolvedTarget);
+      yield* cancelPendingTunnelEntry(remoteStateKey, resolvedTarget);
       entry = null;
     }
 
-    const pending = pendingTunnelEntries.get(key);
+    const pending = pendingTunnelEntries.get(remoteStateKey);
     if (pending) {
-      yield* Effect.logDebug("ssh.environment.tunnel.pending.await", {
-        ...sshTargetLogFields(resolvedTarget),
-        key,
-      });
-      return yield* Deferred.await(pending);
+      if (pending.key === key) {
+        yield* Effect.logDebug("ssh.environment.tunnel.pending.await", {
+          ...sshTargetLogFields(resolvedTarget),
+          key,
+        });
+        return yield* Deferred.await(pending.deferred);
+      }
+      yield* cancelPendingTunnelEntry(remoteStateKey, resolvedTarget);
     }
 
     const deferred = yield* Deferred.make<SshTunnelEntry, SshEnvironmentEffectError>();
-    pendingTunnelEntries.set(key, deferred);
+    pendingTunnelEntries.set(remoteStateKey, { key, deferred });
 
     return yield* createTunnelEntry({
       key,
@@ -1530,8 +1581,8 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ),
       Effect.onExit((exit) =>
         Effect.sync(() => {
-          if (pendingTunnelEntries.get(key) === deferred) {
-            pendingTunnelEntries.delete(key);
+          if (pendingTunnelEntries.get(remoteStateKey)?.deferred === deferred) {
+            pendingTunnelEntries.delete(remoteStateKey);
           }
         }).pipe(Effect.andThen(Deferred.done(deferred, exit))),
       ),
@@ -1616,17 +1667,17 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     };
     const remoteStateKey = deriveRemoteStateKey(target);
     const key = targetConnectionKey(resolvedTarget);
-    const entry = tunnels.get(key) ?? null;
+    const entry = tunnels.get(remoteStateKey) ?? null;
     yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
       ...sshTargetLogFields(resolvedTarget),
       key,
       hasTunnel: entry !== null,
-      hasPendingTunnel: pendingTunnelEntries.has(key),
+      hasPendingTunnel: pendingTunnelEntries.has(remoteStateKey),
     });
     if (entry !== null) {
       yield* closeTunnelEntry(entry);
     }
-    yield* cancelPendingTunnelEntry(key, resolvedTarget);
+    yield* cancelPendingTunnelEntry(remoteStateKey, resolvedTarget);
     if (entry === null) {
       yield* runWithSshAuth({
         key,

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -236,6 +236,15 @@ function validateRemoteStateKey(value: string): string {
   return value;
 }
 
+const requireRemoteStateKey = (value: string): Effect.Effect<string, SshInvalidTargetError> =>
+  Effect.try({
+    try: () => validateRemoteStateKey(value),
+    catch: () =>
+      new SshInvalidTargetError({
+        message: "SSH remote state key is invalid.",
+      }),
+  });
+
 function applyScriptPlaceholders(
   template: string,
   replacements: Readonly<Record<string, string>>,
@@ -740,7 +749,7 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
     SshCommandError | SshInvalidTargetError | SshLaunchError,
     ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
   > {
-    const stateKey = validateRemoteStateKey(remoteStateKey);
+    const stateKey = yield* requireRemoteStateKey(remoteStateKey);
     yield* Effect.logInfo("ssh.remoteServer.launch.start", {
       ...sshTargetLogFields(target),
       ...sshRunnerLogFields(runner),
@@ -801,13 +810,14 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
   SshCommandError | SshInvalidTargetError | SshPairingError,
   ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > {
+  const stateKey = yield* requireRemoteStateKey(remoteStateKey);
   yield* Effect.logDebug("ssh.remoteServer.pairingToken.start", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey,
+    stateKey,
   });
   const result = yield* runSshCommand(target, {
     remoteCommandArgs: ["sh", "-s"],
-    stdin: buildRemotePairingScript(target, runner, remoteStateKey),
+    stdin: buildRemotePairingScript(target, runner, stateKey),
     ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
     ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),
     ...(input?.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),
@@ -836,7 +846,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
   }
   yield* Effect.logDebug("ssh.remoteServer.pairingToken.created", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey,
+    stateKey,
   });
   return {
     credential: parsed.credential,
@@ -852,20 +862,21 @@ export const stopRemoteServer = Effect.fn("ssh/tunnel.stopRemoteServer")(functio
   SshCommandError | SshInvalidTargetError,
   ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > {
+  const stateKey = yield* requireRemoteStateKey(remoteStateKey);
   yield* Effect.logInfo("ssh.remoteServer.stop.start", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey,
+    stateKey,
   });
   yield* runSshCommand(target, {
     remoteCommandArgs: ["sh", "-s"],
-    stdin: buildRemoteStopScript(target, remoteStateKey),
+    stdin: buildRemoteStopScript(target, stateKey),
     ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
     ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),
     ...(input?.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),
   });
   yield* Effect.logInfo("ssh.remoteServer.stop.succeeded", {
     ...sshTargetLogFields(target),
-    stateKey: remoteStateKey,
+    stateKey,
   });
 });
 
@@ -878,9 +889,10 @@ const readRemoteServerLogTail = Effect.fn("ssh/tunnel.readRemoteServerLogTail")(
   SshCommandError | SshInvalidTargetError,
   ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > {
+  const stateKey = yield* requireRemoteStateKey(remoteStateKey);
   const result = yield* runSshCommand(target, {
     remoteCommandArgs: ["sh", "-s"],
-    stdin: buildRemoteLogTailScript(target, remoteStateKey),
+    stdin: buildRemoteLogTailScript(target, stateKey),
     timeoutMs: 10_000,
     ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
     ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -870,6 +870,9 @@ export const stopRemoteServer = Effect.fn("ssh/tunnel.stopRemoteServer")(functio
     stateKey,
   });
   yield* runSshCommand(target, {
+    ...(target.alias.trim().length > 0 && target.hostname.trim().length > 0
+      ? { preHostArgs: ["-o", `HostName=${target.hostname.trim()}`] }
+      : {}),
     remoteCommandArgs: ["sh", "-s"],
     stdin: buildRemoteStopScript(target, stateKey),
     ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
@@ -1265,9 +1268,10 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const cancelPendingTunnelEntry = Effect.fn("ssh/tunnel.cancelPendingTunnelEntry")(function* (
     remoteStateKey: string,
     target: DesktopSshEnvironmentTarget,
+    expected?: PendingSshTunnelEntry,
   ) {
     const pending = pendingTunnelEntries.get(remoteStateKey);
-    if (!pending) {
+    if (!pending || (expected !== undefined && pending !== expected)) {
       return;
     }
     pendingTunnelEntries.delete(remoteStateKey);
@@ -1582,23 +1586,37 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       const start = yield* Deferred.make<void>();
       const fiber = yield* Deferred.await(start).pipe(
         Effect.andThen(
-          createTunnelEntry({
-            key,
-            remoteStateKey,
-            resolvedTarget,
-            ...(runner === undefined ? {} : { runner }),
-          }),
-        ),
-        Effect.flatMap((createdEntry) =>
-          Effect.gen(function* () {
-            if (pendingTunnelEntries.get(remoteStateKey)?.deferred !== deferred) {
-              yield* closeLocalTunnelEntry(createdEntry);
-              return yield* makeSshTunnelCancelledError(resolvedTarget);
-            }
-            pendingTunnelEntries.delete(remoteStateKey);
-            tunnels.set(remoteStateKey, createdEntry);
-            return createdEntry;
-          }),
+          Effect.uninterruptibleMask((restore) =>
+            restore(
+              createTunnelEntry({
+                key,
+                remoteStateKey,
+                resolvedTarget,
+                ...(runner === undefined ? {} : { runner }),
+              }),
+            ).pipe(
+              Effect.flatMap((createdEntry) =>
+                restore(
+                  Effect.gen(function* () {
+                    if (pendingTunnelEntries.get(remoteStateKey)?.deferred !== deferred) {
+                      return yield* makeSshTunnelCancelledError(resolvedTarget);
+                    }
+                    pendingTunnelEntries.delete(remoteStateKey);
+                    tunnels.set(remoteStateKey, createdEntry);
+                    return createdEntry;
+                  }),
+                ).pipe(
+                  Effect.onExit((exit) =>
+                    Exit.isSuccess(exit)
+                      ? Effect.void
+                      : tunnels.get(remoteStateKey) === createdEntry
+                        ? closeTunnelEntry(createdEntry)
+                        : closeLocalTunnelEntry(createdEntry),
+                  ),
+                ),
+              ),
+            ),
+          ),
         ),
         Effect.tapError((cause) =>
           Effect.logWarning("ssh.environment.tunnel.create.failed", {
@@ -1632,7 +1650,9 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     }
 
     return yield* Deferred.await(pendingEntry.deferred).pipe(
-      Effect.onInterrupt(() => cancelPendingTunnelEntry(remoteStateKey, resolvedTarget)),
+      Effect.onInterrupt(() =>
+        cancelPendingTunnelEntry(remoteStateKey, resolvedTarget, pendingEntry),
+      ),
     );
   });
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -13,6 +13,7 @@ import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
@@ -86,6 +87,7 @@ interface SshTunnelEntry {
 interface PendingSshTunnelEntry {
   readonly key: string;
   readonly deferred: Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>;
+  readonly fiber: Fiber.Fiber<void, never>;
 }
 
 type SshEnvironmentEffectContext =
@@ -1270,6 +1272,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     }
     pendingTunnelEntries.delete(remoteStateKey);
     yield* Deferred.fail(pending.deferred, makeSshTunnelCancelledError(target)).pipe(Effect.ignore);
+    yield* Fiber.interrupt(pending.fiber).pipe(Effect.ignore);
   });
 
   yield* Scope.addFinalizer(
@@ -1452,7 +1455,6 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
       ),
     );
-    tunnels.set(input.remoteStateKey, tunnelEntry);
     const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
     const fileSystemService = yield* FileSystem.FileSystem;
     const pathService = yield* Path.Path;
@@ -1575,29 +1577,62 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       yield* cancelPendingTunnelEntry(remoteStateKey, resolvedTarget);
     }
 
-    const deferred = yield* Deferred.make<SshTunnelEntry, SshEnvironmentEffectError>();
-    pendingTunnelEntries.set(remoteStateKey, { key, deferred });
-
-    return yield* createTunnelEntry({
-      key,
-      remoteStateKey,
-      resolvedTarget,
-      ...(runner === undefined ? {} : { runner }),
-    }).pipe(
-      Effect.tapError((cause) =>
-        Effect.logWarning("ssh.environment.tunnel.create.failed", {
-          ...sshTargetLogFields(resolvedTarget),
-          key,
-          cause,
-        }),
-      ),
-      Effect.onExit((exit) =>
-        Effect.sync(() => {
-          if (pendingTunnelEntries.get(remoteStateKey)?.deferred === deferred) {
+    const pendingEntry = yield* Effect.gen(function* () {
+      const deferred = yield* Deferred.make<SshTunnelEntry, SshEnvironmentEffectError>();
+      const start = yield* Deferred.make<void>();
+      const fiber = yield* Deferred.await(start).pipe(
+        Effect.andThen(
+          createTunnelEntry({
+            key,
+            remoteStateKey,
+            resolvedTarget,
+            ...(runner === undefined ? {} : { runner }),
+          }),
+        ),
+        Effect.flatMap((createdEntry) =>
+          Effect.gen(function* () {
+            if (pendingTunnelEntries.get(remoteStateKey)?.deferred !== deferred) {
+              yield* closeLocalTunnelEntry(createdEntry);
+              return yield* makeSshTunnelCancelledError(resolvedTarget);
+            }
             pendingTunnelEntries.delete(remoteStateKey);
-          }
-        }).pipe(Effect.andThen(Deferred.done(deferred, exit))),
-      ),
+            tunnels.set(remoteStateKey, createdEntry);
+            return createdEntry;
+          }),
+        ),
+        Effect.tapError((cause) =>
+          Effect.logWarning("ssh.environment.tunnel.create.failed", {
+            ...sshTargetLogFields(resolvedTarget),
+            key,
+            cause,
+          }),
+        ),
+        Effect.onExit((exit) =>
+          Effect.sync(() => {
+            if (pendingTunnelEntries.get(remoteStateKey)?.deferred === deferred) {
+              pendingTunnelEntries.delete(remoteStateKey);
+            }
+          }).pipe(Effect.andThen(Deferred.done(deferred, exit))),
+        ),
+        Effect.ignore,
+        Effect.forkIn(managerScope, { uninterruptible: false }),
+      );
+      const pendingEntry = { key, deferred, fiber };
+      if (tunnels.has(remoteStateKey) || pendingTunnelEntries.has(remoteStateKey)) {
+        yield* Fiber.interrupt(fiber).pipe(Effect.ignore);
+        return null;
+      }
+      pendingTunnelEntries.set(remoteStateKey, pendingEntry);
+      yield* Deferred.succeed(start, undefined);
+      return pendingEntry;
+    }).pipe(Effect.uninterruptible);
+
+    if (pendingEntry === null) {
+      return yield* ensureTunnelEntry(key, remoteStateKey, resolvedTarget, runner);
+    }
+
+    return yield* Deferred.await(pendingEntry.deferred).pipe(
+      Effect.onInterrupt(() => cancelPendingTunnelEntry(remoteStateKey, resolvedTarget)),
     );
   });
 
@@ -1679,17 +1714,17 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     };
     const remoteStateKey = deriveRemoteStateKey(target);
     const key = targetConnectionKey(resolvedTarget);
-    const entry = tunnels.get(remoteStateKey) ?? null;
     yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
       ...sshTargetLogFields(resolvedTarget),
       key,
-      hasTunnel: entry !== null,
+      hasTunnel: tunnels.has(remoteStateKey),
       hasPendingTunnel: pendingTunnelEntries.has(remoteStateKey),
     });
+    yield* cancelPendingTunnelEntry(remoteStateKey, resolvedTarget);
+    const entry = tunnels.get(remoteStateKey) ?? null;
     if (entry !== null) {
       yield* closeTunnelEntry(entry);
     }
-    yield* cancelPendingTunnelEntry(remoteStateKey, resolvedTarget);
     if (entry === null) {
       yield* runWithSshAuth({
         key,


### PR DESCRIPTION
## What Changed

SSH connections added from a `~/.ssh/config` alias persisted the resolved hostname, username, and port. Reconnects then treated those values as explicit overrides, so an alias whose port changed kept dialing the stale endpoint.

The connection profile now keeps the target the user requested and resolves it again for every connection. User-entered username and port values remain explicit overrides. The remote launcher state key derives from the requested target rather than the resolved endpoint, so changes in alias resolution reuse the same remote state.

## Why

Fixes #7568.

SSH aliases are the stable identifier for hosts whose address or port can change. Connections saved by older versions still need to be removed and added once because their persisted values cannot be distinguished from explicit overrides. The user documentation now calls out that migration.

## Testing

- `vp test run packages/client-runtime/src/connection/onboarding.test.ts packages/client-runtime/src/connection/resolver.test.ts packages/ssh/src/tunnel.test.ts packages/ssh/src/command.test.ts`
- `vp run --filter @t3tools/client-runtime --filter @t3tools/ssh typecheck`
- Targeted lint and formatting checks for the changed files
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes, so before/after screenshots are not applicable
- [x] No animation or interaction changes, so a video is not applicable

Authored with gpt-daybreak-blue-latest in T3 Code via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop SSH connection, tunnel lifecycle, and remote stop/teardown paths; incorrect endpoint or state-key handling could leave stray tunnels or stop the wrong remote server.
> 
> **Overview**
> Fixes SSH environments that used `~/.ssh/config` aliases but kept dialing stale host/port after the alias changed, because saved profiles stored the **resolved** endpoint and reconnect treated it as fixed.
> 
> **Connection persistence** now keeps the **requested** target (alias plus any explicit username/port overrides) in `SshConnectionProfile` at registration and on prepare; the SSH broker no longer overwrites the profile with the provisioned bootstrap target.
> 
> **Runtime behavior** re-runs `ssh -G` resolution on every connect/disconnect (with optional username passed into `resolveSshTarget`). Tunnel lifecycle is keyed by a stable `remoteStateKey` derived from the **requested** target, so the same remote launcher state survives when only the resolved port changes—local tunnels are replaced without stopping the remote server. Host or user changes trigger full teardown including remote stop; `stopRemoteServer` can pass `-o HostName=…` when stopping via an alias. Pending tunnel setup is fiber-based with cancellation when a newer resolution supersedes an in-flight connect, plus validation of remote state keys in remote scripts.
> 
> **Docs** note per-connection alias resolution, override semantics, and that older saved connections may need remove-and-re-add once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f106b5b589ddd1ec6048188538c1d8d48945c94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep SSH aliases dynamic across reconnects in desktop client
> - Stores the originally requested SSH target in `SshConnectionProfile` instead of the resolved target, ensuring alias configuration is re-evaluated on each connection.
> - Refactors `SshEnvironmentManager.make` to key tunnels by `remoteStateKey` derived from the requested target, replacing only the local tunnel when alias port changes and fully stopping the remote server when host or user changes.
> - Validates `remoteStateKey` before use in remote launch, pairing, stop, and log tail scripts.
> - Updates `resolveSshTarget` to honor explicitly provided usernames, preserving them in the returned target.
> - Behavioral Change: `SshEnvironmentManager.make` wraps tunnel creation in uninterruptible masks and interrupts superseded pending tunnel creations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f106b5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SSH connections now preserve the originally configured alias, hostname, username, and port when reconnecting.
  - SSH aliases are re-resolved on each connection, reflecting address or port changes while honoring explicit username and port overrides.
  - Remote sessions remain stable when an alias resolves to a different destination.
  - Improved cleanup and validation for SSH tunnels.
  - Older saved connections may need to be removed and added again to restore alias-based resolution.

- **Documentation**
  - Updated the remote-access guide with SSH alias resolution and migration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->