### PR TITLE
fix(client): use package import for markdown image helpers

### DIFF
--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -4,9 +4,11 @@ import {
   type ThreadId,
   type ToolLifecycleItemType,
 } from "@t3tools/contracts";
+import {
+  classifyMarkdownImageSource,
+  markdownImageSourceFragment,
+} from "@t3tools/client-runtime/markdown-images";
 import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
-
-import { classifyMarkdownImageSource, markdownImageSourceFragment } from "../markdownImages.js";
 
 export function isWorktreeSetupActivity(kind: string): boolean {
   return kind === "setup-script.requested" || kind === "setup-script.started";


### PR DESCRIPTION
## What Changed

Updated work-log presentation code to import markdown image helpers through the `@t3tools/client-runtime/markdown-images` package path.

## Why

Expo failed to build with the `.js` import of a `.ts` file: https://github.com/pingdotgg/t3code/actions/runs/33471730763/job/99742685256

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch markdown image helper imports to package path in `presentation.ts`
> Repoints `classifyMarkdownImageSource` and `markdownImageSourceFragment` from the relative `'../markdownImages.js'` import to `'@t3tools/client-runtime/markdown-images'` in [presentation.ts](https://github.com/pingdotgg/t3code/pull/9010/files#diff-b6852793cd3916fd7bb7704e9bfe1391f7ca44403063a0502eb92d59f5060972). No other code changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00e5198.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->