### PR TITLE
feat(usage): surface estimated cache-write cost

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -18,7 +18,7 @@ import {
   makeWindow,
 } from "@t3tools/shared/usageFormat";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Platform, Pressable, RefreshControl, ScrollView, View } from "react-native";
+import { Alert, Platform, Pressable, RefreshControl, ScrollView, View } from "react-native";
 import Animated, { Easing, FadeIn, LinearTransition, ReduceMotion } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -129,10 +129,17 @@ export function UsageRouteScreen() {
     }
     refreshingRef.current = true;
     setRefreshingUsage(true);
-    void refresh(nextWindow).finally(() => {
-      refreshingRef.current = false;
-      setRefreshingUsage(false);
-    });
+    void refresh(nextWindow)
+      .catch((error: unknown) => {
+        Alert.alert(
+          "Could not refresh usage",
+          error instanceof Error ? error.message : "Try again.",
+        );
+      })
+      .finally(() => {
+        refreshingRef.current = false;
+        setRefreshingUsage(false);
+      });
   };
 
   const showEnvironmentFilter = environments.length > 0 || selectedEnvironmentIds !== null;

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -1,3 +1,4 @@
+import { uuidv4 } from "../lib/uuid";
 /**
  * Multi-environment usage state.
  *
@@ -17,10 +18,16 @@ import {
   type UsageSummaryInput,
 } from "@t3tools/contracts";
 import { refreshUsage } from "@t3tools/client-runtime/state/usage";
-import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
+import {
+  mergeUsage,
+  retainUsageStatuses,
+  type SettledUsageStatuses,
+  type EnvironmentUsage,
+  type MergedUsage,
+} from "@t3tools/shared/usageMerge";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { appAtomRegistry } from "./atom-registry";
 import { environmentPresentations } from "./presentation";
@@ -102,7 +109,13 @@ export function useUsage(
     ],
   );
   const atom = usageByWindowAtom(windowKey);
-  const environments = useAtomValue(atom);
+  const currentEnvironments = useAtomValue(atom);
+  const settledStatuses = useRef<SettledUsageStatuses<EnvironmentUsageStatus> | null>(null);
+  const retained = retainUsageStatuses(windowKey, currentEnvironments, settledStatuses.current);
+  useEffect(() => {
+    settledStatuses.current = retained.settled;
+  }, [retained.settled]);
+  const environments = retained.visible;
   const selectedEnvironments = useMemo(
     () =>
       selectedEnvironmentIds === null
@@ -115,6 +128,7 @@ export function useUsage(
     (nextInput?: UsageSummaryInput) =>
       refreshUsage({
         registry: appAtomRegistry,
+        refreshToken: uuidv4(),
         server: serverEnvironment,
         presentations: environmentPresentations,
         environmentIds: selectedEnvironments.map(({ environmentId }) => environmentId),

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -58,6 +58,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverGetResourceTelemetryHistory]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRetryResourceTelemetry]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverGetUsageSummary]: AuthOrchestrationReadScope,
+  [WS_METHODS.serverGetUsageThreadBreakdown]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshUsageRates]: AuthOrchestrationReadScope,
   [WS_METHODS.serverSignalProcess]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverReportClientActivity]: AuthOrchestrationReadScope,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -28,6 +28,8 @@ import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { pullRequestHttpApiLayer } from "./pullRequest/http.ts";
 import * as PullRequestProviderRegistry from "./pullRequest/PullRequestProviderRegistry.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
+import { ProjectionProjectRepositoryLive } from "./persistence/Layers/ProjectionProjects.ts";
+import { ProjectionThreadRepositoryLive } from "./persistence/Layers/ProjectionThreads.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
@@ -202,7 +204,14 @@ const BackgroundLayerLive = BackgroundPolicy.layer.pipe(
   Layer.provideMerge(ServerSettingsLayerLive),
 );
 
-const UsageLayerLive = UsageService.layer.pipe(Layer.provide(ServerSettingsLayerLive));
+const UsageLayerLive = UsageService.layer.pipe(
+  // Projects resolve each session's cwd to the project it ran in; threads and
+  // resume cursors attribute sessions to threads for the drill-down.
+  Layer.provide(ProjectionProjectRepositoryLive),
+  Layer.provide(ProjectionThreadRepositoryLive),
+  Layer.provide(ProviderSessionRuntime.layer),
+  Layer.provide(ServerSettingsLayerLive),
+);
 
 const ResourceDiagnosticsLayerLive = Layer.mergeAll(
   HostResources.layer,

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -8,27 +8,40 @@ import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
-import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Scheduler from "effect/Scheduler";
+import * as Tracer from "effect/Tracer";
 import * as TestClock from "effect/testing/TestClock";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
+import { ProjectionProjectRepositoryLive } from "../persistence/Layers/ProjectionProjects.ts";
+import { ProjectionThreadRepositoryLive } from "../persistence/Layers/ProjectionThreads.ts";
+import { PersistenceSqlError } from "../persistence/Errors.ts";
+import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import * as ProviderSessionRuntime from "../persistence/ProviderSessionRuntime.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as UsageService from "./UsageService.ts";
 
-function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"): string {
+function claudeLine(
+  id: number,
+  outputTokens: number,
+  model = "claude-fable-5",
+  cwd?: string,
+): string {
   return `${JSON.stringify({
     type: "assistant",
     timestamp: "2026-08-01T10:00:00Z",
     requestId: `req_${id}`,
     sessionId: "session-1",
+    ...(cwd === undefined ? {} : { cwd }),
     message: {
       id: `msg_${id}`,
       model,
@@ -41,6 +54,12 @@ const WINDOW: UsageSummaryInput = {
   timeZone: "UTC",
   sinceDay: UsageDay.make("2026-07-31"),
   untilDay: UsageDay.make("2026-08-02"),
+};
+
+const NARROW_WINDOW: UsageSummaryInput = {
+  ...WINDOW,
+  sinceDay: UsageDay.make("2026-08-01"),
+  untilDay: UsageDay.make("2026-08-01"),
 };
 
 const setup = Effect.gen(function* () {
@@ -71,6 +90,8 @@ const serviceLayers = (input: {
   readonly onRatesFetch?: () => void;
   /** Defaults to an unparsable document so every scan retries the fetch. */
   readonly ratesDocument?: unknown;
+  readonly projectRepository?: ProjectionProjectRepository["Service"];
+  readonly runtimeRepository?: ProviderSessionRuntime.ProviderSessionRuntimeRepository["Service"];
 }) =>
   ServerConfig.layerTest(process.cwd(), { prefix: input.prefix }).pipe(
     Layer.provideMerge(NodeServices.layer),
@@ -91,6 +112,21 @@ const serviceLayers = (input: {
     Layer.provideMerge(
       Layer.succeed(HostProcessEnvironment, { GROK_HOME: NodePath.join(input.home, "grok") }),
     ),
+    Layer.provideMerge(
+      Layer.mergeAll(
+        input.projectRepository === undefined
+          ? ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory))
+          : Layer.succeed(ProjectionProjectRepository, input.projectRepository),
+        ProjectionThreadRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+        input.runtimeRepository === undefined
+          ? ProviderSessionRuntime.layer.pipe(Layer.provideMerge(SqlitePersistenceMemory))
+          : Layer.succeed(
+              ProviderSessionRuntime.ProviderSessionRuntimeRepository,
+              input.runtimeRepository,
+            ),
+        SqlitePersistenceMemory,
+      ),
+    ),
   );
 
 function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens: number } }[] }) {
@@ -98,6 +134,36 @@ function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens
 }
 
 describe("UsageService", () => {
+  it.live("does not hide a project repository defect as unknown attribution", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      const defect = new Error("project repository defect");
+      const repositoryDefect = Effect.die(defect);
+      const defectRepository: ProjectionProjectRepository["Service"] = {
+        upsert: () => repositoryDefect,
+        getById: () => repositoryDefect,
+        listAll: () => repositoryDefect,
+        deleteById: () => repositoryDefect,
+      };
+      const exit = yield* Effect.gen(function* () {
+        const service = yield* UsageService.make;
+        return yield* Effect.exit(service.readSummary(WINDOW));
+      }).pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-project-defect-test",
+            home,
+            settings,
+            projectRepository: defectRepository,
+          }),
+        ),
+      );
+      assert.isTrue(Exit.isFailure(exit));
+      if (Exit.isFailure(exit)) assert.strictEqual(Cause.squash(exit.cause), defect);
+    }).pipe(Effect.scoped),
+  );
+
   it.live("reprices unchanged transcripts when custom prices are added, edited, or removed", () =>
     Effect.gen(function* () {
       const { transcript, settings, home } = yield* setup;
@@ -150,12 +216,92 @@ describe("UsageService", () => {
         Effect.provide(serviceLayers({ prefix: "usage-service-grow-test", home, settings })),
       );
 
-      const first = yield* service.readSummary(WINDOW);
+      const first = yield* service.readSummary(NARROW_WINDOW);
       assert.strictEqual(totalOutputTokens(first), 5);
 
       yield* Effect.promise(() => NodeFSP.appendFile(transcript, claudeLine(2, 7)));
+      // Expanding beyond the cached coverage requires a source update. The
+      // grown transcript resumes at its cached byte position.
       const second = yield* service.readSummary(WINDOW);
       assert.strictEqual(totalOutputTokens(second), 12);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("replaces a cached progressive snapshot when a transcript grows", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(serviceLayers({ prefix: "usage-service-progressive-test", home, settings })),
+      );
+
+      const first = yield* service.readSummary(WINDOW);
+      assert.strictEqual(totalOutputTokens(first), 5);
+
+      yield* Effect.promise(() => NodeFSP.appendFile(transcript, claudeLine(1, 12)));
+      const second = yield* service.readSummary({ ...WINDOW, refreshToken: "progressive-final" });
+      assert.strictEqual(totalOutputTokens(second), 12);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("keeps project attribution unknown when the project repository cannot be read", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() =>
+        NodeFSP.writeFile(transcript, claudeLine(1, 5, "claude-fable-5", "/work/app")),
+      );
+      const repositoryFailure = Effect.fail(
+        new PersistenceSqlError({ operation: "ProjectionProjectRepository.listAll:test" }),
+      );
+      const projectRepository: ProjectionProjectRepository["Service"] = {
+        upsert: () => repositoryFailure,
+        getById: () => repositoryFailure,
+        listAll: () => repositoryFailure,
+        deleteById: () => repositoryFailure,
+      };
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-project-failure-test",
+            home,
+            settings,
+            projectRepository,
+          }),
+        ),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+      assert.strictEqual(summary.buckets[0]?.projectAttribution, "unknown");
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("returns a usage read error when provider runtime state cannot be read", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const repositoryFailure = Effect.die(new Error("runtime repository unavailable"));
+      const runtimeRepository: ProviderSessionRuntime.ProviderSessionRuntimeRepository["Service"] =
+        {
+          upsert: () => repositoryFailure,
+          recordImportedTranscript: () => repositoryFailure,
+          getByThreadId: () => repositoryFailure,
+          list: () => repositoryFailure,
+          deleteByThreadId: () => repositoryFailure,
+        };
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-runtime-failure-test",
+            home,
+            settings,
+            runtimeRepository,
+          }),
+        ),
+      );
+
+      const error = yield* service.readThreadBreakdown(WINDOW).pipe(Effect.flip);
+      assert.strictEqual(error.reason, "scanFailed");
+      assert.strictEqual(error.detail, "Provider runtime state could not be read");
     }).pipe(Effect.scoped),
   );
 
@@ -166,31 +312,14 @@ describe("UsageService", () => {
 
       yield* Effect.gen(function* () {
         const settingsService = yield* ServerSettings.ServerSettingsService;
-        const fileSystem = yield* FileSystem.FileSystem;
         const firstScanStarted = yield* Deferred.make<void>();
-        const secondScanStarted = yield* Deferred.make<void>();
         const releaseRates = yield* Deferred.make<void>();
-        let homeProbes = 0;
         const service = yield* UsageService.make.pipe(
-          Effect.provideService(FileSystem.FileSystem, {
-            ...fileSystem,
-            exists: (path) =>
-              fileSystem.exists(path).pipe(
-                Effect.tap(() => {
-                  if (path !== NodePath.join(home, "claude", ".claude", "projects"))
-                    return Effect.void;
-                  homeProbes += 1;
-                  return Deferred.succeed(
-                    homeProbes === 1 ? firstScanStarted : secondScanStarted,
-                    undefined,
-                  );
-                }),
-              ),
-          }),
           Effect.provideService(
             HttpClient.HttpClient,
             HttpClient.make((request) =>
-              Deferred.await(releaseRates).pipe(
+              Deferred.succeed(firstScanStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseRates)),
                 Effect.as(HttpClientResponse.fromWeb(request, Response.json({}))),
               ),
             ),
@@ -204,7 +333,19 @@ describe("UsageService", () => {
             "example-model": { inputCostPerMillionTokens: 2, outputCostPerMillionTokens: 8 },
           },
         });
-        const second = yield* service.readSummary(WINDOW).pipe(Effect.forkChild);
+        const secondScanStarted = yield* Deferred.make<void>();
+        const tracer = Tracer.make({
+          span: (options) => {
+            const span = new Tracer.NativeSpan(options);
+            if (span.name === "UsageService.scanSummary") {
+              Deferred.doneUnsafe(secondScanStarted, Effect.void);
+            }
+            return span;
+          },
+        });
+        const second = yield* service
+          .readSummary(WINDOW)
+          .pipe(Effect.withTracer(tracer), Effect.forkChild);
         yield* Deferred.await(secondScanStarted);
         yield* Deferred.succeed(releaseRates, undefined);
 
@@ -244,8 +385,141 @@ describe("UsageService", () => {
       assert.deepStrictEqual(first, second);
       assert.strictEqual(ratesFetches, 1);
 
-      // A later request is fresh work again, not a stale cached answer.
+      // A later request within the freshness window reuses the source snapshot.
       yield* service.readSummary(WINDOW);
+      assert.strictEqual(ratesFetches, 1);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("coalesces concurrent caller refresh tokens for the same summary", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      const scanStarted = yield* Deferred.make<void>();
+      const releaseScan = yield* Deferred.make<void>();
+      let projectReads = 0;
+      const unused = Effect.die(new Error("unused project repository operation"));
+      const projectRepository: ProjectionProjectRepository["Service"] = {
+        upsert: () => unused,
+        getById: () => unused,
+        listAll: () =>
+          Effect.sync(() => {
+            projectReads += 1;
+          }).pipe(
+            Effect.andThen(Deferred.succeed(scanStarted, undefined)),
+            Effect.andThen(Deferred.await(releaseScan)),
+            Effect.as([]),
+          ),
+        deleteById: () => unused,
+      };
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-refresh-coalescing-test",
+            home,
+            settings,
+            projectRepository,
+          }),
+        ),
+      );
+
+      const reads = yield* Effect.forEach(
+        Array.from({ length: 16 }, (_, index) => `caller-${index}`),
+        (refreshToken) => service.readSummary({ ...WINDOW, refreshToken }),
+        { concurrency: "unbounded" },
+      ).pipe(Effect.forkChild);
+      yield* Deferred.await(scanStarted);
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(releaseScan, undefined);
+      const summaries = yield* Fiber.join(reads);
+
+      assert.strictEqual(projectReads, 1);
+      assert.strictEqual(new Set(summaries.map(({ readAt }) => readAt)).size, 1);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("reuses a recent scan when only the date range changes", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+
+      let ratesFetches = 0;
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-window-cache-test",
+            home,
+            settings,
+            onRatesFetch: () => {
+              ratesFetches += 1;
+            },
+          }),
+        ),
+      );
+
+      yield* service.readSummary(WINDOW);
+      const narrower = yield* service.readSummary(NARROW_WINDOW);
+
+      assert.strictEqual(totalOutputTokens(narrower), 5);
+      assert.strictEqual(ratesFetches, 1);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("folds thread rows from the same source snapshot as the summary", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+
+      yield* Effect.gen(function* () {
+        const service = yield* UsageService.make;
+        const summary = yield* service.readSummary(WINDOW);
+        yield* Effect.promise(() => NodeFSP.appendFile(transcript, claudeLine(2, 7)));
+        const breakdown = yield* service.readThreadBreakdown(WINDOW);
+
+        assert.strictEqual(totalOutputTokens(summary), 5);
+        assert.strictEqual(
+          breakdown.rows.reduce((total, row) => total + row.totals.outputTokens, 0),
+          5,
+        );
+        assert.strictEqual(breakdown.readAt, summary.readAt);
+      }).pipe(
+        Effect.provide(
+          serviceLayers({ prefix: "usage-service-thread-source-cache-test", home, settings }),
+        ),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("updates fresh source data for a new manual refresh token", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+
+      let ratesFetches = 0;
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-manual-refresh-test",
+            home,
+            settings,
+            onRatesFetch: () => {
+              ratesFetches += 1;
+            },
+          }),
+        ),
+      );
+
+      const first = yield* service.readSummary(WINDOW);
+      assert.strictEqual(totalOutputTokens(first), 5);
+
+      yield* Effect.promise(() => NodeFSP.appendFile(transcript, claudeLine(2, 7)));
+      const refreshedInput = { ...WINDOW, refreshToken: "manual-refresh-1" };
+      const refreshed = yield* service.readSummary(refreshedInput);
+
+      assert.strictEqual(totalOutputTokens(refreshed), 12);
+      assert.strictEqual(ratesFetches, 2);
+
+      yield* service.readSummary(refreshedInput);
       assert.strictEqual(ratesFetches, 2);
     }).pipe(Effect.scoped),
   );
@@ -373,4 +647,79 @@ describe("UsageService", () => {
       );
     }).pipe(Effect.scoped),
   );
+
+  it.live("rejects exact thread windows longer than 24 hours", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({ prefix: "usage-service-thread-window-test", home, settings }),
+        ),
+      );
+      const reason = yield* service
+        .readThreadBreakdown({
+          timeZone: "UTC",
+          sinceDay: UsageDay.make("2026-08-01"),
+          untilDay: UsageDay.make("2026-08-02"),
+          sinceTime: "2026-08-01T00:00:00.000Z",
+          untilTime: "2026-08-02T01:00:00.000Z",
+        })
+        .pipe(
+          Effect.match({
+            onFailure: (error) => error.reason,
+            onSuccess: () => "success" as const,
+          }),
+        );
+
+      assert.strictEqual(reason, "invalidWindow");
+    }).pipe(Effect.scoped),
+  );
 });
+
+describe("isValidUsageDay", () => {
+  it("rejects impossible start and end dates instead of normalising them", () => {
+    assert.isTrue(UsageService.isValidUsageDay("2026-02-28"));
+    assert.isFalse(UsageService.isValidUsageDay("2026-02-29"));
+    assert.isFalse(UsageService.isValidUsageDay("2026-13-01"));
+  });
+});
+
+describe("shortSessionLabel", () => {
+  it("never exposes a file-derived path", () => {
+    assert.strictEqual(
+      UsageService.shortSessionLabel("claude:file:session-dir:updates"),
+      "Untitled session",
+    );
+  });
+});
+
+it.live("shares project reads within a thread request and reloads them for the next request", () =>
+  Effect.gen(function* () {
+    const { settings, home } = yield* setup;
+    let projectReads = 0;
+    const unused = Effect.die(new Error("unused project operation"));
+    const projectRepository: ProjectionProjectRepository["Service"] = {
+      upsert: () => unused,
+      getById: () => unused,
+      listAll: () =>
+        Effect.sync(() => {
+          projectReads += 1;
+          return [];
+        }),
+      deleteById: () => unused,
+    };
+    const dependencies = yield* Layer.build(
+      serviceLayers({
+        prefix: "usage-one-project-snapshot",
+        home,
+        settings,
+        projectRepository,
+      }),
+    );
+    const service = yield* UsageService.make.pipe(Effect.provide(dependencies));
+    yield* service.readThreadBreakdown(WINDOW);
+    assert.equal(projectReads, 1);
+    yield* service.readThreadBreakdown(WINDOW);
+    assert.equal(projectReads, 2);
+  }).pipe(Effect.scoped),
+);

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -22,6 +22,8 @@ import {
   type UsagePricing,
   type UsageSummary,
   type UsageSummaryInput,
+  type UsageThreadBreakdown,
+  type UsageThreadBreakdownInput,
   UsageReadError,
 } from "@t3tools/contracts";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
@@ -41,16 +43,22 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
+import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
+import { ProjectionThreadRepository } from "../persistence/Services/ProjectionThreads.ts";
+import * as ProviderSessionRuntime from "../persistence/ProviderSessionRuntime.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
-import { UsageAggregator } from "./usageAggregation.ts";
+import { makeProjectResolver, UsageAggregator } from "./usageAggregation.ts";
+import { dedicatedUsageWorktreePath } from "./usagePaths.ts";
 import { createOverrideRateTable, parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
   listTranscriptFiles,
   readDirectoryVolumeId,
   readTranscriptRecords,
+  readTranscriptTitle,
 } from "./usageTranscriptReader.ts";
+import { foldThreadRows, ThreadUsageAccumulator, type ThreadRef } from "./usageThreads.ts";
 import {
   decodeScanCache,
   dedupeWithinFile,
@@ -76,8 +84,17 @@ const RATES_REFRESH_FLOOR_MS = 60 * 1000;
 const MTIME_SLACK_MS = 36 * 60 * 60 * 1000;
 const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+/** Match the client query TTL so changing a date range does not rescan fresh sources. */
+const SOURCE_SCAN_TTL_MS = 60 * 1000;
+
 /** Longest window the UI offers, plus slack. Older entries are pruned. */
 const CACHE_RETENTION_DAYS = 90;
+
+/**
+ * Maximum rows sent per breakdown request, including grouped remainders. A
+ * window can hold thousands of sessions, so lower-cost rows fold together.
+ */
+const THREAD_ROW_CAP = 40;
 
 /** On-disk shape of the rate snapshot. */
 const RatesCacheFile = Schema.Struct({
@@ -95,11 +112,20 @@ const encodeRatesCache = Schema.encodeEffect(
 const ScanCacheJson = Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>);
 const decodeScanCacheFile = Schema.decodeUnknownEffect(ScanCacheJson);
 const encodeScanCacheFile = Schema.encodeEffect(ScanCacheJson);
+const encodeSourceKey = Schema.encodeSync(ScanCacheJson);
+
+export function isValidUsageDay(day: string): boolean {
+  const parsed = DateTime.make(`${day}T00:00:00Z`);
+  return Option.isSome(parsed) && DateTime.formatIso(parsed.value).slice(0, 10) === day;
+}
 
 export class UsageService extends Context.Service<
   UsageService,
   {
     readonly readSummary: (input: UsageSummaryInput) => Effect.Effect<UsageSummary, UsageReadError>;
+    readonly readThreadBreakdown: (
+      input: UsageThreadBreakdownInput,
+    ) => Effect.Effect<UsageThreadBreakdown, UsageReadError>;
     /** Refetches the rate table ahead of its TTL. See `ensureRates`. */
     readonly refreshRates: Effect.Effect<UsagePricing>;
   }
@@ -128,6 +154,16 @@ export const layerTest = Layer.succeed(
         pricing: EMPTY_PRICING,
         scanDurationMs: 0,
       }),
+    readThreadBreakdown: (input) =>
+      Effect.succeed({
+        contractVersion: USAGE_CONTRACT_VERSION,
+        readAt: "1970-01-01T00:00:00.000Z",
+        sinceDay: input.sinceDay,
+        untilDay: input.untilDay,
+        rows: [],
+        truncatedRows: 0,
+        scanDurationMs: 0,
+      }),
     refreshRates: Effect.succeed(EMPTY_PRICING),
   }),
 );
@@ -139,6 +175,9 @@ export const make = Effect.gen(function* () {
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
   const hostEnvironment = yield* HostProcessEnvironment;
+  const projectRepository = yield* ProjectionProjectRepository;
+  const threadRepository = yield* ProjectionThreadRepository;
+  const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -271,6 +310,47 @@ export const make = Effect.gen(function* () {
     ];
   });
 
+  const loadProjectThreads = Effect.gen(function* () {
+    const projects = yield* projectRepository
+      .listAll()
+      .pipe(Effect.catch(() => Effect.succeed(null)));
+    if (projects === null) return null;
+    return yield* Effect.forEach(
+      projects,
+      Effect.fnUntraced(function* (project) {
+        const threads = yield* threadRepository
+          .listByProjectId({ projectId: project.projectId })
+          .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
+        return { project, threads };
+      }),
+      { concurrency: 8 },
+    );
+  });
+
+  /** Project names and worktree ownership are re-read for each request. */
+  const resolveProjects = Effect.fn("UsageService.resolveProjects")(function* (
+    snapshot: typeof loadProjectThreads = loadProjectThreads,
+  ) {
+    const projects = yield* snapshot;
+    if (projects === null) return undefined;
+    return makeProjectResolver(
+      projects.flatMap(({ project, threads }) => {
+        const root = {
+          projectId: project.projectId,
+          workspaceRoot: project.workspaceRoot,
+          title: project.title,
+          deleted: project.deletedAt !== null,
+        };
+        return [
+          root,
+          ...threads.flatMap((thread) =>
+            thread.worktreePath === null ? [] : [{ ...root, workspaceRoot: thread.worktreePath }],
+          ),
+        ];
+      }),
+    );
+  });
+
   /**
    * Loads the persisted scan cache exactly once per process.
    *
@@ -329,7 +409,7 @@ export const make = Effect.gen(function* () {
       ) {
         return cached.tailRecords.length === 0
           ? cached.records
-          : [...cached.records, ...cached.tailRecords];
+          : dedupeWithinFile([...cached.records, ...cached.tailRecords]);
       }
 
       // Only a strictly grown file may resume. Same size with a new mtime, or
@@ -347,13 +427,11 @@ export const make = Effect.gen(function* () {
       if (parsed === null) return [];
 
       // Stored already de-duplicated within the file, which is 99% of all
-      // duplicates. The aggregator still runs the cross-file dedupe pass. One
-      // seen set spans the cached base, the new lines, and the tail so a
-      // resumed parse dedupes exactly like a full one.
+      // duplicates. The final snapshot wins so a resumed Claude parse can
+      // replace an earlier progressive snapshot from the cached base.
       const base = parsed.resumed && cached !== undefined ? cached.records : [];
-      const seen = new Set<string>();
-      const records = dedupeWithinFile([...base, ...parsed.records], seen);
-      const tailRecords = dedupeWithinFile(parsed.tailRecords, seen);
+      const records = dedupeWithinFile([...base, ...parsed.records]);
+      const tailRecords = dedupeWithinFile(parsed.tailRecords);
 
       fileCache.set(filePath, {
         size,
@@ -364,7 +442,7 @@ export const make = Effect.gen(function* () {
         position: parsed.position,
       });
       cacheDirty = true;
-      return tailRecords.length === 0 ? records : [...records, ...tailRecords];
+      return tailRecords.length === 0 ? records : dedupeWithinFile([...records, ...tailRecords]);
     });
 
   /** One provider directory's walk and parse, before rates are involved. */
@@ -377,6 +455,19 @@ export const make = Effect.gen(function* () {
       | readonly { readonly path: string; readonly records: readonly UsageRecord[] }[]
       | null;
   }
+
+  interface SourceSnapshot {
+    readonly completedAtMs: number;
+    readonly scanRevision: number;
+    readonly windowStartMs: number;
+    readonly sourceKey: string;
+    readonly dirs: readonly ScannedDir[];
+  }
+
+  let sourceSnapshot: SourceSnapshot | null = null;
+  let sourceScanRevision = 0;
+  let lastRefreshToken: string | null = null;
+  const sourceScanSemaphore = yield* Semaphore.make(1);
 
   const collectDirs = Effect.fn("UsageService.collectDirs")(function* (
     windowStartMs: number,
@@ -408,6 +499,71 @@ export const make = Effect.gen(function* () {
       scanned.push({ provider, dir, volumeId, files: parsedFiles });
     }
     return scanned;
+  });
+
+  const getSourceSnapshot = Effect.fn("UsageService.getSourceSnapshot")(function* (
+    windowStartMs: number,
+    refreshToken: string | undefined,
+    settings: ServerSettingsValue,
+  ) {
+    return yield* sourceScanSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        const startedAtMs = yield* Clock.currentTimeMillis;
+        const currentSnapshot = sourceSnapshot;
+        const snapshotAgeMs =
+          currentSnapshot === null
+            ? Number.POSITIVE_INFINITY
+            : startedAtMs - currentSnapshot.completedAtMs;
+        const snapshotCoversWindow =
+          currentSnapshot !== null && currentSnapshot.windowStartMs <= windowStartMs;
+        const sourceKey = encodeSourceKey([
+          settings.providers.claudeAgent,
+          settings.providers.codex,
+        ]);
+        const snapshotCoversSources = currentSnapshot?.sourceKey === sourceKey;
+        const manualRefresh = refreshToken !== undefined && refreshToken !== lastRefreshToken;
+
+        if (
+          !manualRefresh &&
+          currentSnapshot !== null &&
+          snapshotCoversWindow &&
+          snapshotCoversSources &&
+          snapshotAgeMs < SOURCE_SCAN_TTL_MS
+        ) {
+          return currentSnapshot;
+        }
+
+        // Preserve the widest coverage already loaded. A stale narrow request
+        // should update changed files, not discard older records and force the
+        // next wider range to read them again.
+        const scanWindowStartMs = Math.min(
+          windowStartMs,
+          currentSnapshot?.windowStartMs ?? windowStartMs,
+        );
+
+        // Pricing only matters once records are aggregated, so the rate table
+        // loads while transcripts stream instead of gating them: a cold rates
+        // fetch on a slow network no longer delays the scan by its own timeout.
+        sourceScanRevision += 1;
+        const scanRevision = sourceScanRevision;
+        const [, dirs] = yield* Effect.all(
+          [ensureRates(false), collectDirs(scanWindowStartMs, settings)],
+          { concurrency: 2 },
+        );
+        const now = yield* Clock.currentTimeMillis;
+        const completedAtMs = Math.max(now, (currentSnapshot?.completedAtMs ?? now - 1) + 1);
+        const nextSnapshot = {
+          completedAtMs,
+          scanRevision,
+          windowStartMs: scanWindowStartMs,
+          sourceKey,
+          dirs,
+        } satisfies SourceSnapshot;
+        sourceSnapshot = nextSnapshot;
+        if (refreshToken !== undefined) lastRefreshToken = refreshToken;
+        return nextSnapshot;
+      }),
+    );
   });
 
   const scanSummary = Effect.fn("UsageService.scanSummary")(function* (
@@ -458,15 +614,11 @@ export const make = Effect.gen(function* () {
     }
     const windowStartMs =
       (hourlyWindow?.sinceTimeMs ?? DateTime.toEpochMillis(windowStart.value)) - MTIME_SLACK_MS;
+    const currentSnapshot = yield* getSourceSnapshot(windowStartMs, input.refreshToken, settings);
+    const scannedDirs = currentSnapshot.dirs;
+    const sourceReadAtMs = currentSnapshot.completedAtMs;
 
-    // Pricing only matters once records are aggregated, so the rate table
-    // loads while transcripts stream instead of gating them: a cold rates
-    // fetch on a slow network no longer delays the scan by its own timeout.
-    const [, scannedDirs] = yield* Effect.all(
-      [ensureRates(false), collectDirs(windowStartMs, settings)],
-      { concurrency: 2 },
-    );
-
+    const resolveProject = yield* resolveProjects();
     const aggregator = new UsageAggregator({
       timeZone: input.timeZone,
       sinceDay: input.sinceDay,
@@ -474,6 +626,7 @@ export const make = Effect.gen(function* () {
       resolution: input.resolution ?? "day",
       ...hourlyWindow,
       rates,
+      ...(resolveProject === undefined ? {} : { resolveProject }),
       priceOverrides: createOverrideRateTable(settings.usagePriceOverrides),
     });
 
@@ -498,10 +651,6 @@ export const make = Effect.gen(function* () {
       walkedRoots.push(dir);
       let scannedFiles = 0;
       let skippedFiles = 0;
-      // Distinct per directory. Buckets carry per-cell session counts, but a
-      // session spans days and models, so clients total this figure instead.
-      const sessionIds = new Set<string>();
-
       for (const file of files) {
         livePaths.add(file.path);
         if (file.records.length === 0) {
@@ -510,11 +659,7 @@ export const make = Effect.gen(function* () {
         }
         scannedFiles += 1;
         for (const record of file.records) {
-          // Only sessions that contributed in-window count: the mtime slack
-          // admits boundary files whose records fall outside the range.
-          if (aggregator.add(record) && record.sessionId.length > 0) {
-            sessionIds.add(record.sessionId);
-          }
+          aggregator.add(record);
         }
       }
 
@@ -524,27 +669,31 @@ export const make = Effect.gen(function* () {
         scannedFiles,
         skippedFiles,
         malformedRecords: 0,
-        distinctSessions: sessionIds.size,
+        distinctSessions: aggregator.distinctSessions(provider),
         message: null,
       });
     }
 
-    const pruned = pruneScanCache(fileCache, {
-      livePaths,
-      walkedRoots,
-      windowStartMs,
-      retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
-    });
-    if (pruned > 0) cacheDirty = true;
-    yield* persistScanCache();
+    // A newer source walk may have populated files after this snapshot left
+    // the scan lane. Only the latest walk can prove that an unseen path
+    // disappeared and persist the resulting cache.
+    if (currentSnapshot.scanRevision === sourceScanRevision) {
+      const pruned = pruneScanCache(fileCache, {
+        livePaths,
+        walkedRoots,
+        windowStartMs,
+        retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      });
+      if (pruned > 0) cacheDirty = true;
+      yield* persistScanCache();
+    }
 
     const aggregated = aggregator.finish();
-    const readAt = yield* DateTime.now;
     const finishedAtMs = yield* Clock.currentTimeMillis;
 
     return {
       contractVersion: USAGE_CONTRACT_VERSION,
-      readAt: DateTime.formatIso(readAt),
+      readAt: DateTime.formatIso(DateTime.makeUnsafe(sourceReadAtMs)),
       timeZone: input.timeZone,
       sinceDay: input.sinceDay,
       untilDay: input.untilDay,
@@ -573,6 +722,7 @@ export const make = Effect.gen(function* () {
       input.resolution ?? "day",
       input.sinceTime ?? null,
       input.untilTime ?? null,
+      input.refreshToken === undefined ? null : "refresh",
       priceOverrides,
     ]);
 
@@ -606,7 +756,236 @@ export const make = Effect.gen(function* () {
     return yield* Deferred.await(deferred);
   });
 
-  return { readSummary, refreshRates } as const;
+  /**
+   * Maps each thread's current provider session to the thread, from resume
+   * cursors. Historic sessions of the same thread attribute through the
+   * worktree map instead; sessions that never ran through T3 Code stay
+   * session-granular.
+   */
+  const loadThreadAttribution = Effect.fn("UsageService.loadThreadAttribution")(function* (
+    snapshot: typeof loadProjectThreads = loadProjectThreads,
+  ) {
+    const sessionToThread = new Map<string, ThreadRef>();
+    const worktreeToThread = new Map<string, ThreadRef>();
+    const titles = new Map<string, string>();
+
+    const projects = yield* snapshot;
+    const worktreeClaims = new Map<string, { ref: ThreadRef; shared: boolean }>();
+    for (const { project, threads } of projects ?? []) {
+      for (const thread of threads) {
+        const title = thread.title.trim();
+        if (title.length > 0) titles.set(thread.threadId, title);
+        const worktree = dedicatedUsageWorktreePath(project.workspaceRoot, thread.worktreePath);
+        // The project root is not a dedicated worktree: interactive sessions
+        // run there too, and several threads usually share it.
+        if (worktree === null) continue;
+        const ref: ThreadRef = { threadId: thread.threadId, title: title || thread.threadId };
+        const claim = worktreeClaims.get(worktree);
+        if (claim === undefined) worktreeClaims.set(worktree, { ref, shared: false });
+        else claim.shared = true;
+      }
+    }
+    for (const [worktree, claim] of worktreeClaims) {
+      if (!claim.shared) worktreeToThread.set(worktree, claim.ref);
+    }
+
+    const runtimes = yield* runtimeRepository.list().pipe(
+      Effect.catchCause(
+        (cause) =>
+          new UsageReadError({
+            reason: "scanFailed",
+            detail: "Provider runtime state could not be read",
+            cause: Cause.squash(cause),
+          }),
+      ),
+    );
+    for (const runtime of runtimes) {
+      const cursor = runtime.resumeCursor;
+      if (typeof cursor !== "object" || cursor === null) continue;
+      const cursorRecord = cursor as Record<string, unknown>;
+      // Claude cursors carry the transcript uuid as `resume`; Codex cursors
+      // carry the rollout uuid as `threadId`. Other providers do not surface
+      // usage transcripts, so their cursors are irrelevant here.
+      const sessionId =
+        runtime.providerName === "claudeAgent"
+          ? cursorRecord["resume"]
+          : runtime.providerName === "codex"
+            ? cursorRecord["threadId"]
+            : undefined;
+      if (typeof sessionId !== "string" || sessionId.length === 0) continue;
+      const provider = runtime.providerName === "claudeAgent" ? "claude" : "codex";
+      sessionToThread.set(`${provider}:${sessionId}`, {
+        threadId: runtime.threadId,
+        title: titles.get(runtime.threadId) ?? runtime.threadId,
+      });
+    }
+
+    return { sessionToThread, worktreeToThread };
+  });
+
+  const readThreadBreakdown = Effect.fn("UsageService.readThreadBreakdown")(function* (
+    input: UsageThreadBreakdownInput,
+  ) {
+    if (input.sinceDay > input.untilDay) {
+      return yield* new UsageReadError({
+        reason: "invalidWindow",
+        detail: `sinceDay '${input.sinceDay}' is after untilDay '${input.untilDay}'`,
+      });
+    }
+    const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
+    const windowEnd = DateTime.make(`${input.untilDay}T00:00:00Z`);
+    if (
+      Option.isNone(windowStart) ||
+      Option.isNone(windowEnd) ||
+      !isValidUsageDay(input.sinceDay) ||
+      !isValidUsageDay(input.untilDay)
+    ) {
+      return yield* new UsageReadError({
+        reason: "invalidWindow",
+        detail: "Thread usage requires valid sinceDay and untilDay dates",
+      });
+    }
+
+    let exactWindow: { readonly sinceTimeMs: number; readonly untilTimeMs: number } | null = null;
+    if (input.sinceTime !== undefined || input.untilTime !== undefined) {
+      const sinceTime =
+        input.sinceTime === undefined ? Option.none() : DateTime.make(input.sinceTime);
+      const untilTime =
+        input.untilTime === undefined ? Option.none() : DateTime.make(input.untilTime);
+      if (Option.isNone(sinceTime) || Option.isNone(untilTime)) {
+        return yield* new UsageReadError({
+          reason: "invalidWindow",
+          detail: "Thread usage requires both valid sinceTime and untilTime instants",
+        });
+      }
+      const sinceTimeMs = DateTime.toEpochMillis(sinceTime.value);
+      const untilTimeMs = DateTime.toEpochMillis(untilTime.value);
+      const durationMs = untilTimeMs - sinceTimeMs;
+      if (durationMs <= 0 || durationMs > MAX_HOURLY_WINDOW_MS) {
+        return yield* new UsageReadError({
+          reason: "invalidWindow",
+          detail: "Thread usage exact window must be greater than zero and at most 24 hours",
+        });
+      }
+      exactWindow = { sinceTimeMs, untilTimeMs };
+    }
+
+    const startedAtMs = yield* Clock.currentTimeMillis;
+    const settings = yield* readSettings;
+    yield* ensureScanCacheLoaded;
+
+    const windowStartMs =
+      (exactWindow?.sinceTimeMs ?? DateTime.toEpochMillis(windowStart.value)) - MTIME_SLACK_MS;
+    // Thread rows and the summary must fold the same transcript snapshot. In
+    // particular, a file that grows during the source-cache TTL belongs to the
+    // next refresh on both RPCs instead of appearing in the drill-down alone.
+    const currentSnapshot = yield* getSourceSnapshot(windowStartMs, input.refreshToken, settings);
+
+    const projectSnapshot = yield* Effect.cached(loadProjectThreads);
+    const resolveProject = yield* resolveProjects(projectSnapshot);
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: input.timeZone,
+      sinceDay: input.sinceDay,
+      untilDay: input.untilDay,
+      ...exactWindow,
+      rates,
+      priceOverrides: createOverrideRateTable(settings.usagePriceOverrides),
+      ...(resolveProject === undefined ? {} : { resolveProject }),
+    });
+
+    // Preferred transcript per session for title extraction: the main file,
+    // never a subagent's.
+    const titleFiles = new Map<
+      string,
+      { readonly path: string; readonly provider: UsageProviderKind }
+    >();
+    const livePaths = new Set<string>();
+    const walkedRoots: string[] = [];
+
+    for (const { provider, dir, files } of currentSnapshot.dirs) {
+      if (input.providers !== undefined && !input.providers.includes(provider)) continue;
+      if (files === null) continue;
+      walkedRoots.push(dir);
+      for (const file of files) {
+        livePaths.add(file.path);
+        if (file.records.length === 0) continue;
+        const isSubagent =
+          provider === "claude" && path.basename(path.dirname(file.path)) === "subagents";
+        const agentId = isSubagent ? path.basename(file.path, ".jsonl") : null;
+        for (const record of file.records) {
+          const sessionKey =
+            record.sessionId.length > 0
+              ? `${provider}:${record.sessionId}`
+              : `${provider}:file:${path.basename(path.dirname(file.path))}:${path.basename(file.path, ".jsonl")}`;
+          accumulator.add(record, { sessionKey, agentId });
+          if (!isSubagent && !titleFiles.has(sessionKey)) {
+            titleFiles.set(sessionKey, { path: file.path, provider });
+          }
+        }
+      }
+    }
+
+    // A newer source walk may have populated files after this snapshot left
+    // the scan lane. Only the latest walk can prove that an unseen path
+    // disappeared and persist the resulting cache.
+    if (currentSnapshot.scanRevision === sourceScanRevision) {
+      const pruned = pruneScanCache(fileCache, {
+        livePaths,
+        walkedRoots,
+        windowStartMs,
+        retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      });
+      if (pruned > 0) cacheDirty = true;
+      // A thread-only client must warm and bound the same durable cache as the
+      // summary RPC, otherwise restarts repeat parsing and stale entries grow.
+      yield* persistScanCache();
+    }
+
+    const attribution = yield* loadThreadAttribution(projectSnapshot);
+    const folded = foldThreadRows(accumulator.finish(), attribution, {
+      cap: THREAD_ROW_CAP,
+      ...(input.projectKey === undefined ? {} : { projectFilter: input.projectKey }),
+    });
+
+    // Transcript titles only for retained unattributed rows. Grouped remainder
+    // rows already carry a generated title.
+    const rows = yield* Effect.forEach(
+      folded.rows,
+      Effect.fnUntraced(function* ({ titleSessionKey, ...row }) {
+        if (row.title !== null) return { ...row, title: row.title };
+        const source = titleFiles.get(titleSessionKey);
+        const transcriptTitle =
+          source === undefined
+            ? null
+            : yield* Effect.promise(() => readTranscriptTitle(source.path, source.provider));
+        const fallback = row.key.startsWith("remainder:")
+          ? row.key
+          : shortSessionLabel(titleSessionKey);
+        return { ...row, title: transcriptTitle ?? fallback };
+      }),
+      { concurrency: 8 },
+    );
+
+    const finishedAtMs = yield* Clock.currentTimeMillis;
+    return {
+      contractVersion: USAGE_CONTRACT_VERSION,
+      readAt: DateTime.formatIso(DateTime.makeUnsafe(currentSnapshot.completedAtMs)),
+      sinceDay: input.sinceDay,
+      untilDay: input.untilDay,
+      rows,
+      truncatedRows: folded.truncatedRows,
+      scanDurationMs: Math.max(0, finishedAtMs - startedAtMs),
+    } satisfies UsageThreadBreakdown;
+  });
+
+  return { readSummary, readThreadBreakdown, refreshRates } as const;
 });
+
+/** `claude:8f14e45f-...` reads as `Session 8f14e45f`. */
+export function shortSessionLabel(sessionKey: string): string {
+  if (sessionKey.includes(":file:")) return "Untitled session";
+  const sessionId = sessionKey.slice(sessionKey.lastIndexOf(":") + 1);
+  return sessionId.length > 8 ? `Session ${sessionId.slice(0, 8)}` : `Session ${sessionId}`;
+}
 
 export const layer = Layer.effect(UsageService, make);

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -1,6 +1,8 @@
+import { vi } from "vite-plus/test";
+import { ProjectId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 
-import { UsageAggregator } from "./usageAggregation.ts";
+import { makeProjectResolver, UsageAggregator } from "./usageAggregation.ts";
 import type { RateTable } from "./usagePricing.ts";
 import type { UsageRecord } from "./usageTranscripts.ts";
 
@@ -23,6 +25,7 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
     timestampMs: Date.parse("2026-08-07T04:05:13.944Z"),
     model: "claude-fable-5",
     sessionId: "session-a",
+    cwd: "",
     totals: {
       uncachedInputTokens: 100,
       cachedInputTokens: 1000,
@@ -74,17 +77,25 @@ describe("UsageAggregator", () => {
     ).toThrow("requires exact time bounds");
   });
 
-  it("keeps only the first record for a repeated dedupe key", () => {
+  it("uses the final complete snapshot for a repeated dedupe key", () => {
     const result = aggregate([
-      record({ dedupeKey: "msg_1:" }),
-      record({ dedupeKey: "msg_1:" }),
-      record({ dedupeKey: "msg_1:" }),
+      record({ dedupeKey: "msg_1:", totals: { ...record().totals, outputTokens: 1 } }),
+      record({ dedupeKey: "msg_1:", totals: { ...record().totals, outputTokens: 310 } }),
     ]);
 
-    expect(result.duplicatesDropped).toBe(2);
+    expect(result.duplicatesDropped).toBe(1);
     expect(result.buckets).toHaveLength(1);
     expect(result.buckets[0]?.records).toBe(1);
-    expect(result.buckets[0]?.totals.outputTokens).toBe(50);
+    expect(result.buckets[0]?.totals.outputTokens).toBe(310);
+  });
+
+  it("applies the window to the final complete snapshot", () => {
+    const result = aggregate([
+      record({ dedupeKey: "msg_1:" }),
+      record({ dedupeKey: "msg_1:", timestampMs: Date.parse("2026-09-01T00:00:00Z") }),
+    ]);
+
+    expect(result).toMatchObject({ buckets: [], duplicatesDropped: 1, outOfWindow: 1 });
   });
 
   it("still sums records that carry no dedupe key", () => {
@@ -92,6 +103,38 @@ describe("UsageAggregator", () => {
 
     expect(result.duplicatesDropped).toBe(0);
     expect(result.buckets[0]?.totals.outputTokens).toBe(100);
+  });
+
+  it("distinguishes project, outside, and unknown attribution", () => {
+    const projectId = ProjectId.make("project-app");
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd === "/work/app" ? { projectId, title: "App" } : null),
+    });
+    aggregator.add(record({ cwd: "/work/app" }));
+    aggregator.add(record({ cwd: "/work/app" }));
+    aggregator.add(record({ cwd: "/elsewhere" }));
+    aggregator.add(record({ cwd: "", model: "grok-4" }));
+    const { buckets } = aggregator.finish();
+
+    expect(buckets).toHaveLength(3);
+    const outside = buckets.find((bucket) => bucket.projectAttribution === "outside");
+    expect(outside?.project).toBeUndefined();
+    expect(outside?.records).toBe(1);
+    const project = buckets.find((bucket) => bucket.projectAttribution === "project");
+    expect(project?.project).toBe("App");
+    expect(project?.projectId).toBe(projectId);
+    expect(project?.records).toBe(2);
+    expect(buckets.some((bucket) => bucket.projectAttribution === "unknown")).toBe(true);
+  });
+
+  it("marks every bucket unknown when no project resolver is available", () => {
+    const result = aggregate([record({ cwd: "/work/app" })]);
+
+    expect(result.buckets[0]?.projectAttribution).toBe("unknown");
   });
 
   it("buckets by the day in the requested time zone", () => {
@@ -154,6 +197,26 @@ describe("UsageAggregator", () => {
     // 100*1e-5 + 1000*1e-6 + 10*1.25e-5 + 50*5e-5
     expect(result.buckets[0]?.costUsd).toBeCloseTo(0.004625, 9);
     expect(result.buckets[0]?.costSource).toBe("modelPriced");
+    // Cache writes priced at the cache-write rate: 10 * 1.25e-5.
+    expect(result.buckets[0]?.cacheWriteUsd).toBeCloseTo(1.25e-4, 12);
+  });
+
+  it("distinguishes unavailable cache-write cost from write-free usage", () => {
+    const unpriced = aggregate([record({ model: "kimi-k3" })]);
+    expect(unpriced.buckets[0]?.cacheWriteUsd).toBeUndefined();
+
+    const writeFree = aggregate([
+      record({
+        totals: {
+          uncachedInputTokens: 100,
+          cachedInputTokens: 1000,
+          cacheCreationTokens: 0,
+          outputTokens: 50,
+          reasoningTokens: 0,
+        },
+      }),
+    ]);
+    expect(writeFree.buckets[0]?.cacheWriteUsd).toBe(0);
   });
 
   it("counts tokens but not cost for a model with no rate", () => {
@@ -170,6 +233,7 @@ describe("UsageAggregator", () => {
 
     expect(result.buckets[0]?.costUsd).toBe(1.25);
     expect(result.buckets[0]?.costSource).toBe("providerReported");
+    expect(result.buckets[0]?.cacheWriteUsd).toBeUndefined();
   });
 
   it("drops records outside the window", () => {
@@ -179,7 +243,7 @@ describe("UsageAggregator", () => {
     expect(result.buckets).toHaveLength(0);
   });
 
-  it("reports whether a record contributed", () => {
+  it("reports whether a record falls in the window", () => {
     const aggregator = new UsageAggregator({
       timeZone: "UTC",
       sinceDay: "2026-08-01",
@@ -188,7 +252,7 @@ describe("UsageAggregator", () => {
     });
 
     expect(aggregator.add(record({ dedupeKey: "msg_1:" }))).toBe(true);
-    expect(aggregator.add(record({ dedupeKey: "msg_1:" }))).toBe(false);
+    expect(aggregator.add(record({ dedupeKey: "msg_1:" }))).toBe(true);
     expect(aggregator.add(record({ timestampMs: Date.parse("2026-07-01T12:00:00Z") }))).toBe(false);
   });
 
@@ -201,4 +265,103 @@ describe("UsageAggregator", () => {
 
     expect(result.buckets).toHaveLength(3);
   });
+});
+
+describe("makeProjectResolver", () => {
+  const appId = ProjectId.make("project-app");
+  const vendoredId = ProjectId.make("project-vendored");
+  const legacyDeletedId = ProjectId.make("project-legacy-deleted");
+  const legacyId = ProjectId.make("project-legacy");
+  const untitledId = ProjectId.make("project-untitled");
+  const resolver = makeProjectResolver([
+    { projectId: appId, workspaceRoot: "/work/app", title: "App", deleted: false },
+    {
+      projectId: vendoredId,
+      workspaceRoot: "/work/app/vendored",
+      title: "Vendored",
+      deleted: false,
+    },
+    {
+      projectId: legacyDeletedId,
+      workspaceRoot: "/work/legacy",
+      title: "Legacy Was Deleted",
+      deleted: true,
+    },
+    {
+      projectId: legacyId,
+      workspaceRoot: "/work/legacy",
+      title: "Legacy",
+      deleted: false,
+    },
+    {
+      projectId: untitledId,
+      workspaceRoot: "/work/untitled",
+      title: "   ",
+      deleted: false,
+    },
+  ]);
+
+  it("matches the root itself and any path under it", () => {
+    expect(resolver("/work/app")).toEqual({ projectId: appId, title: "App" });
+    expect(resolver("/work/app/src/deep")).toEqual({ projectId: appId, title: "App" });
+  });
+
+  it("requires a path-segment boundary, not a bare prefix", () => {
+    expect(resolver("/work/app-sibling")).toBeNull();
+  });
+
+  it("prefers the deepest matching root", () => {
+    expect(resolver("/work/app/vendored/lib")).toEqual({
+      projectId: vendoredId,
+      title: "Vendored",
+    });
+  });
+
+  it("prefers a live project over a deleted one sharing the root", () => {
+    expect(resolver("/work/legacy/src")).toEqual({ projectId: legacyId, title: "Legacy" });
+  });
+
+  it("never attributes to a blank title or an empty cwd", () => {
+    expect(resolver("/work/untitled/src")).toBeNull();
+    expect(resolver("")).toBeNull();
+  });
+
+  it("matches descendants when the project root is the filesystem root", () => {
+    const rootId = ProjectId.make("project-root");
+    const rootResolver = makeProjectResolver([
+      { projectId: rootId, workspaceRoot: "/", title: "Root", deleted: false },
+    ]);
+
+    expect(rootResolver("/work/app")).toEqual({ projectId: rootId, title: "Root" });
+  });
+
+  it("matches mixed slash styles and normalized segments", () => {
+    expect(resolver("\\work\\app\\src")).toEqual({ projectId: appId, title: "App" });
+    expect(resolver("/work/app/other/../src")).toEqual({ projectId: appId, title: "App" });
+
+    const windowsResolver = makeProjectResolver([
+      { projectId: appId, workspaceRoot: "C:\\Work\\App", title: "App", deleted: false },
+    ]);
+    expect(windowsResolver("c:/work/app/src")).toEqual({ projectId: appId, title: "App" });
+  });
+});
+
+it("formats a retained record once across provider counts and final folding", () => {
+  const format = vi.spyOn(Intl.DateTimeFormat.prototype, "formatToParts");
+  try {
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+    });
+    aggregator.add(record());
+    for (const provider of ["codex", "claude", "grok"] as const)
+      aggregator.distinctSessions(provider);
+    const result = aggregator.finish();
+    expect(result.buckets[0]?.day).toBe("2026-08-07");
+    expect(format).toHaveBeenCalledOnce();
+  } finally {
+    format.mockRestore();
+  }
 });

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -1,7 +1,7 @@
 // @effect-diagnostics globalDate:off
 /**
- * Folds parsed transcript records into `(day, hourStart?, provider, model)`
- * buckets.
+ * Folds parsed transcript records into `(day, hourStart?, project, provider,
+ * model)` buckets.
  *
  * `Intl.DateTimeFormat` is the only reliable way to resolve a wall-clock day in
  * an arbitrary IANA zone, and it takes a `Date`. That is why the raw `Date`
@@ -12,18 +12,25 @@
  *
  * @module usageAggregation
  */
-import type { UsageBucket, UsageDay, UsageResolution, UsageTokenTotals } from "@t3tools/contracts";
+import type {
+  ProjectId,
+  UsageBucket,
+  UsageDay,
+  UsageResolution,
+  UsageTokenTotals,
+} from "@t3tools/contracts";
 
 import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
-import { cacheSavingsUsd, priceUsage, type RateTable } from "./usagePricing.ts";
+import { normalizeUsagePath } from "./usagePaths.ts";
+import { cacheSavingsUsd, cacheWriteUsd, priceUsage, type RateTable } from "./usagePricing.ts";
 
 /**
  * Formats an instant as a `YYYY-MM-DD` day in `timeZone`.
  *
- * `en-CA` yields ISO-ordered parts, which is why it is used here rather than
- * assembling the day from `Date` getters (those are host-local only).
+ * Numeric parts preserve the requested time zone without depending on the
+ * locale's punctuation or date ordering.
  */
-function makeDayFormatter(timeZone: string): (timestampMs: number) => string {
+export function makeDayFormatter(timeZone: string): (timestampMs: number) => string {
   let format: Intl.DateTimeFormat;
   try {
     format = new Intl.DateTimeFormat("en-CA", {
@@ -41,15 +48,76 @@ function makeDayFormatter(timeZone: string): (timestampMs: number) => string {
       day: "2-digit",
     });
   }
-  return (timestampMs) => format.format(new Date(timestampMs));
+  return (timestampMs) => {
+    const parts = Object.fromEntries(
+      format.formatToParts(new Date(timestampMs)).map(({ type, value }) => [type, value]),
+    );
+    return `${parts.year?.padStart(4, "0")}-${parts.month}-${parts.day}`;
+  };
 }
 
 const HOUR_MS = 60 * 60 * 1000;
+
+export interface ProjectRoot {
+  readonly projectId: ProjectId;
+  readonly workspaceRoot: string;
+  readonly title: string;
+  /** Soft-deleted projects still attribute: the spend happened while they existed. */
+  readonly deleted: boolean;
+}
+
+export interface ProjectAttribution {
+  readonly projectId: ProjectId;
+  readonly title: string;
+}
+
+/**
+ * Builds the cwd → project resolver used by {@link AggregateOptions}.
+ *
+ * Deepest root wins, so a session in a project nested inside another
+ * attributes to the inner one. Live projects outrank deleted ones sharing a
+ * root, since deleting and re-creating a project leaves both rows. Results are
+ * memoised per cwd; a scan sees few distinct cwds but many records.
+ */
+export function makeProjectResolver(
+  projects: readonly ProjectRoot[],
+): (cwd: string) => ProjectAttribution | null {
+  const roots = projects
+    .map((project) => ({
+      projectId: project.projectId,
+      root: normalizeUsagePath(project.workspaceRoot),
+      title: project.title.trim(),
+      deleted: project.deleted,
+    }))
+    .filter((entry) => entry.root.length > 0 && entry.title.length > 0)
+    .sort((a, b) => b.root.length - a.root.length || Number(a.deleted) - Number(b.deleted));
+
+  const byCwd = new Map<string, ProjectAttribution | null>();
+  return (cwd) => {
+    if (cwd.length === 0) return null;
+    if (byCwd.has(cwd)) return byCwd.get(cwd) ?? null;
+    const normalizedCwd = normalizeUsagePath(cwd);
+    let resolved: ProjectAttribution | null = null;
+    for (const { projectId, root, title } of roots) {
+      if (
+        normalizedCwd === root ||
+        (root === "/" ? normalizedCwd.startsWith("/") : normalizedCwd.startsWith(`${root}/`))
+      ) {
+        resolved = { projectId, title };
+        break;
+      }
+    }
+    byCwd.set(cwd, resolved);
+    return resolved;
+  };
+}
 
 interface MutableBucket {
   totals: UsageTokenTotals;
   costUsd: number;
   cacheSavingsUsd: number;
+  cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
   records: number;
   unpricedRecords: number;
   providerReportedRecords: number;
@@ -65,13 +133,18 @@ export interface AggregateOptions {
   readonly resolution?: UsageResolution;
   readonly sinceTimeMs?: number;
   readonly untilTimeMs?: number;
+  /**
+   * Maps a record's working directory to the project it ran in, or `null` when
+   * it ran outside every project. Omitting it leaves every bucket unattributed.
+   */
+  readonly resolveProject?: (cwd: string) => ProjectAttribution | null;
 }
 
 export interface AggregateResult {
   readonly buckets: readonly UsageBucket[];
   /** Records dropped because an earlier record carried the same dedupe key. */
   readonly duplicatesDropped: number;
-  /** Records whose day fell outside the requested window. */
+  /** Retained records whose day fell outside the requested window. */
   readonly outOfWindow: number;
 }
 
@@ -83,13 +156,13 @@ export interface AggregateResult {
  * the same `dedupeKey` legitimately appears in several transcripts.
  */
 export class UsageAggregator {
-  readonly #buckets = new Map<string, MutableBucket>();
-  readonly #seen = new Set<string>();
+  readonly #recordsByKey = new Map<string, UsageRecord>();
+  readonly #unkeyedRecords: UsageRecord[] = [];
   readonly #toDay: (timestampMs: number) => string;
+  readonly #recordDays = new WeakMap<UsageRecord, string>();
   readonly #hourlyWindow: { readonly sinceTimeMs: number; readonly untilTimeMs: number } | null;
   readonly #options: AggregateOptions;
   #duplicatesDropped = 0;
-  #outOfWindow = 0;
 
   constructor(options: AggregateOptions) {
     this.#options = options;
@@ -107,37 +180,64 @@ export class UsageAggregator {
     }
   }
 
-  /**
-   * Folds one record in. Returns whether it actually contributed, so callers
-   * can derive per-window facts (distinct sessions, for one) from the records
-   * that landed rather than everything the mtime prefilter happened to admit.
-   */
+  /** Retains one record and reports whether it falls in the requested window. */
   add(record: UsageRecord): boolean {
-    if (record.dedupeKey !== null) {
-      if (this.#seen.has(record.dedupeKey)) {
-        this.#duplicatesDropped += 1;
-        return false;
-      }
-      this.#seen.add(record.dedupeKey);
+    const inWindow = this.#isInWindow(record);
+    if (record.dedupeKey === null) {
+      this.#unkeyedRecords.push(record);
+      return inWindow;
     }
+    if (this.#recordsByKey.has(record.dedupeKey)) {
+      this.#recordsByKey.set(record.dedupeKey, record);
+      this.#duplicatesDropped += 1;
+      return inWindow;
+    }
+    this.#recordsByKey.set(record.dedupeKey, record);
+    return inWindow;
+  }
 
+  #dayFor(record: UsageRecord): string {
+    const cached = this.#recordDays.get(record);
+    if (cached !== undefined) return cached;
+    const day = this.#toDay(record.timestampMs);
+    this.#recordDays.set(record, day);
+    return day;
+  }
+
+  #isInWindow(record: UsageRecord): boolean {
     if (
       this.#hourlyWindow !== null &&
       (record.timestampMs < this.#hourlyWindow.sinceTimeMs ||
         record.timestampMs >= this.#hourlyWindow.untilTimeMs)
     ) {
-      this.#outOfWindow += 1;
       return false;
     }
 
-    const day = this.#toDay(record.timestampMs);
+    const day = this.#dayFor(record);
     if (
       this.#hourlyWindow === null &&
       (day < this.#options.sinceDay || day > this.#options.untilDay)
     ) {
-      this.#outOfWindow += 1;
       return false;
     }
+    return true;
+  }
+
+  /** Distinct in-window sessions retained after progressive snapshots settle. */
+  distinctSessions(provider: UsageRecord["provider"]): number {
+    const sessionIds = new Set<string>();
+    const addSession = (record: UsageRecord): void => {
+      if (record.provider === provider && this.#isInWindow(record) && record.sessionId.length > 0) {
+        sessionIds.add(record.sessionId);
+      }
+    };
+    for (const record of this.#unkeyedRecords) addSession(record);
+    for (const record of this.#recordsByKey.values()) addSession(record);
+    return sessionIds.size;
+  }
+
+  #foldRecord(record: UsageRecord, buckets: Map<string, MutableBucket>): void {
+    const day = this.#dayFor(record);
 
     const hourStart =
       this.#hourlyWindow === null
@@ -146,19 +246,31 @@ export class UsageAggregator {
             this.#hourlyWindow.sinceTimeMs +
               Math.floor((record.timestampMs - this.#hourlyWindow.sinceTimeMs) / HOUR_MS) * HOUR_MS,
           ).toISOString();
-    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.model}`;
-    let bucket = this.#buckets.get(key);
+    // The key is parsed back apart on NUL, which project fields must not carry.
+    const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
+    const projectAttribution =
+      resolvedProject !== null
+        ? "project"
+        : this.#options.resolveProject === undefined || record.cwd.length === 0
+          ? "unknown"
+          : "outside";
+    const projectId = resolvedProject?.projectId.replaceAll("\u0000", "") ?? "";
+    const project = resolvedProject?.title.replaceAll("\u0000", "") ?? "";
+    const key = `${day}\u0000${hourStart}\u0000${projectAttribution}\u0000${projectId}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
+    let bucket = buckets.get(key);
     if (bucket === undefined) {
       bucket = {
         totals: EMPTY_TOTALS,
         costUsd: 0,
         cacheSavingsUsd: 0,
+        cacheWriteUsd: 0,
+        cacheWriteComplete: true,
         records: 0,
         unpricedRecords: 0,
         providerReportedRecords: 0,
         sessions: new Set<string>(),
       };
-      this.#buckets.set(key, bucket);
+      buckets.set(key, bucket);
     }
 
     const priced = priceUsage(
@@ -177,25 +289,57 @@ export class UsageAggregator {
       record.totals,
       this.#options.priceOverrides,
     );
+    if (priced.costSource === "modelPriced") {
+      bucket.cacheWriteUsd += cacheWriteUsd(
+        this.#options.rates,
+        record.model,
+        record.totals,
+        this.#options.priceOverrides,
+      );
+    } else if (record.totals.cacheCreationTokens > 0) {
+      bucket.cacheWriteComplete = false;
+    }
     bucket.records += 1;
     if (priced.costSource === "unpriced") bucket.unpricedRecords += 1;
     if (priced.costSource === "providerReported") bucket.providerReportedRecords += 1;
     if (record.sessionId.length > 0) bucket.sessions.add(record.sessionId);
-    return true;
   }
 
   finish(): AggregateResult {
+    const bucketsByKey = new Map<string, MutableBucket>();
+    let outOfWindow = 0;
+    const foldIfInWindow = (record: UsageRecord): void => {
+      if (this.#isInWindow(record)) {
+        this.#foldRecord(record, bucketsByKey);
+      } else {
+        outOfWindow += 1;
+      }
+    };
+    for (const record of this.#unkeyedRecords) foldIfInWindow(record);
+    for (const record of this.#recordsByKey.values()) foldIfInWindow(record);
     const buckets: UsageBucket[] = [];
-    for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", provider = "", model = ""] = key.split("\u0000");
+    for (const [key, bucket] of bucketsByKey) {
+      const [
+        day = "",
+        hourStart = "",
+        projectAttribution = "unknown",
+        projectId = "",
+        project = "",
+        provider = "",
+        model = "",
+      ] = key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
+        ...(project === "" ? {} : { project }),
+        ...(projectId === "" ? {} : { projectId: projectId as ProjectId }),
+        projectAttribution: projectAttribution as UsageBucket["projectAttribution"],
         provider: provider as UsageBucket["provider"],
         model,
         totals: bucket.totals,
         costUsd: bucket.costUsd,
         cacheSavingsUsd: bucket.cacheSavingsUsd,
+        ...(bucket.cacheWriteComplete ? { cacheWriteUsd: bucket.cacheWriteUsd } : {}),
         costSource: resolveCostSource(bucket),
         records: bucket.records,
         unpricedRecords: bucket.unpricedRecords,
@@ -207,6 +351,8 @@ export class UsageAggregator {
       (a, b) =>
         a.day.localeCompare(b.day) ||
         (a.hourStart ?? "").localeCompare(b.hourStart ?? "") ||
+        (a.project ?? "").localeCompare(b.project ?? "") ||
+        (a.projectId ?? "").localeCompare(b.projectId ?? "") ||
         a.provider.localeCompare(b.provider) ||
         a.model.localeCompare(b.model),
     );
@@ -214,7 +360,7 @@ export class UsageAggregator {
     return {
       buckets,
       duplicatesDropped: this.#duplicatesDropped,
-      outOfWindow: this.#outOfWindow,
+      outOfWindow,
     };
   }
 }

--- a/apps/server/src/usage/usagePaths.test.ts
+++ b/apps/server/src/usage/usagePaths.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { dedicatedUsageWorktreePath, normalizeUsagePath } from "./usagePaths.ts";
+
+describe("usage path normalization", () => {
+  it("folds slash styles, trailing separators, and dot segments", () => {
+    expect(normalizeUsagePath("C:\\Work\\App\\other\\..\\src\\")).toBe("c:/work/app/src");
+  });
+
+  it("does not treat another spelling of the project root as a dedicated worktree", () => {
+    expect(dedicatedUsageWorktreePath("C:\\Work\\App", "c:/work/app/")).toBeNull();
+  });
+
+  it("returns one stable key for equivalent dedicated worktree paths", () => {
+    expect(dedicatedUsageWorktreePath("C:/work/app", "C:\\WORK\\APP\\.wt\\thread-1\\")).toBe(
+      "c:/work/app/.wt/thread-1",
+    );
+    expect(dedicatedUsageWorktreePath("C:/work/app", "C:/work/app/other/../.wt/thread-1")).toBe(
+      "c:/work/app/.wt/thread-1",
+    );
+  });
+
+  it("preserves case-sensitive POSIX comparisons", () => {
+    expect(normalizeUsagePath("/Work/App")).toBe("/Work/App");
+    expect(normalizeUsagePath("/work/app")).toBe("/work/app");
+  });
+});

--- a/apps/server/src/usage/usagePaths.ts
+++ b/apps/server/src/usage/usagePaths.ts
@@ -1,0 +1,35 @@
+/**
+ * Normalizes persisted provider and worktree paths for usage attribution.
+ *
+ * Provider transcripts can retain paths written on another platform or with a
+ * different slash style, so attribution cannot rely on the host separator.
+ */
+export function normalizeUsagePath(value: string): string {
+  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
+  const slashPath = value.replaceAll("\\", "/");
+  const rooted = slashPath.startsWith("/");
+  const segments: string[] = [];
+  for (const segment of slashPath.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length > 0 && segments.at(-1) !== "..") segments.pop();
+      else if (!rooted) segments.push(segment);
+      continue;
+    }
+    segments.push(segment);
+  }
+  const normalized = `${rooted ? "/" : ""}${segments.join("/")}`;
+  const result = normalized === "" ? (rooted ? "/" : ".") : normalized;
+  return isWindowsPath ? result.toLowerCase() : result;
+}
+
+/** Returns a normalized dedicated worktree, excluding the shared project root. */
+export function dedicatedUsageWorktreePath(
+  projectRoot: string,
+  worktree: string | null,
+): string | null {
+  const candidate = worktree?.trim() ?? "";
+  if (candidate.length === 0) return null;
+  const normalized = normalizeUsagePath(candidate);
+  return normalized === normalizeUsagePath(projectRoot) ? null : normalized;
+}

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -214,3 +214,54 @@ export function cacheSavingsUsd(
   if (rate === null) return 0;
   return totals.cachedInputTokens * (rate.inputCostPerToken - rate.cacheReadCostPerToken);
 }
+
+/**
+ * Estimated cost of this usage's cache-creation tokens at the model's
+ * cache-write rate. Zero when the model is unpriced or the provider reports
+ * no cache-creation tokens.
+ */
+export function cacheWriteUsd(
+  table: RateTable,
+  model: string,
+  totals: UsageTokenTotals,
+  overrides?: RateTable,
+): number {
+  const rate = overrides?.get(model.trim()) ?? lookupRate(table, model);
+  if (rate === null) return 0;
+  return totals.cacheCreationTokens * rate.cacheCreationCostPerToken;
+}
+
+export interface UsageComponentCosts {
+  readonly cacheWriteUsd: number;
+  readonly cacheReadUsd: number;
+  /** Fresh input plus output. */
+  readonly freshUsd: number;
+}
+
+const ZERO_COMPONENT_COSTS: UsageComponentCosts = {
+  cacheWriteUsd: 0,
+  cacheReadUsd: 0,
+  freshUsd: 0,
+};
+
+/**
+ * Splits model-priced usage into cache writes, cache reads, and everything
+ * else. Unpriced models contribute nothing here; token totals still include
+ * them.
+ */
+export function usageComponentCosts(
+  table: RateTable,
+  model: string,
+  totals: UsageTokenTotals,
+  overrides?: RateTable,
+): UsageComponentCosts {
+  const rate = overrides?.get(model.trim()) ?? lookupRate(table, model);
+  if (rate === null) return ZERO_COMPONENT_COSTS;
+  return {
+    cacheWriteUsd: totals.cacheCreationTokens * rate.cacheCreationCostPerToken,
+    cacheReadUsd: totals.cachedInputTokens * rate.cacheReadCostPerToken,
+    freshUsd:
+      totals.uncachedInputTokens * rate.inputCostPerToken +
+      totals.outputTokens * rate.outputCostPerToken,
+  };
+}

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -16,6 +16,7 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
     timestampMs: 1_786_000_000_000,
     model: "claude-fable-5",
     sessionId: "session-a",
+    cwd: "/home/theo/project",
     totals: {
       uncachedInputTokens: 2,
       cachedInputTokens: 1000,
@@ -80,6 +81,7 @@ describe("scan cache round trip", () => {
         codexState: {
           model: "gpt-5.2-codex",
           sessionId: "session-c",
+          cwd: "/home/theo/codex-project",
           lastUsageSignature: '{"input_tokens":1}',
           sawSessionMeta: true,
           suppressingForkCopies: false,
@@ -186,6 +188,22 @@ describe("scan cache round trip", () => {
     const restored = decodeScanCache(JSON.parse(JSON.stringify(poisoned)));
     expect(restored.has("/a.jsonl")).toBe(false);
   });
+
+  it.each([0.5, 99])("drops an entry with invalid cwd index %s", (cwdIndex) => {
+    const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
+    const row = encoded.files["/a.jsonl"]!.r[0]!;
+    const poisoned = {
+      ...encoded,
+      files: {
+        "/a.jsonl": {
+          ...encoded.files["/a.jsonl"]!,
+          r: [[...row.slice(0, 10), cwdIndex]],
+        },
+      },
+    };
+
+    expect(decodeScanCache(JSON.parse(JSON.stringify(poisoned))).has("/a.jsonl")).toBe(false);
+  });
 });
 
 describe("pruneScanCache", () => {
@@ -281,7 +299,7 @@ describe("pruneScanCache with an unwalked root", () => {
 });
 
 describe("dedupeWithinFile", () => {
-  it("keeps the first record per dedupe key", () => {
+  it("keeps the final record per dedupe key", () => {
     const kept = dedupeWithinFile([
       record({ totals: { ...record().totals, outputTokens: 1 } }),
       record({ totals: { ...record().totals, outputTokens: 999 } }),
@@ -289,7 +307,7 @@ describe("dedupeWithinFile", () => {
     ]);
 
     expect(kept).toHaveLength(2);
-    expect(kept[0]?.totals.outputTokens).toBe(1);
+    expect(kept[0]?.totals.outputTokens).toBe(999);
   });
 
   it("keeps every record that has no dedupe key", () => {

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -26,7 +26,9 @@ import type { CodexScanState, UsageRecord } from "./usageTranscripts.ts";
 // entries would keep serving double-counted records forever.
 // v3: entries carry the parse position and reducer state so a grown file
 // re-parses only its appended bytes instead of starting over.
-const USAGE_SCAN_CACHE_VERSION = 3 as const;
+// v4: records carry the session's cwd for project attribution; v3 entries
+// would pin every cached file to "no project" forever.
+const USAGE_SCAN_CACHE_VERSION = 4 as const;
 
 export interface CachedFile {
   readonly size: number;
@@ -61,6 +63,7 @@ type SerializedRecord = readonly [
   reasoningTokens: number,
   dedupeKey: string | null,
   reportedCostUsd: number | null,
+  cwdIndex: number,
 ];
 
 interface SerializedFile {
@@ -82,15 +85,18 @@ interface SerializedCache {
   readonly version: number;
   readonly models: readonly string[];
   readonly sessions: readonly string[];
+  readonly cwds: readonly string[];
   readonly files: Readonly<Record<string, SerializedFile>>;
 }
 
-/** Serialises the cache, interning the repeated model and session strings. */
+/** Serialises the cache, interning the repeated model, session and cwd strings. */
 export function encodeScanCache(cache: ScanCache): SerializedCache {
   const models: string[] = [];
   const sessions: string[] = [];
+  const cwds: string[] = [];
   const modelIndex = new Map<string, number>();
   const sessionIndex = new Map<string, number>();
+  const cwdIndex = new Map<string, number>();
 
   const intern = (table: string[], index: Map<string, number>, value: string): number => {
     const existing = index.get(value);
@@ -112,6 +118,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     record.totals.reasoningTokens,
     record.dedupeKey,
     record.reportedCostUsd,
+    intern(cwds, cwdIndex, record.cwd),
   ];
 
   const files: Record<string, SerializedFile> = {};
@@ -129,7 +136,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     };
   }
 
-  return { version: USAGE_SCAN_CACHE_VERSION, models, sessions, files };
+  return { version: USAGE_SCAN_CACHE_VERSION, models, sessions, cwds, files };
 }
 
 function isRecordArray(value: unknown): value is readonly unknown[] {
@@ -148,7 +155,9 @@ export function decodeScanCache(document: unknown): ScanCache {
 
   const root = document as Partial<SerializedCache>;
   if (root.version !== USAGE_SCAN_CACHE_VERSION) return cache;
-  if (!isRecordArray(root.models) || !isRecordArray(root.sessions)) return cache;
+  if (!isRecordArray(root.models) || !isRecordArray(root.sessions) || !isRecordArray(root.cwds)) {
+    return cache;
+  }
   if (typeof root.files !== "object" || root.files === null) return cache;
 
   // The intern tables must be all strings: a numeric entry would pass the
@@ -156,8 +165,10 @@ export function decodeScanCache(document: unknown): ScanCache {
   // at lookupRate. A corrupt table rejects the whole cache.
   if (!root.models.every((value) => typeof value === "string")) return cache;
   if (!root.sessions.every((value) => typeof value === "string")) return cache;
+  if (!root.cwds.every((value) => typeof value === "string")) return cache;
   const models = root.models as readonly string[];
   const sessions = root.sessions as readonly string[];
+  const cwds = root.cwds as readonly string[];
 
   // Any corrupt row disqualifies the whole entry. Keeping the survivors
   // under the original (size, mtime) would read as a valid warm hit and the
@@ -168,7 +179,7 @@ export function decodeScanCache(document: unknown): ScanCache {
   ): UsageRecord[] | null => {
     const records: UsageRecord[] = [];
     for (const row of rows) {
-      if (!isRecordArray(row) || row.length < 10) return null;
+      if (!isRecordArray(row) || row.length < 11) return null;
       const [
         timestampMs,
         modelIndex,
@@ -180,13 +191,21 @@ export function decodeScanCache(document: unknown): ScanCache {
         reasoning,
         dedupeKey,
         reportedCostUsd,
+        cwdIndex,
       ] = row as SerializedRecord;
 
       const model = typeof modelIndex === "number" ? models[modelIndex] : undefined;
+      const session = typeof sessionIndex === "number" ? sessions[sessionIndex] : undefined;
+      const cwd = typeof cwdIndex === "number" ? cwds[cwdIndex] : undefined;
       if (
         typeof timestampMs !== "number" ||
         !Number.isFinite(timestampMs) ||
         model === undefined ||
+        !Number.isInteger(modelIndex) ||
+        session === undefined ||
+        !Number.isInteger(sessionIndex) ||
+        cwd === undefined ||
+        !Number.isInteger(cwdIndex) ||
         !Number.isFinite(uncached) ||
         !Number.isFinite(cached) ||
         !Number.isFinite(cacheCreation) ||
@@ -200,7 +219,8 @@ export function decodeScanCache(document: unknown): ScanCache {
         provider,
         timestampMs,
         model,
-        sessionId: (typeof sessionIndex === "number" ? sessions[sessionIndex] : undefined) ?? "",
+        sessionId: session,
+        cwd,
         totals: {
           uncachedInputTokens: uncached,
           cachedInputTokens: cached,
@@ -277,6 +297,7 @@ function decodeCodexState(value: unknown): CodexScanState | null | undefined {
   if (
     typeof state.model !== "string" ||
     typeof state.sessionId !== "string" ||
+    typeof state.cwd !== "string" ||
     (state.lastUsageSignature !== null && typeof state.lastUsageSignature !== "string") ||
     typeof state.sawSessionMeta !== "boolean" ||
     typeof state.suppressingForkCopies !== "boolean" ||
@@ -288,6 +309,7 @@ function decodeCodexState(value: unknown): CodexScanState | null | undefined {
   return {
     model: state.model,
     sessionId: state.sessionId,
+    cwd: state.cwd,
     lastUsageSignature: state.lastUsageSignature ?? null,
     sawSessionMeta: state.sawSessionMeta,
     suppressingForkCopies: state.suppressingForkCopies,
@@ -343,22 +365,18 @@ export function pruneScanCache(cache: ScanCache, options: PruneOptions): number 
   return removed;
 }
 
-/**
- * Within-file de-duplication, applied before an entry is cached.
- *
- * Callers stitching an incremental parse together pass one `seen` set across
- * the line and tail record batches so the whole file stays deduplicated as a
- * unit; the set is mutated in place.
- */
-export function dedupeWithinFile(
-  records: readonly UsageRecord[],
-  seen: Set<string> = new Set(),
-): readonly UsageRecord[] {
+/** Within-file de-duplication, retaining the final complete Claude snapshot. */
+export function dedupeWithinFile(records: readonly UsageRecord[]): readonly UsageRecord[] {
+  const indexByKey = new Map<string, number>();
   const kept: UsageRecord[] = [];
   for (const record of records) {
     if (record.dedupeKey !== null) {
-      if (seen.has(record.dedupeKey)) continue;
-      seen.add(record.dedupeKey);
+      const existing = indexByKey.get(record.dedupeKey);
+      if (existing !== undefined) {
+        kept[existing] = record;
+        continue;
+      }
+      indexByKey.set(record.dedupeKey, kept.length);
     }
     kept.push(record);
   }

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -1,0 +1,563 @@
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+
+import { UsageAggregator } from "./usageAggregation.ts";
+import type { RateTable } from "./usagePricing.ts";
+import { foldThreadRows, ThreadUsageAccumulator, type ThreadAttribution } from "./usageThreads.ts";
+import type { UsageRecord } from "./usageTranscripts.ts";
+
+const rates: RateTable = new Map([
+  [
+    "claude-fable-5",
+    {
+      inputCostPerToken: 1e-5,
+      outputCostPerToken: 5e-5,
+      cacheReadCostPerToken: 1e-6,
+      cacheCreationCostPerToken: 1.25e-5,
+    },
+  ],
+]);
+
+const PROJECT_ONE = { projectId: ProjectId.make("project-one"), title: "Project one" };
+const PROJECT_TWO = { projectId: ProjectId.make("project-two"), title: "Project two" };
+
+function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
+  return {
+    provider: "claude",
+    timestampMs: Date.parse("2026-08-07T04:05:13.944Z"),
+    model: "claude-fable-5",
+    sessionId: "session-a",
+    cwd: "/work/app",
+    totals: {
+      uncachedInputTokens: 100,
+      cachedInputTokens: 1000,
+      cacheCreationTokens: 10,
+      outputTokens: 50,
+      reasoningTokens: 0,
+    },
+    reportedCostUsd: null,
+    dedupeKey: null,
+    ...overrides,
+  };
+}
+
+function accumulate(
+  entries: readonly (readonly [UsageRecord, { sessionKey: string; agentId: string | null }])[],
+) {
+  const accumulator = new ThreadUsageAccumulator({
+    timeZone: "UTC",
+    sinceDay: "2026-08-01",
+    untilDay: "2026-08-31",
+    rates,
+  });
+  for (const [item, context] of entries) accumulator.add(item, context);
+  return accumulator.finish();
+}
+
+const NO_ATTRIBUTION: ThreadAttribution = {
+  sessionToThread: new Map(),
+  worktreeToThread: new Map(),
+};
+
+describe("ThreadUsageAccumulator", () => {
+  it("groups records by session and splits subagent slices out", () => {
+    const main = { sessionKey: "claude:session-a", agentId: null };
+    const agent = { sessionKey: "claude:session-a", agentId: "agent-1" };
+    const groups = accumulate([
+      [record(), main],
+      [record(), agent],
+      [record({ sessionId: "session-b" }), { sessionKey: "claude:session-b", agentId: null }],
+    ]);
+
+    expect(groups).toHaveLength(2);
+    const sessionA = groups.find((group) => group.sessionKey === "claude:session-a");
+    expect(sessionA?.totals.outputTokens).toBe(100);
+    expect(sessionA?.agents.get("agent-1")?.totals.outputTokens).toBe(50);
+  });
+
+  it("dedupes globally across files with the summary's semantics", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [record({ dedupeKey: "msg_1:" }), context],
+      [record({ dedupeKey: "msg_1:" }), context],
+    ]);
+
+    expect(groups[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("uses the final complete snapshot across files", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [
+        record({ dedupeKey: "msg_partial:", totals: { ...record().totals, outputTokens: 1 } }),
+        context,
+      ],
+      [
+        record({ dedupeKey: "msg_partial:", totals: { ...record().totals, outputTokens: 310 } }),
+        context,
+      ],
+    ]);
+
+    expect(groups[0]?.totals.outputTokens).toBe(310);
+  });
+
+  it("applies the window to the final complete snapshot", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [record({ dedupeKey: "msg_partial:" }), context],
+      [
+        record({
+          dedupeKey: "msg_partial:",
+          timestampMs: Date.parse("2026-09-01T00:00:00Z"),
+        }),
+        context,
+      ],
+    ]);
+
+    expect(groups).toEqual([]);
+  });
+
+  it("splits each day's model-priced cost into cache components", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([[record(), context]]);
+    const day = groups[0]?.daily.get("2026-08-07");
+
+    expect(day?.cacheWriteUsd).toBeCloseTo(10 * 1.25e-5, 12);
+    expect(day?.cacheReadUsd).toBeCloseTo(1000 * 1e-6, 12);
+    expect(day?.freshUsd).toBeCloseTo(100 * 1e-5 + 50 * 5e-5, 12);
+  });
+
+  it("does not invent component costs for provider-reported totals", () => {
+    const context = { sessionKey: "claude:session-a", agentId: "agent-1" };
+    const groups = accumulate([[record({ reportedCostUsd: 1.25 }), context]]);
+    const rows = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 40 });
+
+    expect(rows.rows[0]?.costUsd).toBe(1.25);
+    expect(rows.rows[0]?.cacheWriteUsd).toBeNull();
+    expect(rows.rows[0]?.agents[0]?.cacheWriteUsd).toBeNull();
+    expect(rows.rows[0]?.daily).toEqual([]);
+  });
+
+  it("uses custom prices for thread totals and component costs", () => {
+    const customRates: RateTable = new Map([
+      [
+        "claude-fable-5",
+        {
+          inputCostPerToken: 2e-5,
+          outputCostPerToken: 1e-4,
+          cacheReadCostPerToken: 2e-6,
+          cacheCreationCostPerToken: 2.5e-5,
+        },
+      ],
+    ]);
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      priceOverrides: customRates,
+    });
+    accumulator.add(record({ reportedCostUsd: 1.25 }), {
+      sessionKey: "claude:session-a",
+      agentId: null,
+    });
+
+    const group = accumulator.finish()[0];
+    const day = group?.daily.get("2026-08-07");
+    expect(group?.costUsd).toBeCloseTo(100 * 2e-5 + 1000 * 2e-6 + 10 * 2.5e-5 + 50 * 1e-4, 12);
+    expect(day?.cacheWriteUsd).toBeCloseTo(10 * 2.5e-5, 12);
+    expect(day?.cacheReadUsd).toBeCloseTo(1000 * 2e-6, 12);
+    expect(day?.freshUsd).toBeCloseTo(100 * 2e-5 + 50 * 1e-4, 12);
+  });
+
+  it("drops records outside the window", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [record({ timestampMs: Date.parse("2026-07-01T00:00:00Z") }), context],
+    ]);
+
+    expect(groups).toHaveLength(0);
+  });
+
+  it("drops timestamps outside the JavaScript date range", () => {
+    const context = { sessionKey: "grok:session-a", agentId: null };
+    expect(() => accumulate([[record({ timestampMs: 1e20 }), context]])).not.toThrow();
+    expect(accumulate([[record({ timestampMs: 1e20 }), context]])).toEqual([]);
+  });
+
+  it("applies exact time bounds inside a shared calendar day", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-07",
+      untilDay: "2026-08-07",
+      sinceTimeMs: Date.parse("2026-08-07T04:00:00Z"),
+      untilTimeMs: Date.parse("2026-08-07T05:00:00Z"),
+      rates,
+    });
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-07T03:59:59Z") }), context);
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-07T04:30:00Z") }), context);
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-07T05:00:00Z") }), context);
+
+    expect(accumulator.finish()[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("uses exact bounds without applying a second calendar-day filter", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-07",
+      untilDay: "2026-08-07",
+      sinceTimeMs: Date.parse("2026-08-08T04:00:00Z"),
+      untilTimeMs: Date.parse("2026-08-08T05:00:00Z"),
+      rates,
+    });
+
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-08T04:30:00Z") }), {
+      sessionKey: "claude:exact-window",
+      agentId: null,
+    });
+
+    expect(accumulator.finish()[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("keeps separate cwd slices when one session crosses projects", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd.endsWith("one") ? PROJECT_ONE : PROJECT_TWO),
+    });
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    accumulator.add(record({ cwd: "/work/one" }), context);
+    accumulator.add(record({ cwd: "/work/two" }), context);
+
+    expect(
+      accumulator
+        .finish()
+        .map((group) => group.projectKey)
+        .toSorted(),
+    ).toEqual(["id:project-one", "id:project-two"]);
+  });
+});
+
+describe("foldThreadRows", () => {
+  const threadId = ThreadId.make("11111111-1111-4111-8111-111111111111");
+
+  it("folds sessions into one row per thread via cursor and worktree matches", () => {
+    const groups = accumulate([
+      [record(), { sessionKey: "claude:session-a", agentId: null }],
+      [
+        record({ sessionId: "session-b", cwd: "/work/app/.wt/thread-1" }),
+        { sessionKey: "claude:session-b", agentId: null },
+      ],
+      [record({ sessionId: "session-c" }), { sessionKey: "claude:session-c", agentId: null }],
+    ]);
+    const attribution: ThreadAttribution = {
+      sessionToThread: new Map([["claude:session-a", { threadId, title: "Fix the flaky test" }]]),
+      worktreeToThread: new Map([
+        ["/work/app/.wt/thread-1", { threadId, title: "Fix the flaky test" }],
+      ]),
+    };
+
+    const { rows, truncatedRows } = foldThreadRows(groups, attribution, { cap: 40 });
+
+    expect(truncatedRows).toBe(0);
+    expect(rows).toHaveLength(2);
+    const threadRow = rows.find((row) => row.threadId === threadId);
+    expect(threadRow?.title).toBe("Fix the flaky test");
+    expect(threadRow?.sessions).toBe(2);
+    const standalone = rows.find((row) => row.threadId === null);
+    // Standalone rows leave the title to the caller's transcript read.
+    expect(standalone?.title).toBeNull();
+    expect(standalone?.key).toContain("claude:session-c");
+  });
+
+  it("uses the deepest worktree ancestor for sessions run in subdirectories", () => {
+    const nestedThreadId = ThreadId.make("22222222-2222-4222-8222-222222222222");
+    const groups = accumulate([
+      [
+        record({ sessionId: "nested", cwd: "/work/app/.wt/thread-1/packages/web" }),
+        { sessionKey: "claude:nested", agentId: null },
+      ],
+    ]);
+    const attribution: ThreadAttribution = {
+      sessionToThread: new Map(),
+      worktreeToThread: new Map([
+        ["/work/app", { threadId, title: "Shared root" }],
+        ["/work/app/.wt/thread-1", { threadId: nestedThreadId, title: "Nested worktree" }],
+      ]),
+    };
+
+    const { rows } = foldThreadRows(groups, attribution, { cap: 40 });
+
+    expect(rows[0]?.threadId).toBe(nestedThreadId);
+    expect(rows[0]?.title).toBe("Nested worktree");
+  });
+
+  it("matches Windows worktrees without changing POSIX case sensitivity", () => {
+    const groups = accumulate([
+      [
+        record({ sessionId: "windows", cwd: "c:\\work\\app\\.wt\\thread-1\\src" }),
+        { sessionKey: "claude:windows", agentId: null },
+      ],
+      [
+        record({ sessionId: "posix", cwd: "/work/app/.wt/thread-1/src" }),
+        { sessionKey: "claude:posix", agentId: null },
+      ],
+    ]);
+    const attribution: ThreadAttribution = {
+      sessionToThread: new Map(),
+      worktreeToThread: new Map([
+        ["C:\\Work\\App\\.wt\\thread-1", { threadId, title: "Windows worktree" }],
+        ["/Work/App/.wt/thread-1", { threadId, title: "Different POSIX worktree" }],
+      ]),
+    };
+
+    const { rows } = foldThreadRows(groups, attribution, { cap: 40 });
+
+    const threadRow = rows.find((row) => row.threadId === threadId);
+    expect(threadRow?.sessions).toBe(1);
+    expect(rows.some((row) => row.threadId === null && row.sessions === 1)).toBe(true);
+  });
+
+  it("scopes one T3 thread by provider and project", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd.endsWith("one") ? PROJECT_ONE : PROJECT_TWO),
+    });
+    const entries = [
+      [record({ sessionId: "claude-one", cwd: "/work/one" }), "claude:claude-one"],
+      [record({ sessionId: "claude-two", cwd: "/work/two" }), "claude:claude-two"],
+      [
+        record({
+          provider: "codex",
+          model: "gpt-5.6-sol",
+          sessionId: "codex-one",
+          cwd: "/work/one",
+        }),
+        "codex:codex-one",
+      ],
+    ] as const;
+    for (const [item, sessionKey] of entries) {
+      accumulator.add(item, { sessionKey, agentId: null });
+    }
+    const attribution: ThreadAttribution = {
+      sessionToThread: new Map(
+        entries.map(([, sessionKey]) => [sessionKey, { threadId, title: "Shared thread" }]),
+      ),
+      worktreeToThread: new Map(),
+    };
+
+    const { rows } = foldThreadRows(accumulator.finish(), attribution, { cap: 40 });
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => [row.provider, row.project]).toSorted()).toEqual([
+      ["claude", "Project one"],
+      ["claude", "Project two"],
+      ["codex", "Project one"],
+    ]);
+    expect(new Set(rows.map((row) => row.key)).size).toBe(3);
+    expect(rows.every((row) => row.threadId === threadId && row.title === "Shared thread")).toBe(
+      true,
+    );
+
+    const projectOne = foldThreadRows(accumulator.finish(), attribution, {
+      cap: 40,
+      projectFilter: "id:project-one",
+    });
+    expect(projectOne.rows.map((row) => [row.provider, row.project]).toSorted()).toEqual([
+      ["claude", "Project one"],
+      ["codex", "Project one"],
+    ]);
+  });
+
+  it("groups rows past the cap without losing their usage", () => {
+    const groups = accumulate(
+      Array.from({ length: 5 }, (_, index) => [
+        record({ sessionId: `session-${index}` }),
+        { sessionKey: `claude:session-${index}`, agentId: null },
+      ]),
+    );
+
+    const { rows, truncatedRows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 3 });
+
+    expect(rows).toHaveLength(3);
+    expect(truncatedRows).toBe(3);
+    expect(rows.find((row) => row.key.startsWith("remainder:"))?.title).toBe("Other threads (3)");
+    expect(rows.find((row) => row.key.startsWith("remainder:"))?.groupedRows).toBe(3);
+    expect(rows.reduce((sum, row) => sum + row.totals.outputTokens, 0)).toBe(250);
+  });
+
+  it("keeps subagent slices when lower-cost rows fold into a remainder", () => {
+    const groups = accumulate([
+      [
+        record({ sessionId: "expensive", totals: { ...record().totals, outputTokens: 100 } }),
+        { sessionKey: "claude:expensive", agentId: null },
+      ],
+      [
+        record({ sessionId: "cheaper" }),
+        { sessionKey: "claude:cheaper", agentId: "agent-cheaper" },
+      ],
+    ]);
+
+    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 1 });
+    const remainder = rows.find((row) => row.key.startsWith("remainder:"));
+    expect(remainder?.agents.map((agent) => agent.agentId)).toEqual(["agent-cheaper"]);
+  });
+
+  it("bounds and reconciles subagents folded into a remainder", () => {
+    const groups = accumulate([
+      [
+        record({ sessionId: "expensive", totals: { ...record().totals, outputTokens: 100 } }),
+        { sessionKey: "claude:expensive", agentId: null },
+      ],
+      ...Array.from(
+        { length: 5 },
+        (_, index) =>
+          [
+            record({ sessionId: `cheaper-${index}` }),
+            { sessionKey: `claude:cheaper-${index}`, agentId: `agent-${index}` },
+          ] as const,
+      ),
+    ]);
+
+    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 2 });
+    const remainder = rows.find((row) => row.key.startsWith("remainder:"));
+
+    expect(remainder?.agents).toHaveLength(2);
+    expect(remainder?.agents.some((agent) => agent.agentId === "Other subagents (4)")).toBe(true);
+    expect(remainder?.agents.reduce((sum, agent) => sum + agent.totals.outputTokens, 0)).toBe(250);
+  });
+
+  it("collapses overflow project scopes without exceeding the response cap", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => ({
+        projectId: ProjectId.make(`project-${cwd.slice(-1)}`),
+        title: `Project ${cwd.slice(-1)}`,
+      }),
+    });
+    for (let index = 0; index < 6; index += 1) {
+      accumulator.add(record({ sessionId: `session-${index}`, cwd: `/work/${index}` }), {
+        sessionKey: `claude:session-${index}`,
+        agentId: null,
+      });
+    }
+
+    const { rows } = foldThreadRows(accumulator.finish(), NO_ATTRIBUTION, { cap: 3 });
+
+    expect(rows.length).toBeLessThanOrEqual(3);
+    expect(rows.reduce((sum, row) => sum + row.totals.outputTokens, 0)).toBe(300);
+  });
+
+  it("reconciles every provider and project after lower-cost rows are grouped", () => {
+    const resolveProject = (cwd: string) => (cwd.endsWith("one") ? PROJECT_ONE : PROJECT_TWO);
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject,
+    });
+    const summary = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      resolution: "day",
+      rates,
+      resolveProject,
+    });
+    for (const [index, provider, project] of [
+      [0, "claude", "one"],
+      [1, "claude", "one"],
+      [2, "claude", "two"],
+      [3, "codex", "one"],
+      [4, "codex", "two"],
+    ] as const) {
+      const item = record({
+        provider,
+        model: provider === "claude" ? "claude-fable-5" : "gpt-5.6-sol",
+        sessionId: `session-${index}`,
+        cwd: `/work/${project}`,
+      });
+      accumulator.add(item, { sessionKey: `${provider}:session-${index}`, agentId: null });
+      summary.add(item);
+    }
+    const groups = accumulator.finish();
+
+    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 4 });
+    expect(rows.length).toBeLessThanOrEqual(4);
+    const expected = new Map<string, number>();
+    for (const bucket of summary.finish().buckets) {
+      const key = `${bucket.provider}:${bucket.project ?? ""}`;
+      expected.set(key, (expected.get(key) ?? 0) + bucket.totals.outputTokens);
+    }
+    const actual = new Map<string, number>();
+    for (const row of rows) {
+      const key = `${row.provider}:${row.project ?? ""}`;
+      actual.set(key, (actual.get(key) ?? 0) + row.totals.outputTokens);
+    }
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("filters by project before capping", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd === "/work/app" ? PROJECT_ONE : null),
+    });
+    accumulator.add(record(), { sessionKey: "claude:session-a", agentId: null });
+    accumulator.add(record({ sessionId: "session-b", cwd: "/elsewhere" }), {
+      sessionKey: "claude:session-b",
+      agentId: null,
+    });
+    const groups = accumulator.finish();
+
+    const app = foldThreadRows(groups, NO_ATTRIBUTION, {
+      cap: 40,
+      projectFilter: "id:project-one",
+    });
+    expect(app.rows.map((row) => row.key)).toHaveLength(1);
+    expect(app.rows[0]?.key).toContain("claude:session-a");
+
+    const outside = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 40, projectFilter: null });
+    expect(outside.rows.map((row) => row.key)).toHaveLength(1);
+    expect(outside.rows[0]?.key).toContain("claude:session-b");
+  });
+
+  it("excludes unknown project attribution from the outside-project filter", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: () => null,
+    });
+    accumulator.add(record({ sessionId: "outside", cwd: "/elsewhere" }), {
+      sessionKey: "claude:outside",
+      agentId: null,
+    });
+    accumulator.add(record({ provider: "grok", sessionId: "unknown", cwd: "" }), {
+      sessionKey: "grok:unknown",
+      agentId: null,
+    });
+
+    const outside = foldThreadRows(accumulator.finish(), NO_ATTRIBUTION, {
+      cap: 40,
+      projectFilter: null,
+    });
+
+    expect(outside.rows).toHaveLength(1);
+    expect(outside.rows[0]?.key).toContain("claude:outside");
+  });
+});

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -1,0 +1,614 @@
+/**
+ * Pure grouping behind the thread drill-down: transcript records fold into
+ * per-session groups, and session groups fold into thread rows using the
+ * attribution the caller extracted from its own state (resume cursors and
+ * dedicated worktrees).
+ *
+ * Pure, so grouping, de-duplication and attribution are testable without the
+ * filesystem or the database.
+ *
+ * @module usageThreads
+ */
+import type {
+  ProjectId,
+  ThreadId,
+  UsageAgentRow,
+  UsageProviderKind,
+  UsageThreadDayCost,
+  UsageThreadRow,
+  UsageTokenTotals,
+} from "@t3tools/contracts";
+import { UsageDay } from "@t3tools/contracts";
+
+import { makeDayFormatter, type ProjectAttribution } from "./usageAggregation.ts";
+import { normalizeUsagePath } from "./usagePaths.ts";
+import { cacheWriteUsd, priceUsage, usageComponentCosts, type RateTable } from "./usagePricing.ts";
+import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
+
+const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+
+/** How the caller identifies the transcript a record came from. */
+export interface ThreadRecordContext {
+  /** `provider:sessionId`, or a file-derived fallback when the id is empty. */
+  readonly sessionKey: string;
+  /** Claude subagent id when the record came from a `subagents/agent-*.jsonl` file. */
+  readonly agentId: string | null;
+}
+
+interface MutableComponentCosts {
+  cacheWriteUsd: number;
+  cacheReadUsd: number;
+  freshUsd: number;
+}
+
+interface MutableAgentSlice {
+  totals: UsageTokenTotals;
+  costUsd: number;
+  cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
+}
+
+export interface SessionUsageGroup {
+  readonly sessionKey: string;
+  readonly provider: UsageProviderKind;
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly projectId: ProjectId | null;
+  readonly projectKey: string | null;
+  readonly projectAttribution: "project" | "outside" | "unknown";
+  readonly project: string;
+  readonly totals: UsageTokenTotals;
+  readonly costUsd: number;
+  readonly cacheWriteUsd: number;
+  readonly cacheWriteComplete: boolean;
+  readonly daily: ReadonlyMap<string, MutableComponentCosts>;
+  readonly agents: ReadonlyMap<string, MutableAgentSlice>;
+}
+
+interface MutableSessionGroup {
+  sessionKey: string;
+  provider: UsageProviderKind;
+  sessionId: string;
+  cwd: string;
+  projectId: ProjectId | null;
+  projectKey: string | null;
+  projectAttribution: "project" | "outside" | "unknown";
+  project: string;
+  totals: UsageTokenTotals;
+  costUsd: number;
+  cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
+  daily: Map<string, MutableComponentCosts>;
+  agents: Map<string, MutableAgentSlice>;
+}
+
+export interface ThreadUsageOptions {
+  readonly timeZone: string;
+  readonly sinceDay: string;
+  readonly untilDay: string;
+  readonly sinceTimeMs?: number;
+  readonly untilTimeMs?: number;
+  readonly rates: RateTable;
+  readonly priceOverrides?: RateTable;
+  /** Same stable project resolver the summary uses. */
+  readonly resolveProject?: (cwd: string) => ProjectAttribution | null;
+}
+
+/**
+ * Folds records into per-session groups with per-day component costs.
+ *
+ * De-duplication is global across the scan with the same semantics as the
+ * summary aggregator, so a thread's number here always reconciles with its
+ * share of the summary.
+ */
+export class ThreadUsageAccumulator {
+  readonly #recordsByKey = new Map<
+    string,
+    { readonly record: UsageRecord; readonly context: ThreadRecordContext }
+  >();
+  readonly #unkeyedRecords: {
+    readonly record: UsageRecord;
+    readonly context: ThreadRecordContext;
+  }[] = [];
+  readonly #toDay: (timestampMs: number) => string;
+  readonly #options: ThreadUsageOptions;
+
+  constructor(options: ThreadUsageOptions) {
+    this.#options = options;
+    this.#toDay = makeDayFormatter(options.timeZone);
+  }
+
+  add(record: UsageRecord, context: ThreadRecordContext): boolean {
+    const inWindow = this.#isInWindow(record);
+    if (record.dedupeKey === null) {
+      this.#unkeyedRecords.push({ record, context });
+      return inWindow;
+    }
+    this.#recordsByKey.set(record.dedupeKey, { record, context });
+    return inWindow;
+  }
+
+  #isInWindow(record: UsageRecord): boolean {
+    if (
+      !Number.isFinite(record.timestampMs) ||
+      Math.abs(record.timestampMs) > MAX_DATE_TIMESTAMP_MS
+    ) {
+      return false;
+    }
+    if (
+      this.#options.sinceTimeMs !== undefined &&
+      this.#options.untilTimeMs !== undefined &&
+      (record.timestampMs < this.#options.sinceTimeMs ||
+        record.timestampMs >= this.#options.untilTimeMs)
+    ) {
+      return false;
+    }
+    const day = this.#toDay(record.timestampMs);
+    if (
+      (this.#options.sinceTimeMs === undefined || this.#options.untilTimeMs === undefined) &&
+      (day < this.#options.sinceDay || day > this.#options.untilDay)
+    )
+      return false;
+    return true;
+  }
+
+  #foldRecord(
+    record: UsageRecord,
+    context: ThreadRecordContext,
+    groups: Map<string, MutableSessionGroup>,
+  ): void {
+    const day = this.#toDay(record.timestampMs);
+    const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
+    const projectAttribution =
+      resolvedProject !== null
+        ? "project"
+        : this.#options.resolveProject === undefined || record.cwd.length === 0
+          ? "unknown"
+          : "outside";
+    const projectKey =
+      resolvedProject === null ? null : `id:${resolvedProject.projectId.replaceAll("\u0000", "")}`;
+    const groupKey = JSON.stringify([context.sessionKey, record.cwd]);
+    let group = groups.get(groupKey);
+    if (group === undefined) {
+      group = {
+        sessionKey: context.sessionKey,
+        provider: record.provider,
+        sessionId: record.sessionId,
+        cwd: record.cwd,
+        projectId: resolvedProject?.projectId ?? null,
+        projectKey,
+        projectAttribution,
+        project: resolvedProject?.title ?? "",
+        totals: EMPTY_TOTALS,
+        costUsd: 0,
+        cacheWriteUsd: 0,
+        cacheWriteComplete: true,
+        daily: new Map(),
+        agents: new Map(),
+      };
+      groups.set(groupKey, group);
+    }
+
+    const priced = priceUsage(
+      this.#options.rates,
+      record.model,
+      record.totals,
+      record.reportedCostUsd,
+      this.#options.priceOverrides,
+    );
+    const cacheWriteComplete =
+      priced.costSource === "modelPriced" || record.totals.cacheCreationTokens === 0;
+    const writeUsd =
+      priced.costSource === "modelPriced"
+        ? cacheWriteUsd(
+            this.#options.rates,
+            record.model,
+            record.totals,
+            this.#options.priceOverrides,
+          )
+        : 0;
+    group.totals = addTotals(group.totals, record.totals);
+    group.costUsd += priced.costUsd;
+    group.cacheWriteUsd += writeUsd;
+    group.cacheWriteComplete &&= cacheWriteComplete;
+
+    if (priced.costSource === "modelPriced") {
+      const components = usageComponentCosts(
+        this.#options.rates,
+        record.model,
+        record.totals,
+        this.#options.priceOverrides,
+      );
+      let dayEntry = group.daily.get(day);
+      if (dayEntry === undefined) {
+        dayEntry = { cacheWriteUsd: 0, cacheReadUsd: 0, freshUsd: 0 };
+        group.daily.set(day, dayEntry);
+      }
+      dayEntry.cacheWriteUsd += components.cacheWriteUsd;
+      dayEntry.cacheReadUsd += components.cacheReadUsd;
+      dayEntry.freshUsd += components.freshUsd;
+    }
+
+    if (context.agentId !== null) {
+      let agent = group.agents.get(context.agentId);
+      if (agent === undefined) {
+        agent = {
+          totals: EMPTY_TOTALS,
+          costUsd: 0,
+          cacheWriteUsd: 0,
+          cacheWriteComplete: true,
+        };
+        group.agents.set(context.agentId, agent);
+      }
+      agent.totals = addTotals(agent.totals, record.totals);
+      agent.costUsd += priced.costUsd;
+      agent.cacheWriteUsd += writeUsd;
+      agent.cacheWriteComplete &&= cacheWriteComplete;
+    }
+  }
+
+  finish(): readonly SessionUsageGroup[] {
+    const groups = new Map<string, MutableSessionGroup>();
+    for (const { record, context } of this.#unkeyedRecords) {
+      if (this.#isInWindow(record)) this.#foldRecord(record, context, groups);
+    }
+    for (const { record, context } of this.#recordsByKey.values()) {
+      if (this.#isInWindow(record)) this.#foldRecord(record, context, groups);
+    }
+    return [...groups.values()].map((group) => ({
+      sessionKey: group.sessionKey,
+      provider: group.provider,
+      sessionId: group.sessionId,
+      cwd: group.cwd,
+      projectId: group.projectId,
+      projectKey: group.projectKey,
+      projectAttribution: group.projectAttribution,
+      project: group.project,
+      totals: group.totals,
+      costUsd: group.costUsd,
+      cacheWriteUsd: group.cacheWriteUsd,
+      cacheWriteComplete: group.cacheWriteComplete,
+      daily: group.daily,
+      agents: group.agents,
+    }));
+  }
+}
+
+/** A thread a session can attribute to, from the environment's own state. */
+export interface ThreadRef {
+  readonly threadId: ThreadId;
+  readonly title: string;
+}
+
+export interface ThreadAttribution {
+  /** `provider:sessionId` of each thread's current session, from resume cursors. */
+  readonly sessionToThread: ReadonlyMap<string, ThreadRef>;
+  /**
+   * Dedicated worktree path → thread. Only paths claimed by exactly one
+   * thread belong here: a shared root would stamp one thread's identity onto
+   * every unrelated session running there.
+   */
+  readonly worktreeToThread: ReadonlyMap<string, ThreadRef>;
+}
+
+export interface FoldThreadRowsOptions {
+  /** A title, `null` for outside-projects sessions, `undefined` for no filter. */
+  readonly projectFilter?: string | null | undefined;
+  /** Maximum returned rows, including grouped remainders. */
+  readonly cap: number;
+}
+
+interface MutableThreadRow {
+  threadId: ThreadId | null;
+  title: string | null;
+  provider: UsageProviderKind;
+  project: string;
+  projectId: ProjectId | null;
+  projectKey: string | null;
+  cwd: string;
+  totals: UsageTokenTotals;
+  costUsd: number;
+  sessionKeys: Set<string>;
+  cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
+  groupedRows: number;
+  daily: Map<string, MutableComponentCosts>;
+  agents: Map<string, MutableAgentSlice>;
+  /** Session whose transcript can supply a title when no thread claims the row. */
+  titleSessionKey: string;
+}
+
+export interface FoldedThreadRows {
+  readonly rows: readonly (Omit<UsageThreadRow, "title"> & {
+    readonly title: string | null;
+    readonly titleSessionKey: string;
+  })[];
+  readonly truncatedRows: number;
+}
+
+function addDailyCosts(
+  target: Map<string, MutableComponentCosts>,
+  source: ReadonlyMap<string, MutableComponentCosts>,
+): void {
+  for (const [day, components] of source) {
+    let dayEntry = target.get(day);
+    if (dayEntry === undefined) {
+      dayEntry = { cacheWriteUsd: 0, cacheReadUsd: 0, freshUsd: 0 };
+      target.set(day, dayEntry);
+    }
+    dayEntry.cacheWriteUsd += components.cacheWriteUsd;
+    dayEntry.cacheReadUsd += components.cacheReadUsd;
+    dayEntry.freshUsd += components.freshUsd;
+  }
+}
+
+function worktreeThreadForCwd(
+  cwd: string,
+  worktreeToThread: Iterable<readonly [string, ThreadRef]>,
+): ThreadRef | undefined {
+  const normalizedCwd = normalizeUsagePath(cwd);
+  let deepest: { readonly pathLength: number; readonly ref: ThreadRef } | undefined;
+  for (const [worktree, ref] of worktreeToThread) {
+    const normalizedWorktree = worktree;
+    const prefix = normalizedWorktree.endsWith("/") ? normalizedWorktree : `${normalizedWorktree}/`;
+    if (normalizedCwd !== normalizedWorktree && !normalizedCwd.startsWith(prefix)) continue;
+    if (deepest === undefined || normalizedWorktree.length > deepest.pathLength) {
+      deepest = { pathLength: normalizedWorktree.length, ref };
+    }
+  }
+  return deepest?.ref;
+}
+
+function toAgentRow([agentId, slice]: readonly [string, MutableAgentSlice]): UsageAgentRow {
+  return {
+    agentId,
+    totals: slice.totals,
+    costUsd: slice.costUsd,
+    cacheWriteUsd: slice.cacheWriteComplete ? slice.cacheWriteUsd : null,
+  };
+}
+
+function boundedAgentRows(
+  agents: ReadonlyMap<string, MutableAgentSlice>,
+  cap: number,
+): readonly UsageAgentRow[] {
+  const sorted = [...agents.entries()].sort(
+    (a, b) =>
+      b[1].costUsd - a[1].costUsd ||
+      totalOf(b[1].totals) - totalOf(a[1].totals) ||
+      a[0].localeCompare(b[0]),
+  );
+  if (sorted.length <= cap) return sorted.map(toAgentRow);
+
+  const kept = sorted.slice(0, Math.max(0, cap - 1));
+  const omitted = sorted.slice(kept.length);
+  const overflow = omitted.reduce<MutableAgentSlice>(
+    (combined, [, slice]) => ({
+      totals: addTotals(combined.totals, slice.totals),
+      costUsd: combined.costUsd + slice.costUsd,
+      cacheWriteUsd: combined.cacheWriteUsd + slice.cacheWriteUsd,
+      cacheWriteComplete: combined.cacheWriteComplete && slice.cacheWriteComplete,
+    }),
+    {
+      totals: EMPTY_TOTALS,
+      costUsd: 0,
+      cacheWriteUsd: 0,
+      cacheWriteComplete: true,
+    },
+  );
+  return [...kept.map(toAgentRow), toAgentRow([`Other subagents (${omitted.length})`, overflow])];
+}
+
+/**
+ * Groups sessions into thread rows: resume-cursor matches first, then unique
+ * worktrees, else one row per session. Rows sort by cost. Rows beyond the cap
+ * fold into provider/project-specific remainders so the returned hierarchy
+ * still reconciles. A `null` title marks retained rows whose name must come
+ * from the transcript.
+ */
+export function foldThreadRows(
+  groups: readonly SessionUsageGroup[],
+  attribution: ThreadAttribution,
+  options: FoldThreadRowsOptions,
+): FoldedThreadRows {
+  const byKey = new Map<string, MutableThreadRow>();
+  const worktrees = Array.from(
+    attribution.worktreeToThread,
+    ([worktree, ref]) => [normalizeUsagePath(worktree), ref] as const,
+  );
+
+  for (const group of groups) {
+    if (
+      options.projectFilter !== undefined &&
+      (options.projectFilter === null
+        ? group.projectAttribution !== "outside"
+        : group.projectKey !== options.projectFilter)
+    )
+      continue;
+
+    const ref =
+      attribution.sessionToThread.get(group.sessionKey) ??
+      (group.cwd.length > 0 ? worktreeThreadForCwd(group.cwd, worktrees) : undefined);
+    const rowKey =
+      ref === undefined
+        ? JSON.stringify(["session", group.provider, group.projectKey, group.sessionKey])
+        : JSON.stringify(["thread", group.provider, group.projectKey, ref.threadId]);
+
+    let row = byKey.get(rowKey);
+    if (row === undefined) {
+      row = {
+        threadId: ref?.threadId ?? null,
+        title: ref?.title ?? null,
+        provider: group.provider,
+        project: group.project,
+        projectId: group.projectId,
+        projectKey: group.projectKey,
+        cwd: group.cwd,
+        totals: EMPTY_TOTALS,
+        costUsd: 0,
+        sessionKeys: new Set(),
+        cacheWriteUsd: 0,
+        cacheWriteComplete: true,
+        groupedRows: 0,
+        daily: new Map(),
+        agents: new Map(),
+        titleSessionKey: group.sessionKey,
+      };
+      byKey.set(rowKey, row);
+    }
+
+    row.totals = addTotals(row.totals, group.totals);
+    row.costUsd += group.costUsd;
+    row.sessionKeys.add(group.sessionKey);
+    row.cacheWriteUsd += group.cacheWriteUsd;
+    row.cacheWriteComplete &&= group.cacheWriteComplete;
+    addDailyCosts(row.daily, group.daily);
+    for (const [agentId, slice] of group.agents) {
+      let agent = row.agents.get(agentId);
+      if (agent === undefined) {
+        agent = {
+          totals: EMPTY_TOTALS,
+          costUsd: 0,
+          cacheWriteUsd: 0,
+          cacheWriteComplete: true,
+        };
+        row.agents.set(agentId, agent);
+      }
+      agent.totals = addTotals(agent.totals, slice.totals);
+      agent.costUsd += slice.costUsd;
+      agent.cacheWriteUsd += slice.cacheWriteUsd;
+      agent.cacheWriteComplete &&= slice.cacheWriteComplete;
+    }
+  }
+
+  const sorted = [...byKey.entries()].sort(
+    (a, b) =>
+      b[1].costUsd - a[1].costUsd ||
+      totalOf(b[1].totals) - totalOf(a[1].totals) ||
+      a[0].localeCompare(b[0]),
+  );
+  let keptCount = Math.min(sorted.length, options.cap);
+  const projectScopeCount = (rows: typeof sorted): number =>
+    new Set(rows.map(([, row]) => JSON.stringify([row.provider, row.projectKey]))).size;
+  while (keptCount > 0 && keptCount + projectScopeCount(sorted.slice(keptCount)) > options.cap) {
+    keptCount -= 1;
+  }
+
+  let kept = sorted.slice(0, keptCount);
+  let omitted = sorted.slice(keptCount);
+  let remainderScope: "project" | "provider" = "project";
+  if (projectScopeCount(omitted) > options.cap) {
+    // More project scopes than the response can represent. Collapse all named
+    // rows and preserve provider totals in provider-wide overflow rows.
+    kept = [];
+    omitted = sorted;
+    remainderScope = "provider";
+    const providerCount = new Set(omitted.map(([, row]) => row.provider)).size;
+    if (providerCount > options.cap) {
+      throw new RangeError("Thread row cap must fit one remainder per provider");
+    }
+  }
+
+  const remainders = new Map<string, MutableThreadRow>();
+  for (const [, omittedRow] of omitted) {
+    const scopeKey = JSON.stringify([
+      omittedRow.provider,
+      remainderScope === "project" ? omittedRow.projectKey : null,
+    ]);
+    let remainder = remainders.get(scopeKey);
+    if (remainder === undefined) {
+      const key = `remainder:${scopeKey}`;
+      remainder = {
+        threadId: null,
+        title: null,
+        provider: omittedRow.provider,
+        project: remainderScope === "project" ? omittedRow.project : "",
+        projectId: remainderScope === "project" ? omittedRow.projectId : null,
+        projectKey: remainderScope === "project" ? omittedRow.projectKey : null,
+        cwd: "",
+        totals: EMPTY_TOTALS,
+        costUsd: 0,
+        sessionKeys: new Set(),
+        cacheWriteUsd: 0,
+        cacheWriteComplete: true,
+        groupedRows: 0,
+        daily: new Map(),
+        agents: new Map(),
+        titleSessionKey: key,
+      };
+      remainders.set(scopeKey, remainder);
+    }
+    remainder.groupedRows += 1;
+    remainder.totals = addTotals(remainder.totals, omittedRow.totals);
+    remainder.costUsd += omittedRow.costUsd;
+    for (const sessionKey of omittedRow.sessionKeys) remainder.sessionKeys.add(sessionKey);
+    remainder.cacheWriteUsd += omittedRow.cacheWriteUsd;
+    remainder.cacheWriteComplete &&= omittedRow.cacheWriteComplete;
+    addDailyCosts(remainder.daily, omittedRow.daily);
+    for (const [agentId, slice] of omittedRow.agents) {
+      let agent = remainder.agents.get(agentId);
+      if (agent === undefined) {
+        agent = {
+          totals: EMPTY_TOTALS,
+          costUsd: 0,
+          cacheWriteUsd: 0,
+          cacheWriteComplete: true,
+        };
+        remainder.agents.set(agentId, agent);
+      }
+      agent.totals = addTotals(agent.totals, slice.totals);
+      agent.costUsd += slice.costUsd;
+      agent.cacheWriteUsd += slice.cacheWriteUsd;
+      agent.cacheWriteComplete &&= slice.cacheWriteComplete;
+    }
+  }
+
+  const displayed = [
+    ...kept,
+    ...[...remainders.entries()].map(([scopeKey, remainder]) => {
+      remainder.title = `Other threads (${remainder.groupedRows})`;
+      return [`remainder:${scopeKey}`, remainder] as const;
+    }),
+  ].sort(
+    (a, b) =>
+      b[1].costUsd - a[1].costUsd ||
+      totalOf(b[1].totals) - totalOf(a[1].totals) ||
+      a[0].localeCompare(b[0]),
+  );
+
+  return {
+    rows: displayed.map(([key, row]) => ({
+      key,
+      threadId: row.threadId,
+      title: row.title,
+      titleSessionKey: row.titleSessionKey,
+      provider: row.provider,
+      ...(row.projectId === null ? {} : { projectId: row.projectId }),
+      ...(row.project === "" ? {} : { project: row.project }),
+      totals: row.totals,
+      costUsd: row.costUsd,
+      cacheWriteUsd: row.cacheWriteComplete ? row.cacheWriteUsd : null,
+      sessions: row.sessionKeys.size,
+      ...(row.groupedRows === 0 ? {} : { groupedRows: row.groupedRows }),
+      agents: boundedAgentRows(row.agents, options.cap),
+      daily: [...row.daily.entries()]
+        .map(([day, components]) => ({
+          day: day as UsageDay,
+          cacheWriteUsd: components.cacheWriteUsd,
+          cacheReadUsd: components.cacheReadUsd,
+          freshUsd: components.freshUsd,
+        }))
+        .sort((a, b) => a.day.localeCompare(b.day)) satisfies UsageThreadDayCost[],
+    })),
+    truncatedRows: omitted.length,
+  };
+}
+
+function totalOf(totals: UsageTokenTotals): number {
+  return (
+    totals.uncachedInputTokens +
+    totals.cachedInputTokens +
+    totals.cacheCreationTokens +
+    totals.outputTokens
+  );
+}

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -7,7 +7,7 @@ import * as NodePath from "node:path";
 
 import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
 
-import { readTranscriptRecords } from "./usageTranscriptReader.ts";
+import { readTranscriptRecords, readTranscriptTitle } from "./usageTranscriptReader.ts";
 
 let dir: string;
 
@@ -206,5 +206,93 @@ describe("readTranscriptRecords resume", () => {
 
   it("returns null for an unreadable file", async () => {
     assert.isNull(await readTranscriptRecords(NodePath.join(dir, "missing.jsonl"), "claude"));
+  });
+});
+
+describe("readTranscriptTitle", () => {
+  it("keeps a real prompt that begins with an angle bracket", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      JSON.stringify({ type: "user", message: { content: "<3 ship this today" } }),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), "<3 ship this today");
+  });
+
+  it("skips a known injected preamble and reads the next user prompt", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      [
+        {
+          type: "user",
+          message: { content: "<system-reminder>generated context</system-reminder>" },
+        },
+        { type: "user", message: { content: "Fix the real bug" } },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), "Fix the real bug");
+  });
+
+  it("skips a user shell command wrapper", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      [
+        {
+          type: "user",
+          message: { content: "<user_shell_command>git status</user_shell_command>" },
+        },
+        { type: "user", message: { content: "Explain the failing check" } },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), "Explain the failing check");
+  });
+
+  it("uses the child prompt instead of copied parent history for a forked Codex rollout", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    const message = (timestamp: string, text: string) => ({
+      type: "event_msg",
+      timestamp,
+      payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+    });
+    await NodeFSP.writeFile(
+      file,
+      [
+        {
+          type: "session_meta",
+          timestamp: "2026-08-01T05:00:00.000Z",
+          payload: { type: "session_meta", id: "child", forked_from_id: "parent" },
+        },
+        message("2026-08-01T05:00:00.600Z", "First copied parent prompt"),
+        message("2026-08-01T05:00:01.100Z", "Second copied parent prompt"),
+        message("2026-08-01T05:00:02.500Z", "Investigate the child task"),
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "codex"), "Investigate the child task");
+  });
+
+  it("truncates titles without splitting a Unicode code point", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      JSON.stringify({ type: "user", message: { content: `${"a".repeat(78)}🙂more` } }),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), `${"a".repeat(78)}🙂…`);
+  });
+
+  it("returns null when the title stream cannot be read", async () => {
+    assert.isNull(await readTranscriptTitle(NodePath.join(dir, "missing.jsonl"), "claude"));
   });
 });

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -15,6 +15,7 @@
  *
  * @module usageTranscriptReader
  */
+import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
 
@@ -310,4 +311,151 @@ export async function readTranscriptRecords(
   } finally {
     await handle.close().catch(() => undefined);
   }
+}
+
+/** Prefixes that mark an injected preamble, not something the user typed. */
+const NOT_TITLE_PREFIXES = [
+  "<system-reminder>",
+  "<command-message>",
+  "<command-name>",
+  "<local-command-caveat>",
+  "<user_shell_command>",
+  "<environment_context>",
+  "<INSTRUCTIONS>",
+  "# AGENTS.md instructions",
+  "Caveat: the messages below",
+];
+
+const TITLE_MAX_LENGTH = 80;
+const TITLE_MAX_LINES = 400;
+const TITLE_MAX_BYTES = 1024 * 1024;
+
+function cleanTitle(text: unknown): string | null {
+  if (typeof text !== "string") return null;
+  const collapsed = text.split(/\s+/).join(" ").trim();
+  if (collapsed.length === 0) return null;
+  if (NOT_TITLE_PREFIXES.some((prefix) => collapsed.startsWith(prefix))) return null;
+  const characters = Array.from(collapsed);
+  return characters.length > TITLE_MAX_LENGTH
+    ? `${characters.slice(0, TITLE_MAX_LENGTH - 1).join("")}\u2026`
+    : collapsed;
+}
+
+function claudeTitleFromLine(line: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record["type"] !== "user") return null;
+  const message = record["message"];
+  if (typeof message !== "object" || message === null) return null;
+  const content = (message as Record<string, unknown>)["content"];
+  if (typeof content === "string") return cleanTitle(content);
+  if (!Array.isArray(content)) return null;
+  for (const block of content) {
+    if (typeof block !== "object" || block === null) continue;
+    const entry = block as Record<string, unknown>;
+    if (entry["type"] !== "text") continue;
+    const title = cleanTitle(entry["text"]);
+    if (title !== null) return title;
+  }
+  return null;
+}
+
+function codexTitleFromLine(
+  line: string,
+): { readonly title: string; readonly timestampMs: number | null } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const payload = (parsed as Record<string, unknown>)["payload"];
+  if (typeof payload !== "object" || payload === null) return null;
+  const record = payload as Record<string, unknown>;
+  if (record["type"] !== "message" || record["role"] !== "user") return null;
+  const content = record["content"];
+  if (!Array.isArray(content)) return null;
+  const timestamp = (parsed as Record<string, unknown>)["timestamp"];
+  const parsedTimestamp = typeof timestamp === "string" ? Date.parse(timestamp) : Number.NaN;
+  const timestampMs = Number.isNaN(parsedTimestamp) ? null : parsedTimestamp;
+  for (const block of content) {
+    if (typeof block !== "object" || block === null) continue;
+    const title = cleanTitle((block as Record<string, unknown>)["text"]);
+    if (title !== null) return { title, timestampMs };
+  }
+  return null;
+}
+
+/**
+ * First thing the user actually typed in a session, as a display title.
+ *
+ * Only called for the handful of unattributed rows that survived the response
+ * cap, so a second bounded read per row is fine. Returns null when the file
+ * cannot be read, holds no user text (Grok logs carry none we trust), or only
+ * injected preambles appear early on.
+ */
+export async function readTranscriptTitle(
+  filePath: string,
+  provider: UsageProviderKind,
+): Promise<string | null> {
+  if (provider === "grok") return null;
+  const codexState = provider === "codex" ? initialCodexScanState() : null;
+  let stream: NodeFS.ReadStream | null = null;
+  try {
+    stream = NodeFS.createReadStream(filePath, { encoding: "utf8" });
+    let pending = "";
+    let seen = 0;
+    let bytesRead = 0;
+    for await (const chunk of stream) {
+      const text = String(chunk);
+      bytesRead += Buffer.byteLength(text);
+      pending += text;
+      for (;;) {
+        const newline = pending.indexOf("\n");
+        if (newline === -1) break;
+        const line = pending.slice(0, newline).replace(/\r$/, "");
+        pending = pending.slice(newline + 1);
+        seen += 1;
+        if (seen > TITLE_MAX_LINES) return null;
+        if (provider === "claude") {
+          if (!line.includes('"user"')) continue;
+          const title = claudeTitleFromLine(line);
+          if (title !== null) return title;
+          continue;
+        }
+        const title = codexTitleFromLine(line);
+        parseCodexLine(line, codexState!);
+        if (title === null) continue;
+        if (!codexState!.suppressingForkCopies) return title.title;
+        if (title.timestampMs !== null) {
+          if (title.timestampMs - codexState!.forkCopyAnchorMs >= 1000) return title.title;
+          codexState!.forkCopyAnchorMs = title.timestampMs;
+        }
+      }
+      if (bytesRead >= TITLE_MAX_BYTES) return null;
+    }
+    if (pending.length > 0 && seen < TITLE_MAX_LINES) {
+      if (provider === "claude") return claudeTitleFromLine(pending);
+      const title = codexTitleFromLine(pending);
+      parseCodexLine(pending, codexState!);
+      if (title === null) return null;
+      if (!codexState!.suppressingForkCopies) return title.title;
+      if (title.timestampMs === null) return null;
+      if (title.timestampMs - codexState!.forkCopyAnchorMs >= 1000) return title.title;
+      codexState!.forkCopyAnchorMs = title.timestampMs;
+      return null;
+    }
+  } catch {
+    return null;
+  } finally {
+    stream?.destroy();
+  }
+  return null;
 }

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -51,6 +51,7 @@ describe("parseClaudeLine", () => {
       reasoningTokens: 0,
     });
     expect(record?.dedupeKey).toBe("msg_1:");
+    expect(record?.cwd).toBe("/home/theo/project");
   });
 
   it("gives every content block of one message the same dedupe key", () => {
@@ -73,7 +74,11 @@ describe("parseCodexLine", () => {
   const sessionMeta = JSON.stringify({
     type: "session_meta",
     timestamp: "2026-08-01T05:17:41.289Z",
-    payload: { type: "session_meta", id: "019fbbc1-b12c-7360-a685-28c181f0025f" },
+    payload: {
+      type: "session_meta",
+      id: "019fbbc1-b12c-7360-a685-28c181f0025f",
+      cwd: "/home/theo/project",
+    },
   });
   const turnContext = JSON.stringify({
     type: "turn_context",
@@ -107,10 +112,32 @@ describe("parseCodexLine", () => {
     expect(record?.provider).toBe("codex");
     expect(record?.model).toBe("gpt-5.6-sol");
     expect(record?.sessionId).toBe("019fbbc1-b12c-7360-a685-28c181f0025f");
+    expect(record?.cwd).toBe("/home/theo/project");
     // Codex reports input_tokens inclusive of the cached portion.
     expect(record?.totals.uncachedInputTokens).toBe(19239 - 11008);
     expect(record?.totals.cachedInputTokens).toBe(11008);
     expect(record?.totals.reasoningTokens).toBe(116);
+  });
+
+  it("attributes resumed usage to the latest turn working directory", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(sessionMeta, state);
+    parseCodexLine(
+      JSON.stringify({
+        type: "turn_context",
+        timestamp: "2026-08-01T05:17:42.694Z",
+        payload: {
+          type: "turn_context",
+          model: "gpt-5.6-sol",
+          cwd: "/home/theo/next-project",
+        },
+      }),
+      state,
+    );
+
+    const record = parseCodexLine(tokenCount(100, 0, 10, 0), state);
+
+    expect(record?.cwd).toBe("/home/theo/next-project");
   });
 
   it("skips a repeated token_count so deltas are not double counted", () => {

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -13,6 +13,11 @@ export interface UsageRecord {
   readonly timestampMs: number;
   readonly model: string;
   readonly sessionId: string;
+  /**
+   * Working directory the session ran in, or `""` when the transcript does not
+   * record one (Grok). Drives project attribution at aggregation time.
+   */
+  readonly cwd: string;
   readonly totals: UsageTokenTotals;
   readonly reportedCostUsd: number | null;
   /**
@@ -136,6 +141,7 @@ export function parseClaudeLine(line: string): UsageRecord | null {
     timestampMs,
     model,
     sessionId: typeof record["sessionId"] === "string" ? record["sessionId"] : "",
+    cwd: typeof record["cwd"] === "string" ? record["cwd"] : "",
     totals: {
       uncachedInputTokens: int(usageRecord["input_tokens"]),
       cachedInputTokens: int(usageRecord["cache_read_input_tokens"]),
@@ -163,6 +169,7 @@ export function parseClaudeLine(line: string): UsageRecord | null {
 export interface CodexScanState {
   model: string;
   sessionId: string;
+  cwd: string;
   lastUsageSignature: string | null;
   sawSessionMeta: boolean;
   /** While true, leading usage events are re-stamped copies of parent history. */
@@ -174,6 +181,7 @@ export function initialCodexScanState(): CodexScanState {
   return {
     model: "",
     sessionId: "",
+    cwd: "",
     lastUsageSignature: null,
     sawSessionMeta: false,
     suppressingForkCopies: false,
@@ -233,6 +241,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     state.sawSessionMeta = true;
     const id = payloadRecord["id"] ?? payloadRecord["session_id"];
     if (typeof id === "string") state.sessionId = id;
+    if (typeof payloadRecord["cwd"] === "string") state.cwd = payloadRecord["cwd"];
     const metaTimestampMs = parseTimestampMs(record["timestamp"]);
     if (metaTimestampMs !== null && isForkedSessionMeta(payloadRecord)) {
       state.suppressingForkCopies = true;
@@ -243,6 +252,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
 
   if (record["type"] === "turn_context") {
     if (typeof payloadRecord["model"] === "string") state.model = payloadRecord["model"];
+    if (typeof payloadRecord["cwd"] === "string") state.cwd = payloadRecord["cwd"];
     return null;
   }
 
@@ -301,6 +311,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     timestampMs,
     model: state.model,
     sessionId: state.sessionId,
+    cwd: state.cwd,
     totals,
     // Codex does not report cost in the rollout.
     reportedCostUsd: null,
@@ -431,6 +442,8 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
         timestampMs,
         model: "grok",
         sessionId,
+        // Grok session logs record no working directory.
+        cwd: "",
         totals: grokTotalsToUsage(topLevel),
         reportedCostUsd: grokCostTicksToUsd(topLevel.costUsdTicks),
         // No prompt id means we cannot tell two same-second updates apart.
@@ -477,6 +490,7 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
       timestampMs,
       model: entry.model,
       sessionId,
+      cwd: "",
       totals,
       reportedCostUsd,
       dedupeKey: promptId === null ? null : `${sessionId}:${promptId}:${entry.model}`,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2068,6 +2068,14 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.serverGetUsageSummary, usage.readSummary(input), {
             "rpc.aggregate": "server",
           }),
+        [WS_METHODS.serverGetUsageThreadBreakdown]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverGetUsageThreadBreakdown,
+            usage.readThreadBreakdown(input),
+            {
+              "rpc.aggregate": "server",
+            },
+          ),
         [WS_METHODS.serverRefreshUsageRates]: (_input) =>
           observeRpcEffect(WS_METHODS.serverRefreshUsageRates, usage.refreshRates, {
             "rpc.aggregate": "server",

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -4,9 +4,14 @@ import { Input as InputPrimitive } from "@base-ui/react/input";
 import type * as React from "react";
 
 import { cn } from "~/lib/utils";
+import {
+  segmentedControlItemSizeClassName,
+  segmentedControlItemVariantClassName,
+} from "~/components/ui/segmented-control-styles";
 
 type InputProps = Omit<InputPrimitive.Props & React.RefAttributes<HTMLInputElement>, "size"> & {
-  size?: "sm" | "compact" | "default" | "lg" | number;
+  size?: "sm" | "compact" | "default" | "lg" | "segmented" | number;
+  variant?: "default" | "segmented";
   unstyled?: boolean;
   nativeInput?: boolean;
 };
@@ -14,6 +19,7 @@ type InputProps = Omit<InputPrimitive.Props & React.RefAttributes<HTMLInputEleme
 function Input({
   className,
   size = "default",
+  variant = "default",
   unstyled = false,
   nativeInput = false,
   ...props
@@ -23,6 +29,7 @@ function Input({
     size === "compact" && "h-7 px-[calc(--spacing(2.5)-1px)] text-xs leading-7 sm:h-7 sm:leading-7",
     size === "sm" && "h-7.5 px-[calc(--spacing(2.5)-1px)] leading-7.5 sm:h-6.5 sm:leading-6.5",
     size === "lg" && "h-9.5 leading-9.5 sm:h-8.5 sm:leading-8.5",
+    size === "segmented" && "h-full px-0 text-xs leading-6 sm:h-full sm:leading-6",
     props.type === "search" &&
       "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none [&::-webkit-search-results-button]:appearance-none [&::-webkit-search-results-decoration]:appearance-none",
     props.type === "file" &&
@@ -59,15 +66,25 @@ function Input({
       className={
         cn(
           !unstyled &&
+            variant === "default" &&
             "relative inline-flex w-full rounded-lg border border-input bg-background not-dark:bg-clip-padding text-base text-foreground shadow-xs/5 ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] not-has-disabled:not-has-focus-visible:not-has-aria-invalid:before:shadow-[0_1px_--theme(--color-black/4%)] has-focus-visible:has-aria-invalid:border-destructive/64 has-focus-visible:has-aria-invalid:ring-destructive/16 has-aria-invalid:border-destructive/36 has-focus-visible:border-ring has-autofill:bg-foreground/4 has-disabled:opacity-64 has-[:disabled,:focus-visible,[aria-invalid]]:shadow-none has-focus-visible:ring-[3px] sm:text-sm dark:bg-input/32 dark:has-autofill:bg-foreground/8 dark:has-aria-invalid:ring-destructive/24 dark:not-has-disabled:not-has-focus-visible:not-has-aria-invalid:before:shadow-[0_-1px_--theme(--color-white/6%)]",
           !unstyled &&
+            variant === "default" &&
             size === "compact" &&
             "rounded-md before:rounded-[calc(var(--radius-md)-1px)]",
+          !unstyled &&
+            variant === "segmented" &&
+            cn(
+              "relative inline-flex w-auto focus-within:bg-background focus-within:text-foreground focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-background has-aria-invalid:text-destructive focus-within:has-aria-invalid:ring-destructive/50 dark:focus-within:bg-input/72 pointer-coarse:h-8.5",
+              segmentedControlItemSizeClassName,
+              segmentedControlItemVariantClassName,
+            ),
           className,
         ) || undefined
       }
       data-size={size}
       data-slot="input-control"
+      data-variant={variant}
     >
       {inputElement}
     </span>

--- a/apps/web/src/components/ui/segmented-control-styles.ts
+++ b/apps/web/src/components/ui/segmented-control-styles.ts
@@ -1,0 +1,8 @@
+/** Shared visual contract for segmented controls and segmented inputs. */
+export const segmentedControlGroupClassName = "gap-0.5 rounded-lg bg-input/40 p-0.5";
+
+export const segmentedControlItemSizeClassName =
+  "h-6 min-w-0 rounded-md px-2.5 text-xs before:rounded-[calc(var(--radius-md)-1px)]";
+
+export const segmentedControlItemVariantClassName =
+  "border-transparent text-muted-foreground shadow-none transition-colors before:shadow-none hover:bg-background/55 hover:text-foreground data-pressed:bg-background data-pressed:text-foreground data-pressed:shadow-xs/10 dark:hover:bg-input/32 dark:data-pressed:bg-input/72";

--- a/apps/web/src/components/ui/toggle-group.tsx
+++ b/apps/web/src/components/ui/toggle-group.tsx
@@ -6,6 +6,7 @@ import type { VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "~/lib/utils";
+import { segmentedControlGroupClassName } from "~/components/ui/segmented-control-styles";
 import { Separator } from "~/components/ui/separator";
 import { Toggle as ToggleComponent, type toggleVariants } from "~/components/ui/toggle";
 
@@ -31,7 +32,7 @@ function ToggleGroup({
           ? "*:pointer-coarse:after:min-w-auto"
           : "*:pointer-coarse:after:min-h-auto",
         variant === "segmented"
-          ? "gap-0.5 rounded-lg bg-input/40 p-0.5"
+          ? segmentedControlGroupClassName
           : variant === "default"
             ? "gap-0.5"
             : orientation === "horizontal"

--- a/apps/web/src/components/ui/toggle.tsx
+++ b/apps/web/src/components/ui/toggle.tsx
@@ -4,6 +4,10 @@ import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "~/lib/utils";
+import {
+  segmentedControlItemSizeClassName,
+  segmentedControlItemVariantClassName,
+} from "~/components/ui/segmented-control-styles";
 
 const toggleVariants = cva(
   "[&_svg]:-mx-0.5 relative inline-flex shrink-0 cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap rounded-lg border font-medium text-base text-foreground outline-none transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 data-pressed:bg-input/64 data-pressed:text-accent-foreground sm:text-sm [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
@@ -18,8 +22,7 @@ const toggleVariants = cva(
           "h-7 min-w-7 rounded-md px-[calc(--spacing(1)-1px)] text-xs before:rounded-[calc(var(--radius-md)-1px)] [&_svg:not([class*='size-'])]:size-3.5",
         default: "h-9 min-w-9 px-[calc(--spacing(2)-1px)] sm:h-8 sm:min-w-8",
         lg: "h-10 min-w-10 px-[calc(--spacing(2.5)-1px)] sm:h-9 sm:min-w-9",
-        segmented:
-          "h-6 min-w-0 rounded-md px-2.5 text-xs before:rounded-[calc(var(--radius-md)-1px)]",
+        segmented: segmentedControlItemSizeClassName,
         sm: "h-8 min-w-8 px-[calc(--spacing(1.5)-1px)] sm:h-7 sm:min-w-7",
         xs: "h-7 min-w-7 px-[calc(--spacing(1)-1px)] sm:h-6 sm:min-w-6 rounded-md",
       },
@@ -29,8 +32,7 @@ const toggleVariants = cva(
           "border-transparent text-foreground shadow-none [:disabled,:active,[data-pressed]]:shadow-none before:shadow-none data-pressed:bg-accent data-pressed:text-accent-foreground disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",
         outline:
           "border-input bg-background not-dark:bg-clip-padding shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:data-pressed:bg-input dark:hover:bg-input/64 dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] dark:not-disabled:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/2%)] [:disabled,:active,[data-pressed]]:shadow-none",
-        segmented:
-          "border-transparent text-muted-foreground shadow-none transition-colors before:shadow-none hover:bg-background/55 hover:text-foreground data-pressed:bg-background data-pressed:text-foreground data-pressed:shadow-xs/10 dark:hover:bg-input/32 dark:data-pressed:bg-input/72",
+        segmented: segmentedControlItemVariantClassName,
       },
     },
   },

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -1,12 +1,22 @@
-import { EnvironmentId, UsageDay, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
+import { EnvironmentId, ProjectId, UsageDay, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { mergeUsage } from "@t3tools/shared/usageMerge";
+import type { ComponentProps, ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
+  customWindow: false,
+  zoomToDays: undefined as ((since: string, until: string) => void) | undefined,
+  resetZoom: undefined as (() => void) | undefined,
   useUsage: vi.fn(),
+  usageThreadTable: vi.fn((_props: unknown) => null),
   metric: "cost" as "cost" | "tokens" | "limits",
-  breakdown: "time" as "model" | "time",
+  breakdown: "time" as "model" | "project" | "thread" | "time",
+  projectFilter: undefined as string | null | undefined,
+  refresh: vi.fn(async () => {}),
+
+  setWindowSelection: vi.fn(),
+  refreshWindow: undefined as (() => void) | undefined,
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -18,7 +28,8 @@ vi.mock("react", async (importOriginal) => {
         ? { metric: testState.metric, windowDays: 30 }
         : typeof initial === "function"
           ? {
-              days: 1,
+              days: testState.customWindow ? 30 : 1,
+              custom: testState.customWindow,
               window: {
                 sinceDay: "2026-08-10",
                 untilDay: "2026-08-11",
@@ -32,15 +43,36 @@ vi.mock("react", async (importOriginal) => {
             ? testState.metric
             : initial === "model"
               ? testState.breakdown
-              : initial,
-      vi.fn(),
+              : initial === undefined
+                ? testState.projectFilter
+                : initial,
+      typeof initial === "function" && initial !== readUsagePagePreferences
+        ? testState.setWindowSelection
+        : vi.fn(),
     ]),
   };
 });
 
 vi.mock("../../env", () => ({ isElectron: false }));
 vi.mock("../../state/usage", () => ({ useUsage: testState.useUsage }));
-vi.mock("../ui/button", () => ({ Button: "button" }));
+vi.mock("../ui/button", () => ({
+  Button: (props: { "aria-label"?: string; children?: ReactNode; onClick?: () => void }) => {
+    if (props["aria-label"] === "Refresh usage") testState.refreshWindow = props.onClick;
+    return <button aria-label={props["aria-label"]}>{props.children}</button>;
+  },
+}));
+vi.mock("../ui/input", () => ({
+  Input: ({
+    nativeInput: _nativeInput,
+    size,
+    variant,
+    ...props
+  }: Omit<ComponentProps<"input">, "size"> & {
+    nativeInput?: boolean;
+    size?: string;
+    variant?: string;
+  }) => <input data-size={size} data-variant={variant} {...props} />,
+}));
 vi.mock("../ui/scroll-area", () => ({ ScrollArea: "div" }));
 vi.mock("../ui/select", () => ({
   Select: "div",
@@ -58,7 +90,17 @@ vi.mock("../WorkspaceBreadcrumb", () => ({
 }));
 vi.mock("../WorkspacePageContainer", () => ({ WorkspacePageContainer: "main" }));
 vi.mock("../WorkspacePageHeader", () => ({ WorkspacePageHeader: "header" }));
-vi.mock("./UsageProviderChart", () => ({ UsageProviderChart: "div" }));
+vi.mock("./UsageProviderChart", () => ({
+  UsageProviderChart: (props: {
+    onZoomToDays?: (since: string, until: string) => void;
+    onResetZoom?: () => void;
+  }) => {
+    testState.zoomToDays = props.onZoomToDays;
+    testState.resetZoom = props.onResetZoom;
+    return <div />;
+  },
+}));
+vi.mock("./UsageThreadTable", () => ({ UsageThreadTable: testState.usageThreadTable }));
 vi.mock("./UsagePriceOverrides", () => ({ UsagePriceOverrides: () => null }));
 vi.mock("./usageProviders", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./usageProviders")>();
@@ -86,6 +128,8 @@ const modelTotals = Object.freeze([
     provider: "claude" as const,
     costUsd: 10,
     totalTokens: 100,
+    cacheWriteTokens: 40,
+    cacheWriteUsd: 2.5,
     records: 1,
     unpricedRecords: 0,
     costShare: 10 / 16,
@@ -95,6 +139,8 @@ const modelTotals = Object.freeze([
     provider: "codex" as const,
     costUsd: 5,
     totalTokens: 1_000,
+    cacheWriteTokens: 0,
+    cacheWriteUsd: 0,
     records: 1,
     unpricedRecords: 0,
     costShare: 5 / 16,
@@ -104,6 +150,8 @@ const modelTotals = Object.freeze([
     provider: "codex" as const,
     costUsd: 1,
     totalTokens: 1_000,
+    cacheWriteTokens: 0,
+    cacheWriteUsd: 0,
     records: 1,
     unpricedRecords: 0,
     costShare: 1 / 16,
@@ -113,6 +161,8 @@ const modelTotals = Object.freeze([
     provider: "codex" as const,
     costUsd: 0,
     totalTokens: 500,
+    cacheWriteTokens: 0,
+    cacheWriteUsd: 0,
     records: 2,
     unpricedRecords: 2,
     costShare: 0,
@@ -139,13 +189,47 @@ const environments = [
   },
 ];
 
+const projectTotals = Object.freeze([
+  {
+    projectId: ProjectId.make("project-expensive"),
+    projectKey: "id:project-expensive",
+    project: "Expensive Project",
+    costUsd: 9,
+    totalTokens: 200,
+    cacheWriteTokens: 60,
+    cacheWriteUsd: 1.75,
+    records: 2,
+    costShare: 9 / 20,
+  },
+  {
+    projectId: null,
+    projectKey: null,
+    project: null,
+    costUsd: 7,
+    totalTokens: 900,
+    cacheWriteTokens: 0,
+    cacheWriteUsd: 0,
+    records: 1,
+    costShare: 7 / 20,
+  },
+]);
+
 beforeEach(() => {
+  testState.customWindow = false;
+  testState.zoomToDays = undefined;
+  testState.resetZoom = undefined;
   testState.metric = "cost";
   testState.breakdown = "time";
+  testState.projectFilter = undefined;
+  testState.usageThreadTable.mockClear();
+  testState.refresh.mockReset();
+  testState.setWindowSelection.mockReset();
+  testState.refreshWindow = undefined;
   testState.useUsage.mockReturnValue({
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
       models: modelTotals,
+      projects: projectTotals,
       hourly: [
         {
           day: "2026-08-10",
@@ -167,11 +251,30 @@ beforeEach(() => {
     selectedEnvironments: environments,
     isPending: false,
     isPartial: false,
-    refresh: vi.fn(),
+    refresh: testState.refresh,
   });
 });
 
 describe("UsagePage hourly breakdown", () => {
+  it("refreshes after rebasing a rolling window", () => {
+    renderToStaticMarkup(<UsagePage />);
+
+    testState.refreshWindow?.();
+
+    expect(testState.setWindowSelection).toHaveBeenCalledOnce();
+    expect(testState.refresh).toHaveBeenCalledOnce();
+  });
+
+  it("keeps custom date fields available in both desktop and compact layouts", () => {
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup.match(/aria-label="From day"/g)).toHaveLength(2);
+    expect(markup.match(/aria-label="To day"/g)).toHaveLength(2);
+    expect(testState.useUsage).toHaveBeenLastCalledWith(expect.anything(), null, undefined, false);
+    expect(markup.match(/data-size="segmented"/g)).toHaveLength(4);
+    expect(markup.match(/data-variant="segmented"/g)).toHaveLength(4);
+  });
+
   it("keeps recent activity visible first without empty hourly rows", () => {
     const markup = renderToStaticMarkup(<UsagePage />);
     const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
@@ -189,6 +292,133 @@ describe("UsagePage hourly breakdown", () => {
     const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
 
     expect(body).toMatch(/\$11\.00.*\$13\.00/);
+  });
+});
+
+describe("UsagePage project breakdown", () => {
+  it("offers a lone project filter when unknown attribution remains in the totals", () => {
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: {
+        ...usage.merged,
+        costUsd: 10,
+        totalTokens: 300,
+        projects: [projectTotals[0]],
+      },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup.match(/aria-label="Project filter"/g)).toHaveLength(2);
+  });
+
+  it("hides a lone project filter when it would not narrow the totals", () => {
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: {
+        ...usage.merged,
+        costUsd: 9,
+        totalTokens: 200,
+        projects: [projectTotals[0]],
+      },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).not.toContain('aria-label="Project filter"');
+  });
+
+  it("ranks projects by cost and labels unattributed work", () => {
+    testState.breakdown = "project";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/Expensive Project.*Outside projects/);
+    expect(body).toContain("$9.00");
+    expect(body).toContain("$7.00");
+    expect(body).toContain("45.0%");
+    expect(body).toContain("35.0%");
+  });
+
+  it("ranks projects by tokens when the token metric is selected", () => {
+    testState.metric = "tokens";
+    testState.breakdown = "project";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/Outside projects.*Expensive Project/);
+  });
+
+  it("shows only the selected project in the project breakdown", () => {
+    testState.breakdown = "project";
+    testState.projectFilter = "id:project-expensive";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toContain("Expensive Project");
+    expect(body).not.toContain("Outside projects");
+    expect(body).toContain("100.0%");
+  });
+
+  it("distinguishes unattributed usage from an empty window", () => {
+    testState.breakdown = "project";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: { ...usage.merged, projects: [], records: 1 },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("No project attribution in this window.");
+    expect(markup).not.toContain("No activity in this window.");
+  });
+
+  it("keeps the empty-window message when there is no usage", () => {
+    testState.breakdown = "project";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: { ...usage.merged, projects: [], records: 0 },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("No activity in this window.");
+    expect(markup).not.toContain("No project attribution in this window.");
+  });
+});
+
+describe("UsagePage thread breakdown", () => {
+  it("requests thread rows in the selected project scope", () => {
+    testState.breakdown = "thread";
+    testState.projectFilter = "id:project-expensive";
+
+    renderToStaticMarkup(<UsagePage />);
+
+    expect(testState.usageThreadTable).toHaveBeenCalledOnce();
+    expect(testState.usageThreadTable.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        sinceDay: "2026-08-10",
+        untilDay: "2026-08-11",
+        timeZone: "UTC",
+        sinceTime: "2026-08-10T12:37:00.000Z",
+        untilTime: "2026-08-11T12:37:00.000Z",
+        projectKey: "id:project-expensive",
+      },
+      providerContributions: [],
+    });
+    expect(testState.useUsage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      null,
+      "id:project-expensive",
+      true,
+    );
   });
 });
 
@@ -213,6 +443,35 @@ describe("UsagePage model breakdown", () => {
     expect(unpricedRow).not.toContain("$0.00");
   });
 
+  it("shows cache-write cost per row, with a dash for write-free providers", () => {
+    testState.breakdown = "model";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    // Claude row carries its cache-write dollars; codex rows never bill writes.
+    expect(body).toContain("$2.50");
+    expect(body).toMatch(/token-heavy-model.*>-</);
+  });
+
+  it("does not present an incomplete cache-write estimate as zero", () => {
+    testState.breakdown = "model";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: {
+        ...usage.merged,
+        models: [{ ...modelTotals[0], cacheWriteUsd: null }],
+        costQuality: { ...usage.merged.costQuality, cacheWriteUsd: null },
+      },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup.match(/Unavailable/g)).toHaveLength(2);
+    expect(markup).not.toContain("NaN%");
+  });
+
   it("sorts models by token usage when the token metric is selected", () => {
     testState.metric = "tokens";
     testState.breakdown = "model";
@@ -228,4 +487,48 @@ describe("UsagePage model breakdown", () => {
       "unpriced-model",
     ]);
   });
+});
+
+it("excludes deselected environments from thread failure counts", () => {
+  testState.breakdown = "thread";
+  const usage = testState.useUsage();
+  const excluded = {
+    ...environments[0]!,
+    environmentId: EnvironmentId.make("excluded"),
+    label: "Excluded",
+    error: "offline",
+    summary: null,
+  };
+  testState.useUsage.mockReturnValue({
+    ...usage,
+    environments: [...usage.environments, excluded],
+    selectedEnvironments: usage.selectedEnvironments,
+  });
+  renderToStaticMarkup(<UsagePage />);
+  expect(testState.usageThreadTable.mock.calls[0]?.[0]).toMatchObject({
+    summaryFailedEnvironments: 0,
+  });
+});
+
+it("restores the original custom window after repeated chart zooms", () => {
+  testState.customWindow = true;
+  renderToStaticMarkup(<UsagePage />);
+  expect(testState.zoomToDays).toBeTypeOf("function");
+  testState.zoomToDays?.("2026-08-10", "2026-08-10");
+  testState.zoomToDays?.("2026-08-11", "2026-08-11");
+  testState.resetZoom?.();
+  expect(testState.setWindowSelection).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      custom: true,
+      window: expect.objectContaining({ sinceDay: "2026-08-10", untilDay: "2026-08-11" }),
+    }),
+  );
+});
+
+it("keeps an unzoomed custom range when the plot is double-clicked", () => {
+  testState.customWindow = true;
+  renderToStaticMarkup(<UsagePage />);
+  expect(testState.resetZoom).toBeTypeOf("function");
+  testState.resetZoom?.();
+  expect(testState.setWindowSelection).not.toHaveBeenCalled();
 });

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -16,8 +16,10 @@ import { useMemo, useRef, useState } from "react";
 import {
   isCompatibleUsageContractVersion,
   isModelCostUnknown,
+  projectFilterForEnvironment,
   type DailyTotals,
   type HourlyTotals,
+  type ProjectTotals,
 } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
@@ -27,6 +29,7 @@ import { serverEnvironment } from "../../state/server";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import { useAtomCommand } from "../../state/use-atom-command";
 import {
+  compareUsageDays,
   enumerateDays,
   enumerateHourStarts,
   formatCount,
@@ -36,9 +39,13 @@ import {
   formatPercent,
   formatTokens,
   formatUsd,
+  makeCustomWindow,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
+import { useCommitOnBlur } from "../../hooks/useCommitOnBlur";
 import { Button } from "../ui/button";
+import { toastManager } from "../ui/toast";
+import { Input } from "../ui/input";
 import {
   Menu,
   MenuCheckboxItem,
@@ -48,6 +55,7 @@ import {
   MenuTrigger,
 } from "../ui/menu";
 import { ScrollArea } from "../ui/scroll-area";
+import { segmentedControlGroupClassName } from "../ui/segmented-control-styles";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { SidebarInset } from "../ui/sidebar";
 import { Skeleton } from "../ui/skeleton";
@@ -62,6 +70,7 @@ import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageLimitsSection } from "./UsageLimits";
 import { UsagePriceOverrides } from "./UsagePriceOverrides";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
+import { UsageThreadTable } from "./UsageThreadTable";
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 import {
   readUsagePagePreferences,
@@ -95,24 +104,31 @@ export function UsagePage() {
   const [preferences, setPreferences] = useState(readUsagePagePreferences);
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: preferences.windowDays,
+    custom: false,
     window: makeWindow(
       preferences.windowDays,
       undefined,
       preferences.windowDays === 1 ? "hour" : "day",
     ),
   }));
+  const preZoomSelection = useRef<typeof windowSelection | null>(null);
   const metric = preferences.metric;
   const showingLimits = metric === "limits";
   const [isRefreshing, setIsRefreshing] = useState(false);
   const refreshingRef = useRef(false);
-  const [breakdown, setBreakdown] = useState<"model" | "time">("model");
+  const [breakdown, setBreakdown] = useState<"model" | "project" | "thread" | "time">("model");
+
   const [selectedEnvironmentIds, setSelectedEnvironmentIds] =
     useState<ReadonlySet<EnvironmentId> | null>(null);
-  const { days: windowDays, window } = windowSelection;
-  const isPast24Hours = windowDays === 1;
+  // A namespaced project key, null for work outside every project, undefined for all.
+  const [projectFilter, setProjectFilter] = useState<string | null | undefined>(undefined);
+  const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
+  const isPast24Hours = !isCustomWindow && windowDays === 1;
   const { merged, environments, selectedEnvironments, isPending, isPartial, refresh } = useUsage(
     window,
     selectedEnvironmentIds,
+    projectFilter,
+    breakdown === "thread",
   );
   const presentations = useAtomValue(environmentPresentations.presentationsAtom);
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
@@ -145,18 +161,82 @@ export function UsagePage() {
         : merged.models,
     [breakdown, merged.models, metric],
   );
+  const breakdownProjects = useMemo(() => {
+    const scoped =
+      projectFilter === undefined
+        ? merged.projects
+        : merged.projects.filter((project) => project.projectKey === projectFilter);
+    return metric === "tokens"
+      ? scoped.toSorted(
+          (left, right) => right.totalTokens - left.totalTokens || right.costUsd - left.costUsd,
+        )
+      : scoped;
+  }, [merged.projects, metric, projectFilter]);
+  const breakdownProjectCostUsd = useMemo(
+    () => breakdownProjects.reduce((sum, project) => sum + project.costUsd, 0),
+    [breakdownProjects],
+  );
+  const projectLabelsRef = useRef(new Map<string, string>());
+  for (const project of merged.projects) {
+    if (project.projectKey !== null && project.project !== null) {
+      projectLabelsRef.current.set(project.projectKey, project.project);
+    }
+  }
+  const selectedProjectLabel =
+    projectFilter === undefined
+      ? null
+      : projectFilter === null
+        ? "Outside projects"
+        : (projectLabelsRef.current.get(projectFilter) ?? "Selected project");
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
+  // Session figures are per transcript directory; a project filter cannot
+  // split them, so they only render unfiltered.
+  const sessionsKnown = projectFilter === undefined;
+  const onlyProject = merged.projects.length === 1 ? merged.projects[0] : undefined;
+  // Unknown attribution remains in the overall totals but is absent from the
+  // project list. Keep a lone known project selectable when that distinction
+  // lets the user remove unknown usage from the page.
+  const showProjectPicker =
+    merged.projects.length > 1 ||
+    projectFilter !== undefined ||
+    (onlyProject !== undefined &&
+      (onlyProject.totalTokens !== merged.totalTokens || onlyProject.costUsd !== merged.costUsd));
 
   const selectWindow = (days: number) => {
     if (!isUsageWindowDays(days)) return;
+    preZoomSelection.current = null;
     const nextPreferences = { metric, windowDays: days };
     setPreferences(nextPreferences);
     saveUsagePagePreferences(nextPreferences);
     setWindowSelection({
       days,
+      custom: false,
       window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
     });
+  };
+  const selectCustomWindow = (sinceDay: string, untilDay: string) => {
+    preZoomSelection.current = null;
+    setWindowSelection({
+      days: windowDays,
+      custom: true,
+      window: makeCustomWindow(sinceDay, untilDay),
+    });
+  };
+  const zoomToDays = (sinceDay: string, untilDay: string) => {
+    preZoomSelection.current ??= windowSelection;
+    setWindowSelection({
+      days: windowDays,
+      custom: true,
+      window: makeCustomWindow(sinceDay, untilDay),
+    });
+  };
+  const resetZoom = () => {
+    const original = preZoomSelection.current;
+    if (original === null) return;
+    preZoomSelection.current = null;
+    if (original.custom) setWindowSelection(original);
+    else selectWindow(original.days);
   };
   const selectMetric = (nextMetric: UsageMetric) => {
     const nextPreferences = { metric: nextMetric, windowDays };
@@ -182,21 +262,31 @@ export function UsagePage() {
       });
       return;
     }
-    const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
+    const nextWindow = isCustomWindow
+      ? window
+      : makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
     if (
       nextWindow.sinceDay !== window.sinceDay ||
       nextWindow.untilDay !== window.untilDay ||
       nextWindow.sinceTime !== window.sinceTime ||
       nextWindow.untilTime !== window.untilTime
     ) {
-      setWindowSelection({ days: windowDays, window: nextWindow });
+      setWindowSelection({ days: windowDays, custom: false, window: nextWindow });
     }
     refreshingRef.current = true;
     setIsRefreshing(true);
-    void refresh(nextWindow).finally(() => {
-      refreshingRef.current = false;
-      setIsRefreshing(false);
-    });
+    void refresh(nextWindow)
+      .catch((error: unknown) => {
+        toastManager.add({
+          type: "error",
+          title: "Could not refresh usage",
+          description: error instanceof Error ? error.message : "Try again.",
+        });
+      })
+      .finally(() => {
+        refreshingRef.current = false;
+        setIsRefreshing(false);
+      });
   };
   const windowLabel =
     isPast24Hours && window.sinceTime !== undefined && window.untilTime !== undefined
@@ -228,6 +318,14 @@ export function UsagePage() {
         </span>
       ) : null}
       <div className="ms-auto hidden min-w-0 items-center justify-end gap-2 xl:flex">
+        {showProjectPicker ? (
+          <UsageProjectSelect
+            projects={merged.projects}
+            filter={projectFilter}
+            selectedLabel={selectedProjectLabel}
+            onChange={setProjectFilter}
+          />
+        ) : null}
         <ToggleGroup
           aria-label="Usage metric"
           variant="segmented"
@@ -243,12 +341,18 @@ export function UsagePage() {
             </Toggle>
           ))}
         </ToggleGroup>
+        <UsageDateRangeInputs
+          sinceDay={window.sinceDay}
+          untilDay={window.untilDay}
+          onChange={selectCustomWindow}
+          disabled={showingLimits}
+        />
         {/* The period does not apply to Limits, so it stays in place but
             disabled; unmounting it shifted the metric toggle ~300px. */}
         <ToggleGroup
           aria-label="Usage period"
           variant="segmented"
-          value={[String(windowDays)]}
+          value={isCustomWindow ? [] : [String(windowDays)]}
           disabled={showingLimits}
           onValueChange={(next) => {
             const value = next[0];
@@ -273,6 +377,14 @@ export function UsagePage() {
         </Button>
       </div>
       <div className="col-span-2 ms-auto flex min-w-0 items-center justify-end gap-1 xl:hidden">
+        {showProjectPicker ? (
+          <UsageProjectSelect
+            projects={merged.projects}
+            filter={projectFilter}
+            selectedLabel={selectedProjectLabel}
+            onChange={setProjectFilter}
+          />
+        ) : null}
         <Select
           value={metric}
           onValueChange={(value) => {
@@ -298,9 +410,11 @@ export function UsagePage() {
           </SelectPopup>
         </Select>
         <Select
-          value={String(windowDays)}
+          value={isCustomWindow ? "custom" : String(windowDays)}
           disabled={showingLimits}
-          onValueChange={(value) => selectWindow(Number(value))}
+          onValueChange={(value) => {
+            if (value !== "custom" && value !== null) selectWindow(Number(value));
+          }}
         >
           <SelectTrigger
             aria-label="Usage period"
@@ -309,7 +423,9 @@ export function UsagePage() {
             className="w-auto min-w-0"
           >
             <SelectValue>
-              {WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
+              {isCustomWindow
+                ? "Custom"
+                : WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
             </SelectValue>
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
@@ -343,6 +459,14 @@ export function UsagePage() {
 
         <ScrollArea className="min-h-0 flex-1">
           <WorkspacePageContainer width="wide">
+            {!showingLimits ? (
+              <UsageDateRangeInputs
+                className="mb-4 flex-wrap xl:hidden"
+                sinceDay={window.sinceDay}
+                untilDay={window.untilDay}
+                onChange={selectCustomWindow}
+              />
+            ) : null}
             {selectedEnvironments.length === 0 ? (
               <p className="text-sm text-muted-foreground">
                 {environments.length === 0
@@ -364,13 +488,17 @@ export function UsagePage() {
                           : formatTokens(merged.totalTokens)}
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        {metric !== "cost"
-                          ? `${formatCount(merged.sessions)} sessions`
-                          : merged.costQuality.unpricedShare > 0
-                            ? `${formatCount(merged.sessions)} sessions · API estimate excludes ${formatPercent(
+                        {(() => {
+                          const scope = sessionsKnown
+                            ? `${formatCount(merged.sessions)} sessions`
+                            : (selectedProjectLabel ?? "Outside projects");
+                          if (metric !== "cost") return scope;
+                          return merged.costQuality.unpricedShare > 0
+                            ? `${scope} · API estimate excludes ${formatPercent(
                                 merged.costQuality.unpricedShare,
                               )} unpriced records`
-                            : `${formatCount(merged.sessions)} sessions · API estimate`}
+                            : `${scope} · API estimate`;
+                        })()}
                       </span>
                     </div>
 
@@ -398,9 +526,11 @@ export function UsagePage() {
                                 <span className="truncate">
                                   {PROVIDER_PRESENTATION[provider].label}
                                 </span>
-                                <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground tabular-nums">
-                                  {sessionLabel}
-                                </span>
+                                {sessionsKnown ? (
+                                  <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground tabular-nums">
+                                    {sessionLabel}
+                                  </span>
+                                ) : null}
                               </span>
                             </span>
                             <span className="shrink-0 text-sm font-medium text-foreground tabular-nums">
@@ -420,10 +550,17 @@ export function UsagePage() {
                   </div>
 
                   <div className="flex min-w-0 flex-col gap-3">
-                    <h2 className="text-sm font-medium text-foreground">
-                      {isPast24Hours ? "Hourly" : "Daily"}{" "}
-                      {metric === "tokens" ? "processed tokens" : "cost"}
-                    </h2>
+                    <div className="flex items-baseline justify-between gap-3">
+                      <h2 className="text-sm font-medium text-foreground">
+                        {isPast24Hours ? "Hourly" : "Daily"}{" "}
+                        {metric === "tokens" ? "processed tokens" : "cost"}
+                      </h2>
+                      {isPast24Hours ? null : (
+                        <span className="text-[10px] tracking-wide text-muted-foreground uppercase">
+                          drag to zoom · double-click resets
+                        </span>
+                      )}
+                    </div>
                     <UsageProviderChart
                       providers={activeProviders}
                       days={days}
@@ -434,13 +571,19 @@ export function UsagePage() {
                       referenceTime={window.untilTime}
                       resolution={isPast24Hours ? "hour" : "day"}
                       timeZone={window.timeZone}
+                      {...(isPast24Hours
+                        ? {}
+                        : {
+                            onZoomToDays: zoomToDays,
+                            onResetZoom: resetZoom,
+                          })}
                     />
                   </div>
                 </section>
 
                 <section className="flex flex-col gap-2">
                   <h2 className="text-sm font-medium text-foreground">Totals</h2>
-                  <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-5">
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-6">
                     <Metric label="Processed tokens" value={formatTokens(merged.totalTokens)} />
                     <Metric label="Cached input" value={formatTokens(merged.cachedInputTokens)} />
                     <Metric
@@ -448,6 +591,19 @@ export function UsagePage() {
                       value={formatTokens(merged.uncachedInputTokens)}
                     />
                     <Metric label="Output" value={formatTokens(merged.outputTokens)} />
+                    <Metric
+                      label="Estimated cache writes"
+                      value={
+                        merged.costQuality.cacheWriteUsd === null
+                          ? "Unavailable"
+                          : formatUsd(merged.costQuality.cacheWriteUsd)
+                      }
+                      {...(merged.costUsd > 0 && merged.costQuality.cacheWriteUsd !== null
+                        ? {
+                            detail: `${formatPercent(merged.costQuality.cacheWriteUsd / merged.costUsd, 0)} of cost`,
+                          }
+                        : {})}
+                    />
                     <Metric
                       label="Cache savings"
                       value={formatUsd(merged.costQuality.cacheSavingsUsd)}
@@ -464,12 +620,21 @@ export function UsagePage() {
                       value={[breakdown]}
                       onValueChange={(next) => {
                         const value = next[0];
-                        if (value === "model" || value === "time") setBreakdown(value);
+                        if (
+                          value === "model" ||
+                          value === "project" ||
+                          value === "thread" ||
+                          value === "time"
+                        ) {
+                          setBreakdown(value);
+                        }
                       }}
                     >
                       {(
                         [
                           { value: "model", label: "Model" },
+                          { value: "project", label: "Project" },
+                          { value: "thread", label: "Thread" },
                           { value: "time", label: isPast24Hours ? "Hour" : "Day" },
                         ] as const
                       ).map((option) => (
@@ -480,18 +645,109 @@ export function UsagePage() {
                     </ToggleGroup>
                   </div>
 
-                  {breakdown === "model" ? (
+                  {breakdown === "thread" ? (
+                    <UsageThreadTable
+                      input={{
+                        sinceDay: window.sinceDay,
+                        untilDay: window.untilDay,
+                        timeZone: window.timeZone,
+                        ...(window.sinceTime === undefined ? {} : { sinceTime: window.sinceTime }),
+                        ...(window.untilTime === undefined ? {} : { untilTime: window.untilTime }),
+                        ...(projectFilter === undefined ? {} : { projectKey: projectFilter }),
+                      }}
+                      providerContributions={merged.providerContributions}
+                      summaryFailedEnvironments={
+                        selectedEnvironments.filter(
+                          (environment) =>
+                            (environment.error !== null ||
+                              merged.staleEnvironments.includes(environment.environmentId)) &&
+                            projectFilterForEnvironment(
+                              projectFilter,
+                              environment.environmentId,
+                            ) !== "environment-mismatch:",
+                        ).length
+                      }
+                    />
+                  ) : breakdown === "project" ? (
                     <table className="w-full table-fixed text-sm">
                       <colgroup>
-                        <col className="w-2/5" />
-                        <col className="w-1/5" />
-                        <col className="w-1/5" />
-                        <col className="w-1/5" />
+                        <col className="w-[32%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                      </colgroup>
+                      <thead>
+                        <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                          <th className="py-2 font-normal">Project</th>
+                          <th className="py-2 text-right font-normal">Cost</th>
+                          <th className="py-2 text-right font-normal">Cache writes</th>
+                          <th className="py-2 text-right font-normal">Share</th>
+                          <th className="py-2 text-right font-normal">Tokens</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {breakdownProjects.length === 0 ? (
+                          <tr>
+                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                              {merged.records === 0
+                                ? "No activity in this window."
+                                : "No project attribution in this window."}
+                            </td>
+                          </tr>
+                        ) : (
+                          breakdownProjects.map((project) => (
+                            <tr
+                              key={project.projectKey ?? "\0"}
+                              className="border-b border-border/50 transition-colors hover:bg-muted/50"
+                            >
+                              <td className="py-2">
+                                {project.project === null ? (
+                                  <span className="text-muted-foreground">Outside projects</span>
+                                ) : (
+                                  <span className="block truncate text-foreground">
+                                    {project.project}
+                                  </span>
+                                )}
+                              </td>
+                              <td className="py-2 text-right text-foreground tabular-nums">
+                                {formatUsd(project.costUsd)}
+                              </td>
+                              <CacheWriteCell
+                                cacheWriteTokens={project.cacheWriteTokens}
+                                cacheWriteUsd={project.cacheWriteUsd}
+                              />
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatPercent(
+                                  projectFilter === undefined
+                                    ? project.costShare
+                                    : breakdownProjectCostUsd === 0
+                                      ? 0
+                                      : project.costUsd / breakdownProjectCostUsd,
+                                )}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatTokens(project.totalTokens)}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  ) : breakdown === "model" ? (
+                    <table className="w-full table-fixed text-sm">
+                      <colgroup>
+                        <col className="w-[32%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
                       </colgroup>
                       <thead>
                         <tr className="border-b border-border text-left text-xs text-muted-foreground">
                           <th className="py-2 font-normal">Model</th>
                           <th className="py-2 text-right font-normal">Cost</th>
+                          <th className="py-2 text-right font-normal">Cache writes</th>
                           <th className="py-2 text-right font-normal">Share</th>
                           <th className="py-2 text-right font-normal">Tokens</th>
                         </tr>
@@ -499,7 +755,7 @@ export function UsagePage() {
                       <tbody>
                         {breakdownModels.length === 0 ? (
                           <tr>
-                            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
                               No activity in this window.
                             </td>
                           </tr>
@@ -522,6 +778,10 @@ export function UsagePage() {
                                   formatUsd(model.costUsd)
                                 )}
                               </td>
+                              <CacheWriteCell
+                                cacheWriteTokens={model.cacheWriteTokens}
+                                cacheWriteUsd={model.cacheWriteUsd}
+                              />
                               <td className="py-2 text-right text-muted-foreground tabular-nums">
                                 {isModelCostUnknown(model) ? "—" : formatPercent(model.costShare)}
                               </td>
@@ -606,6 +866,148 @@ export function UsagePage() {
   );
 }
 
+/**
+ * Free date-range bounds beside the presets. Native date inputs; committing
+ * either bound deselects every preset. Compact layouts render the same control
+ * above the page content so custom ranges remain reachable without crowding
+ * the header.
+ */
+function UsageDateRangeInputs({
+  className,
+  sinceDay,
+  untilDay,
+  onChange,
+  disabled = false,
+}: {
+  readonly className?: string;
+  readonly sinceDay: string;
+  readonly untilDay: string;
+  readonly onChange: (sinceDay: string, untilDay: string) => void;
+  readonly disabled?: boolean;
+}) {
+  // The shared buffered-input hook preserves a focused draft across upstream
+  // range changes and commits on both blur and Enter. Keep the hooks separate
+  // so each bound can validate against the last committed opposite bound.
+  const sinceInput = useCommitOnBlur(sinceDay, (next) => {
+    const comparison = compareUsageDays(next, untilDay);
+    if (comparison !== null && comparison <= 0) onChange(next, untilDay);
+  });
+  const untilInput = useCommitOnBlur(untilDay, (next) => {
+    const comparison = compareUsageDays(sinceDay, next);
+    if (comparison !== null && comparison <= 0) onChange(sinceDay, next);
+  });
+  const comparison = compareUsageDays(sinceInput.value, untilInput.value);
+  const invalid = comparison === null || comparison > 0;
+  const inputClassName =
+    "[color-scheme:inherit] [&_[data-slot=input]::-webkit-calendar-picker-indicator]:opacity-50";
+
+  return (
+    <div
+      className={cn(
+        "flex w-fit items-center text-xs text-muted-foreground",
+        segmentedControlGroupClassName,
+        className,
+      )}
+    >
+      <Input
+        nativeInput
+        type="date"
+        size="segmented"
+        variant="segmented"
+        aria-label="From day"
+        className={inputClassName}
+        max={untilInput.value}
+        disabled={disabled}
+        aria-invalid={invalid || undefined}
+        {...sinceInput}
+      />
+      <span className="px-0.5">to</span>
+      <Input
+        nativeInput
+        type="date"
+        size="segmented"
+        variant="segmented"
+        aria-label="To day"
+        className={inputClassName}
+        min={sinceInput.value}
+        disabled={disabled}
+        aria-invalid={invalid || undefined}
+        {...untilInput}
+      />
+    </div>
+  );
+}
+
+/**
+ * Select values are plain strings, so the three filter states get distinct
+ * encodings: sentinels for "all" and "outside", while attributed projects
+ * already carry a namespaced stable key from the merge layer.
+ */
+const ALL_PROJECTS_VALUE = "all";
+const OUTSIDE_PROJECTS_VALUE = "outside";
+const PROJECT_VALUE_PREFIX = "p:";
+
+function projectFilterValue(filter: string | null | undefined): string {
+  if (filter === undefined) return ALL_PROJECTS_VALUE;
+  if (filter === null) return OUTSIDE_PROJECTS_VALUE;
+  return `${PROJECT_VALUE_PREFIX}${filter}`;
+}
+
+function projectFilterFromValue(value: string): string | null | undefined {
+  if (value === OUTSIDE_PROJECTS_VALUE) return null;
+  if (value.startsWith(PROJECT_VALUE_PREFIX)) return value.slice(PROJECT_VALUE_PREFIX.length);
+  return undefined;
+}
+
+/** Narrows the whole page to one project's buckets. */
+function UsageProjectSelect({
+  projects,
+  filter,
+  selectedLabel,
+  onChange,
+}: {
+  readonly projects: readonly ProjectTotals[];
+  readonly filter: string | null | undefined;
+  readonly selectedLabel: string | null;
+  readonly onChange: (filter: string | null | undefined) => void;
+}) {
+  const label = filter === undefined ? "All projects" : (selectedLabel ?? "Selected project");
+  return (
+    <Select
+      value={projectFilterValue(filter)}
+      onValueChange={(value) => onChange(projectFilterFromValue(value ?? ""))}
+    >
+      <SelectTrigger
+        aria-label="Project filter"
+        size="compact"
+        variant="ghost"
+        className="w-auto max-w-48 min-w-0"
+      >
+        <SelectValue>
+          <span className="truncate">{label}</span>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectItem value={ALL_PROJECTS_VALUE}>All projects</SelectItem>
+        {projects.map((project) =>
+          project.project === null ? (
+            <SelectItem key={OUTSIDE_PROJECTS_VALUE} value={OUTSIDE_PROJECTS_VALUE}>
+              Outside projects
+            </SelectItem>
+          ) : (
+            <SelectItem
+              key={project.projectKey}
+              value={`${PROJECT_VALUE_PREFIX}${project.projectKey}`}
+            >
+              {project.project}
+            </SelectItem>
+          ),
+        )}
+      </SelectPopup>
+    </Select>
+  );
+}
+
 /** Brand mark for the harness a row belongs to. */
 function ProviderMark({
   provider,
@@ -618,13 +1020,47 @@ function ProviderMark({
   return <Mark className={cn("shrink-0", className)} aria-hidden />;
 }
 
-function Metric({ label, value }: { readonly label: string; readonly value: string }) {
+function Metric({
+  label,
+  value,
+  detail,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly detail?: string;
+}) {
   return (
     <div className="flex min-w-0 flex-col gap-0.5">
       <span className="text-xs text-muted-foreground">{label}</span>
       <span className="text-base font-medium text-foreground tabular-nums">{value}</span>
+      {detail === undefined ? null : (
+        <span className="text-xs text-muted-foreground tabular-nums">{detail}</span>
+      )}
     </div>
   );
+}
+
+/**
+ * Cache-write cost cell. Providers that bill no cache writes (Codex) show a
+ * dash rather than a misleading $0.00.
+ */
+function CacheWriteCell({
+  cacheWriteTokens,
+  cacheWriteUsd,
+}: {
+  readonly cacheWriteTokens: number;
+  readonly cacheWriteUsd: number | null;
+}) {
+  return (
+    <td className="py-2 text-right text-muted-foreground tabular-nums">
+      {formatCacheWriteCost(cacheWriteTokens, cacheWriteUsd)}
+    </td>
+  );
+}
+
+function formatCacheWriteCost(cacheWriteTokens: number, cacheWriteUsd: number | null): string {
+  if (cacheWriteTokens === 0) return "-";
+  return cacheWriteUsd === null ? "Unavailable" : formatUsd(cacheWriteUsd);
 }
 
 /**
@@ -860,15 +1296,20 @@ function UsageSkeleton() {
 
       <section className="flex flex-col gap-2">
         <h2 className="text-sm font-medium text-foreground">Totals</h2>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-5">
-          {["Processed tokens", "Cached input", "Uncached input", "Output", "Cache savings"].map(
-            (label) => (
-              <div key={label} className="flex flex-col gap-0.5">
-                <span className="text-xs text-muted-foreground">{label}</span>
-                <Skeleton className="h-6 w-16" />
-              </div>
-            ),
-          )}
+        <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-6">
+          {[
+            "Processed tokens",
+            "Cached input",
+            "Uncached input",
+            "Output",
+            "Estimated cache writes",
+            "Cache savings",
+          ].map((label) => (
+            <div key={label} className="flex flex-col gap-0.5">
+              <span className="text-xs text-muted-foreground">{label}</span>
+              <Skeleton className="h-6 w-16" />
+            </div>
+          ))}
         </div>
       </section>
 

--- a/apps/web/src/components/usage/UsageProviderChart.interaction.test.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.interaction.test.tsx
@@ -1,0 +1,81 @@
+import { act } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { UsageProviderChart } from "./UsageProviderChart";
+
+const days = ["2026-09-01", "2026-09-02", "2026-09-03"];
+let renderer: ReactTestRenderer;
+const onZoomToDays = vi.fn();
+const captures = new Set<number>();
+const plot = {
+  getBoundingClientRect: () => ({ left: 0, top: 0, width: 300, height: 260 }),
+  hasPointerCapture: (id: number) => captures.has(id),
+  setPointerCapture: (id: number) => captures.add(id),
+  releasePointerCapture: (id: number) => captures.delete(id),
+};
+
+function chart(windowDays: readonly string[], resolution: "day" | "hour" = "day") {
+  return (
+    <UsageProviderChart
+      days={windowDays}
+      daily={[]}
+      hours={[]}
+      hourly={[]}
+      providers={[]}
+      metric="cost"
+      resolution={resolution}
+      referenceTime={undefined}
+      timeZone="UTC"
+      onZoomToDays={onZoomToDays}
+    />
+  );
+}
+
+function pointer(name: "onPointerDown" | "onPointerUp", clientX: number) {
+  renderer.root
+    .find((node) => node.type === "div" && node.props.onPointerDown !== undefined)
+    .props[name]({ button: 0, isPrimary: true, pointerId: 1, clientX, currentTarget: plot });
+}
+
+beforeEach(async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  onZoomToDays.mockClear();
+  captures.clear();
+  await act(() => {
+    renderer = create(chart(days), {
+      createNodeMock: (element) => (element.type === "div" ? plot : null),
+    });
+  });
+});
+
+afterEach(async () => {
+  await act(() => renderer.unmount());
+  vi.unstubAllGlobals();
+});
+
+describe("usage chart brush ownership", () => {
+  it("cancels a brush if date-field blur replaces its window before pointer-up", async () => {
+    await act(() => pointer("onPointerDown", 0));
+    expect(captures.has(1)).toBe(true);
+    await act(() => renderer.update(chart(["2026-08-01", "2026-08-02", "2026-08-03"])));
+    await act(() => pointer("onPointerUp", 300));
+    expect(onZoomToDays).not.toHaveBeenCalled();
+    expect(captures.has(1)).toBe(false);
+  });
+
+  it("keeps a brush when the same days are supplied by a fresh array", async () => {
+    await act(() => pointer("onPointerDown", 0));
+    await act(() => renderer.update(chart([...days])));
+    await act(() => pointer("onPointerUp", 300));
+    expect(onZoomToDays).toHaveBeenCalledExactlyOnceWith(days[0], days[2]);
+  });
+
+  it("cancels a brush when the view switches to hourly resolution", async () => {
+    await act(() => pointer("onPointerDown", 0));
+    await act(() => renderer.update(chart(days, "hour")));
+    await act(() => pointer("onPointerUp", 300));
+    expect(onZoomToDays).not.toHaveBeenCalled();
+    expect(captures.has(1)).toBe(false);
+  });
+});

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildPeriodColumns, niceScale } from "./UsageProviderChart";
+import {
+  brushSelection,
+  buildPeriodColumns,
+  chartLabelIndices,
+  niceScale,
+  periodIndexAt,
+  spanSinglePeriodPoints,
+} from "./UsageProviderChart";
 import { providersWithUsage } from "./usageProviders";
 
 describe("niceScale", () => {
@@ -133,5 +140,67 @@ describe("hourly chart columns", () => {
         "cost",
       ).map((column) => column.total),
     ).toEqual([0, 4, 0]);
+  });
+});
+
+describe("brushSelection", () => {
+  const days = ["2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04"];
+
+  it("returns inclusive bounds for a forward drag", () => {
+    expect(brushSelection(days, 1, 3)).toEqual({
+      sinceDay: "2026-08-02",
+      untilDay: "2026-08-04",
+    });
+  });
+
+  it("normalises a backward drag", () => {
+    expect(brushSelection(days, 3, 1)).toEqual({
+      sinceDay: "2026-08-02",
+      untilDay: "2026-08-04",
+    });
+  });
+
+  it("treats a plain click as no selection", () => {
+    expect(brushSelection(days, 2, 2)).toBeNull();
+  });
+
+  it("rejects endpoints outside the day list", () => {
+    expect(brushSelection(days, 0, 9)).toBeNull();
+  });
+});
+
+describe("periodIndexAt", () => {
+  it("clamps a captured pointer to either chart edge", () => {
+    expect(periodIndexAt(-50, 100, 400, 5)).toBe(0);
+    expect(periodIndexAt(750, 100, 400, 5)).toBe(4);
+  });
+});
+
+describe("spanSinglePeriodPoints", () => {
+  it("repeats one point across the chart width", () => {
+    expect(spanSinglePeriodPoints([{ x: 0, y: 42 }])).toEqual([
+      { x: 0, y: 42 },
+      { x: 960, y: 42 },
+    ]);
+  });
+
+  it("leaves multi-period points unchanged", () => {
+    const points = [
+      { x: 0, y: 42 },
+      { x: 960, y: 12 },
+    ];
+
+    expect(spanSinglePeriodPoints(points)).toBe(points);
+  });
+});
+
+describe("chartLabelIndices", () => {
+  it("deduplicates labels for one- and two-period windows", () => {
+    expect(chartLabelIndices(1)).toEqual([0]);
+    expect(chartLabelIndices(2)).toEqual([0, 1]);
+  });
+
+  it("keeps left, middle, and right labels for wider windows", () => {
+    expect(chartLabelIndices(5)).toEqual([0, 2, 4]);
   });
 });

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -2,6 +2,8 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
+
+import { cn } from "../../lib/utils";
 import {
   formatDayShort,
   formatHourShort,
@@ -19,6 +21,13 @@ const PLOT_TOP = 8;
 export type UsageChartMetric = "tokens" | "cost";
 
 interface UsageProviderChartProps {
+  /**
+   * Present only when the window can zoom (daily resolution). Receives the
+   * inclusive day bounds of a completed drag selection.
+   */
+  readonly onZoomToDays?: (sinceDay: string, untilDay: string) => void;
+  /** Restores the preset window on double-click. */
+  readonly onResetZoom?: () => void;
   readonly providers: readonly UsageProviderKind[];
   readonly days: readonly string[];
   readonly daily: readonly DailyTotals[];
@@ -42,6 +51,18 @@ export interface DayColumn {
 interface Point {
   readonly x: number;
   readonly y: number;
+}
+
+/** Gives a one-period daily window enough horizontal span to draw a path. */
+export function spanSinglePeriodPoints(points: readonly Point[]): readonly Point[] {
+  const only = points.length === 1 ? points[0] : undefined;
+  return only === undefined ? points : [only, { ...only, x: VIEW_WIDTH }];
+}
+
+/** Selects distinct left, middle, and right labels for the available span. */
+export function chartLabelIndices(periodCount: number): readonly number[] {
+  if (periodCount <= 0) return [];
+  return [...new Set([0, Math.floor(periodCount / 2), periodCount - 1])];
 }
 
 function valueFor(
@@ -169,7 +190,40 @@ export function niceScale(peak: number, count: number): { max: number; ticks: re
   return { max, ticks };
 }
 
+/**
+ * Inclusive day bounds of a brush selection, or null for a plain click.
+ * Endpoints may arrive in either drag direction.
+ */
+export function brushSelection(
+  days: readonly string[],
+  startIndex: number,
+  endIndex: number,
+): { readonly sinceDay: string; readonly untilDay: string } | null {
+  if (startIndex === endIndex) return null;
+  const [first, last] = startIndex < endIndex ? [startIndex, endIndex] : [endIndex, startIndex];
+  const sinceDay = days[first];
+  const untilDay = days[last];
+  if (sinceDay === undefined || untilDay === undefined) return null;
+  return { sinceDay, untilDay };
+}
+
+/** Period index beneath a pointer, clamped when pointer capture moves outside the plot. */
+export function periodIndexAt(
+  clientX: number,
+  plotLeft: number,
+  plotWidth: number,
+  periodCount: number,
+): number | null {
+  if (plotWidth <= 0 || periodCount <= 0) return null;
+  const localX = Math.min(plotWidth, Math.max(0, clientX - plotLeft));
+  const fraction = localX / plotWidth;
+  const index = Math.round(fraction * (periodCount - 1));
+  return Math.min(periodCount - 1, Math.max(0, index));
+}
+
 export function UsageProviderChart({
+  onZoomToDays,
+  onResetZoom,
   providers,
   days,
   daily,
@@ -189,9 +243,35 @@ export function UsageProviderChart({
     [daily, hourly, resolution],
   );
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  // Drag-selection endpoints, as period indices. Only daily windows zoom.
+  const [brush, setBrush] = useState<{ readonly start: number; readonly end: number } | null>(null);
+  const brushRef = useRef<{
+    readonly pointerId: number;
+    readonly days: readonly string[];
+    readonly start: number;
+    readonly end: number;
+  } | null>(null);
+  const zoomable = resolution === "day" && onZoomToDays !== undefined;
   const plotRef = useRef<HTMLDivElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const hoverPositionRef = useRef<{ x: number; y: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const activeBrush = brushRef.current;
+    if (
+      activeBrush === null ||
+      (zoomable &&
+        activeBrush.days.length === days.length &&
+        activeBrush.days.every((day, index) => day === days[index]))
+    )
+      return;
+    brushRef.current = null;
+    setBrush(null);
+    const plot = plotRef.current;
+    if (plot?.hasPointerCapture(activeBrush.pointerId)) {
+      plot.releasePointerCapture(activeBrush.pointerId);
+    }
+  }, [days, zoomable]);
 
   const { paths, ticks, stepX, toY, series } = useMemo(() => {
     if (periods.length === 0) {
@@ -221,14 +301,11 @@ export function UsageProviderChart({
 
     const built = providers.map((provider) => {
       const providerIndex = PROVIDER_ORDER.indexOf(provider);
-      const line = curvePath(
-        smoothCurve(
-          columns.map((column, periodIndex) => ({
-            x: periodIndex * step,
-            y: toY(column.bands[providerIndex]?.value ?? 0),
-          })),
-        ),
-      );
+      const points = columns.map((column, periodIndex) => ({
+        x: periodIndex * step,
+        y: toY(column.bands[providerIndex]?.value ?? 0),
+      }));
+      const line = curvePath(smoothCurve(spanSinglePeriodPoints(points)));
       return {
         provider,
         total: columns.reduce((sum, column) => sum + (column.bands[providerIndex]?.value ?? 0), 0),
@@ -288,22 +365,95 @@ export function UsageProviderChart({
     return () => observer.disconnect();
   }, [hoverIndex, positionTooltip]);
 
+  const indexAt = useCallback(
+    (clientX: number): number | null => {
+      const plot = plotRef.current;
+      if (plot === null || periods.length === 0) return null;
+      const bounds = plot.getBoundingClientRect();
+      return periodIndexAt(clientX, bounds.left, bounds.width, periods.length);
+    },
+    [periods.length],
+  );
+
   const handleMove = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       const plot = plotRef.current;
       if (plot === null || periods.length === 0) return;
       const bounds = plot.getBoundingClientRect();
       if (bounds.width === 0) return;
+      if (brushRef.current !== null) return;
+      const index = indexAt(event.clientX);
+      if (index === null) return;
       const localX = Math.min(bounds.width, Math.max(0, event.clientX - bounds.left));
       const localY = Math.min(bounds.height, Math.max(0, event.clientY - bounds.top));
-      const fraction = localX / bounds.width;
-      const index = Math.round(fraction * (periods.length - 1));
       hoverPositionRef.current = { x: localX, y: localY };
       positionTooltip();
-      setHoverIndex(Math.min(periods.length - 1, Math.max(0, index)));
+      setHoverIndex(index);
     },
-    [periods.length, positionTooltip],
+    [indexAt, periods.length, positionTooltip],
   );
+
+  const trackBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const activeBrush = brushRef.current;
+      if (
+        activeBrush === null ||
+        activeBrush.pointerId !== event.pointerId ||
+        !event.currentTarget.hasPointerCapture(event.pointerId)
+      ) {
+        return;
+      }
+      const index = indexAt(event.clientX);
+      if (index === null || index === activeBrush.end) return;
+      const nextBrush = { ...activeBrush, end: index };
+      brushRef.current = nextBrush;
+      setBrush(nextBrush);
+    },
+    [indexAt],
+  );
+
+  const beginBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!zoomable || event.button !== 0 || !event.isPrimary || brushRef.current !== null) return;
+      const index = indexAt(event.clientX);
+      if (index === null) return;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      hoverPositionRef.current = null;
+      setHoverIndex(null);
+      const nextBrush = { pointerId: event.pointerId, days, start: index, end: index };
+      brushRef.current = nextBrush;
+      setBrush(nextBrush);
+    },
+    [days, indexAt, zoomable],
+  );
+
+  const finishBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const activeBrush = brushRef.current;
+      if (
+        activeBrush === null ||
+        activeBrush.pointerId !== event.pointerId ||
+        onZoomToDays === undefined
+      ) {
+        return;
+      }
+      const end = indexAt(event.clientX) ?? activeBrush.end;
+      const selection = brushSelection(days, activeBrush.start, end);
+      brushRef.current = null;
+      setBrush(null);
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (selection !== null) onZoomToDays(selection.sinceDay, selection.untilDay);
+    },
+    [days, indexAt, onZoomToDays],
+  );
+
+  const cancelBrush = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (brushRef.current?.pointerId !== event.pointerId) return;
+    brushRef.current = null;
+    setBrush(null);
+  }, []);
 
   const hoveredPeriod = hoverIndex === null ? undefined : periods[hoverIndex];
   const hoveredColumn = hoverIndex === null ? undefined : series[hoverIndex];
@@ -332,8 +482,17 @@ export function UsageProviderChart({
 
         <div
           ref={plotRef}
-          className="relative h-56 flex-1"
+          className={cn(
+            "relative h-56 flex-1",
+            zoomable && "cursor-crosshair touch-pan-y select-none",
+          )}
           onMouseMove={handleMove}
+          onPointerDown={beginBrush}
+          onPointerMove={trackBrush}
+          onPointerUp={finishBrush}
+          onPointerCancel={cancelBrush}
+          onLostPointerCapture={cancelBrush}
+          onDoubleClick={onResetZoom}
           onMouseLeave={() => {
             hoverPositionRef.current = null;
             setHoverIndex(null);
@@ -383,7 +542,22 @@ export function UsageProviderChart({
               />
             ))}
 
-            {hoverIndex === null ? null : (
+            {brush === null || brush.start === brush.end ? null : (
+              <rect
+                x={Math.min(brush.start, brush.end) * stepX}
+                y={PLOT_TOP}
+                width={Math.abs(brush.end - brush.start) * stepX}
+                height={VIEW_HEIGHT - PLOT_TOP}
+                fill="currentColor"
+                fillOpacity={0.08}
+                stroke="currentColor"
+                strokeWidth={1}
+                className="text-muted-foreground"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+
+            {hoverIndex === null || periods.length === 1 ? null : (
               <line
                 x1={hoverIndex * stepX}
                 x2={hoverIndex * stepX}
@@ -435,17 +609,9 @@ export function UsageProviderChart({
       </div>
 
       <div className="flex justify-between pl-16 text-[10px] text-muted-foreground uppercase">
-        <span>{periods[0] === undefined ? "" : formatPeriod(periods[0])}</span>
-        <span>
-          {periods[Math.floor(periods.length / 2)] === undefined
-            ? ""
-            : formatPeriod(periods[Math.floor(periods.length / 2)] ?? "")}
-        </span>
-        <span>
-          {periods[periods.length - 1] === undefined
-            ? ""
-            : formatPeriod(periods[periods.length - 1] ?? "")}
-        </span>
+        {chartLabelIndices(periods.length).map((index) => (
+          <span key={index}>{formatPeriod(periods[index] ?? "")}</span>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/usage/UsageThreadTable.test.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.test.tsx
@@ -1,0 +1,159 @@
+import { EnvironmentId, ThreadId, UsageDay } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({ useUsageThreads: vi.fn() }));
+
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("../../state/usage", () => ({ useUsageThreads: testState.useUsageThreads }));
+vi.mock("../ui/tooltip", async () => {
+  const React = await import("react");
+  return {
+    Tooltip: "span",
+    TooltipPopup: "span",
+    TooltipTrigger: ({
+      render,
+      children,
+    }: {
+      render: React.ReactElement;
+      children: React.ReactNode;
+    }) => React.cloneElement(render, {}, children),
+  };
+});
+vi.mock("./usageProviders", () => ({
+  PROVIDER_PRESENTATION: {
+    claude: { mark: "span" },
+    codex: { mark: "span" },
+    grok: { mark: "span" },
+  },
+}));
+
+import { UsageThreadDailyChart, UsageThreadTable } from "./UsageThreadTable";
+
+const input = {
+  sinceDay: UsageDay.make("2026-08-01"),
+  untilDay: UsageDay.make("2026-08-31"),
+  timeZone: "UTC",
+};
+
+beforeEach(() => {
+  testState.useUsageThreads.mockReset();
+});
+
+describe("UsageThreadTable", () => {
+  it("uses the shared skeleton treatment while thread data is pending", () => {
+    testState.useUsageThreads.mockReturnValue({
+      rows: [],
+      truncatedRows: 0,
+      isPending: true,
+      failedEnvironments: 0,
+    });
+
+    const markup = renderToStaticMarkup(
+      <UsageThreadTable input={input} providerContributions={[]} summaryFailedEnvironments={0} />,
+    );
+
+    expect(markup.match(/motion-safe:animate-skeleton/g)).toHaveLength(4);
+  });
+
+  it("reports an unavailable breakdown when every query failed", () => {
+    testState.useUsageThreads.mockReturnValue({
+      rows: [],
+      truncatedRows: 0,
+      isPending: false,
+      failedEnvironments: 0,
+    });
+
+    const markup = renderToStaticMarkup(
+      <UsageThreadTable input={input} providerContributions={[]} summaryFailedEnvironments={2} />,
+    );
+
+    expect(markup).toContain("Thread activity could not be loaded");
+    expect(markup).not.toContain("No activity in this window");
+  });
+
+  it("uses a keyboard-accessible disclosure button without a native title", () => {
+    testState.useUsageThreads.mockReturnValue({
+      rows: [
+        {
+          environmentId: EnvironmentId.make("environment-one"),
+          key: "row-one",
+          threadId: ThreadId.make("thread-one"),
+          title: "Fix the flaky test",
+          provider: "claude",
+          totals: {
+            uncachedInputTokens: 1,
+            cachedInputTokens: 2,
+            cacheCreationTokens: 3,
+            outputTokens: 4,
+            reasoningTokens: 0,
+          },
+          costUsd: 1,
+          cacheWriteUsd: 0.25,
+          sessions: 1,
+          agents: [
+            {
+              agentId: "agent-one",
+              totals: {
+                uncachedInputTokens: 1,
+                cachedInputTokens: 0,
+                cacheCreationTokens: 0,
+                outputTokens: 1,
+                reasoningTokens: 0,
+              },
+              costUsd: 0.1,
+            },
+          ],
+          daily: [],
+        },
+      ],
+      truncatedRows: 0,
+      isPending: false,
+      failedEnvironments: 0,
+    });
+
+    const markup = renderToStaticMarkup(
+      <UsageThreadTable input={input} providerContributions={[]} summaryFailedEnvironments={0} />,
+    );
+
+    expect(markup).toContain('<button type="button" aria-expanded="false"');
+    expect(markup).toContain('data-slot="badge"');
+    expect(markup).toContain("1 subagent");
+    expect(markup).toContain('aria-label="Open thread"');
+    expect(markup).not.toContain('title="Fix the flaky test"');
+  });
+});
+
+describe("UsageThreadDailyChart", () => {
+  it("renders continuous stacked component bands with a peak and date labels", () => {
+    const markup = renderToStaticMarkup(
+      <UsageThreadDailyChart
+        sinceDay="2026-08-01"
+        untilDay="2026-08-03"
+        daily={[
+          {
+            day: UsageDay.make("2026-08-01"),
+            cacheWriteUsd: 2,
+            cacheReadUsd: 3,
+            freshUsd: 1,
+          },
+          {
+            day: UsageDay.make("2026-08-03"),
+            cacheWriteUsd: 4,
+            cacheReadUsd: 5,
+            freshUsd: 3,
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Peak $12.00");
+    expect(markup).toContain("cache writes");
+    expect(markup).toContain("cache reads");
+    expect(markup).toContain("fresh input + output");
+    expect(markup.match(/<path/g)).toHaveLength(3);
+    expect(markup).toContain("H253.33 V96 H506.67");
+    expect(markup).toContain("Aug 1");
+    expect(markup).toContain("Aug 3");
+  });
+});

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -1,0 +1,458 @@
+import type {
+  UsageProviderKind,
+  UsageThreadBreakdownInput,
+  UsageThreadDayCost,
+} from "@t3tools/contracts";
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowUpRightIcon, ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  enumerateDays,
+  formatDayShort,
+  formatPercent,
+  formatTokens,
+  formatUsd,
+} from "@t3tools/shared/usageFormat";
+import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
+
+import { useUsageThreads, type UsageThreadRowWithEnvironment } from "../../state/usage";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Skeleton } from "../ui/skeleton";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { PROVIDER_PRESENTATION } from "./usageProviders";
+
+/**
+ * On-demand thread drill-down behind the summary. Mounted only while the
+ * Thread breakdown view is open, which is what defers the RPC.
+ */
+export function UsageThreadTable({
+  input,
+  providerContributions,
+  summaryFailedEnvironments,
+}: {
+  readonly input: UsageThreadBreakdownInput;
+  readonly providerContributions: readonly EnvironmentProviderContribution[];
+  readonly summaryFailedEnvironments: number;
+}) {
+  const { rows, truncatedRows, isPending, failedEnvironments } = useUsageThreads(
+    input,
+    providerContributions,
+  );
+  const unavailableEnvironments = failedEnvironments + summaryFailedEnvironments;
+  const [openRows, setOpenRows] = useState<ReadonlySet<string>>(new Set());
+  const totalCostUsd = useMemo(() => rows.reduce((sum, row) => sum + row.costUsd, 0), [rows]);
+
+  const toggleRow = (key: string) => {
+    setOpenRows((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  if (isPending) {
+    return (
+      <div className="flex flex-col gap-2 py-1">
+        {[56, 42, 68, 35].map((width) => (
+          <Skeleton key={width} className="h-6" style={{ width: `${width}%` }} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <table className="w-full table-fixed text-sm">
+      <colgroup>
+        <col className="w-[32%]" />
+        <col className="w-[17%]" />
+        <col className="w-[17%]" />
+        <col className="w-[17%]" />
+        <col className="w-[17%]" />
+      </colgroup>
+      <thead>
+        <tr className="border-b border-border text-left text-xs text-muted-foreground">
+          <th className="py-2 font-normal">Thread</th>
+          <th className="py-2 text-right font-normal">Cost</th>
+          <th className="py-2 text-right font-normal">Cache writes</th>
+          <th className="py-2 text-right font-normal">Share</th>
+          <th className="py-2 text-right font-normal">Tokens</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.length === 0 ? (
+          <tr>
+            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+              {unavailableEnvironments > 0
+                ? "Thread activity could not be loaded for this window."
+                : "No activity in this window."}
+            </td>
+          </tr>
+        ) : (
+          rows.map((row) => {
+            const viewKey = `${row.environmentId}\u0000${row.key}`;
+            const open = openRows.has(viewKey);
+            const tokens =
+              row.totals.uncachedInputTokens +
+              row.totals.cachedInputTokens +
+              row.totals.cacheCreationTokens +
+              row.totals.outputTokens;
+            return (
+              <ThreadRowGroup
+                key={viewKey}
+                row={row}
+                open={open}
+                tokens={tokens}
+                share={totalCostUsd === 0 ? 0 : row.costUsd / totalCostUsd}
+                sinceDay={input.sinceDay}
+                untilDay={input.untilDay}
+                onToggle={() => toggleRow(viewKey)}
+              />
+            );
+          })
+        )}
+        {truncatedRows > 0 ? (
+          <tr>
+            <td colSpan={5} className="py-2 text-xs text-muted-foreground">
+              {truncatedRows === 1
+                ? "1 lower-cost thread row is grouped above."
+                : `${truncatedRows} lower-cost thread rows are grouped above.`}
+            </td>
+          </tr>
+        ) : null}
+        {unavailableEnvironments > 0 && rows.length > 0 ? (
+          <tr>
+            <td colSpan={5} className="py-2 text-xs text-muted-foreground">
+              {unavailableEnvironments === 1
+                ? "1 environment could not report threads."
+                : `${unavailableEnvironments} environments could not report threads.`}
+            </td>
+          </tr>
+        ) : null}
+      </tbody>
+    </table>
+  );
+}
+
+function ThreadRowGroup({
+  row,
+  open,
+  tokens,
+  share,
+  sinceDay,
+  untilDay,
+  onToggle,
+}: {
+  readonly row: UsageThreadRowWithEnvironment;
+  readonly open: boolean;
+  readonly tokens: number;
+  readonly share: number;
+  readonly sinceDay: string;
+  readonly untilDay: string;
+  readonly onToggle: () => void;
+}) {
+  const Chevron = open ? ChevronDownIcon : ChevronRightIcon;
+  const navigate = useNavigate();
+  const threadId = row.threadId;
+  return (
+    <>
+      <tr className="border-b border-border/50 transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50">
+        <td className="py-2 text-foreground">
+          <div className="flex min-w-0 items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={onToggle}
+                    aria-expanded={open}
+                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                }
+              >
+                <Chevron className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                <ProviderMark provider={row.provider} />
+                <span className="truncate">{row.title}</span>
+                {row.agents.length > 0 ? (
+                  <Badge
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0 font-normal text-muted-foreground"
+                  >
+                    {row.agents.length === 1 ? "1 subagent" : `${row.agents.length} subagents`}
+                  </Badge>
+                ) : null}
+              </TooltipTrigger>
+              <TooltipPopup side="top">{row.title}</TooltipPopup>
+            </Tooltip>
+            {threadId === null ? null : (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      size="icon-micro"
+                      variant="ghost-muted"
+                      aria-label="Open thread"
+                      className="shrink-0"
+                      onClick={() => {
+                        void navigate({
+                          to: "/$environmentId/$threadId",
+                          params: { environmentId: row.environmentId, threadId },
+                        });
+                      }}
+                    />
+                  }
+                >
+                  <ArrowUpRightIcon aria-hidden />
+                </TooltipTrigger>
+                <TooltipPopup side="top">Open thread</TooltipPopup>
+              </Tooltip>
+            )}
+          </div>
+        </td>
+        <td className="py-2 text-right text-foreground tabular-nums">{formatUsd(row.costUsd)}</td>
+        <td className="py-2 text-right text-muted-foreground tabular-nums">
+          {formatCacheWriteCost(row.totals.cacheCreationTokens, row.cacheWriteUsd)}
+        </td>
+        <td className="py-2 text-right text-muted-foreground tabular-nums">
+          {formatPercent(share)}
+        </td>
+        <td className="py-2 text-right text-muted-foreground tabular-nums">
+          {formatTokens(tokens)}
+        </td>
+      </tr>
+      {open ? (
+        <tr className="border-b border-border/50">
+          <td colSpan={5} className="py-3 ps-9">
+            <UsageThreadDailyChart daily={row.daily} sinceDay={sinceDay} untilDay={untilDay} />
+            {row.agents.map((agent) => {
+              const agentTokens =
+                agent.totals.uncachedInputTokens +
+                agent.totals.cachedInputTokens +
+                agent.totals.cacheCreationTokens +
+                agent.totals.outputTokens;
+              return (
+                <div
+                  key={agent.agentId}
+                  className="flex items-baseline justify-between gap-4 py-1 text-xs text-muted-foreground"
+                >
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <Badge variant="outline" size="sm" className="shrink-0 font-normal">
+                      agent
+                    </Badge>
+                    <span className="truncate">{agent.agentId}</span>
+                  </span>
+                  <span className="shrink-0 tabular-nums">
+                    {formatUsd(agent.costUsd)} · {formatTokens(agentTokens)} tokens
+                  </span>
+                </div>
+              );
+            })}
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+function formatCacheWriteCost(cacheWriteTokens: number, cacheWriteUsd: number | null): string {
+  if (cacheWriteTokens === 0) return "-";
+  return cacheWriteUsd === null ? "Unavailable" : formatUsd(cacheWriteUsd);
+}
+
+const CHART_WIDTH = 760;
+const CHART_HEIGHT = 96;
+const CHART_TOP = 4;
+
+const EMPTY_DAY: Omit<UsageThreadDayCost, "day"> = {
+  cacheWriteUsd: 0,
+  cacheReadUsd: 0,
+  freshUsd: 0,
+};
+
+const CHART_BANDS = [
+  {
+    key: "freshUsd",
+    label: "fresh input + output",
+    className: "text-success",
+    lowerKeys: [],
+  },
+  {
+    key: "cacheReadUsd",
+    label: "cache reads",
+    className: "text-muted-foreground",
+    lowerKeys: ["freshUsd"],
+  },
+  {
+    key: "cacheWriteUsd",
+    label: "cache writes",
+    className: "text-info",
+    lowerKeys: ["freshUsd", "cacheReadUsd"],
+  },
+] as const;
+
+type ChartCostKey = (typeof CHART_BANDS)[number]["key"];
+
+function dayCost(entry: Omit<UsageThreadDayCost, "day">): number {
+  return entry.cacheWriteUsd + entry.cacheReadUsd + entry.freshUsd;
+}
+
+/** Rounds the ceiling up without leaving a compact thread chart mostly empty. */
+function chartCeiling(peak: number): number {
+  if (peak <= 0) return 0;
+  const magnitude = 10 ** Math.floor(Math.log10(peak));
+  const normalized = peak / magnitude;
+  const step = [1, 2, 2.5, 5, 10].find((candidate) => candidate >= normalized) ?? 10;
+  return step * magnitude;
+}
+
+function chartNumber(value: number): string {
+  return value.toFixed(2).replace(/\.00$/, "");
+}
+
+/** One filled band between two cumulative step boundaries. */
+function steppedAreaPath(
+  columns: readonly Omit<UsageThreadDayCost, "day">[],
+  key: ChartCostKey,
+  lowerKeys: readonly ChartCostKey[],
+  ceiling: number,
+): string {
+  if (columns.length === 0 || ceiling <= 0) return "";
+  if (columns.every((column) => column[key] === 0)) return "";
+
+  const width = CHART_WIDTH / columns.length;
+  const y = (value: number) =>
+    chartNumber(CHART_HEIGHT - (value / ceiling) * (CHART_HEIGHT - CHART_TOP));
+  const lower = columns.map((column) =>
+    lowerKeys.reduce((sum, lowerKey) => sum + column[lowerKey], 0),
+  );
+  const upper = columns.map((column, index) => (lower[index] ?? 0) + column[key]);
+  let path = `M0,${y(upper[0] ?? 0)}`;
+
+  for (let index = 0; index < columns.length; index += 1) {
+    const right = chartNumber((index + 1) * width);
+    path += ` H${right}`;
+    const next = upper[index + 1];
+    if (next !== undefined) path += ` V${y(next)}`;
+  }
+
+  path += ` L${CHART_WIDTH},${y(lower.at(-1) ?? 0)}`;
+  for (let index = columns.length - 1; index >= 0; index -= 1) {
+    const left = chartNumber(index * width);
+    path += ` H${left}`;
+    const previous = lower[index - 1];
+    if (previous !== undefined) path += ` V${y(previous)}`;
+  }
+  return `${path} Z`;
+}
+
+/**
+ * One thread's daily model-priced cost split into continuous stacked bands.
+ * Static SVG, no animation.
+ */
+export function UsageThreadDailyChart({
+  daily,
+  sinceDay,
+  untilDay,
+}: {
+  readonly daily: readonly UsageThreadDayCost[];
+  readonly sinceDay: string;
+  readonly untilDay: string;
+}) {
+  const days = useMemo(() => enumerateDays(sinceDay, untilDay), [sinceDay, untilDay]);
+  const byDay = useMemo(
+    () => new Map<string, UsageThreadDayCost>(daily.map((entry) => [entry.day, entry])),
+    [daily],
+  );
+  const columns = days.map((day) => byDay.get(day) ?? EMPTY_DAY);
+  const peakEntry = daily.reduce<UsageThreadDayCost | undefined>(
+    (largest, entry) =>
+      largest === undefined || dayCost(entry) > dayCost(largest) ? entry : largest,
+    undefined,
+  );
+
+  if (peakEntry === undefined || dayCost(peakEntry) === 0 || days.length === 0) {
+    return <p className="pb-2 text-xs text-muted-foreground">No priced usage in this window.</p>;
+  }
+
+  const peak = dayCost(peakEntry);
+  const ceiling = chartCeiling(peak);
+  const bandWidth = CHART_WIDTH / days.length;
+  const labelDays = [days[0], days[Math.floor((days.length - 1) / 2)], days.at(-1)].filter(
+    (day, index, labels): day is string => day !== undefined && labels.indexOf(day) === index,
+  );
+
+  return (
+    <div className="flex max-w-3xl flex-col gap-1 pb-2">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+        <span>
+          Daily cost, {formatDayShort(sinceDay)} to {formatDayShort(untilDay)}
+        </span>
+        <span className="tabular-nums text-foreground">
+          Peak {formatUsd(peak)} · {formatDayShort(peakEntry.day)}
+        </span>
+      </div>
+      <div className="flex flex-wrap justify-end gap-x-3 gap-y-1 text-[10px] text-muted-foreground">
+        {CHART_BANDS.toReversed().map((band) => (
+          <span key={band.key} className="flex items-center gap-1">
+            <span aria-hidden className={`size-1.5 rounded-[2px] bg-current ${band.className}`} />
+            {band.label}
+          </span>
+        ))}
+      </div>
+      <svg
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className="h-24 w-full"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Daily model-priced cost for this thread by component"
+        shapeRendering="crispEdges"
+      >
+        <line
+          x1={0}
+          y1={CHART_TOP}
+          x2={CHART_WIDTH}
+          y2={CHART_TOP}
+          stroke="currentColor"
+          className="text-border"
+          vectorEffect="non-scaling-stroke"
+        />
+        {CHART_BANDS.map((band) => (
+          <path
+            key={band.key}
+            d={steppedAreaPath(columns, band.key, band.lowerKeys, ceiling)}
+            fill="currentColor"
+            className={band.className}
+          />
+        ))}
+        {days.map((day, index) => {
+          const entry = byDay.get(day) ?? EMPTY_DAY;
+          const total = dayCost(entry);
+          return (
+            <rect
+              key={day}
+              x={index * bandWidth}
+              y={0}
+              width={bandWidth}
+              height={CHART_HEIGHT}
+              fill="transparent"
+            >
+              <title>{`${formatDayShort(day)}: ${formatUsd(total)}. Cache writes ${formatUsd(entry.cacheWriteUsd)}, cache reads ${formatUsd(entry.cacheReadUsd)}, fresh input and output ${formatUsd(entry.freshUsd)}`}</title>
+            </rect>
+          );
+        })}
+      </svg>
+      <div className="flex justify-between text-[10px] text-muted-foreground">
+        {labelDays.map((day) => (
+          <span key={day}>{formatDayShort(day)}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+function ProviderMark({ provider }: { readonly provider: UsageProviderKind }) {
+  const Mark = PROVIDER_PRESENTATION[provider].mark;
+  return <Mark className="size-3.5 shrink-0" aria-hidden />;
+}

--- a/apps/web/src/state/usage.test.ts
+++ b/apps/web/src/state/usage.test.ts
@@ -1,0 +1,166 @@
+import {
+  USAGE_CONTRACT_VERSION,
+  type EnvironmentId,
+  type UsageDay,
+  type UsageProviderKind,
+  type UsageThreadBreakdown,
+  type UsageThreadRow,
+} from "@t3tools/contracts";
+import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  filterUsageEnvironmentsForProject,
+  filterProviderContributionsForProject,
+  makeThreadBreakdownInput,
+  mergeUsageThreadBreakdowns,
+} from "./usage";
+
+describe("filterUsageEnvironmentsForProject", () => {
+  const environments = [
+    { environmentId: "env-a" as EnvironmentId },
+    { environmentId: "env-b" as EnvironmentId },
+  ];
+
+  it("keeps only the environment that owns a namespaced project", () => {
+    expect(
+      filterUsageEnvironmentsForProject(environments, JSON.stringify(["env-a", "id:project-one"])),
+    ).toEqual([environments[0]]);
+  });
+
+  it("keeps every environment for all and outside-project views", () => {
+    expect(filterUsageEnvironmentsForProject(environments, undefined)).toEqual(environments);
+    expect(filterUsageEnvironmentsForProject(environments, null)).toEqual(environments);
+  });
+});
+
+function row(provider: UsageProviderKind, overrides: Partial<UsageThreadRow> = {}): UsageThreadRow {
+  return {
+    key: "same-key",
+    threadId: null,
+    title: `${provider} row`,
+    provider,
+    project: "App",
+    totals: {
+      uncachedInputTokens: 10,
+      cachedInputTokens: 20,
+      cacheCreationTokens: 30,
+      outputTokens: 40,
+      reasoningTokens: 5,
+    },
+    costUsd: 1,
+    cacheWriteUsd: 0.25,
+    sessions: 1,
+    agents: [],
+    daily: [],
+    ...overrides,
+  };
+}
+
+function breakdown(rows: readonly UsageThreadRow[]): UsageThreadBreakdown {
+  return {
+    contractVersion: 8,
+    readAt: "2026-08-28T01:15:00.000Z",
+    sinceDay: "2026-08-01" as UsageDay,
+    untilDay: "2026-08-28" as UsageDay,
+    rows,
+    truncatedRows: rows.reduce((sum, item) => sum + (item.groupedRows ?? 0), 0),
+    scanDurationMs: 1,
+  };
+}
+
+describe("mergeUsageThreadBreakdowns", () => {
+  it("uses the summary's physical-source owner for each provider", () => {
+    const environmentA = "env-a" as EnvironmentId;
+    const environmentB = "env-b" as EnvironmentId;
+    const contributions: readonly EnvironmentProviderContribution[] = [
+      {
+        environmentId: environmentA,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["claude"],
+      },
+      {
+        environmentId: environmentB,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["codex"],
+      },
+    ];
+    const merged = mergeUsageThreadBreakdowns(
+      [
+        {
+          environmentId: environmentA,
+          breakdown: breakdown([
+            row("claude", { groupedRows: 2 }),
+            row("codex", { groupedRows: 7 }),
+          ]),
+        },
+        {
+          environmentId: environmentB,
+          breakdown: breakdown([
+            row("claude", { groupedRows: 11 }),
+            row("codex", { groupedRows: 3 }),
+          ]),
+        },
+      ],
+      contributions,
+    );
+
+    expect(merged.rows.map((item) => [item.provider, item.environmentId])).toEqual([
+      ["claude", environmentA],
+      ["codex", environmentB],
+    ]);
+    expect(merged.rows.reduce((sum, item) => sum + item.costUsd, 0)).toBe(2);
+    expect(merged.truncatedRows).toBe(5);
+  });
+});
+
+describe("makeThreadBreakdownInput", () => {
+  it("preserves exact bounds and limits the environment to its owned providers", () => {
+    expect(
+      makeThreadBreakdownInput(
+        {
+          sinceDay: "2026-08-07" as UsageDay,
+          untilDay: "2026-08-08" as UsageDay,
+          timeZone: "UTC",
+          resolution: "hour",
+          sinceTime: "2026-08-07T12:00:00.000Z",
+          untilTime: "2026-08-08T12:00:00.000Z",
+        },
+        JSON.stringify(["env-a", "id:project-one"]),
+        ["claude"],
+        "env-a" as EnvironmentId,
+      ),
+    ).toEqual({
+      sinceDay: "2026-08-07",
+      untilDay: "2026-08-08",
+      timeZone: "UTC",
+      sinceTime: "2026-08-07T12:00:00.000Z",
+      untilTime: "2026-08-08T12:00:00.000Z",
+      projectKey: "id:project-one",
+      providers: ["claude"],
+    });
+  });
+
+  it("keeps only the environment that owns a namespaced project", () => {
+    const contributions: readonly EnvironmentProviderContribution[] = [
+      {
+        environmentId: "env-a" as EnvironmentId,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["claude"],
+      },
+      {
+        environmentId: "env-b" as EnvironmentId,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["codex"],
+      },
+    ];
+
+    expect(
+      filterProviderContributionsForProject(
+        JSON.stringify(["env-a", "id:project-one"]),
+        contributions,
+      ).map((contribution) => contribution.environmentId),
+    ).toEqual(["env-a"]);
+    expect(filterProviderContributionsForProject(null, contributions)).toEqual(contributions);
+  });
+});

--- a/apps/web/src/state/usage.test.tsx
+++ b/apps/web/src/state/usage.test.tsx
@@ -1,14 +1,40 @@
 import { EnvironmentId, UsageDay, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { serverEnvironment } from "./server";
 import { act, useLayoutEffect } from "react";
 import { create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { useUsage, type EnvironmentUsageStatus, type UsageView } from "./usage";
 
-const testState = vi.hoisted(() => ({ environments: [] as EnvironmentUsageStatus[] }));
+function deferred() {
+  let resolve = () => {};
+  let reject = (_reason?: unknown) => {};
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = () => resolvePromise();
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const testState = vi.hoisted(() => ({
+  environments: [] as EnvironmentUsageStatus[],
+  windowLabel: "",
+  runAtomCommand: vi.fn(),
+  refreshUsage: vi.fn(),
+  refreshAtom: vi.fn(),
+  readSummary: vi.fn(),
+}));
+vi.mock("@t3tools/client-runtime/state/usage", () => ({ refreshUsage: testState.refreshUsage }));
+vi.mock("../rpc/atomRegistry", () => ({
+  appAtomRegistry: { refresh: testState.refreshAtom, get: testState.readSummary },
+}));
 vi.mock("@effect/atom-react", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@effect/atom-react")>()),
-  useAtomValue: () => testState.environments,
+  useAtomValue: (atom: { readonly label?: readonly [string, string] }) => {
+    testState.windowLabel = atom.label?.[0] ?? "";
+    return testState.environments;
+  },
 }));
 
 const input = {
@@ -75,8 +101,14 @@ function environment(id: string, cost: number | null, hostId = id): EnvironmentU
 let renderer: ReactTestRenderer | undefined;
 let latest: UsageView;
 
-function Probe({ selected }: { selected: ReadonlySet<EnvironmentId> | null }) {
-  const usage = useUsage(input, selected);
+function Probe({
+  selected,
+  refreshThreads = false,
+}: {
+  selected: ReadonlySet<EnvironmentId> | null;
+  refreshThreads?: boolean;
+}) {
+  const usage = useUsage(input, selected, undefined, refreshThreads);
   useLayoutEffect(() => {
     latest = usage;
   }, [usage]);
@@ -90,6 +122,13 @@ async function select(...ids: string[]) {
 }
 
 beforeEach(async () => {
+  testState.runAtomCommand.mockReset();
+  testState.refreshUsage.mockReset().mockResolvedValue(undefined);
+  testState.refreshAtom.mockReset();
+  testState.readSummary
+    .mockReset()
+    .mockImplementation(() => AsyncResult.success(testState.environments[0]?.summary));
+
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   testState.environments = [environment("a", 10), environment("b", 20), environment("slow", null)];
   await act(() => {
@@ -163,4 +202,63 @@ describe("usage environment selection", () => {
     expect(latest.isPending).toBe(false);
     expect(latest.isPartial).toBe(false);
   });
+});
+
+describe("thread breakdown refresh", () => {
+  it.each([9, USAGE_CONTRACT_VERSION])(
+    "waits for summary publication before refreshing contract-%i thread rows",
+    async (contractVersion) => {
+      testState.environments = testState.environments.map((entry) => ({
+        ...entry,
+        summary: entry.summary === null ? null : { ...entry.summary, contractVersion },
+      }));
+      const summary = deferred();
+      testState.refreshUsage.mockReturnValue(summary.promise);
+      await act(() => {
+        renderer?.update(
+          <Probe selected={new Set([EnvironmentId.make("a")])} refreshThreads={true} />,
+        );
+      });
+      const refreshing = latest.refresh();
+      expect(testState.refreshAtom).not.toHaveBeenCalled();
+      await act(async () => {
+        summary.resolve();
+        await refreshing;
+      });
+      expect(testState.refreshAtom).toHaveBeenCalledOnce();
+    },
+  );
+});
+
+it("refreshes thread keys with the new window and newly published providers", async () => {
+  await act(() =>
+    renderer?.update(<Probe selected={new Set([EnvironmentId.make("a")])} refreshThreads={true} />),
+  );
+  const nextInput = {
+    ...input,
+    sinceDay: UsageDay.make("2026-09-05"),
+    untilDay: UsageDay.make("2026-09-06"),
+  };
+  const changed = environment("a", 50).summary!;
+  testState.readSummary.mockReturnValue(
+    AsyncResult.success({
+      ...changed,
+      ...nextInput,
+      buckets: changed.buckets.map((bucket) => ({ ...bucket, provider: "claude" })),
+      sources: changed.sources.map((source) => ({
+        ...source,
+        fingerprint: { ...source.fingerprint, provider: "claude" },
+      })),
+    }),
+  );
+  const query = vi.spyOn(serverEnvironment, "usageThreadBreakdown");
+  try {
+    await latest.refresh(nextInput);
+    expect(query).toHaveBeenCalledWith({
+      environmentId: EnvironmentId.make("a"),
+      input: expect.objectContaining({ ...nextInput, providers: ["claude"] }),
+    });
+  } finally {
+    query.mockRestore();
+  }
 });

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "../lib/utils";
 /**
  * Multi-environment usage state.
  *
@@ -9,16 +10,30 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_THREAD_BREAKDOWN_SINCE,
   type EnvironmentId,
   type UsageSummary,
   type UsageSummaryInput,
+  type UsageProviderKind,
+  type UsageThreadBreakdown,
+  type UsageThreadBreakdownInput,
+  type UsageThreadRow,
 } from "@t3tools/contracts";
 import { refreshUsage } from "@t3tools/client-runtime/state/usage";
+
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
+import {
+  mergeUsage,
+  projectFilterForEnvironment,
+  retainUsageStatuses,
+  type EnvironmentProviderContribution,
+  type SettledUsageStatuses,
+  type EnvironmentUsage,
+  type MergedUsage,
+} from "@t3tools/shared/usageMerge";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
@@ -73,9 +88,23 @@ export interface UsageView {
   readonly refresh: (input?: UsageSummaryInput) => Promise<void>;
 }
 
+export function filterUsageEnvironmentsForProject<
+  T extends { readonly environmentId: EnvironmentId },
+>(environments: readonly T[], projectFilter: string | null | undefined): readonly T[] {
+  return environments.filter(
+    (environment) =>
+      projectFilterForEnvironment(projectFilter, environment.environmentId) !==
+      "environment-mismatch:",
+  );
+}
+
 export function useUsage(
   input: UsageSummaryInput,
   selectedEnvironmentIds: ReadonlySet<EnvironmentId> | null = null,
+  /** A namespaced project key, `null` for outside-projects buckets, `undefined` for no filter. */
+  projectFilter?: string | null,
+  /** Refresh the deferred thread query only while its table is mounted. */
+  refreshThreads = false,
 ): UsageView {
   const windowKey = useMemo(
     () =>
@@ -97,7 +126,13 @@ export function useUsage(
     ],
   );
   const atom = usageByWindowAtom(windowKey);
-  const environments = useAtomValue(atom);
+  const currentEnvironments = useAtomValue(atom);
+  const settledStatuses = useRef<SettledUsageStatuses<EnvironmentUsageStatus> | null>(null);
+  const retained = retainUsageStatuses(windowKey, currentEnvironments, settledStatuses.current);
+  useEffect(() => {
+    settledStatuses.current = retained.settled;
+  }, [retained.settled]);
+  const environments = retained.visible;
   const selectedEnvironments = useMemo(
     () =>
       selectedEnvironmentIds === null
@@ -106,18 +141,6 @@ export function useUsage(
             selectedEnvironmentIds.has(environment.environmentId),
           ),
     [environments, selectedEnvironmentIds],
-  );
-
-  const refresh = useCallback(
-    (nextInput?: UsageSummaryInput) =>
-      refreshUsage({
-        registry: appAtomRegistry,
-        server: serverEnvironment,
-        presentations: environmentPresentations,
-        environmentIds: selectedEnvironments.map(({ environmentId }) => environmentId),
-        input: nextInput ?? (JSON.parse(windowKey) as UsageSummaryInput),
-      }),
-    [selectedEnvironments, windowKey],
   );
 
   const merged = useMemo(() => {
@@ -132,13 +155,68 @@ export function useUsage(
             },
           ],
     );
-    return mergeUsage(answered, USAGE_CONTRACT_VERSION);
-  }, [selectedEnvironments]);
+    return mergeUsage(
+      answered,
+      USAGE_CONTRACT_VERSION,
+      projectFilter === undefined ? undefined : { projectFilter },
+    );
+  }, [selectedEnvironments, projectFilter]);
 
-  const answeredCount = selectedEnvironments.filter(
+  const refresh = useCallback(
+    async (nextInput?: UsageSummaryInput) => {
+      const currentInput = nextInput ?? (JSON.parse(windowKey) as UsageSummaryInput);
+      await refreshUsage({
+        registry: appAtomRegistry,
+        refreshToken: randomUUID(),
+        server: serverEnvironment,
+        presentations: environmentPresentations,
+        environmentIds: selectedEnvironments.map(({ environmentId }) => environmentId),
+        input: currentInput,
+      });
+      if (!refreshThreads) return;
+      const refreshed = mergeUsage(
+        selectedEnvironments.flatMap(({ environmentId, label }) => {
+          const summary = Option.getOrNull(
+            AsyncResult.value(
+              appAtomRegistry.get(
+                serverEnvironment.usageSummary({ environmentId, input: currentInput }),
+              ),
+            ),
+          );
+          return summary === null ? [] : [{ environmentId, label, summary }];
+        }),
+        USAGE_CONTRACT_VERSION,
+        projectFilter === undefined ? undefined : { projectFilter },
+      );
+      for (const contribution of filterProviderContributionsForProject(
+        projectFilter,
+        refreshed.providerContributions,
+      )) {
+        if (contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE) continue;
+        appAtomRegistry.refresh(
+          serverEnvironment.usageThreadBreakdown({
+            environmentId: contribution.environmentId,
+            input: makeThreadBreakdownInput(
+              currentInput,
+              projectFilter,
+              contribution.providers,
+              contribution.environmentId,
+            ),
+          }),
+        );
+      }
+    },
+    [projectFilter, windowKey, refreshThreads, selectedEnvironments],
+  );
+
+  const relevantEnvironments = filterUsageEnvironmentsForProject(
+    selectedEnvironments,
+    projectFilter,
+  );
+  const answeredCount = relevantEnvironments.filter(
     (environment) => environment.summary !== null,
   ).length;
-  const stillReporting = selectedEnvironments.filter(
+  const stillReporting = relevantEnvironments.filter(
     (environment) => environment.summary === null && environment.error === null,
   ).length;
 
@@ -150,4 +228,145 @@ export function useUsage(
     isPartial: answeredCount > 0 && stillReporting > 0,
     refresh,
   };
+}
+
+export interface UsageThreadRowWithEnvironment extends UsageThreadRow {
+  /** Environment that reported the row; thread deep links are environment-scoped. */
+  readonly environmentId: EnvironmentId;
+}
+
+export interface UsageThreadsView {
+  readonly rows: readonly UsageThreadRowWithEnvironment[];
+  readonly truncatedRows: number;
+  /** True until every listed environment answered or failed. */
+  readonly isPending: boolean;
+  readonly failedEnvironments: number;
+}
+
+export interface EnvironmentUsageThreadBreakdown {
+  readonly environmentId: EnvironmentId;
+  readonly breakdown: UsageThreadBreakdown;
+}
+
+export function makeThreadBreakdownInput(
+  input: UsageSummaryInput,
+  projectFilter: string | null | undefined,
+  providers: readonly UsageProviderKind[],
+  environmentId: EnvironmentId,
+): UsageThreadBreakdownInput {
+  return {
+    sinceDay: input.sinceDay,
+    untilDay: input.untilDay,
+    timeZone: input.timeZone,
+    ...(input.sinceTime === undefined ? {} : { sinceTime: input.sinceTime }),
+    ...(input.untilTime === undefined ? {} : { untilTime: input.untilTime }),
+    ...(projectFilter === undefined
+      ? {}
+      : { projectKey: projectFilterForEnvironment(projectFilter, environmentId) }),
+    providers: [...providers],
+  };
+}
+
+function withOwnedProviders(
+  input: UsageThreadBreakdownInput,
+  providers: readonly UsageProviderKind[],
+): UsageThreadBreakdownInput {
+  return { ...input, providers: [...providers] };
+}
+
+/** Applies the summary's physical-source ownership to thread rows. */
+export function mergeUsageThreadBreakdowns(
+  environments: readonly EnvironmentUsageThreadBreakdown[],
+  providerContributions: readonly EnvironmentProviderContribution[],
+): Pick<UsageThreadsView, "rows" | "truncatedRows"> {
+  const providersByEnvironment = new Map(
+    providerContributions.map((entry) => [entry.environmentId, new Set(entry.providers)]),
+  );
+  const rows: UsageThreadRowWithEnvironment[] = [];
+  let truncatedRows = 0;
+
+  for (const environment of environments) {
+    const ownedProviders = providersByEnvironment.get(environment.environmentId);
+    if (ownedProviders === undefined) continue;
+    for (const row of environment.breakdown.rows) {
+      if (!ownedProviders.has(row.provider)) continue;
+      rows.push({ ...row, environmentId: environment.environmentId });
+      truncatedRows += row.groupedRows ?? 0;
+    }
+  }
+  rows.sort((a, b) => b.costUsd - a.costUsd);
+  return { rows, truncatedRows };
+}
+
+/** Excludes environments that cannot own a namespaced project selection. */
+export function filterProviderContributionsForProject(
+  projectKey: string | null | undefined,
+  providerContributions: readonly EnvironmentProviderContribution[],
+): readonly EnvironmentProviderContribution[] {
+  if (projectKey === undefined || projectKey === null) return providerContributions;
+  return providerContributions.filter(
+    (contribution) =>
+      projectFilterForEnvironment(projectKey, contribution.environmentId) !==
+      "environment-mismatch:",
+  );
+}
+
+const usageThreadsAtom = Atom.family((requestKey: string) =>
+  Atom.make((get): UsageThreadsView => {
+    const { input, providerContributions } = JSON.parse(requestKey) as {
+      input: UsageThreadBreakdownInput;
+      providerContributions: readonly EnvironmentProviderContribution[];
+    };
+
+    const relevantContributions = filterProviderContributionsForProject(
+      input.projectKey,
+      providerContributions,
+    );
+    const breakdowns: EnvironmentUsageThreadBreakdown[] = [];
+    let pending = 0;
+    let failed = relevantContributions.filter(
+      (contribution) => contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE,
+    ).length;
+    for (const contribution of relevantContributions) {
+      if (contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE) continue;
+      const { environmentId } = contribution;
+      const environmentInput =
+        input.projectKey === undefined
+          ? input
+          : {
+              ...input,
+              projectKey: projectFilterForEnvironment(input.projectKey, environmentId),
+            };
+      const result = get(
+        serverEnvironment.usageThreadBreakdown({
+          environmentId,
+          input: withOwnedProviders(environmentInput, contribution.providers),
+        }),
+      );
+      if (result.waiting) pending += 1;
+      if (result._tag === "Failure") failed += 1;
+      const breakdown = Option.getOrNull(AsyncResult.value(result));
+      if (breakdown === null) continue;
+      breakdowns.push({ environmentId, breakdown });
+    }
+    const merged = mergeUsageThreadBreakdowns(breakdowns, relevantContributions);
+
+    return { ...merged, isPending: pending > 0, failedEnvironments: failed };
+  }).pipe(Atom.withLabel(`web-usage:threads:${requestKey}`)),
+);
+
+/**
+ * Thread drill-down across the environments that contributed to the summary.
+ * Mount the consuming component only while the thread view is open; fetching
+ * starts on first read.
+ */
+export function useUsageThreads(
+  input: UsageThreadBreakdownInput,
+  providerContributions: readonly EnvironmentProviderContribution[],
+): UsageThreadsView {
+  const requestKey = useMemo(
+    () => JSON.stringify({ input, providerContributions }),
+    [input, providerContributions],
+  );
+  return useAtomValue(usageThreadsAtom(requestKey));
 }

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -6,6 +6,37 @@
 environments. It shows token use, cache savings, model breakdowns, and estimated API-equivalent
 cost. These estimates are not your subscription bill.
 
+Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
+**30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
+headline and chart. Changing dates reuses a source snapshot from the last minute when it already
+covers the requested range. An older snapshot, or a range that reaches farther back, updates the
+source data first. The Refresh action always requests an update. Updates parse only new or changed
+transcript content.
+
+Any daily chart zooms: drag across it to make the selection the new date window, and double-click
+to return to the range selected before zooming. The date fields beside the presets accept custom ranges up to 90 days.
+
+The breakdown's **Thread** view drills into where the spend went: sessions group into the T3 Code
+thread they belong to, with sessions that never ran through T3 Code listed under the first thing
+you asked in them. Grok Build has no trusted prompt title, so its rows use a short session label.
+Expanding a row splits its daily model-priced cost into cache writes, cache
+reads, and fresh input plus output, alongside any Claude subagents the thread spawned.
+Provider-reported totals are not split into estimated components.
+Each connected environment contributes at most 40 rows, reserving room to group lower-cost rows
+under **Other threads** by provider and project. Those grouped rows stay in the totals, so the
+thread view still adds up to the selected project or full summary.
+Rows that map to a thread carry a link that opens it.
+
+The **Estimated cache writes** total prices cache-creation tokens at each model's cache-write rate.
+It only applies to model-priced records that report cache-creation tokens. Rows without cache
+writes show a dash; incomplete or unavailable pricing is labeled **Unavailable** instead of zero.
+
+Usage is attributed to the project whose folder a session ran in, including sessions driven
+outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker
+narrows the whole page to one project; work that ran outside every project is grouped under
+"Outside projects". Grok Build sessions record no folder, so they remain in overall totals but are
+omitted from the project breakdown and project filters.
+
 Totals depend on the history available on each server. Grok turns without a saved completed-turn
 record are missing from the totals.
 

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -1048,6 +1048,14 @@ export function createServerEnvironmentAtoms<R, E>(
       staleTimeMs: 60_000,
       refreshTrigger: ({ environmentId }) => usagePricesAtom(environmentId),
     }),
+    // Fetched only when the thread view is opened; scans are cache-warm after
+    // the summary, so a minute of staleness matches it.
+    usageThreadBreakdown: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:usage-thread-breakdown",
+      tag: WS_METHODS.serverGetUsageThreadBreakdown,
+      staleTimeMs: 60_000,
+      refreshTrigger: ({ environmentId }) => usagePricesAtom(environmentId),
+    }),
     configProjection,
     welcome,
     consumeResetCredit: createEnvironmentRpcCommand(runtime, {

--- a/packages/client-runtime/src/state/serverUsage.test.ts
+++ b/packages/client-runtime/src/state/serverUsage.test.ts
@@ -7,6 +7,7 @@ import {
   type ServerConfig,
   type ServerConfigStreamEvent,
   type ServerSettings,
+  type UsageThreadBreakdown,
   type UsageSummary,
   type UsageSummaryInput,
 } from "@t3tools/contracts";
@@ -57,7 +58,21 @@ const makeHarness = Effect.fn("ServerUsageTest.makeHarness")(function* (
   const events = yield* Queue.unbounded<ServerConfigStreamEvent>();
   let settings = DEFAULT_SERVER_SETTINGS;
   let requests = 0;
+  let threadRequests = 0;
   const client = {
+    [WS_METHODS.serverGetUsageThreadBreakdown]: () =>
+      Effect.sync(() => {
+        threadRequests += 1;
+        return {
+          ...INPUT,
+          contractVersion: USAGE_CONTRACT_VERSION,
+          readAt: "2026-09-04T12:00:00Z",
+          rows: [],
+          truncatedRows: 0,
+          scanDurationMs:
+            settings.usagePriceOverrides["custom-model"]?.inputCostPerMillionTokens ?? 0,
+        } satisfies UsageThreadBreakdown;
+      }),
     [WS_METHODS.subscribeServerConfig]: () =>
       Stream.concat(
         Stream.make({ version: 1 as const, type: "snapshot" as const, config: CONFIG }),
@@ -168,6 +183,8 @@ const makeHarness = Effect.fn("ServerUsageTest.makeHarness")(function* (
   return {
     registry,
     requests: () => requests,
+    threadRequests: () => threadRequests,
+    threads: atoms.usageThreadBreakdown({ environmentId: TARGET.environmentId, input: INPUT }),
     updateSettings,
     summary: (input = INPUT) => atoms.usageSummary({ environmentId: TARGET.environmentId, input }),
   };
@@ -257,6 +274,39 @@ it.effect("restarts a pending usage read after a price change", () =>
       yield* waitForCost(harness.registry, summary, 5);
       yield* Deferred.await(interrupted);
       expect(harness.requests()).toBe(2);
+      unmount();
+    }),
+  ),
+);
+
+it.effect("refreshes mounted thread breakdowns when override prices change", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const unmount = harness.registry.mount(harness.threads);
+      const waitForPrice = (price: number) =>
+        AtomRegistry.toStream(harness.registry, harness.threads).pipe(
+          Stream.filter(
+            (result) =>
+              AsyncResult.isSuccess(result) &&
+              !result.waiting &&
+              result.value.scanDurationMs === price,
+          ),
+          Stream.runHead,
+        );
+      yield* waitForPrice(0);
+      expect(harness.threadRequests()).toBe(1);
+      yield* harness.updateSettings({
+        ...DEFAULT_SERVER_SETTINGS,
+        usagePriceOverrides: {
+          "custom-model": { inputCostPerMillionTokens: 3, outputCostPerMillionTokens: 9 },
+        },
+      });
+      yield* waitForPrice(3);
+      expect(harness.threadRequests()).toBe(2);
+      yield* harness.updateSettings(DEFAULT_SERVER_SETTINGS);
+      yield* waitForPrice(0);
+      expect(harness.threadRequests()).toBe(3);
       unmount();
     }),
   ),

--- a/packages/client-runtime/src/state/usage.test.ts
+++ b/packages/client-runtime/src/state/usage.test.ts
@@ -3,14 +3,20 @@ import {
   UsageDay,
   USAGE_CONTRACT_VERSION,
   type UsageSummary,
+  type UsageSummaryInput,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 
 import type { EnvironmentPresentation } from "../connection/presentation.ts";
 import { EnvironmentRpcUnavailableError } from "../rpc/client.ts";
 import { refreshUsage } from "./usage.ts";
+
+class UsageScanTestError extends Schema.TaggedError<UsageScanTestError>()("UsageScanTestError", {
+  cause: Schema.Defect(),
+}) {}
 
 const input = {
   sinceDay: UsageDay.make("2026-09-05"),
@@ -46,9 +52,12 @@ function harness(ids = ["a"]) {
       connection: { phase: "connected" },
     } as EnvironmentPresentation | null);
     const query = Atom.make(
-      Effect.promise(() => {
-        scanStarted.resolve();
-        return scan.promise;
+      Effect.tryPromise({
+        try: () => {
+          scanStarted.resolve();
+          return scan.promise;
+        },
+        catch: (cause) => new UsageScanTestError({ cause }),
       }),
     );
     return { environmentId, rates, scan, scanStarted, presentation, query };
@@ -62,9 +71,14 @@ function harness(ids = ["a"]) {
     registry,
     environmentIds: environments.map((entry) => entry.environmentId),
     input,
+    refreshToken: "test-refresh",
     server: {
-      usageSummary: ({ environmentId }: { environmentId: EnvironmentId }) =>
-        get(environmentId).query,
+      usageSummary: ({
+        environmentId,
+      }: {
+        environmentId: EnvironmentId;
+        input: UsageSummaryInput;
+      }) => get(environmentId).query,
       refreshUsageRates: {
         label: "test:rates",
         run: (
@@ -77,7 +91,7 @@ function harness(ids = ["a"]) {
       presentationAtom: (environmentId: EnvironmentId) => get(environmentId).presentation,
     },
   } satisfies Parameters<typeof refreshUsage>[0];
-  return { registry, environments, refresh: () => refreshUsage(options) };
+  return { registry, environments, options, refresh: () => refreshUsage(options) };
 }
 
 describe("manual usage refresh", () => {
@@ -101,6 +115,68 @@ describe("manual usage refresh", () => {
     expect(finished).toBe(false);
     entry.scan.resolve(summary);
     await refreshing;
+    expect(finished).toBe(true);
+  });
+
+  it("waits for the fresh source scan and ordinary window publication", async () => {
+    const {
+      environments: [entry],
+      options,
+      refresh,
+    } = harness();
+    const tokenScan = Promise.withResolvers<UsageSummary>();
+    const tokenStarted = Promise.withResolvers<void>();
+    const publication = Promise.withResolvers<UsageSummary>();
+    const publicationStarted = Promise.withResolvers<void>();
+    const tokenQuery = Atom.make(
+      Effect.promise(() => {
+        tokenStarted.resolve();
+        return tokenScan.promise;
+      }),
+    );
+    const ordinaryQuery = Atom.make(
+      Effect.promise(() => {
+        publicationStarted.resolve();
+        return publication.promise;
+      }),
+    );
+    options.server.usageSummary = ({ input }) => (input.refreshToken ? tokenQuery : ordinaryQuery);
+    let finished = false;
+    const refreshing = refresh().then(() => {
+      finished = true;
+    });
+    entry!.rates.resolve(AsyncResult.success(pricing));
+    await tokenStarted.promise;
+    expect(finished).toBe(false);
+    tokenScan.resolve(summary);
+    await publicationStarted.promise;
+    expect(finished).toBe(false);
+    publication.resolve(summary);
+    await refreshing;
+    expect(finished).toBe(true);
+  });
+
+  it("reports a scan failure after the other selected environment finishes", async () => {
+    const { environments, refresh } = harness(["failed", "healthy"]);
+    const [failed, healthy] = environments;
+    const failure = new UsageScanTestError({ cause: "Usage scan failed" });
+    failed!.query = Atom.make(Effect.fail(failure));
+    let finished = false;
+    const refreshing = refresh().then(
+      () => {
+        finished = true;
+        return null;
+      },
+      (error: unknown) => {
+        finished = true;
+        return error;
+      },
+    );
+    for (const entry of environments) entry.rates.resolve(AsyncResult.success(pricing));
+    await healthy!.scanStarted.promise;
+    expect(finished).toBe(false);
+    healthy!.scan.resolve(summary);
+    expect(await refreshing).toBe(failure);
     expect(finished).toBe(true);
   });
 
@@ -178,7 +254,8 @@ describe("manual usage refresh", () => {
     entry.rates.resolve(AsyncResult.success(pricing));
     await rescanned.promise;
     await refreshing;
-    expect(reads).toBe(2);
+    // The mock shares one atom for the token scan and normal publication.
+    expect(reads).toBe(3);
     unmount();
   });
 });

--- a/packages/client-runtime/src/state/usage.ts
+++ b/packages/client-runtime/src/state/usage.ts
@@ -16,6 +16,7 @@ export async function refreshUsage({
   presentations,
   environmentIds,
   input,
+  refreshToken,
 }: {
   registry: AtomRegistry.AtomRegistry;
   server: Pick<
@@ -25,8 +26,9 @@ export async function refreshUsage({
   presentations: Pick<ReturnType<typeof createEnvironmentPresentationAtoms>, "presentationAtom">;
   environmentIds: readonly EnvironmentId[];
   input: UsageSummaryInput;
+  refreshToken: string;
 }): Promise<void> {
-  await Promise.all(
+  const results = await Promise.allSettled(
     environmentIds.map(async (environmentId) => {
       const query = server.usageSummary({ environmentId, input });
       const presentation = presentations.presentationAtom(environmentId);
@@ -49,13 +51,31 @@ export async function refreshUsage({
         // Invalidate even on failure so reconnects cannot reuse the old summary.
         registry.refresh(query);
         if (sessionUnavailable || controller.signal.aborted) return;
-        await executeAtomQuery(registry, query, {
+        // The token bypasses the source cache, then the ordinary window query
+        // publishes that completed snapshot to every subscribed client view.
+        const scanned = await executeAtomQuery(
+          registry,
+          server.usageSummary({
+            environmentId,
+            input: { ...input, refreshToken },
+          }),
+          { reportFailure: false, signal: controller.signal, refresh: true },
+        );
+        if (controller.signal.aborted) return;
+        if (scanned._tag === "Failure") throw squashAtomCommandFailure(scanned);
+        const published = await executeAtomQuery(registry, query, {
           reportFailure: false,
           signal: controller.signal,
+          refresh: true,
         });
+        if (!controller.signal.aborted && published._tag === "Failure") {
+          throw squashAtomCommandFailure(published);
+        }
       } finally {
         unsubscribe();
       }
     }),
   );
+  const failed = results.find((result) => result.status === "rejected");
+  if (failed?.status === "rejected") throw failed.reason;
 }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -238,7 +238,14 @@ import {
   ProviderConsumeResetCreditInput,
   ProviderConsumeResetCreditResult,
 } from "./providerUsageLimits.ts";
-import { UsagePricing, UsageReadError, UsageSummary, UsageSummaryInput } from "./usage.ts";
+import {
+  UsagePricing,
+  UsageReadError,
+  UsageSummary,
+  UsageSummaryInput,
+  UsageThreadBreakdown,
+  UsageThreadBreakdownInput,
+} from "./usage.ts";
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
 import {
   SourceControlCloneRepositoryInput,
@@ -361,6 +368,7 @@ export const WS_METHODS = {
   serverReportHostPowerState: "server.reportHostPowerState",
   serverGetBackgroundPolicy: "server.getBackgroundPolicy",
   serverGetUsageSummary: "server.getUsageSummary",
+  serverGetUsageThreadBreakdown: "server.getUsageThreadBreakdown",
   serverRefreshUsageRates: "server.refreshUsageRates",
 
   // Cloud environment methods
@@ -601,6 +609,12 @@ const WsServerRetryResourceTelemetryRpc = Rpc.make(WS_METHODS.serverRetryResourc
 const WsServerGetUsageSummaryRpc = Rpc.make(WS_METHODS.serverGetUsageSummary, {
   payload: UsageSummaryInput,
   success: UsageSummary,
+  error: Schema.Union([EnvironmentAuthorizationError, UsageReadError]),
+});
+
+const WsServerGetUsageThreadBreakdownRpc = Rpc.make(WS_METHODS.serverGetUsageThreadBreakdown, {
+  payload: UsageThreadBreakdownInput,
+  success: UsageThreadBreakdown,
   error: Schema.Union([EnvironmentAuthorizationError, UsageReadError]),
 });
 
@@ -1306,6 +1320,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerGetResourceTelemetryHistoryRpc,
   WsServerRetryResourceTelemetryRpc,
   WsServerGetUsageSummaryRpc,
+  WsServerGetUsageThreadBreakdownRpc,
   WsServerRefreshUsageRatesRpc,
   WsServerSignalProcessRpc,
   WsServerReportClientActivityRpc,

--- a/packages/contracts/src/usage.test.ts
+++ b/packages/contracts/src/usage.test.ts
@@ -1,0 +1,22 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import { UsageThreadBreakdownInput } from "./usage.ts";
+
+const decodeThreadInput = Schema.decodeUnknownSync(UsageThreadBreakdownInput);
+
+describe("UsageThreadBreakdownInput", () => {
+  const input = {
+    sinceDay: "2026-08-01",
+    untilDay: "2026-08-02",
+    timeZone: "UTC",
+  };
+
+  it("accepts and trims a refresh token", () => {
+    expect(decodeThreadInput({ ...input, refreshToken: "  turn-2  " }).refreshToken).toBe("turn-2");
+  });
+
+  it("rejects a blank refresh token", () => {
+    expect(() => decodeThreadInput({ ...input, refreshToken: "   " })).toThrow();
+  });
+});

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -14,23 +14,30 @@
  */
 import * as Schema from "effect/Schema";
 
-import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 /**
  * Bumped whenever the shape of {@link UsageSummary} changes incompatibly. The
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 10 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds the optional bucket
+ * `project`; v7 adds its optional stable `projectId`; v8 distinguishes outside
+ * projects from unknown attribution; v9 adds the separate thread-breakdown RPC;
+ * v10 adds optional cache-write costs. v4 Claude/Codex buckets remain valid, so
+ * mixed-version environments keep those totals instead of treating every older
+ * server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
+/** First contract version that explicitly distinguishes outside from unknown attribution. */
+export const USAGE_PROJECT_ATTRIBUTION_SINCE = 8 as const;
+/** First contract version that exposes the current thread-breakdown RPC. */
+export const USAGE_THREAD_BREAKDOWN_SINCE = 9 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
@@ -80,8 +87,9 @@ export const UsageTokenTotals = Schema.Struct({
 export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 
 /**
- * One `(day, hourStart?, provider, model)` cell. `hourStart` is the UTC start
- * instant of a rolling bucket and is present only for hourly requests.
+ * One `(day, hourStart?, project, provider, model)` cell. `hourStart` is the
+ * UTC start instant of a rolling bucket and is present only for hourly
+ * requests.
  *
  * `costUsd` is the raw API-equivalent cost of these tokens. It is not money
  * spent: subscription plans bill separately. `unpricedRecords` counts records
@@ -91,6 +99,21 @@ export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 export const UsageBucket = Schema.Struct({
   day: UsageDay,
   hourStart: Schema.optional(TrimmedNonEmptyString),
+  /**
+   * Title of the T3 project whose workspace root contains the session's
+   * working directory, resolved per environment at scan time. Absent when the
+   * session ran outside every project on that environment, or when the
+   * transcript carries no working directory (Grok, and summaries from servers
+   * predating this field).
+   */
+  project: Schema.optional(TrimmedNonEmptyString),
+  /** Stable identity for `project`; absent on summaries from pre-v7 servers. */
+  projectId: Schema.optional(ProjectId),
+  /**
+   * Whether the session ran in a project, outside every project, or carried no
+   * working directory. Optional only so current clients can read older summaries.
+   */
+  projectAttribution: Schema.optional(Schema.Literals(["project", "outside", "unknown"])),
   provider: UsageProviderKind,
   model: TrimmedNonEmptyString,
   totals: UsageTokenTotals,
@@ -101,6 +124,12 @@ export const UsageBucket = Schema.Struct({
    * rather than derived on the client.
    */
   cacheSavingsUsd: Schema.Number,
+  /**
+   * Estimated cost of the cache-creation tokens in this bucket at the model's
+   * cache-write rate. A subset of `costUsd` when the bucket is model-priced.
+   * Absent from summaries written before this field existed.
+   */
+  cacheWriteUsd: Schema.optional(Schema.Number),
   costSource: UsageCostSource,
   /** Distinct assistant responses, after de-duplication. */
   records: NonNegativeInt,
@@ -185,6 +214,12 @@ export const UsageSummaryInput = Schema.Struct({
   sinceTime: Schema.optional(TrimmedNonEmptyString),
   /** Exclusive UTC instant for an hourly rolling window. */
   untilTime: Schema.optional(TrimmedNonEmptyString),
+  /**
+   * Opaque identity of the source snapshots visible when the user explicitly
+   * requested a refresh. A new value bypasses the short-lived source cache
+   * once; repeated reads with the same value may reuse the updated snapshot.
+   */
+  refreshToken: Schema.optional(TrimmedNonEmptyString),
 });
 export type UsageSummaryInput = typeof UsageSummaryInput.Type;
 
@@ -201,6 +236,101 @@ export const UsageSummary = Schema.Struct({
   scanDurationMs: NonNegativeInt,
 });
 export type UsageSummary = typeof UsageSummary.Type;
+
+export const UsageThreadBreakdownInput = Schema.Struct({
+  /** Inclusive first day of the window, in `timeZone`. */
+  sinceDay: UsageDay,
+  /** Inclusive last day of the window, in `timeZone`. */
+  untilDay: UsageDay,
+  timeZone: TrimmedNonEmptyString,
+  /** Inclusive UTC instant for a rolling window such as Past 24h. */
+  sinceTime: Schema.optional(TrimmedNonEmptyString),
+  /** Exclusive UTC instant for a rolling window such as Past 24h. */
+  untilTime: Schema.optional(TrimmedNonEmptyString),
+  /** Changed by callers that need to bypass the short-lived source snapshot. */
+  refreshToken: Schema.optional(TrimmedNonEmptyString),
+  /**
+   * Restrict to one project's records: a namespaced stable key selects that
+   * project, `null` selects records outside every project, absent applies no
+   * filter.
+   */
+  projectKey: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  /** Providers this environment owns after physical-source de-duplication. */
+  providers: Schema.optional(Schema.Array(UsageProviderKind)),
+});
+export type UsageThreadBreakdownInput = typeof UsageThreadBreakdownInput.Type;
+
+/** One Claude subagent's slice of its parent thread. */
+export const UsageAgentRow = Schema.Struct({
+  agentId: TrimmedNonEmptyString,
+  totals: UsageTokenTotals,
+  costUsd: Schema.Number,
+  /** `null` when cache-creation tokens lack a model-priced estimate. */
+  cacheWriteUsd: Schema.NullOr(Schema.Number),
+});
+export type UsageAgentRow = typeof UsageAgentRow.Type;
+
+/**
+ * One day of a thread's model-priced cost split by component. Days the thread
+ * was idle are omitted. Unpriced records contribute tokens to the row totals
+ * but nothing here. Provider-reported totals also stay out because an
+ * estimated split could disagree with the provider's authoritative total.
+ */
+export const UsageThreadDayCost = Schema.Struct({
+  day: UsageDay,
+  cacheWriteUsd: Schema.Number,
+  cacheReadUsd: Schema.Number,
+  /** Fresh input plus output. */
+  freshUsd: Schema.Number,
+});
+export type UsageThreadDayCost = typeof UsageThreadDayCost.Type;
+
+/**
+ * One thread's (or unattributed session group's) slice of the window.
+ *
+ * `threadId` is present when the sessions map to a T3 Code thread on this
+ * environment, via the thread's resume cursor or its dedicated worktree.
+ * Sessions that never ran through T3 Code stay session-granular with a title
+ * taken from the transcript.
+ */
+export const UsageThreadRow = Schema.Struct({
+  /** Stable within one environment; opaque to clients. */
+  key: TrimmedNonEmptyString,
+  threadId: Schema.NullOr(ThreadId),
+  title: TrimmedNonEmptyString,
+  provider: UsageProviderKind,
+  projectId: Schema.optional(ProjectId),
+  project: Schema.optional(TrimmedNonEmptyString),
+  totals: UsageTokenTotals,
+  costUsd: Schema.Number,
+  /** `null` when cache-creation tokens lack a model-priced estimate. */
+  cacheWriteUsd: Schema.NullOr(Schema.Number),
+  /** Distinct transcript sessions folded into this row. */
+  sessions: NonNegativeInt,
+  /** Lower-cost thread rows represented by this grouped remainder row. */
+  groupedRows: Schema.optional(NonNegativeInt),
+  agents: Schema.Array(UsageAgentRow),
+  daily: Schema.Array(UsageThreadDayCost),
+});
+export type UsageThreadRow = typeof UsageThreadRow.Type;
+
+/**
+ * On-demand drill-down behind the usage summary. Named rows are capped
+ * server-side because a window can hold thousands of sessions. Lower-cost
+ * rows fold into provider/project-specific remainder rows so totals reconcile
+ * without sending every transcript session over the WebSocket.
+ */
+export const UsageThreadBreakdown = Schema.Struct({
+  contractVersion: Schema.Number,
+  readAt: Schema.String,
+  sinceDay: UsageDay,
+  untilDay: UsageDay,
+  rows: Schema.Array(UsageThreadRow),
+  /** Underlying rows folded into the returned remainder rows. */
+  truncatedRows: NonNegativeInt,
+  scanDurationMs: NonNegativeInt,
+});
+export type UsageThreadBreakdown = typeof UsageThreadBreakdown.Type;
 
 export class UsageReadError extends Schema.TaggedError<UsageReadError>()("UsageReadError", {
   reason: Schema.Literals(["scanFailed", "invalidWindow"]),

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -2,12 +2,27 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  compareUsageDays,
   enumerateHourStarts,
   formatDateTimeShort,
   formatHourShort,
   formatRelativeHourShort,
+  makeCustomWindow,
   makeWindow,
 } from "./usageFormat.ts";
+
+describe("compareUsageDays", () => {
+  it("compares strict four-digit calendar dates numerically", () => {
+    expect(compareUsageDays("2026-08-03", "2026-08-11")).toBe(-1);
+    expect(compareUsageDays("2026-08-11", "2026-08-03")).toBe(1);
+    expect(compareUsageDays("2026-08-03", "2026-08-03")).toBe(0);
+  });
+
+  it("rejects variable-width years and impossible dates", () => {
+    expect(compareUsageDays("10000-01-01", "9999-12-31")).toBeNull();
+    expect(compareUsageDays("2026-02-29", "2026-03-01")).toBeNull();
+  });
+});
 
 describe("hourly usage formatting", () => {
   it("enumerates 24 fixed buckets across a rolling window", () => {
@@ -66,8 +81,68 @@ describe("hourly usage formatting", () => {
 
       expect(makeWindow(1, now, "hour").timeZone).toBe("UTC");
       expect(makeWindow(30, now).timeZone).toBe("UTC");
+      expect(makeCustomWindow("2026-08-01", "2026-08-11").timeZone).toBe("UTC");
     } finally {
       resolvedOptions.mockRestore();
     }
   });
+});
+
+describe("makeCustomWindow", () => {
+  it("builds a daily window over the inclusive range", () => {
+    const window = makeCustomWindow("2026-08-03", "2026-08-11");
+
+    expect(window.sinceDay).toBe("2026-08-03");
+    expect(window.untilDay).toBe("2026-08-11");
+    expect(window.resolution).toBe("day");
+    expect(window.sinceTime).toBeUndefined();
+  });
+
+  it("swaps out-of-order bounds so a raw drag never produces an invalid window", () => {
+    const window = makeCustomWindow("2026-08-11", "2026-08-03");
+
+    expect(window.sinceDay).toBe("2026-08-03");
+    expect(window.untilDay).toBe("2026-08-11");
+  });
+
+  it("caps typed ranges at the largest supported 90-day window", () => {
+    const window = makeCustomWindow("0001-01-01", "9999-12-31");
+
+    expect(window.sinceDay).toBe("0001-01-01");
+    expect(window.untilDay).toBe("0001-03-31");
+  });
+
+  it("rejects bounds outside the strict day format", () => {
+    expect(() => makeCustomWindow("10000-01-01", "9999-12-31")).toThrow(RangeError);
+  });
+});
+
+describe("locale-independent usage windows", () => {
+  it.each(["day", "hour"] as const)("builds %s bounds from numeric date parts", (resolution) => {
+    const descriptor = Object.getOwnPropertyDescriptor(Intl.DateTimeFormat.prototype, "format");
+    if (descriptor === undefined) throw new Error("Expected the Intl format accessor");
+    const formatted = vi.fn(() => () => "09/09/2026");
+    Object.defineProperty(Intl.DateTimeFormat.prototype, "format", {
+      configurable: true,
+      get: formatted,
+    });
+    try {
+      const window = makeWindow(1, new Date("2026-09-09T12:00:00Z"), resolution);
+      expect(window.sinceDay).toMatch(/^2026-09-\d{2}$/);
+      expect(window.untilDay).toMatch(/^2026-09-\d{2}$/);
+      expect(formatted).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(Intl.DateTimeFormat.prototype, "format", descriptor);
+    }
+  });
+});
+
+it("preserves four-digit early years in both daily bounds", () => {
+  const window = makeWindow(1, new Date("0001-07-15T12:00:00Z"));
+  expect(window.sinceDay).toMatch(/^0001-/);
+  expect(window.untilDay).toBe(window.sinceDay);
+});
+
+it("rejects years outside the four-digit usage contract", () => {
+  expect(() => makeWindow(1, new Date("+010000-07-15T12:00:00Z"))).toThrow(RangeError);
 });

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -14,6 +14,31 @@ const CURRENCY = new Intl.NumberFormat("en-US", {
 });
 
 const INTEGER = new Intl.NumberFormat("en-US");
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_CUSTOM_WINDOW_DAYS = 90;
+
+function usageDayOrdinal(value: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match === null) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12) return null;
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+  if (daysInMonth === undefined || day < 1 || day > daysInMonth) return null;
+  return year * 372 + (month - 1) * 31 + day;
+}
+
+/** Compares two strict `YYYY-MM-DD` calendar days, or returns null if either is invalid. */
+export function compareUsageDays(left: string, right: string): -1 | 0 | 1 | null {
+  const leftOrdinal = usageDayOrdinal(left);
+  const rightOrdinal = usageDayOrdinal(right);
+  if (leftOrdinal === null || rightOrdinal === null) return null;
+  if (leftOrdinal < rightOrdinal) return -1;
+  if (leftOrdinal > rightOrdinal) return 1;
+  return 0;
+}
 
 export function formatUsd(value: number): string {
   return CURRENCY.format(value);
@@ -160,8 +185,8 @@ export function formatRelativeHourShort(
     month: "2-digit",
     day: "2-digit",
   });
-  const instantDay = Date.parse(`${dayFormat.format(instant)}T00:00:00Z`);
-  const referenceDay = Date.parse(`${dayFormat.format(reference)}T00:00:00Z`);
+  const instantDay = Date.parse(`${formatUsageDay(dayFormat, instant)}T00:00:00Z`);
+  const referenceDay = Date.parse(`${formatUsageDay(dayFormat, reference)}T00:00:00Z`);
   const calendarDaysAgo = Math.round((referenceDay - instantDay) / (24 * HOUR_MS));
   const hour = formatHourShort(hourStart, timeZone);
 
@@ -170,15 +195,17 @@ export function formatRelativeHourShort(
   return formatDateTimeShort(hourStart, timeZone);
 }
 
-/**
- * The window the page requests, expressed in the viewer's own time zone so days
- * line up with what they actually experienced.
- */
-export function makeWindow(
-  days: number,
-  now = new Date(),
-  resolution: UsageResolution = "day",
-): UsageSummaryInput {
+function formatUsageDay(format: Intl.DateTimeFormat, instant: Date): string {
+  const parts = Object.fromEntries(
+    format.formatToParts(instant).map(({ type, value }) => [type, value]),
+  );
+  const year = parts.year?.padStart(4, "0");
+  if (year === undefined || year.length !== 4)
+    throw new RangeError("Usage years must have four digits");
+  return `${year}-${parts.month}-${parts.day}`;
+}
+
+function viewerDayFormat(): { timeZone: string; format: Intl.DateTimeFormat } {
   let timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
   let format: Intl.DateTimeFormat;
   try {
@@ -198,7 +225,47 @@ export function makeWindow(
       day: "2-digit",
     });
   }
-  const untilDay = format.format(now);
+  return { timeZone, format };
+}
+
+/**
+ * A daily window over an explicit inclusive day range, in the viewer's zone.
+ * Bounds arrive from date inputs or a chart brush; out-of-order bounds are
+ * swapped rather than rejected so callers can pass a drag's raw endpoints.
+ * Typed spans are capped at the same 90 days as the largest preset so day
+ * enumeration remains bounded.
+ */
+export function makeCustomWindow(sinceDay: string, untilDay: string): UsageSummaryInput {
+  const comparison = compareUsageDays(sinceDay, untilDay);
+  if (comparison === null)
+    throw new RangeError("Usage window bounds must be valid YYYY-MM-DD dates");
+  const [first, requestedLast] = comparison <= 0 ? [sinceDay, untilDay] : [untilDay, sinceDay];
+  const firstMs = Date.parse(`${first}T00:00:00Z`);
+  const requestedLastMs = Date.parse(`${requestedLast}T00:00:00Z`);
+  const maximumLastMs = firstMs + (MAX_CUSTOM_WINDOW_DAYS - 1) * DAY_MS;
+  const last =
+    requestedLastMs > maximumLastMs
+      ? new Date(maximumLastMs).toISOString().slice(0, 10)
+      : requestedLast;
+  return {
+    sinceDay: UsageDay.make(first),
+    untilDay: UsageDay.make(last),
+    timeZone: viewerDayFormat().timeZone,
+    resolution: "day",
+  };
+}
+
+/**
+ * The window the page requests, expressed in the viewer's own time zone so days
+ * line up with what they actually experienced.
+ */
+export function makeWindow(
+  days: number,
+  now = new Date(),
+  resolution: UsageResolution = "day",
+): UsageSummaryInput {
+  const { timeZone, format } = viewerDayFormat();
+  const untilDay = formatUsageDay(format, now);
   if (resolution === "hour") {
     // Minute-aligned bounds keep labels readable while still representing an
     // exact rolling 24-hour duration. Fixed-duration buckets remain correct
@@ -208,8 +275,8 @@ export function makeWindow(
     const sinceTime = new Date(sinceTimeMs);
     const untilTime = new Date(untilTimeMs);
     return {
-      sinceDay: UsageDay.make(format.format(sinceTime)),
-      untilDay: UsageDay.make(format.format(untilTime)),
+      sinceDay: UsageDay.make(formatUsageDay(format, sinceTime)),
+      untilDay: UsageDay.make(formatUsageDay(format, untilTime)),
       timeZone,
       resolution,
       sinceTime: sinceTime.toISOString(),
@@ -219,10 +286,7 @@ export function makeWindow(
   // Subtracting fixed milliseconds from `now` lands on the wrong calendar day
   // around a DST transition. The window start is pure calendar arithmetic on
   // the local end day, done in UTC where days are uniform.
-  const [year = 0, month = 1, dayOfMonth = 1] = untilDay
-    .split("-")
-    .map((part) => Number.parseInt(part, 10));
-  const start = new Date(Date.UTC(year, month - 1, dayOfMonth - (days - 1)));
+  const start = new Date(Date.parse(`${untilDay}T00:00:00Z`) - (days - 1) * DAY_MS);
   return {
     sinceDay: UsageDay.make(start.toISOString().slice(0, 10)),
     untilDay: UsageDay.make(untilDay),

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,5 +1,8 @@
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
+  USAGE_PROJECT_ATTRIBUTION_SINCE,
+  ProjectId,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -8,7 +11,13 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { isModelCostUnknown, mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
+import {
+  isModelCostUnknown,
+  mergeUsage,
+  projectFilterForEnvironment,
+  retainUsageStatuses,
+  type EnvironmentUsage,
+} from "./usageMerge.ts";
 
 function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
   return {
@@ -28,6 +37,7 @@ function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
     records: 5,
     unpricedRecords: 0,
     sessions: 1,
+    projectAttribution: "outside",
     ...overrides,
   };
 }
@@ -92,6 +102,10 @@ describe("mergeUsage", () => {
     expect(merged.costUsd).toBe(20);
     expect(merged.records).toBe(10);
     expect(merged.duplicateSources).toHaveLength(0);
+    expect(merged.providerContributions).toEqual([
+      { environmentId: "env-a", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
+      { environmentId: "env-b", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
+    ]);
   });
 
   it("counts a shared transcript directory once", () => {
@@ -110,6 +124,9 @@ describe("mergeUsage", () => {
     expect(merged.sessions).toBe(1);
     expect(merged.duplicateSources).toHaveLength(1);
     expect(merged.contributingEnvironments).toEqual(["env-a"]);
+    expect(merged.providerContributions).toEqual([
+      { environmentId: "env-a", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
+    ]);
   });
 
   it("drops only the duplicated provider, keeping the environment's other one", () => {
@@ -144,6 +161,10 @@ describe("mergeUsage", () => {
         merged.providers.map((provider) => [provider.provider, provider.sessions]),
       ),
     ).toEqual({ claude: 1, codex: 1 });
+    expect(merged.providerContributions).toEqual([
+      { environmentId: "env-a", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
+      { environmentId: "env-b", contractVersion: USAGE_CONTRACT_VERSION, providers: ["codex"] },
+    ]);
   });
 
   it("excludes an environment reporting an older contract version", () => {
@@ -158,7 +179,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket()],
             [{ provider: "claude", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 2,
+            USAGE_MERGE_COMPATIBLE_SINCE - 1,
           ),
         ),
       ],
@@ -369,5 +390,346 @@ describe("mergeUsage", () => {
     ]);
     expect(merged.daily).toHaveLength(1);
     expect(merged.daily[0]?.costUsd).toBe(10);
+  });
+
+  it("rolls buckets up by project, with explicit outside buckets under null", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ project: "App", costUsd: 6 }),
+              bucket({ project: "App", costUsd: 2, model: "claude-opus-5" }),
+              bucket({ costUsd: 2 }),
+            ],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.projects.map((project) => [project.project, project.costUsd])).toEqual([
+      ["App", 8],
+      [null, 2],
+    ]);
+    expect(merged.projects[0]?.costShare).toBeCloseTo(0.8, 9);
+  });
+
+  it("keeps projects with the same title distinct and filters by stable id", () => {
+    const firstId = ProjectId.make("project-first");
+    const secondId = ProjectId.make("project-second");
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ projectId: firstId, project: "App", costUsd: 6 }),
+            bucket({ projectId: secondId, project: "App", costUsd: 2 }),
+          ],
+          [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+        ),
+      ),
+    ];
+
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    expect(
+      merged.projects.map((project) => [project.projectId, project.project, project.costUsd]),
+    ).toEqual([
+      [firstId, "App", 6],
+      [secondId, "App", 2],
+    ]);
+
+    const secondKey = merged.projects.find((project) => project.projectId === secondId)?.projectKey;
+    if (secondKey === undefined) throw new Error("second project key missing");
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: secondKey });
+    expect(filtered.costUsd).toBe(2);
+  });
+
+  it("reconciles aggregate, provider, project, and filtered project totals", () => {
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ project: "App", costUsd: 6 }),
+            bucket({
+              project: "App",
+              provider: "codex",
+              model: "gpt-5.6-sol",
+              costUsd: 3,
+              totals: {
+                uncachedInputTokens: 20,
+                cachedInputTokens: 200,
+                cacheCreationTokens: 0,
+                outputTokens: 10,
+                reasoningTokens: 5,
+              },
+            }),
+            bucket({ costUsd: 2 }),
+          ],
+          [
+            { provider: "claude", hostId: "mac", homePath: "/a/.claude" },
+            { provider: "codex", hostId: "mac", homePath: "/a/.codex" },
+          ],
+        ),
+      ),
+    ];
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+
+    expect(merged.providers.reduce((sum, provider) => sum + provider.costUsd, 0)).toBe(
+      merged.costUsd,
+    );
+    expect(merged.providers.reduce((sum, provider) => sum + provider.totalTokens, 0)).toBe(
+      merged.totalTokens,
+    );
+    expect(merged.projects.reduce((sum, project) => sum + project.costUsd, 0)).toBe(merged.costUsd);
+    expect(merged.projects.reduce((sum, project) => sum + project.totalTokens, 0)).toBe(
+      merged.totalTokens,
+    );
+
+    for (const project of merged.projects) {
+      const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, {
+        projectFilter: project.projectKey,
+      });
+      expect(filtered.costUsd).toBe(project.costUsd);
+      expect(filtered.totalTokens).toBe(project.totalTokens);
+    }
+  });
+
+  it("marks cache-write cost unavailable when a cache-creating bucket omits it", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ cacheWriteUsd: 3 }),
+              bucket({ cacheWriteUsd: 1, model: "claude-opus-5" }),
+              // A summary written before the field existed makes the estimate incomplete.
+              bucket({ model: "claude-opus-5" }),
+            ],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costQuality.cacheWriteUsd).toBeNull();
+    const opus = merged.models.find((model) => model.model === "claude-opus-5");
+    expect(opus?.cacheWriteUsd).toBeNull();
+  });
+
+  it("sums cache-write cost when every cache-creating bucket reports it", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ cacheWriteUsd: 3 }), bucket({ cacheWriteUsd: 1, model: "claude-opus-5" })],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costQuality.cacheWriteUsd).toBe(4);
+    const opus = merged.models.find((model) => model.model === "claude-opus-5");
+    expect(opus?.cacheWriteUsd).toBe(1);
+  });
+
+  it("filters every figure except the project list when a project is selected", () => {
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ project: "App", costUsd: 6 }),
+            bucket({ costUsd: 2, provider: "codex", model: "gpt-5.6-sol" }),
+          ],
+          [
+            { provider: "claude", hostId: "mac", homePath: "/a/.claude" },
+            { provider: "codex", hostId: "mac", homePath: "/a/.codex" },
+          ],
+        ),
+      ),
+    ];
+
+    const unfiltered = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    const appKey = unfiltered.projects.find((project) => project.project === "App")?.projectKey;
+    if (appKey === undefined || appKey === null) throw new Error("app project key missing");
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: appKey });
+    expect(filtered.costUsd).toBe(6);
+    expect(filtered.providers.map((provider) => provider.provider)).toEqual(["claude"]);
+    // Session counts are per source directory and cannot be split by project.
+    expect(filtered.sessions).toBe(0);
+    // The picker keeps its full option list while the filter narrows the rest.
+    expect(filtered.projects.map((project) => project.project)).toEqual(["App", null]);
+
+    const outside = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: null });
+    expect(outside.costUsd).toBe(2);
+    expect(outside.providers.map((provider) => provider.provider)).toEqual(["codex"]);
+  });
+
+  it("namespaces stable project ids by environment", () => {
+    const sharedId = ProjectId.make("cloned-project");
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [bucket({ projectId: sharedId, project: "App", costUsd: 6 })],
+          [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+        ),
+      ),
+      environment(
+        "env-b",
+        summary(
+          [bucket({ projectId: sharedId, project: "App", costUsd: 2 })],
+          [{ provider: "claude", hostId: "linux", homePath: "/b/.claude" }],
+        ),
+      ),
+    ];
+
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    expect(merged.projects.map((project) => project.costUsd)).toEqual([6, 2]);
+    const firstKey = merged.projects[0]?.projectKey;
+    if (firstKey === undefined || firstKey === null) throw new Error("project key missing");
+    expect(projectFilterForEnvironment(firstKey, "env-a" as EnvironmentId)).toBe(`id:${sharedId}`);
+    expect(projectFilterForEnvironment(firstKey, "env-b" as EnvironmentId)).toBe(
+      "environment-mismatch:",
+    );
+  });
+
+  it("does not treat unknown attribution from old summaries as outside projects", () => {
+    const oldEnvironment = environment(
+      "env-old",
+      summary(
+        [bucket({ costUsd: 4, projectAttribution: undefined })],
+        [{ provider: "claude", hostId: "mac", homePath: "/old/.claude" }],
+        USAGE_PROJECT_ATTRIBUTION_SINCE - 1,
+      ),
+    );
+
+    const unfiltered = mergeUsage([oldEnvironment], USAGE_CONTRACT_VERSION);
+    expect(unfiltered.costUsd).toBe(4);
+    expect(unfiltered.projects).toEqual([]);
+
+    const outside = mergeUsage([oldEnvironment], USAGE_CONTRACT_VERSION, {
+      projectFilter: null,
+    });
+    expect(outside.costUsd).toBe(0);
+  });
+
+  it("does not treat current unknown attribution as outside projects", () => {
+    const currentEnvironment = environment(
+      "env-current",
+      summary(
+        [
+          bucket({
+            provider: "grok",
+            model: "grok-code-fast-1",
+            costUsd: 4,
+            projectAttribution: "unknown",
+          }),
+        ],
+        [{ provider: "grok", hostId: "mac", homePath: "/unknown" }],
+      ),
+    );
+
+    const unfiltered = mergeUsage([currentEnvironment], USAGE_CONTRACT_VERSION);
+    expect(unfiltered.costUsd).toBe(4);
+    expect(unfiltered.projects).toEqual([]);
+
+    const outside = mergeUsage([currentEnvironment], USAGE_CONTRACT_VERSION, {
+      projectFilter: null,
+    });
+    expect(outside.costUsd).toBe(0);
+  });
+});
+
+describe("retainUsageStatuses", () => {
+  const status = (
+    id: string,
+    usageSummary: UsageSummary | null,
+    isPending = false,
+  ): {
+    readonly environmentId: EnvironmentId;
+    readonly label: string;
+    readonly isPending: boolean;
+    readonly error: string | null;
+    readonly summary: UsageSummary | null;
+  } => ({
+    environmentId: id as EnvironmentId,
+    label: id,
+    isPending,
+    error: null,
+    summary: usageSummary,
+  });
+
+  it("keeps each environment's settled value while the same range refreshes", () => {
+    const oldA = summary([bucket({ costUsd: 2 })], []);
+    const oldB = summary([bucket({ costUsd: 3 })], []);
+    const newA = { ...oldA, readAt: "2026-08-07T00:01:00.000Z" };
+    const previous = {
+      rangeKey: "range-a",
+      statuses: [status("env-a", oldA), status("env-b", oldB)],
+    };
+
+    const refreshing = retainUsageStatuses(
+      "range-a",
+      [status("env-a", null, true), status("env-b", null, true)],
+      previous,
+    );
+    const partlyAnswered = retainUsageStatuses(
+      "range-a",
+      [status("env-a", newA), status("env-b", null, true)],
+      refreshing.settled,
+    );
+
+    expect(refreshing.visible.map(({ isPending, summary: value }) => [isPending, value])).toEqual([
+      [true, oldA],
+      [true, oldB],
+    ]);
+    expect(
+      partlyAnswered.visible.map(({ isPending, summary: value }) => [isPending, value]),
+    ).toEqual([
+      [false, newA],
+      [true, oldB],
+    ]);
+  });
+
+  it("does not retain values across date ranges", () => {
+    const old = summary([], []);
+    const result = retainUsageStatuses("range-b", [status("env-a", null, true)], {
+      rangeKey: "range-a",
+      statuses: [status("env-a", old)],
+    });
+
+    expect(result.visible[0]?.summary).toBeNull();
+  });
+
+  it("does not revive a settled summary after every environment fails", () => {
+    const old = summary([bucket({ costUsd: 2 })], []);
+    const previous = {
+      rangeKey: "range-a",
+      statuses: [status("env-a", old)],
+    };
+    const failed = retainUsageStatuses(
+      "range-a",
+      [{ ...status("env-a", null), error: "could not report usage" }],
+      previous,
+    );
+    const retrying = retainUsageStatuses("range-a", [status("env-a", null, true)], failed.settled);
+
+    expect(failed.visible[0]).toMatchObject({
+      error: "could not report usage",
+      summary: null,
+    });
+    expect(failed.settled).toBeNull();
+    expect(retrying.visible[0]).toMatchObject({ isPending: true, error: null, summary: null });
+    expect(retrying.settled).toBeNull();
   });
 });

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -9,6 +9,7 @@
 import {
   USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
+  type ProjectId,
   type UsageBucket,
   type UsageProviderKind,
   type UsageSourceFingerprint,
@@ -19,6 +20,50 @@ export interface EnvironmentUsage {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly summary: UsageSummary;
+}
+
+export interface RetainableUsageStatus {
+  readonly environmentId: EnvironmentId;
+  readonly error: string | null;
+  readonly summary: UsageSummary | null;
+}
+
+export interface SettledUsageStatuses<T extends RetainableUsageStatus> {
+  readonly rangeKey: string;
+  readonly statuses: readonly T[];
+}
+
+/**
+ * Keeps each environment's last value visible while a refreshed query for
+ * the same date range starts cold. New answers replace retained values one at
+ * a time; failures and date-range changes never inherit old data.
+ */
+export function retainUsageStatuses<T extends RetainableUsageStatus>(
+  rangeKey: string,
+  current: readonly T[],
+  previous: SettledUsageStatuses<T> | null,
+): {
+  readonly visible: readonly T[];
+  readonly settled: SettledUsageStatuses<T> | null;
+} {
+  const previousByEnvironment =
+    previous?.rangeKey === rangeKey
+      ? new Map(previous.statuses.map((status) => [status.environmentId, status] as const))
+      : null;
+  let retainedAny = false;
+  const withRetained = current.map((status) => {
+    if (status.summary !== null || status.error !== null) return status;
+    const settledStatus = previousByEnvironment?.get(status.environmentId);
+    if (settledStatus?.summary === null || settledStatus === undefined) return status;
+    retainedAny = true;
+    return Object.assign({}, status, { summary: settledStatus.summary });
+  });
+  const visible = retainedAny ? withRetained : current;
+  const settled = visible.some((status) => status.summary !== null)
+    ? { rangeKey, statuses: visible }
+    : null;
+
+  return { visible, settled };
 }
 
 export interface ProviderTotals {
@@ -36,12 +81,28 @@ export interface ModelTotals {
   readonly provider: UsageProviderKind;
   readonly costUsd: number;
   readonly totalTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly cacheWriteUsd: number | null;
   readonly records: number;
   /**
    * Records whose tokens are counted here but which contributed nothing to
    * `costUsd`. When it equals `records` the cost is unknown, not zero.
    */
   readonly unpricedRecords: number;
+  readonly costShare: number;
+}
+
+/** One project's slice of the window. `project` is null for buckets that ran outside every project. */
+export interface ProjectTotals {
+  readonly projectId: ProjectId | null;
+  /** Stable, namespaced value accepted by `MergeUsageOptions.projectFilter`. */
+  readonly projectKey: string | null;
+  readonly project: string | null;
+  readonly costUsd: number;
+  readonly totalTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly cacheWriteUsd: number | null;
+  readonly records: number;
   readonly costShare: number;
 }
 
@@ -73,6 +134,14 @@ export interface CostQuality {
   readonly modelPricedShare: number;
   readonly unpricedShare: number;
   readonly cacheSavingsUsd: number;
+  /** Estimated cost of reported cache-creation tokens at cache-write rates. */
+  readonly cacheWriteUsd: number | null;
+}
+
+export interface EnvironmentProviderContribution {
+  readonly environmentId: EnvironmentId;
+  readonly contractVersion: number;
+  readonly providers: readonly UsageProviderKind[];
 }
 
 export interface MergedUsage {
@@ -87,12 +156,19 @@ export interface MergedUsage {
   readonly sessions: number;
   readonly providers: readonly ProviderTotals[];
   readonly models: readonly ModelTotals[];
+  /**
+   * Always computed from the unfiltered buckets, so a project picker keeps its
+   * full option list while a filter is applied.
+   */
+  readonly projects: readonly ProjectTotals[];
   readonly daily: readonly DailyTotals[];
   readonly hourly: readonly HourlyTotals[];
   readonly costQuality: CostQuality;
   /** Environments whose data was dropped as a duplicate of another's. */
   readonly duplicateSources: readonly string[];
   readonly contributingEnvironments: readonly EnvironmentId[];
+  /** Provider rows this environment owns after physical-source de-duplication. */
+  readonly providerContributions: readonly EnvironmentProviderContribution[];
   readonly staleEnvironments: readonly EnvironmentId[];
 }
 
@@ -202,6 +278,7 @@ const EMPTY_MERGED: MergedUsage = {
   sessions: 0,
   providers: [],
   models: [],
+  projects: [],
   daily: [],
   hourly: [],
   costQuality: {
@@ -209,11 +286,57 @@ const EMPTY_MERGED: MergedUsage = {
     modelPricedShare: 0,
     unpricedShare: 0,
     cacheSavingsUsd: 0,
+    cacheWriteUsd: 0,
   },
   duplicateSources: [],
   contributingEnvironments: [],
+  providerContributions: [],
   staleEnvironments: [],
 };
+
+export interface MergeUsageOptions {
+  /**
+   * Restrict every figure except `projects` to buckets from one project:
+   * a project's namespaced key selects that project, `null` selects buckets
+   * that ran outside every project, and `undefined` applies no filter.
+   *
+   * Sessions are counted per source directory, not per project, so a filtered
+   * merge reports `sessions` as 0 rather than a number it cannot know.
+   */
+  readonly projectFilter?: string | null;
+}
+
+function localBucketProjectKey(bucket: UsageBucket): string | null | undefined {
+  if (bucket.projectId !== undefined) return `id:${bucket.projectId}`;
+  if (bucket.project !== undefined) return `title:${bucket.project}`;
+  return bucket.projectAttribution === "outside" ? null : undefined;
+}
+
+function namespacedProjectKey(environmentId: EnvironmentId, localKey: string): string {
+  return JSON.stringify([environmentId, localKey]);
+}
+
+/** Converts a merged project key back to the key understood by one server. */
+export function projectFilterForEnvironment(
+  filter: string | null | undefined,
+  environmentId: EnvironmentId,
+): string | null | undefined {
+  if (filter === undefined || filter === null) return filter;
+  try {
+    const parsed: unknown = JSON.parse(filter);
+    if (
+      Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      parsed[0] === environmentId &&
+      typeof parsed[1] === "string"
+    ) {
+      return parsed[1];
+    }
+  } catch {
+    // A malformed or foreign key must select nothing in this environment.
+  }
+  return "environment-mismatch:";
+}
 
 /**
  * Merges every connected environment's summary.
@@ -227,8 +350,10 @@ const EMPTY_MERGED: MergedUsage = {
 export function mergeUsage(
   environments: readonly EnvironmentUsage[],
   expectedContractVersion: number,
+  options?: MergeUsageOptions,
 ): MergedUsage {
   if (environments.length === 0) return EMPTY_MERGED;
+  const projectFilter = options?.projectFilter;
 
   const current: EnvironmentUsage[] = [];
   const staleEnvironments: EnvironmentId[] = [];
@@ -253,6 +378,8 @@ export function mergeUsage(
   let records = 0;
   let sessions = 0;
   let cacheSavingsUsd = 0;
+  let cacheWriteUsd = 0;
+  let cacheWriteComplete = true;
   let providerReportedRecords = 0;
   let unpricedRecords = 0;
 
@@ -266,10 +393,30 @@ export function mergeUsage(
       provider: UsageProviderKind;
       costUsd: number;
       totalTokens: number;
+      cacheWriteTokens: number;
+      cacheWriteUsd: number;
+      cacheWriteComplete: boolean;
       records: number;
       unpricedRecords: number;
     }
   >();
+  // Keyed by stable project id where available, with a namespaced title
+  // fallback for pre-v7 summaries. Accumulated before the project filter.
+  const projectAccumulator = new Map<
+    string,
+    {
+      projectId: ProjectId | null;
+      projectKey: string | null;
+      project: string | null;
+      costUsd: number;
+      totalTokens: number;
+      cacheWriteTokens: number;
+      cacheWriteUsd: number;
+      cacheWriteComplete: boolean;
+      records: number;
+    }
+  >();
+  let unfilteredCostUsd = 0;
   const dailyAccumulator = new Map<
     string,
     {
@@ -289,29 +436,79 @@ export function mergeUsage(
     }
   >();
   const contributingEnvironments: EnvironmentId[] = [];
+  const providerContributions: EnvironmentProviderContribution[] = [];
 
   for (const environment of current) {
     const { buckets, sessionsByProvider } = ownedContribution(environment, ownerByFingerprint);
-    if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);
+    if (buckets.length > 0) {
+      contributingEnvironments.push(environment.environmentId);
+      providerContributions.push({
+        environmentId: environment.environmentId,
+        contractVersion: environment.summary.contractVersion,
+        providers: [...new Set(buckets.map((bucket) => bucket.provider))].sort(),
+      });
+    }
 
-    for (const [providerKind, providerSessions] of sessionsByProvider) {
-      sessions += providerSessions;
-      if (providerSessions === 0) continue;
-      const provider = providerAccumulator.get(providerKind) ?? {
-        costUsd: 0,
-        totalTokens: 0,
-        records: 0,
-        sessions: 0,
-      };
-      provider.sessions += providerSessions;
-      providerAccumulator.set(providerKind, provider);
+    // Session counts are per source directory; a project filter cannot split
+    // them, so a filtered merge leaves every session figure at 0.
+    if (projectFilter === undefined) {
+      for (const [providerKind, providerSessions] of sessionsByProvider) {
+        sessions += providerSessions;
+        if (providerSessions === 0) continue;
+        const provider = providerAccumulator.get(providerKind) ?? {
+          costUsd: 0,
+          totalTokens: 0,
+          records: 0,
+          sessions: 0,
+        };
+        provider.sessions += providerSessions;
+        providerAccumulator.set(providerKind, provider);
+      }
     }
 
     for (const bucket of buckets) {
       const tokens = bucketTokens(bucket);
+      const bucketCacheWriteComplete =
+        bucket.totals.cacheCreationTokens === 0 || bucket.cacheWriteUsd !== undefined;
+
+      unfilteredCostUsd += bucket.costUsd;
+      const localProjectKey = localBucketProjectKey(bucket);
+      const projectKey =
+        typeof localProjectKey === "string"
+          ? namespacedProjectKey(environment.environmentId, localProjectKey)
+          : localProjectKey;
+      // Unknown attribution stays in unfiltered totals but never claims to be
+      // part of the explicit Outside projects slice.
+      if (projectKey === undefined) {
+        if (projectFilter !== undefined) continue;
+      } else {
+        const accumulatorKey = projectKey ?? "\0";
+        const project = projectAccumulator.get(accumulatorKey) ?? {
+          projectId: bucket.projectId ?? null,
+          projectKey,
+          project: bucket.project ?? null,
+          costUsd: 0,
+          totalTokens: 0,
+          cacheWriteTokens: 0,
+          cacheWriteUsd: 0,
+          cacheWriteComplete: true,
+          records: 0,
+        };
+        project.costUsd += bucket.costUsd;
+        project.totalTokens += tokens;
+        project.cacheWriteTokens += bucket.totals.cacheCreationTokens;
+        project.cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
+        project.cacheWriteComplete &&= bucketCacheWriteComplete;
+        project.records += bucket.records;
+        projectAccumulator.set(accumulatorKey, project);
+
+        if (projectFilter !== undefined && projectKey !== projectFilter) continue;
+      }
 
       costUsd += bucket.costUsd;
       cacheSavingsUsd += bucket.cacheSavingsUsd;
+      cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
+      cacheWriteComplete &&= bucketCacheWriteComplete;
       uncachedInputTokens += bucket.totals.uncachedInputTokens;
       cachedInputTokens += bucket.totals.cachedInputTokens;
       cacheCreationTokens += bucket.totals.cacheCreationTokens;
@@ -337,11 +534,17 @@ export function mergeUsage(
         provider: bucket.provider,
         costUsd: 0,
         totalTokens: 0,
+        cacheWriteTokens: 0,
+        cacheWriteUsd: 0,
+        cacheWriteComplete: true,
         records: 0,
         unpricedRecords: 0,
       };
       model.costUsd += bucket.costUsd;
       model.totalTokens += tokens;
+      model.cacheWriteTokens += bucket.totals.cacheCreationTokens;
+      model.cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
+      model.cacheWriteComplete &&= bucketCacheWriteComplete;
       model.records += bucket.records;
       model.unpricedRecords += bucket.unpricedRecords;
       modelAccumulator.set(modelKey, model);
@@ -401,9 +604,25 @@ export function mergeUsage(
       provider: totals.provider,
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
+      cacheWriteTokens: totals.cacheWriteTokens,
+      cacheWriteUsd: totals.cacheWriteComplete ? totals.cacheWriteUsd : null,
       records: totals.records,
       unpricedRecords: totals.unpricedRecords,
       costShare: costUsd === 0 ? 0 : totals.costUsd / costUsd,
+    }))
+    .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
+
+  const projects: ProjectTotals[] = [...projectAccumulator.entries()]
+    .map(([, totals]) => ({
+      projectId: totals.projectId,
+      projectKey: totals.projectKey,
+      project: totals.project,
+      costUsd: totals.costUsd,
+      totalTokens: totals.totalTokens,
+      cacheWriteTokens: totals.cacheWriteTokens,
+      cacheWriteUsd: totals.cacheWriteComplete ? totals.cacheWriteUsd : null,
+      records: totals.records,
+      costShare: unfilteredCostUsd === 0 ? 0 : totals.costUsd / unfilteredCostUsd,
     }))
     .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
 
@@ -432,6 +651,7 @@ export function mergeUsage(
     sessions,
     providers,
     models,
+    projects,
     daily,
     hourly,
     costQuality: {
@@ -440,9 +660,13 @@ export function mergeUsage(
       modelPricedShare:
         records === 0 ? 0 : (records - providerReportedRecords - unpricedRecords) / records,
       cacheSavingsUsd,
+      cacheWriteUsd: cacheWriteComplete ? cacheWriteUsd : null,
     },
     duplicateSources: duplicates,
     contributingEnvironments,
+    providerContributions: providerContributions.sort((a, b) =>
+      a.environmentId.localeCompare(b.environmentId),
+    ),
     staleEnvironments,
   };
 }


### PR DESCRIPTION
Usage folds cache-creation cost into input cost, which hides a real billing category. Long-context and one-hour cache writes are hard to explain as a result.

## What changed

- The server prices cache creation as its own component (`cacheWriteUsd`). Five-minute and one-hour writes are priced separately, and custom model prices apply.
- The summary, the model/project/thread breakdowns and the daily thread chart show the estimated cache-write cost next to the total.
- If a rate or provider component is unknown, the cache-write figure reads "Unavailable" instead of `$0.00`. Providers that never bill cache writes show a dash.

## Stack

This PR is cumulative. Merge #9014, #9015, #9016 and #9017 first. After they land, this PR's remaining delta is the cache-write component. The branch was rebased onto `main` (`20ef25037`) as one linear commit. Its earlier history already contained merge commits.

During the rebase I reconciled this PR with #11021, upstream's per-model unpriced flag. Model rows now carry both `unpricedRecords` and the cache-write fields. The summary subtitle keeps this PR's project scope and adds upstream's "excludes N% unpriced records" note.

## Verification

- `vp test run` on the usage suites (server usage, web usage components and state, shared `usageMerge`/`usageFormat`, contracts, client-runtime): 24 files, 297 tests passed.
- Typecheck passed for `t3`, `@t3tools/web`, `@t3tools/shared`, `@t3tools/contracts`, `@t3tools/client-runtime` and `@t3tools/mobile`.
- `vp fmt --check` and `vp lint` passed on the 46 changed files (lint reported warnings only). `git diff --check` is clean.
- No cross-provider review was run for this push because Codex quota headroom was below the threshold.

## UI

The images below are **historical**. They come from a cumulative integration capture (`7e248026`) with synthetic data and price overrides, not from this head. They show where the cache-write figures appear. No fresh capture of this head has been made yet.

![Before: main exposes model/day breakdowns](https://github.com/saphid/t3code/releases/download/pr-evidence-usage-integration-20260905/usage-before-image-annotated.png)

![After: cache-write breakdown](https://github.com/saphid/t3code/releases/download/pr-evidence-usage-integration-20260905/usage-after-image-annotated.png)

[Breakdown recording](https://github.com/saphid/t3code/releases/download/pr-evidence-usage-integration-20260905/usage-breakdown-clean.mp4)

Coordination trace: T3 thread b2c6ad23-2a6a-4586-9d19-cd3246b23024

Rebased and updated with Claude Opus 5 in the Claude Code harness (T3 Code); earlier revisions by GPT-6 and GPT-5.6 Sol in the Codex harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
