### PR TITLE
feat(usage): break down usage by project

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -28,6 +28,7 @@ import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { pullRequestHttpApiLayer } from "./pullRequest/http.ts";
 import * as PullRequestProviderRegistry from "./pullRequest/PullRequestProviderRegistry.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
+import { ProjectionProjectRepositoryLive } from "./persistence/Layers/ProjectionProjects.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
@@ -202,7 +203,11 @@ const BackgroundLayerLive = BackgroundPolicy.layer.pipe(
   Layer.provideMerge(ServerSettingsLayerLive),
 );
 
-const UsageLayerLive = UsageService.layer.pipe(Layer.provide(ServerSettingsLayerLive));
+const UsageLayerLive = UsageService.layer.pipe(
+  // The repository resolves each session's cwd to the project it ran in.
+  Layer.provide(ProjectionProjectRepositoryLive),
+  Layer.provide(ServerSettingsLayerLive),
+);
 
 const ResourceDiagnosticsLayerLive = Layer.mergeAll(
   HostResources.layer,

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -7,7 +7,7 @@ import * as NodePath from "node:path";
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
-import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
+import { ProjectId, UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -20,15 +20,26 @@ import * as TestClock from "effect/testing/TestClock";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
+import { PersistenceSqlError } from "../persistence/Errors.ts";
+import {
+  ProjectionProjectRepository,
+  type ProjectionProject,
+} from "../persistence/Services/ProjectionProjects.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as UsageService from "./UsageService.ts";
 
-function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"): string {
+function claudeLine(
+  id: number,
+  outputTokens: number,
+  model = "claude-fable-5",
+  cwd = "/work/app",
+): string {
   return `${JSON.stringify({
     type: "assistant",
     timestamp: "2026-08-01T10:00:00Z",
     requestId: `req_${id}`,
     sessionId: "session-1",
+    cwd,
     message: {
       id: `msg_${id}`,
       model,
@@ -71,6 +82,8 @@ const serviceLayers = (input: {
   readonly onRatesFetch?: () => void;
   /** Defaults to an unparsable document so every scan retries the fetch. */
   readonly ratesDocument?: unknown;
+  /** Defaults to no projects, so every session with a cwd is outside projects. */
+  readonly listProjects?: ProjectionProjectRepository["Service"]["listAll"];
 }) =>
   ServerConfig.layerTest(process.cwd(), { prefix: input.prefix }).pipe(
     Layer.provideMerge(NodeServices.layer),
@@ -91,13 +104,101 @@ const serviceLayers = (input: {
     Layer.provideMerge(
       Layer.succeed(HostProcessEnvironment, { GROK_HOME: NodePath.join(input.home, "grok") }),
     ),
+    Layer.provideMerge(
+      Layer.succeed(ProjectionProjectRepository, {
+        upsert: () => Effect.die("unused"),
+        getById: () => Effect.die("unused"),
+        listAll: input.listProjects ?? (() => Effect.succeed([])),
+        deleteById: () => Effect.die("unused"),
+      }),
+    ),
   );
+
+function project(projectId: string, workspaceRoot: string, title: string): ProjectionProject {
+  return {
+    projectId: ProjectId.make(projectId),
+    title,
+    workspaceRoot,
+    defaultModelSelection: null,
+    defaultThreadEnvMode: null,
+    autoPull: false,
+    scripts: [],
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    deletedAt: null,
+  };
+}
 
 function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens: number } }[] }) {
   return summary.buckets.reduce((sum, bucket) => sum + bucket.totals.outputTokens, 0);
 }
 
 describe("UsageService", () => {
+  it.live("attributes usage to the project containing each session's cwd", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() =>
+        NodeFSP.writeFile(
+          transcript,
+          claudeLine(1, 5, "claude-fable-5", "/work/app/src") +
+            claudeLine(2, 7, "claude-fable-5", "/elsewhere"),
+        ),
+      );
+
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* UsageService.make;
+        return yield* service.readSummary(WINDOW);
+      }).pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-project-test",
+            home,
+            settings,
+            listProjects: () => Effect.succeed([project("project-app", "/work/app", "App")]),
+          }),
+        ),
+      );
+
+      const attribution = summary.buckets.map((bucket) => [
+        bucket.projectAttribution,
+        bucket.projectId ?? null,
+        bucket.totals.outputTokens,
+      ]);
+      assert.sameDeepMembers(attribution, [
+        ["project", ProjectId.make("project-app"), 5],
+        ["outside", null, 7],
+      ]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("reports unknown attribution when the project list cannot be read", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* UsageService.make;
+        return yield* service.readSummary(WINDOW);
+      }).pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-project-failure-test",
+            home,
+            settings,
+            listProjects: () =>
+              Effect.fail(new PersistenceSqlError({ operation: "ProjectionProjects.listAll" })),
+          }),
+        ),
+      );
+
+      assert.strictEqual(totalOutputTokens(summary), 5);
+      assert.deepStrictEqual(
+        summary.buckets.map((bucket) => bucket.projectAttribution),
+        ["unknown"],
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.live("reprices unchanged transcripts when custom prices are added, edited, or removed", () =>
     Effect.gen(function* () {
       const { transcript, settings, home } = yield* setup;

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -41,10 +41,11 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
+import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
-import { UsageAggregator } from "./usageAggregation.ts";
+import { makeProjectResolver, UsageAggregator } from "./usageAggregation.ts";
 import { createOverrideRateTable, parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
   listTranscriptFiles,
@@ -139,6 +140,7 @@ export const make = Effect.gen(function* () {
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
   const hostEnvironment = yield* HostProcessEnvironment;
+  const projectRepository = yield* ProjectionProjectRepository;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -270,6 +272,29 @@ export const make = Effect.gen(function* () {
       },
     ];
   });
+
+  /**
+   * Builds the cwd → project resolver for one scan.
+   *
+   * Projects are re-read every scan so a project created or renamed since the
+   * last refresh attributes correctly. If the project list cannot be read, the
+   * scan reports unknown attribution rather than claiming the work ran outside
+   * every project.
+   */
+  const resolveProjects = projectRepository.listAll().pipe(
+    Effect.map((projects) =>
+      makeProjectResolver(
+        projects.map((project) => ({
+          projectId: project.projectId,
+          workspaceRoot: project.workspaceRoot,
+          title: project.title,
+          deleted: project.deletedAt !== null,
+        })),
+        path.sep,
+      ),
+    ),
+    Effect.orElseSucceed(() => undefined),
+  );
 
   /**
    * Loads the persisted scan cache exactly once per process.
@@ -474,6 +499,7 @@ export const make = Effect.gen(function* () {
       resolution: input.resolution ?? "day",
       ...hourlyWindow,
       rates,
+      resolveProject: yield* resolveProjects,
       priceOverrides: createOverrideRateTable(settings.usagePriceOverrides),
     });
 

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -1,6 +1,7 @@
+import { ProjectId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 
-import { UsageAggregator } from "./usageAggregation.ts";
+import { makeProjectResolver, UsageAggregator } from "./usageAggregation.ts";
 import type { RateTable } from "./usagePricing.ts";
 import type { UsageRecord } from "./usageTranscripts.ts";
 
@@ -23,6 +24,7 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
     timestampMs: Date.parse("2026-08-07T04:05:13.944Z"),
     model: "claude-fable-5",
     sessionId: "session-a",
+    cwd: "",
     totals: {
       uncachedInputTokens: 100,
       cachedInputTokens: 1000,
@@ -92,6 +94,38 @@ describe("UsageAggregator", () => {
 
     expect(result.duplicatesDropped).toBe(0);
     expect(result.buckets[0]?.totals.outputTokens).toBe(100);
+  });
+
+  it("distinguishes project, outside, and unknown attribution", () => {
+    const projectId = ProjectId.make("project-app");
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd === "/work/app" ? { projectId, title: "App" } : null),
+    });
+    aggregator.add(record({ cwd: "/work/app" }));
+    aggregator.add(record({ cwd: "/work/app" }));
+    aggregator.add(record({ cwd: "/elsewhere" }));
+    aggregator.add(record({ cwd: "", model: "grok-4" }));
+    const { buckets } = aggregator.finish();
+
+    expect(buckets).toHaveLength(3);
+    const outside = buckets.find((bucket) => bucket.projectAttribution === "outside");
+    expect(outside?.project).toBeUndefined();
+    expect(outside?.records).toBe(1);
+    const project = buckets.find((bucket) => bucket.projectAttribution === "project");
+    expect(project?.project).toBe("App");
+    expect(project?.projectId).toBe(projectId);
+    expect(project?.records).toBe(2);
+    expect(buckets.some((bucket) => bucket.projectAttribution === "unknown")).toBe(true);
+  });
+
+  it("marks every bucket unknown when no project resolver is available", () => {
+    const result = aggregate([record({ cwd: "/work/app" })]);
+
+    expect(result.buckets[0]?.projectAttribution).toBe("unknown");
   });
 
   it("buckets by the day in the requested time zone", () => {
@@ -200,5 +234,78 @@ describe("UsageAggregator", () => {
     ]);
 
     expect(result.buckets).toHaveLength(3);
+  });
+});
+
+describe("makeProjectResolver", () => {
+  const appId = ProjectId.make("project-app");
+  const vendoredId = ProjectId.make("project-vendored");
+  const legacyDeletedId = ProjectId.make("project-legacy-deleted");
+  const legacyId = ProjectId.make("project-legacy");
+  const untitledId = ProjectId.make("project-untitled");
+  const resolver = makeProjectResolver(
+    [
+      { projectId: appId, workspaceRoot: "/work/app", title: "App", deleted: false },
+      {
+        projectId: vendoredId,
+        workspaceRoot: "/work/app/vendored",
+        title: "Vendored",
+        deleted: false,
+      },
+      {
+        projectId: legacyDeletedId,
+        workspaceRoot: "/work/legacy",
+        title: "Legacy Was Deleted",
+        deleted: true,
+      },
+      {
+        projectId: legacyId,
+        workspaceRoot: "/work/legacy",
+        title: "Legacy",
+        deleted: false,
+      },
+      {
+        projectId: untitledId,
+        workspaceRoot: "/work/untitled",
+        title: "   ",
+        deleted: false,
+      },
+    ],
+    "/",
+  );
+
+  it("matches the root itself and any path under it", () => {
+    expect(resolver("/work/app")).toEqual({ projectId: appId, title: "App" });
+    expect(resolver("/work/app/src/deep")).toEqual({ projectId: appId, title: "App" });
+  });
+
+  it("requires a path-segment boundary, not a bare prefix", () => {
+    expect(resolver("/work/app-sibling")).toBeNull();
+  });
+
+  it("prefers the deepest matching root", () => {
+    expect(resolver("/work/app/vendored/lib")).toEqual({
+      projectId: vendoredId,
+      title: "Vendored",
+    });
+  });
+
+  it("prefers a live project over a deleted one sharing the root", () => {
+    expect(resolver("/work/legacy/src")).toEqual({ projectId: legacyId, title: "Legacy" });
+  });
+
+  it("never attributes to a blank title or an empty cwd", () => {
+    expect(resolver("/work/untitled/src")).toBeNull();
+    expect(resolver("")).toBeNull();
+  });
+
+  it("matches descendants when the project root is the filesystem root", () => {
+    const rootId = ProjectId.make("project-root");
+    const rootResolver = makeProjectResolver(
+      [{ projectId: rootId, workspaceRoot: "/", title: "Root", deleted: false }],
+      "/",
+    );
+
+    expect(rootResolver("/work/app")).toEqual({ projectId: rootId, title: "Root" });
   });
 });

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -1,7 +1,7 @@
 // @effect-diagnostics globalDate:off
 /**
- * Folds parsed transcript records into `(day, hourStart?, provider, model)`
- * buckets.
+ * Folds parsed transcript records into `(day, hourStart?, project, provider,
+ * model)` buckets.
  *
  * `Intl.DateTimeFormat` is the only reliable way to resolve a wall-clock day in
  * an arbitrary IANA zone, and it takes a `Date`. That is why the raw `Date`
@@ -12,7 +12,13 @@
  *
  * @module usageAggregation
  */
-import type { UsageBucket, UsageDay, UsageResolution, UsageTokenTotals } from "@t3tools/contracts";
+import type {
+  ProjectId,
+  UsageBucket,
+  UsageDay,
+  UsageResolution,
+  UsageTokenTotals,
+} from "@t3tools/contracts";
 
 import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
 import { cacheSavingsUsd, priceUsage, type RateTable } from "./usagePricing.ts";
@@ -46,6 +52,63 @@ function makeDayFormatter(timeZone: string): (timestampMs: number) => string {
 
 const HOUR_MS = 60 * 60 * 1000;
 
+export interface ProjectRoot {
+  readonly projectId: ProjectId;
+  readonly workspaceRoot: string;
+  readonly title: string;
+  /** Soft-deleted projects still attribute: the spend happened while they existed. */
+  readonly deleted: boolean;
+}
+
+export interface ProjectAttribution {
+  readonly projectId: ProjectId;
+  readonly title: string;
+}
+
+/**
+ * Builds the cwd → project resolver used by {@link AggregateOptions}.
+ *
+ * Deepest root wins, so a session in a project nested inside another
+ * attributes to the inner one. Live projects outrank deleted ones sharing a
+ * root, since deleting and re-creating a project leaves both rows. Results are
+ * memoised per cwd; a scan sees few distinct cwds but many records.
+ */
+export function makeProjectResolver(
+  projects: readonly ProjectRoot[],
+  separator: string,
+): (cwd: string) => ProjectAttribution | null {
+  const roots = projects
+    .map((project) => ({
+      projectId: project.projectId,
+      root:
+        project.workspaceRoot.length > 1 && project.workspaceRoot.endsWith(separator)
+          ? project.workspaceRoot.slice(0, -1)
+          : project.workspaceRoot,
+      title: project.title.trim(),
+      deleted: project.deleted,
+    }))
+    .filter((entry) => entry.root.length > 0 && entry.title.length > 0)
+    .sort((a, b) => b.root.length - a.root.length || Number(a.deleted) - Number(b.deleted));
+
+  const byCwd = new Map<string, ProjectAttribution | null>();
+  return (cwd) => {
+    if (cwd.length === 0) return null;
+    if (byCwd.has(cwd)) return byCwd.get(cwd) ?? null;
+    let resolved: ProjectAttribution | null = null;
+    for (const { projectId, root, title } of roots) {
+      if (
+        cwd === root ||
+        (root === separator ? cwd.startsWith(separator) : cwd.startsWith(`${root}${separator}`))
+      ) {
+        resolved = { projectId, title };
+        break;
+      }
+    }
+    byCwd.set(cwd, resolved);
+    return resolved;
+  };
+}
+
 interface MutableBucket {
   totals: UsageTokenTotals;
   costUsd: number;
@@ -65,6 +128,11 @@ export interface AggregateOptions {
   readonly resolution?: UsageResolution;
   readonly sinceTimeMs?: number;
   readonly untilTimeMs?: number;
+  /**
+   * Maps a record's working directory to the project it ran in, or `null` when
+   * it ran outside every project. Omitting it leaves every bucket unattributed.
+   */
+  readonly resolveProject?: ((cwd: string) => ProjectAttribution | null) | undefined;
 }
 
 export interface AggregateResult {
@@ -146,7 +214,17 @@ export class UsageAggregator {
             this.#hourlyWindow.sinceTimeMs +
               Math.floor((record.timestampMs - this.#hourlyWindow.sinceTimeMs) / HOUR_MS) * HOUR_MS,
           ).toISOString();
-    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.model}`;
+    // The key is parsed back apart on NUL, which project fields must not carry.
+    const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
+    const projectAttribution =
+      resolvedProject !== null
+        ? "project"
+        : this.#options.resolveProject === undefined || record.cwd.length === 0
+          ? "unknown"
+          : "outside";
+    const projectId = resolvedProject?.projectId.replaceAll("\u0000", "") ?? "";
+    const project = resolvedProject?.title.replaceAll("\u0000", "") ?? "";
+    const key = `${day}\u0000${hourStart}\u0000${projectAttribution}\u0000${projectId}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
     let bucket = this.#buckets.get(key);
     if (bucket === undefined) {
       bucket = {
@@ -187,10 +265,21 @@ export class UsageAggregator {
   finish(): AggregateResult {
     const buckets: UsageBucket[] = [];
     for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", provider = "", model = ""] = key.split("\u0000");
+      const [
+        day = "",
+        hourStart = "",
+        projectAttribution = "unknown",
+        projectId = "",
+        project = "",
+        provider = "",
+        model = "",
+      ] = key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
+        ...(project === "" ? {} : { project }),
+        ...(projectId === "" ? {} : { projectId: projectId as ProjectId }),
+        projectAttribution: projectAttribution as UsageBucket["projectAttribution"],
         provider: provider as UsageBucket["provider"],
         model,
         totals: bucket.totals,
@@ -207,6 +296,8 @@ export class UsageAggregator {
       (a, b) =>
         a.day.localeCompare(b.day) ||
         (a.hourStart ?? "").localeCompare(b.hourStart ?? "") ||
+        (a.project ?? "").localeCompare(b.project ?? "") ||
+        (a.projectId ?? "").localeCompare(b.projectId ?? "") ||
         a.provider.localeCompare(b.provider) ||
         a.model.localeCompare(b.model),
     );

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -16,6 +16,7 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
     timestampMs: 1_786_000_000_000,
     model: "claude-fable-5",
     sessionId: "session-a",
+    cwd: "/home/theo/project",
     totals: {
       uncachedInputTokens: 2,
       cachedInputTokens: 1000,
@@ -80,6 +81,7 @@ describe("scan cache round trip", () => {
         codexState: {
           model: "gpt-5.2-codex",
           sessionId: "session-c",
+          cwd: "/home/theo/codex-project",
           lastUsageSignature: '{"input_tokens":1}',
           sawSessionMeta: true,
           suppressingForkCopies: false,
@@ -185,6 +187,22 @@ describe("scan cache round trip", () => {
 
     const restored = decodeScanCache(JSON.parse(JSON.stringify(poisoned)));
     expect(restored.has("/a.jsonl")).toBe(false);
+  });
+
+  it.each([0.5, 99])("drops an entry with invalid cwd index %s", (cwdIndex) => {
+    const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
+    const row = encoded.files["/a.jsonl"]!.r[0]!;
+    const poisoned = {
+      ...encoded,
+      files: {
+        "/a.jsonl": {
+          ...encoded.files["/a.jsonl"]!,
+          r: [[...row.slice(0, 10), cwdIndex]],
+        },
+      },
+    };
+
+    expect(decodeScanCache(JSON.parse(JSON.stringify(poisoned))).has("/a.jsonl")).toBe(false);
   });
 });
 

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -26,7 +26,9 @@ import type { CodexScanState, UsageRecord } from "./usageTranscripts.ts";
 // entries would keep serving double-counted records forever.
 // v3: entries carry the parse position and reducer state so a grown file
 // re-parses only its appended bytes instead of starting over.
-const USAGE_SCAN_CACHE_VERSION = 3 as const;
+// v4: records carry the session's cwd for project attribution; v3 entries
+// would pin every cached file to "no project" forever.
+const USAGE_SCAN_CACHE_VERSION = 4 as const;
 
 export interface CachedFile {
   readonly size: number;
@@ -61,6 +63,7 @@ type SerializedRecord = readonly [
   reasoningTokens: number,
   dedupeKey: string | null,
   reportedCostUsd: number | null,
+  cwdIndex: number,
 ];
 
 interface SerializedFile {
@@ -82,15 +85,18 @@ interface SerializedCache {
   readonly version: number;
   readonly models: readonly string[];
   readonly sessions: readonly string[];
+  readonly cwds: readonly string[];
   readonly files: Readonly<Record<string, SerializedFile>>;
 }
 
-/** Serialises the cache, interning the repeated model and session strings. */
+/** Serialises the cache, interning the repeated model, session and cwd strings. */
 export function encodeScanCache(cache: ScanCache): SerializedCache {
   const models: string[] = [];
   const sessions: string[] = [];
+  const cwds: string[] = [];
   const modelIndex = new Map<string, number>();
   const sessionIndex = new Map<string, number>();
+  const cwdIndex = new Map<string, number>();
 
   const intern = (table: string[], index: Map<string, number>, value: string): number => {
     const existing = index.get(value);
@@ -112,6 +118,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     record.totals.reasoningTokens,
     record.dedupeKey,
     record.reportedCostUsd,
+    intern(cwds, cwdIndex, record.cwd),
   ];
 
   const files: Record<string, SerializedFile> = {};
@@ -129,7 +136,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     };
   }
 
-  return { version: USAGE_SCAN_CACHE_VERSION, models, sessions, files };
+  return { version: USAGE_SCAN_CACHE_VERSION, models, sessions, cwds, files };
 }
 
 function isRecordArray(value: unknown): value is readonly unknown[] {
@@ -148,7 +155,9 @@ export function decodeScanCache(document: unknown): ScanCache {
 
   const root = document as Partial<SerializedCache>;
   if (root.version !== USAGE_SCAN_CACHE_VERSION) return cache;
-  if (!isRecordArray(root.models) || !isRecordArray(root.sessions)) return cache;
+  if (!isRecordArray(root.models) || !isRecordArray(root.sessions) || !isRecordArray(root.cwds)) {
+    return cache;
+  }
   if (typeof root.files !== "object" || root.files === null) return cache;
 
   // The intern tables must be all strings: a numeric entry would pass the
@@ -156,8 +165,10 @@ export function decodeScanCache(document: unknown): ScanCache {
   // at lookupRate. A corrupt table rejects the whole cache.
   if (!root.models.every((value) => typeof value === "string")) return cache;
   if (!root.sessions.every((value) => typeof value === "string")) return cache;
+  if (!root.cwds.every((value) => typeof value === "string")) return cache;
   const models = root.models as readonly string[];
   const sessions = root.sessions as readonly string[];
+  const cwds = root.cwds as readonly string[];
 
   // Any corrupt row disqualifies the whole entry. Keeping the survivors
   // under the original (size, mtime) would read as a valid warm hit and the
@@ -168,7 +179,7 @@ export function decodeScanCache(document: unknown): ScanCache {
   ): UsageRecord[] | null => {
     const records: UsageRecord[] = [];
     for (const row of rows) {
-      if (!isRecordArray(row) || row.length < 10) return null;
+      if (!isRecordArray(row) || row.length < 11) return null;
       const [
         timestampMs,
         modelIndex,
@@ -180,13 +191,16 @@ export function decodeScanCache(document: unknown): ScanCache {
         reasoning,
         dedupeKey,
         reportedCostUsd,
+        cwdIndex,
       ] = row as SerializedRecord;
 
       const model = typeof modelIndex === "number" ? models[modelIndex] : undefined;
+      const cwd = Number.isInteger(cwdIndex) ? cwds[cwdIndex] : undefined;
       if (
         typeof timestampMs !== "number" ||
         !Number.isFinite(timestampMs) ||
         model === undefined ||
+        cwd === undefined ||
         !Number.isFinite(uncached) ||
         !Number.isFinite(cached) ||
         !Number.isFinite(cacheCreation) ||
@@ -201,6 +215,7 @@ export function decodeScanCache(document: unknown): ScanCache {
         timestampMs,
         model,
         sessionId: (typeof sessionIndex === "number" ? sessions[sessionIndex] : undefined) ?? "",
+        cwd,
         totals: {
           uncachedInputTokens: uncached,
           cachedInputTokens: cached,
@@ -277,6 +292,7 @@ function decodeCodexState(value: unknown): CodexScanState | null | undefined {
   if (
     typeof state.model !== "string" ||
     typeof state.sessionId !== "string" ||
+    typeof state.cwd !== "string" ||
     (state.lastUsageSignature !== null && typeof state.lastUsageSignature !== "string") ||
     typeof state.sawSessionMeta !== "boolean" ||
     typeof state.suppressingForkCopies !== "boolean" ||
@@ -288,6 +304,7 @@ function decodeCodexState(value: unknown): CodexScanState | null | undefined {
   return {
     model: state.model,
     sessionId: state.sessionId,
+    cwd: state.cwd,
     lastUsageSignature: state.lastUsageSignature ?? null,
     sawSessionMeta: state.sawSessionMeta,
     suppressingForkCopies: state.suppressingForkCopies,

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -51,6 +51,7 @@ describe("parseClaudeLine", () => {
       reasoningTokens: 0,
     });
     expect(record?.dedupeKey).toBe("msg_1:");
+    expect(record?.cwd).toBe("/home/theo/project");
   });
 
   it("gives every content block of one message the same dedupe key", () => {
@@ -73,7 +74,11 @@ describe("parseCodexLine", () => {
   const sessionMeta = JSON.stringify({
     type: "session_meta",
     timestamp: "2026-08-01T05:17:41.289Z",
-    payload: { type: "session_meta", id: "019fbbc1-b12c-7360-a685-28c181f0025f" },
+    payload: {
+      type: "session_meta",
+      id: "019fbbc1-b12c-7360-a685-28c181f0025f",
+      cwd: "/home/theo/project",
+    },
   });
   const turnContext = JSON.stringify({
     type: "turn_context",
@@ -107,10 +112,32 @@ describe("parseCodexLine", () => {
     expect(record?.provider).toBe("codex");
     expect(record?.model).toBe("gpt-5.6-sol");
     expect(record?.sessionId).toBe("019fbbc1-b12c-7360-a685-28c181f0025f");
+    expect(record?.cwd).toBe("/home/theo/project");
     // Codex reports input_tokens inclusive of the cached portion.
     expect(record?.totals.uncachedInputTokens).toBe(19239 - 11008);
     expect(record?.totals.cachedInputTokens).toBe(11008);
     expect(record?.totals.reasoningTokens).toBe(116);
+  });
+
+  it("attributes resumed usage to the latest turn working directory", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(sessionMeta, state);
+    parseCodexLine(
+      JSON.stringify({
+        type: "turn_context",
+        timestamp: "2026-08-01T05:17:42.694Z",
+        payload: {
+          type: "turn_context",
+          model: "gpt-5.6-sol",
+          cwd: "/home/theo/next-project",
+        },
+      }),
+      state,
+    );
+
+    const record = parseCodexLine(tokenCount(100, 0, 10, 0), state);
+
+    expect(record?.cwd).toBe("/home/theo/next-project");
   });
 
   it("skips a repeated token_count so deltas are not double counted", () => {

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -13,6 +13,11 @@ export interface UsageRecord {
   readonly timestampMs: number;
   readonly model: string;
   readonly sessionId: string;
+  /**
+   * Working directory the session ran in, or `""` when the transcript does not
+   * record one (Grok). Drives project attribution at aggregation time.
+   */
+  readonly cwd: string;
   readonly totals: UsageTokenTotals;
   readonly reportedCostUsd: number | null;
   /**
@@ -136,6 +141,7 @@ export function parseClaudeLine(line: string): UsageRecord | null {
     timestampMs,
     model,
     sessionId: typeof record["sessionId"] === "string" ? record["sessionId"] : "",
+    cwd: typeof record["cwd"] === "string" ? record["cwd"] : "",
     totals: {
       uncachedInputTokens: int(usageRecord["input_tokens"]),
       cachedInputTokens: int(usageRecord["cache_read_input_tokens"]),
@@ -163,6 +169,7 @@ export function parseClaudeLine(line: string): UsageRecord | null {
 export interface CodexScanState {
   model: string;
   sessionId: string;
+  cwd: string;
   lastUsageSignature: string | null;
   sawSessionMeta: boolean;
   /** While true, leading usage events are re-stamped copies of parent history. */
@@ -174,6 +181,7 @@ export function initialCodexScanState(): CodexScanState {
   return {
     model: "",
     sessionId: "",
+    cwd: "",
     lastUsageSignature: null,
     sawSessionMeta: false,
     suppressingForkCopies: false,
@@ -233,6 +241,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     state.sawSessionMeta = true;
     const id = payloadRecord["id"] ?? payloadRecord["session_id"];
     if (typeof id === "string") state.sessionId = id;
+    if (typeof payloadRecord["cwd"] === "string") state.cwd = payloadRecord["cwd"];
     const metaTimestampMs = parseTimestampMs(record["timestamp"]);
     if (metaTimestampMs !== null && isForkedSessionMeta(payloadRecord)) {
       state.suppressingForkCopies = true;
@@ -243,6 +252,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
 
   if (record["type"] === "turn_context") {
     if (typeof payloadRecord["model"] === "string") state.model = payloadRecord["model"];
+    if (typeof payloadRecord["cwd"] === "string") state.cwd = payloadRecord["cwd"];
     return null;
   }
 
@@ -301,6 +311,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     timestampMs,
     model: state.model,
     sessionId: state.sessionId,
+    cwd: state.cwd,
     totals,
     // Codex does not report cost in the rollout.
     reportedCostUsd: null,
@@ -431,6 +442,8 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
         timestampMs,
         model: "grok",
         sessionId,
+        // Grok session logs record no working directory.
+        cwd: "",
         totals: grokTotalsToUsage(topLevel),
         reportedCostUsd: grokCostTicksToUsd(topLevel.costUsdTicks),
         // No prompt id means we cannot tell two same-second updates apart.
@@ -477,6 +490,7 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
       timestampMs,
       model: entry.model,
       sessionId,
+      cwd: "",
       totals,
       reportedCostUsd,
       dedupeKey: promptId === null ? null : `${sessionId}:${promptId}:${entry.model}`,

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -1,4 +1,4 @@
-import { EnvironmentId, UsageDay, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
+import { EnvironmentId, ProjectId, UsageDay, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { mergeUsage } from "@t3tools/shared/usageMerge";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
@@ -9,7 +9,8 @@ const testState = vi.hoisted(() => ({
   resetZoom: undefined as (() => void) | undefined,
   useUsage: vi.fn(),
   metric: "cost" as "cost" | "tokens" | "limits",
-  breakdown: "time" as "model" | "time",
+  breakdown: "time" as "model" | "project" | "time",
+  projectSelection: undefined as { key: string | null; label: string } | undefined,
   setWindowSelection: vi.fn(),
 }));
 
@@ -37,7 +38,9 @@ vi.mock("react", async (importOriginal) => {
             ? testState.metric
             : initial === "model"
               ? testState.breakdown
-              : initial,
+              : initial === undefined
+                ? testState.projectSelection
+                : initial,
       typeof initial === "function" && initial !== readUsagePagePreferences
         ? testState.setWindowSelection
         : vi.fn(),
@@ -156,17 +159,42 @@ const environments = [
   },
 ];
 
+const projectTotals = Object.freeze([
+  {
+    projectId: ProjectId.make("project-expensive"),
+    projectKey: "id:project-expensive",
+    project: "Expensive Project",
+    costUsd: 9,
+    totalTokens: 200,
+    records: 2,
+    unpricedRecords: 0,
+    costShare: 9 / 20,
+  },
+  {
+    projectId: null,
+    projectKey: null,
+    project: null,
+    costUsd: 7,
+    totalTokens: 900,
+    records: 1,
+    unpricedRecords: 0,
+    costShare: 7 / 20,
+  },
+]);
+
 beforeEach(() => {
   testState.customWindow = false;
   testState.zoomToDays = undefined;
   testState.resetZoom = undefined;
   testState.metric = "cost";
   testState.breakdown = "time";
+  testState.projectSelection = undefined;
   testState.setWindowSelection.mockReset();
   testState.useUsage.mockReturnValue({
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
       models: modelTotals,
+      projects: projectTotals,
       hourly: [
         {
           day: "2026-08-10",
@@ -210,6 +238,105 @@ describe("UsagePage hourly breakdown", () => {
     const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
 
     expect(body).toMatch(/\$11\.00.*\$13\.00/);
+  });
+});
+
+describe("UsagePage project breakdown", () => {
+  it("offers a lone project filter when unknown attribution remains in the totals", () => {
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: {
+        ...usage.merged,
+        costUsd: 10,
+        totalTokens: 300,
+        projects: [projectTotals[0]],
+      },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup.match(/aria-label="Project filter"/g)).toHaveLength(2);
+  });
+
+  it("hides a lone project filter when it would not narrow the totals", () => {
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: {
+        ...usage.merged,
+        costUsd: 9,
+        totalTokens: 200,
+        projects: [projectTotals[0]],
+      },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).not.toContain('aria-label="Project filter"');
+  });
+
+  it("ranks projects by cost and labels unattributed work", () => {
+    testState.breakdown = "project";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/Expensive Project.*Outside projects/);
+    expect(body).toContain("$9.00");
+    expect(body).toContain("$7.00");
+    expect(body).toContain("45.0%");
+    expect(body).toContain("35.0%");
+  });
+
+  it("ranks projects by tokens when the token metric is selected", () => {
+    testState.metric = "tokens";
+    testState.breakdown = "project";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/Outside projects.*Expensive Project/);
+  });
+
+  it("shows only the selected project in the project breakdown", () => {
+    testState.breakdown = "project";
+    testState.projectSelection = { key: "id:project-expensive", label: "Expensive Project" };
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toContain("Expensive Project");
+    expect(body).not.toContain("Outside projects");
+    expect(body).toContain("100.0%");
+  });
+
+  it("distinguishes unattributed usage from an empty window", () => {
+    testState.breakdown = "project";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: { ...usage.merged, projects: [], records: 1 },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("No project attribution in this window.");
+    expect(markup).not.toContain("No activity in this window.");
+  });
+
+  it("keeps the empty-window message when there is no usage", () => {
+    testState.breakdown = "project";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: { ...usage.merged, projects: [], records: 0 },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("No activity in this window.");
+    expect(markup).not.toContain("No project attribution in this window.");
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -4,9 +4,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
+  customWindow: false,
+  zoomToDays: undefined as ((since: string, until: string) => void) | undefined,
+  resetZoom: undefined as (() => void) | undefined,
   useUsage: vi.fn(),
   metric: "cost" as "cost" | "tokens" | "limits",
   breakdown: "time" as "model" | "time",
+  setWindowSelection: vi.fn(),
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -18,7 +22,8 @@ vi.mock("react", async (importOriginal) => {
         ? { metric: testState.metric, windowDays: 30 }
         : typeof initial === "function"
           ? {
-              days: 1,
+              days: testState.customWindow ? 30 : 1,
+              custom: testState.customWindow,
               window: {
                 sinceDay: "2026-08-10",
                 untilDay: "2026-08-11",
@@ -33,7 +38,9 @@ vi.mock("react", async (importOriginal) => {
             : initial === "model"
               ? testState.breakdown
               : initial,
-      vi.fn(),
+      typeof initial === "function" && initial !== readUsagePagePreferences
+        ? testState.setWindowSelection
+        : vi.fn(),
     ]),
   };
 });
@@ -41,6 +48,7 @@ vi.mock("react", async (importOriginal) => {
 vi.mock("../../env", () => ({ isElectron: false }));
 vi.mock("../../state/usage", () => ({ useUsage: testState.useUsage }));
 vi.mock("../ui/button", () => ({ Button: "button" }));
+vi.mock("../ui/input", () => ({ Input: "input" }));
 vi.mock("../ui/scroll-area", () => ({ ScrollArea: "div" }));
 vi.mock("../ui/select", () => ({
   Select: "div",
@@ -58,7 +66,16 @@ vi.mock("../WorkspaceBreadcrumb", () => ({
 }));
 vi.mock("../WorkspacePageContainer", () => ({ WorkspacePageContainer: "main" }));
 vi.mock("../WorkspacePageHeader", () => ({ WorkspacePageHeader: "header" }));
-vi.mock("./UsageProviderChart", () => ({ UsageProviderChart: "div" }));
+vi.mock("./UsageProviderChart", () => ({
+  UsageProviderChart: (props: {
+    onZoomToDays?: (since: string, until: string) => void;
+    onResetZoom?: () => void;
+  }) => {
+    testState.zoomToDays = props.onZoomToDays;
+    testState.resetZoom = props.onResetZoom;
+    return <div />;
+  },
+}));
 vi.mock("./UsagePriceOverrides", () => ({ UsagePriceOverrides: () => null }));
 vi.mock("./usageProviders", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./usageProviders")>();
@@ -140,8 +157,12 @@ const environments = [
 ];
 
 beforeEach(() => {
+  testState.customWindow = false;
+  testState.zoomToDays = undefined;
+  testState.resetZoom = undefined;
   testState.metric = "cost";
   testState.breakdown = "time";
+  testState.setWindowSelection.mockReset();
   testState.useUsage.mockReturnValue({
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
@@ -228,4 +249,27 @@ describe("UsagePage model breakdown", () => {
       "unpriced-model",
     ]);
   });
+});
+
+it("restores the original custom window after repeated chart zooms", () => {
+  testState.customWindow = true;
+  renderToStaticMarkup(<UsagePage />);
+  expect(testState.zoomToDays).toBeTypeOf("function");
+  testState.zoomToDays?.("2026-08-10", "2026-08-10");
+  testState.zoomToDays?.("2026-08-11", "2026-08-11");
+  testState.resetZoom?.();
+  expect(testState.setWindowSelection).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      custom: true,
+      window: expect.objectContaining({ sinceDay: "2026-08-10", untilDay: "2026-08-11" }),
+    }),
+  );
+});
+
+it("keeps an unzoomed custom range when the plot is double-clicked", () => {
+  testState.customWindow = true;
+  renderToStaticMarkup(<UsagePage />);
+  expect(testState.resetZoom).toBeTypeOf("function");
+  testState.resetZoom?.();
+  expect(testState.setWindowSelection).not.toHaveBeenCalled();
 });

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -27,6 +27,7 @@ import { serverEnvironment } from "../../state/server";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import { useAtomCommand } from "../../state/use-atom-command";
 import {
+  compareUsageDays,
   enumerateDays,
   enumerateHourStarts,
   formatCount,
@@ -36,9 +37,12 @@ import {
   formatPercent,
   formatTokens,
   formatUsd,
+  makeCustomWindow,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
+import { useCommitOnBlur } from "../../hooks/useCommitOnBlur";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 import {
   Menu,
   MenuCheckboxItem,
@@ -95,12 +99,14 @@ export function UsagePage() {
   const [preferences, setPreferences] = useState(readUsagePagePreferences);
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: preferences.windowDays,
+    custom: false,
     window: makeWindow(
       preferences.windowDays,
       undefined,
       preferences.windowDays === 1 ? "hour" : "day",
     ),
   }));
+  const preZoomSelection = useRef<typeof windowSelection | null>(null);
   const metric = preferences.metric;
   const showingLimits = metric === "limits";
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -108,8 +114,8 @@ export function UsagePage() {
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
   const [selectedEnvironmentIds, setSelectedEnvironmentIds] =
     useState<ReadonlySet<EnvironmentId> | null>(null);
-  const { days: windowDays, window } = windowSelection;
-  const isPast24Hours = windowDays === 1;
+  const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
+  const isPast24Hours = !isCustomWindow && windowDays === 1;
   const { merged, environments, selectedEnvironments, isPending, isPartial, refresh } = useUsage(
     window,
     selectedEnvironmentIds,
@@ -150,13 +156,38 @@ export function UsagePage() {
 
   const selectWindow = (days: number) => {
     if (!isUsageWindowDays(days)) return;
+    preZoomSelection.current = null;
     const nextPreferences = { metric, windowDays: days };
     setPreferences(nextPreferences);
     saveUsagePagePreferences(nextPreferences);
     setWindowSelection({
       days,
+      custom: false,
       window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
     });
+  };
+  const selectCustomWindow = (sinceDay: string, untilDay: string) => {
+    preZoomSelection.current = null;
+    setWindowSelection({
+      days: windowDays,
+      custom: true,
+      window: makeCustomWindow(sinceDay, untilDay),
+    });
+  };
+  const zoomToDays = (sinceDay: string, untilDay: string) => {
+    preZoomSelection.current ??= windowSelection;
+    setWindowSelection({
+      days: windowDays,
+      custom: true,
+      window: makeCustomWindow(sinceDay, untilDay),
+    });
+  };
+  const resetZoom = () => {
+    const original = preZoomSelection.current;
+    if (original === null) return;
+    preZoomSelection.current = null;
+    if (original.custom) setWindowSelection(original);
+    else selectWindow(original.days);
   };
   const selectMetric = (nextMetric: UsageMetric) => {
     const nextPreferences = { metric: nextMetric, windowDays };
@@ -182,14 +213,16 @@ export function UsagePage() {
       });
       return;
     }
-    const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
+    const nextWindow = isCustomWindow
+      ? window
+      : makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
     if (
       nextWindow.sinceDay !== window.sinceDay ||
       nextWindow.untilDay !== window.untilDay ||
       nextWindow.sinceTime !== window.sinceTime ||
       nextWindow.untilTime !== window.untilTime
     ) {
-      setWindowSelection({ days: windowDays, window: nextWindow });
+      setWindowSelection({ days: windowDays, custom: false, window: nextWindow });
     }
     refreshingRef.current = true;
     setIsRefreshing(true);
@@ -243,12 +276,18 @@ export function UsagePage() {
             </Toggle>
           ))}
         </ToggleGroup>
+        <UsageDateRangeInputs
+          sinceDay={window.sinceDay}
+          untilDay={window.untilDay}
+          onChange={selectCustomWindow}
+          disabled={showingLimits}
+        />
         {/* The period does not apply to Limits, so it stays in place but
             disabled; unmounting it shifted the metric toggle ~300px. */}
         <ToggleGroup
           aria-label="Usage period"
           variant="segmented"
-          value={[String(windowDays)]}
+          value={isCustomWindow ? [] : [String(windowDays)]}
           disabled={showingLimits}
           onValueChange={(next) => {
             const value = next[0];
@@ -298,9 +337,11 @@ export function UsagePage() {
           </SelectPopup>
         </Select>
         <Select
-          value={String(windowDays)}
+          value={isCustomWindow ? "custom" : String(windowDays)}
           disabled={showingLimits}
-          onValueChange={(value) => selectWindow(Number(value))}
+          onValueChange={(value) => {
+            if (value !== "custom" && value !== null) selectWindow(Number(value));
+          }}
         >
           <SelectTrigger
             aria-label="Usage period"
@@ -309,7 +350,9 @@ export function UsagePage() {
             className="w-auto min-w-0"
           >
             <SelectValue>
-              {WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
+              {isCustomWindow
+                ? "Custom"
+                : WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
             </SelectValue>
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
@@ -343,6 +386,14 @@ export function UsagePage() {
 
         <ScrollArea className="min-h-0 flex-1">
           <WorkspacePageContainer width="wide">
+            {!showingLimits ? (
+              <UsageDateRangeInputs
+                className="mb-4 flex-wrap xl:hidden"
+                sinceDay={window.sinceDay}
+                untilDay={window.untilDay}
+                onChange={selectCustomWindow}
+              />
+            ) : null}
             {selectedEnvironments.length === 0 ? (
               <p className="text-sm text-muted-foreground">
                 {environments.length === 0
@@ -420,10 +471,17 @@ export function UsagePage() {
                   </div>
 
                   <div className="flex min-w-0 flex-col gap-3">
-                    <h2 className="text-sm font-medium text-foreground">
-                      {isPast24Hours ? "Hourly" : "Daily"}{" "}
-                      {metric === "tokens" ? "processed tokens" : "cost"}
-                    </h2>
+                    <div className="flex items-baseline justify-between gap-3">
+                      <h2 className="text-sm font-medium text-foreground">
+                        {isPast24Hours ? "Hourly" : "Daily"}{" "}
+                        {metric === "tokens" ? "processed tokens" : "cost"}
+                      </h2>
+                      {isPast24Hours ? null : (
+                        <span className="text-[10px] tracking-wide text-muted-foreground uppercase">
+                          drag to zoom · double-click resets
+                        </span>
+                      )}
+                    </div>
                     <UsageProviderChart
                       providers={activeProviders}
                       days={days}
@@ -434,6 +492,12 @@ export function UsagePage() {
                       referenceTime={window.untilTime}
                       resolution={isPast24Hours ? "hour" : "day"}
                       timeZone={window.timeZone}
+                      {...(isPast24Hours
+                        ? {}
+                        : {
+                            onZoomToDays: zoomToDays,
+                            onResetZoom: resetZoom,
+                          })}
                     />
                   </div>
                 </section>
@@ -603,6 +667,77 @@ export function UsagePage() {
         </ScrollArea>
       </div>
     </SidebarInset>
+  );
+}
+
+/**
+ * Free date-range bounds beside the presets. Native date inputs; committing
+ * either bound deselects every preset. Compact layouts render the same control
+ * above the page content so custom ranges remain reachable without crowding
+ * the header.
+ */
+function UsageDateRangeInputs({
+  className,
+  sinceDay,
+  untilDay,
+  onChange,
+  disabled = false,
+}: {
+  readonly className?: string;
+  readonly sinceDay: string;
+  readonly untilDay: string;
+  readonly onChange: (sinceDay: string, untilDay: string) => void;
+  readonly disabled?: boolean;
+}) {
+  // The shared buffered-input hook preserves a focused draft across upstream
+  // range changes and commits on both blur and Enter. Keep the hooks separate
+  // so each bound can validate against the last committed opposite bound.
+  const sinceInput = useCommitOnBlur(sinceDay, (next) => {
+    const comparison = compareUsageDays(next, untilDay);
+    if (comparison !== null && comparison <= 0) onChange(next, untilDay);
+  });
+  const untilInput = useCommitOnBlur(untilDay, (next) => {
+    const comparison = compareUsageDays(sinceDay, next);
+    if (comparison !== null && comparison <= 0) onChange(sinceDay, next);
+  });
+  const comparison = compareUsageDays(sinceInput.value, untilInput.value);
+  const invalid = comparison === null || comparison > 0;
+  const inputClassName =
+    "w-auto rounded-md transition-colors hover:bg-background/55 hover:text-foreground focus-within:bg-background focus-within:text-foreground focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-background has-aria-invalid:text-destructive focus-within:has-aria-invalid:ring-destructive/50 dark:hover:bg-input/32 dark:focus-within:bg-input/72 [&_[data-slot=input]]:h-6 [&_[data-slot=input]]:px-2.5 [&_[data-slot=input]]:leading-6 [&_[data-slot=input]]:pointer-coarse:h-8.5 [&_[data-slot=input]]:pointer-coarse:leading-8.5 [&_[data-slot=input]::-webkit-calendar-picker-indicator]:opacity-50";
+
+  return (
+    <div
+      className={cn(
+        "flex w-fit items-center gap-0.5 rounded-lg bg-input/40 p-0.5 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      <Input
+        nativeInput
+        unstyled
+        type="date"
+        size="compact"
+        aria-label="From day"
+        className={cn(inputClassName, "[color-scheme:inherit]")}
+        max={untilInput.value}
+        disabled={disabled}
+        aria-invalid={invalid || undefined}
+        {...sinceInput}
+      />
+      <span className="px-0.5">to</span>
+      <Input
+        nativeInput
+        unstyled
+        type="date"
+        size="compact"
+        aria-label="To day"
+        className={cn(inputClassName, "[color-scheme:inherit]")}
+        min={sinceInput.value}
+        disabled={disabled}
+        aria-invalid={invalid || undefined}
+        {...untilInput}
+      />
+    </div>
   );
 }
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -18,6 +18,7 @@ import {
   isModelCostUnknown,
   type DailyTotals,
   type HourlyTotals,
+  type ProjectTotals,
 } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
@@ -111,14 +112,19 @@ export function UsagePage() {
   const showingLimits = metric === "limits";
   const [isRefreshing, setIsRefreshing] = useState(false);
   const refreshingRef = useRef(false);
-  const [breakdown, setBreakdown] = useState<"model" | "time">("model");
+  const [breakdown, setBreakdown] = useState<"model" | "project" | "time">("model");
   const [selectedEnvironmentIds, setSelectedEnvironmentIds] =
     useState<ReadonlySet<EnvironmentId> | null>(null);
+  // The label travels with the key so it survives a window where the project has no usage.
+  const [selectedProject, setSelectedProject] = useState<ProjectSelection | undefined>(undefined);
+  const projectFilter = selectedProject?.key;
+  const selectedProjectLabel = selectedProject?.label ?? null;
   const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
   const isPast24Hours = !isCustomWindow && windowDays === 1;
   const { merged, environments, selectedEnvironments, isPending, isPartial, refresh } = useUsage(
     window,
     selectedEnvironmentIds,
+    projectFilter,
   );
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
@@ -151,8 +157,31 @@ export function UsagePage() {
         : merged.models,
     [breakdown, merged.models, metric],
   );
+  const breakdownProjects = useMemo(() => {
+    const scoped =
+      projectFilter === undefined
+        ? merged.projects
+        : merged.projects.filter((project) => project.projectKey === projectFilter);
+    return metric === "tokens"
+      ? scoped.toSorted(
+          (left, right) => right.totalTokens - left.totalTokens || right.costUsd - left.costUsd,
+        )
+      : scoped;
+  }, [merged.projects, metric, projectFilter]);
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
+  // Session figures are per transcript directory; a project filter cannot
+  // split them, so they only render unfiltered.
+  const sessionsKnown = projectFilter === undefined;
+  const onlyProject = merged.projects.length === 1 ? merged.projects[0] : undefined;
+  // Unknown attribution remains in the overall totals but is absent from the
+  // project list. Keep a lone known project selectable when that distinction
+  // lets the user remove unknown usage from the page.
+  const showProjectPicker =
+    merged.projects.length > 1 ||
+    projectFilter !== undefined ||
+    (onlyProject !== undefined &&
+      (onlyProject.totalTokens !== merged.totalTokens || onlyProject.costUsd !== merged.costUsd));
 
   const selectWindow = (days: number) => {
     if (!isUsageWindowDays(days)) return;
@@ -261,6 +290,13 @@ export function UsagePage() {
         </span>
       ) : null}
       <div className="ms-auto hidden min-w-0 items-center justify-end gap-2 xl:flex">
+        {showProjectPicker ? (
+          <UsageProjectSelect
+            projects={merged.projects}
+            selection={selectedProject}
+            onChange={setSelectedProject}
+          />
+        ) : null}
         <ToggleGroup
           aria-label="Usage metric"
           variant="segmented"
@@ -312,6 +348,13 @@ export function UsagePage() {
         </Button>
       </div>
       <div className="col-span-2 ms-auto flex min-w-0 items-center justify-end gap-1 xl:hidden">
+        {showProjectPicker ? (
+          <UsageProjectSelect
+            projects={merged.projects}
+            selection={selectedProject}
+            onChange={setSelectedProject}
+          />
+        ) : null}
         <Select
           value={metric}
           onValueChange={(value) => {
@@ -415,13 +458,17 @@ export function UsagePage() {
                           : formatTokens(merged.totalTokens)}
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        {metric !== "cost"
-                          ? `${formatCount(merged.sessions)} sessions`
-                          : merged.costQuality.unpricedShare > 0
-                            ? `${formatCount(merged.sessions)} sessions · API estimate excludes ${formatPercent(
+                        {(() => {
+                          const scope = sessionsKnown
+                            ? `${formatCount(merged.sessions)} sessions`
+                            : (selectedProjectLabel ?? "Outside projects");
+                          if (metric !== "cost") return scope;
+                          return merged.costQuality.unpricedShare > 0
+                            ? `${scope} · API estimate excludes ${formatPercent(
                                 merged.costQuality.unpricedShare,
                               )} unpriced records`
-                            : `${formatCount(merged.sessions)} sessions · API estimate`}
+                            : `${scope} · API estimate`;
+                        })()}
                       </span>
                     </div>
 
@@ -449,9 +496,11 @@ export function UsagePage() {
                                 <span className="truncate">
                                   {PROVIDER_PRESENTATION[provider].label}
                                 </span>
-                                <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground tabular-nums">
-                                  {sessionLabel}
-                                </span>
+                                {sessionsKnown ? (
+                                  <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground tabular-nums">
+                                    {sessionLabel}
+                                  </span>
+                                ) : null}
                               </span>
                             </span>
                             <span className="shrink-0 text-sm font-medium text-foreground tabular-nums">
@@ -528,12 +577,15 @@ export function UsagePage() {
                       value={[breakdown]}
                       onValueChange={(next) => {
                         const value = next[0];
-                        if (value === "model" || value === "time") setBreakdown(value);
+                        if (value === "model" || value === "project" || value === "time") {
+                          setBreakdown(value);
+                        }
                       }}
                     >
                       {(
                         [
                           { value: "model", label: "Model" },
+                          { value: "project", label: "Project" },
                           { value: "time", label: isPast24Hours ? "Hour" : "Day" },
                         ] as const
                       ).map((option) => (
@@ -544,7 +596,72 @@ export function UsagePage() {
                     </ToggleGroup>
                   </div>
 
-                  {breakdown === "model" ? (
+                  {breakdown === "project" ? (
+                    <table className="w-full table-fixed text-sm">
+                      <colgroup>
+                        <col className="w-2/5" />
+                        <col className="w-1/5" />
+                        <col className="w-1/5" />
+                        <col className="w-1/5" />
+                      </colgroup>
+                      <thead>
+                        <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                          <th className="py-2 font-normal">Project</th>
+                          <th className="py-2 text-right font-normal">Cost</th>
+                          <th className="py-2 text-right font-normal">Share</th>
+                          <th className="py-2 text-right font-normal">Tokens</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {breakdownProjects.length === 0 ? (
+                          <tr>
+                            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                              {merged.records === 0
+                                ? "No activity in this window."
+                                : "No project attribution in this window."}
+                            </td>
+                          </tr>
+                        ) : (
+                          breakdownProjects.map((project) => (
+                            <tr
+                              key={project.projectKey ?? "\0"}
+                              className="border-b border-border/50 transition-colors hover:bg-muted/50"
+                            >
+                              <td className="py-2">
+                                {project.project === null ? (
+                                  <span className="text-muted-foreground">Outside projects</span>
+                                ) : (
+                                  <span className="block truncate text-foreground">
+                                    {project.project}
+                                  </span>
+                                )}
+                              </td>
+                              <td className="py-2 text-right text-foreground tabular-nums">
+                                {isModelCostUnknown(project) ? (
+                                  <span className="text-muted-foreground">Unpriced</span>
+                                ) : (
+                                  formatUsd(project.costUsd)
+                                )}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {isModelCostUnknown(project)
+                                  ? "—"
+                                  : formatPercent(
+                                      // A filtered table holds only the selected project.
+                                      projectFilter === undefined
+                                        ? project.costShare
+                                        : Number(project.costUsd > 0),
+                                    )}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatTokens(project.totalTokens)}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  ) : breakdown === "model" ? (
                     <table className="w-full table-fixed text-sm">
                       <colgroup>
                         <col className="w-2/5" />
@@ -738,6 +855,71 @@ function UsageDateRangeInputs({
         {...untilInput}
       />
     </div>
+  );
+}
+
+/** A picked project filter: a namespaced project key, or null for work outside every project. */
+interface ProjectSelection {
+  readonly key: string | null;
+  readonly label: string;
+}
+
+/**
+ * Select values are plain strings, so "all" and "outside" get sentinels while
+ * attributed projects carry the namespaced stable key from the merge layer.
+ */
+const ALL_PROJECTS_VALUE = "all";
+const OUTSIDE_PROJECTS_VALUE = "outside";
+const PROJECT_VALUE_PREFIX = "p:";
+
+function projectSelectValue(key: string | null): string {
+  return key === null ? OUTSIDE_PROJECTS_VALUE : `${PROJECT_VALUE_PREFIX}${key}`;
+}
+
+/** Narrows the whole page to one project's buckets. */
+function UsageProjectSelect({
+  projects,
+  selection,
+  onChange,
+}: {
+  readonly projects: readonly ProjectTotals[];
+  readonly selection: ProjectSelection | undefined;
+  readonly onChange: (selection: ProjectSelection | undefined) => void;
+}) {
+  return (
+    <Select
+      value={selection === undefined ? ALL_PROJECTS_VALUE : projectSelectValue(selection.key)}
+      onValueChange={(value) => {
+        const project = projects.find((entry) => projectSelectValue(entry.projectKey) === value);
+        onChange(
+          project === undefined
+            ? undefined
+            : { key: project.projectKey, label: project.project ?? "Outside projects" },
+        );
+      }}
+    >
+      <SelectTrigger
+        aria-label="Project filter"
+        size="compact"
+        variant="ghost"
+        className="w-auto max-w-48 min-w-0"
+      >
+        <SelectValue>
+          <span className="truncate">{selection?.label ?? "All projects"}</span>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectItem value={ALL_PROJECTS_VALUE}>All projects</SelectItem>
+        {projects.map((project) => (
+          <SelectItem
+            key={projectSelectValue(project.projectKey)}
+            value={projectSelectValue(project.projectKey)}
+          >
+            {project.project ?? "Outside projects"}
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
   );
 }
 

--- a/apps/web/src/components/usage/UsageProviderChart.interaction.test.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.interaction.test.tsx
@@ -1,0 +1,81 @@
+import { act } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { UsageProviderChart } from "./UsageProviderChart";
+
+const days = ["2026-09-01", "2026-09-02", "2026-09-03"];
+let renderer: ReactTestRenderer;
+const onZoomToDays = vi.fn();
+const captures = new Set<number>();
+const plot = {
+  getBoundingClientRect: () => ({ left: 0, top: 0, width: 300, height: 260 }),
+  hasPointerCapture: (id: number) => captures.has(id),
+  setPointerCapture: (id: number) => captures.add(id),
+  releasePointerCapture: (id: number) => captures.delete(id),
+};
+
+function chart(windowDays: readonly string[], resolution: "day" | "hour" = "day") {
+  return (
+    <UsageProviderChart
+      days={windowDays}
+      daily={[]}
+      hours={[]}
+      hourly={[]}
+      providers={[]}
+      metric="cost"
+      resolution={resolution}
+      referenceTime={undefined}
+      timeZone="UTC"
+      onZoomToDays={onZoomToDays}
+    />
+  );
+}
+
+function pointer(name: "onPointerDown" | "onPointerUp", clientX: number) {
+  renderer.root
+    .find((node) => node.type === "div" && node.props.onPointerDown !== undefined)
+    .props[name]({ button: 0, isPrimary: true, pointerId: 1, clientX, currentTarget: plot });
+}
+
+beforeEach(async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  onZoomToDays.mockClear();
+  captures.clear();
+  await act(() => {
+    renderer = create(chart(days), {
+      createNodeMock: (element) => (element.type === "div" ? plot : null),
+    });
+  });
+});
+
+afterEach(async () => {
+  await act(() => renderer.unmount());
+  vi.unstubAllGlobals();
+});
+
+describe("usage chart brush ownership", () => {
+  it("cancels a brush if date-field blur replaces its window before pointer-up", async () => {
+    await act(() => pointer("onPointerDown", 0));
+    expect(captures.has(1)).toBe(true);
+    await act(() => renderer.update(chart(["2026-08-01", "2026-08-02", "2026-08-03"])));
+    await act(() => pointer("onPointerUp", 300));
+    expect(onZoomToDays).not.toHaveBeenCalled();
+    expect(captures.has(1)).toBe(false);
+  });
+
+  it("keeps a brush when the same days are supplied by a fresh array", async () => {
+    await act(() => pointer("onPointerDown", 0));
+    await act(() => renderer.update(chart([...days])));
+    await act(() => pointer("onPointerUp", 300));
+    expect(onZoomToDays).toHaveBeenCalledExactlyOnceWith(days[0], days[2]);
+  });
+
+  it("cancels a brush when the view switches to hourly resolution", async () => {
+    await act(() => pointer("onPointerDown", 0));
+    await act(() => renderer.update(chart(days, "hour")));
+    await act(() => pointer("onPointerUp", 300));
+    expect(onZoomToDays).not.toHaveBeenCalled();
+    expect(captures.has(1)).toBe(false);
+  });
+});

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildPeriodColumns, niceScale } from "./UsageProviderChart";
+import {
+  brushSelection,
+  buildPeriodColumns,
+  chartLabelIndices,
+  niceScale,
+  periodIndexAt,
+  spanSinglePeriodPoints,
+} from "./UsageProviderChart";
 import { providersWithUsage } from "./usageProviders";
 
 describe("niceScale", () => {
@@ -133,5 +140,67 @@ describe("hourly chart columns", () => {
         "cost",
       ).map((column) => column.total),
     ).toEqual([0, 4, 0]);
+  });
+});
+
+describe("brushSelection", () => {
+  const days = ["2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04"];
+
+  it("returns inclusive bounds for a forward drag", () => {
+    expect(brushSelection(days, 1, 3)).toEqual({
+      sinceDay: "2026-08-02",
+      untilDay: "2026-08-04",
+    });
+  });
+
+  it("normalises a backward drag", () => {
+    expect(brushSelection(days, 3, 1)).toEqual({
+      sinceDay: "2026-08-02",
+      untilDay: "2026-08-04",
+    });
+  });
+
+  it("treats a plain click as no selection", () => {
+    expect(brushSelection(days, 2, 2)).toBeNull();
+  });
+
+  it("rejects endpoints outside the day list", () => {
+    expect(brushSelection(days, 0, 9)).toBeNull();
+  });
+});
+
+describe("periodIndexAt", () => {
+  it("clamps a captured pointer to either chart edge", () => {
+    expect(periodIndexAt(-50, 100, 400, 5)).toBe(0);
+    expect(periodIndexAt(750, 100, 400, 5)).toBe(4);
+  });
+});
+
+describe("spanSinglePeriodPoints", () => {
+  it("repeats one point across the chart width", () => {
+    expect(spanSinglePeriodPoints([{ x: 0, y: 42 }])).toEqual([
+      { x: 0, y: 42 },
+      { x: 960, y: 42 },
+    ]);
+  });
+
+  it("leaves multi-period points unchanged", () => {
+    const points = [
+      { x: 0, y: 42 },
+      { x: 960, y: 12 },
+    ];
+
+    expect(spanSinglePeriodPoints(points)).toBe(points);
+  });
+});
+
+describe("chartLabelIndices", () => {
+  it("deduplicates labels for one- and two-period windows", () => {
+    expect(chartLabelIndices(1)).toEqual([0]);
+    expect(chartLabelIndices(2)).toEqual([0, 1]);
+  });
+
+  it("keeps left, middle, and right labels for wider windows", () => {
+    expect(chartLabelIndices(5)).toEqual([0, 2, 4]);
   });
 });

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -2,6 +2,8 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
+
+import { cn } from "../../lib/utils";
 import {
   formatDayShort,
   formatHourShort,
@@ -19,6 +21,13 @@ const PLOT_TOP = 8;
 export type UsageChartMetric = "tokens" | "cost";
 
 interface UsageProviderChartProps {
+  /**
+   * Present only when the window can zoom (daily resolution). Receives the
+   * inclusive day bounds of a completed drag selection.
+   */
+  readonly onZoomToDays?: (sinceDay: string, untilDay: string) => void;
+  /** Restores the preset window on double-click. */
+  readonly onResetZoom?: () => void;
   readonly providers: readonly UsageProviderKind[];
   readonly days: readonly string[];
   readonly daily: readonly DailyTotals[];
@@ -42,6 +51,18 @@ export interface DayColumn {
 interface Point {
   readonly x: number;
   readonly y: number;
+}
+
+/** Gives a one-period daily window enough horizontal span to draw a path. */
+export function spanSinglePeriodPoints(points: readonly Point[]): readonly Point[] {
+  const only = points.length === 1 ? points[0] : undefined;
+  return only === undefined ? points : [only, { ...only, x: VIEW_WIDTH }];
+}
+
+/** Selects distinct left, middle, and right labels for the available span. */
+export function chartLabelIndices(periodCount: number): readonly number[] {
+  if (periodCount <= 0) return [];
+  return [...new Set([0, Math.floor(periodCount / 2), periodCount - 1])];
 }
 
 function valueFor(
@@ -169,7 +190,40 @@ export function niceScale(peak: number, count: number): { max: number; ticks: re
   return { max, ticks };
 }
 
+/**
+ * Inclusive day bounds of a brush selection, or null for a plain click.
+ * Endpoints may arrive in either drag direction.
+ */
+export function brushSelection(
+  days: readonly string[],
+  startIndex: number,
+  endIndex: number,
+): { readonly sinceDay: string; readonly untilDay: string } | null {
+  if (startIndex === endIndex) return null;
+  const [first, last] = startIndex < endIndex ? [startIndex, endIndex] : [endIndex, startIndex];
+  const sinceDay = days[first];
+  const untilDay = days[last];
+  if (sinceDay === undefined || untilDay === undefined) return null;
+  return { sinceDay, untilDay };
+}
+
+/** Period index beneath a pointer, clamped when pointer capture moves outside the plot. */
+export function periodIndexAt(
+  clientX: number,
+  plotLeft: number,
+  plotWidth: number,
+  periodCount: number,
+): number | null {
+  if (plotWidth <= 0 || periodCount <= 0) return null;
+  const localX = Math.min(plotWidth, Math.max(0, clientX - plotLeft));
+  const fraction = localX / plotWidth;
+  const index = Math.round(fraction * (periodCount - 1));
+  return Math.min(periodCount - 1, Math.max(0, index));
+}
+
 export function UsageProviderChart({
+  onZoomToDays,
+  onResetZoom,
   providers,
   days,
   daily,
@@ -189,9 +243,35 @@ export function UsageProviderChart({
     [daily, hourly, resolution],
   );
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  // Drag-selection endpoints, as period indices. Only daily windows zoom.
+  const [brush, setBrush] = useState<{ readonly start: number; readonly end: number } | null>(null);
+  const brushRef = useRef<{
+    readonly pointerId: number;
+    readonly days: readonly string[];
+    readonly start: number;
+    readonly end: number;
+  } | null>(null);
+  const zoomable = resolution === "day" && onZoomToDays !== undefined;
   const plotRef = useRef<HTMLDivElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const hoverPositionRef = useRef<{ x: number; y: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const activeBrush = brushRef.current;
+    if (
+      activeBrush === null ||
+      (zoomable &&
+        activeBrush.days.length === days.length &&
+        activeBrush.days.every((day, index) => day === days[index]))
+    )
+      return;
+    brushRef.current = null;
+    setBrush(null);
+    const plot = plotRef.current;
+    if (plot?.hasPointerCapture(activeBrush.pointerId)) {
+      plot.releasePointerCapture(activeBrush.pointerId);
+    }
+  }, [days, zoomable]);
 
   const { paths, ticks, stepX, toY, series } = useMemo(() => {
     if (periods.length === 0) {
@@ -221,14 +301,11 @@ export function UsageProviderChart({
 
     const built = providers.map((provider) => {
       const providerIndex = PROVIDER_ORDER.indexOf(provider);
-      const line = curvePath(
-        smoothCurve(
-          columns.map((column, periodIndex) => ({
-            x: periodIndex * step,
-            y: toY(column.bands[providerIndex]?.value ?? 0),
-          })),
-        ),
-      );
+      const points = columns.map((column, periodIndex) => ({
+        x: periodIndex * step,
+        y: toY(column.bands[providerIndex]?.value ?? 0),
+      }));
+      const line = curvePath(smoothCurve(spanSinglePeriodPoints(points)));
       return {
         provider,
         total: columns.reduce((sum, column) => sum + (column.bands[providerIndex]?.value ?? 0), 0),
@@ -288,22 +365,95 @@ export function UsageProviderChart({
     return () => observer.disconnect();
   }, [hoverIndex, positionTooltip]);
 
+  const indexAt = useCallback(
+    (clientX: number): number | null => {
+      const plot = plotRef.current;
+      if (plot === null || periods.length === 0) return null;
+      const bounds = plot.getBoundingClientRect();
+      return periodIndexAt(clientX, bounds.left, bounds.width, periods.length);
+    },
+    [periods.length],
+  );
+
   const handleMove = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       const plot = plotRef.current;
       if (plot === null || periods.length === 0) return;
       const bounds = plot.getBoundingClientRect();
       if (bounds.width === 0) return;
+      if (brushRef.current !== null) return;
+      const index = indexAt(event.clientX);
+      if (index === null) return;
       const localX = Math.min(bounds.width, Math.max(0, event.clientX - bounds.left));
       const localY = Math.min(bounds.height, Math.max(0, event.clientY - bounds.top));
-      const fraction = localX / bounds.width;
-      const index = Math.round(fraction * (periods.length - 1));
       hoverPositionRef.current = { x: localX, y: localY };
       positionTooltip();
-      setHoverIndex(Math.min(periods.length - 1, Math.max(0, index)));
+      setHoverIndex(index);
     },
-    [periods.length, positionTooltip],
+    [indexAt, periods.length, positionTooltip],
   );
+
+  const trackBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const activeBrush = brushRef.current;
+      if (
+        activeBrush === null ||
+        activeBrush.pointerId !== event.pointerId ||
+        !event.currentTarget.hasPointerCapture(event.pointerId)
+      ) {
+        return;
+      }
+      const index = indexAt(event.clientX);
+      if (index === null || index === activeBrush.end) return;
+      const nextBrush = { ...activeBrush, end: index };
+      brushRef.current = nextBrush;
+      setBrush(nextBrush);
+    },
+    [indexAt],
+  );
+
+  const beginBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!zoomable || event.button !== 0 || !event.isPrimary || brushRef.current !== null) return;
+      const index = indexAt(event.clientX);
+      if (index === null) return;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      hoverPositionRef.current = null;
+      setHoverIndex(null);
+      const nextBrush = { pointerId: event.pointerId, days, start: index, end: index };
+      brushRef.current = nextBrush;
+      setBrush(nextBrush);
+    },
+    [days, indexAt, zoomable],
+  );
+
+  const finishBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const activeBrush = brushRef.current;
+      if (
+        activeBrush === null ||
+        activeBrush.pointerId !== event.pointerId ||
+        onZoomToDays === undefined
+      ) {
+        return;
+      }
+      const end = indexAt(event.clientX) ?? activeBrush.end;
+      const selection = brushSelection(days, activeBrush.start, end);
+      brushRef.current = null;
+      setBrush(null);
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (selection !== null) onZoomToDays(selection.sinceDay, selection.untilDay);
+    },
+    [days, indexAt, onZoomToDays],
+  );
+
+  const cancelBrush = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (brushRef.current?.pointerId !== event.pointerId) return;
+    brushRef.current = null;
+    setBrush(null);
+  }, []);
 
   const hoveredPeriod = hoverIndex === null ? undefined : periods[hoverIndex];
   const hoveredColumn = hoverIndex === null ? undefined : series[hoverIndex];
@@ -332,8 +482,17 @@ export function UsageProviderChart({
 
         <div
           ref={plotRef}
-          className="relative h-56 flex-1"
+          className={cn(
+            "relative h-56 flex-1",
+            zoomable && "cursor-crosshair touch-pan-y select-none",
+          )}
           onMouseMove={handleMove}
+          onPointerDown={beginBrush}
+          onPointerMove={trackBrush}
+          onPointerUp={finishBrush}
+          onPointerCancel={cancelBrush}
+          onLostPointerCapture={cancelBrush}
+          onDoubleClick={onResetZoom}
           onMouseLeave={() => {
             hoverPositionRef.current = null;
             setHoverIndex(null);
@@ -383,7 +542,22 @@ export function UsageProviderChart({
               />
             ))}
 
-            {hoverIndex === null ? null : (
+            {brush === null || brush.start === brush.end ? null : (
+              <rect
+                x={Math.min(brush.start, brush.end) * stepX}
+                y={PLOT_TOP}
+                width={Math.abs(brush.end - brush.start) * stepX}
+                height={VIEW_HEIGHT - PLOT_TOP}
+                fill="currentColor"
+                fillOpacity={0.08}
+                stroke="currentColor"
+                strokeWidth={1}
+                className="text-muted-foreground"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+
+            {hoverIndex === null || periods.length === 1 ? null : (
               <line
                 x1={hoverIndex * stepX}
                 x2={hoverIndex * stepX}
@@ -435,17 +609,9 @@ export function UsageProviderChart({
       </div>
 
       <div className="flex justify-between pl-16 text-[10px] text-muted-foreground uppercase">
-        <span>{periods[0] === undefined ? "" : formatPeriod(periods[0])}</span>
-        <span>
-          {periods[Math.floor(periods.length / 2)] === undefined
-            ? ""
-            : formatPeriod(periods[Math.floor(periods.length / 2)] ?? "")}
-        </span>
-        <span>
-          {periods[periods.length - 1] === undefined
-            ? ""
-            : formatPeriod(periods[periods.length - 1] ?? "")}
-        </span>
+        {chartLabelIndices(periods.length).map((index) => (
+          <span key={index}>{formatPeriod(periods[index] ?? "")}</span>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -76,6 +76,8 @@ export interface UsageView {
 export function useUsage(
   input: UsageSummaryInput,
   selectedEnvironmentIds: ReadonlySet<EnvironmentId> | null = null,
+  /** A namespaced project key, `null` for outside-projects buckets, `undefined` for no filter. */
+  projectFilter?: string | null,
 ): UsageView {
   const windowKey = useMemo(
     () =>
@@ -132,8 +134,12 @@ export function useUsage(
             },
           ],
     );
-    return mergeUsage(answered, USAGE_CONTRACT_VERSION);
-  }, [selectedEnvironments]);
+    return mergeUsage(
+      answered,
+      USAGE_CONTRACT_VERSION,
+      projectFilter === undefined ? undefined : { projectFilter },
+    );
+  }, [selectedEnvironments, projectFilter]);
 
   const answeredCount = selectedEnvironments.filter(
     (environment) => environment.summary !== null,

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -6,6 +6,10 @@
 environments. It shows token use, cache savings, model breakdowns, and estimated API-equivalent
 cost. These estimates are not your subscription bill.
 
+On web and desktop, the date fields beside the presets accept a custom range of up to 90 days.
+Drag across a daily chart to zoom to that range, and double-click the chart to return to the range
+you had before zooming.
+
 Totals depend on the history available on each server. Grok turns without a saved completed-turn
 record are missing from the totals.
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -10,6 +10,12 @@ On web and desktop, the date fields beside the presets accept a custom range of 
 Drag across a daily chart to zoom to that range, and double-click the chart to return to the range
 you had before zooming.
 
+Usage is attributed to the project whose folder a session ran in, including sessions started
+outside T3 Code. On web and desktop, the breakdown's **Project** view ranks projects by the selected
+metric, and the project picker narrows the whole page to one project. Work that ran outside every
+project is grouped under "Outside projects". Grok Build sessions record no folder, so they count in
+the overall totals but not in the project breakdown or filter.
+
 Totals depend on the history available on each server. Grok turns without a saved completed-turn
 record are missing from the totals.
 

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -14,23 +14,26 @@
  */
 import * as Schema from "effect/Schema";
 
-import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, ProjectId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 /**
  * Bumped whenever the shape of {@link UsageSummary} changes incompatibly. The
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 6 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds optional project
+ * attribution to buckets. v4 Claude/Codex buckets remain valid, so
+ * mixed-version environments keep those totals instead of treating every
+ * older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
+/** First contract version whose buckets carry project attribution. */
+export const USAGE_PROJECT_ATTRIBUTION_SINCE = 6 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
@@ -80,8 +83,9 @@ export const UsageTokenTotals = Schema.Struct({
 export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 
 /**
- * One `(day, hourStart?, provider, model)` cell. `hourStart` is the UTC start
- * instant of a rolling bucket and is present only for hourly requests.
+ * One `(day, hourStart?, project, provider, model)` cell. `hourStart` is the
+ * UTC start instant of a rolling bucket and is present only for hourly
+ * requests.
  *
  * `costUsd` is the raw API-equivalent cost of these tokens. It is not money
  * spent: subscription plans bill separately. `unpricedRecords` counts records
@@ -91,6 +95,21 @@ export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 export const UsageBucket = Schema.Struct({
   day: UsageDay,
   hourStart: Schema.optional(TrimmedNonEmptyString),
+  /**
+   * Title of the T3 project whose workspace root contains the session's
+   * working directory, resolved per environment at scan time. Absent when the
+   * session ran outside every project on that environment, or when the
+   * transcript carries no working directory (Grok, and summaries from servers
+   * predating this field).
+   */
+  project: Schema.optional(TrimmedNonEmptyString),
+  /** Stable identity for `project`. */
+  projectId: Schema.optional(ProjectId),
+  /**
+   * Whether the session ran in a project, outside every project, or carried no
+   * working directory. Optional only so current clients can read older summaries.
+   */
+  projectAttribution: Schema.optional(Schema.Literals(["project", "outside", "unknown"])),
   provider: UsageProviderKind,
   model: TrimmedNonEmptyString,
   totals: UsageTokenTotals,

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -2,10 +2,12 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  compareUsageDays,
   enumerateHourStarts,
   formatDateTimeShort,
   formatHourShort,
   formatRelativeHourShort,
+  makeCustomWindow,
   makeWindow,
 } from "./usageFormat.ts";
 
@@ -66,8 +68,48 @@ describe("hourly usage formatting", () => {
 
       expect(makeWindow(1, now, "hour").timeZone).toBe("UTC");
       expect(makeWindow(30, now).timeZone).toBe("UTC");
+      expect(makeCustomWindow("2026-08-01", "2026-08-11").timeZone).toBe("UTC");
     } finally {
       resolvedOptions.mockRestore();
     }
+  });
+});
+
+describe("compareUsageDays", () => {
+  it("orders valid calendar days", () => {
+    expect(compareUsageDays("2026-08-03", "2026-08-11")).toBe(-1);
+    expect(compareUsageDays("2026-08-11", "2026-08-03")).toBe(1);
+    expect(compareUsageDays("2026-08-03", "2026-08-03")).toBe(0);
+  });
+
+  it("rejects impossible and malformed days", () => {
+    expect(compareUsageDays("2026-02-29", "2026-03-01")).toBeNull();
+    expect(compareUsageDays("10000-01-01", "9999-12-31")).toBeNull();
+    expect(compareUsageDays("", "2026-03-01")).toBeNull();
+  });
+});
+
+describe("makeCustomWindow", () => {
+  it("builds a daily window over the inclusive range", () => {
+    expect(makeCustomWindow("2026-08-03", "2026-08-11")).toMatchObject({
+      sinceDay: "2026-08-03",
+      untilDay: "2026-08-11",
+      resolution: "day",
+    });
+  });
+
+  it("swaps out-of-order bounds from a right-to-left drag", () => {
+    expect(makeCustomWindow("2026-08-11", "2026-08-03")).toMatchObject({
+      sinceDay: "2026-08-03",
+      untilDay: "2026-08-11",
+    });
+  });
+
+  it("caps ranges at 90 days", () => {
+    expect(makeCustomWindow("2026-01-01", "2026-12-31").untilDay).toBe("2026-03-31");
+  });
+
+  it("rejects invalid bounds", () => {
+    expect(() => makeCustomWindow("2026-02-30", "2026-03-01")).toThrow(RangeError);
   });
 });

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -107,6 +107,7 @@ describe("makeCustomWindow", () => {
 
   it("caps ranges at 90 days", () => {
     expect(makeCustomWindow("2026-01-01", "2026-12-31").untilDay).toBe("2026-03-31");
+    expect(makeCustomWindow("9999-12-31", "9999-12-31").untilDay).toBe("9999-12-31");
   });
 
   it("rejects invalid bounds", () => {

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -14,6 +14,8 @@ const CURRENCY = new Intl.NumberFormat("en-US", {
 });
 
 const INTEGER = new Intl.NumberFormat("en-US");
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_CUSTOM_WINDOW_DAYS = 90;
 
 export function formatUsd(value: number): string {
   return CURRENCY.format(value);
@@ -170,15 +172,8 @@ export function formatRelativeHourShort(
   return formatDateTimeShort(hourStart, timeZone);
 }
 
-/**
- * The window the page requests, expressed in the viewer's own time zone so days
- * line up with what they actually experienced.
- */
-export function makeWindow(
-  days: number,
-  now = new Date(),
-  resolution: UsageResolution = "day",
-): UsageSummaryInput {
+/** The viewer's zone and a `YYYY-MM-DD` formatter for it; unknown zones fall back to UTC. */
+function viewerDayFormat(): { timeZone: string; format: Intl.DateTimeFormat } {
   let timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
   let format: Intl.DateTimeFormat;
   try {
@@ -198,6 +193,53 @@ export function makeWindow(
       day: "2-digit",
     });
   }
+  return { timeZone, format };
+}
+
+/** Strict `YYYY-MM-DD` calendar day, rejecting impossible dates such as `2026-02-30`. */
+function isUsageDay(value: string): boolean {
+  return (
+    /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+    new Date(`${value}T00:00:00Z`).toISOString().slice(0, 10) === value
+  );
+}
+
+/** Orders two `YYYY-MM-DD` days, or returns null when either is not a real calendar day. */
+export function compareUsageDays(left: string, right: string): -1 | 0 | 1 | null {
+  if (!isUsageDay(left) || !isUsageDay(right)) return null;
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/**
+ * A daily window over an inclusive day range from the date inputs or a chart
+ * drag. Out-of-order bounds are swapped, and spans are capped at the largest
+ * preset (90 days) so day enumeration stays bounded.
+ */
+export function makeCustomWindow(sinceDay: string, untilDay: string): UsageSummaryInput {
+  const comparison = compareUsageDays(sinceDay, untilDay);
+  if (comparison === null) throw new RangeError("Usage window bounds must be YYYY-MM-DD dates");
+  const [first, last] = comparison <= 0 ? [sinceDay, untilDay] : [untilDay, sinceDay];
+  const maxLast = new Date(Date.parse(`${first}T00:00:00Z`) + (MAX_CUSTOM_WINDOW_DAYS - 1) * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  return {
+    sinceDay: UsageDay.make(first),
+    untilDay: UsageDay.make(last > maxLast ? maxLast : last),
+    timeZone: viewerDayFormat().timeZone,
+    resolution: "day",
+  };
+}
+
+/**
+ * The window the page requests, expressed in the viewer's own time zone so days
+ * line up with what they actually experienced.
+ */
+export function makeWindow(
+  days: number,
+  now = new Date(),
+  resolution: UsageResolution = "day",
+): UsageSummaryInput {
+  const { timeZone, format } = viewerDayFormat();
   const untilDay = format.format(now);
   if (resolution === "hour") {
     // Minute-aligned bounds keep labels readable while still representing an

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -219,12 +219,11 @@ export function makeCustomWindow(sinceDay: string, untilDay: string): UsageSumma
   const comparison = compareUsageDays(sinceDay, untilDay);
   if (comparison === null) throw new RangeError("Usage window bounds must be YYYY-MM-DD dates");
   const [first, last] = comparison <= 0 ? [sinceDay, untilDay] : [untilDay, sinceDay];
-  const maxLast = new Date(Date.parse(`${first}T00:00:00Z`) + (MAX_CUSTOM_WINDOW_DAYS - 1) * DAY_MS)
-    .toISOString()
-    .slice(0, 10);
+  const maxLastMs = Date.parse(`${first}T00:00:00Z`) + (MAX_CUSTOM_WINDOW_DAYS - 1) * DAY_MS;
+  const capped = Date.parse(`${last}T00:00:00Z`) > maxLastMs;
   return {
     sinceDay: UsageDay.make(first),
-    untilDay: UsageDay.make(last > maxLast ? maxLast : last),
+    untilDay: UsageDay.make(capped ? new Date(maxLastMs).toISOString().slice(0, 10) : last),
     timeZone: viewerDayFormat().timeZone,
     resolution: "day",
   };

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,5 +1,8 @@
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
+  USAGE_PROJECT_ATTRIBUTION_SINCE,
+  ProjectId,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -9,6 +12,10 @@ import {
 import { describe, expect, it } from "vite-plus/test";
 
 import { isModelCostUnknown, mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
+
+function inProject(id: string, title: string): Partial<UsageBucket> {
+  return { projectId: ProjectId.make(id), project: title, projectAttribution: "project" };
+}
 
 function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
   return {
@@ -28,6 +35,7 @@ function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
     records: 5,
     unpricedRecords: 0,
     sessions: 1,
+    projectAttribution: "outside",
     ...overrides,
   };
 }
@@ -158,7 +166,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket()],
             [{ provider: "claude", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 2,
+            USAGE_MERGE_COMPATIBLE_SINCE - 1,
           ),
         ),
       ],
@@ -369,5 +377,185 @@ describe("mergeUsage", () => {
     ]);
     expect(merged.daily).toHaveLength(1);
     expect(merged.daily[0]?.costUsd).toBe(10);
+  });
+
+  it("rolls buckets up by project, with explicit outside buckets under null", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ ...inProject("app", "App"), costUsd: 6 }),
+              bucket({ ...inProject("app", "App"), costUsd: 2, model: "claude-opus-5" }),
+              bucket({ costUsd: 2 }),
+            ],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.projects.map((project) => [project.project, project.costUsd])).toEqual([
+      ["App", 8],
+      [null, 2],
+    ]);
+    expect(merged.projects[0]?.costShare).toBeCloseTo(0.8, 9);
+  });
+
+  it("keeps projects with the same title distinct and filters by stable id", () => {
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ ...inProject("project-first", "App"), costUsd: 6 }),
+            bucket({ ...inProject("project-second", "App"), costUsd: 2 }),
+          ],
+          [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+        ),
+      ),
+    ];
+
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    expect(
+      merged.projects.map((project) => [project.projectId, project.project, project.costUsd]),
+    ).toEqual([
+      ["project-first", "App", 6],
+      ["project-second", "App", 2],
+    ]);
+
+    const secondKey = merged.projects[1]?.projectKey;
+    if (typeof secondKey !== "string") throw new Error("second project key missing");
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: secondKey });
+    expect(filtered.costUsd).toBe(2);
+  });
+
+  it("filters every figure except the project list when a project is selected", () => {
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ ...inProject("app", "App"), costUsd: 6 }),
+            bucket({ costUsd: 2, provider: "codex", model: "gpt-5.6-sol" }),
+          ],
+          [
+            { provider: "claude", hostId: "mac", homePath: "/a/.claude" },
+            { provider: "codex", hostId: "mac", homePath: "/a/.codex" },
+          ],
+        ),
+      ),
+    ];
+
+    const unfiltered = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    const appKey = unfiltered.projects.find((project) => project.project === "App")?.projectKey;
+    if (typeof appKey !== "string") throw new Error("app project key missing");
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: appKey });
+    expect(filtered.costUsd).toBe(6);
+    expect(filtered.providers.map((provider) => provider.provider)).toEqual(["claude"]);
+    // Session counts are per source directory and cannot be split by project.
+    expect(filtered.sessions).toBe(0);
+    // The picker keeps its full option list while the filter narrows the rest.
+    expect(filtered.projects.map((project) => project.project)).toEqual(["App", null]);
+
+    const outside = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: null });
+    expect(outside.costUsd).toBe(2);
+    expect(outside.providers.map((provider) => provider.provider)).toEqual(["codex"]);
+  });
+
+  it("keeps equal project ids on different environments apart", () => {
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [bucket({ ...inProject("cloned-project", "App"), costUsd: 6 })],
+          [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+        ),
+      ),
+      environment(
+        "env-b",
+        summary(
+          [bucket({ ...inProject("cloned-project", "App"), costUsd: 2 })],
+          [{ provider: "claude", hostId: "linux", homePath: "/b/.claude" }],
+        ),
+      ),
+    ];
+
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    expect(merged.projects.map((project) => project.costUsd)).toEqual([6, 2]);
+    const firstKey = merged.projects[0]?.projectKey;
+    if (typeof firstKey !== "string") throw new Error("project key missing");
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: firstKey });
+    expect(filtered.costUsd).toBe(6);
+  });
+
+  it("marks a project whose every record lacked rates as unpriced", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ ...inProject("app", "App"), costUsd: 0, records: 3, unpricedRecords: 3 }),
+              bucket({ costUsd: 2 }),
+            ],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.projects.filter(isModelCostUnknown).map((project) => project.project)).toEqual([
+      "App",
+    ]);
+  });
+
+  it("does not treat unknown attribution from old summaries as outside projects", () => {
+    const oldEnvironment = environment(
+      "env-old",
+      summary(
+        [bucket({ costUsd: 4, projectAttribution: undefined })],
+        [{ provider: "claude", hostId: "mac", homePath: "/old/.claude" }],
+        USAGE_PROJECT_ATTRIBUTION_SINCE - 1,
+      ),
+    );
+
+    const unfiltered = mergeUsage([oldEnvironment], USAGE_CONTRACT_VERSION);
+    expect(unfiltered.costUsd).toBe(4);
+    expect(unfiltered.projects).toEqual([]);
+
+    const outside = mergeUsage([oldEnvironment], USAGE_CONTRACT_VERSION, {
+      projectFilter: null,
+    });
+    expect(outside.costUsd).toBe(0);
+  });
+
+  it("does not treat current unknown attribution as outside projects", () => {
+    const currentEnvironment = environment(
+      "env-current",
+      summary(
+        [
+          bucket({
+            provider: "grok",
+            model: "grok-code-fast-1",
+            costUsd: 4,
+            projectAttribution: "unknown",
+          }),
+        ],
+        [{ provider: "grok", hostId: "mac", homePath: "/unknown" }],
+      ),
+    );
+
+    const unfiltered = mergeUsage([currentEnvironment], USAGE_CONTRACT_VERSION);
+    expect(unfiltered.costUsd).toBe(4);
+    expect(unfiltered.projects).toEqual([]);
+
+    const outside = mergeUsage([currentEnvironment], USAGE_CONTRACT_VERSION, {
+      projectFilter: null,
+    });
+    expect(outside.costUsd).toBe(0);
   });
 });

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -9,6 +9,7 @@
 import {
   USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
+  type ProjectId,
   type UsageBucket,
   type UsageProviderKind,
   type UsageSourceFingerprint,
@@ -45,12 +46,27 @@ export interface ModelTotals {
   readonly costShare: number;
 }
 
+/** One project's slice of the window. `project` is null for buckets that ran outside every project. */
+export interface ProjectTotals {
+  readonly projectId: ProjectId | null;
+  /** Stable, environment-namespaced value accepted by `MergeUsageOptions.projectFilter`. */
+  readonly projectKey: string | null;
+  readonly project: string | null;
+  readonly costUsd: number;
+  readonly totalTokens: number;
+  readonly records: number;
+  readonly unpricedRecords: number;
+  readonly costShare: number;
+}
+
 /**
- * A model whose every record lacked rates has an unknown cost, not a zero one.
- * Clients must not present its `costUsd` as a real dollar figure.
+ * A model or project whose every record lacked rates has an unknown cost, not
+ * a zero one. Clients must not present its `costUsd` as a real dollar figure.
  */
-export function isModelCostUnknown(model: ModelTotals): boolean {
-  return model.records > 0 && model.unpricedRecords >= model.records;
+export function isModelCostUnknown(
+  totals: Pick<ModelTotals | ProjectTotals, "records" | "unpricedRecords">,
+): boolean {
+  return totals.records > 0 && totals.unpricedRecords >= totals.records;
 }
 
 export interface DailyTotals {
@@ -87,6 +103,11 @@ export interface MergedUsage {
   readonly sessions: number;
   readonly providers: readonly ProviderTotals[];
   readonly models: readonly ModelTotals[];
+  /**
+   * Always computed from the unfiltered buckets, so a project picker keeps its
+   * full option list while a filter is applied.
+   */
+  readonly projects: readonly ProjectTotals[];
   readonly daily: readonly DailyTotals[];
   readonly hourly: readonly HourlyTotals[];
   readonly costQuality: CostQuality;
@@ -202,6 +223,7 @@ const EMPTY_MERGED: MergedUsage = {
   sessions: 0,
   providers: [],
   models: [],
+  projects: [],
   daily: [],
   hourly: [],
   costQuality: {
@@ -215,6 +237,31 @@ const EMPTY_MERGED: MergedUsage = {
   staleEnvironments: [],
 };
 
+export interface MergeUsageOptions {
+  /**
+   * Restrict every figure except `projects` to buckets from one project:
+   * a project's namespaced key selects that project, `null` selects buckets
+   * that ran outside every project, and `undefined` applies no filter.
+   *
+   * Sessions are counted per source directory, not per project, so a filtered
+   * merge reports `sessions` as 0 rather than a number it cannot know.
+   */
+  readonly projectFilter?: string | null;
+}
+
+/**
+ * Namespaces a bucket's project by environment so equal ids or titles on two
+ * servers stay separate. `null` is the explicit outside-projects slice and
+ * `undefined` is unknown attribution (no working directory, or a pre-v6 server).
+ */
+function bucketProjectKey(
+  environmentId: EnvironmentId,
+  bucket: UsageBucket,
+): string | null | undefined {
+  if (bucket.projectId !== undefined) return JSON.stringify([environmentId, bucket.projectId]);
+  return bucket.projectAttribution === "outside" ? null : undefined;
+}
+
 /**
  * Merges every connected environment's summary.
  *
@@ -227,8 +274,10 @@ const EMPTY_MERGED: MergedUsage = {
 export function mergeUsage(
   environments: readonly EnvironmentUsage[],
   expectedContractVersion: number,
+  options?: MergeUsageOptions,
 ): MergedUsage {
   if (environments.length === 0) return EMPTY_MERGED;
+  const projectFilter = options?.projectFilter;
 
   const current: EnvironmentUsage[] = [];
   const staleEnvironments: EnvironmentId[] = [];
@@ -270,6 +319,20 @@ export function mergeUsage(
       unpricedRecords: number;
     }
   >();
+  // Accumulated before the project filter so the picker keeps every option.
+  const projectAccumulator = new Map<
+    string | null,
+    {
+      projectId: ProjectId | null;
+      projectKey: string | null;
+      project: string | null;
+      costUsd: number;
+      totalTokens: number;
+      records: number;
+      unpricedRecords: number;
+    }
+  >();
+  let unfilteredCostUsd = 0;
   const dailyAccumulator = new Map<
     string,
     {
@@ -294,21 +357,50 @@ export function mergeUsage(
     const { buckets, sessionsByProvider } = ownedContribution(environment, ownerByFingerprint);
     if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);
 
-    for (const [providerKind, providerSessions] of sessionsByProvider) {
-      sessions += providerSessions;
-      if (providerSessions === 0) continue;
-      const provider = providerAccumulator.get(providerKind) ?? {
-        costUsd: 0,
-        totalTokens: 0,
-        records: 0,
-        sessions: 0,
-      };
-      provider.sessions += providerSessions;
-      providerAccumulator.set(providerKind, provider);
+    // Session counts are per source directory; a project filter cannot split
+    // them, so a filtered merge leaves every session figure at 0.
+    if (projectFilter === undefined) {
+      for (const [providerKind, providerSessions] of sessionsByProvider) {
+        sessions += providerSessions;
+        if (providerSessions === 0) continue;
+        const provider = providerAccumulator.get(providerKind) ?? {
+          costUsd: 0,
+          totalTokens: 0,
+          records: 0,
+          sessions: 0,
+        };
+        provider.sessions += providerSessions;
+        providerAccumulator.set(providerKind, provider);
+      }
     }
 
     for (const bucket of buckets) {
       const tokens = bucketTokens(bucket);
+
+      unfilteredCostUsd += bucket.costUsd;
+      const projectKey = bucketProjectKey(environment.environmentId, bucket);
+      // Unknown attribution stays in unfiltered totals but never claims to be
+      // part of the explicit Outside projects slice.
+      if (projectKey === undefined) {
+        if (projectFilter !== undefined) continue;
+      } else {
+        const project = projectAccumulator.get(projectKey) ?? {
+          projectId: bucket.projectId ?? null,
+          projectKey,
+          project: bucket.project ?? null,
+          costUsd: 0,
+          totalTokens: 0,
+          records: 0,
+          unpricedRecords: 0,
+        };
+        project.costUsd += bucket.costUsd;
+        project.totalTokens += tokens;
+        project.records += bucket.records;
+        project.unpricedRecords += bucket.unpricedRecords;
+        projectAccumulator.set(projectKey, project);
+
+        if (projectFilter !== undefined && projectKey !== projectFilter) continue;
+      }
 
       costUsd += bucket.costUsd;
       cacheSavingsUsd += bucket.cacheSavingsUsd;
@@ -407,6 +499,19 @@ export function mergeUsage(
     }))
     .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
 
+  const projects: ProjectTotals[] = [...projectAccumulator.entries()]
+    .map(([, totals]) => ({
+      projectId: totals.projectId,
+      projectKey: totals.projectKey,
+      project: totals.project,
+      costUsd: totals.costUsd,
+      totalTokens: totals.totalTokens,
+      records: totals.records,
+      unpricedRecords: totals.unpricedRecords,
+      costShare: unfilteredCostUsd === 0 ? 0 : totals.costUsd / unfilteredCostUsd,
+    }))
+    .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
+
   const daily: DailyTotals[] = [...dailyAccumulator.entries()]
     .map(([day, totals]) => ({
       day,
@@ -432,6 +537,7 @@ export function mergeUsage(
     sessions,
     providers,
     models,
+    projects,
     daily,
     hourly,
     costQuality: {


### PR DESCRIPTION
Usage totals show which provider and model spent the money, but not which project. When several workspaces share one environment, that's the question users actually have.

**Depends on #9014.** This branch contains #9014's commits (`cf2474d602`, `0f7cd7f00d`) followed by this PR's single commit `80985a75ad`. [Review only the project increment](https://github.com/pingdotgg/t3code/pull/9015/commits/80985a75ad). Merge #9014 first; the PR stays in draft until then.

## How it works

- **Server.** Claude and Codex transcripts already record each session's working directory. The scanner now keeps that `cwd` (Codex follows `turn_context` changes). At scan time it resolves the cwd against the environment's project list (`ProjectionProjectRepository.listAll`, which includes soft-deleted projects so their past spend stays attributed). The deepest workspace root wins. Each bucket is tagged `project`, `outside`, or `unknown`. Grok logs carry no folder, and a project-list read failure also yields `unknown`, never a misleading "outside".
- **Contract.** `UsageBucket` gains optional `project`, `projectId`, and `projectAttribution`; `USAGE_CONTRACT_VERSION` goes 5 → 6. Older servers keep merging, and their buckets count as unknown attribution. The scan cache goes v3 → v4 so cached records carry their cwd; this costs one full rescan after upgrade.
- **Shared merge.** `mergeUsage` rolls buckets up into `projects`, keyed per environment, so equal ids or titles on two servers stay separate. An optional `projectFilter` narrows every other figure. Session counts can't be split by project, so they're hidden while a filter is active. Fully unpriced projects reuse main's unpriced treatment (#11021) instead of showing $0.00.
- **Web.** The breakdown gains a **Project** view, ranked by the selected metric. A project picker (All projects / each project / Outside projects) narrows the page; "All projects" clears it.
- **Mobile.** Not in this PR. Mobile totals still merge correctly with the v6 contract; the project view can follow separately.

## Screenshots

Isolated dev server, synthetic Claude transcripts for two projects (Atlas, Beacon) plus work in an unregistered folder, 30-day window.

Before (#9014 head `0f7cd7f00d`): model and day breakdowns only.

![Before: Usage page with Model and Day breakdowns](https://github.com/saphid/t3code/releases/download/pr-evidence-9015-20260911/usage-9015-before.png)

After (`80985a75ad`): Project breakdown. The rows add up to the $36.04 headline, and unregistered work appears as "Outside projects".

![After: Project breakdown with Beacon, Atlas and Outside projects](https://github.com/saphid/t3code/releases/download/pr-evidence-9015-20260911/usage-9015-after-project-breakdown.png)

After, Atlas selected in the picker: headline, chart, totals and table all narrow to $12.23.

![After: Atlas filter narrows the whole page](https://github.com/saphid/t3code/releases/download/pr-evidence-9015-20260911/usage-9015-after-atlas-filter.png)

## Verification

- `vp test run apps/server/src/usage/ apps/web/src/components/usage/ apps/web/src/state/usage.test.tsx packages/shared/src/usageMerge.test.ts packages/shared/src/usageFormat.test.ts`: 17 files, 210 tests pass. New coverage: service-level attribution (project vs outside), unknown attribution on repository failure, the resolver's nesting/boundary/deleted-project rules, scan-cache cwd round trip, Codex cwd changes, and merge filtering/namespacing/unpriced projects.
- Typecheck passes for `t3`, `@t3tools/web`, `@t3tools/shared`, `@t3tools/contracts`, `@t3tools/mobile`. `vp lint` and `vp fmt` pass on the touched files.
- A cross-provider (Codex) review was skipped because Codex weekly quota was at 7%.

## Rework note

This head replaces the earlier cumulative stack. The refresh-token cache bypass, retained refresh statuses, refresh error toasts/alerts, the segmented `Input` variant, and the three unshipped contract bumps (v6–v8) are gone. They weren't needed for project attribution; any that are still wanted belong in their own PRs.

Coordination trace: T3 thread 7227674d-e4cd-4b7a-b0d4-08e32d2e1e0e

Reworked with Claude Opus 5 in the Claude Code harness (via T3 Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
