### PR TITLE
fix(web): open toast View PR in-app when possible

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1446,7 +1446,7 @@ export default function GitActionsControl({
       const toastCta = actionResult.toast.cta;
       let toastActionProps: {
         children: string;
-        onClick: (event?: MouseEvent<HTMLButtonElement>) => void;
+        onClick: (event: MouseEvent<HTMLButtonElement>) => void;
       } | null = null;
       if (toastCta.kind === "run_action") {
         toastActionProps = {
@@ -1480,6 +1480,7 @@ export default function GitActionsControl({
                   type: "error",
                   title: "Unable to open pull request link",
                   description: err instanceof Error ? err.message : "An error occurred.",
+                  ...(scopedToastData !== undefined ? { data: scopedToastData } : {}),
                 }),
               );
             });

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -17,7 +17,7 @@ import type {
 } from "@t3tools/contracts";
 import { useNavigate } from "@tanstack/react-router";
 import * as Option from "effect/Option";
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState, type MouseEvent } from "react";
 import { flushSync } from "react-dom";
 import {
   CheckIcon,
@@ -1442,7 +1442,7 @@ export default function GitActionsControl({
       const toastCta = actionResult.toast.cta;
       let toastActionProps: {
         children: string;
-        onClick: () => void;
+        onClick: (event?: MouseEvent<HTMLButtonElement>) => void;
       } | null = null;
       if (toastCta.kind === "run_action") {
         toastActionProps = {
@@ -1457,11 +1457,21 @@ export default function GitActionsControl({
       } else if (toastCta.kind === "open_pr") {
         toastActionProps = {
           children: toastCta.label,
-          onClick: () => {
+          onClick: (event) => {
+            const shouldExternal = event?.metaKey || event?.ctrlKey;
+            if (!shouldExternal && onOpenPullRequest) {
+              const match = /\/pull\/(\d+)(?:\/|$)/.exec(toastCta.url);
+              const num = match ? Number(match[1]) : NaN;
+              if (Number.isSafeInteger(num) && num > 0) {
+                onOpenPullRequest(num);
+                closeResultToast();
+                return;
+              }
+            }
             const api = readLocalApi();
             if (!api) return;
             closeResultToast();
-            void api.shell.openExternal(toastCta.url);
+            void openPullRequestLink(api.shell, toastCta.url);
           },
         };
       }

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -91,7 +91,11 @@ import { resolvePathLinkTarget } from "~/terminal-links";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { readLocalApi } from "~/localApi";
 import { getSourceControlPresentation } from "~/sourceControlPresentation";
-import { openPullRequestLink } from "~/lib/openPullRequestLink";
+import {
+  openPullRequestLink,
+  parseChangeRequestUrl,
+  shouldOpenPullRequestExternally,
+} from "~/lib/openPullRequestLink";
 
 interface GitActionsControlProps {
   gitCwd: string | null;
@@ -1458,12 +1462,10 @@ export default function GitActionsControl({
         toastActionProps = {
           children: toastCta.label,
           onClick: (event) => {
-            const shouldExternal = event?.metaKey || event?.ctrlKey;
-            if (!shouldExternal && onOpenPullRequest) {
-              const match = /\/pull\/(\d+)(?:\/|$)/.exec(toastCta.url);
-              const num = match ? Number(match[1]) : NaN;
-              if (Number.isSafeInteger(num) && num > 0) {
-                onOpenPullRequest(num);
+            if (!shouldOpenPullRequestExternally(event) && onOpenPullRequest) {
+              const parsed = parseChangeRequestUrl(toastCta.url);
+              if (parsed) {
+                onOpenPullRequest(parsed.number);
                 closeResultToast();
                 return;
               }
@@ -1471,7 +1473,16 @@ export default function GitActionsControl({
             const api = readLocalApi();
             if (!api) return;
             closeResultToast();
-            void openPullRequestLink(api.shell, toastCta.url);
+            void openPullRequestLink(api.shell, toastCta.url).catch((err: unknown) => {
+              console.error(err);
+              toastManager.add(
+                stackedThreadToast({
+                  type: "error",
+                  title: "Unable to open pull request link",
+                  description: err instanceof Error ? err.message : "An error occurred.",
+                }),
+              );
+            });
           },
         };
       }


### PR DESCRIPTION
Closes #9004

The View PR action in the Git actions control opens in the in-app
panel via onOpenPullRequest when available, with modifier-click
preserved for external. The success toast for Push & create PR
always called api.shell.openExternal, so a plain click always left
the app.

Make the toast's open_pr CTA try onOpenPullRequest for plain
clicks (parsing the PR number from toastCta.url) and fall back to
openPullRequestLink, matching the regular action's routing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX routing change in Git toast CTAs; no auth, data, or server behavior changes.
> 
> **Overview**
> After **Push & create PR** (and similar actions), the success toast **View PR** button no longer always opens the browser. It now follows the same rules as the main Git **View PR** action.
> 
> On a normal click, when `onOpenPullRequest` is available and the toast URL parses to a PR number, the change request opens **in-app** beside the thread. Modifier clicks still open externally via `shouldOpenPullRequestExternally`. Otherwise the handler uses **`openPullRequestLink`** instead of calling `api.shell.openExternal` directly, and link failures show an error toast instead of failing quietly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3d1db0262a163b9fe656e50d7c7eedfad32753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open toast 'View PR' in-app when URL parses and event is not external
> Updates the `open_pr` toast CTA in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/9007/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) to attempt in-app navigation via `onOpenPullRequest` when `shouldOpenPullRequestExternally(event)` is false and `parseChangeRequestUrl` succeeds. Falls back to `openPullRequestLink`, with a new error toast on rejection. Closes the result toast before opening.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b3d1db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->