### PR TITLE
fix(desktop): refuse same-home port fallback

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -30,7 +30,6 @@ import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWslBackend from "../wsl/DesktopWslBackend.ts";
 
 const DEFAULT_DESKTOP_BACKEND_PORT = 3773;
-const MAX_TCP_PORT = 65_535;
 const DESKTOP_BACKEND_PORT_PROBE_HOSTS = ["127.0.0.1", "0.0.0.0", "::"] as const;
 
 const makeDesktopRunId = Crypto.Crypto.pipe(
@@ -38,16 +37,19 @@ const makeDesktopRunId = Crypto.Crypto.pipe(
   Effect.map((value) => value.replaceAll("-", "").slice(0, 12)),
 );
 
-export class DesktopBackendPortUnavailableError extends Schema.TaggedErrorClass<DesktopBackendPortUnavailableError>()(
-  "DesktopBackendPortUnavailableError",
+export class DesktopBackendPortInUseError extends Schema.TaggedErrorClass<DesktopBackendPortInUseError>()(
+  "DesktopBackendPortInUseError",
   {
-    startPort: Schema.Int,
-    maxPort: Schema.Int,
+    port: Schema.Int,
     hosts: Schema.Array(Schema.String),
   },
 ) {
   override get message(): string {
-    return `No desktop backend port is available on hosts ${this.hosts.join(", ")} between ${this.startPort} and ${this.maxPort}.`;
+    return [
+      `Desktop backend port ${this.port} is already in use on ${this.hosts.join(", ")}.`,
+      "T3 Code will not start another backend on a fallback port while using the same data directory.",
+      "Connect to the running T3 Code server, stop it cleanly, or use a different T3CODE_HOME.",
+    ].join("\n");
   }
 }
 
@@ -66,40 +68,31 @@ const { logInfo: logBootstrapInfo, logWarning: logBootstrapWarning } =
 const { logInfo: logStartupInfo, logError: logStartupError } =
   DesktopObservability.makeComponentLogger("desktop-startup");
 
-const resolveDesktopBackendPort = Effect.fn("resolveDesktopBackendPort")(function* (
+export const resolveDesktopBackendPort = Effect.fn("resolveDesktopBackendPort")(function* (
   configuredPort: Option.Option<number>,
 ) {
   if (Option.isSome(configuredPort)) {
     return {
       port: configuredPort.value,
-      selectedByScan: false,
     } as const;
   }
 
   const net = yield* NetService.NetService;
-  for (let port = DEFAULT_DESKTOP_BACKEND_PORT; port <= MAX_TCP_PORT; port += 1) {
-    let availableOnEveryHost = true;
-
-    for (const host of DESKTOP_BACKEND_PORT_PROBE_HOSTS) {
-      if (!(yield* net.canListenOnHost(port, host))) {
-        availableOnEveryHost = false;
-        break;
-      }
-    }
-
-    if (availableOnEveryHost) {
-      return {
-        port,
-        selectedByScan: true,
-      } as const;
+  const unavailableHosts: string[] = [];
+  for (const host of DESKTOP_BACKEND_PORT_PROBE_HOSTS) {
+    if (!(yield* net.canListenOnHost(DEFAULT_DESKTOP_BACKEND_PORT, host))) {
+      unavailableHosts.push(host);
     }
   }
-
-  return yield* new DesktopBackendPortUnavailableError({
-    startPort: DEFAULT_DESKTOP_BACKEND_PORT,
-    maxPort: MAX_TCP_PORT,
-    hosts: DESKTOP_BACKEND_PORT_PROBE_HOSTS,
-  });
+  if (unavailableHosts.length > 0) {
+    return yield* new DesktopBackendPortInUseError({
+      port: DEFAULT_DESKTOP_BACKEND_PORT,
+      hosts: unavailableHosts,
+    });
+  }
+  return {
+    port: DEFAULT_DESKTOP_BACKEND_PORT,
+  } as const;
 });
 
 const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupError")(function* (
@@ -157,12 +150,11 @@ const bootstrap = Effect.gen(function* () {
   const backendPortSelection = yield* resolveDesktopBackendPort(environment.configuredBackendPort);
   const backendPort = backendPortSelection.port;
   yield* logBootstrapInfo(
-    backendPortSelection.selectedByScan
-      ? "selected backend port via sequential scan"
-      : "using configured backend port",
+    Option.isSome(environment.configuredBackendPort)
+      ? "using configured backend port"
+      : "using default backend port",
     {
       port: backendPort,
-      ...(backendPortSelection.selectedByScan ? { startPort: DEFAULT_DESKTOP_BACKEND_PORT } : {}),
     },
   );
 

--- a/apps/desktop/src/app/DesktopAppErrors.test.ts
+++ b/apps/desktop/src/app/DesktopAppErrors.test.ts
@@ -1,26 +1,80 @@
+import * as NetService from "@t3tools/shared/Net";
 import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 
 import {
-  DesktopBackendPortUnavailableError,
+  DesktopBackendPortInUseError,
   DesktopDevelopmentBackendPortRequiredError,
+  resolveDesktopBackendPort,
 } from "./DesktopApp.ts";
 
+const netLayer = (canListenOnHost: (port: number, host: string) => boolean) =>
+  Layer.succeed(NetService.NetService, {
+    canListenOnHost: (port, host) => Effect.succeed(canListenOnHost(port, host)),
+    isPortAvailableOnLoopback: () => Effect.die("unexpected isPortAvailableOnLoopback"),
+    hasListenerOnHost: () => Effect.die("unexpected hasListenerOnHost"),
+    reserveLoopbackPort: () => Effect.die("unexpected reserveLoopbackPort"),
+    findAvailablePort: () => Effect.die("unexpected findAvailablePort"),
+  } satisfies NetService.NetService["Service"]);
+
 describe("DesktopApp errors", () => {
-  it("preserves unavailable backend port context", () => {
-    const error = new DesktopBackendPortUnavailableError({
-      startPort: 3_773,
-      maxPort: 65_535,
-      hosts: ["127.0.0.1", "0.0.0.0", "::"],
+  it("preserves occupied default-port context", () => {
+    const error = new DesktopBackendPortInUseError({
+      port: 3_773,
+      hosts: ["127.0.0.1"],
     });
 
-    assert.equal(error.startPort, 3_773);
-    assert.equal(error.maxPort, 65_535);
-    assert.deepEqual(error.hosts, ["127.0.0.1", "0.0.0.0", "::"]);
+    assert.equal(error.port, 3_773);
+    assert.deepEqual(error.hosts, ["127.0.0.1"]);
     assert.equal(
       error.message,
-      "No desktop backend port is available on hosts 127.0.0.1, 0.0.0.0, :: between 3773 and 65535.",
+      [
+        "Desktop backend port 3773 is already in use on 127.0.0.1.",
+        "T3 Code will not start another backend on a fallback port while using the same data directory.",
+        "Connect to the running T3 Code server, stop it cleanly, or use a different T3CODE_HOME.",
+      ].join("\n"),
     );
   });
+
+  it.effect("uses the default port when every bind host is available", () =>
+    Effect.gen(function* () {
+      const selection = yield* resolveDesktopBackendPort(Option.none());
+      assert.deepEqual(selection, { port: 3_773 });
+    }).pipe(Effect.provide(netLayer(() => true))),
+  );
+
+  it.effect("refuses instead of scanning to another same-home port", () => {
+    const probes: Array<{ readonly port: number; readonly host: string }> = [];
+    return Effect.gen(function* () {
+      const failure = yield* resolveDesktopBackendPort(Option.none()).pipe(Effect.flip);
+      assert.strictEqual(failure._tag, "DesktopBackendPortInUseError");
+      if (failure._tag === "DesktopBackendPortInUseError") {
+        assert.strictEqual(failure.port, 3_773);
+        assert.deepEqual(failure.hosts, ["127.0.0.1"]);
+      }
+      assert.deepEqual(probes, [
+        { port: 3_773, host: "127.0.0.1" },
+        { port: 3_773, host: "0.0.0.0" },
+        { port: 3_773, host: "::" },
+      ]);
+    }).pipe(
+      Effect.provide(
+        netLayer((port, host) => {
+          probes.push({ port, host });
+          return host !== "127.0.0.1";
+        }),
+      ),
+    );
+  });
+
+  it.effect("preserves an explicitly configured backend port", () =>
+    Effect.gen(function* () {
+      const selection = yield* resolveDesktopBackendPort(Option.some(9_999));
+      assert.deepEqual(selection, { port: 9_999 });
+    }).pipe(Effect.provide(netLayer(() => false))),
+  );
 
   it("reports the required development port", () => {
     const error = new DesktopDevelopmentBackendPortRequiredError();


### PR DESCRIPTION
## What Changed

Packaged Desktop startup now uses the default backend port (`3773`) or fails before spawning the embedded server. It no longer scans to `3774+` while retaining the same T3 home.

An explicitly configured `T3CODE_PORT` still behaves as before.

## Why

If an older/background T3 backend already owns `3773`, the sequential scan currently launches another backend on `3774` against the same `state.sqlite`, settings, and provider state. The second backend appears healthy but creates split-brain writers; with Codex single-writer thread persistence this can surface as `thread <id> already has an active writer`.

Failing before `primaryBackend.start` closes that Desktop-specific path without requiring process killing, database repair, or a speculative attach/auth lifecycle. The error explains that automatic fallback is intentionally refused and names the safe choices.

This is the small Desktop boundary from #6097. Generic server-level ownership remains separate in #8442/#8960.

Fixes #6097.

## UI Changes

Only the existing fatal-startup error box changes: when default port `3773` is occupied, it now explains that T3 will not start a second same-home backend on a fallback port. No ordinary-startup UI changes.

## Verification

- `pnpm exec vp test run apps/desktop/src/app/DesktopAppErrors.test.ts` — 5 passed
- `pnpm exec vp run --filter @t3tools/desktop typecheck`
- targeted lint and format checks
- exact committed two-file source review — GLM `GO`, no findings

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (error-only startup path; not captured)
- [x] I included a video for animation/interaction changes (n/a)

Scope check: no attach-to-existing flow, server lock, provider lifecycle, or live-state change is included.

Model: GPT-5.6 Sol  
Harness: T3 Code / Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop startup behavior when the default port is busy—users see a fatal error instead of a silent fallback that could cause split-brain SQLite writers—but scope is limited to port resolution with explicit `T3CODE_PORT` unchanged.
> 
> **Overview**
> Packaged desktop startup **no longer scans** from `3773` upward for a free backend port. When no `T3CODE_PORT` is set, it only uses the default port or **fails fast** if that port cannot bind on the usual probe hosts.
> 
> `DesktopBackendPortUnavailableError` is replaced by **`DesktopBackendPortInUseError`**, with a clearer multi-line message that explains T3 Code will not start a second backend on a fallback port against the same data directory. Bootstrap logging drops the “selected via sequential scan” path and only distinguishes configured vs default port.
> 
> `resolveDesktopBackendPort` is **exported** for testing. **`DesktopAppErrors.test.ts`** adds Effect tests with a stub `NetService` to cover default-port success, occupied-port refusal (probes only `3773`, no scan), and explicit port passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a426bdd37a64ea40607bdb9780c5d1285c6d1e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse same-home port fallback in `resolveDesktopBackendPort`
> - When no explicit port is configured, `resolveDesktopBackendPort` now probes only `DEFAULT_DESKTOP_BACKEND_PORT` across `DESKTOP_BACKEND_PORT_PROBE_HOSTS`; if any host cannot bind, it throws `DesktopBackendPortInUseError` with `{ port, hosts }` instead of scanning for an alternative port.
> - Replaces `DesktopBackendPortUnavailableError` (which carried `{ startPort, maxPort, hosts }`) with `DesktopBackendPortInUseError` (carrying `{ port, hosts }`), whose message advises stopping the running server or changing `T3CODE_HOME`.
> - Removes the `MAX_TCP_PORT` constant and the `selectedByScan` return field; updates `desktop.bootstrap` logging accordingly.
> - Risk: callers expecting `{ port, selectedByScan }` or catching `DesktopBackendPortUnavailableError` will break — in-tree usages in [DesktopApp.ts](https://github.com/pingdotgg/t3code/pull/9003/files#diff-267cf20af5c499f356b88a4bc3d3dec61aa6c7a3398f93f8836975b3bcf764e9) and [DesktopAppErrors.test.ts](https://github.com/pingdotgg/t3code/pull/9003/files#diff-f5db36e8d9ac97dae601b1879467c16eb4beb9ff7538a5a564a2c7f8a3705948) are updated, but out-of-tree consumers are not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a426bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->