### PR TITLE
fix(server): stop OpenCode child sessions

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -69,6 +69,8 @@ const runtimeMock = {
     abortImplementation: null as
       | ((sessionID: string, signal?: AbortSignal) => Promise<void>)
       | null,
+    sessionChildrenCalls: [] as string[],
+    sessionChildrenById: new Map<string, Array<{ id: string }>>(),
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
@@ -116,6 +118,8 @@ const runtimeMock = {
     this.state.abortCalls.length = 0;
     this.state.abortSignals.length = 0;
     this.state.abortImplementation = null;
+    this.state.sessionChildrenCalls.length = 0;
+    this.state.sessionChildrenById.clear();
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.messageCalls.length = 0;
@@ -251,6 +255,10 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             runtimeMock.state.abortSignals.push(options.signal);
           }
           await runtimeMock.state.abortImplementation?.(sessionID, options?.signal);
+        },
+        children: async ({ sessionID }: { sessionID: string }) => {
+          runtimeMock.state.sessionChildrenCalls.push(sessionID);
+          return { data: runtimeMock.state.sessionChildrenById.get(sessionID) ?? [] };
         },
         status: async () => {
           runtimeMock.state.sessionStatusCalls += 1;
@@ -1129,6 +1137,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
   it.effect("stops a configured-server session without trying to own server lifecycle", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
+      const rootSessionId = "http://127.0.0.1:9999/session";
+      runtimeMock.state.sessionChildrenById.set(rootSessionId, [{ id: "ses_stop_child" }]);
+      runtimeMock.state.sessionChildrenById.set("ses_stop_child", [{ id: "ses_stop_grandchild" }]);
       yield* adapter.startSession({
         provider: ProviderDriverKind.make("opencode"),
         threadId: asThreadId("thread-opencode"),
@@ -1138,10 +1149,11 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       yield* adapter.stopSession(asThreadId("thread-opencode"));
 
       NodeAssert.deepEqual(runtimeMock.state.startCalls, []);
-      NodeAssert.deepEqual(
-        runtimeMock.state.abortCalls.includes("http://127.0.0.1:9999/session"),
-        true,
-      );
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, [
+        rootSessionId,
+        "ses_stop_child",
+        "ses_stop_grandchild",
+      ]);
     }),
   );
 
@@ -2999,6 +3011,189 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("stops the full OpenCode child tree before it completes the interrupt", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-child-tree");
+      const parentAbortEvent = promiseWithResolvers<unknown>();
+      const markerEvent = promiseWithResolvers<unknown>();
+      const parentAbortStarted = promiseWithResolvers<void>();
+      const parentAbortRelease = promiseWithResolvers<void>();
+      const childAbortStarted = promiseWithResolvers<void>();
+      const childAbortRelease = promiseWithResolvers<void>();
+      const rootSessionId = "http://127.0.0.1:9999/session";
+      runtimeMock.state.subscribedEvents = [parentAbortEvent.promise, markerEvent.promise];
+      runtimeMock.state.sessionChildrenById.set(rootSessionId, [
+        { id: "ses_child_a" },
+        { id: "ses_child_b" },
+      ]);
+      runtimeMock.state.sessionChildrenById.set("ses_child_a", [{ id: "ses_grandchild" }]);
+      runtimeMock.state.sessionChildrenById.set("ses_unrelated", [{ id: "ses_unrelated_child" }]);
+      runtimeMock.state.abortImplementation = async (sessionID) => {
+        if (sessionID === rootSessionId) {
+          parentAbortStarted.resolve(undefined);
+          await parentAbortRelease.promise;
+        }
+        if (sessionID === "ses_child_a") {
+          childAbortStarted.resolve(undefined);
+          await childAbortRelease.promise;
+        }
+      };
+
+      const markerFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) => event.threadId === threadId && event.type === "thread.metadata.updated",
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Run child agents",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.promise(() => parentAbortStarted.promise);
+      runtimeMock.state.sessionChildrenById.get(rootSessionId)?.push({ id: "ses_late_child" });
+      parentAbortEvent.resolve({
+        id: "evt-parent-aborted",
+        type: "session.error",
+        properties: {
+          sessionID: rootSessionId,
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      });
+      markerEvent.resolve({
+        id: "evt-after-parent-abort",
+        type: "session.updated",
+        properties: { info: { id: rootSessionId, title: "Parent abort received" } },
+      });
+      yield* Fiber.join(markerFiber);
+
+      NodeAssert.equal(interruptFiber.pollUnsafe(), undefined);
+      yield* Effect.promise(() => childAbortStarted.promise);
+      NodeAssert.equal(interruptFiber.pollUnsafe(), undefined);
+      NodeAssert.equal(runtimeMock.state.abortCalls.includes("ses_unrelated"), false);
+      NodeAssert.equal(runtimeMock.state.abortCalls.includes("ses_unrelated_child"), false);
+      const sessionsDuringCleanup = yield* adapter.listSessions();
+      const sessionDuringCleanup = sessionsDuringCleanup.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionDuringCleanup?.status, "running");
+      NodeAssert.equal(sessionDuringCleanup?.activeTurnId, turn.turnId);
+      const nextTurnFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Start after every child stops",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+
+      childAbortRelease.resolve(undefined);
+      parentAbortRelease.resolve(undefined);
+      const result = yield* Fiber.join(interruptFiber);
+      const nextTurn = yield* Fiber.join(nextTurnFiber);
+      NodeAssert.equal(result._tag, "Success");
+      NodeAssert.notEqual(nextTurn.turnId, turn.turnId);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 2);
+      NodeAssert.equal(runtimeMock.state.abortCalls[0], rootSessionId);
+      NodeAssert.deepEqual(
+        new Set(runtimeMock.state.abortCalls.slice(1)),
+        new Set(["ses_child_a", "ses_child_b", "ses_grandchild", "ses_late_child"]),
+      );
+      NodeAssert.deepEqual(
+        new Set(runtimeMock.state.sessionChildrenCalls),
+        new Set([rootSessionId, "ses_child_a", "ses_child_b", "ses_grandchild", "ses_late_child"]),
+      );
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "running");
+      NodeAssert.equal(session?.activeTurnId, nextTurn.turnId);
+
+      runtimeMock.state.abortImplementation = null;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("attempts every child abort and fails the interrupt when one child abort fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-child-failure");
+      const rootSessionId = "http://127.0.0.1:9999/session";
+      const failingChildStarted = promiseWithResolvers<void>();
+      const failingChildRelease = promiseWithResolvers<void>();
+      const siblingAbortStarted = promiseWithResolvers<void>();
+      runtimeMock.state.sessionChildrenById.set(rootSessionId, [
+        { id: "ses_failing_child" },
+        { id: "ses_surviving_sibling" },
+      ]);
+      runtimeMock.state.abortImplementation = async (sessionID) => {
+        if (sessionID === "ses_failing_child") {
+          failingChildStarted.resolve(undefined);
+          await failingChildRelease.promise;
+          throw new Error("child abort failed");
+        }
+        if (sessionID === "ses_surviving_sibling") {
+          siblingAbortStarted.resolve(undefined);
+        }
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Run child agents",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.promise(() => failingChildStarted.promise);
+      yield* Effect.promise(() => siblingAbortStarted.promise);
+      NodeAssert.equal(interruptFiber.pollUnsafe(), undefined);
+      failingChildRelease.resolve(undefined);
+      const result = yield* Fiber.join(interruptFiber);
+
+      NodeAssert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        NodeAssert.equal(result.failure._tag, "ProviderAdapterRequestError");
+        NodeAssert.equal(result.failure.detail, "child abort failed");
+      }
+      NodeAssert.equal(runtimeMock.state.abortCalls.includes("ses_failing_child"), true);
+      NodeAssert.equal(runtimeMock.state.abortCalls.includes("ses_surviving_sibling"), true);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "running");
+      NodeAssert.equal(session?.activeTurnId, turn.turnId);
+
+      runtimeMock.state.abortImplementation = null;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("keeps an idle event from completing a turn while its abort request is pending", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -4278,11 +4473,20 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const threadId = asThreadId("thread-interrupt-provider-error");
       const errorEvent = promiseWithResolvers<unknown>();
       const abortStarted = promiseWithResolvers<void>();
-      const abortRelease = promiseWithResolvers<void>();
+      const childAbortStarted = promiseWithResolvers<void>();
+      const childAbortRelease = promiseWithResolvers<void>();
+      const rootSessionId = "http://127.0.0.1:9999/session";
       runtimeMock.state.subscribedEvents = [errorEvent.promise];
-      runtimeMock.state.abortImplementation = async () => {
-        abortStarted.resolve(undefined);
-        await abortRelease.promise;
+      runtimeMock.state.sessionChildrenById.set(rootSessionId, [{ id: "ses_error_child" }]);
+      runtimeMock.state.abortImplementation = async (sessionID) => {
+        if (sessionID === rootSessionId) {
+          abortStarted.resolve(undefined);
+          await new Promise<void>(() => {});
+        }
+        if (sessionID === "ses_error_child") {
+          childAbortStarted.resolve(undefined);
+          await childAbortRelease.promise;
+        }
       };
 
       const eventsFiber = yield* adapter.streamEvents.pipe(
@@ -4313,16 +4517,14 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         id: "evt-provider-error-after-stop",
         type: "session.error",
         properties: {
-          sessionID: "http://127.0.0.1:9999/session",
+          sessionID: rootSessionId,
           error: {
             name: "APIError",
             data: { message: "Upstream failed", isRetryable: false },
           },
         },
       });
-      yield* Effect.yieldNow;
-      abortRelease.resolve(undefined);
-      yield* Fiber.join(interruptFiber);
+      yield* Effect.promise(() => childAbortStarted.promise);
 
       const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
       NodeAssert.deepEqual(
@@ -4341,7 +4543,41 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         failed?.type === "turn.completed" ? failed.payload.state : undefined,
         "failed",
       );
+      const sessionsDuringCleanup = yield* adapter.listSessions();
+      const sessionDuringCleanup = sessionsDuringCleanup.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionDuringCleanup?.status, "error");
+      NodeAssert.equal(sessionDuringCleanup?.activeTurnId, undefined);
 
+      const secondInterruptFiber = yield* adapter.interruptTurn(threadId).pipe(Effect.forkChild);
+      const nextTurnFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Start after child cleanup",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(
+        runtimeMock.state.abortCalls.filter((sessionID) => sessionID === rootSessionId).length,
+        1,
+      );
+      NodeAssert.equal(secondInterruptFiber.pollUnsafe(), undefined);
+      NodeAssert.equal(nextTurnFiber.pollUnsafe(), undefined);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+
+      childAbortRelease.resolve(undefined);
+      yield* Fiber.join(interruptFiber);
+      yield* Fiber.join(secondInterruptFiber);
+      const nextTurn = yield* Fiber.join(nextTurnFiber);
+      NodeAssert.notEqual(nextTurn.turnId, turn.turnId);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 2);
+
+      runtimeMock.state.abortImplementation = null;
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -71,6 +71,9 @@ const runtimeMock = {
       | null,
     sessionChildrenCalls: [] as string[],
     sessionChildrenById: new Map<string, Array<{ id: string }>>(),
+    sessionChildrenImplementation: null as
+      | ((sessionID: string) => Promise<Array<{ id: string }>>)
+      | null,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
@@ -120,6 +123,7 @@ const runtimeMock = {
     this.state.abortImplementation = null;
     this.state.sessionChildrenCalls.length = 0;
     this.state.sessionChildrenById.clear();
+    this.state.sessionChildrenImplementation = null;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.messageCalls.length = 0;
@@ -258,7 +262,11 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         children: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.sessionChildrenCalls.push(sessionID);
-          return { data: runtimeMock.state.sessionChildrenById.get(sessionID) ?? [] };
+          return {
+            data: runtimeMock.state.sessionChildrenImplementation
+              ? await runtimeMock.state.sessionChildrenImplementation(sessionID)
+              : (runtimeMock.state.sessionChildrenById.get(sessionID) ?? []),
+          };
         },
         status: async () => {
           runtimeMock.state.sessionStatusCalls += 1;
@@ -3127,6 +3135,79 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(session?.activeTurnId, nextTurn.turnId);
 
       runtimeMock.state.abortImplementation = null;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("limits SDK requests across the full OpenCode child tree", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-child-request-limit");
+      const rootSessionId = "http://127.0.0.1:9999/session";
+      const requestRelease = promiseWithResolvers<void>();
+      const limitReached = promiseWithResolvers<void>();
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const holdRequest = async <T>(result: T): Promise<T> => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (inFlight === 8) {
+          limitReached.resolve(undefined);
+        }
+        await requestRelease.promise;
+        inFlight -= 1;
+        return result;
+      };
+
+      const children = Array.from({ length: 8 }, (_, index) => ({ id: `ses_child_${index}` }));
+      runtimeMock.state.sessionChildrenById.set(rootSessionId, children);
+      for (const child of children.slice(1)) {
+        runtimeMock.state.sessionChildrenById.set(
+          child.id,
+          Array.from({ length: 8 }, (_, index) => ({ id: `${child.id}_nested_${index}` })),
+        );
+      }
+      runtimeMock.state.abortImplementation = async (sessionID) => {
+        if (sessionID.includes("_nested_")) {
+          await holdRequest(undefined);
+        }
+      };
+      runtimeMock.state.sessionChildrenImplementation = async (sessionID) => {
+        if (sessionID === "ses_child_0") {
+          return await holdRequest([]);
+        }
+        return runtimeMock.state.sessionChildrenById.get(sessionID) ?? [];
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Run a nested child tree",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => limitReached.promise);
+      yield* Effect.yieldNow;
+
+      NodeAssert.equal(inFlight, 8);
+      NodeAssert.equal(maxInFlight, 8);
+
+      requestRelease.resolve(undefined);
+      yield* Fiber.join(interruptFiber);
+
+      runtimeMock.state.abortImplementation = null;
+      runtimeMock.state.sessionChildrenImplementation = null;
+      runtimeMock.state.sessionChildrenById.clear();
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -192,8 +192,10 @@ const decodeOpenCodeSessionStatusMap = Schema.decodeUnknownOption(OpenCodeSessio
 
 interface OpenCodeCancellation {
   readonly turnId: TurnId | undefined;
+  readonly acknowledgment: Deferred.Deferred<void>;
   readonly completion: Deferred.Deferred<void, ProviderAdapterRequestError>;
   acknowledged?: boolean;
+  turnSettled?: boolean;
   deferredIdleEvent?: OpenCodeSessionStatusEvent;
 }
 
@@ -698,10 +700,79 @@ const failPendingOpenCodeCancellation = Effect.fn("failPendingOpenCodeCancellati
   ).pipe(Effect.ignore);
 });
 
-const abortOpenCodeSessionForTeardown = (context: OpenCodeSessionContext) =>
-  runOpenCodeSdk("session.abort", (signal) =>
+const abortOpenCodeDescendants = Effect.fn("abortOpenCodeDescendants")(function* (
+  context: OpenCodeSessionContext,
+) {
+  const visited = new Set([context.openCodeSessionId]);
+
+  const visit = (
+    sessionId: string,
+    abortSession: boolean,
+  ): Effect.Effect<OpenCodeRuntimeError | undefined> =>
+    Effect.gen(function* () {
+      let firstFailure: OpenCodeRuntimeError | undefined;
+      if (abortSession) {
+        const abortResult = yield* runOpenCodeSdk("session.abort", (signal) =>
+          context.client.session.abort({ sessionID: sessionId }, { signal }),
+        ).pipe(
+          Effect.catchIf(
+            (cause) => isOpenCodeNotFound(cause),
+            () => Effect.void,
+          ),
+          Effect.result,
+        );
+        if (abortResult._tag === "Failure") {
+          firstFailure = abortResult.failure;
+        }
+      }
+
+      const childrenResult = yield* runOpenCodeSdk("session.children", (signal) =>
+        context.client.session.children({ sessionID: sessionId }, { signal }),
+      ).pipe(
+        Effect.catchIf(
+          (cause) => isOpenCodeNotFound(cause),
+          () => Effect.void,
+        ),
+        Effect.result,
+      );
+      if (childrenResult._tag === "Failure") {
+        return firstFailure ?? childrenResult.failure;
+      }
+
+      const children = childrenResult.success?.data ?? [];
+      const newChildren = children.filter((child) => {
+        if (visited.has(child.id)) {
+          return false;
+        }
+        visited.add(child.id);
+        return true;
+      });
+      const childFailures = yield* Effect.forEach(newChildren, (child) => visit(child.id, true), {
+        concurrency: 8,
+      });
+      firstFailure ??= childFailures.find((failure) => failure !== undefined);
+      return firstFailure;
+    });
+
+  const firstFailure = yield* visit(context.openCodeSessionId, false);
+  if (firstFailure) {
+    return yield* firstFailure;
+  }
+});
+
+const abortOpenCodeSessionForTeardown = Effect.fn("abortOpenCodeSessionForTeardown")(function* (
+  context: OpenCodeSessionContext,
+) {
+  // Stop the parent before the snapshot so it cannot add another child after
+  // the adapter reads the tree.
+  yield* runOpenCodeSdk("session.abort", (signal) =>
     context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
   ).pipe(Effect.timeout("1 second"), Effect.ignore({ log: true }));
+  yield* abortOpenCodeDescendants(context).pipe(
+    Effect.timeout("1 second"),
+    Effect.ignore({ log: true }),
+  );
+});
 
 const cancelPendingOpenCodePrompt = Effect.fn("cancelPendingOpenCodePrompt")(function* (
   context: OpenCodeSessionContext,
@@ -2154,13 +2225,12 @@ export function makeOpenCodeAdapter(
           if (isOpenCodeAbortError(event.properties.error)) {
             if (cancellation !== undefined && cancellation.turnId === undefined) {
               cancellation.acknowledged = true;
-              context.cancellation = undefined;
-              context.reconcileIdleStatus = true;
-              yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
+              yield* Deferred.succeed(cancellation.acknowledgment, undefined).pipe(Effect.ignore);
               break;
             }
             if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
-              yield* interruptOpenCodeTurn(context, activeTurnId, event);
+              cancellation.acknowledged = true;
+              yield* Deferred.succeed(cancellation.acknowledgment, undefined).pipe(Effect.ignore);
               break;
             }
             if (context.interruptedTurnId !== undefined || context.reconcileIdleStatus) {
@@ -2168,9 +2238,13 @@ export function makeOpenCodeAdapter(
             }
           }
           yield* cancelIdleReconciliation(context);
-          if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
-            context.cancellation = undefined;
-            yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
+          const terminalCancellation =
+            activeTurnId !== undefined && cancellation?.turnId === activeTurnId
+              ? cancellation
+              : undefined;
+          if (terminalCancellation) {
+            terminalCancellation.turnSettled = true;
+            terminalCancellation.acknowledged = true;
           }
           context.activeTurnId = undefined;
           context.activeAgent = undefined;
@@ -2210,6 +2284,11 @@ export function makeOpenCodeAdapter(
               detail: event.properties.error,
             },
           });
+          if (terminalCancellation) {
+            yield* Deferred.succeed(terminalCancellation.acknowledgment, undefined).pipe(
+              Effect.ignore,
+            );
+          }
           break;
         }
 
@@ -2905,14 +2984,12 @@ export function makeOpenCodeAdapter(
           return;
         }
         const existingCancellation = context.cancellation;
-        if (
-          existingCancellation !== undefined &&
-          existingCancellation.turnId === interruptedTurnId
-        ) {
+        if (existingCancellation !== undefined) {
           return yield* Deferred.await(existingCancellation.completion);
         }
         const cancellation: OpenCodeCancellation = {
           turnId: interruptedTurnId,
+          acknowledgment: Deferred.makeUnsafe<void>(),
           completion: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
         };
         context.cancellation = cancellation;
@@ -2925,10 +3002,11 @@ export function makeOpenCodeAdapter(
           yield* Deferred.await(promptAdmission.submissionSettled);
         }
 
-        const abortOutcome = yield* Effect.raceFirst(
+        const parentAbortOutcome = yield* Effect.raceFirst(
           runOpenCodeSdk("session.abort", (signal) =>
             context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
           ).pipe(
+            Effect.asVoid,
             Effect.timeout("10 seconds"),
             Effect.catchTags({
               OpenCodeRuntimeError: (cause) => Effect.fail(toRequestError(cause)),
@@ -2945,33 +3023,67 @@ export function makeOpenCodeAdapter(
             Effect.exit,
             Effect.map((exit) => ({ source: "request" as const, exit })),
           ),
-          Deferred.await(cancellation.completion).pipe(
-            Effect.exit,
-            Effect.map((exit) => ({ source: "event" as const, exit })),
+          Effect.raceFirst(
+            Deferred.await(cancellation.acknowledgment).pipe(
+              Effect.map(() => ({ source: "acknowledgment" as const })),
+            ),
+            Deferred.await(cancellation.completion).pipe(
+              Effect.exit,
+              Effect.map((exit) => ({ source: "completion" as const, exit })),
+            ),
           ),
         );
-        if (abortOutcome.source === "event") {
-          return Exit.isFailure(abortOutcome.exit)
-            ? yield* Effect.failCause(abortOutcome.exit.cause)
+        if (parentAbortOutcome.source === "completion") {
+          return Exit.isFailure(parentAbortOutcome.exit)
+            ? yield* Effect.failCause(parentAbortOutcome.exit.cause)
             : undefined;
         }
-        const abortExit = abortOutcome.exit;
-        if (Exit.isFailure(abortExit)) {
-          if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {
-            yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
-            return;
-          }
-          if (cancellation.turnId === undefined && cancellation.acknowledged) {
-            if (context.cancellation === cancellation) {
-              context.cancellation = undefined;
-              context.reconcileIdleStatus = true;
-            }
-            yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
-            return;
-          }
+        const parentAbortExit =
+          parentAbortOutcome.source === "request" ? parentAbortOutcome.exit : Exit.void;
+
+        const descendantAbortOutcome = yield* Effect.raceFirst(
+          abortOpenCodeDescendants(context).pipe(
+            Effect.timeout("10 seconds"),
+            Effect.catchTags({
+              OpenCodeRuntimeError: (cause) => Effect.fail(toRequestError(cause)),
+              TimeoutError: (cause) =>
+                Effect.fail(
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "session.abort",
+                    detail: "OpenCode child session cleanup did not complete within 10 seconds.",
+                    cause,
+                  }),
+                ),
+            }),
+            Effect.exit,
+            Effect.map((exit) => ({ source: "request" as const, exit })),
+          ),
+          Deferred.await(cancellation.completion).pipe(
+            Effect.exit,
+            Effect.map((exit) => ({ source: "completion" as const, exit })),
+          ),
+        );
+        if (descendantAbortOutcome.source === "completion") {
+          return Exit.isFailure(descendantAbortOutcome.exit)
+            ? yield* Effect.failCause(descendantAbortOutcome.exit.cause)
+            : undefined;
+        }
+
+        const parentAbortFailed = Exit.isFailure(parentAbortExit) && !cancellation.acknowledged;
+        const failedExit = parentAbortFailed
+          ? parentAbortExit
+          : Exit.isFailure(descendantAbortOutcome.exit)
+            ? descendantAbortOutcome.exit
+            : undefined;
+        if (failedExit !== undefined && Exit.isFailure(failedExit)) {
           if (context.cancellation === cancellation) {
             context.cancellation = undefined;
-            if (cancellation.turnId !== undefined && cancellation.deferredIdleEvent) {
+            if (
+              parentAbortFailed &&
+              cancellation.turnId !== undefined &&
+              cancellation.deferredIdleEvent
+            ) {
               yield* scheduleIdleReconciliation(
                 context,
                 cancellation.turnId,
@@ -2979,12 +3091,14 @@ export function makeOpenCodeAdapter(
               );
             }
           }
-          yield* Deferred.done(cancellation.completion, abortExit).pipe(Effect.ignore);
-          return yield* Effect.failCause(abortExit.cause);
+          yield* Deferred.done(cancellation.completion, failedExit).pipe(Effect.ignore);
+          return yield* Effect.failCause(failedExit.cause);
         }
 
         if (context.cancellation === cancellation) {
-          if (cancellation.turnId !== undefined) {
+          if (cancellation.turnSettled) {
+            context.cancellation = undefined;
+          } else if (cancellation.turnId !== undefined) {
             yield* interruptOpenCodeTurn(context, cancellation.turnId);
           } else {
             context.cancellation = undefined;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -704,6 +704,7 @@ const abortOpenCodeDescendants = Effect.fn("abortOpenCodeDescendants")(function*
   context: OpenCodeSessionContext,
 ) {
   const visited = new Set([context.openCodeSessionId]);
+  const requestSemaphore = Semaphore.makeUnsafe(8);
 
   const visit = (
     sessionId: string,
@@ -712,29 +713,37 @@ const abortOpenCodeDescendants = Effect.fn("abortOpenCodeDescendants")(function*
     Effect.gen(function* () {
       let firstFailure: OpenCodeRuntimeError | undefined;
       if (abortSession) {
-        const abortResult = yield* runOpenCodeSdk("session.abort", (signal) =>
-          context.client.session.abort({ sessionID: sessionId }, { signal }),
-        ).pipe(
+        const abortResult = yield* requestSemaphore
+          .withPermit(
+            runOpenCodeSdk("session.abort", (signal) =>
+              context.client.session.abort({ sessionID: sessionId }, { signal }),
+            ),
+          )
+          .pipe(
+            Effect.catchIf(
+              (cause) => isOpenCodeNotFound(cause),
+              () => Effect.void,
+            ),
+            Effect.result,
+          );
+        if (abortResult._tag === "Failure") {
+          firstFailure = abortResult.failure;
+        }
+      }
+
+      const childrenResult = yield* requestSemaphore
+        .withPermit(
+          runOpenCodeSdk("session.children", (signal) =>
+            context.client.session.children({ sessionID: sessionId }, { signal }),
+          ),
+        )
+        .pipe(
           Effect.catchIf(
             (cause) => isOpenCodeNotFound(cause),
             () => Effect.void,
           ),
           Effect.result,
         );
-        if (abortResult._tag === "Failure") {
-          firstFailure = abortResult.failure;
-        }
-      }
-
-      const childrenResult = yield* runOpenCodeSdk("session.children", (signal) =>
-        context.client.session.children({ sessionID: sessionId }, { signal }),
-      ).pipe(
-        Effect.catchIf(
-          (cause) => isOpenCodeNotFound(cause),
-          () => Effect.void,
-        ),
-        Effect.result,
-      );
       if (childrenResult._tag === "Failure") {
         return firstFailure ?? childrenResult.failure;
       }

--- a/docs/user/providers-opencode.md
+++ b/docs/user/providers-opencode.md
@@ -17,6 +17,15 @@ With a server URL, T3 Code connects to that external server and uses only the pa
 provider settings. It does not send a local `OPENCODE_SERVER_PASSWORD` to an external server.
 OpenCode uses this password for HTTP Basic authentication.
 
+## Stop a turn
+
+When you select **Stop**, T3 Code stops the main OpenCode session and all nested child sessions.
+T3 Code waits for this cleanup before it marks the turn as stopped or sends the next prompt. It
+does not stop unrelated OpenCode sessions.
+
+Stop reports an error if OpenCode cannot list or stop a child session. When T3 Code closes an
+OpenCode session, it also tries to stop the child sessions, but this teardown is best effort.
+
 ## Refresh the model list
 
 T3 Code loads the model list when an enabled OpenCode provider starts and keeps the list in its


### PR DESCRIPTION
OpenCode runs each subagent in a separate child session. T3 Code only stopped the parent session, so child model requests could continue after Stop.

This change walks the parent session's full child tree and stops each descendant. It keeps Stop pending until child cleanup ends, so a parent abort event cannot release the next prompt early. Provider session teardown uses the same cleanup as a best-effort step.

Tests cover nested and late child sessions, unrelated-session isolation, repeated Stop requests, child failures, prompt gating, configured-server teardown, and the global SDK request limit.

Verified with:

- 83 OpenCode adapter tests
- 4 shared interrupt tests
- Server typecheck
- Targeted lint and format checks

Closes https://github.com/pingdotgg/t3code/issues/7769

Made with GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interrupt completion ordering and timing (waits on full child tree, up to 10s timeouts), which affects prompt gating and race behavior around `session.error` during stop.
> 
> **Overview**
> **Stop** and session teardown now walk the full OpenCode **child session tree** (via `session.children`) and abort every descendant, not only the parent—so subagent work cannot keep running after the user stops a turn.
> 
> **`interruptTurn`** aborts the parent first, races provider abort acknowledgment against turn completion, then runs descendant cleanup before it finishes. Prompts stay blocked until that cleanup completes (including sessions that appear while the parent is aborting). Unrelated sessions are not touched. A failed child list/abort fails the interrupt with **`ProviderAdapterRequestError`**. Concurrency for list/abort SDK calls is capped at **8**.
> 
> Cancellation handling adds an **`acknowledgment`** deferred so a parent **`MessageAbortedError`** does not complete the interrupt before child sessions are stopped; real provider errors can still settle the turn while cleanup is in flight.
> 
> **Teardown** aborts the parent, then best-effort descendant abort (failures ignored). User docs describe stop semantics and error vs best-effort teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c463930d3aeafa810a12857ce9d1b2fd285a0ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop OpenCode child sessions during interrupt and teardown
> - Adds `abortOpenCodeDescendants` util that walks the session tree via `session.children`, issuing `session.abort` for each descendant with a concurrency cap of 8 and surfacing the first failure
> - Reworks `makeOpenCodeAdapter.interruptTurn` into two phases: phase 1 aborts the parent and races provider acknowledgment against completion (10s timeout); phase 2 cleans up all descendants (10s timeout). Next prompts are deferred until cleanup completes
> - Extends `OpenCodeCancellation` with an `acknowledgment` Deferred and `turnSettled` flag so the adapter can coordinate on explicit provider acknowledgment before proceeding
> - Updates `abortOpenCodeSessionForTeardown` to best-effort abort discovered children after the parent (1s timeout each)
> - Behavioral Change: `interruptTurn` now fails the interrupt if any descendant abort fails (after parent acknowledgment); previously only the parent session was aborted. Reviewers should check the failure-preference logic in `interruptTurn` and the `abortOpenCodeDescendants` error collection in [OpenCodeAdapter.ts](apps/server/src/provider/Layers/OpenCodeAdapter.ts)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c463930.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
