### PR TITLE
feat(usage): refresh incrementally every thirty minutes

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -204,14 +204,14 @@ function ChartCard(props: {
       <View className="flex-row items-start justify-between gap-3">
         <View className="min-w-0 flex-1 gap-0.5">
           <Text className="text-sm text-foreground-muted">
-            {metric === "cost" ? "Raw token cost" : "Processed tokens"}
+            {metric === "cost" ? "Local public-list estimate" : "Processed tokens"}
           </Text>
           <Text className="text-4xl font-t3-bold tabular-nums text-foreground">
             {metric === "cost" ? `${formatUsd(merged.costUsd)}*` : formatTokens(merged.totalTokens)}
           </Text>
           <Text className="text-sm text-foreground-muted">
             {metric === "cost"
-              ? "* if billed at full API rate"
+              ? "* estimated from local transcripts at public list rates"
               : `Across ${formatCount(merged.sessions)} sessions`}
           </Text>
         </View>
@@ -382,7 +382,16 @@ function TotalsSection(props: { readonly merged: MergedUsage; readonly isPast24H
         <MetricCell
           label="Uncached input"
           value={formatTokens(merged.uncachedInputTokens)}
-          detail={`${formatTokens(merged.cacheCreationTokens)} cache writes`}
+          detail="fresh input tokens"
+        />
+        <MetricCell
+          label="Cache writes, estimated"
+          value={
+            merged.costQuality.cacheWriteUsd === null
+              ? "Unavailable"
+              : formatUsd(merged.costQuality.cacheWriteUsd)
+          }
+          detail={`${formatTokens(merged.cacheCreationTokens)} tokens · not an expiry measure`}
         />
         <MetricCell
           label="Output"

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -17,9 +17,10 @@ import {
   type UsageSummaryInput,
 } from "@t3tools/contracts";
 import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
+import { startUsageAutoRefresh } from "@t3tools/shared/usageRefresh";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { appAtomRegistry } from "./atom-registry";
 import { environmentPresentations } from "./presentation";
@@ -108,6 +109,10 @@ export function useUsage(input: UsageSummaryInput): UsageView {
       );
     }
   }, [environments, windowKey]);
+
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+  useEffect(() => startUsageAutoRefresh(() => refreshRef.current()), []);
 
   const merged = useMemo(() => {
     const answered: EnvironmentUsage[] = environments.flatMap((environment) =>

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -46,6 +46,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverGetResourceTelemetryHistory]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRetryResourceTelemetry]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverGetUsageSummary]: AuthOrchestrationReadScope,
+  [WS_METHODS.serverGetUsageThreadBreakdown]: AuthOrchestrationReadScope,
   [WS_METHODS.serverSignalProcess]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverReportClientActivity]: AuthOrchestrationReadScope,
   [WS_METHODS.serverReportHostPowerState]: AuthOrchestrationOperateScope,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -28,7 +28,6 @@ import * as PullRequestProviderRegistry from "./pullRequest/PullRequestProviderR
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
 import { ProjectionProjectRepositoryLive } from "./persistence/Layers/ProjectionProjects.ts";
 import { ProjectionThreadRepositoryLive } from "./persistence/Layers/ProjectionThreads.ts";
-import { ProviderSessionRuntimeRepositoryLive } from "./persistence/Layers/ProviderSessionRuntime.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
@@ -186,7 +185,7 @@ const UsageLayerLive = UsageService.layer.pipe(
   // resume cursors attribute sessions to threads for the drill-down.
   Layer.provide(ProjectionProjectRepositoryLive),
   Layer.provide(ProjectionThreadRepositoryLive),
-  Layer.provide(ProviderSessionRuntimeRepositoryLive),
+  Layer.provide(ProviderSessionRuntime.layer),
   Layer.provide(ServerSettingsLayerLive),
 );
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -26,6 +26,7 @@ import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { pullRequestHttpApiLayer } from "./pullRequest/http.ts";
 import * as PullRequestProviderRegistry from "./pullRequest/PullRequestProviderRegistry.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
+import { ProjectionProjectRepositoryLive } from "./persistence/Layers/ProjectionProjects.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
@@ -178,7 +179,11 @@ const BackgroundLayerLive = BackgroundPolicy.layer.pipe(
   Layer.provideMerge(ServerSettingsLayerLive),
 );
 
-const UsageLayerLive = UsageService.layer.pipe(Layer.provide(ServerSettingsLayerLive));
+const UsageLayerLive = UsageService.layer.pipe(
+  // The repository resolves each session's cwd to the project it ran in.
+  Layer.provide(ProjectionProjectRepositoryLive),
+  Layer.provide(ServerSettingsLayerLive),
+);
 
 const ResourceDiagnosticsLayerLive = Layer.mergeAll(
   ResourceTelemetryLayerLive,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -27,6 +27,8 @@ import { pullRequestHttpApiLayer } from "./pullRequest/http.ts";
 import * as PullRequestProviderRegistry from "./pullRequest/PullRequestProviderRegistry.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
 import { ProjectionProjectRepositoryLive } from "./persistence/Layers/ProjectionProjects.ts";
+import { ProjectionThreadRepositoryLive } from "./persistence/Layers/ProjectionThreads.ts";
+import { ProviderSessionRuntimeRepositoryLive } from "./persistence/Layers/ProviderSessionRuntime.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
@@ -180,8 +182,11 @@ const BackgroundLayerLive = BackgroundPolicy.layer.pipe(
 );
 
 const UsageLayerLive = UsageService.layer.pipe(
-  // The repository resolves each session's cwd to the project it ran in.
+  // Projects resolve each session's cwd to the project it ran in; threads and
+  // resume cursors attribute sessions to threads for the drill-down.
   Layer.provide(ProjectionProjectRepositoryLive),
+  Layer.provide(ProjectionThreadRepositoryLive),
+  Layer.provide(ProviderSessionRuntimeRepositoryLive),
   Layer.provide(ServerSettingsLayerLive),
 );
 

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -232,3 +232,20 @@ describe("UsageService", () => {
     }).pipe(Effect.scoped),
   );
 });
+
+describe("isValidUsageDay", () => {
+  it("rejects impossible start and end dates instead of normalising them", () => {
+    assert.isTrue(UsageService.isValidUsageDay("2026-02-28"));
+    assert.isFalse(UsageService.isValidUsageDay("2026-02-29"));
+    assert.isFalse(UsageService.isValidUsageDay("2026-13-01"));
+  });
+});
+
+describe("shortSessionLabel", () => {
+  it("never exposes a file-derived path", () => {
+    assert.strictEqual(
+      UsageService.shortSessionLabel("claude:file:session-dir:updates"),
+      "Untitled session",
+    );
+  });
+});

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -16,6 +16,8 @@ import * as Scheduler from "effect/Scheduler";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
+import { ProjectionProjectRepositoryLive } from "../persistence/Layers/ProjectionProjects.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as UsageService from "./UsageService.ts";
 
@@ -84,6 +86,12 @@ const serviceLayers = (input: {
     ),
     Layer.provideMerge(
       Layer.succeed(HostProcessEnvironment, { GROK_HOME: NodePath.join(input.home, "grok") }),
+    ),
+    Layer.provideMerge(
+      Layer.mergeAll(
+        ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+        SqlitePersistenceMemory,
+      ),
     ),
   );
 

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -235,6 +235,33 @@ describe("UsageService", () => {
       );
     }).pipe(Effect.scoped),
   );
+
+  it.live("rejects exact thread windows longer than 24 hours", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({ prefix: "usage-service-thread-window-test", home, settings }),
+        ),
+      );
+      const reason = yield* service
+        .readThreadBreakdown({
+          timeZone: "UTC",
+          sinceDay: UsageDay.make("2026-08-01"),
+          untilDay: UsageDay.make("2026-08-02"),
+          sinceTime: "2026-08-01T00:00:00.000Z",
+          untilTime: "2026-08-02T01:00:00.000Z",
+        })
+        .pipe(
+          Effect.match({
+            onFailure: (error) => error.reason,
+            onSuccess: () => "success" as const,
+          }),
+        );
+
+      assert.strictEqual(reason, "invalidWindow");
+    }).pipe(Effect.scoped),
+  );
 });
 
 describe("isValidUsageDay", () => {

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -17,7 +17,9 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
 import { ProjectionProjectRepositoryLive } from "../persistence/Layers/ProjectionProjects.ts";
+import { ProjectionThreadRepositoryLive } from "../persistence/Layers/ProjectionThreads.ts";
 import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import * as ProviderSessionRuntime from "../persistence/ProviderSessionRuntime.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as UsageService from "./UsageService.ts";
 
@@ -90,6 +92,8 @@ const serviceLayers = (input: {
     Layer.provideMerge(
       Layer.mergeAll(
         ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+        ProjectionThreadRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+        ProviderSessionRuntime.layer.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
         SqlitePersistenceMemory,
       ),
     ),

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -5,10 +5,10 @@
  * Grok Build) rather than T3 Code's orchestration projections, so usage covers
  * turns driven outside T3 Code too. This is the approach `ccusage` takes.
  *
- * Transcripts are append-only, so parsed records are memoised per file by
- * `(size, mtime)`. A cold 30-day scan of ~1.4 GB lands around 2-3 seconds; warm
- * scans only reparse files that changed, and a file that merely grew resumes
- * from its cached parse position so only the appended bytes are read.
+ * Parsed records are memoised per file by a full SHA-256 fingerprint. Every
+ * refresh hashes the observed bytes, so even same-size rewrites with preserved
+ * metadata invalidate the parse cache. When a file only grows, the old prefix
+ * hash must match before parsing resumes from the cached byte position.
  *
  * @module UsageService
  */
@@ -39,6 +39,7 @@ import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
+import { writeFileStringAtomically } from "../atomicWrite.ts";
 import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
 import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
@@ -52,8 +53,11 @@ import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
   listTranscriptFiles,
   readDirectoryVolumeId,
+  readTranscriptFingerprint,
   readTranscriptRecords,
   readTranscriptTitle,
+  type TranscriptFile,
+  type TranscriptParsePosition,
 } from "./usageTranscriptReader.ts";
 import { foldThreadRows, ThreadUsageAccumulator, type ThreadRef } from "./usageThreads.ts";
 import {
@@ -86,7 +90,8 @@ const CACHE_RETENTION_DAYS = 90;
  * window can hold thousands of sessions, so lower-cost rows fold together.
  */
 const THREAD_ROW_CAP = 40;
-
+/** Bounded disk parallelism for hashing and parsing sorted transcript files. */
+const SCAN_FILE_CONCURRENCY = 8;
 /** On-disk shape of the rate snapshot. */
 const RatesCacheFile = Schema.Struct({
   fetchedAtMs: Schema.Number,
@@ -168,6 +173,7 @@ export const make = Effect.gen(function* () {
   let cacheRevision = 0;
   let persistedCacheRevision = 0;
   const cachePersistSemaphore = yield* Semaphore.make(1);
+  const scanSemaphore = yield* Semaphore.make(1);
 
   const ratesCachePath = path.join(config.stateDir, "usage-model-rates.json");
   const scanCachePath = path.join(config.stateDir, "usage-scan-cache.json");
@@ -336,7 +342,12 @@ export const make = Effect.gen(function* () {
     if (cacheRevision === persistedCacheRevision) return;
     const revision = cacheRevision;
     yield* encodeScanCacheFile(encodeScanCache(fileCache)).pipe(
-      Effect.flatMap((serialized) => fileSystem.writeFileString(scanCachePath, serialized)),
+      Effect.flatMap((serialized) =>
+        writeFileStringAtomically({ filePath: scanCachePath, contents: serialized }).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
+        ),
+      ),
       Effect.map(() => {
         persistedCacheRevision = revision;
       }),
@@ -346,82 +357,105 @@ export const make = Effect.gen(function* () {
   });
   const persistScanCache = () => cachePersistSemaphore.withPermits(1)(persistScanCacheUnlocked());
 
-  /**
-   * Parses one transcript, reusing the cached result when it is unchanged.
-   *
-   * A file that only grew re-parses from the cached position, so an actively
-   * written multi-hundred-megabyte rollout costs its appended bytes per scan
-   * rather than a full re-read. The reader verifies the position's guard bytes
-   * and silently restarts from byte 0 when they no longer match.
-   */
+  /** Parses one transcript after proving its observed content identity. */
   const readFileRecords = (
-    filePath: string,
-    size: number,
-    mtimeMs: number,
+    file: TranscriptFile,
     provider: UsageProviderKind,
   ): Effect.Effect<readonly UsageRecord[]> =>
     Effect.gen(function* () {
-      const cached = fileCache.get(filePath);
-      // Provider is part of the identity: if both providers were ever pointed
-      // at one directory, a hit parsed by the other parser must not be reused.
-      if (
-        cached &&
-        cached.size === size &&
-        cached.mtimeMs === mtimeMs &&
-        cached.provider === provider
-      ) {
+      const cached = fileCache.get(file.path);
+      let fingerprint = yield* Effect.promise(() =>
+        readTranscriptFingerprint(file.path, file.size),
+      );
+      if (fingerprint === null) return [];
+
+      // A touch, rename replacement, or timestamp normalization can change
+      // metadata without changing content. Reuse the parsed records after the
+      // full hash proves the observed snapshot is identical.
+      if (cached && cached.fingerprint === fingerprint && cached.provider === provider) {
+        if (
+          cached.size !== file.size ||
+          cached.mtimeMs !== file.mtimeMs ||
+          cached.mtimeNs !== file.mtimeNs ||
+          cached.device !== file.device ||
+          cached.inode !== file.inode
+        ) {
+          fileCache.set(file.path, {
+            ...cached,
+            size: file.size,
+            mtimeMs: file.mtimeMs,
+            mtimeNs: file.mtimeNs,
+            device: file.device,
+            inode: file.inode,
+          });
+          cacheRevision += 1;
+        }
         return cached.tailRecords.length === 0
           ? cached.records
           : dedupeWithinFile([...cached.records, ...cached.tailRecords]);
       }
 
-      // Only a strictly grown file may resume. Same size with a new mtime, or
-      // a shrunken file, means rewritten content; re-parse it whole.
-      const resumeFrom =
-        cached !== undefined && cached.provider === provider && size > cached.size
-          ? cached.position
-          : undefined;
+      // Hash and parse are separate streaming passes. Re-check the full hash so
+      // an in-place rewrite between them cannot cache records under the wrong
+      // identity. A grown file resumes only after its complete old prefix also
+      // matches the cached hash. Retry one moving snapshot, then defer it.
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        let resumeFrom: TranscriptParsePosition | undefined;
+        if (cached !== undefined && cached.provider === provider && file.size > cached.size) {
+          const prefixFingerprint = yield* Effect.promise(() =>
+            readTranscriptFingerprint(file.path, cached.size),
+          );
+          if (prefixFingerprint === cached.fingerprint) resumeFrom = cached.position;
+        }
+        const parsed = yield* Effect.promise(() =>
+          readTranscriptRecords(file.path, provider, resumeFrom, file.size),
+        );
+        // A read failure is not an empty transcript: caching it would silently
+        // drop the file's usage until its next content change.
+        if (parsed === null) return [];
+        const verifiedFingerprint = yield* Effect.promise(() =>
+          readTranscriptFingerprint(file.path, file.size),
+        );
+        if (verifiedFingerprint === null) return [];
+        if (verifiedFingerprint !== fingerprint) {
+          fingerprint = verifiedFingerprint;
+          continue;
+        }
 
-      const parsed = yield* Effect.promise(() =>
-        readTranscriptRecords(filePath, provider, resumeFrom),
-      );
-      // A read failure is not an empty transcript: caching it under this
-      // (size, mtime) would silently drop the file's usage until it changes.
-      if (parsed === null) return [];
-
-      // Stored already de-duplicated within the file, which is 99% of all
-      // duplicates. The final snapshot wins so a resumed Claude parse can
-      // replace an earlier progressive snapshot from the cached base.
-      const base = parsed.resumed && cached !== undefined ? cached.records : [];
-      const records = dedupeWithinFile([...base, ...parsed.records]);
-      const tailRecords = dedupeWithinFile(parsed.tailRecords);
-
-      fileCache.set(filePath, {
-        size,
-        mtimeMs,
-        provider,
-        records,
-        tailRecords,
-        position: parsed.position,
-      });
-      cacheRevision += 1;
-      return tailRecords.length === 0 ? records : dedupeWithinFile([...records, ...tailRecords]);
+        // Final-wins replacement lets an appended complete Claude snapshot
+        // supersede an earlier progressive snapshot from the cached prefix.
+        const base = parsed.resumed && cached !== undefined ? cached.records : [];
+        const records = dedupeWithinFile([...base, ...parsed.records]);
+        const tailRecords = dedupeWithinFile(parsed.tailRecords);
+        fileCache.set(file.path, {
+          size: file.size,
+          mtimeMs: file.mtimeMs,
+          mtimeNs: file.mtimeNs,
+          device: file.device,
+          inode: file.inode,
+          fingerprint,
+          provider,
+          records,
+          tailRecords,
+          position: parsed.position,
+        });
+        cacheRevision += 1;
+        return tailRecords.length === 0 ? records : dedupeWithinFile([...records, ...tailRecords]);
+      }
+      return [];
     });
 
-  /** One provider directory's walk and parse, before rates are involved. */
+  /** One provider directory's deterministic walk and bounded concurrent parse. */
   interface ScannedDir {
     readonly provider: UsageProviderKind;
     readonly dir: string;
     readonly volumeId: string;
-    /** Parsed records per file, or `null` when the directory does not exist. */
     readonly files:
       | readonly { readonly path: string; readonly records: readonly UsageRecord[] }[]
       | null;
   }
 
   const collectDirs = Effect.fn("UsageService.collectDirs")(function* (windowStartMs: number) {
-    // The home resolvers ask for `Path` themselves; satisfy them from the
-    // instance we already hold so the scan stays context-free.
     const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
     const scanned: ScannedDir[] = [];
     for (const { provider, dir, fileName } of dirs) {
@@ -436,11 +470,14 @@ export const make = Effect.gen(function* () {
       const files = yield* Effect.promise(() =>
         listTranscriptFiles(dir, windowStartMs, fileName === undefined ? undefined : { fileName }),
       );
-      const parsedFiles: { path: string; records: readonly UsageRecord[] }[] = [];
-      for (const file of files) {
-        const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
-        parsedFiles.push({ path: file.path, records });
-      }
+      const parsedFiles = yield* Effect.forEach(
+        files,
+        (file) =>
+          readFileRecords(file, provider).pipe(
+            Effect.map((records) => ({ path: file.path, records })),
+          ),
+        { concurrency: SCAN_FILE_CONCURRENCY },
+      );
       scanned.push({ provider, dir, volumeId, files: parsedFiles });
     }
     return scanned;
@@ -505,6 +542,7 @@ export const make = Effect.gen(function* () {
       untilDay: input.untilDay,
       resolution: input.resolution ?? "day",
       ...hourlyWindow,
+      cutoffTimeMs: startedAtMs,
       rates,
       resolveProject: yield* resolveProjects(),
     });
@@ -565,12 +603,11 @@ export const make = Effect.gen(function* () {
     yield* persistScanCache();
 
     const aggregated = aggregator.finish();
-    const readAt = yield* DateTime.now;
     const finishedAtMs = yield* Clock.currentTimeMillis;
 
     return {
       contractVersion: USAGE_CONTRACT_VERSION,
-      readAt: DateTime.formatIso(readAt),
+      readAt: DateTime.formatIso(DateTime.makeUnsafe(startedAtMs)),
       timeZone: input.timeZone,
       sinceDay: input.sinceDay,
       untilDay: input.untilDay,
@@ -619,14 +656,16 @@ export const make = Effect.gen(function* () {
         inflightScans.set(key, created);
         // Detached so one departing client cannot tear the scan out from under
         // the fibers awaiting it; a finished scan warms the cache either way.
-        yield* scanSummary(input).pipe(
-          Effect.onExit((exit) =>
-            Effect.sync(() => inflightScans.delete(key)).pipe(
-              Effect.andThen(Deferred.done(created, exit)),
+        yield* scanSemaphore
+          .withPermits(1)(scanSummary(input))
+          .pipe(
+            Effect.onExit((exit) =>
+              Effect.sync(() => inflightScans.delete(key)).pipe(
+                Effect.andThen(Deferred.done(created, exit)),
+              ),
             ),
-          ),
-          Effect.forkDetach,
-        );
+            Effect.forkDetach,
+          );
         return created;
       }),
     );
@@ -698,7 +737,7 @@ export const make = Effect.gen(function* () {
     return { sessionToThread, worktreeToThread };
   });
 
-  const readThreadBreakdown = Effect.fn("UsageService.readThreadBreakdown")(function* (
+  const readThreadBreakdownUnlocked = Effect.fn("UsageService.readThreadBreakdown")(function* (
     input: UsageThreadBreakdownInput,
   ) {
     if (input.sinceDay > input.untilDay) {
@@ -758,6 +797,7 @@ export const make = Effect.gen(function* () {
       sinceDay: input.sinceDay,
       untilDay: input.untilDay,
       ...exactWindow,
+      cutoffTimeMs: startedAtMs,
       rates,
       resolveProject: yield* resolveProjects(),
     });
@@ -782,9 +822,14 @@ export const make = Effect.gen(function* () {
       const files = yield* Effect.promise(() =>
         listTranscriptFiles(dir, windowStartMs, fileName === undefined ? undefined : { fileName }),
       );
-      for (const file of files) {
-        livePaths.add(file.path);
-        const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+      for (const file of files) livePaths.add(file.path);
+      const fileRecords = yield* Effect.forEach(
+        files,
+        (file) =>
+          readFileRecords(file, provider).pipe(Effect.map((records) => ({ file, records }))),
+        { concurrency: SCAN_FILE_CONCURRENCY },
+      );
+      for (const { file, records } of fileRecords) {
         if (records.length === 0) continue;
         const isSubagent =
           provider === "claude" && path.basename(path.dirname(file.path)) === "subagents";
@@ -838,11 +883,10 @@ export const make = Effect.gen(function* () {
       { concurrency: 8 },
     );
 
-    const readAt = yield* DateTime.now;
     const finishedAtMs = yield* Clock.currentTimeMillis;
     return {
       contractVersion: USAGE_CONTRACT_VERSION,
-      readAt: DateTime.formatIso(readAt),
+      readAt: DateTime.formatIso(DateTime.makeUnsafe(startedAtMs)),
       sinceDay: input.sinceDay,
       untilDay: input.untilDay,
       rows,
@@ -850,6 +894,12 @@ export const make = Effect.gen(function* () {
       scanDurationMs: Math.max(0, finishedAtMs - startedAtMs),
     } satisfies UsageThreadBreakdown;
   });
+
+  // Summary and thread scans share one mutable per-file cache. Serialising them
+  // also folds a burst of page requests into warm follow-up reads rather than
+  // racing two cold parses and two cache writes.
+  const readThreadBreakdown = (input: UsageThreadBreakdownInput) =>
+    scanSemaphore.withPermits(1)(readThreadBreakdownUnlocked(input));
 
   return { readSummary, readThreadBreakdown } as const;
 });

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -36,6 +36,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../config.ts";
@@ -164,7 +165,9 @@ export const make = Effect.gen(function* () {
   const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
 
   const fileCache: ScanCache = new Map();
-  let cacheDirty = false;
+  let cacheRevision = 0;
+  let persistedCacheRevision = 0;
+  const cachePersistSemaphore = yield* Semaphore.make(1);
 
   const ratesCachePath = path.join(config.stateDir, "usage-model-rates.json");
   const scanCachePath = path.join(config.stateDir, "usage-scan-cache.json");
@@ -329,19 +332,19 @@ export const make = Effect.gen(function* () {
     }),
   );
 
-  const persistScanCache = Effect.fn("UsageService.persistScanCache")(function* () {
-    if (!cacheDirty) return;
-    // Cleared only after the write lands, so a failed persist is retried on
-    // the next scan instead of leaving disk permanently stale.
+  const persistScanCacheUnlocked = Effect.fn("UsageService.persistScanCacheUnlocked")(function* () {
+    if (cacheRevision === persistedCacheRevision) return;
+    const revision = cacheRevision;
     yield* encodeScanCacheFile(encodeScanCache(fileCache)).pipe(
       Effect.flatMap((serialized) => fileSystem.writeFileString(scanCachePath, serialized)),
       Effect.map(() => {
-        cacheDirty = false;
+        persistedCacheRevision = revision;
       }),
       // A cache we cannot write is a slower next start, not a failed read.
       Effect.catchCause(() => Effect.void),
     );
   });
+  const persistScanCache = () => cachePersistSemaphore.withPermits(1)(persistScanCacheUnlocked());
 
   /**
    * Parses one transcript, reusing the cached result when it is unchanged.
@@ -401,7 +404,7 @@ export const make = Effect.gen(function* () {
         tailRecords,
         position: parsed.position,
       });
-      cacheDirty = true;
+      cacheRevision += 1;
       return tailRecords.length === 0 ? records : dedupeWithinFile([...records, ...tailRecords]);
     });
 
@@ -558,7 +561,7 @@ export const make = Effect.gen(function* () {
       windowStartMs,
       retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
     });
-    if (pruned > 0) cacheDirty = true;
+    if (pruned > 0) cacheRevision += 1;
     yield* persistScanCache();
 
     const aggregated = aggregator.finish();
@@ -805,7 +808,7 @@ export const make = Effect.gen(function* () {
       windowStartMs,
       retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
     });
-    if (pruned > 0) cacheDirty = true;
+    if (pruned > 0) cacheRevision += 1;
     // A thread-only client must warm and bound the same durable cache as the
     // summary RPC, otherwise restarts repeat parsing and stale entries grow.
     yield* persistScanCache();

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -16,7 +16,6 @@ import * as NodeOS from "node:os";
 
 import {
   USAGE_CONTRACT_VERSION,
-  type ThreadId,
   type UsageProviderKind,
   type UsageSource,
   type UsageSummary,
@@ -43,7 +42,7 @@ import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
 import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
 import { ProjectionThreadRepository } from "../persistence/Services/ProjectionThreads.ts";
-import { ProviderSessionRuntimeRepository } from "../persistence/ProviderSessionRuntime.ts";
+import * as ProviderSessionRuntime from "../persistence/ProviderSessionRuntime.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
@@ -82,8 +81,8 @@ const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 const CACHE_RETENTION_DAYS = 90;
 
 /**
- * Named thread rows sent per breakdown request. A window can hold thousands
- * of sessions; lower-cost rows fold into provider/project remainders.
+ * Maximum rows sent per breakdown request, including grouped remainders. A
+ * window can hold thousands of sessions, so lower-cost rows fold together.
  */
 const THREAD_ROW_CAP = 40;
 
@@ -103,6 +102,11 @@ const encodeRatesCache = Schema.encodeEffect(
 const ScanCacheJson = Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>);
 const decodeScanCacheFile = Schema.decodeUnknownEffect(ScanCacheJson);
 const encodeScanCacheFile = Schema.encodeEffect(ScanCacheJson);
+
+export function isValidUsageDay(day: string): boolean {
+  const parsed = DateTime.make(`${day}T00:00:00Z`);
+  return Option.isSome(parsed) && DateTime.formatIso(parsed.value).slice(0, 10) === day;
+}
 
 export class UsageService extends Context.Service<
   UsageService,
@@ -157,7 +161,7 @@ export const make = Effect.gen(function* () {
   const hostEnvironment = yield* HostProcessEnvironment;
   const projectRepository = yield* ProjectionProjectRepository;
   const threadRepository = yield* ProjectionThreadRepository;
-  const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+  const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -696,11 +700,40 @@ export const make = Effect.gen(function* () {
       });
     }
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
-    if (Option.isNone(windowStart)) {
+    const windowEnd = DateTime.make(`${input.untilDay}T00:00:00Z`);
+    if (
+      Option.isNone(windowStart) ||
+      Option.isNone(windowEnd) ||
+      !isValidUsageDay(input.sinceDay) ||
+      !isValidUsageDay(input.untilDay)
+    ) {
       return yield* new UsageReadError({
         reason: "invalidWindow",
-        detail: `sinceDay '${input.sinceDay}' is not a valid date`,
+        detail: "Thread usage requires valid sinceDay and untilDay dates",
       });
+    }
+
+    let exactWindow: { readonly sinceTimeMs: number; readonly untilTimeMs: number } | null = null;
+    if (input.sinceTime !== undefined || input.untilTime !== undefined) {
+      const sinceTime =
+        input.sinceTime === undefined ? Option.none() : DateTime.make(input.sinceTime);
+      const untilTime =
+        input.untilTime === undefined ? Option.none() : DateTime.make(input.untilTime);
+      if (Option.isNone(sinceTime) || Option.isNone(untilTime)) {
+        return yield* new UsageReadError({
+          reason: "invalidWindow",
+          detail: "Thread usage requires both valid sinceTime and untilTime instants",
+        });
+      }
+      const sinceTimeMs = DateTime.toEpochMillis(sinceTime.value);
+      const untilTimeMs = DateTime.toEpochMillis(untilTime.value);
+      if (untilTimeMs <= sinceTimeMs) {
+        return yield* new UsageReadError({
+          reason: "invalidWindow",
+          detail: "Thread usage untilTime must be after sinceTime",
+        });
+      }
+      exactWindow = { sinceTimeMs, untilTimeMs };
     }
 
     const startedAtMs = yield* Clock.currentTimeMillis;
@@ -708,12 +741,14 @@ export const make = Effect.gen(function* () {
     yield* ensureScanCacheLoaded;
 
     const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
-    const windowStartMs = DateTime.toEpochMillis(windowStart.value) - MTIME_SLACK_MS;
+    const windowStartMs =
+      (exactWindow?.sinceTimeMs ?? DateTime.toEpochMillis(windowStart.value)) - MTIME_SLACK_MS;
 
     const accumulator = new ThreadUsageAccumulator({
       timeZone: input.timeZone,
       sinceDay: input.sinceDay,
       untilDay: input.untilDay,
+      ...exactWindow,
       rates,
       resolveProject: yield* resolveProjects(),
     });
@@ -726,6 +761,7 @@ export const make = Effect.gen(function* () {
     >();
 
     for (const { provider, dir, fileName } of dirs) {
+      if (input.providers !== undefined && !input.providers.includes(provider)) continue;
       const exists = yield* fileSystem
         .exists(dir)
         .pipe(Effect.catchCause(() => Effect.succeed(false)));
@@ -744,11 +780,10 @@ export const make = Effect.gen(function* () {
           const sessionKey =
             record.sessionId.length > 0
               ? `${provider}:${record.sessionId}`
-              : `${provider}:file:${file.path}`;
-          if (accumulator.add(record, { sessionKey, agentId }) && !isSubagent) {
-            if (!titleFiles.has(sessionKey)) {
-              titleFiles.set(sessionKey, { path: file.path, provider });
-            }
+              : `${provider}:file:${path.basename(path.dirname(file.path))}:${path.basename(file.path, ".jsonl")}`;
+          accumulator.add(record, { sessionKey, agentId });
+          if (!isSubagent && !titleFiles.has(sessionKey)) {
+            titleFiles.set(sessionKey, { path: file.path, provider });
           }
         }
       }
@@ -757,7 +792,7 @@ export const make = Effect.gen(function* () {
     const attribution = yield* loadThreadAttribution();
     const folded = foldThreadRows(accumulator.finish(), attribution, {
       cap: THREAD_ROW_CAP,
-      ...(input.project === undefined ? {} : { projectFilter: input.project }),
+      ...(input.projectKey === undefined ? {} : { projectFilter: input.projectKey }),
     });
 
     // Transcript titles only for retained unattributed rows. Grouped remainder
@@ -771,7 +806,9 @@ export const make = Effect.gen(function* () {
           source === undefined
             ? null
             : yield* Effect.promise(() => readTranscriptTitle(source.path, source.provider));
-        const fallback = row.key.startsWith("session:") ? shortSessionLabel(row.key) : row.key;
+        const fallback = row.key.startsWith("remainder:")
+          ? row.key
+          : shortSessionLabel(titleSessionKey);
         return { ...row, title: transcriptTitle ?? fallback };
       }),
       { concurrency: 8 },
@@ -793,9 +830,10 @@ export const make = Effect.gen(function* () {
   return { readSummary, readThreadBreakdown } as const;
 });
 
-/** `session:claude:8f14e45f-...` reads as `Session 8f14e45f`. */
-function shortSessionLabel(rowKey: string): string {
-  const sessionId = rowKey.slice(rowKey.lastIndexOf(":") + 1);
+/** `claude:8f14e45f-...` reads as `Session 8f14e45f`. */
+export function shortSessionLabel(sessionKey: string): string {
+  if (sessionKey.includes(":file:")) return "Untitled session";
+  const sessionId = sessionKey.slice(sessionKey.lastIndexOf(":") + 1);
   return sessionId.length > 8 ? `Session ${sessionId.slice(0, 8)}` : `Session ${sessionId}`;
 }
 

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -38,10 +38,11 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
+import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
-import { UsageAggregator } from "./usageAggregation.ts";
+import { makeProjectResolver, UsageAggregator } from "./usageAggregation.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
   listTranscriptFiles,
@@ -128,6 +129,7 @@ export const make = Effect.gen(function* () {
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
   const hostEnvironment = yield* HostProcessEnvironment;
+  const projectRepository = yield* ProjectionProjectRepository;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -240,6 +242,27 @@ export const make = Effect.gen(function* () {
         fileName: "updates.jsonl",
       },
     ];
+  });
+
+  /**
+   * Builds the cwd → project-title resolver for one scan.
+   *
+   * Projects are re-read every scan so a project created or renamed since the
+   * last refresh attributes correctly. A repository failure degrades to "no
+   * attribution" rather than failing the page.
+   */
+  const resolveProjects = Effect.fn("UsageService.resolveProjects")(function* () {
+    const projects = yield* projectRepository
+      .listAll()
+      .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
+    return makeProjectResolver(
+      projects.map((project) => ({
+        workspaceRoot: project.workspaceRoot,
+        title: project.title,
+        deleted: project.deletedAt !== null,
+      })),
+      path.sep,
+    );
   });
 
   /**
@@ -436,6 +459,7 @@ export const make = Effect.gen(function* () {
       resolution: input.resolution ?? "day",
       ...hourlyWindow,
       rates,
+      resolveProject: yield* resolveProjects(),
     });
 
     const sources: UsageSource[] = [];

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -287,15 +287,28 @@ export const make = Effect.gen(function* () {
     const projects = yield* projectRepository
       .listAll()
       .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
-    return makeProjectResolver(
-      projects.map((project) => ({
-        projectId: project.projectId,
-        workspaceRoot: project.workspaceRoot,
-        title: project.title,
-        deleted: project.deletedAt !== null,
-      })),
-      path.sep,
+    const projectRoots = yield* Effect.forEach(
+      projects,
+      Effect.fnUntraced(function* (project) {
+        const threads = yield* threadRepository
+          .listByProjectId({ projectId: project.projectId })
+          .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
+        const root = {
+          projectId: project.projectId,
+          workspaceRoot: project.workspaceRoot,
+          title: project.title,
+          deleted: project.deletedAt !== null,
+        };
+        return [
+          root,
+          ...threads.flatMap((thread) =>
+            thread.worktreePath === null ? [] : [{ ...root, workspaceRoot: thread.worktreePath }],
+          ),
+        ];
+      }),
+      { concurrency: 8 },
     );
+    return makeProjectResolver(projectRoots.flat(), path.sep);
   });
 
   /**
@@ -727,10 +740,11 @@ export const make = Effect.gen(function* () {
       }
       const sinceTimeMs = DateTime.toEpochMillis(sinceTime.value);
       const untilTimeMs = DateTime.toEpochMillis(untilTime.value);
-      if (untilTimeMs <= sinceTimeMs) {
+      const durationMs = untilTimeMs - sinceTimeMs;
+      if (durationMs <= 0 || durationMs > MAX_HOURLY_WINDOW_MS) {
         return yield* new UsageReadError({
           reason: "invalidWindow",
-          detail: "Thread usage untilTime must be after sinceTime",
+          detail: "Thread usage exact window must be greater than zero and at most 24 hours",
         });
       }
       exactWindow = { sinceTimeMs, untilTimeMs };
@@ -759,6 +773,8 @@ export const make = Effect.gen(function* () {
       string,
       { readonly path: string; readonly provider: UsageProviderKind }
     >();
+    const livePaths = new Set<string>();
+    const walkedRoots: string[] = [];
 
     for (const { provider, dir, fileName } of dirs) {
       if (input.providers !== undefined && !input.providers.includes(provider)) continue;
@@ -766,11 +782,13 @@ export const make = Effect.gen(function* () {
         .exists(dir)
         .pipe(Effect.catchCause(() => Effect.succeed(false)));
       if (!exists) continue;
+      walkedRoots.push(dir);
 
       const files = yield* Effect.promise(() =>
         listTranscriptFiles(dir, windowStartMs, fileName === undefined ? undefined : { fileName }),
       );
       for (const file of files) {
+        livePaths.add(file.path);
         const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
         if (records.length === 0) continue;
         const isSubagent =
@@ -789,8 +807,15 @@ export const make = Effect.gen(function* () {
       }
     }
 
-    // A thread-only client must warm the same durable cache as the summary
-    // RPC, otherwise every server restart repeats the full transcript parse.
+    const pruned = pruneScanCache(fileCache, {
+      livePaths,
+      walkedRoots,
+      windowStartMs,
+      retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    });
+    if (pruned > 0) cacheDirty = true;
+    // A thread-only client must warm and bound the same durable cache as the
+    // summary RPC, otherwise restarts repeat parsing and stale entries grow.
     yield* persistScanCache();
 
     const attribution = yield* loadThreadAttribution();

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -16,10 +16,13 @@ import * as NodeOS from "node:os";
 
 import {
   USAGE_CONTRACT_VERSION,
+  type ThreadId,
   type UsageProviderKind,
   type UsageSource,
   type UsageSummary,
   type UsageSummaryInput,
+  type UsageThreadBreakdown,
+  type UsageThreadBreakdownInput,
   UsageReadError,
 } from "@t3tools/contracts";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
@@ -39,6 +42,8 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
 import { ProjectionProjectRepository } from "../persistence/Services/ProjectionProjects.ts";
+import { ProjectionThreadRepository } from "../persistence/Services/ProjectionThreads.ts";
+import { ProviderSessionRuntimeRepository } from "../persistence/ProviderSessionRuntime.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
@@ -48,7 +53,9 @@ import {
   listTranscriptFiles,
   readDirectoryVolumeId,
   readTranscriptRecords,
+  readTranscriptTitle,
 } from "./usageTranscriptReader.ts";
+import { foldThreadRows, ThreadUsageAccumulator, type ThreadRef } from "./usageThreads.ts";
 import {
   decodeScanCache,
   dedupeWithinFile,
@@ -74,6 +81,12 @@ const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 /** Longest window the UI offers, plus slack. Older entries are pruned. */
 const CACHE_RETENTION_DAYS = 90;
 
+/**
+ * Thread rows sent per breakdown request. A window can hold thousands of
+ * sessions; everything past the cap is counted, not shipped.
+ */
+const THREAD_ROW_CAP = 40;
+
 /** On-disk shape of the rate snapshot. */
 const RatesCacheFile = Schema.Struct({
   fetchedAtMs: Schema.Number,
@@ -95,6 +108,9 @@ export class UsageService extends Context.Service<
   UsageService,
   {
     readonly readSummary: (input: UsageSummaryInput) => Effect.Effect<UsageSummary, UsageReadError>;
+    readonly readThreadBreakdown: (
+      input: UsageThreadBreakdownInput,
+    ) => Effect.Effect<UsageThreadBreakdown, UsageReadError>;
   }
 >()("t3/usage/UsageService") {}
 
@@ -119,6 +135,16 @@ export const layerTest = Layer.succeed(
         },
         scanDurationMs: 0,
       }),
+    readThreadBreakdown: (input) =>
+      Effect.succeed({
+        contractVersion: USAGE_CONTRACT_VERSION,
+        readAt: "1970-01-01T00:00:00.000Z",
+        sinceDay: input.sinceDay,
+        untilDay: input.untilDay,
+        rows: [],
+        truncatedRows: 0,
+        scanDurationMs: 0,
+      }),
   }),
 );
 
@@ -130,6 +156,8 @@ export const make = Effect.gen(function* () {
   const httpClient = yield* HttpClient.HttpClient;
   const hostEnvironment = yield* HostProcessEnvironment;
   const projectRepository = yield* ProjectionProjectRepository;
+  const threadRepository = yield* ProjectionThreadRepository;
+  const runtimeRepository = yield* ProviderSessionRuntimeRepository;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -595,7 +623,179 @@ export const make = Effect.gen(function* () {
     return yield* Deferred.await(deferred);
   });
 
-  return { readSummary } as const;
+  /**
+   * Maps each thread's current provider session to the thread, from resume
+   * cursors. Historic sessions of the same thread attribute through the
+   * worktree map instead; sessions that never ran through T3 Code stay
+   * session-granular.
+   */
+  const loadThreadAttribution = Effect.fn("UsageService.loadThreadAttribution")(function* () {
+    const sessionToThread = new Map<string, ThreadRef>();
+    const worktreeToThread = new Map<string, ThreadRef>();
+    const titles = new Map<string, string>();
+
+    const projects = yield* projectRepository
+      .listAll()
+      .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
+    const worktreeClaims = new Map<string, { ref: ThreadRef; shared: boolean }>();
+    for (const project of projects) {
+      const threads = yield* threadRepository
+        .listByProjectId({ projectId: project.projectId })
+        .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
+      for (const thread of threads) {
+        const title = thread.title.trim();
+        if (title.length > 0) titles.set(thread.threadId, title);
+        const worktree = thread.worktreePath?.trim() ?? "";
+        // The project root is not a dedicated worktree: interactive sessions
+        // run there too, and several threads usually share it.
+        if (worktree.length === 0 || worktree === project.workspaceRoot) continue;
+        const ref: ThreadRef = { threadId: thread.threadId, title: title || thread.threadId };
+        const claim = worktreeClaims.get(worktree);
+        if (claim === undefined) worktreeClaims.set(worktree, { ref, shared: false });
+        else claim.shared = true;
+      }
+    }
+    for (const [worktree, claim] of worktreeClaims) {
+      if (!claim.shared) worktreeToThread.set(worktree, claim.ref);
+    }
+
+    const runtimes = yield* runtimeRepository
+      .list()
+      .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
+    for (const runtime of runtimes) {
+      const cursor = runtime.resumeCursor;
+      if (typeof cursor !== "object" || cursor === null) continue;
+      const cursorRecord = cursor as Record<string, unknown>;
+      // Claude cursors carry the transcript uuid as `resume`; Codex cursors
+      // carry the rollout uuid as `threadId`. Other providers do not surface
+      // usage transcripts, so their cursors are irrelevant here.
+      const sessionId =
+        runtime.providerName === "claudeAgent"
+          ? cursorRecord["resume"]
+          : runtime.providerName === "codex"
+            ? cursorRecord["threadId"]
+            : undefined;
+      if (typeof sessionId !== "string" || sessionId.length === 0) continue;
+      const provider = runtime.providerName === "claudeAgent" ? "claude" : "codex";
+      sessionToThread.set(`${provider}:${sessionId}`, {
+        threadId: runtime.threadId,
+        title: titles.get(runtime.threadId) ?? runtime.threadId,
+      });
+    }
+
+    return { sessionToThread, worktreeToThread };
+  });
+
+  const readThreadBreakdown = Effect.fn("UsageService.readThreadBreakdown")(function* (
+    input: UsageThreadBreakdownInput,
+  ) {
+    if (input.sinceDay > input.untilDay) {
+      return yield* new UsageReadError({
+        reason: "invalidWindow",
+        detail: `sinceDay '${input.sinceDay}' is after untilDay '${input.untilDay}'`,
+      });
+    }
+    const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
+    if (Option.isNone(windowStart)) {
+      return yield* new UsageReadError({
+        reason: "invalidWindow",
+        detail: `sinceDay '${input.sinceDay}' is not a valid date`,
+      });
+    }
+
+    const startedAtMs = yield* Clock.currentTimeMillis;
+    yield* ensureRates();
+    yield* ensureScanCacheLoaded;
+
+    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
+    const windowStartMs = DateTime.toEpochMillis(windowStart.value) - MTIME_SLACK_MS;
+
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: input.timeZone,
+      sinceDay: input.sinceDay,
+      untilDay: input.untilDay,
+      rates,
+      resolveProject: yield* resolveProjects(),
+    });
+
+    // Preferred transcript per session for title extraction: the main file,
+    // never a subagent's.
+    const titleFiles = new Map<
+      string,
+      { readonly path: string; readonly provider: UsageProviderKind }
+    >();
+
+    for (const { provider, dir, fileName } of dirs) {
+      const exists = yield* fileSystem
+        .exists(dir)
+        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      if (!exists) continue;
+
+      const files = yield* Effect.promise(() =>
+        listTranscriptFiles(dir, windowStartMs, fileName === undefined ? undefined : { fileName }),
+      );
+      for (const file of files) {
+        const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        if (records.length === 0) continue;
+        const isSubagent =
+          provider === "claude" && path.basename(path.dirname(file.path)) === "subagents";
+        const agentId = isSubagent ? path.basename(file.path, ".jsonl") : null;
+        for (const record of records) {
+          const sessionKey =
+            record.sessionId.length > 0
+              ? `${provider}:${record.sessionId}`
+              : `${provider}:file:${file.path}`;
+          if (accumulator.add(record, { sessionKey, agentId }) && !isSubagent) {
+            if (!titleFiles.has(sessionKey)) {
+              titleFiles.set(sessionKey, { path: file.path, provider });
+            }
+          }
+        }
+      }
+    }
+
+    const attribution = yield* loadThreadAttribution();
+    const folded = foldThreadRows(accumulator.finish(), attribution, {
+      cap: THREAD_ROW_CAP,
+      ...(input.project === undefined ? {} : { projectFilter: input.project }),
+    });
+
+    // Transcript titles only for unattributed rows that survived the cap.
+    const rows = yield* Effect.forEach(
+      folded.rows,
+      Effect.fnUntraced(function* ({ titleSessionKey, ...row }) {
+        if (row.title !== null) return { ...row, title: row.title };
+        const source = titleFiles.get(titleSessionKey);
+        const transcriptTitle =
+          source === undefined
+            ? null
+            : yield* Effect.promise(() => readTranscriptTitle(source.path, source.provider));
+        const fallback = row.key.startsWith("session:") ? shortSessionLabel(row.key) : row.key;
+        return { ...row, title: transcriptTitle ?? fallback };
+      }),
+      { concurrency: 8 },
+    );
+
+    const readAt = yield* DateTime.now;
+    const finishedAtMs = yield* Clock.currentTimeMillis;
+    return {
+      contractVersion: USAGE_CONTRACT_VERSION,
+      readAt: DateTime.formatIso(readAt),
+      sinceDay: input.sinceDay,
+      untilDay: input.untilDay,
+      rows,
+      truncatedRows: folded.truncatedRows,
+      scanDurationMs: Math.max(0, finishedAtMs - startedAtMs),
+    } satisfies UsageThreadBreakdown;
+  });
+
+  return { readSummary, readThreadBreakdown } as const;
 });
+
+/** `session:claude:8f14e45f-...` reads as `Session 8f14e45f`. */
+function shortSessionLabel(rowKey: string): string {
+  const sessionId = rowKey.slice(rowKey.lastIndexOf(":") + 1);
+  return sessionId.length > 8 ? `Session ${sessionId.slice(0, 8)}` : `Session ${sessionId}`;
+}
 
 export const layer = Layer.effect(UsageService, make);

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -789,6 +789,10 @@ export const make = Effect.gen(function* () {
       }
     }
 
+    // A thread-only client must warm the same durable cache as the summary
+    // RPC, otherwise every server restart repeats the full transcript parse.
+    yield* persistScanCache();
+
     const attribution = yield* loadThreadAttribution();
     const folded = foldThreadRows(accumulator.finish(), attribution, {
       cap: THREAD_ROW_CAP,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -369,7 +369,7 @@ export const make = Effect.gen(function* () {
       ) {
         return cached.tailRecords.length === 0
           ? cached.records
-          : [...cached.records, ...cached.tailRecords];
+          : dedupeWithinFile([...cached.records, ...cached.tailRecords]);
       }
 
       // Only a strictly grown file may resume. Same size with a new mtime, or
@@ -387,13 +387,11 @@ export const make = Effect.gen(function* () {
       if (parsed === null) return [];
 
       // Stored already de-duplicated within the file, which is 99% of all
-      // duplicates. The aggregator still runs the cross-file dedupe pass. One
-      // seen set spans the cached base, the new lines, and the tail so a
-      // resumed parse dedupes exactly like a full one.
+      // duplicates. The final snapshot wins so a resumed Claude parse can
+      // replace an earlier progressive snapshot from the cached base.
       const base = parsed.resumed && cached !== undefined ? cached.records : [];
-      const seen = new Set<string>();
-      const records = dedupeWithinFile([...base, ...parsed.records], seen);
-      const tailRecords = dedupeWithinFile(parsed.tailRecords, seen);
+      const records = dedupeWithinFile([...base, ...parsed.records]);
+      const tailRecords = dedupeWithinFile(parsed.tailRecords);
 
       fileCache.set(filePath, {
         size,
@@ -404,7 +402,7 @@ export const make = Effect.gen(function* () {
         position: parsed.position,
       });
       cacheDirty = true;
-      return tailRecords.length === 0 ? records : [...records, ...tailRecords];
+      return tailRecords.length === 0 ? records : dedupeWithinFile([...records, ...tailRecords]);
     });
 
   /** One provider directory's walk and parse, before rates are involved. */
@@ -529,10 +527,6 @@ export const make = Effect.gen(function* () {
       walkedRoots.push(dir);
       let scannedFiles = 0;
       let skippedFiles = 0;
-      // Distinct per directory. Buckets carry per-cell session counts, but a
-      // session spans days and models, so clients total this figure instead.
-      const sessionIds = new Set<string>();
-
       for (const file of files) {
         livePaths.add(file.path);
         if (file.records.length === 0) {
@@ -541,11 +535,7 @@ export const make = Effect.gen(function* () {
         }
         scannedFiles += 1;
         for (const record of file.records) {
-          // Only sessions that contributed in-window count: the mtime slack
-          // admits boundary files whose records fall outside the range.
-          if (aggregator.add(record) && record.sessionId.length > 0) {
-            sessionIds.add(record.sessionId);
-          }
+          aggregator.add(record);
         }
       }
 
@@ -555,7 +545,9 @@ export const make = Effect.gen(function* () {
         scannedFiles,
         skippedFiles,
         malformedRecords: 0,
-        distinctSessions: sessionIds.size,
+        // Read from the settled records so a progressive snapshot replacement
+        // cannot leave the source count attached to the superseded session.
+        distinctSessions: aggregator.distinctSessions(provider),
         message: null,
       });
     }

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -257,6 +257,7 @@ export const make = Effect.gen(function* () {
       .pipe(Effect.catchCause(() => Effect.succeed<readonly never[]>([])));
     return makeProjectResolver(
       projects.map((project) => ({
+        projectId: project.projectId,
         workspaceRoot: project.workspaceRoot,
         title: project.title,
         deleted: project.deletedAt !== null,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -82,8 +82,8 @@ const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 const CACHE_RETENTION_DAYS = 90;
 
 /**
- * Thread rows sent per breakdown request. A window can hold thousands of
- * sessions; everything past the cap is counted, not shipped.
+ * Named thread rows sent per breakdown request. A window can hold thousands
+ * of sessions; lower-cost rows fold into provider/project remainders.
  */
 const THREAD_ROW_CAP = 40;
 
@@ -760,7 +760,8 @@ export const make = Effect.gen(function* () {
       ...(input.project === undefined ? {} : { projectFilter: input.project }),
     });
 
-    // Transcript titles only for unattributed rows that survived the cap.
+    // Transcript titles only for retained unattributed rows. Grouped remainder
+    // rows already carry a generated title.
     const rows = yield* Effect.forEach(
       folded.rows,
       Effect.fnUntraced(function* ({ titleSessionKey, ...row }) {

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { UsageAggregator } from "./usageAggregation.ts";
+import { makeProjectResolver, UsageAggregator } from "./usageAggregation.ts";
 import type { RateTable } from "./usagePricing.ts";
 import type { UsageRecord } from "./usageTranscripts.ts";
 
@@ -23,6 +23,7 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
     timestampMs: Date.parse("2026-08-07T04:05:13.944Z"),
     model: "claude-fable-5",
     sessionId: "session-a",
+    cwd: "",
     totals: {
       uncachedInputTokens: 100,
       cachedInputTokens: 1000,
@@ -92,6 +93,27 @@ describe("UsageAggregator", () => {
 
     expect(result.duplicatesDropped).toBe(0);
     expect(result.buckets[0]?.totals.outputTokens).toBe(100);
+  });
+
+  it("splits buckets by resolved project and omits the field when unresolved", () => {
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd === "/work/app" ? "App" : ""),
+    });
+    aggregator.add(record({ cwd: "/work/app" }));
+    aggregator.add(record({ cwd: "/work/app" }));
+    aggregator.add(record({ cwd: "/elsewhere" }));
+    const { buckets } = aggregator.finish();
+
+    // Same day, provider and model, so only the project splits the cell.
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0]?.project).toBeUndefined();
+    expect(buckets[0]?.records).toBe(1);
+    expect(buckets[1]?.project).toBe("App");
+    expect(buckets[1]?.records).toBe(2);
   });
 
   it("buckets by the day in the requested time zone", () => {
@@ -200,5 +222,40 @@ describe("UsageAggregator", () => {
     ]);
 
     expect(result.buckets).toHaveLength(3);
+  });
+});
+
+describe("makeProjectResolver", () => {
+  const resolver = makeProjectResolver(
+    [
+      { workspaceRoot: "/work/app", title: "App", deleted: false },
+      { workspaceRoot: "/work/app/vendored", title: "Vendored", deleted: false },
+      { workspaceRoot: "/work/legacy", title: "Legacy Was Deleted", deleted: true },
+      { workspaceRoot: "/work/legacy", title: "Legacy", deleted: false },
+      { workspaceRoot: "/work/untitled", title: "   ", deleted: false },
+    ],
+    "/",
+  );
+
+  it("matches the root itself and any path under it", () => {
+    expect(resolver("/work/app")).toBe("App");
+    expect(resolver("/work/app/src/deep")).toBe("App");
+  });
+
+  it("requires a path-segment boundary, not a bare prefix", () => {
+    expect(resolver("/work/app-sibling")).toBe("");
+  });
+
+  it("prefers the deepest matching root", () => {
+    expect(resolver("/work/app/vendored/lib")).toBe("Vendored");
+  });
+
+  it("prefers a live project over a deleted one sharing the root", () => {
+    expect(resolver("/work/legacy/src")).toBe("Legacy");
+  });
+
+  it("never attributes to a blank title or an empty cwd", () => {
+    expect(resolver("/work/untitled/src")).toBe("");
+    expect(resolver("")).toBe("");
   });
 });

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -77,7 +77,7 @@ describe("UsageAggregator", () => {
     ).toThrow("requires exact time bounds");
   });
 
-  it("keeps only the first record for a repeated dedupe key", () => {
+  it("counts only one record for a repeated dedupe key", () => {
     const result = aggregate([
       record({ dedupeKey: "msg_1:" }),
       record({ dedupeKey: "msg_1:" }),
@@ -104,6 +104,23 @@ describe("UsageAggregator", () => {
 
     expect(result.buckets[0]?.records).toBe(1);
     expect(result.buckets[0]?.totals.outputTokens).toBe(310);
+  });
+
+  it("holds records newer than the request-start cutoff for the next refresh", () => {
+    const cutoffTimeMs = Date.parse("2026-08-07T04:05:14.000Z");
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      cutoffTimeMs,
+      rates,
+    });
+    aggregator.add(record({ timestampMs: cutoffTimeMs }));
+    aggregator.add(record({ timestampMs: cutoffTimeMs + 1 }));
+
+    const result = aggregator.finish();
+    expect(result.buckets[0]?.records).toBe(1);
+    expect(result.outOfWindow).toBe(1);
   });
 
   it("still sums records that carry no dedupe key", () => {

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -1,3 +1,4 @@
+import { ProjectId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 
 import { makeProjectResolver, UsageAggregator } from "./usageAggregation.ts";
@@ -96,12 +97,13 @@ describe("UsageAggregator", () => {
   });
 
   it("splits buckets by resolved project and omits the field when unresolved", () => {
+    const projectId = ProjectId.make("project-app");
     const aggregator = new UsageAggregator({
       timeZone: "UTC",
       sinceDay: "2026-08-01",
       untilDay: "2026-08-31",
       rates,
-      resolveProject: (cwd) => (cwd === "/work/app" ? "App" : ""),
+      resolveProject: (cwd) => (cwd === "/work/app" ? { projectId, title: "App" } : null),
     });
     aggregator.add(record({ cwd: "/work/app" }));
     aggregator.add(record({ cwd: "/work/app" }));
@@ -113,6 +115,7 @@ describe("UsageAggregator", () => {
     expect(buckets[0]?.project).toBeUndefined();
     expect(buckets[0]?.records).toBe(1);
     expect(buckets[1]?.project).toBe("App");
+    expect(buckets[1]?.projectId).toBe(projectId);
     expect(buckets[1]?.records).toBe(2);
   });
 
@@ -226,36 +229,74 @@ describe("UsageAggregator", () => {
 });
 
 describe("makeProjectResolver", () => {
+  const appId = ProjectId.make("project-app");
+  const vendoredId = ProjectId.make("project-vendored");
+  const legacyDeletedId = ProjectId.make("project-legacy-deleted");
+  const legacyId = ProjectId.make("project-legacy");
+  const untitledId = ProjectId.make("project-untitled");
   const resolver = makeProjectResolver(
     [
-      { workspaceRoot: "/work/app", title: "App", deleted: false },
-      { workspaceRoot: "/work/app/vendored", title: "Vendored", deleted: false },
-      { workspaceRoot: "/work/legacy", title: "Legacy Was Deleted", deleted: true },
-      { workspaceRoot: "/work/legacy", title: "Legacy", deleted: false },
-      { workspaceRoot: "/work/untitled", title: "   ", deleted: false },
+      { projectId: appId, workspaceRoot: "/work/app", title: "App", deleted: false },
+      {
+        projectId: vendoredId,
+        workspaceRoot: "/work/app/vendored",
+        title: "Vendored",
+        deleted: false,
+      },
+      {
+        projectId: legacyDeletedId,
+        workspaceRoot: "/work/legacy",
+        title: "Legacy Was Deleted",
+        deleted: true,
+      },
+      {
+        projectId: legacyId,
+        workspaceRoot: "/work/legacy",
+        title: "Legacy",
+        deleted: false,
+      },
+      {
+        projectId: untitledId,
+        workspaceRoot: "/work/untitled",
+        title: "   ",
+        deleted: false,
+      },
     ],
     "/",
   );
 
   it("matches the root itself and any path under it", () => {
-    expect(resolver("/work/app")).toBe("App");
-    expect(resolver("/work/app/src/deep")).toBe("App");
+    expect(resolver("/work/app")).toEqual({ projectId: appId, title: "App" });
+    expect(resolver("/work/app/src/deep")).toEqual({ projectId: appId, title: "App" });
   });
 
   it("requires a path-segment boundary, not a bare prefix", () => {
-    expect(resolver("/work/app-sibling")).toBe("");
+    expect(resolver("/work/app-sibling")).toBeNull();
   });
 
   it("prefers the deepest matching root", () => {
-    expect(resolver("/work/app/vendored/lib")).toBe("Vendored");
+    expect(resolver("/work/app/vendored/lib")).toEqual({
+      projectId: vendoredId,
+      title: "Vendored",
+    });
   });
 
   it("prefers a live project over a deleted one sharing the root", () => {
-    expect(resolver("/work/legacy/src")).toBe("Legacy");
+    expect(resolver("/work/legacy/src")).toEqual({ projectId: legacyId, title: "Legacy" });
   });
 
   it("never attributes to a blank title or an empty cwd", () => {
-    expect(resolver("/work/untitled/src")).toBe("");
-    expect(resolver("")).toBe("");
+    expect(resolver("/work/untitled/src")).toBeNull();
+    expect(resolver("")).toBeNull();
+  });
+
+  it("matches descendants when the project root is the filesystem root", () => {
+    const rootId = ProjectId.make("project-root");
+    const rootResolver = makeProjectResolver(
+      [{ projectId: rootId, workspaceRoot: "/", title: "Root", deleted: false }],
+      "/",
+    );
+
+    expect(rootResolver("/work/app")).toEqual({ projectId: rootId, title: "Root" });
   });
 });

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -13,6 +13,7 @@ const rates: RateTable = new Map([
       outputCostPerToken: 5e-5,
       cacheReadCostPerToken: 1e-6,
       cacheCreationCostPerToken: 1.25e-5,
+      cacheCreation1hCostPerToken: 2e-5,
     },
   ],
 ]);
@@ -87,6 +88,22 @@ describe("UsageAggregator", () => {
     expect(result.buckets).toHaveLength(1);
     expect(result.buckets[0]?.records).toBe(1);
     expect(result.buckets[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("uses the final complete snapshot for a repeated dedupe key", () => {
+    const result = aggregate([
+      record({
+        dedupeKey: "msg_partial:",
+        totals: { ...record().totals, outputTokens: 1 },
+      }),
+      record({
+        dedupeKey: "msg_partial:",
+        totals: { ...record().totals, outputTokens: 310 },
+      }),
+    ]);
+
+    expect(result.buckets[0]?.records).toBe(1);
+    expect(result.buckets[0]?.totals.outputTokens).toBe(310);
   });
 
   it("still sums records that carry no dedupe key", () => {
@@ -192,6 +209,21 @@ describe("UsageAggregator", () => {
     expect(result.buckets[0]?.cacheWriteUsd).toBeCloseTo(1.25e-4, 12);
   });
 
+  it("prices one-hour cache writes at their separate rate", () => {
+    const result = aggregate([
+      record({
+        totals: {
+          ...record().totals,
+          cacheCreationTokens: 30,
+          cacheCreation5mTokens: 10,
+          cacheCreation1hTokens: 20,
+        },
+      }),
+    ]);
+
+    expect(result.buckets[0]?.cacheWriteUsd).toBeCloseTo(10 * 1.25e-5 + 20 * 2e-5, 12);
+  });
+
   it("distinguishes unavailable cache-write cost from write-free usage", () => {
     const unpriced = aggregate([record({ model: "kimi-k3" })]);
     expect(unpriced.buckets[0]?.cacheWriteUsd).toBeUndefined();
@@ -234,7 +266,7 @@ describe("UsageAggregator", () => {
     expect(result.buckets).toHaveLength(0);
   });
 
-  it("reports whether a record contributed", () => {
+  it("reports whether a record falls in the window", () => {
     const aggregator = new UsageAggregator({
       timeZone: "UTC",
       sinceDay: "2026-08-01",
@@ -243,8 +275,39 @@ describe("UsageAggregator", () => {
     });
 
     expect(aggregator.add(record({ dedupeKey: "msg_1:" }))).toBe(true);
-    expect(aggregator.add(record({ dedupeKey: "msg_1:" }))).toBe(false);
+    expect(aggregator.add(record({ dedupeKey: "msg_1:" }))).toBe(true);
     expect(aggregator.add(record({ timestampMs: Date.parse("2026-07-01T12:00:00Z") }))).toBe(false);
+  });
+
+  it("counts sessions from the final progressive snapshot", () => {
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+    });
+
+    aggregator.add(record({ dedupeKey: "msg_1:", sessionId: "partial-session" }));
+    aggregator.add(record({ dedupeKey: "msg_1:", sessionId: "final-session" }));
+
+    expect(aggregator.distinctSessions("claude")).toBe(1);
+    expect(aggregator.finish().buckets[0]?.sessions).toBe(1);
+  });
+
+  it("applies the window to the final progressive snapshot", () => {
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+    });
+
+    aggregator.add(record({ dedupeKey: "msg_1:" }));
+    aggregator.add(
+      record({ dedupeKey: "msg_1:", timestampMs: Date.parse("2026-09-01T00:00:00Z") }),
+    );
+
+    expect(aggregator.finish()).toMatchObject({ buckets: [], outOfWindow: 1 });
   });
 
   it("separates providers and models into their own buckets", () => {

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -96,7 +96,7 @@ describe("UsageAggregator", () => {
     expect(result.buckets[0]?.totals.outputTokens).toBe(100);
   });
 
-  it("splits buckets by resolved project and omits the field when unresolved", () => {
+  it("distinguishes project, outside, and unknown attribution", () => {
     const projectId = ProjectId.make("project-app");
     const aggregator = new UsageAggregator({
       timeZone: "UTC",
@@ -108,15 +108,24 @@ describe("UsageAggregator", () => {
     aggregator.add(record({ cwd: "/work/app" }));
     aggregator.add(record({ cwd: "/work/app" }));
     aggregator.add(record({ cwd: "/elsewhere" }));
+    aggregator.add(record({ cwd: "", model: "grok-4" }));
     const { buckets } = aggregator.finish();
 
-    // Same day, provider and model, so only the project splits the cell.
-    expect(buckets).toHaveLength(2);
-    expect(buckets[0]?.project).toBeUndefined();
-    expect(buckets[0]?.records).toBe(1);
-    expect(buckets[1]?.project).toBe("App");
-    expect(buckets[1]?.projectId).toBe(projectId);
-    expect(buckets[1]?.records).toBe(2);
+    expect(buckets).toHaveLength(3);
+    const outside = buckets.find((bucket) => bucket.projectAttribution === "outside");
+    expect(outside?.project).toBeUndefined();
+    expect(outside?.records).toBe(1);
+    const project = buckets.find((bucket) => bucket.projectAttribution === "project");
+    expect(project?.project).toBe("App");
+    expect(project?.projectId).toBe(projectId);
+    expect(project?.records).toBe(2);
+    expect(buckets.some((bucket) => bucket.projectAttribution === "unknown")).toBe(true);
+  });
+
+  it("marks every bucket unknown when no project resolver is available", () => {
+    const result = aggregate([record({ cwd: "/work/app" })]);
+
+    expect(result.buckets[0]?.projectAttribution).toBe("unknown");
   });
 
   it("buckets by the day in the requested time zone", () => {

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -188,6 +188,26 @@ describe("UsageAggregator", () => {
     // 100*1e-5 + 1000*1e-6 + 10*1.25e-5 + 50*5e-5
     expect(result.buckets[0]?.costUsd).toBeCloseTo(0.004625, 9);
     expect(result.buckets[0]?.costSource).toBe("modelPriced");
+    // Cache writes priced at the cache-write rate: 10 * 1.25e-5.
+    expect(result.buckets[0]?.cacheWriteUsd).toBeCloseTo(1.25e-4, 12);
+  });
+
+  it("reports zero cache-write cost for unpriced models and write-free usage", () => {
+    const unpriced = aggregate([record({ model: "kimi-k3" })]);
+    expect(unpriced.buckets[0]?.cacheWriteUsd).toBe(0);
+
+    const writeFree = aggregate([
+      record({
+        totals: {
+          uncachedInputTokens: 100,
+          cachedInputTokens: 1000,
+          cacheCreationTokens: 0,
+          outputTokens: 50,
+          reasoningTokens: 0,
+        },
+      }),
+    ]);
+    expect(writeFree.buckets[0]?.cacheWriteUsd).toBe(0);
   });
 
   it("counts tokens but not cost for a model with no rate", () => {

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -192,9 +192,9 @@ describe("UsageAggregator", () => {
     expect(result.buckets[0]?.cacheWriteUsd).toBeCloseTo(1.25e-4, 12);
   });
 
-  it("reports zero cache-write cost for unpriced models and write-free usage", () => {
+  it("distinguishes unavailable cache-write cost from write-free usage", () => {
     const unpriced = aggregate([record({ model: "kimi-k3" })]);
-    expect(unpriced.buckets[0]?.cacheWriteUsd).toBe(0);
+    expect(unpriced.buckets[0]?.cacheWriteUsd).toBeUndefined();
 
     const writeFree = aggregate([
       record({
@@ -224,6 +224,7 @@ describe("UsageAggregator", () => {
 
     expect(result.buckets[0]?.costUsd).toBe(1.25);
     expect(result.buckets[0]?.costSource).toBe("providerReported");
+    expect(result.buckets[0]?.cacheWriteUsd).toBeUndefined();
   });
 
   it("drops records outside the window", () => {

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -1,7 +1,7 @@
 // @effect-diagnostics globalDate:off
 /**
- * Folds parsed transcript records into `(day, hourStart?, provider, model)`
- * buckets.
+ * Folds parsed transcript records into `(day, hourStart?, project, provider,
+ * model)` buckets.
  *
  * `Intl.DateTimeFormat` is the only reliable way to resolve a wall-clock day in
  * an arbitrary IANA zone, and it takes a `Date`. That is why the raw `Date`
@@ -46,6 +46,54 @@ export function makeDayFormatter(timeZone: string): (timestampMs: number) => str
 
 const HOUR_MS = 60 * 60 * 1000;
 
+export interface ProjectRoot {
+  readonly workspaceRoot: string;
+  readonly title: string;
+  /** Soft-deleted projects still attribute: the spend happened while they existed. */
+  readonly deleted: boolean;
+}
+
+/**
+ * Builds the cwd → project-title resolver used by {@link AggregateOptions}.
+ *
+ * Deepest root wins, so a session in a project nested inside another
+ * attributes to the inner one. Live projects outrank deleted ones sharing a
+ * root, since deleting and re-creating a project leaves both rows. Results are
+ * memoised per cwd; a scan sees few distinct cwds but many records.
+ */
+export function makeProjectResolver(
+  projects: readonly ProjectRoot[],
+  separator: string,
+): (cwd: string) => string {
+  const roots = projects
+    .map((project) => ({
+      root:
+        project.workspaceRoot.length > 1 && project.workspaceRoot.endsWith(separator)
+          ? project.workspaceRoot.slice(0, -1)
+          : project.workspaceRoot,
+      title: project.title.trim(),
+      deleted: project.deleted,
+    }))
+    .filter((entry) => entry.root.length > 0 && entry.title.length > 0)
+    .sort((a, b) => b.root.length - a.root.length || Number(a.deleted) - Number(b.deleted));
+
+  const byCwd = new Map<string, string>();
+  return (cwd) => {
+    if (cwd.length === 0) return "";
+    const cached = byCwd.get(cwd);
+    if (cached !== undefined) return cached;
+    let resolved = "";
+    for (const { root, title } of roots) {
+      if (cwd === root || (cwd.startsWith(root) && cwd[root.length] === separator)) {
+        resolved = title;
+        break;
+      }
+    }
+    byCwd.set(cwd, resolved);
+    return resolved;
+  };
+}
+
 interface MutableBucket {
   totals: UsageTokenTotals;
   costUsd: number;
@@ -64,6 +112,12 @@ export interface AggregateOptions {
   readonly resolution?: UsageResolution;
   readonly sinceTimeMs?: number;
   readonly untilTimeMs?: number;
+  /**
+   * Maps a record's working directory to the title of the project it ran in,
+   * or `""` when it ran outside every project. Omitting it leaves every bucket
+   * unattributed.
+   */
+  readonly resolveProject?: (cwd: string) => string;
 }
 
 export interface AggregateResult {
@@ -145,7 +199,12 @@ export class UsageAggregator {
             this.#hourlyWindow.sinceTimeMs +
               Math.floor((record.timestampMs - this.#hourlyWindow.sinceTimeMs) / HOUR_MS) * HOUR_MS,
           ).toISOString();
-    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.model}`;
+    // The key is parsed back apart on NUL, which project titles must not carry.
+    const project =
+      this.#options.resolveProject === undefined
+        ? ""
+        : this.#options.resolveProject(record.cwd).replaceAll("\u0000", "");
+    const key = `${day}\u0000${hourStart}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
     let bucket = this.#buckets.get(key);
     if (bucket === undefined) {
       bucket = {
@@ -180,10 +239,12 @@ export class UsageAggregator {
   finish(): AggregateResult {
     const buckets: UsageBucket[] = [];
     for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", provider = "", model = ""] = key.split("\u0000");
+      const [day = "", hourStart = "", project = "", provider = "", model = ""] =
+        key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
+        ...(project === "" ? {} : { project }),
         provider: provider as UsageBucket["provider"],
         model,
         totals: bucket.totals,
@@ -200,6 +261,7 @@ export class UsageAggregator {
       (a, b) =>
         a.day.localeCompare(b.day) ||
         (a.hourStart ?? "").localeCompare(b.hourStart ?? "") ||
+        (a.project ?? "").localeCompare(b.project ?? "") ||
         a.provider.localeCompare(b.provider) ||
         a.model.localeCompare(b.model),
     );

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -129,6 +129,8 @@ export interface AggregateOptions {
   readonly resolution?: UsageResolution;
   readonly sinceTimeMs?: number;
   readonly untilTimeMs?: number;
+  /** Request-start ceiling. Records written later wait for the next refresh. */
+  readonly cutoffTimeMs?: number;
   /**
    * Maps a record's working directory to the project it ran in, or `null` when
    * it ran outside every project. Omitting it leaves every bucket unattributed.
@@ -194,6 +196,12 @@ export class UsageAggregator {
   }
 
   #isInWindow(record: UsageRecord): boolean {
+    if (
+      this.#options.cutoffTimeMs !== undefined &&
+      record.timestampMs > this.#options.cutoffTimeMs
+    ) {
+      return false;
+    }
     if (
       this.#hourlyWindow !== null &&
       (record.timestampMs < this.#hourlyWindow.sinceTimeMs ||

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -12,7 +12,13 @@
  *
  * @module usageAggregation
  */
-import type { UsageBucket, UsageDay, UsageResolution, UsageTokenTotals } from "@t3tools/contracts";
+import type {
+  ProjectId,
+  UsageBucket,
+  UsageDay,
+  UsageResolution,
+  UsageTokenTotals,
+} from "@t3tools/contracts";
 
 import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
 import { cacheSavingsUsd, priceUsage, type RateTable } from "./usagePricing.ts";
@@ -47,14 +53,20 @@ export function makeDayFormatter(timeZone: string): (timestampMs: number) => str
 const HOUR_MS = 60 * 60 * 1000;
 
 export interface ProjectRoot {
+  readonly projectId: ProjectId;
   readonly workspaceRoot: string;
   readonly title: string;
   /** Soft-deleted projects still attribute: the spend happened while they existed. */
   readonly deleted: boolean;
 }
 
+export interface ProjectAttribution {
+  readonly projectId: ProjectId;
+  readonly title: string;
+}
+
 /**
- * Builds the cwd → project-title resolver used by {@link AggregateOptions}.
+ * Builds the cwd → project resolver used by {@link AggregateOptions}.
  *
  * Deepest root wins, so a session in a project nested inside another
  * attributes to the inner one. Live projects outrank deleted ones sharing a
@@ -64,9 +76,10 @@ export interface ProjectRoot {
 export function makeProjectResolver(
   projects: readonly ProjectRoot[],
   separator: string,
-): (cwd: string) => string {
+): (cwd: string) => ProjectAttribution | null {
   const roots = projects
     .map((project) => ({
+      projectId: project.projectId,
       root:
         project.workspaceRoot.length > 1 && project.workspaceRoot.endsWith(separator)
           ? project.workspaceRoot.slice(0, -1)
@@ -77,15 +90,17 @@ export function makeProjectResolver(
     .filter((entry) => entry.root.length > 0 && entry.title.length > 0)
     .sort((a, b) => b.root.length - a.root.length || Number(a.deleted) - Number(b.deleted));
 
-  const byCwd = new Map<string, string>();
+  const byCwd = new Map<string, ProjectAttribution | null>();
   return (cwd) => {
-    if (cwd.length === 0) return "";
-    const cached = byCwd.get(cwd);
-    if (cached !== undefined) return cached;
-    let resolved = "";
-    for (const { root, title } of roots) {
-      if (cwd === root || (cwd.startsWith(root) && cwd[root.length] === separator)) {
-        resolved = title;
+    if (cwd.length === 0) return null;
+    if (byCwd.has(cwd)) return byCwd.get(cwd) ?? null;
+    let resolved: ProjectAttribution | null = null;
+    for (const { projectId, root, title } of roots) {
+      if (
+        cwd === root ||
+        (root === separator ? cwd.startsWith(separator) : cwd.startsWith(`${root}${separator}`))
+      ) {
+        resolved = { projectId, title };
         break;
       }
     }
@@ -113,11 +128,10 @@ export interface AggregateOptions {
   readonly sinceTimeMs?: number;
   readonly untilTimeMs?: number;
   /**
-   * Maps a record's working directory to the title of the project it ran in,
-   * or `""` when it ran outside every project. Omitting it leaves every bucket
-   * unattributed.
+   * Maps a record's working directory to the project it ran in, or `null` when
+   * it ran outside every project. Omitting it leaves every bucket unattributed.
    */
-  readonly resolveProject?: (cwd: string) => string;
+  readonly resolveProject?: (cwd: string) => ProjectAttribution | null;
 }
 
 export interface AggregateResult {
@@ -199,12 +213,11 @@ export class UsageAggregator {
             this.#hourlyWindow.sinceTimeMs +
               Math.floor((record.timestampMs - this.#hourlyWindow.sinceTimeMs) / HOUR_MS) * HOUR_MS,
           ).toISOString();
-    // The key is parsed back apart on NUL, which project titles must not carry.
-    const project =
-      this.#options.resolveProject === undefined
-        ? ""
-        : this.#options.resolveProject(record.cwd).replaceAll("\u0000", "");
-    const key = `${day}\u0000${hourStart}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
+    // The key is parsed back apart on NUL, which project fields must not carry.
+    const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
+    const projectId = resolvedProject?.projectId.replaceAll("\u0000", "") ?? "";
+    const project = resolvedProject?.title.replaceAll("\u0000", "") ?? "";
+    const key = `${day}\u0000${hourStart}\u0000${projectId}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
     let bucket = this.#buckets.get(key);
     if (bucket === undefined) {
       bucket = {
@@ -239,12 +252,13 @@ export class UsageAggregator {
   finish(): AggregateResult {
     const buckets: UsageBucket[] = [];
     for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", project = "", provider = "", model = ""] =
+      const [day = "", hourStart = "", projectId = "", project = "", provider = "", model = ""] =
         key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
         ...(project === "" ? {} : { project }),
+        ...(projectId === "" ? {} : { projectId: projectId as ProjectId }),
         provider: provider as UsageBucket["provider"],
         model,
         totals: bucket.totals,
@@ -262,6 +276,7 @@ export class UsageAggregator {
         a.day.localeCompare(b.day) ||
         (a.hourStart ?? "").localeCompare(b.hourStart ?? "") ||
         (a.project ?? "").localeCompare(b.project ?? "") ||
+        (a.projectId ?? "").localeCompare(b.projectId ?? "") ||
         a.provider.localeCompare(b.provider) ||
         a.model.localeCompare(b.model),
     );

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -114,6 +114,7 @@ interface MutableBucket {
   costUsd: number;
   cacheSavingsUsd: number;
   cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
   records: number;
   unpricedRecords: number;
   providerReportedRecords: number;
@@ -232,6 +233,7 @@ export class UsageAggregator {
         costUsd: 0,
         cacheSavingsUsd: 0,
         cacheWriteUsd: 0,
+        cacheWriteComplete: true,
         records: 0,
         unpricedRecords: 0,
         providerReportedRecords: 0,
@@ -250,7 +252,11 @@ export class UsageAggregator {
     bucket.totals = addTotals(bucket.totals, record.totals);
     bucket.costUsd += priced.costUsd;
     bucket.cacheSavingsUsd += cacheSavingsUsd(this.#options.rates, record.model, record.totals);
-    bucket.cacheWriteUsd += cacheWriteUsd(this.#options.rates, record.model, record.totals);
+    if (priced.costSource === "modelPriced") {
+      bucket.cacheWriteUsd += cacheWriteUsd(this.#options.rates, record.model, record.totals);
+    } else if (record.totals.cacheCreationTokens > 0) {
+      bucket.cacheWriteComplete = false;
+    }
     bucket.records += 1;
     if (priced.costSource === "unpriced") bucket.unpricedRecords += 1;
     if (priced.costSource === "providerReported") bucket.providerReportedRecords += 1;
@@ -281,7 +287,7 @@ export class UsageAggregator {
         totals: bucket.totals,
         costUsd: bucket.costUsd,
         cacheSavingsUsd: bucket.cacheSavingsUsd,
-        cacheWriteUsd: bucket.cacheWriteUsd,
+        ...(bucket.cacheWriteComplete ? { cacheWriteUsd: bucket.cacheWriteUsd } : {}),
         costSource: resolveCostSource(bucket),
         records: bucket.records,
         unpricedRecords: bucket.unpricedRecords,

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -140,7 +140,7 @@ export interface AggregateResult {
   readonly buckets: readonly UsageBucket[];
   /** Records dropped because an earlier record carried the same dedupe key. */
   readonly duplicatesDropped: number;
-  /** Records whose day fell outside the requested window. */
+  /** Retained records whose day fell outside the requested window. */
   readonly outOfWindow: number;
 }
 
@@ -152,13 +152,12 @@ export interface AggregateResult {
  * the same `dedupeKey` legitimately appears in several transcripts.
  */
 export class UsageAggregator {
-  readonly #buckets = new Map<string, MutableBucket>();
-  readonly #seen = new Set<string>();
+  readonly #recordsByKey = new Map<string, UsageRecord>();
+  readonly #unkeyedRecords: UsageRecord[] = [];
   readonly #toDay: (timestampMs: number) => string;
   readonly #hourlyWindow: { readonly sinceTimeMs: number; readonly untilTimeMs: number } | null;
   readonly #options: AggregateOptions;
   #duplicatesDropped = 0;
-  #outOfWindow = 0;
 
   constructor(options: AggregateOptions) {
     this.#options = options;
@@ -176,26 +175,30 @@ export class UsageAggregator {
     }
   }
 
-  /**
-   * Folds one record in. Returns whether it actually contributed, so callers
-   * can derive per-window facts (distinct sessions, for one) from the records
-   * that landed rather than everything the mtime prefilter happened to admit.
-   */
+  /** Retains one record and reports whether it falls in the requested window. */
   add(record: UsageRecord): boolean {
-    if (record.dedupeKey !== null) {
-      if (this.#seen.has(record.dedupeKey)) {
-        this.#duplicatesDropped += 1;
-        return false;
-      }
-      this.#seen.add(record.dedupeKey);
+    const inWindow = this.#isInWindow(record);
+    if (record.dedupeKey === null) {
+      this.#unkeyedRecords.push(record);
+      return inWindow;
     }
+    if (this.#recordsByKey.has(record.dedupeKey)) {
+      // Claude writes progressive snapshots for one response. The final copy
+      // is complete, so replace the earlier one without counting it twice.
+      this.#recordsByKey.set(record.dedupeKey, record);
+      this.#duplicatesDropped += 1;
+      return inWindow;
+    }
+    this.#recordsByKey.set(record.dedupeKey, record);
+    return inWindow;
+  }
 
+  #isInWindow(record: UsageRecord): boolean {
     if (
       this.#hourlyWindow !== null &&
       (record.timestampMs < this.#hourlyWindow.sinceTimeMs ||
         record.timestampMs >= this.#hourlyWindow.untilTimeMs)
     ) {
-      this.#outOfWindow += 1;
       return false;
     }
 
@@ -204,9 +207,26 @@ export class UsageAggregator {
       this.#hourlyWindow === null &&
       (day < this.#options.sinceDay || day > this.#options.untilDay)
     ) {
-      this.#outOfWindow += 1;
       return false;
     }
+    return true;
+  }
+
+  /** Distinct in-window sessions retained after progressive snapshots settle. */
+  distinctSessions(provider: UsageRecord["provider"]): number {
+    const sessionIds = new Set<string>();
+    const addSession = (record: UsageRecord): void => {
+      if (this.#isInWindow(record) && record.provider === provider && record.sessionId.length > 0) {
+        sessionIds.add(record.sessionId);
+      }
+    };
+    for (const record of this.#unkeyedRecords) addSession(record);
+    for (const record of this.#recordsByKey.values()) addSession(record);
+    return sessionIds.size;
+  }
+
+  #foldRecord(record: UsageRecord, buckets: Map<string, MutableBucket>): void {
+    const day = this.#toDay(record.timestampMs);
 
     const hourStart =
       this.#hourlyWindow === null
@@ -226,7 +246,7 @@ export class UsageAggregator {
     const projectId = resolvedProject?.projectId.replaceAll("\u0000", "") ?? "";
     const project = resolvedProject?.title.replaceAll("\u0000", "") ?? "";
     const key = `${day}\u0000${hourStart}\u0000${projectAttribution}\u0000${projectId}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
-    let bucket = this.#buckets.get(key);
+    let bucket = buckets.get(key);
     if (bucket === undefined) {
       bucket = {
         totals: EMPTY_TOTALS,
@@ -239,7 +259,7 @@ export class UsageAggregator {
         providerReportedRecords: 0,
         sessions: new Set<string>(),
       };
-      this.#buckets.set(key, bucket);
+      buckets.set(key, bucket);
     }
 
     const priced = priceUsage(
@@ -261,12 +281,22 @@ export class UsageAggregator {
     if (priced.costSource === "unpriced") bucket.unpricedRecords += 1;
     if (priced.costSource === "providerReported") bucket.providerReportedRecords += 1;
     if (record.sessionId.length > 0) bucket.sessions.add(record.sessionId);
-    return true;
   }
 
   finish(): AggregateResult {
+    const bucketsByKey = new Map<string, MutableBucket>();
+    let outOfWindow = 0;
+    const foldIfInWindow = (record: UsageRecord): void => {
+      if (this.#isInWindow(record)) {
+        this.#foldRecord(record, bucketsByKey);
+      } else {
+        outOfWindow += 1;
+      }
+    };
+    for (const record of this.#unkeyedRecords) foldIfInWindow(record);
+    for (const record of this.#recordsByKey.values()) foldIfInWindow(record);
     const buckets: UsageBucket[] = [];
-    for (const [key, bucket] of this.#buckets) {
+    for (const [key, bucket] of bucketsByKey) {
       const [
         day = "",
         hourStart = "",
@@ -308,7 +338,7 @@ export class UsageAggregator {
     return {
       buckets,
       duplicatesDropped: this.#duplicatesDropped,
-      outOfWindow: this.#outOfWindow,
+      outOfWindow,
     };
   }
 }

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -215,9 +215,15 @@ export class UsageAggregator {
           ).toISOString();
     // The key is parsed back apart on NUL, which project fields must not carry.
     const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
+    const projectAttribution =
+      resolvedProject !== null
+        ? "project"
+        : this.#options.resolveProject === undefined || record.cwd.length === 0
+          ? "unknown"
+          : "outside";
     const projectId = resolvedProject?.projectId.replaceAll("\u0000", "") ?? "";
     const project = resolvedProject?.title.replaceAll("\u0000", "") ?? "";
-    const key = `${day}\u0000${hourStart}\u0000${projectId}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
+    const key = `${day}\u0000${hourStart}\u0000${projectAttribution}\u0000${projectId}\u0000${project}\u0000${record.provider}\u0000${record.model}`;
     let bucket = this.#buckets.get(key);
     if (bucket === undefined) {
       bucket = {
@@ -252,13 +258,21 @@ export class UsageAggregator {
   finish(): AggregateResult {
     const buckets: UsageBucket[] = [];
     for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", projectId = "", project = "", provider = "", model = ""] =
-        key.split("\u0000");
+      const [
+        day = "",
+        hourStart = "",
+        projectAttribution = "unknown",
+        projectId = "",
+        project = "",
+        provider = "",
+        model = "",
+      ] = key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
         ...(project === "" ? {} : { project }),
         ...(projectId === "" ? {} : { projectId: projectId as ProjectId }),
+        projectAttribution: projectAttribution as UsageBucket["projectAttribution"],
         provider: provider as UsageBucket["provider"],
         model,
         totals: bucket.totals,

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -21,7 +21,7 @@ import type {
 } from "@t3tools/contracts";
 
 import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
-import { cacheSavingsUsd, priceUsage, type RateTable } from "./usagePricing.ts";
+import { cacheSavingsUsd, cacheWriteUsd, priceUsage, type RateTable } from "./usagePricing.ts";
 
 /**
  * Formats an instant as a `YYYY-MM-DD` day in `timeZone`.
@@ -113,6 +113,7 @@ interface MutableBucket {
   totals: UsageTokenTotals;
   costUsd: number;
   cacheSavingsUsd: number;
+  cacheWriteUsd: number;
   records: number;
   unpricedRecords: number;
   providerReportedRecords: number;
@@ -230,6 +231,7 @@ export class UsageAggregator {
         totals: EMPTY_TOTALS,
         costUsd: 0,
         cacheSavingsUsd: 0,
+        cacheWriteUsd: 0,
         records: 0,
         unpricedRecords: 0,
         providerReportedRecords: 0,
@@ -248,6 +250,7 @@ export class UsageAggregator {
     bucket.totals = addTotals(bucket.totals, record.totals);
     bucket.costUsd += priced.costUsd;
     bucket.cacheSavingsUsd += cacheSavingsUsd(this.#options.rates, record.model, record.totals);
+    bucket.cacheWriteUsd += cacheWriteUsd(this.#options.rates, record.model, record.totals);
     bucket.records += 1;
     if (priced.costSource === "unpriced") bucket.unpricedRecords += 1;
     if (priced.costSource === "providerReported") bucket.providerReportedRecords += 1;
@@ -278,6 +281,7 @@ export class UsageAggregator {
         totals: bucket.totals,
         costUsd: bucket.costUsd,
         cacheSavingsUsd: bucket.cacheSavingsUsd,
+        cacheWriteUsd: bucket.cacheWriteUsd,
         costSource: resolveCostSource(bucket),
         records: bucket.records,
         unpricedRecords: bucket.unpricedRecords,

--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { lookupRate, normalizeModelName, parseRateTable } from "./usagePricing.ts";
+import { cacheWriteUsd, lookupRate, normalizeModelName, parseRateTable } from "./usagePricing.ts";
 
 const rate = (input: number, cacheRead?: number) => ({
   input_cost_per_token: input,
@@ -51,5 +51,49 @@ describe("usage pricing", () => {
     expect(lookupRate(table, "provider-a/example-model")?.inputCostPerToken).toBe(1);
     expect(lookupRate(table, "provider-b/example-model")?.inputCostPerToken).toBe(3);
     expect(lookupRate(table, "example-model")).toBeNull();
+  });
+
+  it("keeps a bare name ambiguous when only the one-hour cache rate differs", () => {
+    const common = {
+      input_cost_per_token: 1,
+      output_cost_per_token: 5,
+      cache_read_input_token_cost: 0.1,
+      cache_creation_input_token_cost: 1.25,
+    };
+    const table = parseRateTable({
+      "provider-a/example-model": {
+        ...common,
+        cache_creation_input_token_cost_above_1hr: 2,
+      },
+      "provider-b/example-model": {
+        ...common,
+        cache_creation_input_token_cost_above_1hr: 3,
+      },
+    });
+
+    expect(lookupRate(table, "example-model")).toBeNull();
+  });
+
+  it("cannot price more TTL-specific tokens than total cache creation", () => {
+    const table = parseRateTable({
+      "example-model": {
+        input_cost_per_token: 1,
+        output_cost_per_token: 5,
+        cache_creation_input_token_cost: 1.25,
+        cache_creation_input_token_cost_above_1hr: 2,
+      },
+    });
+
+    expect(
+      cacheWriteUsd(table, "example-model", {
+        uncachedInputTokens: 0,
+        cachedInputTokens: 0,
+        cacheCreationTokens: 10,
+        cacheCreation5mTokens: 20,
+        cacheCreation1hTokens: 20,
+        outputTokens: 0,
+        reasoningTokens: 0,
+      }),
+    ).toBe(20);
   });
 });

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -22,6 +22,7 @@ export interface ModelRate {
   readonly outputCostPerToken: number;
   readonly cacheReadCostPerToken: number;
   readonly cacheCreationCostPerToken: number;
+  readonly cacheCreation1hCostPerToken?: number;
 }
 
 export type RateTable = ReadonlyMap<string, ModelRate>;
@@ -32,6 +33,7 @@ interface LiteLlmEntry {
   readonly output_cost_per_token?: unknown;
   readonly cache_read_input_token_cost?: unknown;
   readonly cache_creation_input_token_cost?: unknown;
+  readonly cache_creation_input_token_cost_above_1hr?: unknown;
 }
 
 function finiteNumber(value: unknown): number | null {
@@ -69,6 +71,10 @@ export function parseRateTable(document: unknown): RateTable {
       // input rather than as free.
       cacheReadCostPerToken: finiteNumber(entry.cache_read_input_token_cost) ?? input,
       cacheCreationCostPerToken: finiteNumber(entry.cache_creation_input_token_cost) ?? input,
+      cacheCreation1hCostPerToken:
+        finiteNumber(entry.cache_creation_input_token_cost_above_1hr) ??
+        finiteNumber(entry.cache_creation_input_token_cost) ??
+        input,
     });
   }
 
@@ -96,7 +102,8 @@ function sameRate(a: ModelRate, b: ModelRate): boolean {
     a.inputCostPerToken === b.inputCostPerToken &&
     a.outputCostPerToken === b.outputCostPerToken &&
     a.cacheReadCostPerToken === b.cacheReadCostPerToken &&
-    a.cacheCreationCostPerToken === b.cacheCreationCostPerToken
+    a.cacheCreationCostPerToken === b.cacheCreationCostPerToken &&
+    a.cacheCreation1hCostPerToken === b.cacheCreation1hCostPerToken
   );
 }
 
@@ -147,6 +154,22 @@ export interface PricedUsage {
   readonly costSource: UsageCostSource;
 }
 
+function cacheCreationCost(totals: UsageTokenTotals, rate: ModelRate): number {
+  const oneHour = Math.min(
+    totals.cacheCreationTokens,
+    Math.max(0, totals.cacheCreation1hTokens ?? 0),
+  );
+  const fiveMinute = Math.min(
+    totals.cacheCreationTokens - oneHour,
+    Math.max(0, totals.cacheCreation5mTokens ?? 0),
+  );
+  const unclassified = totals.cacheCreationTokens - fiveMinute - oneHour;
+  return (
+    (unclassified + fiveMinute) * rate.cacheCreationCostPerToken +
+    oneHour * (rate.cacheCreation1hCostPerToken ?? rate.cacheCreationCostPerToken)
+  );
+}
+
 /**
  * Prices a bucket's tokens.
  *
@@ -169,7 +192,7 @@ export function priceUsage(
   const costUsd =
     totals.uncachedInputTokens * rate.inputCostPerToken +
     totals.cachedInputTokens * rate.cacheReadCostPerToken +
-    totals.cacheCreationTokens * rate.cacheCreationCostPerToken +
+    cacheCreationCost(totals, rate) +
     totals.outputTokens * rate.outputCostPerToken;
 
   return { costUsd, costSource: "modelPriced" };
@@ -186,14 +209,13 @@ export function cacheSavingsUsd(table: RateTable, model: string, totals: UsageTo
 }
 
 /**
- * Estimated cost of this usage's cache-creation tokens at the model's
- * cache-write rate. Zero when the model is unpriced or the provider reports
- * no cache-creation tokens.
+ * Estimates what this usage's cache writes cost at the model and TTL-specific rates.
+ * Cache creation is a billing category, not proof of an expiry rewrite.
  */
 export function cacheWriteUsd(table: RateTable, model: string, totals: UsageTokenTotals): number {
   const rate = lookupRate(table, model);
   if (rate === null) return 0;
-  return totals.cacheCreationTokens * rate.cacheCreationCostPerToken;
+  return cacheCreationCost(totals, rate);
 }
 
 export interface UsageComponentCosts {
@@ -218,7 +240,7 @@ export function usageComponentCosts(
   const rate = lookupRate(table, model);
   if (rate === null) return ZERO_COMPONENTS;
   return {
-    cacheWriteUsd: totals.cacheCreationTokens * rate.cacheCreationCostPerToken,
+    cacheWriteUsd: cacheCreationCost(totals, rate),
     cacheReadUsd: totals.cachedInputTokens * rate.cacheReadCostPerToken,
     freshUsd:
       totals.uncachedInputTokens * rate.inputCostPerToken +

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -184,3 +184,44 @@ export function cacheSavingsUsd(table: RateTable, model: string, totals: UsageTo
   if (rate === null) return 0;
   return totals.cachedInputTokens * (rate.inputCostPerToken - rate.cacheReadCostPerToken);
 }
+
+/**
+ * Estimated cost of this usage's cache-creation tokens at the model's
+ * cache-write rate. Zero when the model is unpriced or the provider reports
+ * no cache-creation tokens.
+ */
+export function cacheWriteUsd(table: RateTable, model: string, totals: UsageTokenTotals): number {
+  const rate = lookupRate(table, model);
+  if (rate === null) return 0;
+  return totals.cacheCreationTokens * rate.cacheCreationCostPerToken;
+}
+
+export interface UsageComponentCosts {
+  readonly cacheWriteUsd: number;
+  readonly cacheReadUsd: number;
+  /** Fresh input plus output. */
+  readonly freshUsd: number;
+}
+
+const ZERO_COMPONENTS: UsageComponentCosts = { cacheWriteUsd: 0, cacheReadUsd: 0, freshUsd: 0 };
+
+/**
+ * Splits model-priced usage into cache writes, cache reads, and everything
+ * else. Unpriced models contribute nothing here; token totals still include
+ * them.
+ */
+export function usageComponentCosts(
+  table: RateTable,
+  model: string,
+  totals: UsageTokenTotals,
+): UsageComponentCosts {
+  const rate = lookupRate(table, model);
+  if (rate === null) return ZERO_COMPONENTS;
+  return {
+    cacheWriteUsd: totals.cacheCreationTokens * rate.cacheCreationCostPerToken,
+    cacheReadUsd: totals.cachedInputTokens * rate.cacheReadCostPerToken,
+    freshUsd:
+      totals.uncachedInputTokens * rate.inputCostPerToken +
+      totals.outputTokens * rate.outputCostPerToken,
+  };
+}

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -16,6 +16,7 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
     timestampMs: 1_786_000_000_000,
     model: "claude-fable-5",
     sessionId: "session-a",
+    cwd: "/home/theo/project",
     totals: {
       uncachedInputTokens: 2,
       cachedInputTokens: 1000,

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -187,6 +187,22 @@ describe("scan cache round trip", () => {
     const restored = decodeScanCache(JSON.parse(JSON.stringify(poisoned)));
     expect(restored.has("/a.jsonl")).toBe(false);
   });
+
+  it.each([0.5, 99])("drops an entry with invalid cwd index %s", (cwdIndex) => {
+    const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
+    const row = encoded.files["/a.jsonl"]!.r[0]!;
+    const poisoned = {
+      ...encoded,
+      files: {
+        "/a.jsonl": {
+          ...encoded.files["/a.jsonl"]!,
+          r: [[...row.slice(0, 10), cwdIndex]],
+        },
+      },
+    };
+
+    expect(decodeScanCache(JSON.parse(JSON.stringify(poisoned))).has("/a.jsonl")).toBe(false);
+  });
 });
 
 describe("pruneScanCache", () => {

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -81,6 +81,7 @@ describe("scan cache round trip", () => {
         codexState: {
           model: "gpt-5.2-codex",
           sessionId: "session-c",
+          cwd: "/home/theo/codex-project",
           lastUsageSignature: '{"input_tokens":1}',
           sawSessionMeta: true,
           suppressingForkCopies: false,

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -21,6 +21,7 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
       uncachedInputTokens: 2,
       cachedInputTokens: 1000,
       cacheCreationTokens: 10,
+      cacheCreation5mTokens: 10,
       outputTokens: 50,
       reasoningTokens: 0,
     },
@@ -197,7 +198,27 @@ describe("scan cache round trip", () => {
       files: {
         "/a.jsonl": {
           ...encoded.files["/a.jsonl"]!,
-          r: [[...row.slice(0, 10), cwdIndex]],
+          r: [[...row.slice(0, 10), cwdIndex, ...row.slice(11)]],
+        },
+      },
+    };
+
+    expect(decodeScanCache(JSON.parse(JSON.stringify(poisoned))).has("/a.jsonl")).toBe(false);
+  });
+
+  it.each([
+    [20, 0],
+    [-1, 11],
+    [5.5, 4.5],
+  ])("drops an entry with invalid cache TTL counters %s + %s", (fiveMinute, oneHour) => {
+    const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
+    const row = encoded.files["/a.jsonl"]!.r[0]!;
+    const poisoned = {
+      ...encoded,
+      files: {
+        "/a.jsonl": {
+          ...encoded.files["/a.jsonl"]!,
+          r: [[...row.slice(0, 11), fiveMinute, oneHour]],
         },
       },
     };
@@ -299,7 +320,7 @@ describe("pruneScanCache with an unwalked root", () => {
 });
 
 describe("dedupeWithinFile", () => {
-  it("keeps the first record per dedupe key", () => {
+  it("keeps the final record per dedupe key", () => {
     const kept = dedupeWithinFile([
       record({ totals: { ...record().totals, outputTokens: 1 } }),
       record({ totals: { ...record().totals, outputTokens: 999 } }),
@@ -307,7 +328,7 @@ describe("dedupeWithinFile", () => {
     ]);
 
     expect(kept).toHaveLength(2);
-    expect(kept[0]?.totals.outputTokens).toBe(1);
+    expect(kept[0]?.totals.outputTokens).toBe(999);
   });
 
   it("keeps every record that has no dedupe key", () => {

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -45,8 +45,12 @@ function cacheWith(entries: readonly [string, number, readonly UsageRecord[]][])
   const cache: ScanCache = new Map();
   for (const [path, mtimeMs, records] of entries) {
     cache.set(path, {
-      size: records.length * 10,
+      size: 200 + records.length * 10,
       mtimeMs,
+      mtimeNs: `${mtimeMs}000000`,
+      device: "1",
+      inode: path,
+      fingerprint: `sha256:${path}`,
       provider: "claude",
       records,
       tailRecords: [],
@@ -65,6 +69,10 @@ describe("scan cache round trip", () => {
     original.set("/grok.jsonl", {
       size: 40,
       mtimeMs: 300,
+      mtimeNs: "300000000",
+      device: "1",
+      inode: "grok",
+      fingerprint: "sha256:grok",
       provider: "grok",
       records: [
         record({ provider: "grok", model: "grok-4.5-build", dedupeKey: "s:p:grok-4.5-build" }),
@@ -73,8 +81,12 @@ describe("scan cache round trip", () => {
       position: position({ resumeOffset: 30, guardLength: 30, guardHash: 123 }),
     });
     original.set("/codex.jsonl", {
-      size: 80,
+      size: 200,
       mtimeMs: 400,
+      mtimeNs: "400000000",
+      device: "1",
+      inode: "codex",
+      fingerprint: "sha256:codex",
       provider: "codex",
       records: [record({ provider: "codex", model: "gpt-5.2-codex", dedupeKey: null })],
       tailRecords: [],

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -28,7 +28,8 @@ import type { CodexScanState, UsageRecord } from "./usageTranscripts.ts";
 // re-parses only its appended bytes instead of starting over.
 // v4: records carry the session's cwd for project attribution; v3 entries
 // would pin every cached file to "no project" forever.
-export const USAGE_SCAN_CACHE_VERSION = 4 as const;
+// v5: Claude records retain cache TTLs and expanded fallback iterations.
+export const USAGE_SCAN_CACHE_VERSION = 5 as const;
 
 export interface CachedFile {
   readonly size: number;
@@ -64,6 +65,8 @@ type SerializedRecord = readonly [
   dedupeKey: string | null,
   reportedCostUsd: number | null,
   cwdIndex: number,
+  cacheCreation5mTokens: number,
+  cacheCreation1hTokens: number,
 ];
 
 interface SerializedFile {
@@ -107,19 +110,30 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     return next;
   };
 
-  const serializeRecord = (record: UsageRecord): SerializedRecord => [
-    record.timestampMs,
-    intern(models, modelIndex, record.model),
-    intern(sessions, sessionIndex, record.sessionId),
-    record.totals.uncachedInputTokens,
-    record.totals.cachedInputTokens,
-    record.totals.cacheCreationTokens,
-    record.totals.outputTokens,
-    record.totals.reasoningTokens,
-    record.dedupeKey,
-    record.reportedCostUsd,
-    intern(cwds, cwdIndex, record.cwd),
-  ];
+  const serializeRecord = (record: UsageRecord): SerializedRecord => {
+    const oneHour = Math.min(
+      record.totals.cacheCreationTokens,
+      Math.max(0, record.totals.cacheCreation1hTokens ?? 0),
+    );
+    // Unclassified cache creation uses the five-minute price. Persist it in
+    // that bucket so the serialized TTL counters retain an exact sum.
+    const fiveMinute = record.totals.cacheCreationTokens - oneHour;
+    return [
+      record.timestampMs,
+      intern(models, modelIndex, record.model),
+      intern(sessions, sessionIndex, record.sessionId),
+      record.totals.uncachedInputTokens,
+      record.totals.cachedInputTokens,
+      record.totals.cacheCreationTokens,
+      record.totals.outputTokens,
+      record.totals.reasoningTokens,
+      record.dedupeKey,
+      record.reportedCostUsd,
+      intern(cwds, cwdIndex, record.cwd),
+      fiveMinute,
+      oneHour,
+    ];
+  };
 
   const files: Record<string, SerializedFile> = {};
   for (const [path, entry] of cache) {
@@ -141,6 +155,10 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
 
 function isRecordArray(value: unknown): value is readonly unknown[] {
   return Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 /**
@@ -179,7 +197,7 @@ export function decodeScanCache(document: unknown): ScanCache {
   ): UsageRecord[] | null => {
     const records: UsageRecord[] = [];
     for (const row of rows) {
-      if (!isRecordArray(row) || row.length < 11) return null;
+      if (!isRecordArray(row) || row.length < 13) return null;
       const [
         timestampMs,
         modelIndex,
@@ -192,6 +210,8 @@ export function decodeScanCache(document: unknown): ScanCache {
         dedupeKey,
         reportedCostUsd,
         cwdIndex,
+        cacheCreation5m,
+        cacheCreation1h,
       ] = row as SerializedRecord;
 
       const model = typeof modelIndex === "number" ? models[modelIndex] : undefined;
@@ -206,11 +226,14 @@ export function decodeScanCache(document: unknown): ScanCache {
         !Number.isInteger(sessionIndex) ||
         cwd === undefined ||
         !Number.isInteger(cwdIndex) ||
-        !Number.isFinite(uncached) ||
-        !Number.isFinite(cached) ||
-        !Number.isFinite(cacheCreation) ||
-        !Number.isFinite(output) ||
-        !Number.isFinite(reasoning)
+        !isNonNegativeInteger(uncached) ||
+        !isNonNegativeInteger(cached) ||
+        !isNonNegativeInteger(cacheCreation) ||
+        !isNonNegativeInteger(cacheCreation5m) ||
+        !isNonNegativeInteger(cacheCreation1h) ||
+        cacheCreation5m + cacheCreation1h !== cacheCreation ||
+        !isNonNegativeInteger(output) ||
+        !isNonNegativeInteger(reasoning)
       ) {
         return null;
       }
@@ -225,6 +248,8 @@ export function decodeScanCache(document: unknown): ScanCache {
           uncachedInputTokens: uncached,
           cachedInputTokens: cached,
           cacheCreationTokens: cacheCreation,
+          ...(cacheCreation5m === 0 ? {} : { cacheCreation5mTokens: cacheCreation5m }),
+          ...(cacheCreation1h === 0 ? {} : { cacheCreation1hTokens: cacheCreation1h }),
           outputTokens: output,
           reasoningTokens: reasoning,
         },
@@ -365,22 +390,18 @@ export function pruneScanCache(cache: ScanCache, options: PruneOptions): number 
   return removed;
 }
 
-/**
- * Within-file de-duplication, applied before an entry is cached.
- *
- * Callers stitching an incremental parse together pass one `seen` set across
- * the line and tail record batches so the whole file stays deduplicated as a
- * unit; the set is mutated in place.
- */
-export function dedupeWithinFile(
-  records: readonly UsageRecord[],
-  seen: Set<string> = new Set(),
-): readonly UsageRecord[] {
+/** Within-file de-duplication, retaining the final complete Claude snapshot. */
+export function dedupeWithinFile(records: readonly UsageRecord[]): readonly UsageRecord[] {
+  const indexByKey = new Map<string, number>();
   const kept: UsageRecord[] = [];
   for (const record of records) {
     if (record.dedupeKey !== null) {
-      if (seen.has(record.dedupeKey)) continue;
-      seen.add(record.dedupeKey);
+      const existing = indexByKey.get(record.dedupeKey);
+      if (existing !== undefined) {
+        kept[existing] = record;
+        continue;
+      }
+      indexByKey.set(record.dedupeKey, kept.length);
     }
     kept.push(record);
   }

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -26,7 +26,9 @@ import type { CodexScanState, UsageRecord } from "./usageTranscripts.ts";
 // entries would keep serving double-counted records forever.
 // v3: entries carry the parse position and reducer state so a grown file
 // re-parses only its appended bytes instead of starting over.
-export const USAGE_SCAN_CACHE_VERSION = 3 as const;
+// v4: records carry the session's cwd for project attribution; v3 entries
+// would pin every cached file to "no project" forever.
+export const USAGE_SCAN_CACHE_VERSION = 4 as const;
 
 export interface CachedFile {
   readonly size: number;
@@ -61,6 +63,7 @@ type SerializedRecord = readonly [
   reasoningTokens: number,
   dedupeKey: string | null,
   reportedCostUsd: number | null,
+  cwdIndex: number,
 ];
 
 interface SerializedFile {
@@ -82,15 +85,18 @@ interface SerializedCache {
   readonly version: number;
   readonly models: readonly string[];
   readonly sessions: readonly string[];
+  readonly cwds: readonly string[];
   readonly files: Readonly<Record<string, SerializedFile>>;
 }
 
-/** Serialises the cache, interning the repeated model and session strings. */
+/** Serialises the cache, interning the repeated model, session and cwd strings. */
 export function encodeScanCache(cache: ScanCache): SerializedCache {
   const models: string[] = [];
   const sessions: string[] = [];
+  const cwds: string[] = [];
   const modelIndex = new Map<string, number>();
   const sessionIndex = new Map<string, number>();
+  const cwdIndex = new Map<string, number>();
 
   const intern = (table: string[], index: Map<string, number>, value: string): number => {
     const existing = index.get(value);
@@ -112,6 +118,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     record.totals.reasoningTokens,
     record.dedupeKey,
     record.reportedCostUsd,
+    intern(cwds, cwdIndex, record.cwd),
   ];
 
   const files: Record<string, SerializedFile> = {};
@@ -129,7 +136,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     };
   }
 
-  return { version: USAGE_SCAN_CACHE_VERSION, models, sessions, files };
+  return { version: USAGE_SCAN_CACHE_VERSION, models, sessions, cwds, files };
 }
 
 function isRecordArray(value: unknown): value is readonly unknown[] {
@@ -148,7 +155,9 @@ export function decodeScanCache(document: unknown): ScanCache {
 
   const root = document as Partial<SerializedCache>;
   if (root.version !== USAGE_SCAN_CACHE_VERSION) return cache;
-  if (!isRecordArray(root.models) || !isRecordArray(root.sessions)) return cache;
+  if (!isRecordArray(root.models) || !isRecordArray(root.sessions) || !isRecordArray(root.cwds)) {
+    return cache;
+  }
   if (typeof root.files !== "object" || root.files === null) return cache;
 
   // The intern tables must be all strings: a numeric entry would pass the
@@ -156,8 +165,10 @@ export function decodeScanCache(document: unknown): ScanCache {
   // at lookupRate. A corrupt table rejects the whole cache.
   if (!root.models.every((value) => typeof value === "string")) return cache;
   if (!root.sessions.every((value) => typeof value === "string")) return cache;
+  if (!root.cwds.every((value) => typeof value === "string")) return cache;
   const models = root.models as readonly string[];
   const sessions = root.sessions as readonly string[];
+  const cwds = root.cwds as readonly string[];
 
   // Any corrupt row disqualifies the whole entry. Keeping the survivors
   // under the original (size, mtime) would read as a valid warm hit and the
@@ -168,7 +179,7 @@ export function decodeScanCache(document: unknown): ScanCache {
   ): UsageRecord[] | null => {
     const records: UsageRecord[] = [];
     for (const row of rows) {
-      if (!isRecordArray(row) || row.length < 10) return null;
+      if (!isRecordArray(row) || row.length < 11) return null;
       const [
         timestampMs,
         modelIndex,
@@ -180,6 +191,7 @@ export function decodeScanCache(document: unknown): ScanCache {
         reasoning,
         dedupeKey,
         reportedCostUsd,
+        cwdIndex,
       ] = row as SerializedRecord;
 
       const model = typeof modelIndex === "number" ? models[modelIndex] : undefined;
@@ -201,6 +213,7 @@ export function decodeScanCache(document: unknown): ScanCache {
         timestampMs,
         model,
         sessionId: (typeof sessionIndex === "number" ? sessions[sessionIndex] : undefined) ?? "",
+        cwd: (typeof cwdIndex === "number" ? cwds[cwdIndex] : undefined) ?? "",
         totals: {
           uncachedInputTokens: uncached,
           cachedInputTokens: cached,

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -297,6 +297,7 @@ function decodeCodexState(value: unknown): CodexScanState | null | undefined {
   if (
     typeof state.model !== "string" ||
     typeof state.sessionId !== "string" ||
+    typeof state.cwd !== "string" ||
     (state.lastUsageSignature !== null && typeof state.lastUsageSignature !== "string") ||
     typeof state.sawSessionMeta !== "boolean" ||
     typeof state.suppressingForkCopies !== "boolean" ||
@@ -308,6 +309,7 @@ function decodeCodexState(value: unknown): CodexScanState | null | undefined {
   return {
     model: state.model,
     sessionId: state.sessionId,
+    cwd: state.cwd,
     lastUsageSignature: state.lastUsageSignature ?? null,
     sawSessionMeta: state.sawSessionMeta,
     suppressingForkCopies: state.suppressingForkCopies,

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -1,10 +1,10 @@
 /**
  * Durable per-file scan cache.
  *
- * Transcripts are append-only and a file that has not changed can never yield
- * different usage, so parsed records are keyed by `(size, mtime)` and reused.
- * Without this every server restart re-parses the whole window: roughly 3.5s
- * for a 30-day scan here, against ~11ms to reload this cache.
+ * Every refresh hashes each observed file. Parsed records are reused only when
+ * the full SHA-256 fingerprint is unchanged, including for same-size rewrites
+ * that preserve filesystem metadata. A warm refresh still reads every observed
+ * byte once for hashing, but avoids JSONL parsing for unchanged fingerprints.
  *
  * Caching *per file* rather than per day is deliberate. It is timezone
  * independent, so changing the reporting zone does not invalidate anything, and
@@ -14,7 +14,7 @@
  *
  * @module usageScanCache
  */
-// @effect-diagnostics nodeBuiltinImport:off
+// @effect-diagnostics nodeBuiltinImport:off - path-boundary checks use the host platform's separator.
 import * as NodePath from "node:path";
 
 import type { UsageProviderKind } from "@t3tools/contracts";
@@ -29,11 +29,16 @@ import type { CodexScanState, UsageRecord } from "./usageTranscripts.ts";
 // v4: records carry the session's cwd for project attribution; v3 entries
 // would pin every cached file to "no project" forever.
 // v5: Claude records retain cache TTLs and expanded fallback iterations.
-export const USAGE_SCAN_CACHE_VERSION = 5 as const;
+// v6: cache hits require a full content hash and retain exact file metadata.
+export const USAGE_SCAN_CACHE_VERSION = 6 as const;
 
 export interface CachedFile {
   readonly size: number;
   readonly mtimeMs: number;
+  readonly mtimeNs: string;
+  readonly device: string;
+  readonly inode: string;
+  readonly fingerprint: string;
   readonly provider: UsageProviderKind;
   /** Records from newline-terminated lines, up to `position.resumeOffset`. */
   readonly records: readonly UsageRecord[];
@@ -72,6 +77,10 @@ type SerializedRecord = readonly [
 interface SerializedFile {
   readonly s: number;
   readonly m: number;
+  readonly n: string;
+  readonly d: string;
+  readonly i: string;
+  readonly h: string;
   readonly p: UsageProviderKind;
   readonly r: readonly SerializedRecord[];
   /** Tail records; see `CachedFile.tailRecords`. */
@@ -140,6 +149,10 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     files[path] = {
       s: entry.size,
       m: entry.mtimeMs,
+      n: entry.mtimeNs,
+      d: entry.device,
+      i: entry.inode,
+      h: entry.fingerprint,
       p: entry.provider,
       r: entry.records.map(serializeRecord),
       t: entry.tailRecords.map(serializeRecord),
@@ -189,7 +202,7 @@ export function decodeScanCache(document: unknown): ScanCache {
   const cwds = root.cwds as readonly string[];
 
   // Any corrupt row disqualifies the whole entry. Keeping the survivors
-  // under the original (size, mtime) would read as a valid warm hit and the
+  // under the original fingerprint would read as a valid warm hit and the
   // file would never be re-parsed, silently losing the dropped rows' usage.
   const decodeRecords = (
     rows: readonly unknown[],
@@ -263,7 +276,20 @@ export function decodeScanCache(document: unknown): ScanCache {
   for (const [path, raw] of Object.entries(root.files)) {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Partial<SerializedFile>;
-    if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
+    if (
+      typeof entry.s !== "number" ||
+      !Number.isSafeInteger(entry.s) ||
+      entry.s < 0 ||
+      typeof entry.m !== "number" ||
+      !Number.isFinite(entry.m) ||
+      typeof entry.n !== "string" ||
+      typeof entry.d !== "string" ||
+      typeof entry.i !== "string" ||
+      typeof entry.h !== "string" ||
+      entry.h.length === 0
+    ) {
+      continue;
+    }
     if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "grok") continue;
     if (!isRecordArray(entry.r) || !isRecordArray(entry.t)) continue;
     // Position fields feed byte offsets and a Buffer allocation in the reader,
@@ -274,6 +300,7 @@ export function decodeScanCache(document: unknown): ScanCache {
       typeof entry.o !== "number" ||
       !Number.isSafeInteger(entry.o) ||
       entry.o < 0 ||
+      entry.o > entry.s ||
       typeof entry.gl !== "number" ||
       !Number.isSafeInteger(entry.gl) ||
       entry.gl < 0 ||
@@ -295,6 +322,10 @@ export function decodeScanCache(document: unknown): ScanCache {
     cache.set(path, {
       size: entry.s,
       mtimeMs: entry.m,
+      mtimeNs: entry.n,
+      device: entry.d,
+      inode: entry.i,
+      fingerprint: entry.h,
       provider,
       records,
       tailRecords,

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -195,10 +195,17 @@ export function decodeScanCache(document: unknown): ScanCache {
       ] = row as SerializedRecord;
 
       const model = typeof modelIndex === "number" ? models[modelIndex] : undefined;
+      const session = typeof sessionIndex === "number" ? sessions[sessionIndex] : undefined;
+      const cwd = typeof cwdIndex === "number" ? cwds[cwdIndex] : undefined;
       if (
         typeof timestampMs !== "number" ||
         !Number.isFinite(timestampMs) ||
         model === undefined ||
+        !Number.isInteger(modelIndex) ||
+        session === undefined ||
+        !Number.isInteger(sessionIndex) ||
+        cwd === undefined ||
+        !Number.isInteger(cwdIndex) ||
         !Number.isFinite(uncached) ||
         !Number.isFinite(cached) ||
         !Number.isFinite(cacheCreation) ||
@@ -212,8 +219,8 @@ export function decodeScanCache(document: unknown): ScanCache {
         provider,
         timestampMs,
         model,
-        sessionId: (typeof sessionIndex === "number" ? sessions[sessionIndex] : undefined) ?? "",
-        cwd: (typeof cwdIndex === "number" ? cwds[cwdIndex] : undefined) ?? "",
+        sessionId: session,
+        cwd,
         totals: {
           uncachedInputTokens: uncached,
           cachedInputTokens: cached,

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -1,0 +1,169 @@
+import { ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+
+import type { RateTable } from "./usagePricing.ts";
+import { foldThreadRows, ThreadUsageAccumulator, type ThreadAttribution } from "./usageThreads.ts";
+import type { UsageRecord } from "./usageTranscripts.ts";
+
+const rates: RateTable = new Map([
+  [
+    "claude-fable-5",
+    {
+      inputCostPerToken: 1e-5,
+      outputCostPerToken: 5e-5,
+      cacheReadCostPerToken: 1e-6,
+      cacheCreationCostPerToken: 1.25e-5,
+    },
+  ],
+]);
+
+function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
+  return {
+    provider: "claude",
+    timestampMs: Date.parse("2026-08-07T04:05:13.944Z"),
+    model: "claude-fable-5",
+    sessionId: "session-a",
+    cwd: "/work/app",
+    totals: {
+      uncachedInputTokens: 100,
+      cachedInputTokens: 1000,
+      cacheCreationTokens: 10,
+      outputTokens: 50,
+      reasoningTokens: 0,
+    },
+    reportedCostUsd: null,
+    dedupeKey: null,
+    ...overrides,
+  };
+}
+
+function accumulate(
+  entries: readonly (readonly [UsageRecord, { sessionKey: string; agentId: string | null }])[],
+) {
+  const accumulator = new ThreadUsageAccumulator({
+    timeZone: "UTC",
+    sinceDay: "2026-08-01",
+    untilDay: "2026-08-31",
+    rates,
+  });
+  for (const [item, context] of entries) accumulator.add(item, context);
+  return accumulator.finish();
+}
+
+const NO_ATTRIBUTION: ThreadAttribution = {
+  sessionToThread: new Map(),
+  worktreeToThread: new Map(),
+};
+
+describe("ThreadUsageAccumulator", () => {
+  it("groups records by session and splits subagent slices out", () => {
+    const main = { sessionKey: "claude:session-a", agentId: null };
+    const agent = { sessionKey: "claude:session-a", agentId: "agent-1" };
+    const groups = accumulate([
+      [record(), main],
+      [record(), agent],
+      [record({ sessionId: "session-b" }), { sessionKey: "claude:session-b", agentId: null }],
+    ]);
+
+    expect(groups).toHaveLength(2);
+    const sessionA = groups.find((group) => group.sessionKey === "claude:session-a");
+    expect(sessionA?.totals.outputTokens).toBe(100);
+    expect(sessionA?.agents.get("agent-1")?.totals.outputTokens).toBe(50);
+  });
+
+  it("dedupes globally across files with the summary's semantics", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [record({ dedupeKey: "msg_1:" }), context],
+      [record({ dedupeKey: "msg_1:" }), context],
+    ]);
+
+    expect(groups[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("records each day's estimated cost", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([[record(), context]]);
+    const day = groups[0]?.daily.get("2026-08-07");
+
+    expect(day).toBeCloseTo(100 * 1e-5 + 1000 * 1e-6 + 10 * 1.25e-5 + 50 * 5e-5, 12);
+  });
+
+  it("drops records outside the window", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [record({ timestampMs: Date.parse("2026-07-01T00:00:00Z") }), context],
+    ]);
+
+    expect(groups).toHaveLength(0);
+  });
+});
+
+describe("foldThreadRows", () => {
+  const threadId = ThreadId.make("11111111-1111-4111-8111-111111111111");
+
+  it("folds sessions into one row per thread via cursor and worktree matches", () => {
+    const groups = accumulate([
+      [record(), { sessionKey: "claude:session-a", agentId: null }],
+      [
+        record({ sessionId: "session-b", cwd: "/work/app/.wt/thread-1" }),
+        { sessionKey: "claude:session-b", agentId: null },
+      ],
+      [record({ sessionId: "session-c" }), { sessionKey: "claude:session-c", agentId: null }],
+    ]);
+    const attribution: ThreadAttribution = {
+      sessionToThread: new Map([["claude:session-a", { threadId, title: "Fix the flaky test" }]]),
+      worktreeToThread: new Map([
+        ["/work/app/.wt/thread-1", { threadId, title: "Fix the flaky test" }],
+      ]),
+    };
+
+    const { rows, truncatedRows } = foldThreadRows(groups, attribution, { cap: 40 });
+
+    expect(truncatedRows).toBe(0);
+    expect(rows).toHaveLength(2);
+    const threadRow = rows.find((row) => row.threadId === threadId);
+    expect(threadRow?.title).toBe("Fix the flaky test");
+    expect(threadRow?.sessions).toBe(2);
+    const standalone = rows.find((row) => row.threadId === null);
+    // Standalone rows leave the title to the caller's transcript read.
+    expect(standalone?.title).toBeNull();
+    expect(standalone?.key).toBe("session:claude:session-c");
+  });
+
+  it("caps rows by cost and counts the rest", () => {
+    const groups = accumulate(
+      Array.from({ length: 5 }, (_, index) => [
+        record({ sessionId: `session-${index}` }),
+        { sessionKey: `claude:session-${index}`, agentId: null },
+      ]),
+    );
+
+    const { rows, truncatedRows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 3 });
+
+    expect(rows).toHaveLength(3);
+    expect(truncatedRows).toBe(2);
+  });
+
+  it("filters by project before capping", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd === "/work/app" ? "App" : ""),
+    });
+    accumulator.add(record(), { sessionKey: "claude:session-a", agentId: null });
+    accumulator.add(record({ sessionId: "session-b", cwd: "/elsewhere" }), {
+      sessionKey: "claude:session-b",
+      agentId: null,
+    });
+    const groups = accumulator.finish();
+
+    const app = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 40, projectFilter: "App" });
+    expect(app.rows.map((row) => row.key)).toEqual(["session:claude:session-a"]);
+
+    const outside = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 40, projectFilter: null });
+    expect(outside.rows.map((row) => row.key)).toEqual(["session:claude:session-b"]);
+  });
+});

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -208,6 +208,22 @@ describe("ThreadUsageAccumulator", () => {
         .toSorted(),
     ).toEqual(["id:project-one", "id:project-two"]);
   });
+
+  it("holds records newer than the request-start cutoff for the next refresh", () => {
+    const cutoffTimeMs = Date.parse("2026-08-07T04:05:14.000Z");
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      cutoffTimeMs,
+      rates,
+    });
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    accumulator.add(record({ timestampMs: cutoffTimeMs }), context);
+    accumulator.add(record({ timestampMs: cutoffTimeMs + 1 }), context);
+
+    expect(accumulator.finish()[0]?.totals.outputTokens).toBe(50);
+  });
 });
 
 describe("foldThreadRows", () => {

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -1,4 +1,4 @@
-import { ThreadId } from "@t3tools/contracts";
+import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 
 import { UsageAggregator } from "./usageAggregation.ts";
@@ -17,6 +17,9 @@ const rates: RateTable = new Map([
     },
   ],
 ]);
+
+const PROJECT_ONE = { projectId: ProjectId.make("project-one"), title: "Project one" };
+const PROJECT_TWO = { projectId: ProjectId.make("project-two"), title: "Project two" };
 
 function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
   return {
@@ -98,6 +101,43 @@ describe("ThreadUsageAccumulator", () => {
 
     expect(groups).toHaveLength(0);
   });
+
+  it("applies exact time bounds inside a shared calendar day", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-07",
+      untilDay: "2026-08-07",
+      sinceTimeMs: Date.parse("2026-08-07T04:00:00Z"),
+      untilTimeMs: Date.parse("2026-08-07T05:00:00Z"),
+      rates,
+    });
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-07T03:59:59Z") }), context);
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-07T04:30:00Z") }), context);
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-07T05:00:00Z") }), context);
+
+    expect(accumulator.finish()[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("keeps separate cwd slices when one session crosses projects", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd.endsWith("one") ? PROJECT_ONE : PROJECT_TWO),
+    });
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    accumulator.add(record({ cwd: "/work/one" }), context);
+    accumulator.add(record({ cwd: "/work/two" }), context);
+
+    expect(
+      accumulator
+        .finish()
+        .map((group) => group.projectKey)
+        .toSorted(),
+    ).toEqual(["id:project-one", "id:project-two"]);
+  });
 });
 
 describe("foldThreadRows", () => {
@@ -129,7 +169,7 @@ describe("foldThreadRows", () => {
     const standalone = rows.find((row) => row.threadId === null);
     // Standalone rows leave the title to the caller's transcript read.
     expect(standalone?.title).toBeNull();
-    expect(standalone?.key).toBe("session:claude:session-c");
+    expect(standalone?.key).toContain("claude:session-c");
   });
 
   it("scopes one T3 thread by provider and project", () => {
@@ -138,7 +178,7 @@ describe("foldThreadRows", () => {
       sinceDay: "2026-08-01",
       untilDay: "2026-08-31",
       rates,
-      resolveProject: (cwd) => (cwd.endsWith("one") ? "Project one" : "Project two"),
+      resolveProject: (cwd) => (cwd.endsWith("one") ? PROJECT_ONE : PROJECT_TWO),
     });
     const entries = [
       [record({ sessionId: "claude-one", cwd: "/work/one" }), "claude:claude-one"],
@@ -178,7 +218,7 @@ describe("foldThreadRows", () => {
 
     const projectOne = foldThreadRows(accumulator.finish(), attribution, {
       cap: 40,
-      projectFilter: "Project one",
+      projectFilter: "id:project-one",
     });
     expect(projectOne.rows.map((row) => [row.provider, row.project]).toSorted()).toEqual([
       ["claude", "Project one"],
@@ -196,15 +236,56 @@ describe("foldThreadRows", () => {
 
     const { rows, truncatedRows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 3 });
 
-    expect(rows).toHaveLength(4);
-    expect(truncatedRows).toBe(2);
-    expect(rows.find((row) => row.key.startsWith("remainder:"))?.title).toBe("Other threads (2)");
-    expect(rows.find((row) => row.key.startsWith("remainder:"))?.groupedRows).toBe(2);
+    expect(rows).toHaveLength(3);
+    expect(truncatedRows).toBe(3);
+    expect(rows.find((row) => row.key.startsWith("remainder:"))?.title).toBe("Other threads (3)");
+    expect(rows.find((row) => row.key.startsWith("remainder:"))?.groupedRows).toBe(3);
     expect(rows.reduce((sum, row) => sum + row.totals.outputTokens, 0)).toBe(250);
   });
 
+  it("keeps subagent slices when lower-cost rows fold into a remainder", () => {
+    const groups = accumulate([
+      [
+        record({ sessionId: "expensive", totals: { ...record().totals, outputTokens: 100 } }),
+        { sessionKey: "claude:expensive", agentId: null },
+      ],
+      [
+        record({ sessionId: "cheaper" }),
+        { sessionKey: "claude:cheaper", agentId: "agent-cheaper" },
+      ],
+    ]);
+
+    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 1 });
+    const remainder = rows.find((row) => row.key.startsWith("remainder:"));
+    expect(remainder?.agents.map((agent) => agent.agentId)).toEqual(["agent-cheaper"]);
+  });
+
+  it("collapses overflow project scopes without exceeding the response cap", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => ({
+        projectId: ProjectId.make(`project-${cwd.slice(-1)}`),
+        title: `Project ${cwd.slice(-1)}`,
+      }),
+    });
+    for (let index = 0; index < 6; index += 1) {
+      accumulator.add(record({ sessionId: `session-${index}`, cwd: `/work/${index}` }), {
+        sessionKey: `claude:session-${index}`,
+        agentId: null,
+      });
+    }
+
+    const { rows } = foldThreadRows(accumulator.finish(), NO_ATTRIBUTION, { cap: 3 });
+
+    expect(rows.length).toBeLessThanOrEqual(3);
+    expect(rows.reduce((sum, row) => sum + row.totals.outputTokens, 0)).toBe(300);
+  });
+
   it("reconciles every provider and project after lower-cost rows are grouped", () => {
-    const resolveProject = (cwd: string) => (cwd.endsWith("one") ? "Project one" : "Project two");
+    const resolveProject = (cwd: string) => (cwd.endsWith("one") ? PROJECT_ONE : PROJECT_TWO);
     const accumulator = new ThreadUsageAccumulator({
       timeZone: "UTC",
       sinceDay: "2026-08-01",
@@ -238,7 +319,8 @@ describe("foldThreadRows", () => {
     }
     const groups = accumulator.finish();
 
-    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 1 });
+    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 4 });
+    expect(rows.length).toBeLessThanOrEqual(4);
     const expected = new Map<string, number>();
     for (const bucket of summary.finish().buckets) {
       const key = `${bucket.provider}:${bucket.project ?? ""}`;
@@ -259,7 +341,7 @@ describe("foldThreadRows", () => {
       sinceDay: "2026-08-01",
       untilDay: "2026-08-31",
       rates,
-      resolveProject: (cwd) => (cwd === "/work/app" ? "App" : ""),
+      resolveProject: (cwd) => (cwd === "/work/app" ? PROJECT_ONE : null),
     });
     accumulator.add(record(), { sessionKey: "claude:session-a", agentId: null });
     accumulator.add(record({ sessionId: "session-b", cwd: "/elsewhere" }), {
@@ -268,10 +350,15 @@ describe("foldThreadRows", () => {
     });
     const groups = accumulator.finish();
 
-    const app = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 40, projectFilter: "App" });
-    expect(app.rows.map((row) => row.key)).toEqual(["session:claude:session-a"]);
+    const app = foldThreadRows(groups, NO_ATTRIBUTION, {
+      cap: 40,
+      projectFilter: "id:project-one",
+    });
+    expect(app.rows.map((row) => row.key)).toHaveLength(1);
+    expect(app.rows[0]?.key).toContain("claude:session-a");
 
     const outside = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 40, projectFilter: null });
-    expect(outside.rows.map((row) => row.key)).toEqual(["session:claude:session-b"]);
+    expect(outside.rows.map((row) => row.key)).toHaveLength(1);
+    expect(outside.rows[0]?.key).toContain("claude:session-b");
   });
 });

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -1,6 +1,7 @@
 import { ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 
+import { UsageAggregator } from "./usageAggregation.ts";
 import type { RateTable } from "./usagePricing.ts";
 import { foldThreadRows, ThreadUsageAccumulator, type ThreadAttribution } from "./usageThreads.ts";
 import type { UsageRecord } from "./usageTranscripts.ts";
@@ -131,7 +132,61 @@ describe("foldThreadRows", () => {
     expect(standalone?.key).toBe("session:claude:session-c");
   });
 
-  it("caps rows by cost and counts the rest", () => {
+  it("scopes one T3 thread by provider and project", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject: (cwd) => (cwd.endsWith("one") ? "Project one" : "Project two"),
+    });
+    const entries = [
+      [record({ sessionId: "claude-one", cwd: "/work/one" }), "claude:claude-one"],
+      [record({ sessionId: "claude-two", cwd: "/work/two" }), "claude:claude-two"],
+      [
+        record({
+          provider: "codex",
+          model: "gpt-5.6-sol",
+          sessionId: "codex-one",
+          cwd: "/work/one",
+        }),
+        "codex:codex-one",
+      ],
+    ] as const;
+    for (const [item, sessionKey] of entries) {
+      accumulator.add(item, { sessionKey, agentId: null });
+    }
+    const attribution: ThreadAttribution = {
+      sessionToThread: new Map(
+        entries.map(([, sessionKey]) => [sessionKey, { threadId, title: "Shared thread" }]),
+      ),
+      worktreeToThread: new Map(),
+    };
+
+    const { rows } = foldThreadRows(accumulator.finish(), attribution, { cap: 40 });
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => [row.provider, row.project]).toSorted()).toEqual([
+      ["claude", "Project one"],
+      ["claude", "Project two"],
+      ["codex", "Project one"],
+    ]);
+    expect(new Set(rows.map((row) => row.key)).size).toBe(3);
+    expect(rows.every((row) => row.threadId === threadId && row.title === "Shared thread")).toBe(
+      true,
+    );
+
+    const projectOne = foldThreadRows(accumulator.finish(), attribution, {
+      cap: 40,
+      projectFilter: "Project one",
+    });
+    expect(projectOne.rows.map((row) => [row.provider, row.project]).toSorted()).toEqual([
+      ["claude", "Project one"],
+      ["codex", "Project one"],
+    ]);
+  });
+
+  it("groups rows past the cap without losing their usage", () => {
     const groups = accumulate(
       Array.from({ length: 5 }, (_, index) => [
         record({ sessionId: `session-${index}` }),
@@ -141,8 +196,61 @@ describe("foldThreadRows", () => {
 
     const { rows, truncatedRows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 3 });
 
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(4);
     expect(truncatedRows).toBe(2);
+    expect(rows.find((row) => row.key.startsWith("remainder:"))?.title).toBe("Other threads (2)");
+    expect(rows.find((row) => row.key.startsWith("remainder:"))?.groupedRows).toBe(2);
+    expect(rows.reduce((sum, row) => sum + row.totals.outputTokens, 0)).toBe(250);
+  });
+
+  it("reconciles every provider and project after lower-cost rows are grouped", () => {
+    const resolveProject = (cwd: string) => (cwd.endsWith("one") ? "Project one" : "Project two");
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+      resolveProject,
+    });
+    const summary = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      resolution: "day",
+      rates,
+      resolveProject,
+    });
+    for (const [index, provider, project] of [
+      [0, "claude", "one"],
+      [1, "claude", "one"],
+      [2, "claude", "two"],
+      [3, "codex", "one"],
+      [4, "codex", "two"],
+    ] as const) {
+      const item = record({
+        provider,
+        model: provider === "claude" ? "claude-fable-5" : "gpt-5.6-sol",
+        sessionId: `session-${index}`,
+        cwd: `/work/${project}`,
+      });
+      accumulator.add(item, { sessionKey: `${provider}:session-${index}`, agentId: null });
+      summary.add(item);
+    }
+    const groups = accumulator.finish();
+
+    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 1 });
+    const expected = new Map<string, number>();
+    for (const bucket of summary.finish().buckets) {
+      const key = `${bucket.provider}:${bucket.project ?? ""}`;
+      expected.set(key, (expected.get(key) ?? 0) + bucket.totals.outputTokens);
+    }
+    const actual = new Map<string, number>();
+    for (const row of rows) {
+      const key = `${row.provider}:${row.project ?? ""}`;
+      actual.set(key, (actual.get(key) ?? 0) + row.totals.outputTokens);
+    }
+
+    expect(actual).toEqual(expected);
   });
 
   it("filters by project before capping", () => {

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -95,6 +95,17 @@ describe("ThreadUsageAccumulator", () => {
     expect(day?.freshUsd).toBeCloseTo(100 * 1e-5 + 50 * 5e-5, 12);
   });
 
+  it("does not invent component costs for provider-reported totals", () => {
+    const context = { sessionKey: "claude:session-a", agentId: "agent-1" };
+    const groups = accumulate([[record({ reportedCostUsd: 1.25 }), context]]);
+    const rows = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 40 });
+
+    expect(rows.rows[0]?.costUsd).toBe(1.25);
+    expect(rows.rows[0]?.cacheWriteUsd).toBeNull();
+    expect(rows.rows[0]?.agents[0]?.cacheWriteUsd).toBeNull();
+    expect(rows.rows[0]?.daily).toEqual([]);
+  });
+
   it("drops records outside the window", () => {
     const context = { sessionKey: "claude:session-a", agentId: null };
     const groups = accumulate([

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -102,6 +102,12 @@ describe("ThreadUsageAccumulator", () => {
     expect(groups).toHaveLength(0);
   });
 
+  it("drops timestamps outside the JavaScript date range", () => {
+    const context = { sessionKey: "grok:session-a", agentId: null };
+    expect(() => accumulate([[record({ timestampMs: 1e20 }), context]])).not.toThrow();
+    expect(accumulate([[record({ timestampMs: 1e20 }), context]])).toEqual([]);
+  });
+
   it("applies exact time bounds inside a shared calendar day", () => {
     const accumulator = new ThreadUsageAccumulator({
       timeZone: "UTC",
@@ -115,6 +121,24 @@ describe("ThreadUsageAccumulator", () => {
     accumulator.add(record({ timestampMs: Date.parse("2026-08-07T03:59:59Z") }), context);
     accumulator.add(record({ timestampMs: Date.parse("2026-08-07T04:30:00Z") }), context);
     accumulator.add(record({ timestampMs: Date.parse("2026-08-07T05:00:00Z") }), context);
+
+    expect(accumulator.finish()[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("uses exact bounds without applying a second calendar-day filter", () => {
+    const accumulator = new ThreadUsageAccumulator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-07",
+      untilDay: "2026-08-07",
+      sinceTimeMs: Date.parse("2026-08-08T04:00:00Z"),
+      untilTimeMs: Date.parse("2026-08-08T05:00:00Z"),
+      rates,
+    });
+
+    accumulator.add(record({ timestampMs: Date.parse("2026-08-08T04:30:00Z") }), {
+      sessionKey: "claude:exact-window",
+      agentId: null,
+    });
 
     expect(accumulator.finish()[0]?.totals.outputTokens).toBe(50);
   });
@@ -170,6 +194,28 @@ describe("foldThreadRows", () => {
     // Standalone rows leave the title to the caller's transcript read.
     expect(standalone?.title).toBeNull();
     expect(standalone?.key).toContain("claude:session-c");
+  });
+
+  it("uses the deepest worktree ancestor for sessions run in subdirectories", () => {
+    const nestedThreadId = ThreadId.make("22222222-2222-4222-8222-222222222222");
+    const groups = accumulate([
+      [
+        record({ sessionId: "nested", cwd: "/work/app/.wt/thread-1/packages/web" }),
+        { sessionKey: "claude:nested", agentId: null },
+      ],
+    ]);
+    const attribution: ThreadAttribution = {
+      sessionToThread: new Map(),
+      worktreeToThread: new Map([
+        ["/work/app", { threadId, title: "Shared root" }],
+        ["/work/app/.wt/thread-1", { threadId: nestedThreadId, title: "Nested worktree" }],
+      ]),
+    };
+
+    const { rows } = foldThreadRows(groups, attribution, { cap: 40 });
+
+    expect(rows[0]?.threadId).toBe(nestedThreadId);
+    expect(rows[0]?.title).toBe("Nested worktree");
   });
 
   it("scopes one T3 thread by provider and project", () => {
@@ -258,6 +304,30 @@ describe("foldThreadRows", () => {
     const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 1 });
     const remainder = rows.find((row) => row.key.startsWith("remainder:"));
     expect(remainder?.agents.map((agent) => agent.agentId)).toEqual(["agent-cheaper"]);
+  });
+
+  it("bounds and reconciles subagents folded into a remainder", () => {
+    const groups = accumulate([
+      [
+        record({ sessionId: "expensive", totals: { ...record().totals, outputTokens: 100 } }),
+        { sessionKey: "claude:expensive", agentId: null },
+      ],
+      ...Array.from(
+        { length: 5 },
+        (_, index) =>
+          [
+            record({ sessionId: `cheaper-${index}` }),
+            { sessionKey: `claude:cheaper-${index}`, agentId: `agent-${index}` },
+          ] as const,
+      ),
+    ]);
+
+    const { rows } = foldThreadRows(groups, NO_ATTRIBUTION, { cap: 2 });
+    const remainder = rows.find((row) => row.key.startsWith("remainder:"));
+
+    expect(remainder?.agents).toHaveLength(2);
+    expect(remainder?.agents.some((agent) => agent.agentId === "Other subagents (4)")).toBe(true);
+    expect(remainder?.agents.reduce((sum, agent) => sum + agent.totals.outputTokens, 0)).toBe(250);
   });
 
   it("collapses overflow project scopes without exceeding the response cap", () => {

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -85,12 +85,14 @@ describe("ThreadUsageAccumulator", () => {
     expect(groups[0]?.totals.outputTokens).toBe(50);
   });
 
-  it("records each day's estimated cost", () => {
+  it("splits each day's model-priced cost into cache components", () => {
     const context = { sessionKey: "claude:session-a", agentId: null };
     const groups = accumulate([[record(), context]]);
     const day = groups[0]?.daily.get("2026-08-07");
 
-    expect(day).toBeCloseTo(100 * 1e-5 + 1000 * 1e-6 + 10 * 1.25e-5 + 50 * 5e-5, 12);
+    expect(day?.cacheWriteUsd).toBeCloseTo(10 * 1.25e-5, 12);
+    expect(day?.cacheReadUsd).toBeCloseTo(1000 * 1e-6, 12);
+    expect(day?.freshUsd).toBeCloseTo(100 * 1e-5 + 50 * 5e-5, 12);
   });
 
   it("drops records outside the window", () => {

--- a/apps/server/src/usage/usageThreads.test.ts
+++ b/apps/server/src/usage/usageThreads.test.ts
@@ -14,6 +14,7 @@ const rates: RateTable = new Map([
       outputCostPerToken: 5e-5,
       cacheReadCostPerToken: 1e-6,
       cacheCreationCostPerToken: 1.25e-5,
+      cacheCreation1hCostPerToken: 2e-5,
     },
   ],
 ]);
@@ -83,6 +84,38 @@ describe("ThreadUsageAccumulator", () => {
     ]);
 
     expect(groups[0]?.totals.outputTokens).toBe(50);
+  });
+
+  it("uses the final complete snapshot across files", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [
+        record({ dedupeKey: "msg_partial:", totals: { ...record().totals, outputTokens: 1 } }),
+        context,
+      ],
+      [
+        record({ dedupeKey: "msg_partial:", totals: { ...record().totals, outputTokens: 310 } }),
+        context,
+      ],
+    ]);
+
+    expect(groups[0]?.totals.outputTokens).toBe(310);
+  });
+
+  it("applies the window to the final complete snapshot", () => {
+    const context = { sessionKey: "claude:session-a", agentId: null };
+    const groups = accumulate([
+      [record({ dedupeKey: "msg_partial:" }), context],
+      [
+        record({
+          dedupeKey: "msg_partial:",
+          timestampMs: Date.parse("2026-09-01T00:00:00Z"),
+        }),
+        context,
+      ],
+    ]);
+
+    expect(groups).toEqual([]);
   });
 
   it("splits each day's model-priced cost into cache components", () => {

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -10,6 +10,7 @@
  * @module usageThreads
  */
 import type {
+  ProjectId,
   ThreadId,
   UsageAgentRow,
   UsageProviderKind,
@@ -19,7 +20,7 @@ import type {
 } from "@t3tools/contracts";
 import { UsageDay } from "@t3tools/contracts";
 
-import { makeDayFormatter } from "./usageAggregation.ts";
+import { makeDayFormatter, type ProjectAttribution } from "./usageAggregation.ts";
 import { priceUsage, type RateTable } from "./usagePricing.ts";
 import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
 
@@ -41,6 +42,8 @@ export interface SessionUsageGroup {
   readonly provider: UsageProviderKind;
   readonly sessionId: string;
   readonly cwd: string;
+  readonly projectId: ProjectId | null;
+  readonly projectKey: string | null;
   readonly project: string;
   readonly totals: UsageTokenTotals;
   readonly costUsd: number;
@@ -49,9 +52,13 @@ export interface SessionUsageGroup {
 }
 
 interface MutableSessionGroup {
+  sessionKey: string;
   provider: UsageProviderKind;
   sessionId: string;
   cwd: string;
+  projectId: ProjectId | null;
+  projectKey: string | null;
+  project: string;
   totals: UsageTokenTotals;
   costUsd: number;
   daily: Map<string, number>;
@@ -62,9 +69,11 @@ export interface ThreadUsageOptions {
   readonly timeZone: string;
   readonly sinceDay: string;
   readonly untilDay: string;
+  readonly sinceTimeMs?: number;
+  readonly untilTimeMs?: number;
   readonly rates: RateTable;
-  /** Same resolver the summary uses; `""` means outside every project. */
-  readonly resolveProject?: (cwd: string) => string;
+  /** Same stable project resolver the summary uses. */
+  readonly resolveProject?: (cwd: string) => ProjectAttribution | null;
 }
 
 /**
@@ -92,23 +101,37 @@ export class ThreadUsageAccumulator {
     }
 
     const day = this.#toDay(record.timestampMs);
+    if (
+      this.#options.sinceTimeMs !== undefined &&
+      this.#options.untilTimeMs !== undefined &&
+      (record.timestampMs < this.#options.sinceTimeMs ||
+        record.timestampMs >= this.#options.untilTimeMs)
+    ) {
+      return false;
+    }
     if (day < this.#options.sinceDay || day > this.#options.untilDay) return false;
 
-    let group = this.#groups.get(context.sessionKey);
+    const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
+    const projectKey =
+      resolvedProject === null ? null : `id:${resolvedProject.projectId.replaceAll("\u0000", "")}`;
+    const groupKey = JSON.stringify([context.sessionKey, record.cwd]);
+    let group = this.#groups.get(groupKey);
     if (group === undefined) {
       group = {
+        sessionKey: context.sessionKey,
         provider: record.provider,
         sessionId: record.sessionId,
-        cwd: "",
+        cwd: record.cwd,
+        projectId: resolvedProject?.projectId ?? null,
+        projectKey,
+        project: resolvedProject?.title ?? "",
         totals: EMPTY_TOTALS,
         costUsd: 0,
         daily: new Map(),
         agents: new Map(),
       };
-      this.#groups.set(context.sessionKey, group);
+      this.#groups.set(groupKey, group);
     }
-
-    if (group.cwd.length === 0 && record.cwd.length > 0) group.cwd = record.cwd;
 
     const priced = priceUsage(
       this.#options.rates,
@@ -133,13 +156,14 @@ export class ThreadUsageAccumulator {
   }
 
   finish(): readonly SessionUsageGroup[] {
-    const resolve = this.#options.resolveProject;
-    return [...this.#groups.entries()].map(([sessionKey, group]) => ({
-      sessionKey,
+    return [...this.#groups.values()].map((group) => ({
+      sessionKey: group.sessionKey,
       provider: group.provider,
       sessionId: group.sessionId,
       cwd: group.cwd,
-      project: resolve === undefined ? "" : resolve(group.cwd),
+      projectId: group.projectId,
+      projectKey: group.projectKey,
+      project: group.project,
       totals: group.totals,
       costUsd: group.costUsd,
       daily: group.daily,
@@ -168,7 +192,7 @@ export interface ThreadAttribution {
 export interface FoldThreadRowsOptions {
   /** A title, `null` for outside-projects sessions, `undefined` for no filter. */
   readonly projectFilter?: string | null | undefined;
-  /** Rows kept after sorting by cost; the rest are counted, not sent. */
+  /** Maximum returned rows, including grouped remainders. */
   readonly cap: number;
 }
 
@@ -177,10 +201,12 @@ interface MutableThreadRow {
   title: string | null;
   provider: UsageProviderKind;
   project: string;
+  projectId: ProjectId | null;
+  projectKey: string | null;
   cwd: string;
   totals: UsageTokenTotals;
   costUsd: number;
-  sessions: number;
+  sessionKeys: Set<string>;
   groupedRows: number;
   daily: Map<string, number>;
   agents: Map<string, MutableAgentSlice>;
@@ -217,18 +243,15 @@ export function foldThreadRows(
   const byKey = new Map<string, MutableThreadRow>();
 
   for (const group of groups) {
-    if (options.projectFilter !== undefined) {
-      const project = group.project.length === 0 ? null : group.project;
-      if (project !== options.projectFilter) continue;
-    }
+    if (options.projectFilter !== undefined && group.projectKey !== options.projectFilter) continue;
 
     const ref =
       attribution.sessionToThread.get(group.sessionKey) ??
       (group.cwd.length > 0 ? attribution.worktreeToThread.get(group.cwd) : undefined);
     const rowKey =
       ref === undefined
-        ? `session:${group.sessionKey}`
-        : JSON.stringify(["thread", group.provider, group.project, ref.threadId]);
+        ? JSON.stringify(["session", group.provider, group.projectKey, group.sessionKey])
+        : JSON.stringify(["thread", group.provider, group.projectKey, ref.threadId]);
 
     let row = byKey.get(rowKey);
     if (row === undefined) {
@@ -237,10 +260,12 @@ export function foldThreadRows(
         title: ref?.title ?? null,
         provider: group.provider,
         project: group.project,
+        projectId: group.projectId,
+        projectKey: group.projectKey,
         cwd: group.cwd,
         totals: EMPTY_TOTALS,
         costUsd: 0,
-        sessions: 0,
+        sessionKeys: new Set(),
         groupedRows: 0,
         daily: new Map(),
         agents: new Map(),
@@ -251,7 +276,7 @@ export function foldThreadRows(
 
     row.totals = addTotals(row.totals, group.totals);
     row.costUsd += group.costUsd;
-    row.sessions += 1;
+    row.sessionKeys.add(group.sessionKey);
     addDailyCosts(row.daily, group.daily);
     for (const [agentId, slice] of group.agents) {
       let agent = row.agents.get(agentId);
@@ -270,11 +295,34 @@ export function foldThreadRows(
       totalOf(b[1].totals) - totalOf(a[1].totals) ||
       a[0].localeCompare(b[0]),
   );
-  const kept = sorted.slice(0, options.cap);
-  const omitted = sorted.slice(options.cap);
+  let keptCount = Math.min(sorted.length, options.cap);
+  const projectScopeCount = (rows: typeof sorted): number =>
+    new Set(rows.map(([, row]) => JSON.stringify([row.provider, row.projectKey]))).size;
+  while (keptCount > 0 && keptCount + projectScopeCount(sorted.slice(keptCount)) > options.cap) {
+    keptCount -= 1;
+  }
+
+  let kept = sorted.slice(0, keptCount);
+  let omitted = sorted.slice(keptCount);
+  let remainderScope: "project" | "provider" = "project";
+  if (projectScopeCount(omitted) > options.cap) {
+    // More project scopes than the response can represent. Collapse all named
+    // rows and preserve provider totals in provider-wide overflow rows.
+    kept = [];
+    omitted = sorted;
+    remainderScope = "provider";
+    const providerCount = new Set(omitted.map(([, row]) => row.provider)).size;
+    if (providerCount > options.cap) {
+      throw new RangeError("Thread row cap must fit one remainder per provider");
+    }
+  }
+
   const remainders = new Map<string, MutableThreadRow>();
   for (const [, omittedRow] of omitted) {
-    const scopeKey = JSON.stringify([omittedRow.provider, omittedRow.project]);
+    const scopeKey = JSON.stringify([
+      omittedRow.provider,
+      remainderScope === "project" ? omittedRow.projectKey : null,
+    ]);
     let remainder = remainders.get(scopeKey);
     if (remainder === undefined) {
       const key = `remainder:${scopeKey}`;
@@ -282,11 +330,13 @@ export function foldThreadRows(
         threadId: null,
         title: null,
         provider: omittedRow.provider,
-        project: omittedRow.project,
+        project: remainderScope === "project" ? omittedRow.project : "",
+        projectId: remainderScope === "project" ? omittedRow.projectId : null,
+        projectKey: remainderScope === "project" ? omittedRow.projectKey : null,
         cwd: "",
         totals: EMPTY_TOTALS,
         costUsd: 0,
-        sessions: 0,
+        sessionKeys: new Set(),
         groupedRows: 0,
         daily: new Map(),
         agents: new Map(),
@@ -297,8 +347,17 @@ export function foldThreadRows(
     remainder.groupedRows += 1;
     remainder.totals = addTotals(remainder.totals, omittedRow.totals);
     remainder.costUsd += omittedRow.costUsd;
-    remainder.sessions += omittedRow.sessions;
+    for (const sessionKey of omittedRow.sessionKeys) remainder.sessionKeys.add(sessionKey);
     addDailyCosts(remainder.daily, omittedRow.daily);
+    for (const [agentId, slice] of omittedRow.agents) {
+      let agent = remainder.agents.get(agentId);
+      if (agent === undefined) {
+        agent = { totals: EMPTY_TOTALS, costUsd: 0 };
+        remainder.agents.set(agentId, agent);
+      }
+      agent.totals = addTotals(agent.totals, slice.totals);
+      agent.costUsd += slice.costUsd;
+    }
   }
 
   const displayed = [
@@ -321,10 +380,11 @@ export function foldThreadRows(
       title: row.title,
       titleSessionKey: row.titleSessionKey,
       provider: row.provider,
+      ...(row.projectId === null ? {} : { projectId: row.projectId }),
       ...(row.project === "" ? {} : { project: row.project }),
       totals: row.totals,
       costUsd: row.costUsd,
-      sessions: row.sessions,
+      sessions: row.sessionKeys.size,
       ...(row.groupedRows === 0 ? {} : { groupedRows: row.groupedRows }),
       agents: [...row.agents.entries()]
         .map(([agentId, slice]) => ({

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -181,6 +181,7 @@ interface MutableThreadRow {
   totals: UsageTokenTotals;
   costUsd: number;
   sessions: number;
+  groupedRows: number;
   daily: Map<string, number>;
   agents: Map<string, MutableAgentSlice>;
   /** Session whose transcript can supply a title when no thread claims the row. */
@@ -195,11 +196,18 @@ export interface FoldedThreadRows {
   readonly truncatedRows: number;
 }
 
+function addDailyCosts(target: Map<string, number>, source: ReadonlyMap<string, number>): void {
+  for (const [day, costUsd] of source) {
+    target.set(day, (target.get(day) ?? 0) + costUsd);
+  }
+}
+
 /**
  * Groups sessions into thread rows: resume-cursor matches first, then unique
- * worktrees, else one row per session. Rows sort by cost and cap; a `null`
- * title marks rows whose name must come from the transcript (the caller only
- * reads titles for rows that survived the cap).
+ * worktrees, else one row per session. Rows sort by cost. Rows beyond the cap
+ * fold into provider/project-specific remainders so the returned hierarchy
+ * still reconciles. A `null` title marks retained rows whose name must come
+ * from the transcript.
  */
 export function foldThreadRows(
   groups: readonly SessionUsageGroup[],
@@ -217,7 +225,10 @@ export function foldThreadRows(
     const ref =
       attribution.sessionToThread.get(group.sessionKey) ??
       (group.cwd.length > 0 ? attribution.worktreeToThread.get(group.cwd) : undefined);
-    const rowKey = ref === undefined ? `session:${group.sessionKey}` : `thread:${ref.threadId}`;
+    const rowKey =
+      ref === undefined
+        ? `session:${group.sessionKey}`
+        : JSON.stringify(["thread", group.provider, group.project, ref.threadId]);
 
     let row = byKey.get(rowKey);
     if (row === undefined) {
@@ -230,6 +241,7 @@ export function foldThreadRows(
         totals: EMPTY_TOTALS,
         costUsd: 0,
         sessions: 0,
+        groupedRows: 0,
         daily: new Map(),
         agents: new Map(),
         titleSessionKey: group.sessionKey,
@@ -240,9 +252,7 @@ export function foldThreadRows(
     row.totals = addTotals(row.totals, group.totals);
     row.costUsd += group.costUsd;
     row.sessions += 1;
-    for (const [day, costUsd] of group.daily) {
-      row.daily.set(day, (row.daily.get(day) ?? 0) + costUsd);
-    }
+    addDailyCosts(row.daily, group.daily);
     for (const [agentId, slice] of group.agents) {
       let agent = row.agents.get(agentId);
       if (agent === undefined) {
@@ -261,9 +271,51 @@ export function foldThreadRows(
       a[0].localeCompare(b[0]),
   );
   const kept = sorted.slice(0, options.cap);
+  const omitted = sorted.slice(options.cap);
+  const remainders = new Map<string, MutableThreadRow>();
+  for (const [, omittedRow] of omitted) {
+    const scopeKey = JSON.stringify([omittedRow.provider, omittedRow.project]);
+    let remainder = remainders.get(scopeKey);
+    if (remainder === undefined) {
+      const key = `remainder:${scopeKey}`;
+      remainder = {
+        threadId: null,
+        title: null,
+        provider: omittedRow.provider,
+        project: omittedRow.project,
+        cwd: "",
+        totals: EMPTY_TOTALS,
+        costUsd: 0,
+        sessions: 0,
+        groupedRows: 0,
+        daily: new Map(),
+        agents: new Map(),
+        titleSessionKey: key,
+      };
+      remainders.set(scopeKey, remainder);
+    }
+    remainder.groupedRows += 1;
+    remainder.totals = addTotals(remainder.totals, omittedRow.totals);
+    remainder.costUsd += omittedRow.costUsd;
+    remainder.sessions += omittedRow.sessions;
+    addDailyCosts(remainder.daily, omittedRow.daily);
+  }
+
+  const displayed = [
+    ...kept,
+    ...[...remainders.entries()].map(([scopeKey, remainder]) => {
+      remainder.title = `Other threads (${remainder.groupedRows})`;
+      return [`remainder:${scopeKey}`, remainder] as const;
+    }),
+  ].sort(
+    (a, b) =>
+      b[1].costUsd - a[1].costUsd ||
+      totalOf(b[1].totals) - totalOf(a[1].totals) ||
+      a[0].localeCompare(b[0]),
+  );
 
   return {
-    rows: kept.map(([key, row]) => ({
+    rows: displayed.map(([key, row]) => ({
       key,
       threadId: row.threadId,
       title: row.title,
@@ -273,6 +325,7 @@ export function foldThreadRows(
       totals: row.totals,
       costUsd: row.costUsd,
       sessions: row.sessions,
+      ...(row.groupedRows === 0 ? {} : { groupedRows: row.groupedRows }),
       agents: [...row.agents.entries()]
         .map(([agentId, slice]) => ({
           agentId,
@@ -287,7 +340,7 @@ export function foldThreadRows(
         }))
         .sort((a, b) => a.day.localeCompare(b.day)) satisfies UsageThreadDayCost[],
     })),
-    truncatedRows: sorted.length - kept.length,
+    truncatedRows: omitted.length,
   };
 }
 

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -1,0 +1,301 @@
+/**
+ * Pure grouping behind the thread drill-down: transcript records fold into
+ * per-session groups, and session groups fold into thread rows using the
+ * attribution the caller extracted from its own state (resume cursors and
+ * dedicated worktrees).
+ *
+ * Pure, so grouping, de-duplication and attribution are testable without the
+ * filesystem or the database.
+ *
+ * @module usageThreads
+ */
+import type {
+  ThreadId,
+  UsageAgentRow,
+  UsageProviderKind,
+  UsageThreadDayCost,
+  UsageThreadRow,
+  UsageTokenTotals,
+} from "@t3tools/contracts";
+import { UsageDay } from "@t3tools/contracts";
+
+import { makeDayFormatter } from "./usageAggregation.ts";
+import { priceUsage, type RateTable } from "./usagePricing.ts";
+import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
+
+/** How the caller identifies the transcript a record came from. */
+export interface ThreadRecordContext {
+  /** `provider:sessionId`, or a file-derived fallback when the id is empty. */
+  readonly sessionKey: string;
+  /** Claude subagent id when the record came from a `subagents/agent-*.jsonl` file. */
+  readonly agentId: string | null;
+}
+
+interface MutableAgentSlice {
+  totals: UsageTokenTotals;
+  costUsd: number;
+}
+
+export interface SessionUsageGroup {
+  readonly sessionKey: string;
+  readonly provider: UsageProviderKind;
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly project: string;
+  readonly totals: UsageTokenTotals;
+  readonly costUsd: number;
+  readonly daily: ReadonlyMap<string, number>;
+  readonly agents: ReadonlyMap<string, MutableAgentSlice>;
+}
+
+interface MutableSessionGroup {
+  provider: UsageProviderKind;
+  sessionId: string;
+  cwd: string;
+  totals: UsageTokenTotals;
+  costUsd: number;
+  daily: Map<string, number>;
+  agents: Map<string, MutableAgentSlice>;
+}
+
+export interface ThreadUsageOptions {
+  readonly timeZone: string;
+  readonly sinceDay: string;
+  readonly untilDay: string;
+  readonly rates: RateTable;
+  /** Same resolver the summary uses; `""` means outside every project. */
+  readonly resolveProject?: (cwd: string) => string;
+}
+
+/**
+ * Folds records into per-session groups with per-day estimated costs.
+ *
+ * De-duplication is global across the scan with the same semantics as the
+ * summary aggregator, so a thread's number here always reconciles with its
+ * share of the summary.
+ */
+export class ThreadUsageAccumulator {
+  readonly #groups = new Map<string, MutableSessionGroup>();
+  readonly #seen = new Set<string>();
+  readonly #toDay: (timestampMs: number) => string;
+  readonly #options: ThreadUsageOptions;
+
+  constructor(options: ThreadUsageOptions) {
+    this.#options = options;
+    this.#toDay = makeDayFormatter(options.timeZone);
+  }
+
+  add(record: UsageRecord, context: ThreadRecordContext): boolean {
+    if (record.dedupeKey !== null) {
+      if (this.#seen.has(record.dedupeKey)) return false;
+      this.#seen.add(record.dedupeKey);
+    }
+
+    const day = this.#toDay(record.timestampMs);
+    if (day < this.#options.sinceDay || day > this.#options.untilDay) return false;
+
+    let group = this.#groups.get(context.sessionKey);
+    if (group === undefined) {
+      group = {
+        provider: record.provider,
+        sessionId: record.sessionId,
+        cwd: "",
+        totals: EMPTY_TOTALS,
+        costUsd: 0,
+        daily: new Map(),
+        agents: new Map(),
+      };
+      this.#groups.set(context.sessionKey, group);
+    }
+
+    if (group.cwd.length === 0 && record.cwd.length > 0) group.cwd = record.cwd;
+
+    const priced = priceUsage(
+      this.#options.rates,
+      record.model,
+      record.totals,
+      record.reportedCostUsd,
+    );
+    group.totals = addTotals(group.totals, record.totals);
+    group.costUsd += priced.costUsd;
+    group.daily.set(day, (group.daily.get(day) ?? 0) + priced.costUsd);
+
+    if (context.agentId !== null) {
+      let agent = group.agents.get(context.agentId);
+      if (agent === undefined) {
+        agent = { totals: EMPTY_TOTALS, costUsd: 0 };
+        group.agents.set(context.agentId, agent);
+      }
+      agent.totals = addTotals(agent.totals, record.totals);
+      agent.costUsd += priced.costUsd;
+    }
+    return true;
+  }
+
+  finish(): readonly SessionUsageGroup[] {
+    const resolve = this.#options.resolveProject;
+    return [...this.#groups.entries()].map(([sessionKey, group]) => ({
+      sessionKey,
+      provider: group.provider,
+      sessionId: group.sessionId,
+      cwd: group.cwd,
+      project: resolve === undefined ? "" : resolve(group.cwd),
+      totals: group.totals,
+      costUsd: group.costUsd,
+      daily: group.daily,
+      agents: group.agents,
+    }));
+  }
+}
+
+/** A thread a session can attribute to, from the environment's own state. */
+export interface ThreadRef {
+  readonly threadId: ThreadId;
+  readonly title: string;
+}
+
+export interface ThreadAttribution {
+  /** `provider:sessionId` of each thread's current session, from resume cursors. */
+  readonly sessionToThread: ReadonlyMap<string, ThreadRef>;
+  /**
+   * Dedicated worktree path → thread. Only paths claimed by exactly one
+   * thread belong here: a shared root would stamp one thread's identity onto
+   * every unrelated session running there.
+   */
+  readonly worktreeToThread: ReadonlyMap<string, ThreadRef>;
+}
+
+export interface FoldThreadRowsOptions {
+  /** A title, `null` for outside-projects sessions, `undefined` for no filter. */
+  readonly projectFilter?: string | null | undefined;
+  /** Rows kept after sorting by cost; the rest are counted, not sent. */
+  readonly cap: number;
+}
+
+interface MutableThreadRow {
+  threadId: ThreadId | null;
+  title: string | null;
+  provider: UsageProviderKind;
+  project: string;
+  cwd: string;
+  totals: UsageTokenTotals;
+  costUsd: number;
+  sessions: number;
+  daily: Map<string, number>;
+  agents: Map<string, MutableAgentSlice>;
+  /** Session whose transcript can supply a title when no thread claims the row. */
+  titleSessionKey: string;
+}
+
+export interface FoldedThreadRows {
+  readonly rows: readonly (Omit<UsageThreadRow, "title"> & {
+    readonly title: string | null;
+    readonly titleSessionKey: string;
+  })[];
+  readonly truncatedRows: number;
+}
+
+/**
+ * Groups sessions into thread rows: resume-cursor matches first, then unique
+ * worktrees, else one row per session. Rows sort by cost and cap; a `null`
+ * title marks rows whose name must come from the transcript (the caller only
+ * reads titles for rows that survived the cap).
+ */
+export function foldThreadRows(
+  groups: readonly SessionUsageGroup[],
+  attribution: ThreadAttribution,
+  options: FoldThreadRowsOptions,
+): FoldedThreadRows {
+  const byKey = new Map<string, MutableThreadRow>();
+
+  for (const group of groups) {
+    if (options.projectFilter !== undefined) {
+      const project = group.project.length === 0 ? null : group.project;
+      if (project !== options.projectFilter) continue;
+    }
+
+    const ref =
+      attribution.sessionToThread.get(group.sessionKey) ??
+      (group.cwd.length > 0 ? attribution.worktreeToThread.get(group.cwd) : undefined);
+    const rowKey = ref === undefined ? `session:${group.sessionKey}` : `thread:${ref.threadId}`;
+
+    let row = byKey.get(rowKey);
+    if (row === undefined) {
+      row = {
+        threadId: ref?.threadId ?? null,
+        title: ref?.title ?? null,
+        provider: group.provider,
+        project: group.project,
+        cwd: group.cwd,
+        totals: EMPTY_TOTALS,
+        costUsd: 0,
+        sessions: 0,
+        daily: new Map(),
+        agents: new Map(),
+        titleSessionKey: group.sessionKey,
+      };
+      byKey.set(rowKey, row);
+    }
+
+    row.totals = addTotals(row.totals, group.totals);
+    row.costUsd += group.costUsd;
+    row.sessions += 1;
+    for (const [day, costUsd] of group.daily) {
+      row.daily.set(day, (row.daily.get(day) ?? 0) + costUsd);
+    }
+    for (const [agentId, slice] of group.agents) {
+      let agent = row.agents.get(agentId);
+      if (agent === undefined) {
+        agent = { totals: EMPTY_TOTALS, costUsd: 0 };
+        row.agents.set(agentId, agent);
+      }
+      agent.totals = addTotals(agent.totals, slice.totals);
+      agent.costUsd += slice.costUsd;
+    }
+  }
+
+  const sorted = [...byKey.entries()].sort(
+    (a, b) =>
+      b[1].costUsd - a[1].costUsd ||
+      totalOf(b[1].totals) - totalOf(a[1].totals) ||
+      a[0].localeCompare(b[0]),
+  );
+  const kept = sorted.slice(0, options.cap);
+
+  return {
+    rows: kept.map(([key, row]) => ({
+      key,
+      threadId: row.threadId,
+      title: row.title,
+      titleSessionKey: row.titleSessionKey,
+      provider: row.provider,
+      ...(row.project === "" ? {} : { project: row.project }),
+      totals: row.totals,
+      costUsd: row.costUsd,
+      sessions: row.sessions,
+      agents: [...row.agents.entries()]
+        .map(([agentId, slice]) => ({
+          agentId,
+          totals: slice.totals,
+          costUsd: slice.costUsd,
+        }))
+        .sort((a, b) => b.costUsd - a.costUsd) satisfies UsageAgentRow[],
+      daily: [...row.daily.entries()]
+        .map(([day, costUsd]) => ({
+          day: day as UsageDay,
+          costUsd,
+        }))
+        .sort((a, b) => a.day.localeCompare(b.day)) satisfies UsageThreadDayCost[],
+    })),
+    truncatedRows: sorted.length - kept.length,
+  };
+}
+
+function totalOf(totals: UsageTokenTotals): number {
+  return (
+    totals.uncachedInputTokens +
+    totals.cachedInputTokens +
+    totals.cacheCreationTokens +
+    totals.outputTokens
+  );
+}

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -24,6 +24,8 @@ import { makeDayFormatter, type ProjectAttribution } from "./usageAggregation.ts
 import { priceUsage, type RateTable } from "./usagePricing.ts";
 import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
 
+const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+
 /** How the caller identifies the transcript a record came from. */
 export interface ThreadRecordContext {
   /** `provider:sessionId`, or a file-derived fallback when the id is empty. */
@@ -100,7 +102,12 @@ export class ThreadUsageAccumulator {
       this.#seen.add(record.dedupeKey);
     }
 
-    const day = this.#toDay(record.timestampMs);
+    if (
+      !Number.isFinite(record.timestampMs) ||
+      Math.abs(record.timestampMs) > MAX_DATE_TIMESTAMP_MS
+    ) {
+      return false;
+    }
     if (
       this.#options.sinceTimeMs !== undefined &&
       this.#options.untilTimeMs !== undefined &&
@@ -109,7 +116,12 @@ export class ThreadUsageAccumulator {
     ) {
       return false;
     }
-    if (day < this.#options.sinceDay || day > this.#options.untilDay) return false;
+    const day = this.#toDay(record.timestampMs);
+    if (
+      (this.#options.sinceTimeMs === undefined || this.#options.untilTimeMs === undefined) &&
+      (day < this.#options.sinceDay || day > this.#options.untilDay)
+    )
+      return false;
 
     const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
     const projectKey =
@@ -228,6 +240,75 @@ function addDailyCosts(target: Map<string, number>, source: ReadonlyMap<string, 
   }
 }
 
+function worktreeThreadForCwd(
+  cwd: string,
+  worktreeToThread: ReadonlyMap<string, ThreadRef>,
+): ThreadRef | undefined {
+  const normalizedCwd = normalizePath(cwd);
+  let deepest: { readonly pathLength: number; readonly ref: ThreadRef } | undefined;
+  for (const [worktree, ref] of worktreeToThread) {
+    const normalizedWorktree = normalizePath(worktree);
+    const prefix = normalizedWorktree.endsWith("/") ? normalizedWorktree : `${normalizedWorktree}/`;
+    if (normalizedCwd !== normalizedWorktree && !normalizedCwd.startsWith(prefix)) continue;
+    if (deepest === undefined || normalizedWorktree.length > deepest.pathLength) {
+      deepest = { pathLength: normalizedWorktree.length, ref };
+    }
+  }
+  return deepest?.ref;
+}
+
+function normalizePath(value: string): string {
+  const slashPath = value.replaceAll("\\", "/");
+  const rooted = slashPath.startsWith("/");
+  const segments: string[] = [];
+  for (const segment of slashPath.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length > 0 && segments.at(-1) !== "..") segments.pop();
+      else if (!rooted) segments.push(segment);
+      continue;
+    }
+    segments.push(segment);
+  }
+  const normalized = `${rooted ? "/" : ""}${segments.join("/")}`;
+  return normalized === "" ? (rooted ? "/" : ".") : normalized;
+}
+
+function toAgentRow([agentId, slice]: readonly [string, MutableAgentSlice]): UsageAgentRow {
+  return {
+    agentId,
+    totals: slice.totals,
+    costUsd: slice.costUsd,
+  };
+}
+
+function boundedAgentRows(
+  agents: ReadonlyMap<string, MutableAgentSlice>,
+  cap: number,
+): readonly UsageAgentRow[] {
+  const sorted = [...agents.entries()].sort(
+    (a, b) =>
+      b[1].costUsd - a[1].costUsd ||
+      totalOf(b[1].totals) - totalOf(a[1].totals) ||
+      a[0].localeCompare(b[0]),
+  );
+  if (sorted.length <= cap) return sorted.map(toAgentRow);
+
+  const kept = sorted.slice(0, Math.max(0, cap - 1));
+  const omitted = sorted.slice(kept.length);
+  const overflow = omitted.reduce<MutableAgentSlice>(
+    (combined, [, slice]) => ({
+      totals: addTotals(combined.totals, slice.totals),
+      costUsd: combined.costUsd + slice.costUsd,
+    }),
+    {
+      totals: EMPTY_TOTALS,
+      costUsd: 0,
+    },
+  );
+  return [...kept.map(toAgentRow), toAgentRow([`Other subagents (${omitted.length})`, overflow])];
+}
+
 /**
  * Groups sessions into thread rows: resume-cursor matches first, then unique
  * worktrees, else one row per session. Rows sort by cost. Rows beyond the cap
@@ -247,7 +328,9 @@ export function foldThreadRows(
 
     const ref =
       attribution.sessionToThread.get(group.sessionKey) ??
-      (group.cwd.length > 0 ? attribution.worktreeToThread.get(group.cwd) : undefined);
+      (group.cwd.length > 0
+        ? worktreeThreadForCwd(group.cwd, attribution.worktreeToThread)
+        : undefined);
     const rowKey =
       ref === undefined
         ? JSON.stringify(["session", group.provider, group.projectKey, group.sessionKey])
@@ -386,13 +469,7 @@ export function foldThreadRows(
       costUsd: row.costUsd,
       sessions: row.sessionKeys.size,
       ...(row.groupedRows === 0 ? {} : { groupedRows: row.groupedRows }),
-      agents: [...row.agents.entries()]
-        .map(([agentId, slice]) => ({
-          agentId,
-          totals: slice.totals,
-          costUsd: slice.costUsd,
-        }))
-        .sort((a, b) => b.costUsd - a.costUsd) satisfies UsageAgentRow[],
+      agents: boundedAgentRows(row.agents, options.cap),
       daily: [...row.daily.entries()]
         .map(([day, costUsd]) => ({
           day: day as UsageDay,

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -85,6 +85,8 @@ export interface ThreadUsageOptions {
   readonly untilDay: string;
   readonly sinceTimeMs?: number;
   readonly untilTimeMs?: number;
+  /** Request-start ceiling. Records written later wait for the next refresh. */
+  readonly cutoffTimeMs?: number;
   readonly rates: RateTable;
   /** Same stable project resolver the summary uses. */
   readonly resolveProject?: (cwd: string) => ProjectAttribution | null;
@@ -132,6 +134,12 @@ export class ThreadUsageAccumulator {
     if (
       !Number.isFinite(record.timestampMs) ||
       Math.abs(record.timestampMs) > MAX_DATE_TIMESTAMP_MS
+    ) {
+      return false;
+    }
+    if (
+      this.#options.cutoffTimeMs !== undefined &&
+      record.timestampMs > this.#options.cutoffTimeMs
     ) {
       return false;
     }

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -21,7 +21,7 @@ import type {
 import { UsageDay } from "@t3tools/contracts";
 
 import { makeDayFormatter, type ProjectAttribution } from "./usageAggregation.ts";
-import { priceUsage, type RateTable } from "./usagePricing.ts";
+import { cacheWriteUsd, priceUsage, usageComponentCosts, type RateTable } from "./usagePricing.ts";
 import { addTotals, EMPTY_TOTALS, type UsageRecord } from "./usageTranscripts.ts";
 
 const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
@@ -34,9 +34,16 @@ export interface ThreadRecordContext {
   readonly agentId: string | null;
 }
 
+interface MutableComponentCosts {
+  cacheWriteUsd: number;
+  cacheReadUsd: number;
+  freshUsd: number;
+}
+
 interface MutableAgentSlice {
   totals: UsageTokenTotals;
   costUsd: number;
+  cacheWriteUsd: number;
 }
 
 export interface SessionUsageGroup {
@@ -49,7 +56,8 @@ export interface SessionUsageGroup {
   readonly project: string;
   readonly totals: UsageTokenTotals;
   readonly costUsd: number;
-  readonly daily: ReadonlyMap<string, number>;
+  readonly cacheWriteUsd: number;
+  readonly daily: ReadonlyMap<string, MutableComponentCosts>;
   readonly agents: ReadonlyMap<string, MutableAgentSlice>;
 }
 
@@ -63,7 +71,8 @@ interface MutableSessionGroup {
   project: string;
   totals: UsageTokenTotals;
   costUsd: number;
-  daily: Map<string, number>;
+  cacheWriteUsd: number;
+  daily: Map<string, MutableComponentCosts>;
   agents: Map<string, MutableAgentSlice>;
 }
 
@@ -79,7 +88,7 @@ export interface ThreadUsageOptions {
 }
 
 /**
- * Folds records into per-session groups with per-day estimated costs.
+ * Folds records into per-session groups with per-day component costs.
  *
  * De-duplication is global across the scan with the same semantics as the
  * summary aggregator, so a thread's number here always reconciles with its
@@ -139,6 +148,7 @@ export class ThreadUsageAccumulator {
         project: resolvedProject?.title ?? "",
         totals: EMPTY_TOTALS,
         costUsd: 0,
+        cacheWriteUsd: 0,
         daily: new Map(),
         agents: new Map(),
       };
@@ -151,18 +161,30 @@ export class ThreadUsageAccumulator {
       record.totals,
       record.reportedCostUsd,
     );
+    const writeUsd = cacheWriteUsd(this.#options.rates, record.model, record.totals);
     group.totals = addTotals(group.totals, record.totals);
     group.costUsd += priced.costUsd;
-    group.daily.set(day, (group.daily.get(day) ?? 0) + priced.costUsd);
+    group.cacheWriteUsd += writeUsd;
+
+    const components = usageComponentCosts(this.#options.rates, record.model, record.totals);
+    let dayEntry = group.daily.get(day);
+    if (dayEntry === undefined) {
+      dayEntry = { cacheWriteUsd: 0, cacheReadUsd: 0, freshUsd: 0 };
+      group.daily.set(day, dayEntry);
+    }
+    dayEntry.cacheWriteUsd += components.cacheWriteUsd;
+    dayEntry.cacheReadUsd += components.cacheReadUsd;
+    dayEntry.freshUsd += components.freshUsd;
 
     if (context.agentId !== null) {
       let agent = group.agents.get(context.agentId);
       if (agent === undefined) {
-        agent = { totals: EMPTY_TOTALS, costUsd: 0 };
+        agent = { totals: EMPTY_TOTALS, costUsd: 0, cacheWriteUsd: 0 };
         group.agents.set(context.agentId, agent);
       }
       agent.totals = addTotals(agent.totals, record.totals);
       agent.costUsd += priced.costUsd;
+      agent.cacheWriteUsd += writeUsd;
     }
     return true;
   }
@@ -178,6 +200,7 @@ export class ThreadUsageAccumulator {
       project: group.project,
       totals: group.totals,
       costUsd: group.costUsd,
+      cacheWriteUsd: group.cacheWriteUsd,
       daily: group.daily,
       agents: group.agents,
     }));
@@ -219,8 +242,9 @@ interface MutableThreadRow {
   totals: UsageTokenTotals;
   costUsd: number;
   sessionKeys: Set<string>;
+  cacheWriteUsd: number;
   groupedRows: number;
-  daily: Map<string, number>;
+  daily: Map<string, MutableComponentCosts>;
   agents: Map<string, MutableAgentSlice>;
   /** Session whose transcript can supply a title when no thread claims the row. */
   titleSessionKey: string;
@@ -234,9 +258,19 @@ export interface FoldedThreadRows {
   readonly truncatedRows: number;
 }
 
-function addDailyCosts(target: Map<string, number>, source: ReadonlyMap<string, number>): void {
-  for (const [day, costUsd] of source) {
-    target.set(day, (target.get(day) ?? 0) + costUsd);
+function addDailyCosts(
+  target: Map<string, MutableComponentCosts>,
+  source: ReadonlyMap<string, MutableComponentCosts>,
+): void {
+  for (const [day, components] of source) {
+    let dayEntry = target.get(day);
+    if (dayEntry === undefined) {
+      dayEntry = { cacheWriteUsd: 0, cacheReadUsd: 0, freshUsd: 0 };
+      target.set(day, dayEntry);
+    }
+    dayEntry.cacheWriteUsd += components.cacheWriteUsd;
+    dayEntry.cacheReadUsd += components.cacheReadUsd;
+    dayEntry.freshUsd += components.freshUsd;
   }
 }
 
@@ -279,6 +313,7 @@ function toAgentRow([agentId, slice]: readonly [string, MutableAgentSlice]): Usa
     agentId,
     totals: slice.totals,
     costUsd: slice.costUsd,
+    cacheWriteUsd: slice.cacheWriteUsd,
   };
 }
 
@@ -300,10 +335,12 @@ function boundedAgentRows(
     (combined, [, slice]) => ({
       totals: addTotals(combined.totals, slice.totals),
       costUsd: combined.costUsd + slice.costUsd,
+      cacheWriteUsd: combined.cacheWriteUsd + slice.cacheWriteUsd,
     }),
     {
       totals: EMPTY_TOTALS,
       costUsd: 0,
+      cacheWriteUsd: 0,
     },
   );
   return [...kept.map(toAgentRow), toAgentRow([`Other subagents (${omitted.length})`, overflow])];
@@ -349,6 +386,7 @@ export function foldThreadRows(
         totals: EMPTY_TOTALS,
         costUsd: 0,
         sessionKeys: new Set(),
+        cacheWriteUsd: 0,
         groupedRows: 0,
         daily: new Map(),
         agents: new Map(),
@@ -360,15 +398,17 @@ export function foldThreadRows(
     row.totals = addTotals(row.totals, group.totals);
     row.costUsd += group.costUsd;
     row.sessionKeys.add(group.sessionKey);
+    row.cacheWriteUsd += group.cacheWriteUsd;
     addDailyCosts(row.daily, group.daily);
     for (const [agentId, slice] of group.agents) {
       let agent = row.agents.get(agentId);
       if (agent === undefined) {
-        agent = { totals: EMPTY_TOTALS, costUsd: 0 };
+        agent = { totals: EMPTY_TOTALS, costUsd: 0, cacheWriteUsd: 0 };
         row.agents.set(agentId, agent);
       }
       agent.totals = addTotals(agent.totals, slice.totals);
       agent.costUsd += slice.costUsd;
+      agent.cacheWriteUsd += slice.cacheWriteUsd;
     }
   }
 
@@ -420,6 +460,7 @@ export function foldThreadRows(
         totals: EMPTY_TOTALS,
         costUsd: 0,
         sessionKeys: new Set(),
+        cacheWriteUsd: 0,
         groupedRows: 0,
         daily: new Map(),
         agents: new Map(),
@@ -431,15 +472,17 @@ export function foldThreadRows(
     remainder.totals = addTotals(remainder.totals, omittedRow.totals);
     remainder.costUsd += omittedRow.costUsd;
     for (const sessionKey of omittedRow.sessionKeys) remainder.sessionKeys.add(sessionKey);
+    remainder.cacheWriteUsd += omittedRow.cacheWriteUsd;
     addDailyCosts(remainder.daily, omittedRow.daily);
     for (const [agentId, slice] of omittedRow.agents) {
       let agent = remainder.agents.get(agentId);
       if (agent === undefined) {
-        agent = { totals: EMPTY_TOTALS, costUsd: 0 };
+        agent = { totals: EMPTY_TOTALS, costUsd: 0, cacheWriteUsd: 0 };
         remainder.agents.set(agentId, agent);
       }
       agent.totals = addTotals(agent.totals, slice.totals);
       agent.costUsd += slice.costUsd;
+      agent.cacheWriteUsd += slice.cacheWriteUsd;
     }
   }
 
@@ -467,13 +510,16 @@ export function foldThreadRows(
       ...(row.project === "" ? {} : { project: row.project }),
       totals: row.totals,
       costUsd: row.costUsd,
+      cacheWriteUsd: row.cacheWriteUsd,
       sessions: row.sessionKeys.size,
       ...(row.groupedRows === 0 ? {} : { groupedRows: row.groupedRows }),
       agents: boundedAgentRows(row.agents, options.cap),
       daily: [...row.daily.entries()]
-        .map(([day, costUsd]) => ({
+        .map(([day, components]) => ({
           day: day as UsageDay,
-          costUsd,
+          cacheWriteUsd: components.cacheWriteUsd,
+          cacheReadUsd: components.cacheReadUsd,
+          freshUsd: components.freshUsd,
         }))
         .sort((a, b) => a.day.localeCompare(b.day)) satisfies UsageThreadDayCost[],
     })),

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -98,8 +98,14 @@ export interface ThreadUsageOptions {
  * share of the summary.
  */
 export class ThreadUsageAccumulator {
-  readonly #groups = new Map<string, MutableSessionGroup>();
-  readonly #seen = new Set<string>();
+  readonly #recordsByKey = new Map<
+    string,
+    { readonly record: UsageRecord; readonly context: ThreadRecordContext }
+  >();
+  readonly #unkeyedRecords: {
+    readonly record: UsageRecord;
+    readonly context: ThreadRecordContext;
+  }[] = [];
   readonly #toDay: (timestampMs: number) => string;
   readonly #options: ThreadUsageOptions;
 
@@ -109,11 +115,20 @@ export class ThreadUsageAccumulator {
   }
 
   add(record: UsageRecord, context: ThreadRecordContext): boolean {
-    if (record.dedupeKey !== null) {
-      if (this.#seen.has(record.dedupeKey)) return false;
-      this.#seen.add(record.dedupeKey);
+    const inWindow = this.#isInWindow(record);
+    if (record.dedupeKey === null) {
+      this.#unkeyedRecords.push({ record, context });
+      return inWindow;
     }
+    if (this.#recordsByKey.has(record.dedupeKey)) {
+      this.#recordsByKey.set(record.dedupeKey, { record, context });
+      return inWindow;
+    }
+    this.#recordsByKey.set(record.dedupeKey, { record, context });
+    return inWindow;
+  }
 
+  #isInWindow(record: UsageRecord): boolean {
     if (
       !Number.isFinite(record.timestampMs) ||
       Math.abs(record.timestampMs) > MAX_DATE_TIMESTAMP_MS
@@ -134,12 +149,20 @@ export class ThreadUsageAccumulator {
       (day < this.#options.sinceDay || day > this.#options.untilDay)
     )
       return false;
+    return true;
+  }
 
+  #foldRecord(
+    record: UsageRecord,
+    context: ThreadRecordContext,
+    groups: Map<string, MutableSessionGroup>,
+  ): void {
+    const day = this.#toDay(record.timestampMs);
     const resolvedProject = this.#options.resolveProject?.(record.cwd) ?? null;
     const projectKey =
       resolvedProject === null ? null : `id:${resolvedProject.projectId.replaceAll("\u0000", "")}`;
     const groupKey = JSON.stringify([context.sessionKey, record.cwd]);
-    let group = this.#groups.get(groupKey);
+    let group = groups.get(groupKey);
     if (group === undefined) {
       group = {
         sessionKey: context.sessionKey,
@@ -156,7 +179,7 @@ export class ThreadUsageAccumulator {
         daily: new Map(),
         agents: new Map(),
       };
-      this.#groups.set(groupKey, group);
+      groups.set(groupKey, group);
     }
 
     const priced = priceUsage(
@@ -204,11 +227,17 @@ export class ThreadUsageAccumulator {
       agent.cacheWriteUsd += writeUsd;
       agent.cacheWriteComplete &&= cacheWriteComplete;
     }
-    return true;
   }
 
   finish(): readonly SessionUsageGroup[] {
-    return [...this.#groups.values()].map((group) => ({
+    const groups = new Map<string, MutableSessionGroup>();
+    for (const { record, context } of this.#unkeyedRecords) {
+      if (this.#isInWindow(record)) this.#foldRecord(record, context, groups);
+    }
+    for (const { record, context } of this.#recordsByKey.values()) {
+      if (this.#isInWindow(record)) this.#foldRecord(record, context, groups);
+    }
+    return [...groups.values()].map((group) => ({
       sessionKey: group.sessionKey,
       provider: group.provider,
       sessionId: group.sessionId,

--- a/apps/server/src/usage/usageThreads.ts
+++ b/apps/server/src/usage/usageThreads.ts
@@ -44,6 +44,7 @@ interface MutableAgentSlice {
   totals: UsageTokenTotals;
   costUsd: number;
   cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
 }
 
 export interface SessionUsageGroup {
@@ -57,6 +58,7 @@ export interface SessionUsageGroup {
   readonly totals: UsageTokenTotals;
   readonly costUsd: number;
   readonly cacheWriteUsd: number;
+  readonly cacheWriteComplete: boolean;
   readonly daily: ReadonlyMap<string, MutableComponentCosts>;
   readonly agents: ReadonlyMap<string, MutableAgentSlice>;
 }
@@ -72,6 +74,7 @@ interface MutableSessionGroup {
   totals: UsageTokenTotals;
   costUsd: number;
   cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
   daily: Map<string, MutableComponentCosts>;
   agents: Map<string, MutableAgentSlice>;
 }
@@ -149,6 +152,7 @@ export class ThreadUsageAccumulator {
         totals: EMPTY_TOTALS,
         costUsd: 0,
         cacheWriteUsd: 0,
+        cacheWriteComplete: true,
         daily: new Map(),
         agents: new Map(),
       };
@@ -161,30 +165,44 @@ export class ThreadUsageAccumulator {
       record.totals,
       record.reportedCostUsd,
     );
-    const writeUsd = cacheWriteUsd(this.#options.rates, record.model, record.totals);
+    const cacheWriteComplete =
+      priced.costSource === "modelPriced" || record.totals.cacheCreationTokens === 0;
+    const writeUsd =
+      priced.costSource === "modelPriced"
+        ? cacheWriteUsd(this.#options.rates, record.model, record.totals)
+        : 0;
     group.totals = addTotals(group.totals, record.totals);
     group.costUsd += priced.costUsd;
     group.cacheWriteUsd += writeUsd;
+    group.cacheWriteComplete &&= cacheWriteComplete;
 
-    const components = usageComponentCosts(this.#options.rates, record.model, record.totals);
-    let dayEntry = group.daily.get(day);
-    if (dayEntry === undefined) {
-      dayEntry = { cacheWriteUsd: 0, cacheReadUsd: 0, freshUsd: 0 };
-      group.daily.set(day, dayEntry);
+    if (priced.costSource === "modelPriced") {
+      const components = usageComponentCosts(this.#options.rates, record.model, record.totals);
+      let dayEntry = group.daily.get(day);
+      if (dayEntry === undefined) {
+        dayEntry = { cacheWriteUsd: 0, cacheReadUsd: 0, freshUsd: 0 };
+        group.daily.set(day, dayEntry);
+      }
+      dayEntry.cacheWriteUsd += components.cacheWriteUsd;
+      dayEntry.cacheReadUsd += components.cacheReadUsd;
+      dayEntry.freshUsd += components.freshUsd;
     }
-    dayEntry.cacheWriteUsd += components.cacheWriteUsd;
-    dayEntry.cacheReadUsd += components.cacheReadUsd;
-    dayEntry.freshUsd += components.freshUsd;
 
     if (context.agentId !== null) {
       let agent = group.agents.get(context.agentId);
       if (agent === undefined) {
-        agent = { totals: EMPTY_TOTALS, costUsd: 0, cacheWriteUsd: 0 };
+        agent = {
+          totals: EMPTY_TOTALS,
+          costUsd: 0,
+          cacheWriteUsd: 0,
+          cacheWriteComplete: true,
+        };
         group.agents.set(context.agentId, agent);
       }
       agent.totals = addTotals(agent.totals, record.totals);
       agent.costUsd += priced.costUsd;
       agent.cacheWriteUsd += writeUsd;
+      agent.cacheWriteComplete &&= cacheWriteComplete;
     }
     return true;
   }
@@ -201,6 +219,7 @@ export class ThreadUsageAccumulator {
       totals: group.totals,
       costUsd: group.costUsd,
       cacheWriteUsd: group.cacheWriteUsd,
+      cacheWriteComplete: group.cacheWriteComplete,
       daily: group.daily,
       agents: group.agents,
     }));
@@ -243,6 +262,7 @@ interface MutableThreadRow {
   costUsd: number;
   sessionKeys: Set<string>;
   cacheWriteUsd: number;
+  cacheWriteComplete: boolean;
   groupedRows: number;
   daily: Map<string, MutableComponentCosts>;
   agents: Map<string, MutableAgentSlice>;
@@ -313,7 +333,7 @@ function toAgentRow([agentId, slice]: readonly [string, MutableAgentSlice]): Usa
     agentId,
     totals: slice.totals,
     costUsd: slice.costUsd,
-    cacheWriteUsd: slice.cacheWriteUsd,
+    cacheWriteUsd: slice.cacheWriteComplete ? slice.cacheWriteUsd : null,
   };
 }
 
@@ -336,11 +356,13 @@ function boundedAgentRows(
       totals: addTotals(combined.totals, slice.totals),
       costUsd: combined.costUsd + slice.costUsd,
       cacheWriteUsd: combined.cacheWriteUsd + slice.cacheWriteUsd,
+      cacheWriteComplete: combined.cacheWriteComplete && slice.cacheWriteComplete,
     }),
     {
       totals: EMPTY_TOTALS,
       costUsd: 0,
       cacheWriteUsd: 0,
+      cacheWriteComplete: true,
     },
   );
   return [...kept.map(toAgentRow), toAgentRow([`Other subagents (${omitted.length})`, overflow])];
@@ -387,6 +409,7 @@ export function foldThreadRows(
         costUsd: 0,
         sessionKeys: new Set(),
         cacheWriteUsd: 0,
+        cacheWriteComplete: true,
         groupedRows: 0,
         daily: new Map(),
         agents: new Map(),
@@ -399,16 +422,23 @@ export function foldThreadRows(
     row.costUsd += group.costUsd;
     row.sessionKeys.add(group.sessionKey);
     row.cacheWriteUsd += group.cacheWriteUsd;
+    row.cacheWriteComplete &&= group.cacheWriteComplete;
     addDailyCosts(row.daily, group.daily);
     for (const [agentId, slice] of group.agents) {
       let agent = row.agents.get(agentId);
       if (agent === undefined) {
-        agent = { totals: EMPTY_TOTALS, costUsd: 0, cacheWriteUsd: 0 };
+        agent = {
+          totals: EMPTY_TOTALS,
+          costUsd: 0,
+          cacheWriteUsd: 0,
+          cacheWriteComplete: true,
+        };
         row.agents.set(agentId, agent);
       }
       agent.totals = addTotals(agent.totals, slice.totals);
       agent.costUsd += slice.costUsd;
       agent.cacheWriteUsd += slice.cacheWriteUsd;
+      agent.cacheWriteComplete &&= slice.cacheWriteComplete;
     }
   }
 
@@ -461,6 +491,7 @@ export function foldThreadRows(
         costUsd: 0,
         sessionKeys: new Set(),
         cacheWriteUsd: 0,
+        cacheWriteComplete: true,
         groupedRows: 0,
         daily: new Map(),
         agents: new Map(),
@@ -473,16 +504,23 @@ export function foldThreadRows(
     remainder.costUsd += omittedRow.costUsd;
     for (const sessionKey of omittedRow.sessionKeys) remainder.sessionKeys.add(sessionKey);
     remainder.cacheWriteUsd += omittedRow.cacheWriteUsd;
+    remainder.cacheWriteComplete &&= omittedRow.cacheWriteComplete;
     addDailyCosts(remainder.daily, omittedRow.daily);
     for (const [agentId, slice] of omittedRow.agents) {
       let agent = remainder.agents.get(agentId);
       if (agent === undefined) {
-        agent = { totals: EMPTY_TOTALS, costUsd: 0, cacheWriteUsd: 0 };
+        agent = {
+          totals: EMPTY_TOTALS,
+          costUsd: 0,
+          cacheWriteUsd: 0,
+          cacheWriteComplete: true,
+        };
         remainder.agents.set(agentId, agent);
       }
       agent.totals = addTotals(agent.totals, slice.totals);
       agent.costUsd += slice.costUsd;
       agent.cacheWriteUsd += slice.cacheWriteUsd;
+      agent.cacheWriteComplete &&= slice.cacheWriteComplete;
     }
   }
 
@@ -510,7 +548,7 @@ export function foldThreadRows(
       ...(row.project === "" ? {} : { project: row.project }),
       totals: row.totals,
       costUsd: row.costUsd,
-      cacheWriteUsd: row.cacheWriteUsd,
+      cacheWriteUsd: row.cacheWriteComplete ? row.cacheWriteUsd : null,
       sessions: row.sessionKeys.size,
       ...(row.groupedRows === 0 ? {} : { groupedRows: row.groupedRows }),
       agents: boundedAgentRows(row.agents, options.cap),

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -237,4 +237,8 @@ describe("readTranscriptTitle", () => {
 
     assert.strictEqual(await readTranscriptTitle(file, "claude"), "Fix the real bug");
   });
+
+  it("returns null when the title stream cannot be read", async () => {
+    assert.isNull(await readTranscriptTitle(NodePath.join(dir, "missing.jsonl"), "claude"));
+  });
 });

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -238,6 +238,60 @@ describe("readTranscriptTitle", () => {
     assert.strictEqual(await readTranscriptTitle(file, "claude"), "Fix the real bug");
   });
 
+  it("skips a user shell command wrapper", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      [
+        {
+          type: "user",
+          message: { content: "<user_shell_command>git status</user_shell_command>" },
+        },
+        { type: "user", message: { content: "Explain the failing check" } },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), "Explain the failing check");
+  });
+
+  it("uses the child prompt instead of copied parent history for a forked Codex rollout", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    const message = (timestamp: string, text: string) => ({
+      type: "event_msg",
+      timestamp,
+      payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+    });
+    await NodeFSP.writeFile(
+      file,
+      [
+        {
+          type: "session_meta",
+          timestamp: "2026-08-01T05:00:00.000Z",
+          payload: { type: "session_meta", id: "child", forked_from_id: "parent" },
+        },
+        message("2026-08-01T05:00:00.600Z", "First copied parent prompt"),
+        message("2026-08-01T05:00:01.100Z", "Second copied parent prompt"),
+        message("2026-08-01T05:00:02.500Z", "Investigate the child task"),
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "codex"), "Investigate the child task");
+  });
+
+  it("truncates titles without splitting a Unicode code point", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      JSON.stringify({ type: "user", message: { content: `${"a".repeat(78)}🙂more` } }),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), `${"a".repeat(78)}🙂…`);
+  });
+
   it("returns null when the title stream cannot be read", async () => {
     assert.isNull(await readTranscriptTitle(NodePath.join(dir, "missing.jsonl"), "claude"));
   });

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -7,7 +7,7 @@ import * as NodePath from "node:path";
 
 import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
 
-import { readTranscriptRecords } from "./usageTranscriptReader.ts";
+import { readTranscriptRecords, readTranscriptTitle } from "./usageTranscriptReader.ts";
 
 let dir: string;
 
@@ -206,5 +206,35 @@ describe("readTranscriptRecords resume", () => {
 
   it("returns null for an unreadable file", async () => {
     assert.isNull(await readTranscriptRecords(NodePath.join(dir, "missing.jsonl"), "claude"));
+  });
+});
+
+describe("readTranscriptTitle", () => {
+  it("keeps a real prompt that begins with an angle bracket", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      JSON.stringify({ type: "user", message: { content: "<3 ship this today" } }),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), "<3 ship this today");
+  });
+
+  it("skips a known injected preamble and reads the next user prompt", async () => {
+    const file = NodePath.join(dir, "session.jsonl");
+    await NodeFSP.writeFile(
+      file,
+      [
+        {
+          type: "user",
+          message: { content: "<system-reminder>generated context</system-reminder>" },
+        },
+        { type: "user", message: { content: "Fix the real bug" } },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+    );
+
+    assert.strictEqual(await readTranscriptTitle(file, "claude"), "Fix the real bug");
   });
 });

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -1,13 +1,19 @@
 // @effect-diagnostics nodeBuiltinImport:off - resume coverage writes, appends
 // to, and truncates real transcript files byte-exactly, mirroring the reader's
 // own deliberate node:fs usage.
+import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
-import { afterEach, assert, beforeEach, describe, it } from "@effect/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it } from "@effect/vitest";
 
-import { readTranscriptRecords, readTranscriptTitle } from "./usageTranscriptReader.ts";
+import {
+  listTranscriptFiles,
+  readTranscriptFingerprint,
+  readTranscriptRecords,
+  readTranscriptTitle,
+} from "./usageTranscriptReader.ts";
 
 let dir: string;
 
@@ -294,5 +300,47 @@ describe("readTranscriptTitle", () => {
 
   it("returns null when the title stream cannot be read", async () => {
     assert.isNull(await readTranscriptTitle(NodePath.join(dir, "missing.jsonl"), "claude"));
+  });
+});
+
+describe("listTranscriptFiles", () => {
+  it("returns stable path ordering and exact file identity", async () => {
+    NodeFS.writeFileSync(NodePath.join(dir, "z.jsonl"), "z\n");
+    NodeFS.writeFileSync(NodePath.join(dir, "a.jsonl"), "a\n");
+
+    const files = await listTranscriptFiles(dir, 0);
+
+    expect(files.map((file) => NodePath.basename(file.path))).toEqual(["a.jsonl", "z.jsonl"]);
+    expect(files.every((file) => file.mtimeNs.length > 0)).toBe(true);
+    expect(files.every((file) => file.device.length > 0 && file.inode.length > 0)).toBe(true);
+  });
+});
+
+describe("transcript snapshots", () => {
+  it("changes the fingerprint for a same-size rewrite with restored mtime", async () => {
+    const filePath = NodePath.join(dir, "session.jsonl");
+    NodeFS.writeFileSync(filePath, "a".repeat(10_000));
+    const originalStats = NodeFS.statSync(filePath);
+    const first = await readTranscriptFingerprint(filePath, 10_000);
+
+    NodeFS.writeFileSync(filePath, `${"a".repeat(5_000)}b${"a".repeat(4_999)}`);
+    NodeFS.utimesSync(filePath, originalStats.atime, originalStats.mtime);
+    const second = await readTranscriptFingerprint(filePath, 10_000);
+
+    expect(NodeFS.statSync(filePath).size).toBe(originalStats.size);
+    expect(first).not.toBeNull();
+    expect(second).not.toBe(first);
+  });
+
+  it("does not read bytes appended after the observed size", async () => {
+    const filePath = NodePath.join(dir, "session.jsonl");
+    const firstLine = claudeLine(1, 10);
+    NodeFS.writeFileSync(filePath, firstLine);
+    const observedSize = NodeFS.statSync(filePath).size;
+    NodeFS.appendFileSync(filePath, claudeLine(2, 20));
+
+    const parsed = await readTranscriptRecords(filePath, "claude", undefined, observedSize);
+
+    expect(parsed?.records.map((record) => record.totals.outputTokens)).toEqual([10]);
   });
 });

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -319,6 +319,7 @@ const NOT_TITLE_PREFIXES = [
   "<command-message>",
   "<command-name>",
   "<local-command-caveat>",
+  "<user_shell_command>",
   "<environment_context>",
   "<INSTRUCTIONS>",
   "# AGENTS.md instructions",
@@ -334,8 +335,9 @@ function cleanTitle(text: unknown): string | null {
   const collapsed = text.split(/\s+/).join(" ").trim();
   if (collapsed.length === 0) return null;
   if (NOT_TITLE_PREFIXES.some((prefix) => collapsed.startsWith(prefix))) return null;
-  return collapsed.length > TITLE_MAX_LENGTH
-    ? `${collapsed.slice(0, TITLE_MAX_LENGTH - 1)}\u2026`
+  const characters = Array.from(collapsed);
+  return characters.length > TITLE_MAX_LENGTH
+    ? `${characters.slice(0, TITLE_MAX_LENGTH - 1).join("")}\u2026`
     : collapsed;
 }
 
@@ -364,7 +366,9 @@ function claudeTitleFromLine(line: string): string | null {
   return null;
 }
 
-function codexTitleFromLine(line: string): string | null {
+function codexTitleFromLine(
+  line: string,
+): { readonly title: string; readonly timestampMs: number | null } | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(line);
@@ -378,10 +382,13 @@ function codexTitleFromLine(line: string): string | null {
   if (record["type"] !== "message" || record["role"] !== "user") return null;
   const content = record["content"];
   if (!Array.isArray(content)) return null;
+  const timestamp = (parsed as Record<string, unknown>)["timestamp"];
+  const parsedTimestamp = typeof timestamp === "string" ? Date.parse(timestamp) : Number.NaN;
+  const timestampMs = Number.isNaN(parsedTimestamp) ? null : parsedTimestamp;
   for (const block of content) {
     if (typeof block !== "object" || block === null) continue;
     const title = cleanTitle((block as Record<string, unknown>)["text"]);
-    if (title !== null) return title;
+    if (title !== null) return { title, timestampMs };
   }
   return null;
 }
@@ -399,7 +406,7 @@ export async function readTranscriptTitle(
   provider: UsageProviderKind,
 ): Promise<string | null> {
   if (provider === "grok") return null;
-  const titleFromLine = provider === "claude" ? claudeTitleFromLine : codexTitleFromLine;
+  const codexState = provider === "codex" ? initialCodexScanState() : null;
   let stream: NodeFS.ReadStream | null = null;
   try {
     stream = NodeFS.createReadStream(filePath, { encoding: "utf8" });
@@ -417,14 +424,34 @@ export async function readTranscriptTitle(
         pending = pending.slice(newline + 1);
         seen += 1;
         if (seen > TITLE_MAX_LINES) return null;
-        const gate = provider === "claude" ? '"user"' : '"message"';
-        if (!line.includes(gate)) continue;
-        const title = titleFromLine(line);
-        if (title !== null) return title;
+        if (provider === "claude") {
+          if (!line.includes('"user"')) continue;
+          const title = claudeTitleFromLine(line);
+          if (title !== null) return title;
+          continue;
+        }
+        const title = codexTitleFromLine(line);
+        parseCodexLine(line, codexState!);
+        if (title === null) continue;
+        if (!codexState!.suppressingForkCopies) return title.title;
+        if (title.timestampMs !== null) {
+          if (title.timestampMs - codexState!.forkCopyAnchorMs >= 1000) return title.title;
+          codexState!.forkCopyAnchorMs = title.timestampMs;
+        }
       }
       if (bytesRead >= TITLE_MAX_BYTES) return null;
     }
-    if (pending.length > 0 && seen < TITLE_MAX_LINES) return titleFromLine(pending);
+    if (pending.length > 0 && seen < TITLE_MAX_LINES) {
+      if (provider === "claude") return claudeTitleFromLine(pending);
+      const title = codexTitleFromLine(pending);
+      parseCodexLine(pending, codexState!);
+      if (title === null) return null;
+      if (!codexState!.suppressingForkCopies) return title.title;
+      if (title.timestampMs === null) return null;
+      if (title.timestampMs - codexState!.forkCopyAnchorMs >= 1000) return title.title;
+      codexState!.forkCopyAnchorMs = title.timestampMs;
+      return null;
+    }
   } catch {
     return null;
   } finally {

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -18,7 +18,6 @@
 import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
-import * as NodeReadline from "node:readline";
 
 import type { UsageProviderKind } from "@t3tools/contracts";
 

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -15,6 +15,7 @@
  *
  * @module usageTranscriptReader
  */
+import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
 
@@ -326,6 +327,7 @@ const NOT_TITLE_PREFIXES = [
 
 const TITLE_MAX_LENGTH = 80;
 const TITLE_MAX_LINES = 400;
+const TITLE_MAX_BYTES = 1024 * 1024;
 
 function cleanTitle(text: unknown): string | null {
   if (typeof text !== "string") return null;
@@ -397,28 +399,36 @@ export async function readTranscriptTitle(
   provider: UsageProviderKind,
 ): Promise<string | null> {
   if (provider === "grok") return null;
+  const titleFromLine = provider === "claude" ? claudeTitleFromLine : codexTitleFromLine;
+  let stream: NodeFS.ReadStream | null = null;
   try {
-    const stream = NodeFS.createReadStream(filePath, { encoding: "utf8" });
-    const lines = NodeReadline.createInterface({
-      input: stream,
-      crlfDelay: Infinity,
-    });
-    try {
-      let seen = 0;
-      for await (const line of lines) {
+    stream = NodeFS.createReadStream(filePath, { encoding: "utf8" });
+    let pending = "";
+    let seen = 0;
+    let bytesRead = 0;
+    for await (const chunk of stream) {
+      const text = String(chunk);
+      bytesRead += Buffer.byteLength(text);
+      pending += text;
+      for (;;) {
+        const newline = pending.indexOf("\n");
+        if (newline === -1) break;
+        const line = pending.slice(0, newline).replace(/\r$/, "");
+        pending = pending.slice(newline + 1);
         seen += 1;
-        if (seen > TITLE_MAX_LINES) break;
+        if (seen > TITLE_MAX_LINES) return null;
         const gate = provider === "claude" ? '"user"' : '"message"';
         if (!line.includes(gate)) continue;
-        const title = provider === "claude" ? claudeTitleFromLine(line) : codexTitleFromLine(line);
+        const title = titleFromLine(line);
         if (title !== null) return title;
       }
-    } finally {
-      lines.close();
-      stream.destroy();
+      if (bytesRead >= TITLE_MAX_BYTES) return null;
     }
+    if (pending.length > 0 && seen < TITLE_MAX_LINES) return titleFromLine(pending);
   } catch {
     return null;
+  } finally {
+    stream?.destroy();
   }
   return null;
 }

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -313,7 +313,16 @@ export async function readTranscriptRecords(
 }
 
 /** Prefixes that mark an injected preamble, not something the user typed. */
-const NOT_TITLE_PREFIXES = ["<", "# AGENTS.md instructions", "Caveat: the messages below"];
+const NOT_TITLE_PREFIXES = [
+  "<system-reminder>",
+  "<command-message>",
+  "<command-name>",
+  "<local-command-caveat>",
+  "<environment_context>",
+  "<INSTRUCTIONS>",
+  "# AGENTS.md instructions",
+  "Caveat: the messages below",
+];
 
 const TITLE_MAX_LENGTH = 80;
 const TITLE_MAX_LINES = 400;
@@ -389,21 +398,24 @@ export async function readTranscriptTitle(
 ): Promise<string | null> {
   if (provider === "grok") return null;
   try {
+    const stream = NodeFS.createReadStream(filePath, { encoding: "utf8" });
     const lines = NodeReadline.createInterface({
-      input: NodeFS.createReadStream(filePath, { encoding: "utf8" }),
+      input: stream,
       crlfDelay: Infinity,
     });
-    let seen = 0;
-    for await (const line of lines) {
-      seen += 1;
-      if (seen > TITLE_MAX_LINES) break;
-      const gate = provider === "claude" ? '"user"' : '"message"';
-      if (!line.includes(gate)) continue;
-      const title = provider === "claude" ? claudeTitleFromLine(line) : codexTitleFromLine(line);
-      if (title !== null) {
-        lines.close();
-        return title;
+    try {
+      let seen = 0;
+      for await (const line of lines) {
+        seen += 1;
+        if (seen > TITLE_MAX_LINES) break;
+        const gate = provider === "claude" ? '"user"' : '"message"';
+        if (!line.includes(gate)) continue;
+        const title = provider === "claude" ? claudeTitleFromLine(line) : codexTitleFromLine(line);
+        if (title !== null) return title;
       }
+    } finally {
+      lines.close();
+      stream.destroy();
     }
   } catch {
     return null;

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -18,13 +18,14 @@
 import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
+import * as NodeReadline from "node:readline";
 
 import type { UsageProviderKind } from "@t3tools/contracts";
 
 import {
   initialCodexScanState,
   mightCarryUsage,
-  parseClaudeLine,
+  parseClaudeLineRecords,
   parseCodexLine,
   parseGrokLine,
   type CodexScanState,
@@ -236,8 +237,7 @@ export async function readTranscriptRecords(
         for (const grokRecord of parseGrokLine(line)) out.push(grokRecord);
         return;
       }
-      const record = parseClaudeLine(line);
-      if (record !== null) out.push(record);
+      for (const record of parseClaudeLineRecords(line)) out.push(record);
     };
 
     const toLineString = (lineBuffer: Buffer): string => {

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -1,4 +1,4 @@
-// @effect-diagnostics nodeBuiltinImport:off
+// @effect-diagnostics nodeBuiltinImport:off - streaming and hashing multi-gigabyte local transcripts requires Node filesystem primitives.
 /**
  * Raw filesystem access for transcript scanning.
  *
@@ -18,6 +18,7 @@
 import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
+import * as NodeCrypto from "node:crypto";
 
 import type { UsageProviderKind } from "@t3tools/contracts";
 
@@ -35,7 +36,12 @@ export interface TranscriptFile {
   readonly path: string;
   readonly size: number;
   readonly mtimeMs: number;
+  readonly mtimeNs: string;
+  readonly device: string;
+  readonly inode: string;
 }
+
+const FINGERPRINT_CHUNK_BYTES = 64 * 1024;
 
 /**
  * Where a parse stopped, with enough state to continue from there.
@@ -125,9 +131,17 @@ export async function listTranscriptFiles(
         continue;
       }
       try {
-        const stats = await NodeFSP.stat(child);
-        if (stats.mtimeMs >= sinceMs) {
-          found.push({ path: child, size: stats.size, mtimeMs: stats.mtimeMs });
+        const stats = await NodeFSP.stat(child, { bigint: true });
+        const mtimeMs = Number(stats.mtimeNs) / 1_000_000;
+        if (mtimeMs >= sinceMs) {
+          found.push({
+            path: child,
+            size: Number(stats.size),
+            mtimeMs,
+            mtimeNs: String(stats.mtimeNs),
+            device: String(stats.dev),
+            inode: String(stats.ino),
+          });
         }
       } catch {
         // Vanished between readdir and stat.
@@ -136,7 +150,41 @@ export async function listTranscriptFiles(
   };
 
   await walk(root);
-  return found;
+  return found.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/**
+ * SHA-256 of every byte in the observed snapshot. Metadata remains part of
+ * cache identity, while the full content hash catches same-size rewrites even
+ * when a filesystem timestamp is preserved.
+ */
+export async function readTranscriptFingerprint(
+  filePath: string,
+  observedSize: number,
+): Promise<string | null> {
+  let handle: NodeFSP.FileHandle | null = null;
+  try {
+    handle = await NodeFSP.open(filePath, "r");
+    const hash = NodeCrypto.createHash("sha256");
+    hash.update(String(observedSize));
+    hash.update("\0");
+
+    const chunk = Buffer.allocUnsafe(Math.min(observedSize, FINGERPRINT_CHUNK_BYTES));
+    let offset = 0;
+    while (offset < observedSize) {
+      const length = Math.min(chunk.length, observedSize - offset);
+      const read = await handle.read(chunk, 0, length, offset);
+      if (read.bytesRead === 0) return null;
+      hash.update(chunk.subarray(0, read.bytesRead));
+      offset += read.bytesRead;
+    }
+
+    return hash.digest("hex");
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
 }
 
 /**
@@ -180,7 +228,7 @@ async function guardMatches(
  *
  * The distinction matters to the caller's cache: a genuinely empty transcript
  * is a stable fact worth memoising, while a transient read failure memoised
- * under the same `(size, mtime)` key would silently drop that file's usage
+ * under the same content fingerprint would silently drop that file's usage
  * until the file next changes.
  *
  * With `resumeFrom`, parsing continues from that position when its guard bytes
@@ -195,6 +243,7 @@ export async function readTranscriptRecords(
   filePath: string,
   provider: UsageProviderKind,
   resumeFrom?: TranscriptParsePosition,
+  observedSize?: number,
 ): Promise<TranscriptParseResult | null> {
   let handle: NodeFSP.FileHandle;
   try {
@@ -216,6 +265,20 @@ export async function readTranscriptRecords(
       if (resumeFrom.codexState !== null) codexState = { ...resumeFrom.codexState };
       start = resumeFrom.resumeOffset;
       resumed = true;
+    }
+
+    if (observedSize !== undefined && observedSize <= start) {
+      return {
+        records: [],
+        tailRecords: [],
+        position: {
+          resumeOffset: start,
+          guardLength: resumeFrom?.guardLength ?? 0,
+          guardHash: resumeFrom?.guardHash ?? 0,
+          codexState: provider === "codex" ? codexState : null,
+        },
+        resumed,
+      };
     }
 
     const parseLine = (line: string, state: CodexScanState, out: UsageRecord[]): void => {
@@ -256,6 +319,7 @@ export async function readTranscriptRecords(
     let pendingChunks: Buffer[] = [];
     const stream = handle.createReadStream({
       start,
+      ...(observedSize === undefined ? {} : { end: observedSize - 1 }),
       autoClose: false,
     }) as AsyncIterable<Buffer>;
     for await (const chunk of stream) {

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -311,3 +311,102 @@ export async function readTranscriptRecords(
     await handle.close().catch(() => undefined);
   }
 }
+
+/** Prefixes that mark an injected preamble, not something the user typed. */
+const NOT_TITLE_PREFIXES = ["<", "# AGENTS.md instructions", "Caveat: the messages below"];
+
+const TITLE_MAX_LENGTH = 80;
+const TITLE_MAX_LINES = 400;
+
+function cleanTitle(text: unknown): string | null {
+  if (typeof text !== "string") return null;
+  const collapsed = text.split(/\s+/).join(" ").trim();
+  if (collapsed.length === 0) return null;
+  if (NOT_TITLE_PREFIXES.some((prefix) => collapsed.startsWith(prefix))) return null;
+  return collapsed.length > TITLE_MAX_LENGTH
+    ? `${collapsed.slice(0, TITLE_MAX_LENGTH - 1)}\u2026`
+    : collapsed;
+}
+
+function claudeTitleFromLine(line: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record["type"] !== "user") return null;
+  const message = record["message"];
+  if (typeof message !== "object" || message === null) return null;
+  const content = (message as Record<string, unknown>)["content"];
+  if (typeof content === "string") return cleanTitle(content);
+  if (!Array.isArray(content)) return null;
+  for (const block of content) {
+    if (typeof block !== "object" || block === null) continue;
+    const entry = block as Record<string, unknown>;
+    if (entry["type"] !== "text") continue;
+    const title = cleanTitle(entry["text"]);
+    if (title !== null) return title;
+  }
+  return null;
+}
+
+function codexTitleFromLine(line: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const payload = (parsed as Record<string, unknown>)["payload"];
+  if (typeof payload !== "object" || payload === null) return null;
+  const record = payload as Record<string, unknown>;
+  if (record["type"] !== "message" || record["role"] !== "user") return null;
+  const content = record["content"];
+  if (!Array.isArray(content)) return null;
+  for (const block of content) {
+    if (typeof block !== "object" || block === null) continue;
+    const title = cleanTitle((block as Record<string, unknown>)["text"]);
+    if (title !== null) return title;
+  }
+  return null;
+}
+
+/**
+ * First thing the user actually typed in a session, as a display title.
+ *
+ * Only called for the handful of unattributed rows that survived the response
+ * cap, so a second bounded read per row is fine. Returns null when the file
+ * cannot be read, holds no user text (Grok logs carry none we trust), or only
+ * injected preambles appear early on.
+ */
+export async function readTranscriptTitle(
+  filePath: string,
+  provider: UsageProviderKind,
+): Promise<string | null> {
+  if (provider === "grok") return null;
+  try {
+    const lines = NodeReadline.createInterface({
+      input: NodeFS.createReadStream(filePath, { encoding: "utf8" }),
+      crlfDelay: Infinity,
+    });
+    let seen = 0;
+    for await (const line of lines) {
+      seen += 1;
+      if (seen > TITLE_MAX_LINES) break;
+      const gate = provider === "claude" ? '"user"' : '"message"';
+      if (!line.includes(gate)) continue;
+      const title = provider === "claude" ? claudeTitleFromLine(line) : codexTitleFromLine(line);
+      if (title !== null) {
+        lines.close();
+        return title;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -51,6 +51,7 @@ describe("parseClaudeLine", () => {
       reasoningTokens: 0,
     });
     expect(record?.dedupeKey).toBe("msg_1:");
+    expect(record?.cwd).toBe("/home/theo/project");
   });
 
   it("gives every content block of one message the same dedupe key", () => {
@@ -73,7 +74,11 @@ describe("parseCodexLine", () => {
   const sessionMeta = JSON.stringify({
     type: "session_meta",
     timestamp: "2026-08-01T05:17:41.289Z",
-    payload: { type: "session_meta", id: "019fbbc1-b12c-7360-a685-28c181f0025f" },
+    payload: {
+      type: "session_meta",
+      id: "019fbbc1-b12c-7360-a685-28c181f0025f",
+      cwd: "/home/theo/project",
+    },
   });
   const turnContext = JSON.stringify({
     type: "turn_context",
@@ -107,6 +112,7 @@ describe("parseCodexLine", () => {
     expect(record?.provider).toBe("codex");
     expect(record?.model).toBe("gpt-5.6-sol");
     expect(record?.sessionId).toBe("019fbbc1-b12c-7360-a685-28c181f0025f");
+    expect(record?.cwd).toBe("/home/theo/project");
     // Codex reports input_tokens inclusive of the cached portion.
     expect(record?.totals.uncachedInputTokens).toBe(19239 - 11008);
     expect(record?.totals.cachedInputTokens).toBe(11008);

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -138,7 +138,41 @@ describe("parseClaudeLine", () => {
     });
     expect(records.map((record) => record.dedupeKey)).toEqual([
       "msg_fallback:req_fallback:0",
-      "msg_fallback:req_fallback:1",
+      "msg_fallback:req_fallback",
+    ]);
+  });
+
+  it("replaces a progressive Claude snapshot with its final serving iteration", () => {
+    const partial = parseClaudeLineRecords(
+      claudeLine({
+        messageId: "msg_progressive",
+        requestId: "req_progressive",
+        contentType: "text",
+      }),
+    );
+    const complete = parseClaudeLineRecords(
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-08-18T01:13:44.675Z",
+        requestId: "req_progressive",
+        message: {
+          id: "msg_progressive",
+          model: "claude-opus-5",
+          usage: {
+            output_tokens: 300,
+            iterations: [
+              { model: "claude-fable-5", output_tokens: 100 },
+              { model: "claude-opus-5", output_tokens: 300 },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(partial[0]?.dedupeKey).toBe("msg_progressive:req_progressive");
+    expect(complete.map((record) => record.dedupeKey)).toEqual([
+      "msg_progressive:req_progressive:0",
+      "msg_progressive:req_progressive",
     ]);
   });
 

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -119,6 +119,27 @@ describe("parseCodexLine", () => {
     expect(record?.totals.reasoningTokens).toBe(116);
   });
 
+  it("attributes resumed usage to the latest turn working directory", () => {
+    const state = initialCodexScanState();
+    parseCodexLine(sessionMeta, state);
+    parseCodexLine(
+      JSON.stringify({
+        type: "turn_context",
+        timestamp: "2026-08-01T05:17:42.694Z",
+        payload: {
+          type: "turn_context",
+          model: "gpt-5.6-sol",
+          cwd: "/home/theo/next-project",
+        },
+      }),
+      state,
+    );
+
+    const record = parseCodexLine(tokenCount(100, 0, 10, 0), state);
+
+    expect(record?.cwd).toBe("/home/theo/next-project");
+  });
+
   it("skips a repeated token_count so deltas are not double counted", () => {
     const state = initialCodexScanState();
     parseCodexLine(turnContext, state);

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -4,6 +4,7 @@ import {
   GROK_COST_USD_TICKS_PER_DOLLAR,
   initialCodexScanState,
   parseClaudeLine,
+  parseClaudeLineRecords,
   parseCodexLine,
   parseGrokLine,
   totalTokens,
@@ -15,12 +16,14 @@ function claudeLine(overrides: {
   contentType: string;
   model?: string;
   outputTokens?: number;
+  requestId?: string;
 }): string {
   return JSON.stringify({
     type: "assistant",
     timestamp: "2026-08-07T04:05:13.944Z",
     sessionId: "5a128faa-8253-489e-b935-6c08e8e670c0",
     cwd: "/home/theo/project",
+    ...(overrides.requestId === undefined ? {} : { requestId: overrides.requestId }),
     message: {
       id: overrides.messageId,
       role: "assistant",
@@ -62,6 +65,81 @@ describe("parseClaudeLine", () => {
 
     expect(text?.dedupeKey).toBe(toolUse?.dedupeKey);
     expect(text?.totals).toEqual(toolUse?.totals);
+  });
+
+  it("keeps a shared message id when the request id differs", () => {
+    const first = parseClaudeLine(
+      claudeLine({ messageId: "msg_shared", requestId: "req_1", contentType: "text" }),
+    );
+    const second = parseClaudeLine(
+      claudeLine({ messageId: "msg_shared", requestId: "req_2", contentType: "text" }),
+    );
+
+    expect(first?.dedupeKey).toBe("msg_shared:req_1");
+    expect(second?.dedupeKey).toBe("msg_shared:req_2");
+  });
+
+  it("expands fallback iterations under their own models and TTL counters", () => {
+    const records = parseClaudeLineRecords(
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-08-18T01:13:44.675Z",
+        requestId: "req_fallback",
+        sessionId: "session-fallback",
+        cwd: "/work/app",
+        message: {
+          id: "msg_fallback",
+          model: "claude-opus-5",
+          usage: {
+            output_tokens: 300,
+            output_tokens_details: { thinking_tokens: 125 },
+            iterations: [
+              {
+                type: "message",
+                model: "claude-fable-5",
+                input_tokens: 2,
+                cache_read_input_tokens: 10,
+                cache_creation_input_tokens: 20,
+                cache_creation: {
+                  ephemeral_5m_input_tokens: 20,
+                  ephemeral_1h_input_tokens: 0,
+                },
+                output_tokens: 100,
+              },
+              {
+                type: "fallback_message",
+                model: "claude-opus-5",
+                input_tokens: 3,
+                cache_read_input_tokens: 11,
+                cache_creation_input_tokens: 40,
+                cache_creation: {
+                  ephemeral_5m_input_tokens: 0,
+                  ephemeral_1h_input_tokens: 40,
+                },
+                output_tokens: 300,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => record.model)).toEqual(["claude-fable-5", "claude-opus-5"]);
+    expect(records[0]?.totals).toMatchObject({
+      cacheCreationTokens: 20,
+      cacheCreation5mTokens: 20,
+      reasoningTokens: 0,
+    });
+    expect(records[1]?.totals).toMatchObject({
+      cacheCreationTokens: 40,
+      cacheCreation1hTokens: 40,
+      reasoningTokens: 125,
+    });
+    expect(records.map((record) => record.dedupeKey)).toEqual([
+      "msg_fallback:req_fallback:0",
+      "msg_fallback:req_fallback:1",
+    ]);
   });
 
   it("ignores records that are not assistant messages", () => {

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -13,6 +13,11 @@ export interface UsageRecord {
   readonly timestampMs: number;
   readonly model: string;
   readonly sessionId: string;
+  /**
+   * Working directory the session ran in, or `""` when the transcript does not
+   * record one (Grok). Drives project attribution at aggregation time.
+   */
+  readonly cwd: string;
   readonly totals: UsageTokenTotals;
   readonly reportedCostUsd: number | null;
   /**
@@ -136,6 +141,7 @@ export function parseClaudeLine(line: string): UsageRecord | null {
     timestampMs,
     model,
     sessionId: typeof record["sessionId"] === "string" ? record["sessionId"] : "",
+    cwd: typeof record["cwd"] === "string" ? record["cwd"] : "",
     totals: {
       uncachedInputTokens: int(usageRecord["input_tokens"]),
       cachedInputTokens: int(usageRecord["cache_read_input_tokens"]),
@@ -163,6 +169,7 @@ export function parseClaudeLine(line: string): UsageRecord | null {
 export interface CodexScanState {
   model: string;
   sessionId: string;
+  cwd: string;
   lastUsageSignature: string | null;
   sawSessionMeta: boolean;
   /** While true, leading usage events are re-stamped copies of parent history. */
@@ -174,6 +181,7 @@ export function initialCodexScanState(): CodexScanState {
   return {
     model: "",
     sessionId: "",
+    cwd: "",
     lastUsageSignature: null,
     sawSessionMeta: false,
     suppressingForkCopies: false,
@@ -233,6 +241,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     state.sawSessionMeta = true;
     const id = payloadRecord["id"] ?? payloadRecord["session_id"];
     if (typeof id === "string") state.sessionId = id;
+    if (typeof payloadRecord["cwd"] === "string") state.cwd = payloadRecord["cwd"];
     const metaTimestampMs = parseTimestampMs(record["timestamp"]);
     if (metaTimestampMs !== null && isForkedSessionMeta(payloadRecord)) {
       state.suppressingForkCopies = true;
@@ -301,6 +310,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     timestampMs,
     model: state.model,
     sessionId: state.sessionId,
+    cwd: state.cwd,
     totals,
     // Codex does not report cost in the rollout.
     reportedCostUsd: null,
@@ -431,6 +441,8 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
         timestampMs,
         model: "grok",
         sessionId,
+        // Grok session logs record no working directory.
+        cwd: "",
         totals: grokTotalsToUsage(topLevel),
         reportedCostUsd: grokCostTicksToUsd(topLevel.costUsdTicks),
         // No prompt id means we cannot tell two same-second updates apart.
@@ -477,6 +489,7 @@ export function parseGrokLine(line: string): readonly UsageRecord[] {
       timestampMs,
       model: entry.model,
       sessionId,
+      cwd: "",
       totals,
       reportedCostUsd,
       dedupeKey: promptId === null ? null : `${sessionId}:${promptId}:${entry.model}`,

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -46,10 +46,14 @@ function parseTimestampMs(value: unknown): number | null {
 }
 
 export function addTotals(a: UsageTokenTotals, b: UsageTokenTotals): UsageTokenTotals {
+  const cacheCreation5mTokens = (a.cacheCreation5mTokens ?? 0) + (b.cacheCreation5mTokens ?? 0);
+  const cacheCreation1hTokens = (a.cacheCreation1hTokens ?? 0) + (b.cacheCreation1hTokens ?? 0);
   return {
     uncachedInputTokens: a.uncachedInputTokens + b.uncachedInputTokens,
     cachedInputTokens: a.cachedInputTokens + b.cachedInputTokens,
     cacheCreationTokens: a.cacheCreationTokens + b.cacheCreationTokens,
+    ...(cacheCreation5mTokens === 0 ? {} : { cacheCreation5mTokens }),
+    ...(cacheCreation1hTokens === 0 ? {} : { cacheCreation1hTokens }),
     outputTokens: a.outputTokens + b.outputTokens,
     reasoningTokens: a.reasoningTokens + b.reasoningTokens,
   };
@@ -96,36 +100,36 @@ export function grokCostTicksToUsd(ticks: unknown): number | null {
 /**
  * Parses one line of a Claude Code transcript.
  *
- * T3 Code writes one record per assistant *content block*, and every one of
- * those records repeats the same complete `usage` object for the parent
- * message. Summing them overcounts by roughly 2.4x on a real workload, so the
- * caller must drop repeats by `dedupeKey` and keep the first.
+ * Claude Code can write several snapshots for one assistant message. The last
+ * snapshot is the complete one, so callers replace an earlier record carrying
+ * the same `dedupeKey`. `usage.iterations` is expanded into one record per
+ * attempted model; the top-level usage is the serving iteration and must not
+ * be added again.
  */
-export function parseClaudeLine(line: string): UsageRecord | null {
+export function parseClaudeLineRecords(line: string): readonly UsageRecord[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(line);
   } catch {
-    return null;
+    return [];
   }
-  if (typeof parsed !== "object" || parsed === null) return null;
+  if (typeof parsed !== "object" || parsed === null) return [];
 
   const record = parsed as Record<string, unknown>;
-  if (record["type"] !== "assistant") return null;
+  if (record["type"] !== "assistant") return [];
 
   const message = record["message"];
-  if (typeof message !== "object" || message === null) return null;
+  if (typeof message !== "object" || message === null) return [];
   const messageRecord = message as Record<string, unknown>;
 
   const usage = messageRecord["usage"];
-  if (typeof usage !== "object" || usage === null) return null;
+  if (typeof usage !== "object" || usage === null) return [];
   const usageRecord = usage as Record<string, unknown>;
 
   const timestampMs = parseTimestampMs(record["timestamp"]);
-  if (timestampMs === null) return null;
+  if (timestampMs === null) return [];
 
   const model = typeof messageRecord["model"] === "string" ? messageRecord["model"] : "";
-  if (model.length === 0) return null;
 
   const messageId = typeof messageRecord["id"] === "string" ? messageRecord["id"] : null;
   const requestId = typeof record["requestId"] === "string" ? record["requestId"] : null;
@@ -134,25 +138,71 @@ export function parseClaudeLine(line: string): UsageRecord | null {
   const dedupeKey =
     messageId === null && requestId === null ? null : `${messageId ?? ""}:${requestId ?? ""}`;
 
+  const iterations = Array.isArray(usageRecord["iterations"])
+    ? usageRecord["iterations"].filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const attempts = iterations.length > 0 ? iterations : [usageRecord];
+  const topLevelThinking =
+    typeof usageRecord["output_tokens_details"] === "object" &&
+    usageRecord["output_tokens_details"] !== null
+      ? int((usageRecord["output_tokens_details"] as Record<string, unknown>)["thinking_tokens"])
+      : 0;
   const cost = record["costUSD"];
 
-  return {
-    provider: "claude",
-    timestampMs,
-    model,
-    sessionId: typeof record["sessionId"] === "string" ? record["sessionId"] : "",
-    cwd: typeof record["cwd"] === "string" ? record["cwd"] : "",
-    totals: {
-      uncachedInputTokens: int(usageRecord["input_tokens"]),
-      cachedInputTokens: int(usageRecord["cache_read_input_tokens"]),
-      cacheCreationTokens: int(usageRecord["cache_creation_input_tokens"]),
-      outputTokens: int(usageRecord["output_tokens"]),
-      // Anthropic folds thinking tokens into output and does not break them out.
-      reasoningTokens: 0,
-    },
-    reportedCostUsd: typeof cost === "number" && Number.isFinite(cost) ? cost : null,
-    dedupeKey,
-  };
+  return attempts.flatMap((attempt, index) => {
+    const attemptModel =
+      typeof attempt["model"] === "string"
+        ? attempt["model"]
+        : iterations.length === 0
+          ? model
+          : "";
+    if (attemptModel.length === 0) return [];
+
+    const cacheCreation =
+      typeof attempt["cache_creation"] === "object" && attempt["cache_creation"] !== null
+        ? (attempt["cache_creation"] as Record<string, unknown>)
+        : null;
+    const cacheCreation5mTokens = int(cacheCreation?.["ephemeral_5m_input_tokens"]);
+    const cacheCreation1hTokens = int(cacheCreation?.["ephemeral_1h_input_tokens"]);
+    const detailedCacheCreation = cacheCreation5mTokens + cacheCreation1hTokens;
+    const outputTokens = int(attempt["output_tokens"]);
+    const isServingIteration = iterations.length === 0 || index === attempts.length - 1;
+
+    return [
+      {
+        provider: "claude" as const,
+        timestampMs,
+        model: attemptModel,
+        sessionId: typeof record["sessionId"] === "string" ? record["sessionId"] : "",
+        cwd: typeof record["cwd"] === "string" ? record["cwd"] : "",
+        totals: {
+          uncachedInputTokens: int(attempt["input_tokens"]),
+          cachedInputTokens: int(attempt["cache_read_input_tokens"]),
+          cacheCreationTokens:
+            detailedCacheCreation > 0
+              ? detailedCacheCreation
+              : int(attempt["cache_creation_input_tokens"]),
+          ...(cacheCreation5mTokens === 0 ? {} : { cacheCreation5mTokens }),
+          ...(cacheCreation1hTokens === 0 ? {} : { cacheCreation1hTokens }),
+          outputTokens,
+          reasoningTokens: isServingIteration ? Math.min(outputTokens, topLevelThinking) : 0,
+        },
+        reportedCostUsd:
+          iterations.length === 0 && typeof cost === "number" && Number.isFinite(cost)
+            ? cost
+            : null,
+        dedupeKey:
+          dedupeKey === null || iterations.length === 0 ? dedupeKey : `${dedupeKey}:${index}`,
+      },
+    ];
+  });
+}
+
+/** Compatibility helper for callers that only need a non-iterated line. */
+export function parseClaudeLine(line: string): UsageRecord | null {
+  return parseClaudeLineRecords(line)[0] ?? null;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -194,7 +194,9 @@ export function parseClaudeLineRecords(line: string): readonly UsageRecord[] {
             ? cost
             : null,
         dedupeKey:
-          dedupeKey === null || iterations.length === 0 ? dedupeKey : `${dedupeKey}:${index}`,
+          dedupeKey === null || iterations.length === 0 || isServingIteration
+            ? dedupeKey
+            : `${dedupeKey}:${index}`,
       },
     ];
   });

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -252,6 +252,7 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
 
   if (record["type"] === "turn_context") {
     if (typeof payloadRecord["model"] === "string") state.model = payloadRecord["model"];
+    if (typeof payloadRecord["cwd"] === "string") state.cwd = payloadRecord["cwd"];
     return null;
   }
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1754,6 +1754,14 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.serverGetUsageSummary, usage.readSummary(input), {
             "rpc.aggregate": "server",
           }),
+        [WS_METHODS.serverGetUsageThreadBreakdown]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverGetUsageThreadBreakdown,
+            usage.readThreadBreakdown(input),
+            {
+              "rpc.aggregate": "server",
+            },
+          ),
         [WS_METHODS.serverRetryResourceTelemetry]: (_input) =>
           observeRpcEffect(WS_METHODS.serverRetryResourceTelemetry, resourceTelemetry.retry, {
             "rpc.aggregate": "server",

--- a/apps/web/src/components/usage/UsageCacheWriteCell.tsx
+++ b/apps/web/src/components/usage/UsageCacheWriteCell.tsx
@@ -1,0 +1,19 @@
+import { formatUsd } from "@t3tools/shared/usageFormat";
+
+/** Consistent cache-write treatment across project, model, and thread tables. */
+export function UsageCacheWriteCell({
+  cacheWriteTokens,
+  cacheWriteUsd,
+}: {
+  readonly cacheWriteTokens: number;
+  readonly cacheWriteUsd: number | null;
+}) {
+  const value =
+    cacheWriteTokens === 0
+      ? "-"
+      : cacheWriteUsd === null
+        ? "Unavailable"
+        : formatUsd(cacheWriteUsd);
+
+  return <td className="py-2 text-right text-muted-foreground tabular-nums">{value}</td>;
+}

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -5,8 +5,9 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
   useUsage: vi.fn(),
+  usageThreadTable: vi.fn((_props: unknown) => null),
   metric: "cost" as "cost" | "tokens",
-  breakdown: "time" as "model" | "project" | "time",
+  breakdown: "time" as "model" | "project" | "thread" | "time",
   projectFilter: undefined as string | null | undefined,
 }));
 
@@ -61,6 +62,7 @@ vi.mock("../WorkspaceBreadcrumb", () => ({
 vi.mock("../WorkspacePageContainer", () => ({ WorkspacePageContainer: "main" }));
 vi.mock("../WorkspacePageHeader", () => ({ WorkspacePageHeader: "header" }));
 vi.mock("./UsageProviderChart", () => ({ UsageProviderChart: "div" }));
+vi.mock("./UsageThreadTable", () => ({ UsageThreadTable: testState.usageThreadTable }));
 vi.mock("./usageProviders", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./usageProviders")>();
   return {
@@ -132,6 +134,7 @@ beforeEach(() => {
   testState.metric = "cost";
   testState.breakdown = "time";
   testState.projectFilter = undefined;
+  testState.usageThreadTable.mockClear();
   testState.useUsage.mockReturnValue({
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
@@ -251,6 +254,26 @@ describe("UsagePage project breakdown", () => {
 
     expect(markup).toContain("No activity in this window.");
     expect(markup).not.toContain("No project attribution in this window.");
+  });
+});
+
+describe("UsagePage thread breakdown", () => {
+  it("requests thread rows in the selected project scope", () => {
+    testState.breakdown = "thread";
+    testState.projectFilter = "id:project-expensive";
+
+    renderToStaticMarkup(<UsagePage />);
+
+    expect(testState.usageThreadTable).toHaveBeenCalledOnce();
+    expect(testState.usageThreadTable.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        sinceDay: "2026-08-10",
+        untilDay: "2026-08-11",
+        timeZone: "UTC",
+        project: "id:project-expensive",
+      },
+      providerContributions: [],
+    });
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -39,6 +39,7 @@ vi.mock("react", async (importOriginal) => {
 vi.mock("../../env", () => ({ isElectron: false }));
 vi.mock("../../state/usage", () => ({ useUsage: testState.useUsage }));
 vi.mock("../ui/button", () => ({ Button: "button" }));
+vi.mock("../ui/input", () => ({ Input: "input" }));
 vi.mock("../ui/scroll-area", () => ({ ScrollArea: "div" }));
 vi.mock("../ui/select", () => ({
   Select: "div",
@@ -135,6 +136,13 @@ beforeEach(() => {
 });
 
 describe("UsagePage hourly breakdown", () => {
+  it("keeps custom date fields available in both desktop and compact layouts", () => {
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup.match(/aria-label="From day"/g)).toHaveLength(2);
+    expect(markup.match(/aria-label="To day"/g)).toHaveLength(2);
+  });
+
   it("keeps recent activity visible first without empty hourly rows", () => {
     const markup = renderToStaticMarkup(<UsagePage />);
     const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -1,4 +1,4 @@
-import { USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
+import { ProjectId, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { mergeUsage } from "@t3tools/shared/usageMerge";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
@@ -7,6 +7,7 @@ const testState = vi.hoisted(() => ({
   useUsage: vi.fn(),
   metric: "cost" as "cost" | "tokens",
   breakdown: "time" as "model" | "project" | "time",
+  projectFilter: undefined as string | null | undefined,
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -30,7 +31,9 @@ vi.mock("react", async (importOriginal) => {
           ? testState.metric
           : initial === "model"
             ? testState.breakdown
-            : initial,
+            : initial === undefined
+              ? testState.projectFilter
+              : initial,
       vi.fn(),
     ]),
   };
@@ -106,6 +109,8 @@ const modelTotals = Object.freeze([
 
 const projectTotals = Object.freeze([
   {
+    projectId: ProjectId.make("project-expensive"),
+    projectKey: "id:project-expensive",
     project: "Expensive Project",
     costUsd: 9,
     totalTokens: 200,
@@ -113,6 +118,8 @@ const projectTotals = Object.freeze([
     costShare: 9 / 16,
   },
   {
+    projectId: null,
+    projectKey: null,
     project: null,
     costUsd: 7,
     totalTokens: 900,
@@ -124,6 +131,7 @@ const projectTotals = Object.freeze([
 beforeEach(() => {
   testState.metric = "cost";
   testState.breakdown = "time";
+  testState.projectFilter = undefined;
   testState.useUsage.mockReturnValue({
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
@@ -201,6 +209,17 @@ describe("UsagePage project breakdown", () => {
     const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
 
     expect(body).toMatch(/Outside projects.*Expensive Project/);
+  });
+
+  it("shows only the selected project in the project breakdown", () => {
+    testState.breakdown = "project";
+    testState.projectFilter = "id:project-expensive";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toContain("Expensive Project");
+    expect(body).not.toContain("Outside projects");
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -88,6 +88,8 @@ const modelTotals = Object.freeze([
     provider: "claude" as const,
     costUsd: 10,
     totalTokens: 100,
+    cacheWriteTokens: 40,
+    cacheWriteUsd: 2.5,
     records: 1,
     costShare: 10 / 16,
   },
@@ -96,6 +98,8 @@ const modelTotals = Object.freeze([
     provider: "codex" as const,
     costUsd: 5,
     totalTokens: 1_000,
+    cacheWriteTokens: 0,
+    cacheWriteUsd: 0,
     records: 1,
     costShare: 5 / 16,
   },
@@ -104,6 +108,8 @@ const modelTotals = Object.freeze([
     provider: "codex" as const,
     costUsd: 1,
     totalTokens: 1_000,
+    cacheWriteTokens: 0,
+    cacheWriteUsd: 0,
     records: 1,
     costShare: 1 / 16,
   },
@@ -116,6 +122,8 @@ const projectTotals = Object.freeze([
     project: "Expensive Project",
     costUsd: 9,
     totalTokens: 200,
+    cacheWriteTokens: 60,
+    cacheWriteUsd: 1.75,
     records: 2,
     costShare: 9 / 20,
   },
@@ -125,6 +133,8 @@ const projectTotals = Object.freeze([
     project: null,
     costUsd: 7,
     totalTokens: 900,
+    cacheWriteTokens: 0,
+    cacheWriteUsd: 0,
     records: 1,
     costShare: 7 / 20,
   },
@@ -293,6 +303,17 @@ describe("UsagePage model breakdown", () => {
     const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
 
     expect(body).toMatch(/expensive-model.*token-heavy-model.*token-heavy-cheaper-model/);
+  });
+
+  it("shows cache-write cost per row, with a dash for write-free providers", () => {
+    testState.breakdown = "model";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    // Claude row carries its cache-write dollars; codex rows never bill writes.
+    expect(body).toContain("$2.50");
+    expect(body).toMatch(/token-heavy-model.*>-</);
   });
 
   it("sorts models by token usage when the token metric is selected", () => {

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -115,7 +115,7 @@ const projectTotals = Object.freeze([
     costUsd: 9,
     totalTokens: 200,
     records: 2,
-    costShare: 9 / 16,
+    costShare: 9 / 20,
   },
   {
     projectId: null,
@@ -124,7 +124,7 @@ const projectTotals = Object.freeze([
     costUsd: 7,
     totalTokens: 900,
     records: 1,
-    costShare: 7 / 16,
+    costShare: 7 / 20,
   },
 ]);
 
@@ -199,6 +199,8 @@ describe("UsagePage project breakdown", () => {
     expect(body).toMatch(/Expensive Project.*Outside projects/);
     expect(body).toContain("$9.00");
     expect(body).toContain("$7.00");
+    expect(body).toContain("45.0%");
+    expect(body).toContain("35.0%");
   });
 
   it("ranks projects by tokens when the token metric is selected", () => {
@@ -220,6 +222,35 @@ describe("UsagePage project breakdown", () => {
 
     expect(body).toContain("Expensive Project");
     expect(body).not.toContain("Outside projects");
+    expect(body).toContain("100.0%");
+  });
+
+  it("distinguishes unattributed usage from an empty window", () => {
+    testState.breakdown = "project";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: { ...usage.merged, projects: [], records: 1 },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("No project attribution in this window.");
+    expect(markup).not.toContain("No activity in this window.");
+  });
+
+  it("keeps the empty-window message when there is no usage", () => {
+    testState.breakdown = "project";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: { ...usage.merged, projects: [], records: 0 },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("No activity in this window.");
+    expect(markup).not.toContain("No project attribution in this window.");
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -181,6 +181,7 @@ describe("UsagePage hourly breakdown", () => {
     expect(markup.match(/aria-label="From day"/g)).toHaveLength(2);
     expect(markup.match(/aria-label="To day"/g)).toHaveLength(2);
     expect(testState.useUsage).toHaveBeenLastCalledWith(expect.anything(), undefined, false);
+    expect(markup.match(/pointer-coarse:h-8\.5/g)).toHaveLength(4);
   });
 
   it("keeps recent activity visible first without empty hourly rows", () => {

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -316,6 +316,24 @@ describe("UsagePage model breakdown", () => {
     expect(body).toMatch(/token-heavy-model.*>-</);
   });
 
+  it("does not present an incomplete cache-write estimate as zero", () => {
+    testState.breakdown = "model";
+    const usage = testState.useUsage();
+    testState.useUsage.mockReturnValue({
+      ...usage,
+      merged: {
+        ...usage.merged,
+        models: [{ ...modelTotals[0], cacheWriteUsd: null }],
+        costQuality: { ...usage.merged.costQuality, cacheWriteUsd: null },
+      },
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup.match(/Unavailable/g)).toHaveLength(2);
+    expect(markup).not.toContain("NaN%");
+  });
+
   it("sorts models by token usage when the token metric is selected", () => {
     testState.metric = "tokens";
     testState.breakdown = "model";

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -270,7 +270,9 @@ describe("UsagePage thread breakdown", () => {
         sinceDay: "2026-08-10",
         untilDay: "2026-08-11",
         timeZone: "UTC",
-        project: "id:project-expensive",
+        sinceTime: "2026-08-10T12:37:00.000Z",
+        untilTime: "2026-08-11T12:37:00.000Z",
+        projectKey: "id:project-expensive",
       },
       providerContributions: [],
     });

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 const testState = vi.hoisted(() => ({
   useUsage: vi.fn(),
   metric: "cost" as "cost" | "tokens",
-  breakdown: "time" as "model" | "time",
+  breakdown: "time" as "model" | "project" | "time",
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -104,6 +104,23 @@ const modelTotals = Object.freeze([
   },
 ]);
 
+const projectTotals = Object.freeze([
+  {
+    project: "Expensive Project",
+    costUsd: 9,
+    totalTokens: 200,
+    records: 2,
+    costShare: 9 / 16,
+  },
+  {
+    project: null,
+    costUsd: 7,
+    totalTokens: 900,
+    records: 1,
+    costShare: 7 / 16,
+  },
+]);
+
 beforeEach(() => {
   testState.metric = "cost";
   testState.breakdown = "time";
@@ -111,6 +128,7 @@ beforeEach(() => {
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
       models: modelTotals,
+      projects: projectTotals,
       hourly: [
         {
           day: "2026-08-10",
@@ -160,6 +178,29 @@ describe("UsagePage hourly breakdown", () => {
     const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
 
     expect(body).toMatch(/\$11\.00.*\$13\.00/);
+  });
+});
+
+describe("UsagePage project breakdown", () => {
+  it("ranks projects by cost and labels unattributed work", () => {
+    testState.breakdown = "project";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/Expensive Project.*Outside projects/);
+    expect(body).toContain("$9.00");
+    expect(body).toContain("$7.00");
+  });
+
+  it("ranks projects by tokens when the token metric is selected", () => {
+    testState.metric = "tokens";
+    testState.breakdown = "project";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/Outside projects.*Expensive Project/);
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -170,6 +170,7 @@ describe("UsagePage hourly breakdown", () => {
 
     expect(markup.match(/aria-label="From day"/g)).toHaveLength(2);
     expect(markup.match(/aria-label="To day"/g)).toHaveLength(2);
+    expect(testState.useUsage).toHaveBeenLastCalledWith(expect.anything(), undefined, false);
   });
 
   it("keeps recent activity visible first without empty hourly rows", () => {
@@ -276,6 +277,11 @@ describe("UsagePage thread breakdown", () => {
       },
       providerContributions: [],
     });
+    expect(testState.useUsage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "id:project-expensive",
+      true,
+    );
   });
 });
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -17,6 +17,7 @@ import {
   formatPercent,
   formatTokens,
   formatUsd,
+  makeCustomWindow,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
 import { Button } from "../ui/button";
@@ -42,14 +43,17 @@ const WINDOW_OPTIONS = [
 ] as const;
 
 export function UsagePage() {
+  // `days` remembers the last preset even while a custom (brushed or typed)
+  // range is active, so a reset lands back where the user started.
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: 30,
+    custom: false,
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
-  const { days: windowDays, window } = windowSelection;
-  const isPast24Hours = windowDays === 1;
+  const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
+  const isPast24Hours = !isCustomWindow && windowDays === 1;
   const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
 
   // Hold the content until every environment is terminal. Rendering merged
@@ -89,10 +93,24 @@ export function UsagePage() {
   const selectWindow = (days: number) => {
     setWindowSelection({
       days,
+      custom: false,
       window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
     });
   };
+  const selectCustomWindow = (sinceDay: string, untilDay: string) => {
+    setWindowSelection({
+      days: windowDays,
+      custom: true,
+      window: makeCustomWindow(sinceDay, untilDay),
+    });
+  };
   const refreshWindow = () => {
+    // A custom range is a fixed span of past days; rescanning is all a
+    // refresh can mean for it.
+    if (isCustomWindow) {
+      refresh();
+      return;
+    }
     const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
     if (
       nextWindow.sinceDay === window.sinceDay &&
@@ -102,7 +120,7 @@ export function UsagePage() {
     ) {
       refresh();
     } else {
-      setWindowSelection({ days: windowDays, window: nextWindow });
+      setWindowSelection({ days: windowDays, custom: false, window: nextWindow });
     }
   };
   const windowLabel =
@@ -136,10 +154,15 @@ export function UsagePage() {
             </Toggle>
           ))}
         </ToggleGroup>
+        <UsageDateRangeInputs
+          sinceDay={window.sinceDay}
+          untilDay={window.untilDay}
+          onChange={selectCustomWindow}
+        />
         <ToggleGroup
           aria-label="Usage period"
           variant="segmented"
-          value={[String(windowDays)]}
+          value={isCustomWindow ? [] : [String(windowDays)]}
           onValueChange={(next) => {
             const value = next[0];
             if (value) selectWindow(Number(value));
@@ -175,7 +198,12 @@ export function UsagePage() {
             <SelectItem value="tokens">Tokens</SelectItem>
           </SelectPopup>
         </Select>
-        <Select value={String(windowDays)} onValueChange={(value) => selectWindow(Number(value))}>
+        <Select
+          value={isCustomWindow ? "custom" : String(windowDays)}
+          onValueChange={(value) => {
+            if (value !== "custom" && value !== null) selectWindow(Number(value));
+          }}
+        >
           <SelectTrigger
             aria-label="Usage period"
             size="compact"
@@ -183,7 +211,9 @@ export function UsagePage() {
             className="w-auto min-w-0"
           >
             <SelectValue>
-              {WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
+              {isCustomWindow
+                ? "Custom"
+                : WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
             </SelectValue>
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
@@ -282,10 +312,17 @@ export function UsagePage() {
                   </div>
 
                   <div className="flex min-w-0 flex-col gap-3">
-                    <h2 className="text-sm font-medium text-foreground">
-                      {isPast24Hours ? "Hourly" : "Daily"}{" "}
-                      {metric === "tokens" ? "processed tokens" : "cost"}
-                    </h2>
+                    <div className="flex items-baseline justify-between gap-3">
+                      <h2 className="text-sm font-medium text-foreground">
+                        {isPast24Hours ? "Hourly" : "Daily"}{" "}
+                        {metric === "tokens" ? "processed tokens" : "cost"}
+                      </h2>
+                      {isPast24Hours ? null : (
+                        <span className="text-[10px] tracking-wide text-muted-foreground uppercase">
+                          drag to zoom · double-click resets
+                        </span>
+                      )}
+                    </div>
                     <UsageProviderChart
                       providers={activeProviders}
                       days={days}
@@ -296,6 +333,12 @@ export function UsagePage() {
                       referenceTime={window.untilTime}
                       resolution={isPast24Hours ? "hour" : "day"}
                       timeZone={window.timeZone}
+                      {...(isPast24Hours
+                        ? {}
+                        : {
+                            onZoomToDays: selectCustomWindow,
+                            onResetZoom: () => selectWindow(windowDays),
+                          })}
                     />
                   </div>
                 </section>
@@ -461,6 +504,49 @@ export function UsagePage() {
         </ScrollArea>
       </div>
     </SidebarInset>
+  );
+}
+
+/**
+ * Free date-range bounds beside the presets. Native date inputs; committing
+ * either bound deselects every preset. Hidden below lg with the rest of the
+ * expanded toolbar.
+ */
+function UsageDateRangeInputs({
+  sinceDay,
+  untilDay,
+  onChange,
+}: {
+  readonly sinceDay: string;
+  readonly untilDay: string;
+  readonly onChange: (sinceDay: string, untilDay: string) => void;
+}) {
+  const inputClass =
+    "h-7 rounded-md border border-border bg-transparent px-2 text-xs text-foreground [color-scheme:inherit] focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none";
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <input
+        type="date"
+        aria-label="From day"
+        className={inputClass}
+        value={sinceDay}
+        max={untilDay}
+        onChange={(event) => {
+          if (event.target.value) onChange(event.target.value, untilDay);
+        }}
+      />
+      <span>to</span>
+      <input
+        type="date"
+        aria-label="To day"
+        className={inputClass}
+        value={untilDay}
+        min={sinceDay}
+        onChange={(event) => {
+          if (event.target.value) onChange(sinceDay, event.target.value);
+        }}
+      />
+    </div>
   );
 }
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -21,6 +21,7 @@ import {
   makeWindow,
 } from "@t3tools/shared/usageFormat";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 import { ScrollArea } from "../ui/scroll-area";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { SidebarInset } from "../ui/sidebar";
@@ -238,6 +239,12 @@ export function UsagePage() {
 
         <ScrollArea className="min-h-0 flex-1">
           <WorkspacePageContainer width="wide">
+            <UsageDateRangeInputs
+              className="mb-4 flex-wrap lg:hidden"
+              sinceDay={window.sinceDay}
+              untilDay={window.untilDay}
+              onChange={selectCustomWindow}
+            />
             {settling ? (
               <>
                 {environments.length > 1 ? <UsageDeviceStrip environments={environments} /> : null}
@@ -509,26 +516,29 @@ export function UsagePage() {
 
 /**
  * Free date-range bounds beside the presets. Native date inputs; committing
- * either bound deselects every preset. Hidden below lg with the rest of the
- * expanded toolbar.
+ * either bound deselects every preset. Compact layouts render the same control
+ * above the page content so custom ranges remain reachable without crowding
+ * the header.
  */
 function UsageDateRangeInputs({
+  className,
   sinceDay,
   untilDay,
   onChange,
 }: {
+  readonly className?: string;
   readonly sinceDay: string;
   readonly untilDay: string;
   readonly onChange: (sinceDay: string, untilDay: string) => void;
 }) {
-  const inputClass =
-    "h-7 rounded-md border border-border bg-transparent px-2 text-xs text-foreground [color-scheme:inherit] focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none";
   return (
-    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-      <input
+    <div className={cn("flex items-center gap-1.5 text-xs text-muted-foreground", className)}>
+      <Input
+        nativeInput
         type="date"
+        size="compact"
         aria-label="From day"
-        className={inputClass}
+        className="w-auto [color-scheme:inherit]"
         value={sinceDay}
         max={untilDay}
         onChange={(event) => {
@@ -536,10 +546,12 @@ function UsageDateRangeInputs({
         }}
       />
       <span>to</span>
-      <input
+      <Input
+        nativeInput
         type="date"
+        size="compact"
         aria-label="To day"
-        className={inputClass}
+        className="w-auto [color-scheme:inherit]"
         value={untilDay}
         min={sinceDay}
         onChange={(event) => {

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -5,9 +5,11 @@ import { useMemo, useState } from "react";
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
+import { useCommitOnBlur } from "../../hooks/useCommitOnBlur";
 import { cn } from "../../lib/utils";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import {
+  compareUsageDays,
   enumerateDays,
   enumerateHourStarts,
   formatCount,
@@ -531,6 +533,20 @@ function UsageDateRangeInputs({
   readonly untilDay: string;
   readonly onChange: (sinceDay: string, untilDay: string) => void;
 }) {
+  // The shared buffered-input hook preserves a focused draft across upstream
+  // range changes and commits on both blur and Enter. Keep the hooks separate
+  // so each bound can validate against the last committed opposite bound.
+  const sinceInput = useCommitOnBlur(sinceDay, (next) => {
+    const comparison = compareUsageDays(next, untilDay);
+    if (comparison !== null && comparison <= 0) onChange(next, untilDay);
+  });
+  const untilInput = useCommitOnBlur(untilDay, (next) => {
+    const comparison = compareUsageDays(sinceDay, next);
+    if (comparison !== null && comparison <= 0) onChange(sinceDay, next);
+  });
+  const comparison = compareUsageDays(sinceInput.value, untilInput.value);
+  const invalid = comparison === null || comparison > 0;
+
   return (
     <div className={cn("flex items-center gap-1.5 text-xs text-muted-foreground", className)}>
       <Input
@@ -539,11 +555,9 @@ function UsageDateRangeInputs({
         size="compact"
         aria-label="From day"
         className="w-auto [color-scheme:inherit]"
-        value={sinceDay}
-        max={untilDay}
-        onChange={(event) => {
-          if (event.target.value) onChange(event.target.value, untilDay);
-        }}
+        max={untilInput.value}
+        aria-invalid={invalid || undefined}
+        {...sinceInput}
       />
       <span>to</span>
       <Input
@@ -552,11 +566,9 @@ function UsageDateRangeInputs({
         size="compact"
         aria-label="To day"
         className="w-auto [color-scheme:inherit]"
-        value={untilDay}
-        min={sinceDay}
-        onChange={(event) => {
-          if (event.target.value) onChange(sinceDay, event.target.value);
-        }}
+        min={sinceInput.value}
+        aria-invalid={invalid || undefined}
+        {...untilInput}
       />
     </div>
   );

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -41,6 +41,7 @@ import {
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
+import { UsageCacheWriteCell } from "./UsageCacheWriteCell";
 import { UsageThreadTable } from "./UsageThreadTable";
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
@@ -334,7 +335,9 @@ export function UsagePage() {
                           const scope = sessionsKnown
                             ? `${formatCount(merged.sessions)} sessions`
                             : (selectedProjectLabel ?? "Outside projects");
-                          return metric === "cost" ? `${scope} · API estimate` : scope;
+                          return metric === "cost"
+                            ? `${scope} · local public-list estimate`
+                            : scope;
                         })()}
                       </span>
                     </div>
@@ -429,7 +432,7 @@ export function UsagePage() {
                     />
                     <Metric label="Output" value={formatTokens(merged.outputTokens)} />
                     <Metric
-                      label="Estimated cache writes"
+                      label="Cache writes, estimated"
                       value={
                         merged.costQuality.cacheWriteUsd === null
                           ? "Unavailable"
@@ -437,7 +440,7 @@ export function UsagePage() {
                       }
                       {...(merged.costUsd > 0 && merged.costQuality.cacheWriteUsd !== null
                         ? {
-                            detail: `${formatPercent(merged.costQuality.cacheWriteUsd / merged.costUsd, 0)} of cost`,
+                            detail: `${formatPercent(merged.costQuality.cacheWriteUsd / merged.costUsd, 0)} of estimate · not an expiry measure`,
                           }
                         : {})}
                     />
@@ -550,7 +553,7 @@ export function UsagePage() {
                               <td className="py-2 text-right text-foreground tabular-nums">
                                 {formatUsd(project.costUsd)}
                               </td>
-                              <CacheWriteCell
+                              <UsageCacheWriteCell
                                 cacheWriteTokens={project.cacheWriteTokens}
                                 cacheWriteUsd={project.cacheWriteUsd}
                               />
@@ -611,7 +614,7 @@ export function UsagePage() {
                               <td className="py-2 text-right text-foreground tabular-nums">
                                 {formatUsd(model.costUsd)}
                               </td>
-                              <CacheWriteCell
+                              <UsageCacheWriteCell
                                 cacheWriteTokens={model.cacheWriteTokens}
                                 cacheWriteUsd={model.cacheWriteUsd}
                               />
@@ -860,29 +863,6 @@ function Metric({
 }
 
 /**
- * Cache-write cost cell. Providers that bill no cache writes (Codex) show a
- * dash rather than a misleading $0.00.
- */
-function CacheWriteCell({
-  cacheWriteTokens,
-  cacheWriteUsd,
-}: {
-  readonly cacheWriteTokens: number;
-  readonly cacheWriteUsd: number | null;
-}) {
-  return (
-    <td className="py-2 text-right text-muted-foreground tabular-nums">
-      {formatCacheWriteCost(cacheWriteTokens, cacheWriteUsd)}
-    </td>
-  );
-}
-
-function formatCacheWriteCost(cacheWriteTokens: number, cacheWriteUsd: number | null): string {
-  if (cacheWriteTokens === 0) return "-";
-  return cacheWriteUsd === null ? "Unavailable" : formatUsd(cacheWriteUsd);
-}
-
-/**
  * Says plainly when the totals are incomplete: an environment that failed, or
  * one whose transcripts another environment already reported. Environments
  * that are still answering never reach this notice; the page shows the
@@ -1026,7 +1006,7 @@ function UsageSkeleton() {
             "Cached input",
             "Uncached input",
             "Output",
-            "Estimated cache writes",
+            "Cache writes, estimated",
             "Cache savings",
           ].map((label) => (
             <div key={label} className="flex flex-col gap-0.5">

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -733,7 +733,7 @@ function UsageDateRangeInputs({
   const comparison = compareUsageDays(sinceInput.value, untilInput.value);
   const invalid = comparison === null || comparison > 0;
   const inputClassName =
-    "w-auto rounded-md transition-colors hover:bg-background/55 hover:text-foreground focus-within:bg-background focus-within:text-foreground focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-background has-aria-invalid:text-destructive focus-within:has-aria-invalid:ring-destructive/50 dark:hover:bg-input/32 dark:focus-within:bg-input/72 [&_[data-slot=input]]:h-6 [&_[data-slot=input]]:px-2.5 [&_[data-slot=input]]:leading-6 [&_[data-slot=input]::-webkit-calendar-picker-indicator]:opacity-50";
+    "w-auto rounded-md transition-colors hover:bg-background/55 hover:text-foreground focus-within:bg-background focus-within:text-foreground focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-background has-aria-invalid:text-destructive focus-within:has-aria-invalid:ring-destructive/50 dark:hover:bg-input/32 dark:focus-within:bg-input/72 [&_[data-slot=input]]:h-6 [&_[data-slot=input]]:px-2.5 [&_[data-slot=input]]:leading-6 [&_[data-slot=input]]:pointer-coarse:h-8.5 [&_[data-slot=input]]:pointer-coarse:leading-8.5 [&_[data-slot=input]::-webkit-calendar-picker-indicator]:opacity-50";
 
   return (
     <div

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -2,7 +2,12 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
-import type { DailyTotals, HourlyTotals, ProjectTotals } from "@t3tools/shared/usageMerge";
+import {
+  projectFilterForEnvironment,
+  type DailyTotals,
+  type HourlyTotals,
+  type ProjectTotals,
+} from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
 import { useCommitOnBlur } from "../../hooks/useCommitOnBlur";
@@ -60,7 +65,11 @@ export function UsagePage() {
   const [projectFilter, setProjectFilter] = useState<string | null | undefined>(undefined);
   const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
   const isPast24Hours = !isCustomWindow && windowDays === 1;
-  const { merged, environments, isPending, isPartial, refresh } = useUsage(window, projectFilter);
+  const { merged, environments, isPending, isPartial, refresh } = useUsage(
+    window,
+    projectFilter,
+    breakdown === "thread",
+  );
 
   // Hold the content until every environment is terminal. Rendering merged
   // totals while devices are still answering makes every number on the page
@@ -471,6 +480,17 @@ export function UsagePage() {
                         ...(projectFilter === undefined ? {} : { projectKey: projectFilter }),
                       }}
                       providerContributions={merged.providerContributions}
+                      summaryFailedEnvironments={
+                        environments.filter(
+                          (environment) =>
+                            (environment.error !== null ||
+                              merged.staleEnvironments.includes(environment.environmentId)) &&
+                            projectFilterForEnvironment(
+                              projectFilter,
+                              environment.environmentId,
+                            ) !== "environment-mismatch:",
+                        ).length
+                      }
                     />
                   ) : breakdown === "project" ? (
                     <table className="w-full table-fixed text-sm">

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -2,7 +2,7 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
+import type { DailyTotals, HourlyTotals, ProjectTotals } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
 import { useCommitOnBlur } from "../../hooks/useCommitOnBlur";
@@ -54,10 +54,12 @@ export function UsagePage() {
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
-  const [breakdown, setBreakdown] = useState<"model" | "time">("model");
+  const [breakdown, setBreakdown] = useState<"model" | "project" | "time">("model");
+  // A project title, null for work outside every project, undefined for all.
+  const [projectFilter, setProjectFilter] = useState<string | null | undefined>(undefined);
   const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
   const isPast24Hours = !isCustomWindow && windowDays === 1;
-  const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
+  const { merged, environments, isPending, isPartial, refresh } = useUsage(window, projectFilter);
 
   // Hold the content until every environment is terminal. Rendering merged
   // totals while devices are still answering makes every number on the page
@@ -90,8 +92,23 @@ export function UsagePage() {
         : merged.models,
     [breakdown, merged.models, metric],
   );
+  const breakdownProjects = useMemo(
+    () =>
+      metric === "tokens"
+        ? merged.projects.toSorted(
+            (left, right) => right.totalTokens - left.totalTokens || right.costUsd - left.costUsd,
+          )
+        : merged.projects,
+    [merged.projects, metric],
+  );
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
+  // Session figures are per transcript directory; a project filter cannot
+  // split them, so they only render unfiltered.
+  const sessionsKnown = projectFilter === undefined;
+  // Only offer the picker once a second grouping exists; a lone group can
+  // only ever filter to itself.
+  const showProjectPicker = merged.projects.length > 1 || projectFilter !== undefined;
 
   const selectWindow = (days: number) => {
     setWindowSelection({
@@ -142,6 +159,13 @@ export function UsagePage() {
         </WorkspaceBreadcrumbItem>
       </WorkspaceBreadcrumb>
       <div className="ms-auto hidden min-w-0 items-center justify-end gap-2 lg:flex">
+        {showProjectPicker ? (
+          <UsageProjectSelect
+            projects={merged.projects}
+            filter={projectFilter}
+            onChange={setProjectFilter}
+          />
+        ) : null}
         <ToggleGroup
           aria-label="Usage metric"
           variant="segmented"
@@ -182,6 +206,13 @@ export function UsagePage() {
         </Button>
       </div>
       <div className="ms-auto flex min-w-0 items-center justify-end gap-1 lg:hidden">
+        {showProjectPicker ? (
+          <UsageProjectSelect
+            projects={merged.projects}
+            filter={projectFilter}
+            onChange={setProjectFilter}
+          />
+        ) : null}
         <Select
           value={metric}
           onValueChange={(value) => {
@@ -269,9 +300,12 @@ export function UsagePage() {
                           : formatTokens(merged.totalTokens)}
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        {metric === "cost"
-                          ? `${formatCount(merged.sessions)} sessions · API estimate`
-                          : `${formatCount(merged.sessions)} sessions`}
+                        {(() => {
+                          const scope = sessionsKnown
+                            ? `${formatCount(merged.sessions)} sessions`
+                            : (projectFilter ?? "Outside projects");
+                          return metric === "cost" ? `${scope} · API estimate` : scope;
+                        })()}
                       </span>
                     </div>
 
@@ -299,9 +333,11 @@ export function UsagePage() {
                                 <span className="truncate">
                                   {PROVIDER_PRESENTATION[provider].label}
                                 </span>
-                                <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground tabular-nums">
-                                  {sessionLabel}
-                                </span>
+                                {sessionsKnown ? (
+                                  <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground tabular-nums">
+                                    {sessionLabel}
+                                  </span>
+                                ) : null}
                               </span>
                             </span>
                             <span className="shrink-0 text-sm font-medium text-foreground tabular-nums">
@@ -378,12 +414,15 @@ export function UsagePage() {
                       value={[breakdown]}
                       onValueChange={(next) => {
                         const value = next[0];
-                        if (value === "model" || value === "time") setBreakdown(value);
+                        if (value === "model" || value === "project" || value === "time") {
+                          setBreakdown(value);
+                        }
                       }}
                     >
                       {(
                         [
                           { value: "model", label: "Model" },
+                          { value: "project", label: "Project" },
                           { value: "time", label: isPast24Hours ? "Hour" : "Day" },
                         ] as const
                       ).map((option) => (
@@ -394,7 +433,59 @@ export function UsagePage() {
                     </ToggleGroup>
                   </div>
 
-                  {breakdown === "model" ? (
+                  {breakdown === "project" ? (
+                    <table className="w-full table-fixed text-sm">
+                      <colgroup>
+                        <col className="w-2/5" />
+                        <col className="w-1/5" />
+                        <col className="w-1/5" />
+                        <col className="w-1/5" />
+                      </colgroup>
+                      <thead>
+                        <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                          <th className="py-2 font-normal">Project</th>
+                          <th className="py-2 text-right font-normal">Cost</th>
+                          <th className="py-2 text-right font-normal">Share</th>
+                          <th className="py-2 text-right font-normal">Tokens</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {breakdownProjects.length === 0 ? (
+                          <tr>
+                            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                              No activity in this window.
+                            </td>
+                          </tr>
+                        ) : (
+                          breakdownProjects.map((project) => (
+                            <tr
+                              key={project.project ?? "\0"}
+                              className="border-b border-border/50 transition-colors hover:bg-muted/50"
+                            >
+                              <td className="py-2">
+                                {project.project === null ? (
+                                  <span className="text-muted-foreground">Outside projects</span>
+                                ) : (
+                                  <span className="block truncate text-foreground">
+                                    {project.project}
+                                  </span>
+                                )}
+                              </td>
+                              <td className="py-2 text-right text-foreground tabular-nums">
+                                {formatUsd(project.costUsd)}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatPercent(project.costShare)}
+                              </td>
+                              <td className="py-2 text-right text-muted-foreground tabular-nums">
+                                {formatTokens(project.totalTokens)}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  ) : breakdown === "model" ? (
                     <table className="w-full table-fixed text-sm">
                       <colgroup>
                         <col className="w-2/5" />
@@ -571,6 +662,71 @@ function UsageDateRangeInputs({
         {...untilInput}
       />
     </div>
+  );
+}
+
+/**
+ * Select values are plain strings, so the three filter states get distinct
+ * encodings: sentinels for "all" and "outside", a prefix for titles so a
+ * project literally named "all" cannot collide with the sentinel.
+ */
+const ALL_PROJECTS_VALUE = "all";
+const OUTSIDE_PROJECTS_VALUE = "outside";
+const PROJECT_VALUE_PREFIX = "p:";
+
+function projectFilterValue(filter: string | null | undefined): string {
+  if (filter === undefined) return ALL_PROJECTS_VALUE;
+  if (filter === null) return OUTSIDE_PROJECTS_VALUE;
+  return `${PROJECT_VALUE_PREFIX}${filter}`;
+}
+
+function projectFilterFromValue(value: string): string | null | undefined {
+  if (value === OUTSIDE_PROJECTS_VALUE) return null;
+  if (value.startsWith(PROJECT_VALUE_PREFIX)) return value.slice(PROJECT_VALUE_PREFIX.length);
+  return undefined;
+}
+
+/** Narrows the whole page to one project's buckets. */
+function UsageProjectSelect({
+  projects,
+  filter,
+  onChange,
+}: {
+  readonly projects: readonly ProjectTotals[];
+  readonly filter: string | null | undefined;
+  readonly onChange: (filter: string | null | undefined) => void;
+}) {
+  const label = filter === undefined ? "All projects" : (filter ?? "Outside projects");
+  return (
+    <Select
+      value={projectFilterValue(filter)}
+      onValueChange={(value) => onChange(projectFilterFromValue(value ?? ""))}
+    >
+      <SelectTrigger
+        aria-label="Project filter"
+        size="compact"
+        variant="ghost"
+        className="w-auto max-w-48 min-w-0"
+      >
+        <SelectValue>
+          <span className="truncate">{label}</span>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectItem value={ALL_PROJECTS_VALUE}>All projects</SelectItem>
+        {projects.map((project) =>
+          project.project === null ? (
+            <SelectItem key={OUTSIDE_PROJECTS_VALUE} value={OUTSIDE_PROJECTS_VALUE}>
+              Outside projects
+            </SelectItem>
+          ) : (
+            <SelectItem key={project.project} value={`${PROJECT_VALUE_PREFIX}${project.project}`}>
+              {project.project}
+            </SelectItem>
+          ),
+        )}
+      </SelectPopup>
+    </Select>
   );
 }
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -466,7 +466,9 @@ export function UsagePage() {
                         sinceDay: window.sinceDay,
                         untilDay: window.untilDay,
                         timeZone: window.timeZone,
-                        ...(projectFilter === undefined ? {} : { project: projectFilter }),
+                        ...(window.sinceTime === undefined ? {} : { sinceTime: window.sinceTime }),
+                        ...(window.untilTime === undefined ? {} : { untilTime: window.untilTime }),
+                        ...(projectFilter === undefined ? {} : { projectKey: projectFilter }),
                       }}
                       providerContributions={merged.providerContributions}
                     />

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -55,7 +55,7 @@ export function UsagePage() {
   }));
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
   const [breakdown, setBreakdown] = useState<"model" | "project" | "time">("model");
-  // A project title, null for work outside every project, undefined for all.
+  // A namespaced project key, null for work outside every project, undefined for all.
   const [projectFilter, setProjectFilter] = useState<string | null | undefined>(undefined);
   const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
   const isPast24Hours = !isCustomWindow && windowDays === 1;
@@ -92,15 +92,22 @@ export function UsagePage() {
         : merged.models,
     [breakdown, merged.models, metric],
   );
-  const breakdownProjects = useMemo(
-    () =>
-      metric === "tokens"
-        ? merged.projects.toSorted(
-            (left, right) => right.totalTokens - left.totalTokens || right.costUsd - left.costUsd,
-          )
-        : merged.projects,
-    [merged.projects, metric],
-  );
+  const breakdownProjects = useMemo(() => {
+    const scoped =
+      projectFilter === undefined
+        ? merged.projects
+        : merged.projects.filter((project) => project.projectKey === projectFilter);
+    return metric === "tokens"
+      ? scoped.toSorted(
+          (left, right) => right.totalTokens - left.totalTokens || right.costUsd - left.costUsd,
+        )
+      : scoped;
+  }, [merged.projects, metric, projectFilter]);
+  const selectedProjectLabel =
+    projectFilter === undefined
+      ? null
+      : (merged.projects.find((project) => project.projectKey === projectFilter)?.project ??
+        "Outside projects");
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
   // Session figures are per transcript directory; a project filter cannot
@@ -303,7 +310,7 @@ export function UsagePage() {
                         {(() => {
                           const scope = sessionsKnown
                             ? `${formatCount(merged.sessions)} sessions`
-                            : (projectFilter ?? "Outside projects");
+                            : (selectedProjectLabel ?? "Outside projects");
                           return metric === "cost" ? `${scope} · API estimate` : scope;
                         })()}
                       </span>
@@ -459,7 +466,7 @@ export function UsagePage() {
                         ) : (
                           breakdownProjects.map((project) => (
                             <tr
-                              key={project.project ?? "\0"}
+                              key={project.projectKey ?? "\0"}
                               className="border-b border-border/50 transition-colors hover:bg-muted/50"
                             >
                               <td className="py-2">
@@ -667,8 +674,8 @@ function UsageDateRangeInputs({
 
 /**
  * Select values are plain strings, so the three filter states get distinct
- * encodings: sentinels for "all" and "outside", a prefix for titles so a
- * project literally named "all" cannot collide with the sentinel.
+ * encodings: sentinels for "all" and "outside", while attributed projects
+ * already carry a namespaced stable key from the merge layer.
  */
 const ALL_PROJECTS_VALUE = "all";
 const OUTSIDE_PROJECTS_VALUE = "outside";
@@ -696,7 +703,10 @@ function UsageProjectSelect({
   readonly filter: string | null | undefined;
   readonly onChange: (filter: string | null | undefined) => void;
 }) {
-  const label = filter === undefined ? "All projects" : (filter ?? "Outside projects");
+  const label =
+    filter === undefined
+      ? "All projects"
+      : (projects.find((project) => project.projectKey === filter)?.project ?? "Outside projects");
   return (
     <Select
       value={projectFilterValue(filter)}
@@ -720,7 +730,10 @@ function UsageProjectSelect({
               Outside projects
             </SelectItem>
           ) : (
-            <SelectItem key={project.project} value={`${PROJECT_VALUE_PREFIX}${project.project}`}>
+            <SelectItem
+              key={project.projectKey}
+              value={`${PROJECT_VALUE_PREFIX}${project.projectKey}`}
+            >
               {project.project}
             </SelectItem>
           ),

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -103,6 +103,10 @@ export function UsagePage() {
         )
       : scoped;
   }, [merged.projects, metric, projectFilter]);
+  const breakdownProjectCostUsd = useMemo(
+    () => breakdownProjects.reduce((sum, project) => sum + project.costUsd, 0),
+    [breakdownProjects],
+  );
   const projectLabelsRef = useRef(new Map<string, string>());
   for (const project of merged.projects) {
     if (project.projectKey !== null && project.project !== null) {
@@ -469,7 +473,9 @@ export function UsagePage() {
                         {breakdownProjects.length === 0 ? (
                           <tr>
                             <td colSpan={4} className="py-6 text-center text-muted-foreground">
-                              No activity in this window.
+                              {merged.records === 0
+                                ? "No activity in this window."
+                                : "No project attribution in this window."}
                             </td>
                           </tr>
                         ) : (
@@ -491,7 +497,13 @@ export function UsagePage() {
                                 {formatUsd(project.costUsd)}
                               </td>
                               <td className="py-2 text-right text-muted-foreground tabular-nums">
-                                {formatPercent(project.costShare)}
+                                {formatPercent(
+                                  projectFilter === undefined
+                                    ? project.costShare
+                                    : breakdownProjectCostUsd === 0
+                                      ? 0
+                                      : project.costUsd / breakdownProjectCostUsd,
+                                )}
                               </td>
                               <td className="py-2 text-right text-muted-foreground tabular-nums">
                                 {formatTokens(project.totalTokens)}

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -420,7 +420,7 @@ export function UsagePage() {
 
                 <section className="flex flex-col gap-2">
                   <h2 className="text-sm font-medium text-foreground">Totals</h2>
-                  <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-5">
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-6">
                     <Metric label="Processed tokens" value={formatTokens(merged.totalTokens)} />
                     <Metric label="Cached input" value={formatTokens(merged.cachedInputTokens)} />
                     <Metric
@@ -428,6 +428,15 @@ export function UsagePage() {
                       value={formatTokens(merged.uncachedInputTokens)}
                     />
                     <Metric label="Output" value={formatTokens(merged.outputTokens)} />
+                    <Metric
+                      label="Estimated cache writes"
+                      value={formatUsd(merged.costQuality.cacheWriteUsd)}
+                      {...(merged.costUsd > 0
+                        ? {
+                            detail: `${formatPercent(merged.costQuality.cacheWriteUsd / merged.costUsd, 0)} of cost`,
+                          }
+                        : {})}
+                    />
                     <Metric
                       label="Cache savings"
                       value={formatUsd(merged.costQuality.cacheSavingsUsd)}
@@ -495,15 +504,17 @@ export function UsagePage() {
                   ) : breakdown === "project" ? (
                     <table className="w-full table-fixed text-sm">
                       <colgroup>
-                        <col className="w-2/5" />
-                        <col className="w-1/5" />
-                        <col className="w-1/5" />
-                        <col className="w-1/5" />
+                        <col className="w-[32%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
                       </colgroup>
                       <thead>
                         <tr className="border-b border-border text-left text-xs text-muted-foreground">
                           <th className="py-2 font-normal">Project</th>
                           <th className="py-2 text-right font-normal">Cost</th>
+                          <th className="py-2 text-right font-normal">Cache writes</th>
                           <th className="py-2 text-right font-normal">Share</th>
                           <th className="py-2 text-right font-normal">Tokens</th>
                         </tr>
@@ -511,7 +522,7 @@ export function UsagePage() {
                       <tbody>
                         {breakdownProjects.length === 0 ? (
                           <tr>
-                            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
                               {merged.records === 0
                                 ? "No activity in this window."
                                 : "No project attribution in this window."}
@@ -535,6 +546,10 @@ export function UsagePage() {
                               <td className="py-2 text-right text-foreground tabular-nums">
                                 {formatUsd(project.costUsd)}
                               </td>
+                              <CacheWriteCell
+                                cacheWriteTokens={project.cacheWriteTokens}
+                                cacheWriteUsd={project.cacheWriteUsd}
+                              />
                               <td className="py-2 text-right text-muted-foreground tabular-nums">
                                 {formatPercent(
                                   projectFilter === undefined
@@ -555,15 +570,17 @@ export function UsagePage() {
                   ) : breakdown === "model" ? (
                     <table className="w-full table-fixed text-sm">
                       <colgroup>
-                        <col className="w-2/5" />
-                        <col className="w-1/5" />
-                        <col className="w-1/5" />
-                        <col className="w-1/5" />
+                        <col className="w-[32%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
+                        <col className="w-[17%]" />
                       </colgroup>
                       <thead>
                         <tr className="border-b border-border text-left text-xs text-muted-foreground">
                           <th className="py-2 font-normal">Model</th>
                           <th className="py-2 text-right font-normal">Cost</th>
+                          <th className="py-2 text-right font-normal">Cache writes</th>
                           <th className="py-2 text-right font-normal">Share</th>
                           <th className="py-2 text-right font-normal">Tokens</th>
                         </tr>
@@ -571,7 +588,7 @@ export function UsagePage() {
                       <tbody>
                         {breakdownModels.length === 0 ? (
                           <tr>
-                            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
                               No activity in this window.
                             </td>
                           </tr>
@@ -590,6 +607,10 @@ export function UsagePage() {
                               <td className="py-2 text-right text-foreground tabular-nums">
                                 {formatUsd(model.costUsd)}
                               </td>
+                              <CacheWriteCell
+                                cacheWriteTokens={model.cacheWriteTokens}
+                                cacheWriteUsd={model.cacheWriteUsd}
+                              />
                               <td className="py-2 text-right text-muted-foreground tabular-nums">
                                 {formatPercent(model.costShare)}
                               </td>
@@ -814,12 +835,41 @@ function ProviderMark({
   return <Mark className={cn("shrink-0", className)} aria-hidden />;
 }
 
-function Metric({ label, value }: { readonly label: string; readonly value: string }) {
+function Metric({
+  label,
+  value,
+  detail,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly detail?: string;
+}) {
   return (
     <div className="flex min-w-0 flex-col gap-0.5">
       <span className="text-xs text-muted-foreground">{label}</span>
       <span className="text-base font-medium text-foreground tabular-nums">{value}</span>
+      {detail === undefined ? null : (
+        <span className="text-xs text-muted-foreground tabular-nums">{detail}</span>
+      )}
     </div>
+  );
+}
+
+/**
+ * Cache-write cost cell. Providers that bill no cache writes (Codex) show a
+ * dash rather than a misleading $0.00.
+ */
+function CacheWriteCell({
+  cacheWriteTokens,
+  cacheWriteUsd,
+}: {
+  readonly cacheWriteTokens: number;
+  readonly cacheWriteUsd: number;
+}) {
+  return (
+    <td className="py-2 text-right text-muted-foreground tabular-nums">
+      {cacheWriteTokens === 0 ? "-" : formatUsd(cacheWriteUsd)}
+    </td>
   );
 }
 
@@ -961,15 +1011,20 @@ function UsageSkeleton() {
 
       <section className="flex flex-col gap-2">
         <h2 className="text-sm font-medium text-foreground">Totals</h2>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-5">
-          {["Processed tokens", "Cached input", "Uncached input", "Output", "Cache savings"].map(
-            (label) => (
-              <div key={label} className="flex flex-col gap-0.5">
-                <span className="text-xs text-muted-foreground">{label}</span>
-                <div className="h-6 w-16 rounded-sm bg-muted" />
-              </div>
-            ),
-          )}
+        <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-6">
+          {[
+            "Processed tokens",
+            "Cached input",
+            "Uncached input",
+            "Output",
+            "Estimated cache writes",
+            "Cache savings",
+          ].map((label) => (
+            <div key={label} className="flex flex-col gap-0.5">
+              <span className="text-xs text-muted-foreground">{label}</span>
+              <div className="h-6 w-16 rounded-sm bg-muted" />
+            </div>
+          ))}
         </div>
       </section>
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -36,6 +36,7 @@ import {
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
+import { UsageThreadTable } from "./UsageThreadTable";
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
@@ -54,7 +55,7 @@ export function UsagePage() {
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
-  const [breakdown, setBreakdown] = useState<"model" | "project" | "time">("model");
+  const [breakdown, setBreakdown] = useState<"model" | "project" | "thread" | "time">("model");
   // A namespaced project key, null for work outside every project, undefined for all.
   const [projectFilter, setProjectFilter] = useState<string | null | undefined>(undefined);
   const { days: windowDays, custom: isCustomWindow, window } = windowSelection;
@@ -434,7 +435,12 @@ export function UsagePage() {
                       value={[breakdown]}
                       onValueChange={(next) => {
                         const value = next[0];
-                        if (value === "model" || value === "project" || value === "time") {
+                        if (
+                          value === "model" ||
+                          value === "project" ||
+                          value === "thread" ||
+                          value === "time"
+                        ) {
                           setBreakdown(value);
                         }
                       }}
@@ -443,6 +449,7 @@ export function UsagePage() {
                         [
                           { value: "model", label: "Model" },
                           { value: "project", label: "Project" },
+                          { value: "thread", label: "Thread" },
                           { value: "time", label: isPast24Hours ? "Hour" : "Day" },
                         ] as const
                       ).map((option) => (
@@ -453,7 +460,17 @@ export function UsagePage() {
                     </ToggleGroup>
                   </div>
 
-                  {breakdown === "project" ? (
+                  {breakdown === "thread" ? (
+                    <UsageThreadTable
+                      input={{
+                        sinceDay: window.sinceDay,
+                        untilDay: window.untilDay,
+                        timeZone: window.timeZone,
+                        ...(projectFilter === undefined ? {} : { project: projectFilter }),
+                      }}
+                      environmentIds={merged.contributingEnvironments}
+                    />
+                  ) : breakdown === "project" ? (
                     <table className="w-full table-fixed text-sm">
                       <colgroup>
                         <col className="w-2/5" />

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -732,26 +732,35 @@ function UsageDateRangeInputs({
   });
   const comparison = compareUsageDays(sinceInput.value, untilInput.value);
   const invalid = comparison === null || comparison > 0;
+  const inputClassName =
+    "w-auto rounded-md transition-colors hover:bg-background/55 hover:text-foreground focus-within:bg-background focus-within:text-foreground focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-background has-aria-invalid:text-destructive focus-within:has-aria-invalid:ring-destructive/50 dark:hover:bg-input/32 dark:focus-within:bg-input/72 [&_[data-slot=input]]:h-6 [&_[data-slot=input]]:px-2.5 [&_[data-slot=input]]:leading-6 [&_[data-slot=input]::-webkit-calendar-picker-indicator]:opacity-50";
 
   return (
-    <div className={cn("flex items-center gap-1.5 text-xs text-muted-foreground", className)}>
+    <div
+      className={cn(
+        "flex w-fit items-center gap-0.5 rounded-lg bg-input/40 p-0.5 text-xs text-muted-foreground",
+        className,
+      )}
+    >
       <Input
         nativeInput
+        unstyled
         type="date"
         size="compact"
         aria-label="From day"
-        className="w-auto [color-scheme:inherit]"
+        className={cn(inputClassName, "[color-scheme:inherit]")}
         max={untilInput.value}
         aria-invalid={invalid || undefined}
         {...sinceInput}
       />
-      <span>to</span>
+      <span className="px-0.5">to</span>
       <Input
         nativeInput
+        unstyled
         type="date"
         size="compact"
         aria-label="To day"
-        className="w-auto [color-scheme:inherit]"
+        className={cn(inputClassName, "[color-scheme:inherit]")}
         min={sinceInput.value}
         aria-invalid={invalid || undefined}
         {...untilInput}

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -430,8 +430,12 @@ export function UsagePage() {
                     <Metric label="Output" value={formatTokens(merged.outputTokens)} />
                     <Metric
                       label="Estimated cache writes"
-                      value={formatUsd(merged.costQuality.cacheWriteUsd)}
-                      {...(merged.costUsd > 0
+                      value={
+                        merged.costQuality.cacheWriteUsd === null
+                          ? "Unavailable"
+                          : formatUsd(merged.costQuality.cacheWriteUsd)
+                      }
+                      {...(merged.costUsd > 0 && merged.costQuality.cacheWriteUsd !== null
                         ? {
                             detail: `${formatPercent(merged.costQuality.cacheWriteUsd / merged.costUsd, 0)} of cost`,
                           }
@@ -864,13 +868,18 @@ function CacheWriteCell({
   cacheWriteUsd,
 }: {
   readonly cacheWriteTokens: number;
-  readonly cacheWriteUsd: number;
+  readonly cacheWriteUsd: number | null;
 }) {
   return (
     <td className="py-2 text-right text-muted-foreground tabular-nums">
-      {cacheWriteTokens === 0 ? "-" : formatUsd(cacheWriteUsd)}
+      {formatCacheWriteCost(cacheWriteTokens, cacheWriteUsd)}
     </td>
   );
+}
+
+function formatCacheWriteCost(cacheWriteTokens: number, cacheWriteUsd: number | null): string {
+  if (cacheWriteTokens === 0) return "-";
+  return cacheWriteUsd === null ? "Unavailable" : formatUsd(cacheWriteUsd);
 }
 
 /**

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -468,7 +468,7 @@ export function UsagePage() {
                         timeZone: window.timeZone,
                         ...(projectFilter === undefined ? {} : { project: projectFilter }),
                       }}
-                      environmentIds={merged.contributingEnvironments}
+                      providerContributions={merged.providerContributions}
                     />
                   ) : breakdown === "project" ? (
                     <table className="w-full table-fixed text-sm">

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import type { DailyTotals, HourlyTotals, ProjectTotals } from "@t3tools/shared/usageMerge";
 
@@ -103,11 +103,18 @@ export function UsagePage() {
         )
       : scoped;
   }, [merged.projects, metric, projectFilter]);
+  const projectLabelsRef = useRef(new Map<string, string>());
+  for (const project of merged.projects) {
+    if (project.projectKey !== null && project.project !== null) {
+      projectLabelsRef.current.set(project.projectKey, project.project);
+    }
+  }
   const selectedProjectLabel =
     projectFilter === undefined
       ? null
-      : (merged.projects.find((project) => project.projectKey === projectFilter)?.project ??
-        "Outside projects");
+      : projectFilter === null
+        ? "Outside projects"
+        : (projectLabelsRef.current.get(projectFilter) ?? "Selected project");
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
   // Session figures are per transcript directory; a project filter cannot
@@ -170,6 +177,7 @@ export function UsagePage() {
           <UsageProjectSelect
             projects={merged.projects}
             filter={projectFilter}
+            selectedLabel={selectedProjectLabel}
             onChange={setProjectFilter}
           />
         ) : null}
@@ -217,6 +225,7 @@ export function UsagePage() {
           <UsageProjectSelect
             projects={merged.projects}
             filter={projectFilter}
+            selectedLabel={selectedProjectLabel}
             onChange={setProjectFilter}
           />
         ) : null}
@@ -697,16 +706,15 @@ function projectFilterFromValue(value: string): string | null | undefined {
 function UsageProjectSelect({
   projects,
   filter,
+  selectedLabel,
   onChange,
 }: {
   readonly projects: readonly ProjectTotals[];
   readonly filter: string | null | undefined;
+  readonly selectedLabel: string | null;
   readonly onChange: (filter: string | null | undefined) => void;
 }) {
-  const label =
-    filter === undefined
-      ? "All projects"
-      : (projects.find((project) => project.projectKey === filter)?.project ?? "Outside projects");
+  const label = filter === undefined ? "All projects" : (selectedLabel ?? "Selected project");
   return (
     <Select
       value={projectFilterValue(filter)}

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildDayColumns, niceScale } from "./UsageProviderChart";
+import { brushSelection, buildDayColumns, niceScale } from "./UsageProviderChart";
 import { providersWithUsage } from "./usageProviders";
 
 describe("niceScale", () => {
@@ -131,5 +131,31 @@ describe("hourly chart columns", () => {
         "cost",
       ).map((column) => column.total),
     ).toEqual([0, 4, 0]);
+  });
+});
+
+describe("brushSelection", () => {
+  const days = ["2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04"];
+
+  it("returns inclusive bounds for a forward drag", () => {
+    expect(brushSelection(days, 1, 3)).toEqual({
+      sinceDay: "2026-08-02",
+      untilDay: "2026-08-04",
+    });
+  });
+
+  it("normalises a backward drag", () => {
+    expect(brushSelection(days, 3, 1)).toEqual({
+      sinceDay: "2026-08-02",
+      untilDay: "2026-08-04",
+    });
+  });
+
+  it("treats a plain click as no selection", () => {
+    expect(brushSelection(days, 2, 2)).toBeNull();
+  });
+
+  it("rejects endpoints outside the day list", () => {
+    expect(brushSelection(days, 0, 9)).toBeNull();
   });
 });

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { brushSelection, buildDayColumns, periodIndexAt, niceScale } from "./UsageProviderChart";
+import {
+  brushSelection,
+  buildDayColumns,
+  chartLabelIndices,
+  periodIndexAt,
+  niceScale,
+  spanSinglePeriodPoints,
+} from "./UsageProviderChart";
 import { providersWithUsage } from "./usageProviders";
 
 describe("niceScale", () => {
@@ -164,5 +171,34 @@ describe("periodIndexAt", () => {
   it("clamps a captured pointer to either chart edge", () => {
     expect(periodIndexAt(-50, 100, 400, 5)).toBe(0);
     expect(periodIndexAt(750, 100, 400, 5)).toBe(4);
+  });
+});
+
+describe("spanSinglePeriodPoints", () => {
+  it("repeats one point across the chart width", () => {
+    expect(spanSinglePeriodPoints([{ x: 0, y: 42 }])).toEqual([
+      { x: 0, y: 42 },
+      { x: 960, y: 42 },
+    ]);
+  });
+
+  it("leaves multi-period points unchanged", () => {
+    const points = [
+      { x: 0, y: 42 },
+      { x: 960, y: 12 },
+    ];
+
+    expect(spanSinglePeriodPoints(points)).toBe(points);
+  });
+});
+
+describe("chartLabelIndices", () => {
+  it("deduplicates labels for one- and two-period windows", () => {
+    expect(chartLabelIndices(1)).toEqual([0]);
+    expect(chartLabelIndices(2)).toEqual([0, 1]);
+  });
+
+  it("keeps left, middle, and right labels for wider windows", () => {
+    expect(chartLabelIndices(5)).toEqual([0, 2, 4]);
   });
 });

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { brushSelection, buildDayColumns, niceScale } from "./UsageProviderChart";
+import { brushSelection, buildDayColumns, periodIndexAt, niceScale } from "./UsageProviderChart";
 import { providersWithUsage } from "./usageProviders";
 
 describe("niceScale", () => {
@@ -157,5 +157,12 @@ describe("brushSelection", () => {
 
   it("rejects endpoints outside the day list", () => {
     expect(brushSelection(days, 0, 9)).toBeNull();
+  });
+});
+
+describe("periodIndexAt", () => {
+  it("clamps a captured pointer to either chart edge", () => {
+    expect(periodIndexAt(-50, 100, 400, 5)).toBe(0);
+    expect(periodIndexAt(750, 100, 400, 5)).toBe(4);
   });
 });

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -1,7 +1,9 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
+
+import { cn } from "../../lib/utils";
 import {
   formatDayShort,
   formatHourShort,
@@ -19,6 +21,13 @@ const PLOT_TOP = 8;
 export type UsageChartMetric = "tokens" | "cost";
 
 interface UsageProviderChartProps {
+  /**
+   * Present only when the window can zoom (daily resolution). Receives the
+   * inclusive day bounds of a completed drag selection.
+   */
+  readonly onZoomToDays?: (sinceDay: string, untilDay: string) => void;
+  /** Restores the preset window on double-click. */
+  readonly onResetZoom?: () => void;
   readonly providers: readonly UsageProviderKind[];
   readonly days: readonly string[];
   readonly daily: readonly DailyTotals[];
@@ -187,7 +196,26 @@ export function buildDayColumns(
   return buildPeriodColumns(days, byDay, metric);
 }
 
+/**
+ * Inclusive day bounds of a brush selection, or null for a plain click.
+ * Endpoints may arrive in either drag direction.
+ */
+export function brushSelection(
+  days: readonly string[],
+  startIndex: number,
+  endIndex: number,
+): { readonly sinceDay: string; readonly untilDay: string } | null {
+  if (startIndex === endIndex) return null;
+  const [first, last] = startIndex < endIndex ? [startIndex, endIndex] : [endIndex, startIndex];
+  const sinceDay = days[first];
+  const untilDay = days[last];
+  if (sinceDay === undefined || untilDay === undefined) return null;
+  return { sinceDay, untilDay };
+}
+
 export function UsageProviderChart({
+  onZoomToDays,
+  onResetZoom,
   providers,
   days,
   daily,
@@ -207,6 +235,9 @@ export function UsageProviderChart({
     [daily, hourly, resolution],
   );
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  // Drag-selection endpoints, as period indices. Only daily windows zoom.
+  const [brush, setBrush] = useState<{ readonly start: number; readonly end: number } | null>(null);
+  const zoomable = resolution === "day" && onZoomToDays !== undefined;
   const plotRef = useRef<HTMLDivElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const hoverPositionRef = useRef<{ x: number; y: number } | null>(null);
@@ -306,22 +337,66 @@ export function UsageProviderChart({
     return () => observer.disconnect();
   }, [hoverIndex, positionTooltip]);
 
+  const indexAt = useCallback(
+    (clientX: number): number | null => {
+      const plot = plotRef.current;
+      if (plot === null || periods.length === 0) return null;
+      const bounds = plot.getBoundingClientRect();
+      if (bounds.width === 0) return null;
+      const localX = Math.min(bounds.width, Math.max(0, clientX - bounds.left));
+      const fraction = localX / bounds.width;
+      const index = Math.round(fraction * (periods.length - 1));
+      return Math.min(periods.length - 1, Math.max(0, index));
+    },
+    [periods.length],
+  );
+
   const handleMove = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       const plot = plotRef.current;
       if (plot === null || periods.length === 0) return;
       const bounds = plot.getBoundingClientRect();
       if (bounds.width === 0) return;
+      const index = indexAt(event.clientX);
+      if (index === null) return;
+      if (brush !== null) {
+        // While selecting, the crosshair and tooltip give way to the band.
+        if (index !== brush.end) setBrush({ start: brush.start, end: index });
+        return;
+      }
       const localX = Math.min(bounds.width, Math.max(0, event.clientX - bounds.left));
       const localY = Math.min(bounds.height, Math.max(0, event.clientY - bounds.top));
-      const fraction = localX / bounds.width;
-      const index = Math.round(fraction * (periods.length - 1));
       hoverPositionRef.current = { x: localX, y: localY };
       positionTooltip();
-      setHoverIndex(Math.min(periods.length - 1, Math.max(0, index)));
+      setHoverIndex(index);
     },
-    [periods.length, positionTooltip],
+    [brush, indexAt, periods.length, positionTooltip],
   );
+
+  const beginBrush = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!zoomable || event.button !== 0) return;
+      const index = indexAt(event.clientX);
+      if (index === null) return;
+      event.preventDefault();
+      hoverPositionRef.current = null;
+      setHoverIndex(null);
+      setBrush({ start: index, end: index });
+    },
+    [indexAt, zoomable],
+  );
+
+  // A drag may end anywhere on the page, so the commit listens on the window.
+  useEffect(() => {
+    if (brush === null || onZoomToDays === undefined) return;
+    const commit = () => {
+      const selection = brushSelection(days, brush.start, brush.end);
+      setBrush(null);
+      if (selection !== null) onZoomToDays(selection.sinceDay, selection.untilDay);
+    };
+    window.addEventListener("mouseup", commit);
+    return () => window.removeEventListener("mouseup", commit);
+  }, [brush, days, onZoomToDays]);
 
   const hoveredPeriod = hoverIndex === null ? undefined : periods[hoverIndex];
   const hoveredColumn = hoverIndex === null ? undefined : series[hoverIndex];
@@ -350,8 +425,10 @@ export function UsageProviderChart({
 
         <div
           ref={plotRef}
-          className="relative h-56 flex-1"
+          className={cn("relative h-56 flex-1", zoomable && "cursor-crosshair")}
           onMouseMove={handleMove}
+          onMouseDown={beginBrush}
+          onDoubleClick={onResetZoom}
           onMouseLeave={() => {
             hoverPositionRef.current = null;
             setHoverIndex(null);
@@ -400,6 +477,21 @@ export function UsageProviderChart({
                 vectorEffect="non-scaling-stroke"
               />
             ))}
+
+            {brush === null || brush.start === brush.end ? null : (
+              <rect
+                x={Math.min(brush.start, brush.end) * stepX}
+                y={PLOT_TOP}
+                width={Math.abs(brush.end - brush.start) * stepX}
+                height={VIEW_HEIGHT - PLOT_TOP}
+                fill="currentColor"
+                fillOpacity={0.08}
+                stroke="currentColor"
+                strokeWidth={1}
+                className="text-muted-foreground"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
 
             {hoverIndex === null ? null : (
               <line

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -368,18 +368,9 @@ export function UsageProviderChart({
       if (plot === null || periods.length === 0) return;
       const bounds = plot.getBoundingClientRect();
       if (bounds.width === 0) return;
+      if (brushRef.current !== null) return;
       const index = indexAt(event.clientX);
       if (index === null) return;
-      const activeBrush = brushRef.current;
-      if (activeBrush !== null) {
-        // While selecting, the crosshair and tooltip give way to the band.
-        if (index !== activeBrush.end) {
-          const nextBrush = { start: activeBrush.start, end: index };
-          brushRef.current = nextBrush;
-          setBrush(nextBrush);
-        }
-        return;
-      }
       const localX = Math.min(bounds.width, Math.max(0, event.clientX - bounds.left));
       const localY = Math.min(bounds.height, Math.max(0, event.clientY - bounds.top));
       hoverPositionRef.current = { x: localX, y: localY };
@@ -387,6 +378,19 @@ export function UsageProviderChart({
       setHoverIndex(index);
     },
     [indexAt, periods.length, positionTooltip],
+  );
+
+  const trackBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const activeBrush = brushRef.current;
+      if (activeBrush === null || !event.currentTarget.hasPointerCapture(event.pointerId)) return;
+      const index = indexAt(event.clientX);
+      if (index === null || index === activeBrush.end) return;
+      const nextBrush = { start: activeBrush.start, end: index };
+      brushRef.current = nextBrush;
+      setBrush(nextBrush);
+    },
+    [indexAt],
   );
 
   const beginBrush = useCallback(
@@ -453,9 +457,10 @@ export function UsageProviderChart({
 
         <div
           ref={plotRef}
-          className={cn("relative h-56 flex-1", zoomable && "cursor-crosshair")}
+          className={cn("relative h-56 flex-1", zoomable && "cursor-crosshair touch-none")}
           onMouseMove={handleMove}
           onPointerDown={beginBrush}
+          onPointerMove={trackBrush}
           onPointerUp={finishBrush}
           onPointerCancel={cancelBrush}
           onDoubleClick={onResetZoom}

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -251,7 +251,11 @@ export function UsageProviderChart({
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
   // Drag-selection endpoints, as period indices. Only daily windows zoom.
   const [brush, setBrush] = useState<{ readonly start: number; readonly end: number } | null>(null);
-  const brushRef = useRef<{ readonly start: number; readonly end: number } | null>(null);
+  const brushRef = useRef<{
+    readonly pointerId: number;
+    readonly start: number;
+    readonly end: number;
+  } | null>(null);
   const zoomable = resolution === "day" && onZoomToDays !== undefined;
   const plotRef = useRef<HTMLDivElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
@@ -383,10 +387,16 @@ export function UsageProviderChart({
   const trackBrush = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       const activeBrush = brushRef.current;
-      if (activeBrush === null || !event.currentTarget.hasPointerCapture(event.pointerId)) return;
+      if (
+        activeBrush === null ||
+        activeBrush.pointerId !== event.pointerId ||
+        !event.currentTarget.hasPointerCapture(event.pointerId)
+      ) {
+        return;
+      }
       const index = indexAt(event.clientX);
       if (index === null || index === activeBrush.end) return;
-      const nextBrush = { start: activeBrush.start, end: index };
+      const nextBrush = { ...activeBrush, end: index };
       brushRef.current = nextBrush;
       setBrush(nextBrush);
     },
@@ -395,14 +405,16 @@ export function UsageProviderChart({
 
   const beginBrush = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      if (!zoomable || event.button !== 0) return;
+      if (!zoomable || event.button !== 0 || !event.isPrimary || brushRef.current !== null) return;
       const index = indexAt(event.clientX);
       if (index === null) return;
-      event.preventDefault();
+      // `touch-pan-y` owns vertical gestures. Avoid canceling that browser
+      // default while still suppressing text selection for mouse and pen.
+      if (event.pointerType !== "touch") event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
       hoverPositionRef.current = null;
       setHoverIndex(null);
-      const nextBrush = { start: index, end: index };
+      const nextBrush = { pointerId: event.pointerId, start: index, end: index };
       brushRef.current = nextBrush;
       setBrush(nextBrush);
     },
@@ -412,7 +424,14 @@ export function UsageProviderChart({
   const finishBrush = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       const activeBrush = brushRef.current;
-      if (activeBrush === null || onZoomToDays === undefined) return;
+      if (
+        activeBrush === null ||
+        activeBrush.pointerId !== event.pointerId ||
+        !event.currentTarget.hasPointerCapture(event.pointerId) ||
+        onZoomToDays === undefined
+      ) {
+        return;
+      }
       const end = indexAt(event.clientX) ?? activeBrush.end;
       const selection = brushSelection(days, activeBrush.start, end);
       brushRef.current = null;
@@ -425,7 +444,8 @@ export function UsageProviderChart({
     [days, indexAt, onZoomToDays],
   );
 
-  const cancelBrush = useCallback(() => {
+  const cancelBrush = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (brushRef.current?.pointerId !== event.pointerId) return;
     brushRef.current = null;
     setBrush(null);
   }, []);
@@ -457,7 +477,7 @@ export function UsageProviderChart({
 
         <div
           ref={plotRef}
-          className={cn("relative h-56 flex-1", zoomable && "cursor-crosshair touch-none")}
+          className={cn("relative h-56 flex-1", zoomable && "cursor-crosshair touch-pan-y")}
           onMouseMove={handleMove}
           onPointerDown={beginBrush}
           onPointerMove={trackBrush}

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -1,5 +1,5 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
 
@@ -213,6 +213,20 @@ export function brushSelection(
   return { sinceDay, untilDay };
 }
 
+/** Period index beneath a pointer, clamped when pointer capture moves outside the plot. */
+export function periodIndexAt(
+  clientX: number,
+  plotLeft: number,
+  plotWidth: number,
+  periodCount: number,
+): number | null {
+  if (plotWidth <= 0 || periodCount <= 0) return null;
+  const localX = Math.min(plotWidth, Math.max(0, clientX - plotLeft));
+  const fraction = localX / plotWidth;
+  const index = Math.round(fraction * (periodCount - 1));
+  return Math.min(periodCount - 1, Math.max(0, index));
+}
+
 export function UsageProviderChart({
   onZoomToDays,
   onResetZoom,
@@ -237,6 +251,7 @@ export function UsageProviderChart({
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
   // Drag-selection endpoints, as period indices. Only daily windows zoom.
   const [brush, setBrush] = useState<{ readonly start: number; readonly end: number } | null>(null);
+  const brushRef = useRef<{ readonly start: number; readonly end: number } | null>(null);
   const zoomable = resolution === "day" && onZoomToDays !== undefined;
   const plotRef = useRef<HTMLDivElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
@@ -342,11 +357,7 @@ export function UsageProviderChart({
       const plot = plotRef.current;
       if (plot === null || periods.length === 0) return null;
       const bounds = plot.getBoundingClientRect();
-      if (bounds.width === 0) return null;
-      const localX = Math.min(bounds.width, Math.max(0, clientX - bounds.left));
-      const fraction = localX / bounds.width;
-      const index = Math.round(fraction * (periods.length - 1));
-      return Math.min(periods.length - 1, Math.max(0, index));
+      return periodIndexAt(clientX, bounds.left, bounds.width, periods.length);
     },
     [periods.length],
   );
@@ -359,9 +370,14 @@ export function UsageProviderChart({
       if (bounds.width === 0) return;
       const index = indexAt(event.clientX);
       if (index === null) return;
-      if (brush !== null) {
+      const activeBrush = brushRef.current;
+      if (activeBrush !== null) {
         // While selecting, the crosshair and tooltip give way to the band.
-        if (index !== brush.end) setBrush({ start: brush.start, end: index });
+        if (index !== activeBrush.end) {
+          const nextBrush = { start: activeBrush.start, end: index };
+          brushRef.current = nextBrush;
+          setBrush(nextBrush);
+        }
         return;
       }
       const localX = Math.min(bounds.width, Math.max(0, event.clientX - bounds.left));
@@ -370,33 +386,45 @@ export function UsageProviderChart({
       positionTooltip();
       setHoverIndex(index);
     },
-    [brush, indexAt, periods.length, positionTooltip],
+    [indexAt, periods.length, positionTooltip],
   );
 
   const beginBrush = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
+    (event: React.PointerEvent<HTMLDivElement>) => {
       if (!zoomable || event.button !== 0) return;
       const index = indexAt(event.clientX);
       if (index === null) return;
       event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
       hoverPositionRef.current = null;
       setHoverIndex(null);
-      setBrush({ start: index, end: index });
+      const nextBrush = { start: index, end: index };
+      brushRef.current = nextBrush;
+      setBrush(nextBrush);
     },
     [indexAt, zoomable],
   );
 
-  // A drag may end anywhere on the page, so the commit listens on the window.
-  useEffect(() => {
-    if (brush === null || onZoomToDays === undefined) return;
-    const commit = () => {
-      const selection = brushSelection(days, brush.start, brush.end);
+  const finishBrush = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const activeBrush = brushRef.current;
+      if (activeBrush === null || onZoomToDays === undefined) return;
+      const end = indexAt(event.clientX) ?? activeBrush.end;
+      const selection = brushSelection(days, activeBrush.start, end);
+      brushRef.current = null;
       setBrush(null);
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
       if (selection !== null) onZoomToDays(selection.sinceDay, selection.untilDay);
-    };
-    window.addEventListener("mouseup", commit);
-    return () => window.removeEventListener("mouseup", commit);
-  }, [brush, days, onZoomToDays]);
+    },
+    [days, indexAt, onZoomToDays],
+  );
+
+  const cancelBrush = useCallback(() => {
+    brushRef.current = null;
+    setBrush(null);
+  }, []);
 
   const hoveredPeriod = hoverIndex === null ? undefined : periods[hoverIndex];
   const hoveredColumn = hoverIndex === null ? undefined : series[hoverIndex];
@@ -427,7 +455,9 @@ export function UsageProviderChart({
           ref={plotRef}
           className={cn("relative h-56 flex-1", zoomable && "cursor-crosshair")}
           onMouseMove={handleMove}
-          onMouseDown={beginBrush}
+          onPointerDown={beginBrush}
+          onPointerUp={finishBrush}
+          onPointerCancel={cancelBrush}
           onDoubleClick={onResetZoom}
           onMouseLeave={() => {
             hoverPositionRef.current = null;

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -53,6 +53,18 @@ interface Point {
   readonly y: number;
 }
 
+/** Gives a one-period daily window enough horizontal span to draw a path. */
+export function spanSinglePeriodPoints(points: readonly Point[]): readonly Point[] {
+  const only = points.length === 1 ? points[0] : undefined;
+  return only === undefined ? points : [only, { ...only, x: VIEW_WIDTH }];
+}
+
+/** Selects distinct left, middle, and right labels for the available span. */
+export function chartLabelIndices(periodCount: number): readonly number[] {
+  if (periodCount <= 0) return [];
+  return [...new Set([0, Math.floor(periodCount / 2), periodCount - 1])];
+}
+
 function valueFor(
   totals: DailyTotals | HourlyTotals | undefined,
   provider: UsageProviderKind,
@@ -289,14 +301,11 @@ export function UsageProviderChart({
 
     const built = providers.map((provider) => {
       const providerIndex = PROVIDER_ORDER.indexOf(provider);
-      const line = curvePath(
-        smoothCurve(
-          columns.map((column, periodIndex) => ({
-            x: periodIndex * step,
-            y: toY(column.bands[providerIndex]?.value ?? 0),
-          })),
-        ),
-      );
+      const points = columns.map((column, periodIndex) => ({
+        x: periodIndex * step,
+        y: toY(column.bands[providerIndex]?.value ?? 0),
+      }));
+      const line = curvePath(smoothCurve(spanSinglePeriodPoints(points)));
       return {
         provider,
         total: columns.reduce((sum, column) => sum + (column.bands[providerIndex]?.value ?? 0), 0),
@@ -408,9 +417,6 @@ export function UsageProviderChart({
       if (!zoomable || event.button !== 0 || !event.isPrimary || brushRef.current !== null) return;
       const index = indexAt(event.clientX);
       if (index === null) return;
-      // `touch-pan-y` owns vertical gestures. Avoid canceling that browser
-      // default while still suppressing text selection for mouse and pen.
-      if (event.pointerType !== "touch") event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
       hoverPositionRef.current = null;
       setHoverIndex(null);
@@ -427,7 +433,6 @@ export function UsageProviderChart({
       if (
         activeBrush === null ||
         activeBrush.pointerId !== event.pointerId ||
-        !event.currentTarget.hasPointerCapture(event.pointerId) ||
         onZoomToDays === undefined
       ) {
         return;
@@ -477,12 +482,16 @@ export function UsageProviderChart({
 
         <div
           ref={plotRef}
-          className={cn("relative h-56 flex-1", zoomable && "cursor-crosshair touch-pan-y")}
+          className={cn(
+            "relative h-56 flex-1",
+            zoomable && "cursor-crosshair touch-pan-y select-none",
+          )}
           onMouseMove={handleMove}
           onPointerDown={beginBrush}
           onPointerMove={trackBrush}
           onPointerUp={finishBrush}
           onPointerCancel={cancelBrush}
+          onLostPointerCapture={cancelBrush}
           onDoubleClick={onResetZoom}
           onMouseLeave={() => {
             hoverPositionRef.current = null;
@@ -548,7 +557,7 @@ export function UsageProviderChart({
               />
             )}
 
-            {hoverIndex === null ? null : (
+            {hoverIndex === null || periods.length === 1 ? null : (
               <line
                 x1={hoverIndex * stepX}
                 x2={hoverIndex * stepX}
@@ -600,17 +609,9 @@ export function UsageProviderChart({
       </div>
 
       <div className="flex justify-between pl-16 text-[10px] text-muted-foreground uppercase">
-        <span>{periods[0] === undefined ? "" : formatPeriod(periods[0])}</span>
-        <span>
-          {periods[Math.floor(periods.length / 2)] === undefined
-            ? ""
-            : formatPeriod(periods[Math.floor(periods.length / 2)] ?? "")}
-        </span>
-        <span>
-          {periods[periods.length - 1] === undefined
-            ? ""
-            : formatPeriod(periods[periods.length - 1] ?? "")}
-        </span>
+        {chartLabelIndices(periods.length).map((index) => (
+          <span key={index}>{formatPeriod(periods[index] ?? "")}</span>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/usage/UsageThreadTable.test.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.test.tsx
@@ -1,0 +1,93 @@
+import { EnvironmentId, ThreadId, UsageDay } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({ useUsageThreads: vi.fn() }));
+
+vi.mock("../../state/usage", () => ({ useUsageThreads: testState.useUsageThreads }));
+vi.mock("../ui/tooltip", async () => {
+  const React = await import("react");
+  return {
+    Tooltip: "span",
+    TooltipPopup: "span",
+    TooltipTrigger: ({
+      render,
+      children,
+    }: {
+      render: React.ReactElement;
+      children: React.ReactNode;
+    }) => React.cloneElement(render, {}, children),
+  };
+});
+vi.mock("./usageProviders", () => ({
+  PROVIDER_PRESENTATION: {
+    claude: { mark: "span" },
+    codex: { mark: "span" },
+    grok: { mark: "span" },
+  },
+}));
+
+import { UsageThreadTable } from "./UsageThreadTable";
+
+const input = {
+  sinceDay: UsageDay.make("2026-08-01"),
+  untilDay: UsageDay.make("2026-08-31"),
+  timeZone: "UTC",
+};
+
+beforeEach(() => {
+  testState.useUsageThreads.mockReset();
+});
+
+describe("UsageThreadTable", () => {
+  it("reports an unavailable breakdown when every query failed", () => {
+    testState.useUsageThreads.mockReturnValue({
+      rows: [],
+      truncatedRows: 0,
+      isPending: false,
+      failedEnvironments: 2,
+    });
+
+    const markup = renderToStaticMarkup(
+      <UsageThreadTable input={input} providerContributions={[]} />,
+    );
+
+    expect(markup).toContain("Thread activity could not be loaded");
+    expect(markup).not.toContain("No activity in this window");
+  });
+
+  it("uses a keyboard-accessible disclosure button without a native title", () => {
+    testState.useUsageThreads.mockReturnValue({
+      rows: [
+        {
+          environmentId: EnvironmentId.make("environment-one"),
+          key: "row-one",
+          threadId: ThreadId.make("thread-one"),
+          title: "Fix the flaky test",
+          provider: "claude",
+          totals: {
+            uncachedInputTokens: 1,
+            cachedInputTokens: 2,
+            cacheCreationTokens: 3,
+            outputTokens: 4,
+            reasoningTokens: 0,
+          },
+          costUsd: 1,
+          sessions: 1,
+          agents: [],
+          daily: [],
+        },
+      ],
+      truncatedRows: 0,
+      isPending: false,
+      failedEnvironments: 0,
+    });
+
+    const markup = renderToStaticMarkup(
+      <UsageThreadTable input={input} providerContributions={[]} />,
+    );
+
+    expect(markup).toContain('<button type="button" aria-expanded="false"');
+    expect(markup).not.toContain('title="Fix the flaky test"');
+  });
+});

--- a/apps/web/src/components/usage/UsageThreadTable.test.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({ useUsageThreads: vi.fn() }));
 
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
 vi.mock("../../state/usage", () => ({ useUsageThreads: testState.useUsageThreads }));
 vi.mock("../ui/tooltip", async () => {
   const React = await import("react");
@@ -117,6 +118,7 @@ describe("UsageThreadTable", () => {
     expect(markup).toContain('<button type="button" aria-expanded="false"');
     expect(markup).toContain('data-slot="badge"');
     expect(markup).toContain("1 subagent");
+    expect(markup).toContain('aria-label="Open thread"');
     expect(markup).not.toContain('title="Fix the flaky test"');
   });
 });

--- a/apps/web/src/components/usage/UsageThreadTable.test.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.test.tsx
@@ -89,6 +89,7 @@ describe("UsageThreadTable", () => {
             reasoningTokens: 0,
           },
           costUsd: 1,
+          cacheWriteUsd: 0.25,
           sessions: 1,
           agents: [
             {

--- a/apps/web/src/components/usage/UsageThreadTable.test.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.test.tsx
@@ -40,16 +40,31 @@ beforeEach(() => {
 });
 
 describe("UsageThreadTable", () => {
+  it("uses the shared skeleton treatment while thread data is pending", () => {
+    testState.useUsageThreads.mockReturnValue({
+      rows: [],
+      truncatedRows: 0,
+      isPending: true,
+      failedEnvironments: 0,
+    });
+
+    const markup = renderToStaticMarkup(
+      <UsageThreadTable input={input} providerContributions={[]} summaryFailedEnvironments={0} />,
+    );
+
+    expect(markup).toContain("after:animate-skeleton");
+  });
+
   it("reports an unavailable breakdown when every query failed", () => {
     testState.useUsageThreads.mockReturnValue({
       rows: [],
       truncatedRows: 0,
       isPending: false,
-      failedEnvironments: 2,
+      failedEnvironments: 0,
     });
 
     const markup = renderToStaticMarkup(
-      <UsageThreadTable input={input} providerContributions={[]} />,
+      <UsageThreadTable input={input} providerContributions={[]} summaryFailedEnvironments={2} />,
     );
 
     expect(markup).toContain("Thread activity could not be loaded");
@@ -74,7 +89,19 @@ describe("UsageThreadTable", () => {
           },
           costUsd: 1,
           sessions: 1,
-          agents: [],
+          agents: [
+            {
+              agentId: "agent-one",
+              totals: {
+                uncachedInputTokens: 1,
+                cachedInputTokens: 0,
+                cacheCreationTokens: 0,
+                outputTokens: 1,
+                reasoningTokens: 0,
+              },
+              costUsd: 0.1,
+            },
+          ],
           daily: [],
         },
       ],
@@ -84,10 +111,12 @@ describe("UsageThreadTable", () => {
     });
 
     const markup = renderToStaticMarkup(
-      <UsageThreadTable input={input} providerContributions={[]} />,
+      <UsageThreadTable input={input} providerContributions={[]} summaryFailedEnvironments={0} />,
     );
 
     expect(markup).toContain('<button type="button" aria-expanded="false"');
+    expect(markup).toContain('data-slot="badge"');
+    expect(markup).toContain("1 subagent");
     expect(markup).not.toContain('title="Fix the flaky test"');
   });
 });

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -16,6 +16,7 @@ import {
 } from "@t3tools/shared/usageFormat";
 import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
 
+import { cn } from "../../lib/utils";
 import { useUsageThreads, type UsageThreadRowWithEnvironment } from "../../state/usage";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -66,15 +67,17 @@ export function UsageThreadTable({
   return (
     <table className="w-full table-fixed text-sm">
       <colgroup>
-        <col className="w-[40%]" />
-        <col className="w-[20%]" />
-        <col className="w-[20%]" />
-        <col className="w-[20%]" />
+        <col className="w-[32%]" />
+        <col className="w-[17%]" />
+        <col className="w-[17%]" />
+        <col className="w-[17%]" />
+        <col className="w-[17%]" />
       </colgroup>
       <thead>
         <tr className="border-b border-border text-left text-xs text-muted-foreground">
           <th className="py-2 font-normal">Thread</th>
           <th className="py-2 text-right font-normal">Cost</th>
+          <th className="py-2 text-right font-normal">Cache writes</th>
           <th className="py-2 text-right font-normal">Share</th>
           <th className="py-2 text-right font-normal">Tokens</th>
         </tr>
@@ -82,7 +85,7 @@ export function UsageThreadTable({
       <tbody>
         {rows.length === 0 ? (
           <tr>
-            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+            <td colSpan={5} className="py-6 text-center text-muted-foreground">
               {unavailableEnvironments > 0
                 ? "Thread activity could not be loaded for this window."
                 : "No activity in this window."}
@@ -113,7 +116,7 @@ export function UsageThreadTable({
         )}
         {truncatedRows > 0 ? (
           <tr>
-            <td colSpan={4} className="py-2 text-xs text-muted-foreground">
+            <td colSpan={5} className="py-2 text-xs text-muted-foreground">
               {truncatedRows === 1
                 ? "1 lower-cost thread row is grouped above."
                 : `${truncatedRows} lower-cost thread rows are grouped above.`}
@@ -122,7 +125,7 @@ export function UsageThreadTable({
         ) : null}
         {unavailableEnvironments > 0 && rows.length > 0 ? (
           <tr>
-            <td colSpan={4} className="py-2 text-xs text-muted-foreground">
+            <td colSpan={5} className="py-2 text-xs text-muted-foreground">
               {unavailableEnvironments === 1
                 ? "1 environment could not report threads."
                 : `${unavailableEnvironments} environments could not report threads.`}
@@ -212,6 +215,9 @@ function ThreadRowGroup({
         </td>
         <td className="py-2 text-right text-foreground tabular-nums">{formatUsd(row.costUsd)}</td>
         <td className="py-2 text-right text-muted-foreground tabular-nums">
+          {row.totals.cacheCreationTokens === 0 ? "-" : formatUsd(row.cacheWriteUsd)}
+        </td>
+        <td className="py-2 text-right text-muted-foreground tabular-nums">
           {formatPercent(share)}
         </td>
         <td className="py-2 text-right text-muted-foreground tabular-nums">
@@ -220,7 +226,7 @@ function ThreadRowGroup({
       </tr>
       {open ? (
         <tr className="border-b border-border/50">
-          <td colSpan={4} className="py-3 ps-9">
+          <td colSpan={5} className="py-3 ps-9">
             <UsageThreadDailyChart daily={row.daily} sinceDay={sinceDay} untilDay={untilDay} />
             {row.agents.map((agent) => {
               const agentTokens =
@@ -256,7 +262,8 @@ const CHART_WIDTH = 760;
 const CHART_HEIGHT = 96;
 
 /**
- * One thread's daily estimated cost. Static SVG, no animation.
+ * One thread's daily model-priced cost split into cache writes, cache reads,
+ * and fresh input plus output. Static SVG, no animation.
  */
 export function UsageThreadDailyChart({
   daily,
@@ -272,7 +279,10 @@ export function UsageThreadDailyChart({
     () => new Map<string, UsageThreadDayCost>(daily.map((entry) => [entry.day, entry])),
     [daily],
   );
-  const peak = daily.reduce((max, entry) => Math.max(max, entry.costUsd), 0);
+  const peak = daily.reduce(
+    (max, entry) => Math.max(max, entry.cacheWriteUsd + entry.cacheReadUsd + entry.freshUsd),
+    0,
+  );
 
   if (peak === 0 || days.length === 0) {
     return <p className="pb-2 text-xs text-muted-foreground">No priced usage in this window.</p>;
@@ -283,40 +293,71 @@ export function UsageThreadDailyChart({
 
   return (
     <div className="flex max-w-3xl flex-col gap-1 pb-2">
-      <div className="text-[11px] text-muted-foreground">
+      <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
         <span>
           Daily cost, {formatDayShort(sinceDay)} to {formatDayShort(untilDay)}
         </span>
+        <LegendSwatch className="text-sky-500" label="cache writes" />
+        <LegendSwatch className="text-muted-foreground" label="cache reads" />
+        <LegendSwatch className="text-success" label="fresh input + output" />
       </div>
       <svg
         viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
         className="h-24 w-full"
         preserveAspectRatio="none"
         role="img"
-        aria-label="Daily estimated cost for this thread"
+        aria-label="Daily model-priced cost for this thread by component"
       >
         {days.map((day, index) => {
           const entry = byDay.get(day);
           if (entry === undefined) return null;
           const x = index * bandWidth + (bandWidth - barWidth) / 2;
-          const height = (entry.costUsd / peak) * (CHART_HEIGHT - 4);
-          const renderedHeight = height === 0 ? 0 : Math.max(height, 0.75);
+          const segments = [
+            { value: entry.freshUsd, className: "text-success" },
+            { value: entry.cacheReadUsd, className: "text-muted-foreground" },
+            { value: entry.cacheWriteUsd, className: "text-sky-500" },
+          ];
+          let y = CHART_HEIGHT;
+          const total = entry.cacheWriteUsd + entry.cacheReadUsd + entry.freshUsd;
           return (
             <g key={day}>
-              <title>{`${formatDayShort(day)}: ${formatUsd(entry.costUsd)}`}</title>
-              <rect
-                x={x}
-                y={CHART_HEIGHT - renderedHeight}
-                width={barWidth}
-                height={renderedHeight}
-                fill="currentColor"
-                className="text-success"
-              />
+              <title>{`${formatDayShort(day)}: ${formatUsd(total)}. Cache writes ${formatUsd(entry.cacheWriteUsd)}, cache reads ${formatUsd(entry.cacheReadUsd)}, fresh input and output ${formatUsd(entry.freshUsd)}`}</title>
+              {segments.map((segment) => {
+                if (segment.value <= 0) return null;
+                const height = (segment.value / peak) * (CHART_HEIGHT - 4);
+                y -= height;
+                return (
+                  <rect
+                    key={segment.className}
+                    x={x}
+                    y={y}
+                    width={barWidth}
+                    height={height}
+                    fill="currentColor"
+                    className={segment.className}
+                  />
+                );
+              })}
             </g>
           );
         })}
       </svg>
     </div>
+  );
+}
+
+function LegendSwatch({
+  className,
+  label,
+}: {
+  readonly className: string;
+  readonly label: string;
+}) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span aria-hidden className={cn("size-2 rounded-[2px] bg-current", className)} />
+      {label}
+    </span>
   );
 }
 

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -16,6 +16,8 @@ import {
 import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
 
 import { useUsageThreads, type UsageThreadRowWithEnvironment } from "../../state/usage";
+import { Badge } from "../ui/badge";
+import { Skeleton } from "../ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
 
@@ -26,14 +28,17 @@ import { PROVIDER_PRESENTATION } from "./usageProviders";
 export function UsageThreadTable({
   input,
   providerContributions,
+  summaryFailedEnvironments,
 }: {
   readonly input: UsageThreadBreakdownInput;
   readonly providerContributions: readonly EnvironmentProviderContribution[];
+  readonly summaryFailedEnvironments: number;
 }) {
   const { rows, truncatedRows, isPending, failedEnvironments } = useUsageThreads(
     input,
     providerContributions,
   );
+  const unavailableEnvironments = failedEnvironments + summaryFailedEnvironments;
   const [openRows, setOpenRows] = useState<ReadonlySet<string>>(new Set());
   const totalCostUsd = useMemo(() => rows.reduce((sum, row) => sum + row.costUsd, 0), [rows]);
 
@@ -50,7 +55,7 @@ export function UsageThreadTable({
     return (
       <div className="flex flex-col gap-2 py-1">
         {[56, 42, 68, 35].map((width) => (
-          <div key={width} className="h-6 rounded-sm bg-muted/50" style={{ width: `${width}%` }} />
+          <Skeleton key={width} className="h-6" style={{ width: `${width}%` }} />
         ))}
       </div>
     );
@@ -76,7 +81,7 @@ export function UsageThreadTable({
         {rows.length === 0 ? (
           <tr>
             <td colSpan={4} className="py-6 text-center text-muted-foreground">
-              {failedEnvironments > 0
+              {unavailableEnvironments > 0
                 ? "Thread activity could not be loaded for this window."
                 : "No activity in this window."}
             </td>
@@ -113,12 +118,12 @@ export function UsageThreadTable({
             </td>
           </tr>
         ) : null}
-        {failedEnvironments > 0 && rows.length > 0 ? (
+        {unavailableEnvironments > 0 && rows.length > 0 ? (
           <tr>
             <td colSpan={4} className="py-2 text-xs text-muted-foreground">
-              {failedEnvironments === 1
+              {unavailableEnvironments === 1
                 ? "1 environment could not report threads."
-                : `${failedEnvironments} environments could not report threads.`}
+                : `${unavailableEnvironments} environments could not report threads.`}
             </td>
           </tr>
         ) : null}
@@ -164,9 +169,13 @@ function ThreadRowGroup({
               <ProviderMark provider={row.provider} />
               <span className="truncate">{row.title}</span>
               {row.agents.length > 0 ? (
-                <span className="shrink-0 rounded border border-border px-1 text-[10px] text-muted-foreground">
+                <Badge
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0 font-normal text-muted-foreground"
+                >
                   {row.agents.length === 1 ? "1 subagent" : `${row.agents.length} subagents`}
-                </span>
+                </Badge>
               ) : null}
             </TooltipTrigger>
             <TooltipPopup side="top">{row.title}</TooltipPopup>
@@ -196,9 +205,9 @@ function ThreadRowGroup({
                   className="flex items-baseline justify-between gap-4 py-1 text-xs text-muted-foreground"
                 >
                   <span className="flex min-w-0 items-center gap-1.5">
-                    <span className="shrink-0 rounded border border-border px-1 text-[10px]">
+                    <Badge variant="outline" size="sm" className="shrink-0 font-normal">
                       agent
-                    </span>
+                    </Badge>
                     <span className="truncate">{agent.agentId}</span>
                   </span>
                   <span className="shrink-0 tabular-nums">
@@ -262,7 +271,7 @@ export function UsageThreadDailyChart({
           if (entry === undefined) return null;
           const x = index * bandWidth + (bandWidth - barWidth) / 2;
           const height = (entry.costUsd / peak) * (CHART_HEIGHT - 4);
-          const renderedHeight = Math.max(height, 0.75);
+          const renderedHeight = height === 0 ? 0 : Math.max(height, 0.75);
           return (
             <g key={day}>
               <title>{`${formatDayShort(day)}: ${formatUsd(entry.costUsd)}`}</title>
@@ -272,7 +281,7 @@ export function UsageThreadDailyChart({
                 width={barWidth}
                 height={renderedHeight}
                 fill="currentColor"
-                className="text-emerald-500"
+                className="text-success"
               />
             </g>
           );

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -9,12 +9,14 @@ import { useMemo, useState } from "react";
 import {
   enumerateDays,
   formatDayShort,
+  formatPercent,
   formatTokens,
   formatUsd,
 } from "@t3tools/shared/usageFormat";
 import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
 
 import { useUsageThreads, type UsageThreadRowWithEnvironment } from "../../state/usage";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
 
 /**
@@ -74,7 +76,9 @@ export function UsageThreadTable({
         {rows.length === 0 ? (
           <tr>
             <td colSpan={4} className="py-6 text-center text-muted-foreground">
-              No activity in this window.
+              {failedEnvironments > 0
+                ? "Thread activity could not be loaded for this window."
+                : "No activity in this window."}
             </td>
           </tr>
         ) : (
@@ -109,7 +113,7 @@ export function UsageThreadTable({
             </td>
           </tr>
         ) : null}
-        {failedEnvironments > 0 ? (
+        {failedEnvironments > 0 && rows.length > 0 ? (
           <tr>
             <td colSpan={4} className="py-2 text-xs text-muted-foreground">
               {failedEnvironments === 1
@@ -143,28 +147,34 @@ function ThreadRowGroup({
   const Chevron = open ? ChevronDownIcon : ChevronRightIcon;
   return (
     <>
-      <tr
-        className="cursor-pointer border-b border-border/50 transition-colors hover:bg-muted/50"
-        onClick={onToggle}
-        aria-expanded={open}
-      >
+      <tr className="border-b border-border/50 transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50">
         <td className="py-2 text-foreground">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <Chevron className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-            <ProviderMark provider={row.provider} />
-            <span className="truncate" title={row.title}>
-              {row.title}
-            </span>
-            {row.agents.length > 0 ? (
-              <span className="shrink-0 rounded border border-border px-1 text-[10px] text-muted-foreground">
-                {row.agents.length === 1 ? "1 subagent" : `${row.agents.length} subagents`}
-              </span>
-            ) : null}
-          </span>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  onClick={onToggle}
+                  aria-expanded={open}
+                  className="flex w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              }
+            >
+              <Chevron className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              <ProviderMark provider={row.provider} />
+              <span className="truncate">{row.title}</span>
+              {row.agents.length > 0 ? (
+                <span className="shrink-0 rounded border border-border px-1 text-[10px] text-muted-foreground">
+                  {row.agents.length === 1 ? "1 subagent" : `${row.agents.length} subagents`}
+                </span>
+              ) : null}
+            </TooltipTrigger>
+            <TooltipPopup side="top">{row.title}</TooltipPopup>
+          </Tooltip>
         </td>
         <td className="py-2 text-right text-foreground tabular-nums">{formatUsd(row.costUsd)}</td>
         <td className="py-2 text-right text-muted-foreground tabular-nums">
-          {`${(share * 100).toFixed(1)}%`}
+          {formatPercent(share)}
         </td>
         <td className="py-2 text-right text-muted-foreground tabular-nums">
           {formatTokens(tokens)}
@@ -231,7 +241,7 @@ export function UsageThreadDailyChart({
   }
 
   const bandWidth = CHART_WIDTH / days.length;
-  const barWidth = Math.max(1, bandWidth - (days.length > 120 ? 0.5 : 2));
+  const barWidth = bandWidth * 0.8;
 
   return (
     <div className="flex max-w-3xl flex-col gap-1 pb-2">
@@ -250,16 +260,17 @@ export function UsageThreadDailyChart({
         {days.map((day, index) => {
           const entry = byDay.get(day);
           if (entry === undefined) return null;
-          const x = index * bandWidth;
+          const x = index * bandWidth + (bandWidth - barWidth) / 2;
           const height = (entry.costUsd / peak) * (CHART_HEIGHT - 4);
+          const renderedHeight = Math.max(height, 0.75);
           return (
             <g key={day}>
               <title>{`${formatDayShort(day)}: ${formatUsd(entry.costUsd)}`}</title>
               <rect
                 x={x}
-                y={CHART_HEIGHT - height}
+                y={CHART_HEIGHT - renderedHeight}
                 width={barWidth}
-                height={Math.max(height - 0.75, 0.75)}
+                height={renderedHeight}
                 fill="currentColor"
                 className="text-emerald-500"
               />

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -22,6 +22,7 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Skeleton } from "../ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { UsageCacheWriteCell } from "./UsageCacheWriteCell";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
 
 /**
@@ -214,9 +215,10 @@ function ThreadRowGroup({
           </div>
         </td>
         <td className="py-2 text-right text-foreground tabular-nums">{formatUsd(row.costUsd)}</td>
-        <td className="py-2 text-right text-muted-foreground tabular-nums">
-          {formatCacheWriteCost(row.totals.cacheCreationTokens, row.cacheWriteUsd)}
-        </td>
+        <UsageCacheWriteCell
+          cacheWriteTokens={row.totals.cacheCreationTokens}
+          cacheWriteUsd={row.cacheWriteUsd}
+        />
         <td className="py-2 text-right text-muted-foreground tabular-nums">
           {formatPercent(share)}
         </td>
@@ -258,17 +260,13 @@ function ThreadRowGroup({
   );
 }
 
-function formatCacheWriteCost(cacheWriteTokens: number, cacheWriteUsd: number | null): string {
-  if (cacheWriteTokens === 0) return "-";
-  return cacheWriteUsd === null ? "Unavailable" : formatUsd(cacheWriteUsd);
-}
-
 const CHART_WIDTH = 760;
 const CHART_HEIGHT = 96;
 
 /**
- * One thread's daily model-priced cost split into cache writes, cache reads,
- * and fresh input plus output. Static SVG, no animation.
+ * One thread's daily model-priced cost stacked by component: cache writes,
+ * cache reads, and fresh input plus output. Cache writes are a billing
+ * category, not an inferred cause. Static SVG, no animation.
  */
 export function UsageThreadDailyChart({
   daily,

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -1,9 +1,7 @@
 import type {
-  EnvironmentId,
   UsageProviderKind,
   UsageThreadBreakdownInput,
   UsageThreadDayCost,
-  UsageThreadRow,
 } from "@t3tools/contracts";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -14,8 +12,9 @@ import {
   formatTokens,
   formatUsd,
 } from "@t3tools/shared/usageFormat";
+import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
 
-import { useUsageThreads } from "../../state/usage";
+import { useUsageThreads, type UsageThreadRowWithEnvironment } from "../../state/usage";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
 
 /**
@@ -24,14 +23,14 @@ import { PROVIDER_PRESENTATION } from "./usageProviders";
  */
 export function UsageThreadTable({
   input,
-  environmentIds,
+  providerContributions,
 }: {
   readonly input: UsageThreadBreakdownInput;
-  readonly environmentIds: readonly EnvironmentId[];
+  readonly providerContributions: readonly EnvironmentProviderContribution[];
 }) {
   const { rows, truncatedRows, isPending, failedEnvironments } = useUsageThreads(
     input,
-    environmentIds,
+    providerContributions,
   );
   const [openRows, setOpenRows] = useState<ReadonlySet<string>>(new Set());
   const totalCostUsd = useMemo(() => rows.reduce((sum, row) => sum + row.costUsd, 0), [rows]);
@@ -80,7 +79,8 @@ export function UsageThreadTable({
           </tr>
         ) : (
           rows.map((row) => {
-            const open = openRows.has(row.key);
+            const viewKey = `${row.environmentId}\u0000${row.key}`;
+            const open = openRows.has(viewKey);
             const tokens =
               row.totals.uncachedInputTokens +
               row.totals.cachedInputTokens +
@@ -88,14 +88,14 @@ export function UsageThreadTable({
               row.totals.outputTokens;
             return (
               <ThreadRowGroup
-                key={row.key}
+                key={viewKey}
                 row={row}
                 open={open}
                 tokens={tokens}
                 share={totalCostUsd === 0 ? 0 : row.costUsd / totalCostUsd}
                 sinceDay={input.sinceDay}
                 untilDay={input.untilDay}
-                onToggle={() => toggleRow(row.key)}
+                onToggle={() => toggleRow(viewKey)}
               />
             );
           })
@@ -104,8 +104,8 @@ export function UsageThreadTable({
           <tr>
             <td colSpan={4} className="py-2 text-xs text-muted-foreground">
               {truncatedRows === 1
-                ? "1 more thread not shown."
-                : `${truncatedRows} more threads not shown.`}
+                ? "1 lower-cost thread row is grouped above."
+                : `${truncatedRows} lower-cost thread rows are grouped above.`}
             </td>
           </tr>
         ) : null}
@@ -132,7 +132,7 @@ function ThreadRowGroup({
   untilDay,
   onToggle,
 }: {
-  readonly row: UsageThreadRow;
+  readonly row: UsageThreadRowWithEnvironment;
   readonly open: boolean;
   readonly tokens: number;
   readonly share: number;

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -3,7 +3,8 @@ import type {
   UsageThreadBreakdownInput,
   UsageThreadDayCost,
 } from "@t3tools/contracts";
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowUpRightIcon, ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import {
@@ -17,6 +18,7 @@ import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge
 
 import { useUsageThreads, type UsageThreadRowWithEnvironment } from "../../state/usage";
 import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
 import { Skeleton } from "../ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
@@ -150,36 +152,63 @@ function ThreadRowGroup({
   readonly onToggle: () => void;
 }) {
   const Chevron = open ? ChevronDownIcon : ChevronRightIcon;
+  const navigate = useNavigate();
+  const threadId = row.threadId;
   return (
     <>
       <tr className="border-b border-border/50 transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50">
         <td className="py-2 text-foreground">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <button
-                  type="button"
-                  onClick={onToggle}
-                  aria-expanded={open}
-                  className="flex w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                />
-              }
-            >
-              <Chevron className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-              <ProviderMark provider={row.provider} />
-              <span className="truncate">{row.title}</span>
-              {row.agents.length > 0 ? (
-                <Badge
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0 font-normal text-muted-foreground"
+          <div className="flex min-w-0 items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={onToggle}
+                    aria-expanded={open}
+                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                }
+              >
+                <Chevron className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                <ProviderMark provider={row.provider} />
+                <span className="truncate">{row.title}</span>
+                {row.agents.length > 0 ? (
+                  <Badge
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0 font-normal text-muted-foreground"
+                  >
+                    {row.agents.length === 1 ? "1 subagent" : `${row.agents.length} subagents`}
+                  </Badge>
+                ) : null}
+              </TooltipTrigger>
+              <TooltipPopup side="top">{row.title}</TooltipPopup>
+            </Tooltip>
+            {threadId === null ? null : (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      size="icon-micro"
+                      variant="ghost-muted"
+                      aria-label="Open thread"
+                      className="shrink-0"
+                      onClick={() => {
+                        void navigate({
+                          to: "/$environmentId/$threadId",
+                          params: { environmentId: row.environmentId, threadId },
+                        });
+                      }}
+                    />
+                  }
                 >
-                  {row.agents.length === 1 ? "1 subagent" : `${row.agents.length} subagents`}
-                </Badge>
-              ) : null}
-            </TooltipTrigger>
-            <TooltipPopup side="top">{row.title}</TooltipPopup>
-          </Tooltip>
+                  <ArrowUpRightIcon aria-hidden />
+                </TooltipTrigger>
+                <TooltipPopup side="top">Open thread</TooltipPopup>
+              </Tooltip>
+            )}
+          </div>
         </td>
         <td className="py-2 text-right text-foreground tabular-nums">{formatUsd(row.costUsd)}</td>
         <td className="py-2 text-right text-muted-foreground tabular-nums">

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -1,0 +1,277 @@
+import type {
+  EnvironmentId,
+  UsageProviderKind,
+  UsageThreadBreakdownInput,
+  UsageThreadDayCost,
+  UsageThreadRow,
+} from "@t3tools/contracts";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  enumerateDays,
+  formatDayShort,
+  formatTokens,
+  formatUsd,
+} from "@t3tools/shared/usageFormat";
+
+import { useUsageThreads } from "../../state/usage";
+import { PROVIDER_PRESENTATION } from "./usageProviders";
+
+/**
+ * On-demand thread drill-down behind the summary. Mounted only while the
+ * Thread breakdown view is open, which is what defers the RPC.
+ */
+export function UsageThreadTable({
+  input,
+  environmentIds,
+}: {
+  readonly input: UsageThreadBreakdownInput;
+  readonly environmentIds: readonly EnvironmentId[];
+}) {
+  const { rows, truncatedRows, isPending, failedEnvironments } = useUsageThreads(
+    input,
+    environmentIds,
+  );
+  const [openRows, setOpenRows] = useState<ReadonlySet<string>>(new Set());
+  const totalCostUsd = useMemo(() => rows.reduce((sum, row) => sum + row.costUsd, 0), [rows]);
+
+  const toggleRow = (key: string) => {
+    setOpenRows((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  if (isPending) {
+    return (
+      <div className="flex flex-col gap-2 py-1">
+        {[56, 42, 68, 35].map((width) => (
+          <div key={width} className="h-6 rounded-sm bg-muted/50" style={{ width: `${width}%` }} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <table className="w-full table-fixed text-sm">
+      <colgroup>
+        <col className="w-[40%]" />
+        <col className="w-[20%]" />
+        <col className="w-[20%]" />
+        <col className="w-[20%]" />
+      </colgroup>
+      <thead>
+        <tr className="border-b border-border text-left text-xs text-muted-foreground">
+          <th className="py-2 font-normal">Thread</th>
+          <th className="py-2 text-right font-normal">Cost</th>
+          <th className="py-2 text-right font-normal">Share</th>
+          <th className="py-2 text-right font-normal">Tokens</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.length === 0 ? (
+          <tr>
+            <td colSpan={4} className="py-6 text-center text-muted-foreground">
+              No activity in this window.
+            </td>
+          </tr>
+        ) : (
+          rows.map((row) => {
+            const open = openRows.has(row.key);
+            const tokens =
+              row.totals.uncachedInputTokens +
+              row.totals.cachedInputTokens +
+              row.totals.cacheCreationTokens +
+              row.totals.outputTokens;
+            return (
+              <ThreadRowGroup
+                key={row.key}
+                row={row}
+                open={open}
+                tokens={tokens}
+                share={totalCostUsd === 0 ? 0 : row.costUsd / totalCostUsd}
+                sinceDay={input.sinceDay}
+                untilDay={input.untilDay}
+                onToggle={() => toggleRow(row.key)}
+              />
+            );
+          })
+        )}
+        {truncatedRows > 0 ? (
+          <tr>
+            <td colSpan={4} className="py-2 text-xs text-muted-foreground">
+              {truncatedRows === 1
+                ? "1 more thread not shown."
+                : `${truncatedRows} more threads not shown.`}
+            </td>
+          </tr>
+        ) : null}
+        {failedEnvironments > 0 ? (
+          <tr>
+            <td colSpan={4} className="py-2 text-xs text-muted-foreground">
+              {failedEnvironments === 1
+                ? "1 environment could not report threads."
+                : `${failedEnvironments} environments could not report threads.`}
+            </td>
+          </tr>
+        ) : null}
+      </tbody>
+    </table>
+  );
+}
+
+function ThreadRowGroup({
+  row,
+  open,
+  tokens,
+  share,
+  sinceDay,
+  untilDay,
+  onToggle,
+}: {
+  readonly row: UsageThreadRow;
+  readonly open: boolean;
+  readonly tokens: number;
+  readonly share: number;
+  readonly sinceDay: string;
+  readonly untilDay: string;
+  readonly onToggle: () => void;
+}) {
+  const Chevron = open ? ChevronDownIcon : ChevronRightIcon;
+  return (
+    <>
+      <tr
+        className="cursor-pointer border-b border-border/50 transition-colors hover:bg-muted/50"
+        onClick={onToggle}
+        aria-expanded={open}
+      >
+        <td className="py-2 text-foreground">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <Chevron className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+            <ProviderMark provider={row.provider} />
+            <span className="truncate" title={row.title}>
+              {row.title}
+            </span>
+            {row.agents.length > 0 ? (
+              <span className="shrink-0 rounded border border-border px-1 text-[10px] text-muted-foreground">
+                {row.agents.length === 1 ? "1 subagent" : `${row.agents.length} subagents`}
+              </span>
+            ) : null}
+          </span>
+        </td>
+        <td className="py-2 text-right text-foreground tabular-nums">{formatUsd(row.costUsd)}</td>
+        <td className="py-2 text-right text-muted-foreground tabular-nums">
+          {`${(share * 100).toFixed(1)}%`}
+        </td>
+        <td className="py-2 text-right text-muted-foreground tabular-nums">
+          {formatTokens(tokens)}
+        </td>
+      </tr>
+      {open ? (
+        <tr className="border-b border-border/50">
+          <td colSpan={4} className="py-3 ps-9">
+            <UsageThreadDailyChart daily={row.daily} sinceDay={sinceDay} untilDay={untilDay} />
+            {row.agents.map((agent) => {
+              const agentTokens =
+                agent.totals.uncachedInputTokens +
+                agent.totals.cachedInputTokens +
+                agent.totals.cacheCreationTokens +
+                agent.totals.outputTokens;
+              return (
+                <div
+                  key={agent.agentId}
+                  className="flex items-baseline justify-between gap-4 py-1 text-xs text-muted-foreground"
+                >
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <span className="shrink-0 rounded border border-border px-1 text-[10px]">
+                      agent
+                    </span>
+                    <span className="truncate">{agent.agentId}</span>
+                  </span>
+                  <span className="shrink-0 tabular-nums">
+                    {formatUsd(agent.costUsd)} · {formatTokens(agentTokens)} tokens
+                  </span>
+                </div>
+              );
+            })}
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+const CHART_WIDTH = 760;
+const CHART_HEIGHT = 96;
+
+/**
+ * One thread's daily estimated cost. Static SVG, no animation.
+ */
+export function UsageThreadDailyChart({
+  daily,
+  sinceDay,
+  untilDay,
+}: {
+  readonly daily: readonly UsageThreadDayCost[];
+  readonly sinceDay: string;
+  readonly untilDay: string;
+}) {
+  const days = useMemo(() => enumerateDays(sinceDay, untilDay), [sinceDay, untilDay]);
+  const byDay = useMemo(
+    () => new Map<string, UsageThreadDayCost>(daily.map((entry) => [entry.day, entry])),
+    [daily],
+  );
+  const peak = daily.reduce((max, entry) => Math.max(max, entry.costUsd), 0);
+
+  if (peak === 0 || days.length === 0) {
+    return <p className="pb-2 text-xs text-muted-foreground">No priced usage in this window.</p>;
+  }
+
+  const bandWidth = CHART_WIDTH / days.length;
+  const barWidth = Math.max(1, bandWidth - (days.length > 120 ? 0.5 : 2));
+
+  return (
+    <div className="flex max-w-3xl flex-col gap-1 pb-2">
+      <div className="text-[11px] text-muted-foreground">
+        <span>
+          Daily cost, {formatDayShort(sinceDay)} to {formatDayShort(untilDay)}
+        </span>
+      </div>
+      <svg
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className="h-24 w-full"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Daily estimated cost for this thread"
+      >
+        {days.map((day, index) => {
+          const entry = byDay.get(day);
+          if (entry === undefined) return null;
+          const x = index * bandWidth;
+          const height = (entry.costUsd / peak) * (CHART_HEIGHT - 4);
+          return (
+            <g key={day}>
+              <title>{`${formatDayShort(day)}: ${formatUsd(entry.costUsd)}`}</title>
+              <rect
+                x={x}
+                y={CHART_HEIGHT - height}
+                width={barWidth}
+                height={Math.max(height - 0.75, 0.75)}
+                fill="currentColor"
+                className="text-emerald-500"
+              />
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function ProviderMark({ provider }: { readonly provider: UsageProviderKind }) {
+  const Mark = PROVIDER_PRESENTATION[provider].mark;
+  return <Mark className="size-3.5 shrink-0" aria-hidden />;
+}

--- a/apps/web/src/components/usage/UsageThreadTable.tsx
+++ b/apps/web/src/components/usage/UsageThreadTable.tsx
@@ -215,7 +215,7 @@ function ThreadRowGroup({
         </td>
         <td className="py-2 text-right text-foreground tabular-nums">{formatUsd(row.costUsd)}</td>
         <td className="py-2 text-right text-muted-foreground tabular-nums">
-          {row.totals.cacheCreationTokens === 0 ? "-" : formatUsd(row.cacheWriteUsd)}
+          {formatCacheWriteCost(row.totals.cacheCreationTokens, row.cacheWriteUsd)}
         </td>
         <td className="py-2 text-right text-muted-foreground tabular-nums">
           {formatPercent(share)}
@@ -256,6 +256,11 @@ function ThreadRowGroup({
       ) : null}
     </>
   );
+}
+
+function formatCacheWriteCost(cacheWriteTokens: number, cacheWriteUsd: number | null): string {
+  if (cacheWriteTokens === 0) return "-";
+  return cacheWriteUsd === null ? "Unavailable" : formatUsd(cacheWriteUsd);
 }
 
 const CHART_WIDTH = 760;

--- a/apps/web/src/state/usage.test.ts
+++ b/apps/web/src/state/usage.test.ts
@@ -49,6 +49,7 @@ function row(provider: UsageProviderKind, overrides: Partial<UsageThreadRow> = {
       reasoningTokens: 5,
     },
     costUsd: 1,
+    cacheWriteUsd: 0.25,
     sessions: 1,
     agents: [],
     daily: [],
@@ -58,7 +59,7 @@ function row(provider: UsageProviderKind, overrides: Partial<UsageThreadRow> = {
 
 function breakdown(rows: readonly UsageThreadRow[]): UsageThreadBreakdown {
   return {
-    contractVersion: 7,
+    contractVersion: 8,
     readAt: "2026-08-28T01:15:00.000Z",
     sinceDay: "2026-08-01" as UsageDay,
     untilDay: "2026-08-28" as UsageDay,

--- a/apps/web/src/state/usage.test.ts
+++ b/apps/web/src/state/usage.test.ts
@@ -1,9 +1,10 @@
-import type {
-  EnvironmentId,
-  UsageDay,
-  UsageProviderKind,
-  UsageThreadBreakdown,
-  UsageThreadRow,
+import {
+  USAGE_CONTRACT_VERSION,
+  type EnvironmentId,
+  type UsageDay,
+  type UsageProviderKind,
+  type UsageThreadBreakdown,
+  type UsageThreadRow,
 } from "@t3tools/contracts";
 import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
 import { describe, expect, it } from "vite-plus/test";
@@ -49,8 +50,16 @@ describe("mergeUsageThreadBreakdowns", () => {
     const environmentA = "env-a" as EnvironmentId;
     const environmentB = "env-b" as EnvironmentId;
     const contributions: readonly EnvironmentProviderContribution[] = [
-      { environmentId: environmentA, providers: ["claude"] },
-      { environmentId: environmentB, providers: ["codex"] },
+      {
+        environmentId: environmentA,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["claude"],
+      },
+      {
+        environmentId: environmentB,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["codex"],
+      },
     ];
     const merged = mergeUsageThreadBreakdowns(
       [
@@ -93,8 +102,9 @@ describe("makeThreadBreakdownInput", () => {
           sinceTime: "2026-08-07T12:00:00.000Z",
           untilTime: "2026-08-08T12:00:00.000Z",
         },
-        "id:project-one",
+        JSON.stringify(["env-a", "id:project-one"]),
         ["claude"],
+        "env-a" as EnvironmentId,
       ),
     ).toEqual({
       sinceDay: "2026-08-07",

--- a/apps/web/src/state/usage.test.ts
+++ b/apps/web/src/state/usage.test.ts
@@ -8,7 +8,7 @@ import type {
 import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
 import { describe, expect, it } from "vite-plus/test";
 
-import { mergeUsageThreadBreakdowns } from "./usage";
+import { makeThreadBreakdownInput, mergeUsageThreadBreakdowns } from "./usage";
 
 function row(provider: UsageProviderKind, overrides: Partial<UsageThreadRow> = {}): UsageThreadRow {
   return {
@@ -78,5 +78,32 @@ describe("mergeUsageThreadBreakdowns", () => {
     ]);
     expect(merged.rows.reduce((sum, item) => sum + item.costUsd, 0)).toBe(2);
     expect(merged.truncatedRows).toBe(5);
+  });
+});
+
+describe("makeThreadBreakdownInput", () => {
+  it("preserves exact bounds and limits the environment to its owned providers", () => {
+    expect(
+      makeThreadBreakdownInput(
+        {
+          sinceDay: "2026-08-07" as UsageDay,
+          untilDay: "2026-08-08" as UsageDay,
+          timeZone: "UTC",
+          resolution: "hour",
+          sinceTime: "2026-08-07T12:00:00.000Z",
+          untilTime: "2026-08-08T12:00:00.000Z",
+        },
+        "id:project-one",
+        ["claude"],
+      ),
+    ).toEqual({
+      sinceDay: "2026-08-07",
+      untilDay: "2026-08-08",
+      timeZone: "UTC",
+      sinceTime: "2026-08-07T12:00:00.000Z",
+      untilTime: "2026-08-08T12:00:00.000Z",
+      projectKey: "id:project-one",
+      providers: ["claude"],
+    });
   });
 });

--- a/apps/web/src/state/usage.test.ts
+++ b/apps/web/src/state/usage.test.ts
@@ -9,7 +9,30 @@ import {
 import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
 import { describe, expect, it } from "vite-plus/test";
 
-import { makeThreadBreakdownInput, mergeUsageThreadBreakdowns } from "./usage";
+import {
+  filterUsageEnvironmentsForProject,
+  filterProviderContributionsForProject,
+  makeThreadBreakdownInput,
+  mergeUsageThreadBreakdowns,
+} from "./usage";
+
+describe("filterUsageEnvironmentsForProject", () => {
+  const environments = [
+    { environmentId: "env-a" as EnvironmentId },
+    { environmentId: "env-b" as EnvironmentId },
+  ];
+
+  it("keeps only the environment that owns a namespaced project", () => {
+    expect(
+      filterUsageEnvironmentsForProject(environments, JSON.stringify(["env-a", "id:project-one"])),
+    ).toEqual([environments[0]]);
+  });
+
+  it("keeps every environment for all and outside-project views", () => {
+    expect(filterUsageEnvironmentsForProject(environments, undefined)).toEqual(environments);
+    expect(filterUsageEnvironmentsForProject(environments, null)).toEqual(environments);
+  });
+});
 
 function row(provider: UsageProviderKind, overrides: Partial<UsageThreadRow> = {}): UsageThreadRow {
   return {
@@ -115,5 +138,28 @@ describe("makeThreadBreakdownInput", () => {
       projectKey: "id:project-one",
       providers: ["claude"],
     });
+  });
+
+  it("keeps only the environment that owns a namespaced project", () => {
+    const contributions: readonly EnvironmentProviderContribution[] = [
+      {
+        environmentId: "env-a" as EnvironmentId,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["claude"],
+      },
+      {
+        environmentId: "env-b" as EnvironmentId,
+        contractVersion: USAGE_CONTRACT_VERSION,
+        providers: ["codex"],
+      },
+    ];
+
+    expect(
+      filterProviderContributionsForProject(
+        JSON.stringify(["env-a", "id:project-one"]),
+        contributions,
+      ).map((contribution) => contribution.environmentId),
+    ).toEqual(["env-a"]);
+    expect(filterProviderContributionsForProject(null, contributions)).toEqual(contributions);
   });
 });

--- a/apps/web/src/state/usage.test.ts
+++ b/apps/web/src/state/usage.test.ts
@@ -1,0 +1,82 @@
+import type {
+  EnvironmentId,
+  UsageDay,
+  UsageProviderKind,
+  UsageThreadBreakdown,
+  UsageThreadRow,
+} from "@t3tools/contracts";
+import type { EnvironmentProviderContribution } from "@t3tools/shared/usageMerge";
+import { describe, expect, it } from "vite-plus/test";
+
+import { mergeUsageThreadBreakdowns } from "./usage";
+
+function row(provider: UsageProviderKind, overrides: Partial<UsageThreadRow> = {}): UsageThreadRow {
+  return {
+    key: "same-key",
+    threadId: null,
+    title: `${provider} row`,
+    provider,
+    project: "App",
+    totals: {
+      uncachedInputTokens: 10,
+      cachedInputTokens: 20,
+      cacheCreationTokens: 30,
+      outputTokens: 40,
+      reasoningTokens: 5,
+    },
+    costUsd: 1,
+    sessions: 1,
+    agents: [],
+    daily: [],
+    ...overrides,
+  };
+}
+
+function breakdown(rows: readonly UsageThreadRow[]): UsageThreadBreakdown {
+  return {
+    contractVersion: 7,
+    readAt: "2026-08-28T01:15:00.000Z",
+    sinceDay: "2026-08-01" as UsageDay,
+    untilDay: "2026-08-28" as UsageDay,
+    rows,
+    truncatedRows: rows.reduce((sum, item) => sum + (item.groupedRows ?? 0), 0),
+    scanDurationMs: 1,
+  };
+}
+
+describe("mergeUsageThreadBreakdowns", () => {
+  it("uses the summary's physical-source owner for each provider", () => {
+    const environmentA = "env-a" as EnvironmentId;
+    const environmentB = "env-b" as EnvironmentId;
+    const contributions: readonly EnvironmentProviderContribution[] = [
+      { environmentId: environmentA, providers: ["claude"] },
+      { environmentId: environmentB, providers: ["codex"] },
+    ];
+    const merged = mergeUsageThreadBreakdowns(
+      [
+        {
+          environmentId: environmentA,
+          breakdown: breakdown([
+            row("claude", { groupedRows: 2 }),
+            row("codex", { groupedRows: 7 }),
+          ]),
+        },
+        {
+          environmentId: environmentB,
+          breakdown: breakdown([
+            row("claude", { groupedRows: 11 }),
+            row("codex", { groupedRows: 3 }),
+          ]),
+        },
+      ],
+      contributions,
+    );
+
+    expect(merged.rows.map((item) => [item.provider, item.environmentId])).toEqual([
+      ["claude", environmentA],
+      ["codex", environmentB],
+    ]);
+    expect(merged.rows.reduce((sum, item) => sum + item.costUsd, 0)).toBe(2);
+    expect(merged.truncatedRows).toBe(5);
+  });
+});

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -71,7 +71,11 @@ export interface UsageView {
   readonly refresh: () => void;
 }
 
-export function useUsage(input: UsageSummaryInput): UsageView {
+export function useUsage(
+  input: UsageSummaryInput,
+  /** A project title, `null` for outside-projects buckets, `undefined` for no filter. */
+  projectFilter?: string | null,
+): UsageView {
   const windowKey = useMemo(
     () =>
       JSON.stringify({
@@ -118,8 +122,12 @@ export function useUsage(input: UsageSummaryInput): UsageView {
             },
           ],
     );
-    return mergeUsage(answered, USAGE_CONTRACT_VERSION);
-  }, [environments]);
+    return mergeUsage(
+      answered,
+      USAGE_CONTRACT_VERSION,
+      projectFilter === undefined ? undefined : { projectFilter },
+    );
+  }, [environments, projectFilter]);
 
   const answeredCount = environments.filter((environment) => environment.summary !== null).length;
   const stillReporting = environments.filter(

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -12,6 +12,8 @@ import {
   type EnvironmentId,
   type UsageSummary,
   type UsageSummaryInput,
+  type UsageThreadBreakdownInput,
+  type UsageThreadRow,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
@@ -141,4 +143,62 @@ export function useUsage(
     isPartial: answeredCount > 0 && stillReporting > 0,
     refresh,
   };
+}
+
+export interface UsageThreadsView {
+  readonly rows: readonly UsageThreadRow[];
+  readonly truncatedRows: number;
+  /** True until every listed environment answered or failed. */
+  readonly isPending: boolean;
+  readonly failedEnvironments: number;
+}
+
+const usageThreadsAtom = Atom.family((requestKey: string) =>
+  Atom.make((get): UsageThreadsView => {
+    const { input, environmentIds } = JSON.parse(requestKey) as {
+      input: UsageThreadBreakdownInput;
+      environmentIds: readonly EnvironmentId[];
+    };
+
+    const rows: UsageThreadRow[] = [];
+    // Environments sharing a transcript directory report the same sessions;
+    // row keys are derived from provider session ids, so first-in wins.
+    const seen = new Set<string>();
+    let truncatedRows = 0;
+    let pending = 0;
+    let failed = 0;
+    for (const environmentId of environmentIds) {
+      const result = get(serverEnvironment.usageThreadBreakdown({ environmentId, input }));
+      if (result.waiting) pending += 1;
+      if (result._tag === "Failure") failed += 1;
+      const breakdown = Option.getOrNull(AsyncResult.value(result));
+      if (breakdown === null) continue;
+      truncatedRows += breakdown.truncatedRows;
+      for (const row of breakdown.rows) {
+        const dedupeKey = `${row.provider}\u0000${row.key}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        rows.push(row);
+      }
+    }
+    rows.sort((a, b) => b.costUsd - a.costUsd);
+
+    return { rows, truncatedRows, isPending: pending > 0, failedEnvironments: failed };
+  }).pipe(Atom.withLabel(`web-usage:threads:${requestKey}`)),
+);
+
+/**
+ * Thread drill-down across the environments that contributed to the summary.
+ * Mount the consuming component only while the thread view is open; fetching
+ * starts on first read.
+ */
+export function useUsageThreads(
+  input: UsageThreadBreakdownInput,
+  environmentIds: readonly EnvironmentId[],
+): UsageThreadsView {
+  const requestKey = useMemo(
+    () => JSON.stringify({ input, environmentIds }),
+    [input, environmentIds],
+  );
+  return useAtomValue(usageThreadsAtom(requestKey));
 }

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -12,6 +12,7 @@ import {
   type EnvironmentId,
   type UsageSummary,
   type UsageSummaryInput,
+  type UsageThreadBreakdown,
   type UsageThreadBreakdownInput,
   type UsageThreadRow,
 } from "@t3tools/contracts";
@@ -19,7 +20,12 @@ import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
-import { mergeUsage, type EnvironmentUsage, type MergedUsage } from "@t3tools/shared/usageMerge";
+import {
+  mergeUsage,
+  type EnvironmentProviderContribution,
+  type EnvironmentUsage,
+  type MergedUsage,
+} from "@t3tools/shared/usageMerge";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
@@ -145,45 +151,68 @@ export function useUsage(
   };
 }
 
+export interface UsageThreadRowWithEnvironment extends UsageThreadRow {
+  readonly environmentId: EnvironmentId;
+}
+
 export interface UsageThreadsView {
-  readonly rows: readonly UsageThreadRow[];
+  readonly rows: readonly UsageThreadRowWithEnvironment[];
   readonly truncatedRows: number;
   /** True until every listed environment answered or failed. */
   readonly isPending: boolean;
   readonly failedEnvironments: number;
 }
 
+export interface EnvironmentUsageThreadBreakdown {
+  readonly environmentId: EnvironmentId;
+  readonly breakdown: UsageThreadBreakdown;
+}
+
+/** Applies the summary's physical-source ownership to thread rows. */
+export function mergeUsageThreadBreakdowns(
+  environments: readonly EnvironmentUsageThreadBreakdown[],
+  providerContributions: readonly EnvironmentProviderContribution[],
+): Pick<UsageThreadsView, "rows" | "truncatedRows"> {
+  const providersByEnvironment = new Map(
+    providerContributions.map((entry) => [entry.environmentId, new Set(entry.providers)]),
+  );
+  const rows: UsageThreadRowWithEnvironment[] = [];
+  let truncatedRows = 0;
+
+  for (const environment of environments) {
+    const ownedProviders = providersByEnvironment.get(environment.environmentId);
+    if (ownedProviders === undefined) continue;
+    for (const row of environment.breakdown.rows) {
+      if (!ownedProviders.has(row.provider)) continue;
+      rows.push({ ...row, environmentId: environment.environmentId });
+      truncatedRows += row.groupedRows ?? 0;
+    }
+  }
+  rows.sort((a, b) => b.costUsd - a.costUsd);
+  return { rows, truncatedRows };
+}
+
 const usageThreadsAtom = Atom.family((requestKey: string) =>
   Atom.make((get): UsageThreadsView => {
-    const { input, environmentIds } = JSON.parse(requestKey) as {
+    const { input, providerContributions } = JSON.parse(requestKey) as {
       input: UsageThreadBreakdownInput;
-      environmentIds: readonly EnvironmentId[];
+      providerContributions: readonly EnvironmentProviderContribution[];
     };
 
-    const rows: UsageThreadRow[] = [];
-    // Environments sharing a transcript directory report the same sessions;
-    // row keys are derived from provider session ids, so first-in wins.
-    const seen = new Set<string>();
-    let truncatedRows = 0;
+    const breakdowns: EnvironmentUsageThreadBreakdown[] = [];
     let pending = 0;
     let failed = 0;
-    for (const environmentId of environmentIds) {
+    for (const { environmentId } of providerContributions) {
       const result = get(serverEnvironment.usageThreadBreakdown({ environmentId, input }));
       if (result.waiting) pending += 1;
       if (result._tag === "Failure") failed += 1;
       const breakdown = Option.getOrNull(AsyncResult.value(result));
       if (breakdown === null) continue;
-      truncatedRows += breakdown.truncatedRows;
-      for (const row of breakdown.rows) {
-        const dedupeKey = `${row.provider}\u0000${row.key}`;
-        if (seen.has(dedupeKey)) continue;
-        seen.add(dedupeKey);
-        rows.push(row);
-      }
+      breakdowns.push({ environmentId, breakdown });
     }
-    rows.sort((a, b) => b.costUsd - a.costUsd);
+    const merged = mergeUsageThreadBreakdowns(breakdowns, providerContributions);
 
-    return { rows, truncatedRows, isPending: pending > 0, failedEnvironments: failed };
+    return { ...merged, isPending: pending > 0, failedEnvironments: failed };
   }).pipe(Atom.withLabel(`web-usage:threads:${requestKey}`)),
 );
 
@@ -194,11 +223,11 @@ const usageThreadsAtom = Atom.family((requestKey: string) =>
  */
 export function useUsageThreads(
   input: UsageThreadBreakdownInput,
-  environmentIds: readonly EnvironmentId[],
+  providerContributions: readonly EnvironmentProviderContribution[],
 ): UsageThreadsView {
   const requestKey = useMemo(
-    () => JSON.stringify({ input, environmentIds }),
-    [input, environmentIds],
+    () => JSON.stringify({ input, providerContributions }),
+    [input, providerContributions],
   );
   return useAtomValue(usageThreadsAtom(requestKey));
 }

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -20,7 +20,7 @@ import {
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import {
   mergeUsage,
@@ -29,6 +29,7 @@ import {
   type EnvironmentUsage,
   type MergedUsage,
 } from "@t3tools/shared/usageMerge";
+import { startUsageAutoRefresh } from "@t3tools/shared/usageRefresh";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
@@ -170,6 +171,10 @@ export function useUsage(
       }
     }
   }, [environments, merged.providerContributions, projectFilter, refreshThreads, windowKey]);
+
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+  useEffect(() => startUsageAutoRefresh(() => refreshRef.current()), []);
 
   const relevantEnvironments = filterUsageEnvironmentsForProject(environments, projectFilter);
   const answeredCount = relevantEnvironments.filter(

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -189,6 +189,7 @@ export function useUsage(
 }
 
 export interface UsageThreadRowWithEnvironment extends UsageThreadRow {
+  /** Environment that reported the row; thread deep links are environment-scoped. */
   readonly environmentId: EnvironmentId;
 }
 

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -73,7 +73,7 @@ export interface UsageView {
 
 export function useUsage(
   input: UsageSummaryInput,
-  /** A project title, `null` for outside-projects buckets, `undefined` for no filter. */
+  /** A namespaced project key, `null` for outside-projects buckets, `undefined` for no filter. */
   projectFilter?: string | null,
 ): UsageView {
   const windowKey = useMemo(

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -9,6 +9,7 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_THREAD_BREAKDOWN_SINCE,
   type EnvironmentId,
   type UsageSummary,
   type UsageSummaryInput,
@@ -23,6 +24,7 @@ import { useCallback, useMemo } from "react";
 
 import {
   mergeUsage,
+  projectFilterForEnvironment,
   type EnvironmentProviderContribution,
   type EnvironmentUsage,
   type MergedUsage,
@@ -137,10 +139,16 @@ export function useUsage(
       );
     }
     for (const contribution of merged.providerContributions) {
+      if (contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE) continue;
       appAtomRegistry.refresh(
         serverEnvironment.usageThreadBreakdown({
           environmentId: contribution.environmentId,
-          input: makeThreadBreakdownInput(input, projectFilter, contribution.providers),
+          input: makeThreadBreakdownInput(
+            input,
+            projectFilter,
+            contribution.providers,
+            contribution.environmentId,
+          ),
         }),
       );
     }
@@ -181,6 +189,7 @@ export function makeThreadBreakdownInput(
   input: UsageSummaryInput,
   projectFilter: string | null | undefined,
   providers: readonly UsageProviderKind[],
+  environmentId: EnvironmentId,
 ): UsageThreadBreakdownInput {
   return {
     sinceDay: input.sinceDay,
@@ -188,7 +197,9 @@ export function makeThreadBreakdownInput(
     timeZone: input.timeZone,
     ...(input.sinceTime === undefined ? {} : { sinceTime: input.sinceTime }),
     ...(input.untilTime === undefined ? {} : { untilTime: input.untilTime }),
-    ...(projectFilter === undefined ? {} : { projectKey: projectFilter }),
+    ...(projectFilter === undefined
+      ? {}
+      : { projectKey: projectFilterForEnvironment(projectFilter, environmentId) }),
     providers: [...providers],
   };
 }
@@ -233,13 +244,23 @@ const usageThreadsAtom = Atom.family((requestKey: string) =>
 
     const breakdowns: EnvironmentUsageThreadBreakdown[] = [];
     let pending = 0;
-    let failed = 0;
+    let failed = providerContributions.filter(
+      (contribution) => contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE,
+    ).length;
     for (const contribution of providerContributions) {
+      if (contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE) continue;
       const { environmentId } = contribution;
+      const environmentInput =
+        input.projectKey === undefined
+          ? input
+          : {
+              ...input,
+              projectKey: projectFilterForEnvironment(input.projectKey, environmentId),
+            };
       const result = get(
         serverEnvironment.usageThreadBreakdown({
           environmentId,
-          input: withOwnedProviders(input, contribution.providers),
+          input: withOwnedProviders(environmentInput, contribution.providers),
         }),
       );
       if (result.waiting) pending += 1;

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -12,6 +12,7 @@ import {
   type EnvironmentId,
   type UsageSummary,
   type UsageSummaryInput,
+  type UsageProviderKind,
   type UsageThreadBreakdown,
   type UsageThreadBreakdownInput,
   type UsageThreadRow,
@@ -106,18 +107,6 @@ export function useUsage(
   const atom = usageByWindowAtom(windowKey);
   const environments = useAtomValue(atom);
 
-  // Refreshing only the derived atom would re-read the per-environment SWR
-  // queries within their stale window and change nothing. Refresh each
-  // environment's query so the button always rescans.
-  const refresh = useCallback(() => {
-    const input = JSON.parse(windowKey) as UsageSummaryInput;
-    for (const environment of environments) {
-      appAtomRegistry.refresh(
-        serverEnvironment.usageSummary({ environmentId: environment.environmentId, input }),
-      );
-    }
-  }, [environments, windowKey]);
-
   const merged = useMemo(() => {
     const answered: EnvironmentUsage[] = environments.flatMap((environment) =>
       environment.summary === null
@@ -136,6 +125,26 @@ export function useUsage(
       projectFilter === undefined ? undefined : { projectFilter },
     );
   }, [environments, projectFilter]);
+
+  // Refresh the source queries, not just their derived atoms. When the thread
+  // table is mounted, refresh its provider-owned query at the same time so the
+  // two views cannot show different scans.
+  const refresh = useCallback(() => {
+    const input = JSON.parse(windowKey) as UsageSummaryInput;
+    for (const environment of environments) {
+      appAtomRegistry.refresh(
+        serverEnvironment.usageSummary({ environmentId: environment.environmentId, input }),
+      );
+    }
+    for (const contribution of merged.providerContributions) {
+      appAtomRegistry.refresh(
+        serverEnvironment.usageThreadBreakdown({
+          environmentId: contribution.environmentId,
+          input: makeThreadBreakdownInput(input, projectFilter, contribution.providers),
+        }),
+      );
+    }
+  }, [environments, merged.providerContributions, projectFilter, windowKey]);
 
   const answeredCount = environments.filter((environment) => environment.summary !== null).length;
   const stillReporting = environments.filter(
@@ -166,6 +175,29 @@ export interface UsageThreadsView {
 export interface EnvironmentUsageThreadBreakdown {
   readonly environmentId: EnvironmentId;
   readonly breakdown: UsageThreadBreakdown;
+}
+
+export function makeThreadBreakdownInput(
+  input: UsageSummaryInput,
+  projectFilter: string | null | undefined,
+  providers: readonly UsageProviderKind[],
+): UsageThreadBreakdownInput {
+  return {
+    sinceDay: input.sinceDay,
+    untilDay: input.untilDay,
+    timeZone: input.timeZone,
+    ...(input.sinceTime === undefined ? {} : { sinceTime: input.sinceTime }),
+    ...(input.untilTime === undefined ? {} : { untilTime: input.untilTime }),
+    ...(projectFilter === undefined ? {} : { projectKey: projectFilter }),
+    providers: [...providers],
+  };
+}
+
+function withOwnedProviders(
+  input: UsageThreadBreakdownInput,
+  providers: readonly UsageProviderKind[],
+): UsageThreadBreakdownInput {
+  return { ...input, providers: [...providers] };
 }
 
 /** Applies the summary's physical-source ownership to thread rows. */
@@ -202,8 +234,14 @@ const usageThreadsAtom = Atom.family((requestKey: string) =>
     const breakdowns: EnvironmentUsageThreadBreakdown[] = [];
     let pending = 0;
     let failed = 0;
-    for (const { environmentId } of providerContributions) {
-      const result = get(serverEnvironment.usageThreadBreakdown({ environmentId, input }));
+    for (const contribution of providerContributions) {
+      const { environmentId } = contribution;
+      const result = get(
+        serverEnvironment.usageThreadBreakdown({
+          environmentId,
+          input: withOwnedProviders(input, contribution.providers),
+        }),
+      );
       if (result.waiting) pending += 1;
       if (result._tag === "Failure") failed += 1;
       const breakdown = Option.getOrNull(AsyncResult.value(result));

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -82,10 +82,22 @@ export interface UsageView {
   readonly refresh: () => void;
 }
 
+export function filterUsageEnvironmentsForProject<
+  T extends { readonly environmentId: EnvironmentId },
+>(environments: readonly T[], projectFilter: string | null | undefined): readonly T[] {
+  return environments.filter(
+    (environment) =>
+      projectFilterForEnvironment(projectFilter, environment.environmentId) !==
+      "environment-mismatch:",
+  );
+}
+
 export function useUsage(
   input: UsageSummaryInput,
   /** A namespaced project key, `null` for outside-projects buckets, `undefined` for no filter. */
   projectFilter?: string | null,
+  /** Refresh the deferred thread query only while its table is mounted. */
+  refreshThreads = false,
 ): UsageView {
   const windowKey = useMemo(
     () =>
@@ -138,24 +150,32 @@ export function useUsage(
         serverEnvironment.usageSummary({ environmentId: environment.environmentId, input }),
       );
     }
-    for (const contribution of merged.providerContributions) {
-      if (contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE) continue;
-      appAtomRegistry.refresh(
-        serverEnvironment.usageThreadBreakdown({
-          environmentId: contribution.environmentId,
-          input: makeThreadBreakdownInput(
-            input,
-            projectFilter,
-            contribution.providers,
-            contribution.environmentId,
-          ),
-        }),
-      );
+    if (refreshThreads) {
+      for (const contribution of filterProviderContributionsForProject(
+        projectFilter,
+        merged.providerContributions,
+      )) {
+        if (contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE) continue;
+        appAtomRegistry.refresh(
+          serverEnvironment.usageThreadBreakdown({
+            environmentId: contribution.environmentId,
+            input: makeThreadBreakdownInput(
+              input,
+              projectFilter,
+              contribution.providers,
+              contribution.environmentId,
+            ),
+          }),
+        );
+      }
     }
-  }, [environments, merged.providerContributions, projectFilter, windowKey]);
+  }, [environments, merged.providerContributions, projectFilter, refreshThreads, windowKey]);
 
-  const answeredCount = environments.filter((environment) => environment.summary !== null).length;
-  const stillReporting = environments.filter(
+  const relevantEnvironments = filterUsageEnvironmentsForProject(environments, projectFilter);
+  const answeredCount = relevantEnvironments.filter(
+    (environment) => environment.summary !== null,
+  ).length;
+  const stillReporting = relevantEnvironments.filter(
     (environment) => environment.summary === null && environment.error === null,
   ).length;
 
@@ -235,6 +255,19 @@ export function mergeUsageThreadBreakdowns(
   return { rows, truncatedRows };
 }
 
+/** Excludes environments that cannot own a namespaced project selection. */
+export function filterProviderContributionsForProject(
+  projectKey: string | null | undefined,
+  providerContributions: readonly EnvironmentProviderContribution[],
+): readonly EnvironmentProviderContribution[] {
+  if (projectKey === undefined || projectKey === null) return providerContributions;
+  return providerContributions.filter(
+    (contribution) =>
+      projectFilterForEnvironment(projectKey, contribution.environmentId) !==
+      "environment-mismatch:",
+  );
+}
+
 const usageThreadsAtom = Atom.family((requestKey: string) =>
   Atom.make((get): UsageThreadsView => {
     const { input, providerContributions } = JSON.parse(requestKey) as {
@@ -242,12 +275,16 @@ const usageThreadsAtom = Atom.family((requestKey: string) =>
       providerContributions: readonly EnvironmentProviderContribution[];
     };
 
+    const relevantContributions = filterProviderContributionsForProject(
+      input.projectKey,
+      providerContributions,
+    );
     const breakdowns: EnvironmentUsageThreadBreakdown[] = [];
     let pending = 0;
-    let failed = providerContributions.filter(
+    let failed = relevantContributions.filter(
       (contribution) => contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE,
     ).length;
-    for (const contribution of providerContributions) {
+    for (const contribution of relevantContributions) {
       if (contribution.contractVersion < USAGE_THREAD_BREAKDOWN_SINCE) continue;
       const { environmentId } = contribution;
       const environmentInput =
@@ -269,7 +306,7 @@ const usageThreadsAtom = Atom.family((requestKey: string) =>
       if (breakdown === null) continue;
       breakdowns.push({ environmentId, breakdown });
     }
-    const merged = mergeUsageThreadBreakdowns(breakdowns, providerContributions);
+    const merged = mergeUsageThreadBreakdowns(breakdowns, relevantContributions);
 
     return { ...merged, isPending: pending > 0, failedEnvironments: failed };
   }).pipe(Atom.withLabel(`web-usage:threads:${requestKey}`)),

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -11,3 +11,6 @@ completed-turn record will not appear.
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
 headline and chart, and refreshing rescans every connected environment.
+
+Any daily chart zooms: drag across it to make the selection the new date window, and double-click
+to return to the preset. The date fields beside the presets accept any custom range directly.

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -14,3 +14,8 @@ headline and chart, and refreshing rescans every connected environment.
 
 Any daily chart zooms: drag across it to make the selection the new date window, and double-click
 to return to the preset. The date fields beside the presets accept any custom range directly.
+
+Usage is attributed to the project whose folder a session ran in, including sessions driven
+outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker
+narrows the whole page to one project; work that ran outside every project is grouped under
+"Outside projects". Grok Build sessions record no folder and always count there.

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -22,6 +22,7 @@ Expanding a row shows its daily estimated cost, along with any Claude subagents 
 Each connected environment contributes at most 40 rows, reserving room to group
 lower-cost rows under **Other threads** by provider and project. Those grouped rows stay in the
 totals, so the thread view still adds up to the selected project or full summary.
+Rows that map to a thread carry a link that opens it.
 
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -18,4 +18,5 @@ to return to the preset. The date fields beside the presets accept any custom ra
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker
 narrows the whole page to one project; work that ran outside every project is grouped under
-"Outside projects". Grok Build sessions record no folder and always count there.
+"Outside projects". Grok Build sessions record no folder, so they remain in overall totals but are
+omitted from the project breakdown and project filters.

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -15,6 +15,11 @@ headline and chart, and refreshing rescans every connected environment.
 Any daily chart zooms: drag across it to make the selection the new date window, and double-click
 to return to the preset. The date fields beside the presets accept any custom range directly.
 
+The breakdown's **Thread** view drills into where the spend went: sessions group into the T3 Code
+thread they belong to, with sessions that never ran through T3 Code listed under the first thing
+you asked in them. Expanding a row shows its daily estimated cost, along with any Claude subagents
+the thread spawned and their share.
+
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker
 narrows the whole page to one project; work that ran outside every project is grouped under

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -17,6 +17,13 @@ Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. 
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
 headline and chart, and refreshing rescans every connected environment.
 
+Opening the page starts a refresh, and a page left open refreshes every 30 minutes. Each refresh
+hashes every observed transcript byte with bounded disk parallelism so same-size rewrites cannot
+hide behind unchanged file metadata. It reuses cached parsed records for matching hashes and
+for a grown file verifies the old prefix hash before parsing only its appended bytes. Rewritten
+files are parsed from the beginning. Summary and thread scans are serialized against the same cache
+and use request-start cutoffs, so one refresh represents one stable observed window.
+
 Any daily chart zooms: drag across it to make the selection the new date window, and double-click
 to return to the preset. The date fields beside the presets accept custom ranges up to 90 days.
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -19,6 +19,9 @@ The breakdown's **Thread** view drills into where the spend went: sessions group
 thread they belong to, with sessions that never ran through T3 Code listed under the first thing
 you asked in them. Expanding a row shows its daily estimated cost, along with any Claude subagents
 the thread spawned and their share.
+The view names the 40 highest-cost rows and groups lower-cost rows under **Other threads** by
+provider and project. Those grouped rows stay in the totals, so the thread view still adds up to
+the selected project or full summary.
 
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -18,10 +18,10 @@ to return to the preset. The date fields beside the presets accept custom ranges
 The breakdown's **Thread** view drills into where the spend went: sessions group into the T3 Code
 thread they belong to, with sessions that never ran through T3 Code listed under the first thing
 you asked in them. Grok Build has no trusted prompt title, so its rows use a short session label.
-Expanding a row shows its daily estimated cost, along with any Claude subagents the thread spawned
-and their share. The view returns at most 40 rows, reserving room to group lower-cost rows under
-**Other threads** by provider and project. Those grouped rows stay in the totals, so the thread
-view still adds up to the selected project or full summary.
+Expanding a row shows its daily estimated cost, along with any Claude subagents the thread spawned.
+Each connected environment contributes at most 40 rows, reserving room to group
+lower-cost rows under **Other threads** by provider and project. Those grouped rows stay in the
+totals, so the thread view still adds up to the selected project or full summary.
 
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -20,13 +20,15 @@ thread they belong to, with sessions that never ran through T3 Code listed under
 you asked in them. Grok Build has no trusted prompt title, so its rows use a short session label.
 Expanding a row splits its daily model-priced cost into cache writes, cache
 reads, and fresh input plus output, alongside any Claude subagents the thread spawned.
+Provider-reported totals are not split into estimated components.
 Each connected environment contributes at most 40 rows, reserving room to group lower-cost rows
 under **Other threads** by provider and project. Those grouped rows stay in the totals, so the
 thread view still adds up to the selected project or full summary.
 Rows that map to a thread carry a link that opens it.
 
 The **Estimated cache writes** total prices cache-creation tokens at each model's cache-write rate.
-It only applies to providers that report cache-creation tokens, so rows without them show a dash.
+It only applies to model-priced records that report cache-creation tokens. Rows without cache
+writes show a dash; incomplete or unavailable pricing is labeled **Unavailable** instead of zero.
 
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,9 +1,14 @@
 # Review usage
 
 The Usage page combines Codex, Claude Code, and Grok Build activity from your connected
-environments. It reads the providers' local session history and shows API-equivalent token cost,
+environments. It reads the providers' local session history and shows a public-list-rate estimate,
 processed tokens, cache savings, provider shares, and model breakdowns. Subscription billing is
-separate from the raw token cost shown here.
+separate from this local estimate.
+
+Claude Code accounting keeps the final progressive snapshot for each response and prices every
+attempt in a model-fallback sequence. Five-minute and one-hour cache writes use their distinct
+public rates when the transcript provides the TTL. Thinking tokens remain part of output rather
+than being charged twice.
 
 Grok Build totals come from persisted session updates. Interactive turns that never wrote a
 completed-turn record will not appear.
@@ -26,9 +31,10 @@ under **Other threads** by provider and project. Those grouped rows stay in the 
 thread view still adds up to the selected project or full summary.
 Rows that map to a thread carry a link that opens it.
 
-The **Estimated cache writes** total prices cache-creation tokens at each model's cache-write rate.
+The **Cache writes, estimated** total prices cache-creation tokens at each model's cache-write rate.
 It only applies to model-priced records that report cache-creation tokens. Rows without cache
 writes show a dash; incomplete or unavailable pricing is labeled **Unavailable** instead of zero.
+Cache creation is a billing category, not evidence that a cache entry expired.
 
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -18,11 +18,15 @@ to return to the preset. The date fields beside the presets accept custom ranges
 The breakdown's **Thread** view drills into where the spend went: sessions group into the T3 Code
 thread they belong to, with sessions that never ran through T3 Code listed under the first thing
 you asked in them. Grok Build has no trusted prompt title, so its rows use a short session label.
-Expanding a row shows its daily estimated cost, along with any Claude subagents the thread spawned.
-Each connected environment contributes at most 40 rows, reserving room to group
-lower-cost rows under **Other threads** by provider and project. Those grouped rows stay in the
-totals, so the thread view still adds up to the selected project or full summary.
+Expanding a row splits its daily model-priced cost into cache writes, cache
+reads, and fresh input plus output, alongside any Claude subagents the thread spawned.
+Each connected environment contributes at most 40 rows, reserving room to group lower-cost rows
+under **Other threads** by provider and project. Those grouped rows stay in the totals, so the
+thread view still adds up to the selected project or full summary.
 Rows that map to a thread carry a link that opens it.
+
+The **Estimated cache writes** total prices cache-creation tokens at each model's cache-write rate.
+It only applies to providers that report cache-creation tokens, so rows without them show a dash.
 
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -13,15 +13,15 @@ Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. 
 headline and chart, and refreshing rescans every connected environment.
 
 Any daily chart zooms: drag across it to make the selection the new date window, and double-click
-to return to the preset. The date fields beside the presets accept any custom range directly.
+to return to the preset. The date fields beside the presets accept custom ranges up to 90 days.
 
 The breakdown's **Thread** view drills into where the spend went: sessions group into the T3 Code
 thread they belong to, with sessions that never ran through T3 Code listed under the first thing
-you asked in them. Expanding a row shows its daily estimated cost, along with any Claude subagents
-the thread spawned and their share.
-The view names the 40 highest-cost rows and groups lower-cost rows under **Other threads** by
-provider and project. Those grouped rows stay in the totals, so the thread view still adds up to
-the selected project or full summary.
+you asked in them. Grok Build has no trusted prompt title, so its rows use a short session label.
+Expanding a row shows its daily estimated cost, along with any Claude subagents the thread spawned
+and their share. The view returns at most 40 rows, reserving room to group lower-cost rows under
+**Other threads** by provider and project. Those grouped rows stay in the totals, so the thread
+view still adds up to the selected project or full summary.
 
 Usage is attributed to the project whose folder a session ran in, including sessions driven
 outside T3 Code. The breakdown's **Project** view ranks projects by spend, and the project picker

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -697,6 +697,13 @@ export function createServerEnvironmentAtoms<R, E>(
       tag: WS_METHODS.serverGetUsageSummary,
       staleTimeMs: 60_000,
     }),
+    // Fetched only when the thread view is opened; scans are cache-warm after
+    // the summary, so a minute of staleness matches it.
+    usageThreadBreakdown: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:usage-thread-breakdown",
+      tag: WS_METHODS.serverGetUsageThreadBreakdown,
+      staleTimeMs: 60_000,
+    }),
     configProjection,
     welcome: createEnvironmentRpcSubscriptionAtomFamily(runtime, {
       label: "environment-data:server:welcome",

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -192,7 +192,13 @@ import {
   ResourceTelemetryRetryResult,
   ResourceTelemetrySnapshot,
 } from "./resourceTelemetry.ts";
-import { UsageReadError, UsageSummary, UsageSummaryInput } from "./usage.ts";
+import {
+  UsageReadError,
+  UsageSummary,
+  UsageSummaryInput,
+  UsageThreadBreakdown,
+  UsageThreadBreakdownInput,
+} from "./usage.ts";
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
 import {
   SourceControlCloneRepositoryInput,
@@ -291,6 +297,7 @@ export const WS_METHODS = {
   serverReportHostPowerState: "server.reportHostPowerState",
   serverGetBackgroundPolicy: "server.getBackgroundPolicy",
   serverGetUsageSummary: "server.getUsageSummary",
+  serverGetUsageThreadBreakdown: "server.getUsageThreadBreakdown",
 
   // Cloud environment methods
   cloudGetRelayClientStatus: "cloud.getRelayClientStatus",
@@ -452,6 +459,15 @@ export const WsServerGetUsageSummaryRpc = Rpc.make(WS_METHODS.serverGetUsageSumm
   success: UsageSummary,
   error: Schema.Union([EnvironmentAuthorizationError, UsageReadError]),
 });
+
+export const WsServerGetUsageThreadBreakdownRpc = Rpc.make(
+  WS_METHODS.serverGetUsageThreadBreakdown,
+  {
+    payload: UsageThreadBreakdownInput,
+    success: UsageThreadBreakdown,
+    error: Schema.Union([EnvironmentAuthorizationError, UsageReadError]),
+  },
+);
 
 export const WsServerSignalProcessRpc = Rpc.make(WS_METHODS.serverSignalProcess, {
   payload: ServerSignalProcessInput,
@@ -1044,6 +1060,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerGetResourceTelemetryHistoryRpc,
   WsServerRetryResourceTelemetryRpc,
   WsServerGetUsageSummaryRpc,
+  WsServerGetUsageThreadBreakdownRpc,
   WsServerSignalProcessRpc,
   WsServerReportClientActivityRpc,
   WsServerReportHostPowerStateRpc,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -21,14 +21,15 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 6 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5 only adds `grok` to {@link UsageProviderKind}; v6 only adds the optional
+ * bucket `project`. v4 Claude/Codex buckets remain valid, so mixed-version
+ * environments keep those totals instead of treating every older server as
+ * stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 
@@ -80,8 +81,9 @@ export const UsageTokenTotals = Schema.Struct({
 export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 
 /**
- * One `(day, hourStart?, provider, model)` cell. `hourStart` is the UTC start
- * instant of a rolling bucket and is present only for hourly requests.
+ * One `(day, hourStart?, project, provider, model)` cell. `hourStart` is the
+ * UTC start instant of a rolling bucket and is present only for hourly
+ * requests.
  *
  * `costUsd` is the raw API-equivalent cost of these tokens. It is not money
  * spent: subscription plans bill separately. `unpricedRecords` counts records
@@ -91,6 +93,14 @@ export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 export const UsageBucket = Schema.Struct({
   day: UsageDay,
   hourStart: Schema.optional(TrimmedNonEmptyString),
+  /**
+   * Title of the T3 project whose workspace root contains the session's
+   * working directory, resolved per environment at scan time. Absent when the
+   * session ran outside every project on that environment, or when the
+   * transcript carries no working directory (Grok, and summaries from servers
+   * predating this field).
+   */
+  project: Schema.optional(TrimmedNonEmptyString),
   provider: UsageProviderKind,
   model: TrimmedNonEmptyString,
   totals: UsageTokenTotals,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -21,22 +21,23 @@ import { NonNegativeInt, ProjectId, ThreadId, TrimmedNonEmptyString } from "./ba
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 9 as const;
+export const USAGE_CONTRACT_VERSION = 10 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
  * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds the optional bucket
  * `project`; v7 adds its optional stable `projectId`; v8 distinguishes outside
- * projects from unknown attribution; v9 adds the separate thread-breakdown RPC.
- * v4 Claude/Codex buckets remain valid, so mixed-version environments keep
- * those totals instead of treating every older server as stale.
+ * projects from unknown attribution; v9 adds the separate thread-breakdown RPC;
+ * v10 adds optional cache-write costs. v4 Claude/Codex buckets remain valid, so
+ * mixed-version environments keep those totals instead of treating every older
+ * server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 /** First contract version that explicitly distinguishes outside from unknown attribution. */
 export const USAGE_PROJECT_ATTRIBUTION_SINCE = 8 as const;
 /** First contract version that exposes the current thread-breakdown RPC. */
-export const USAGE_THREAD_BREAKDOWN_SINCE = 9 as const;
+export const USAGE_THREAD_BREAKDOWN_SINCE = 10 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
@@ -123,6 +124,12 @@ export const UsageBucket = Schema.Struct({
    * rather than derived on the client.
    */
   cacheSavingsUsd: Schema.Number,
+  /**
+   * Estimated cost of the cache-creation tokens in this bucket at the model's
+   * cache-write rate. A subset of `costUsd` when the bucket is model-priced.
+   * Absent from summaries written before this field existed.
+   */
+  cacheWriteUsd: Schema.optional(Schema.Number),
   costSource: UsageCostSource,
   /** Distinct assistant responses, after de-duplication. */
   records: NonNegativeInt,
@@ -250,16 +257,21 @@ export const UsageAgentRow = Schema.Struct({
   agentId: TrimmedNonEmptyString,
   totals: UsageTokenTotals,
   costUsd: Schema.Number,
+  cacheWriteUsd: Schema.Number,
 });
 export type UsageAgentRow = typeof UsageAgentRow.Type;
 
 /**
- * One day of a thread's estimated cost. Days the thread was idle are omitted.
- * Unpriced records contribute tokens to the row totals but nothing here.
+ * One day of a thread's model-priced cost split by component. Days the thread
+ * was idle are omitted. Unpriced records contribute tokens to the row totals
+ * but nothing here.
  */
 export const UsageThreadDayCost = Schema.Struct({
   day: UsageDay,
-  costUsd: Schema.Number,
+  cacheWriteUsd: Schema.Number,
+  cacheReadUsd: Schema.Number,
+  /** Fresh input plus output. */
+  freshUsd: Schema.Number,
 });
 export type UsageThreadDayCost = typeof UsageThreadDayCost.Type;
 
@@ -281,6 +293,7 @@ export const UsageThreadRow = Schema.Struct({
   project: Schema.optional(TrimmedNonEmptyString),
   totals: UsageTokenTotals,
   costUsd: Schema.Number,
+  cacheWriteUsd: Schema.Number,
   /** Distinct transcript sessions folded into this row. */
   sessions: NonNegativeInt,
   /** Lower-cost thread rows represented by this grouped remainder row. */

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -14,23 +14,23 @@
  */
 import * as Schema from "effect/Schema";
 
-import { NonNegativeInt, ProjectId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 /**
  * Bumped whenever the shape of {@link UsageSummary} changes incompatibly. The
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 8 as const;
+export const USAGE_CONTRACT_VERSION = 9 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
  * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds the optional bucket
  * `project`; v7 adds its optional stable `projectId`; v8 distinguishes outside
- * projects from unknown attribution. v4 Claude/Codex buckets remain valid, so
- * mixed-version environments keep those totals instead of treating every
- * older server as stale.
+ * projects from unknown attribution; v9 adds the separate thread-breakdown RPC.
+ * v4 Claude/Codex buckets remain valid, so mixed-version environments keep
+ * those totals instead of treating every older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 /** First contract version that explicitly distinguishes outside from unknown attribution. */
@@ -221,6 +221,79 @@ export const UsageSummary = Schema.Struct({
   scanDurationMs: NonNegativeInt,
 });
 export type UsageSummary = typeof UsageSummary.Type;
+
+export const UsageThreadBreakdownInput = Schema.Struct({
+  /** Inclusive first day of the window, in `timeZone`. */
+  sinceDay: UsageDay,
+  /** Inclusive last day of the window, in `timeZone`. */
+  untilDay: UsageDay,
+  timeZone: TrimmedNonEmptyString,
+  /**
+   * Restrict to one project's sessions: a title selects that project, `null`
+   * selects sessions outside every project, absent applies no filter.
+   */
+  project: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+});
+export type UsageThreadBreakdownInput = typeof UsageThreadBreakdownInput.Type;
+
+/** One Claude subagent's slice of its parent thread. */
+export const UsageAgentRow = Schema.Struct({
+  agentId: TrimmedNonEmptyString,
+  totals: UsageTokenTotals,
+  costUsd: Schema.Number,
+});
+export type UsageAgentRow = typeof UsageAgentRow.Type;
+
+/**
+ * One day of a thread's estimated cost. Days the thread was idle are omitted.
+ * Unpriced records contribute tokens to the row totals but nothing here.
+ */
+export const UsageThreadDayCost = Schema.Struct({
+  day: UsageDay,
+  costUsd: Schema.Number,
+});
+export type UsageThreadDayCost = typeof UsageThreadDayCost.Type;
+
+/**
+ * One thread's (or unattributed session group's) slice of the window.
+ *
+ * `threadId` is present when the sessions map to a T3 Code thread on this
+ * environment, via the thread's resume cursor or its dedicated worktree.
+ * Sessions that never ran through T3 Code stay session-granular with a title
+ * taken from the transcript.
+ */
+export const UsageThreadRow = Schema.Struct({
+  /** Stable within one environment; opaque to clients. */
+  key: TrimmedNonEmptyString,
+  threadId: Schema.NullOr(ThreadId),
+  title: TrimmedNonEmptyString,
+  provider: UsageProviderKind,
+  project: Schema.optional(TrimmedNonEmptyString),
+  totals: UsageTokenTotals,
+  costUsd: Schema.Number,
+  /** Distinct transcript sessions folded into this row. */
+  sessions: NonNegativeInt,
+  agents: Schema.Array(UsageAgentRow),
+  daily: Schema.Array(UsageThreadDayCost),
+});
+export type UsageThreadRow = typeof UsageThreadRow.Type;
+
+/**
+ * On-demand drill-down behind the usage summary. Rows are capped server-side
+ * (cost-descending) because a window can hold thousands of sessions and this
+ * payload rides the same WebSocket as everything else.
+ */
+export const UsageThreadBreakdown = Schema.Struct({
+  contractVersion: Schema.Number,
+  readAt: Schema.String,
+  sinceDay: UsageDay,
+  untilDay: UsageDay,
+  rows: Schema.Array(UsageThreadRow),
+  /** Rows dropped by the cap, so the UI can say coverage is partial. */
+  truncatedRows: NonNegativeInt,
+  scanDurationMs: NonNegativeInt,
+});
+export type UsageThreadBreakdown = typeof UsageThreadBreakdown.Type;
 
 export class UsageReadError extends Schema.TaggedErrorClass<UsageReadError>()("UsageReadError", {
   reason: Schema.Literals(["scanFailed", "invalidWindow"]),

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -228,11 +228,18 @@ export const UsageThreadBreakdownInput = Schema.Struct({
   /** Inclusive last day of the window, in `timeZone`. */
   untilDay: UsageDay,
   timeZone: TrimmedNonEmptyString,
+  /** Inclusive UTC instant for a rolling window such as Past 24h. */
+  sinceTime: Schema.optional(TrimmedNonEmptyString),
+  /** Exclusive UTC instant for a rolling window such as Past 24h. */
+  untilTime: Schema.optional(TrimmedNonEmptyString),
   /**
-   * Restrict to one project's sessions: a title selects that project, `null`
-   * selects sessions outside every project, absent applies no filter.
+   * Restrict to one project's records: a namespaced stable key selects that
+   * project, `null` selects records outside every project, absent applies no
+   * filter.
    */
-  project: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  projectKey: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  /** Providers this environment owns after physical-source de-duplication. */
+  providers: Schema.optional(Schema.Array(UsageProviderKind)),
 });
 export type UsageThreadBreakdownInput = typeof UsageThreadBreakdownInput.Type;
 
@@ -268,6 +275,7 @@ export const UsageThreadRow = Schema.Struct({
   threadId: Schema.NullOr(ThreadId),
   title: TrimmedNonEmptyString,
   provider: UsageProviderKind,
+  projectId: Schema.optional(ProjectId),
   project: Schema.optional(TrimmedNonEmptyString),
   totals: UsageTokenTotals,
   costUsd: Schema.Number,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -273,15 +273,18 @@ export const UsageThreadRow = Schema.Struct({
   costUsd: Schema.Number,
   /** Distinct transcript sessions folded into this row. */
   sessions: NonNegativeInt,
+  /** Lower-cost thread rows represented by this grouped remainder row. */
+  groupedRows: Schema.optional(NonNegativeInt),
   agents: Schema.Array(UsageAgentRow),
   daily: Schema.Array(UsageThreadDayCost),
 });
 export type UsageThreadRow = typeof UsageThreadRow.Type;
 
 /**
- * On-demand drill-down behind the usage summary. Rows are capped server-side
- * (cost-descending) because a window can hold thousands of sessions and this
- * payload rides the same WebSocket as everything else.
+ * On-demand drill-down behind the usage summary. Named rows are capped
+ * server-side because a window can hold thousands of sessions. Lower-cost
+ * rows fold into provider/project-specific remainder rows so totals reconcile
+ * without sending every transcript session over the WebSocket.
  */
 export const UsageThreadBreakdown = Schema.Struct({
   contractVersion: Schema.Number,
@@ -289,7 +292,7 @@ export const UsageThreadBreakdown = Schema.Struct({
   sinceDay: UsageDay,
   untilDay: UsageDay,
   rows: Schema.Array(UsageThreadRow),
-  /** Rows dropped by the cap, so the UI can say coverage is partial. */
+  /** Underlying rows folded into the returned remainder rows. */
   truncatedRows: NonNegativeInt,
   scanDurationMs: NonNegativeInt,
 });

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -21,7 +21,7 @@ import { NonNegativeInt, ProjectId, ThreadId, TrimmedNonEmptyString } from "./ba
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 10 as const;
+export const USAGE_CONTRACT_VERSION = 11 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
@@ -29,9 +29,9 @@ export const USAGE_CONTRACT_VERSION = 10 as const;
  * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds the optional bucket
  * `project`; v7 adds its optional stable `projectId`; v8 distinguishes outside
  * projects from unknown attribution; v9 adds the separate thread-breakdown RPC;
- * v10 adds optional cache-write costs. v4 Claude/Codex buckets remain valid, so
- * mixed-version environments keep those totals instead of treating every older
- * server as stale.
+ * v10 adds optional cache-write costs; v11 adds optional cache-write TTL counters.
+ * v4 Claude/Codex buckets remain valid, so mixed-version environments keep those
+ * totals instead of treating every older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 /** First contract version that explicitly distinguishes outside from unknown attribution. */
@@ -81,6 +81,10 @@ export const UsageTokenTotals = Schema.Struct({
   uncachedInputTokens: NonNegativeInt,
   cachedInputTokens: NonNegativeInt,
   cacheCreationTokens: NonNegativeInt,
+  /** Anthropic five-minute cache writes, when the transcript reports the TTL. */
+  cacheCreation5mTokens: Schema.optional(NonNegativeInt),
+  /** Anthropic one-hour cache writes, when the transcript reports the TTL. */
+  cacheCreation1hTokens: Schema.optional(NonNegativeInt),
   outputTokens: NonNegativeInt,
   reasoningTokens: NonNegativeInt,
 });
@@ -125,9 +129,9 @@ export const UsageBucket = Schema.Struct({
    */
   cacheSavingsUsd: Schema.Number,
   /**
-   * Estimated cost of the cache-creation tokens in this bucket at the model's
-   * cache-write rate. A subset of `costUsd` when the bucket is model-priced.
-   * Absent from summaries written before this field existed.
+   * Estimated cache-write cost at the model and TTL-specific rates. Cache
+   * creation is a billing category, not proof of expiry. A subset of `costUsd`
+   * when the bucket is model-priced. Absent from older summaries.
    */
   cacheWriteUsd: Schema.optional(Schema.Number),
   costSource: UsageCostSource,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -35,7 +35,7 @@ export const USAGE_CONTRACT_VERSION = 9 as const;
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 /** First contract version that explicitly distinguishes outside from unknown attribution. */
 export const USAGE_PROJECT_ATTRIBUTION_SINCE = 8 as const;
-/** First contract version that exposes the thread-breakdown RPC. */
+/** First contract version that exposes the current thread-breakdown RPC. */
 export const USAGE_THREAD_BREAKDOWN_SINCE = 9 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -257,14 +257,16 @@ export const UsageAgentRow = Schema.Struct({
   agentId: TrimmedNonEmptyString,
   totals: UsageTokenTotals,
   costUsd: Schema.Number,
-  cacheWriteUsd: Schema.Number,
+  /** `null` when cache-creation tokens lack a model-priced estimate. */
+  cacheWriteUsd: Schema.NullOr(Schema.Number),
 });
 export type UsageAgentRow = typeof UsageAgentRow.Type;
 
 /**
  * One day of a thread's model-priced cost split by component. Days the thread
  * was idle are omitted. Unpriced records contribute tokens to the row totals
- * but nothing here.
+ * but nothing here. Provider-reported totals also stay out because an
+ * estimated split could disagree with the provider's authoritative total.
  */
 export const UsageThreadDayCost = Schema.Struct({
   day: UsageDay,
@@ -293,7 +295,8 @@ export const UsageThreadRow = Schema.Struct({
   project: Schema.optional(TrimmedNonEmptyString),
   totals: UsageTokenTotals,
   costUsd: Schema.Number,
-  cacheWriteUsd: Schema.Number,
+  /** `null` when cache-creation tokens lack a model-priced estimate. */
+  cacheWriteUsd: Schema.NullOr(Schema.Number),
   /** Distinct transcript sessions folded into this row. */
   sessions: NonNegativeInt,
   /** Lower-cost thread rows represented by this grouped remainder row. */

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -35,6 +35,8 @@ export const USAGE_CONTRACT_VERSION = 9 as const;
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 /** First contract version that explicitly distinguishes outside from unknown attribution. */
 export const USAGE_PROJECT_ATTRIBUTION_SINCE = 8 as const;
+/** First contract version that exposes the thread-breakdown RPC. */
+export const USAGE_THREAD_BREAKDOWN_SINCE = 9 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -21,19 +21,20 @@ import { NonNegativeInt, ProjectId, TrimmedNonEmptyString } from "./baseSchemas.
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 7 as const;
+export const USAGE_CONTRACT_VERSION = 8 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
  * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds the optional bucket
- * `project`; v7 adds its optional stable `projectId`. v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * `project`; v7 adds its optional stable `projectId`; v8 distinguishes outside
+ * projects from unknown attribution. v4 Claude/Codex buckets remain valid, so
+ * mixed-version environments keep those totals instead of treating every
+ * older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
-/** First contract version whose absent project fields mean outside all projects. */
-export const USAGE_PROJECT_ATTRIBUTION_SINCE = 6 as const;
+/** First contract version that explicitly distinguishes outside from unknown attribution. */
+export const USAGE_PROJECT_ATTRIBUTION_SINCE = 8 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
@@ -105,6 +106,11 @@ export const UsageBucket = Schema.Struct({
   project: Schema.optional(TrimmedNonEmptyString),
   /** Stable identity for `project`; absent on summaries from pre-v7 servers. */
   projectId: Schema.optional(ProjectId),
+  /**
+   * Whether the session ran in a project, outside every project, or carried no
+   * working directory. Optional only so current clients can read older summaries.
+   */
+  projectAttribution: Schema.optional(Schema.Literals(["project", "outside", "unknown"])),
   provider: UsageProviderKind,
   model: TrimmedNonEmptyString,
   totals: UsageTokenTotals,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -32,6 +32,8 @@ export const USAGE_CONTRACT_VERSION = 7 as const;
  * treating every older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
+/** First contract version whose absent project fields mean outside all projects. */
+export const USAGE_PROJECT_ATTRIBUTION_SINCE = 6 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -14,22 +14,22 @@
  */
 import * as Schema from "effect/Schema";
 
-import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, ProjectId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 /**
  * Bumped whenever the shape of {@link UsageSummary} changes incompatibly. The
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 6 as const;
+export const USAGE_CONTRACT_VERSION = 7 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v6 only adds the optional
- * bucket `project`. v4 Claude/Codex buckets remain valid, so mixed-version
- * environments keep those totals instead of treating every older server as
- * stale.
+ * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds the optional bucket
+ * `project`; v7 adds its optional stable `projectId`. v4 Claude/Codex buckets
+ * remain valid, so mixed-version environments keep those totals instead of
+ * treating every older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 
@@ -101,6 +101,8 @@ export const UsageBucket = Schema.Struct({
    * predating this field).
    */
   project: Schema.optional(TrimmedNonEmptyString),
+  /** Stable identity for `project`; absent on summaries from pre-v7 servers. */
+  projectId: Schema.optional(ProjectId),
   provider: UsageProviderKind,
   model: TrimmedNonEmptyString,
   totals: UsageTokenTotals,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -231,6 +231,10 @@
       "types": "./src/usageFormat.ts",
       "import": "./src/usageFormat.ts"
     },
+    "./usageRefresh": {
+      "types": "./src/usageRefresh.ts",
+      "import": "./src/usageRefresh.ts"
+    },
     "./claudeCompaction": {
       "types": "./src/claudeCompaction.ts",
       "import": "./src/claudeCompaction.ts"

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -6,6 +6,7 @@ import {
   formatDateTimeShort,
   formatHourShort,
   formatRelativeHourShort,
+  makeCustomWindow,
   makeWindow,
 } from "./usageFormat.ts";
 
@@ -69,5 +70,23 @@ describe("hourly usage formatting", () => {
     } finally {
       resolvedOptions.mockRestore();
     }
+  });
+});
+
+describe("makeCustomWindow", () => {
+  it("builds a daily window over the inclusive range", () => {
+    const window = makeCustomWindow("2026-08-03", "2026-08-11");
+
+    expect(window.sinceDay).toBe("2026-08-03");
+    expect(window.untilDay).toBe("2026-08-11");
+    expect(window.resolution).toBe("day");
+    expect(window.sinceTime).toBeUndefined();
+  });
+
+  it("swaps out-of-order bounds so a raw drag never produces an invalid window", () => {
+    const window = makeCustomWindow("2026-08-11", "2026-08-03");
+
+    expect(window.sinceDay).toBe("2026-08-03");
+    expect(window.untilDay).toBe("2026-08-11");
   });
 });

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  compareUsageDays,
   enumerateHourStarts,
   formatDateTimeShort,
   formatHourShort,
@@ -9,6 +10,19 @@ import {
   makeCustomWindow,
   makeWindow,
 } from "./usageFormat.ts";
+
+describe("compareUsageDays", () => {
+  it("compares strict four-digit calendar dates numerically", () => {
+    expect(compareUsageDays("2026-08-03", "2026-08-11")).toBe(-1);
+    expect(compareUsageDays("2026-08-11", "2026-08-03")).toBe(1);
+    expect(compareUsageDays("2026-08-03", "2026-08-03")).toBe(0);
+  });
+
+  it("rejects variable-width years and impossible dates", () => {
+    expect(compareUsageDays("10000-01-01", "9999-12-31")).toBeNull();
+    expect(compareUsageDays("2026-02-29", "2026-03-01")).toBeNull();
+  });
+});
 
 describe("hourly usage formatting", () => {
   it("enumerates 24 fixed buckets across a rolling window", () => {
@@ -95,5 +109,9 @@ describe("makeCustomWindow", () => {
 
     expect(window.sinceDay).toBe("0001-01-01");
     expect(window.untilDay).toBe("0001-03-31");
+  });
+
+  it("rejects bounds outside the strict day format", () => {
+    expect(() => makeCustomWindow("10000-01-01", "9999-12-31")).toThrow(RangeError);
   });
 });

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -89,4 +89,11 @@ describe("makeCustomWindow", () => {
     expect(window.sinceDay).toBe("2026-08-03");
     expect(window.untilDay).toBe("2026-08-11");
   });
+
+  it("caps typed ranges at the largest supported 90-day window", () => {
+    const window = makeCustomWindow("0001-01-01", "9999-12-31");
+
+    expect(window.sinceDay).toBe("0001-01-01");
+    expect(window.untilDay).toBe("0001-03-31");
+  });
 });

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -171,6 +171,21 @@ export function formatRelativeHourShort(
 }
 
 /**
+ * A daily window over an explicit inclusive day range, in the viewer's zone.
+ * Bounds arrive from date inputs or a chart brush; out-of-order bounds are
+ * swapped rather than rejected so callers can pass a drag's raw endpoints.
+ */
+export function makeCustomWindow(sinceDay: string, untilDay: string): UsageSummaryInput {
+  const [first, last] = sinceDay <= untilDay ? [sinceDay, untilDay] : [untilDay, sinceDay];
+  return {
+    sinceDay: UsageDay.make(first),
+    untilDay: UsageDay.make(last),
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    resolution: "day",
+  };
+}
+
+/**
  * The window the page requests, expressed in the viewer's own time zone so days
  * line up with what they actually experienced.
  */

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -14,6 +14,8 @@ const CURRENCY = new Intl.NumberFormat("en-US", {
 });
 
 const INTEGER = new Intl.NumberFormat("en-US");
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_CUSTOM_WINDOW_DAYS = 90;
 
 export function formatUsd(value: number): string {
   return CURRENCY.format(value);
@@ -174,9 +176,18 @@ export function formatRelativeHourShort(
  * A daily window over an explicit inclusive day range, in the viewer's zone.
  * Bounds arrive from date inputs or a chart brush; out-of-order bounds are
  * swapped rather than rejected so callers can pass a drag's raw endpoints.
+ * Typed spans are capped at the same 90 days as the largest preset so day
+ * enumeration remains bounded.
  */
 export function makeCustomWindow(sinceDay: string, untilDay: string): UsageSummaryInput {
-  const [first, last] = sinceDay <= untilDay ? [sinceDay, untilDay] : [untilDay, sinceDay];
+  const [first, requestedLast] = sinceDay <= untilDay ? [sinceDay, untilDay] : [untilDay, sinceDay];
+  const firstMs = Date.parse(`${first}T00:00:00Z`);
+  const requestedLastMs = Date.parse(`${requestedLast}T00:00:00Z`);
+  const maximumLastMs = firstMs + (MAX_CUSTOM_WINDOW_DAYS - 1) * DAY_MS;
+  const last =
+    requestedLastMs > maximumLastMs
+      ? new Date(maximumLastMs).toISOString().slice(0, 10)
+      : requestedLast;
   return {
     sinceDay: UsageDay.make(first),
     untilDay: UsageDay.make(last),

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -17,6 +17,29 @@ const INTEGER = new Intl.NumberFormat("en-US");
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_CUSTOM_WINDOW_DAYS = 90;
 
+function usageDayOrdinal(value: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match === null) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12) return null;
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+  if (daysInMonth === undefined || day < 1 || day > daysInMonth) return null;
+  return year * 372 + (month - 1) * 31 + day;
+}
+
+/** Compares two strict `YYYY-MM-DD` calendar days, or returns null if either is invalid. */
+export function compareUsageDays(left: string, right: string): -1 | 0 | 1 | null {
+  const leftOrdinal = usageDayOrdinal(left);
+  const rightOrdinal = usageDayOrdinal(right);
+  if (leftOrdinal === null || rightOrdinal === null) return null;
+  if (leftOrdinal < rightOrdinal) return -1;
+  if (leftOrdinal > rightOrdinal) return 1;
+  return 0;
+}
+
 export function formatUsd(value: number): string {
   return CURRENCY.format(value);
 }
@@ -180,7 +203,10 @@ export function formatRelativeHourShort(
  * enumeration remains bounded.
  */
 export function makeCustomWindow(sinceDay: string, untilDay: string): UsageSummaryInput {
-  const [first, requestedLast] = sinceDay <= untilDay ? [sinceDay, untilDay] : [untilDay, sinceDay];
+  const comparison = compareUsageDays(sinceDay, untilDay);
+  if (comparison === null)
+    throw new RangeError("Usage window bounds must be valid YYYY-MM-DD dates");
+  const [first, requestedLast] = comparison <= 0 ? [sinceDay, untilDay] : [untilDay, sinceDay];
   const firstMs = Date.parse(`${first}T00:00:00Z`);
   const requestedLastMs = Date.parse(`${requestedLast}T00:00:00Z`);
   const maximumLastMs = firstMs + (MAX_CUSTOM_WINDOW_DAYS - 1) * DAY_MS;

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,5 +1,6 @@
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -158,7 +159,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket()],
             [{ provider: "claude", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 2,
+            USAGE_MERGE_COMPATIBLE_SINCE - 1,
           ),
         ),
       ],
@@ -337,5 +338,60 @@ describe("mergeUsage", () => {
     ]);
     expect(merged.daily).toHaveLength(1);
     expect(merged.daily[0]?.costUsd).toBe(10);
+  });
+
+  it("rolls buckets up by project, with unattributed buckets under null", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ project: "App", costUsd: 6 }),
+              bucket({ project: "App", costUsd: 2, model: "claude-opus-5" }),
+              bucket({ costUsd: 2 }),
+            ],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.projects.map((project) => [project.project, project.costUsd])).toEqual([
+      ["App", 8],
+      [null, 2],
+    ]);
+    expect(merged.projects[0]?.costShare).toBeCloseTo(0.8, 9);
+  });
+
+  it("filters every figure except the project list when a project is selected", () => {
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ project: "App", costUsd: 6 }),
+            bucket({ costUsd: 2, provider: "codex", model: "gpt-5.6-sol" }),
+          ],
+          [
+            { provider: "claude", hostId: "mac", homePath: "/a/.claude" },
+            { provider: "codex", hostId: "mac", homePath: "/a/.codex" },
+          ],
+        ),
+      ),
+    ];
+
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: "App" });
+    expect(filtered.costUsd).toBe(6);
+    expect(filtered.providers.map((provider) => provider.provider)).toEqual(["claude"]);
+    // Session counts are per source directory and cannot be split by project.
+    expect(filtered.sessions).toBe(0);
+    // The picker keeps its full option list while the filter narrows the rest.
+    expect(filtered.projects.map((project) => project.project)).toEqual(["App", null]);
+
+    const outside = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: null });
+    expect(outside.costUsd).toBe(2);
+    expect(outside.providers.map((provider) => provider.provider)).toEqual(["codex"]);
   });
 });

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,6 +1,7 @@
 import {
   USAGE_CONTRACT_VERSION,
   USAGE_MERGE_COMPATIBLE_SINCE,
+  USAGE_PROJECT_ATTRIBUTION_SINCE,
   ProjectId,
   type EnvironmentId,
   type UsageBucket,
@@ -10,7 +11,7 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
+import { mergeUsage, projectFilterForEnvironment, type EnvironmentUsage } from "./usageMerge.ts";
 
 function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
   return {
@@ -413,9 +414,10 @@ describe("mergeUsage", () => {
       ),
     ];
 
-    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, {
-      projectFilter: "title:App",
-    });
+    const unfiltered = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    const appKey = unfiltered.projects.find((project) => project.project === "App")?.projectKey;
+    if (appKey === undefined || appKey === null) throw new Error("app project key missing");
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: appKey });
     expect(filtered.costUsd).toBe(6);
     expect(filtered.providers.map((provider) => provider.provider)).toEqual(["claude"]);
     // Session counts are per source directory and cannot be split by project.
@@ -426,5 +428,54 @@ describe("mergeUsage", () => {
     const outside = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: null });
     expect(outside.costUsd).toBe(2);
     expect(outside.providers.map((provider) => provider.provider)).toEqual(["codex"]);
+  });
+
+  it("namespaces stable project ids by environment", () => {
+    const sharedId = ProjectId.make("cloned-project");
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [bucket({ projectId: sharedId, project: "App", costUsd: 6 })],
+          [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+        ),
+      ),
+      environment(
+        "env-b",
+        summary(
+          [bucket({ projectId: sharedId, project: "App", costUsd: 2 })],
+          [{ provider: "claude", hostId: "linux", homePath: "/b/.claude" }],
+        ),
+      ),
+    ];
+
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    expect(merged.projects.map((project) => project.costUsd)).toEqual([6, 2]);
+    const firstKey = merged.projects[0]?.projectKey;
+    if (firstKey === undefined || firstKey === null) throw new Error("project key missing");
+    expect(projectFilterForEnvironment(firstKey, "env-a" as EnvironmentId)).toBe(`id:${sharedId}`);
+    expect(projectFilterForEnvironment(firstKey, "env-b" as EnvironmentId)).toBe(
+      "environment-mismatch:",
+    );
+  });
+
+  it("does not treat unknown attribution from old summaries as outside projects", () => {
+    const oldEnvironment = environment(
+      "env-old",
+      summary(
+        [bucket({ costUsd: 4 })],
+        [{ provider: "claude", hostId: "mac", homePath: "/old/.claude" }],
+        USAGE_PROJECT_ATTRIBUTION_SINCE - 1,
+      ),
+    );
+
+    const unfiltered = mergeUsage([oldEnvironment], USAGE_CONTRACT_VERSION);
+    expect(unfiltered.costUsd).toBe(4);
+    expect(unfiltered.projects).toEqual([]);
+
+    const outside = mergeUsage([oldEnvironment], USAGE_CONTRACT_VERSION, {
+      projectFilter: null,
+    });
+    expect(outside.costUsd).toBe(0);
   });
 });

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -96,6 +96,10 @@ describe("mergeUsage", () => {
     expect(merged.costUsd).toBe(20);
     expect(merged.records).toBe(10);
     expect(merged.duplicateSources).toHaveLength(0);
+    expect(merged.providerContributions).toEqual([
+      { environmentId: "env-a", providers: ["claude"] },
+      { environmentId: "env-b", providers: ["claude"] },
+    ]);
   });
 
   it("counts a shared transcript directory once", () => {
@@ -114,6 +118,9 @@ describe("mergeUsage", () => {
     expect(merged.sessions).toBe(1);
     expect(merged.duplicateSources).toHaveLength(1);
     expect(merged.contributingEnvironments).toEqual(["env-a"]);
+    expect(merged.providerContributions).toEqual([
+      { environmentId: "env-a", providers: ["claude"] },
+    ]);
   });
 
   it("drops only the duplicated provider, keeping the environment's other one", () => {
@@ -148,6 +155,10 @@ describe("mergeUsage", () => {
         merged.providers.map((provider) => [provider.provider, provider.sessions]),
       ),
     ).toEqual({ claude: 1, codex: 1 });
+    expect(merged.providerContributions).toEqual([
+      { environmentId: "env-a", providers: ["claude"] },
+      { environmentId: "env-b", providers: ["codex"] },
+    ]);
   });
 
   it("excludes an environment reporting an older contract version", () => {

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -97,8 +97,8 @@ describe("mergeUsage", () => {
     expect(merged.records).toBe(10);
     expect(merged.duplicateSources).toHaveLength(0);
     expect(merged.providerContributions).toEqual([
-      { environmentId: "env-a", providers: ["claude"] },
-      { environmentId: "env-b", providers: ["claude"] },
+      { environmentId: "env-a", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
+      { environmentId: "env-b", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
     ]);
   });
 
@@ -119,7 +119,7 @@ describe("mergeUsage", () => {
     expect(merged.duplicateSources).toHaveLength(1);
     expect(merged.contributingEnvironments).toEqual(["env-a"]);
     expect(merged.providerContributions).toEqual([
-      { environmentId: "env-a", providers: ["claude"] },
+      { environmentId: "env-a", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
     ]);
   });
 
@@ -156,8 +156,8 @@ describe("mergeUsage", () => {
       ),
     ).toEqual({ claude: 1, codex: 1 });
     expect(merged.providerContributions).toEqual([
-      { environmentId: "env-a", providers: ["claude"] },
-      { environmentId: "env-b", providers: ["codex"] },
+      { environmentId: "env-a", contractVersion: USAGE_CONTRACT_VERSION, providers: ["claude"] },
+      { environmentId: "env-b", contractVersion: USAGE_CONTRACT_VERSION, providers: ["codex"] },
     ]);
   });
 

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -409,6 +409,81 @@ describe("mergeUsage", () => {
     expect(filtered.costUsd).toBe(2);
   });
 
+  it("reconciles aggregate, provider, project, and filtered project totals", () => {
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ project: "App", costUsd: 6 }),
+            bucket({
+              project: "App",
+              provider: "codex",
+              model: "gpt-5.6-sol",
+              costUsd: 3,
+              totals: {
+                uncachedInputTokens: 20,
+                cachedInputTokens: 200,
+                cacheCreationTokens: 0,
+                outputTokens: 10,
+                reasoningTokens: 5,
+              },
+            }),
+            bucket({ costUsd: 2 }),
+          ],
+          [
+            { provider: "claude", hostId: "mac", homePath: "/a/.claude" },
+            { provider: "codex", hostId: "mac", homePath: "/a/.codex" },
+          ],
+        ),
+      ),
+    ];
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+
+    expect(merged.providers.reduce((sum, provider) => sum + provider.costUsd, 0)).toBe(
+      merged.costUsd,
+    );
+    expect(merged.providers.reduce((sum, provider) => sum + provider.totalTokens, 0)).toBe(
+      merged.totalTokens,
+    );
+    expect(merged.projects.reduce((sum, project) => sum + project.costUsd, 0)).toBe(merged.costUsd);
+    expect(merged.projects.reduce((sum, project) => sum + project.totalTokens, 0)).toBe(
+      merged.totalTokens,
+    );
+
+    for (const project of merged.projects) {
+      const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, {
+        projectFilter: project.projectKey,
+      });
+      expect(filtered.costUsd).toBe(project.costUsd);
+      expect(filtered.totalTokens).toBe(project.totalTokens);
+    }
+  });
+
+  it("sums cache-write cost overall and per model, tolerating summaries without it", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ cacheWriteUsd: 3 }),
+              bucket({ cacheWriteUsd: 1, model: "claude-opus-5" }),
+              // A summary written before the field existed contributes nothing.
+              bucket({ model: "claude-opus-5" }),
+            ],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costQuality.cacheWriteUsd).toBe(4);
+    const opus = merged.models.find((model) => model.model === "claude-opus-5");
+    expect(opus?.cacheWriteUsd).toBe(1);
+  });
+
   it("filters every figure except the project list when a project is selected", () => {
     const environments = [
       environment(

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -31,6 +31,7 @@ function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
     records: 5,
     unpricedRecords: 0,
     sessions: 1,
+    projectAttribution: "outside",
     ...overrides,
   };
 }
@@ -342,7 +343,7 @@ describe("mergeUsage", () => {
     expect(merged.daily[0]?.costUsd).toBe(10);
   });
 
-  it("rolls buckets up by project, with unattributed buckets under null", () => {
+  it("rolls buckets up by project, with explicit outside buckets under null", () => {
     const merged = mergeUsage(
       [
         environment(
@@ -463,7 +464,7 @@ describe("mergeUsage", () => {
     const oldEnvironment = environment(
       "env-old",
       summary(
-        [bucket({ costUsd: 4 })],
+        [bucket({ costUsd: 4, projectAttribution: undefined })],
         [{ provider: "claude", hostId: "mac", homePath: "/old/.claude" }],
         USAGE_PROJECT_ATTRIBUTION_SINCE - 1,
       ),
@@ -474,6 +475,32 @@ describe("mergeUsage", () => {
     expect(unfiltered.projects).toEqual([]);
 
     const outside = mergeUsage([oldEnvironment], USAGE_CONTRACT_VERSION, {
+      projectFilter: null,
+    });
+    expect(outside.costUsd).toBe(0);
+  });
+
+  it("does not treat current unknown attribution as outside projects", () => {
+    const currentEnvironment = environment(
+      "env-current",
+      summary(
+        [
+          bucket({
+            provider: "grok",
+            model: "grok-code-fast-1",
+            costUsd: 4,
+            projectAttribution: "unknown",
+          }),
+        ],
+        [{ provider: "grok", hostId: "mac", homePath: "/unknown" }],
+      ),
+    );
+
+    const unfiltered = mergeUsage([currentEnvironment], USAGE_CONTRACT_VERSION);
+    expect(unfiltered.costUsd).toBe(4);
+    expect(unfiltered.projects).toEqual([]);
+
+    const outside = mergeUsage([currentEnvironment], USAGE_CONTRACT_VERSION, {
       projectFilter: null,
     });
     expect(outside.costUsd).toBe(0);

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -460,7 +460,7 @@ describe("mergeUsage", () => {
     }
   });
 
-  it("sums cache-write cost overall and per model, tolerating summaries without it", () => {
+  it("marks cache-write cost unavailable when a cache-creating bucket omits it", () => {
     const merged = mergeUsage(
       [
         environment(
@@ -469,9 +469,28 @@ describe("mergeUsage", () => {
             [
               bucket({ cacheWriteUsd: 3 }),
               bucket({ cacheWriteUsd: 1, model: "claude-opus-5" }),
-              // A summary written before the field existed contributes nothing.
+              // A summary written before the field existed makes the estimate incomplete.
               bucket({ model: "claude-opus-5" }),
             ],
+            [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costQuality.cacheWriteUsd).toBeNull();
+    const opus = merged.models.find((model) => model.model === "claude-opus-5");
+    expect(opus?.cacheWriteUsd).toBeNull();
+  });
+
+  it("sums cache-write cost when every cache-creating bucket reports it", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ cacheWriteUsd: 3 }), bucket({ cacheWriteUsd: 1, model: "claude-opus-5" })],
             [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
           ),
         ),

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,6 +1,7 @@
 import {
   USAGE_CONTRACT_VERSION,
   USAGE_MERGE_COMPATIBLE_SINCE,
+  ProjectId,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -365,6 +366,36 @@ describe("mergeUsage", () => {
     expect(merged.projects[0]?.costShare).toBeCloseTo(0.8, 9);
   });
 
+  it("keeps projects with the same title distinct and filters by stable id", () => {
+    const firstId = ProjectId.make("project-first");
+    const secondId = ProjectId.make("project-second");
+    const environments = [
+      environment(
+        "env-a",
+        summary(
+          [
+            bucket({ projectId: firstId, project: "App", costUsd: 6 }),
+            bucket({ projectId: secondId, project: "App", costUsd: 2 }),
+          ],
+          [{ provider: "claude", hostId: "mac", homePath: "/a/.claude" }],
+        ),
+      ),
+    ];
+
+    const merged = mergeUsage(environments, USAGE_CONTRACT_VERSION);
+    expect(
+      merged.projects.map((project) => [project.projectId, project.project, project.costUsd]),
+    ).toEqual([
+      [firstId, "App", 6],
+      [secondId, "App", 2],
+    ]);
+
+    const secondKey = merged.projects.find((project) => project.projectId === secondId)?.projectKey;
+    if (secondKey === undefined) throw new Error("second project key missing");
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: secondKey });
+    expect(filtered.costUsd).toBe(2);
+  });
+
   it("filters every figure except the project list when a project is selected", () => {
     const environments = [
       environment(
@@ -382,7 +413,9 @@ describe("mergeUsage", () => {
       ),
     ];
 
-    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, { projectFilter: "App" });
+    const filtered = mergeUsage(environments, USAGE_CONTRACT_VERSION, {
+      projectFilter: "title:App",
+    });
     expect(filtered.costUsd).toBe(6);
     expect(filtered.providers.map((provider) => provider.provider)).toEqual(["claude"]);
     // Session counts are per source directory and cannot be split by project.

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -40,6 +40,15 @@ export interface ModelTotals {
   readonly costShare: number;
 }
 
+/** One project's slice of the window. `project` is null for buckets that ran outside every project. */
+export interface ProjectTotals {
+  readonly project: string | null;
+  readonly costUsd: number;
+  readonly totalTokens: number;
+  readonly records: number;
+  readonly costShare: number;
+}
+
 export interface DailyTotals {
   readonly day: string;
   readonly costUsd: number;
@@ -74,6 +83,11 @@ export interface MergedUsage {
   readonly sessions: number;
   readonly providers: readonly ProviderTotals[];
   readonly models: readonly ModelTotals[];
+  /**
+   * Always computed from the unfiltered buckets, so a project picker keeps its
+   * full option list while a filter is applied.
+   */
+  readonly projects: readonly ProjectTotals[];
   readonly daily: readonly DailyTotals[];
   readonly hourly: readonly HourlyTotals[];
   readonly costQuality: CostQuality;
@@ -189,6 +203,7 @@ const EMPTY_MERGED: MergedUsage = {
   sessions: 0,
   providers: [],
   models: [],
+  projects: [],
   daily: [],
   hourly: [],
   costQuality: {
@@ -202,6 +217,18 @@ const EMPTY_MERGED: MergedUsage = {
   staleEnvironments: [],
 };
 
+export interface MergeUsageOptions {
+  /**
+   * Restrict every figure except `projects` to buckets from one project:
+   * a title selects that project, `null` selects buckets that ran outside
+   * every project, and `undefined` applies no filter.
+   *
+   * Sessions are counted per source directory, not per project, so a filtered
+   * merge reports `sessions` as 0 rather than a number it cannot know.
+   */
+  readonly projectFilter?: string | null;
+}
+
 /**
  * Merges every connected environment's summary.
  *
@@ -214,8 +241,10 @@ const EMPTY_MERGED: MergedUsage = {
 export function mergeUsage(
   environments: readonly EnvironmentUsage[],
   expectedContractVersion: number,
+  options?: MergeUsageOptions,
 ): MergedUsage {
   if (environments.length === 0) return EMPTY_MERGED;
+  const projectFilter = options?.projectFilter;
 
   const current: EnvironmentUsage[] = [];
   const staleEnvironments: EnvironmentId[] = [];
@@ -249,6 +278,13 @@ export function mergeUsage(
     string,
     { provider: UsageProviderKind; costUsd: number; totalTokens: number; records: number }
   >();
+  // Keyed by title, with null (outside every project) under a NUL sentinel no
+  // title can contain. Accumulated before the project filter applies.
+  const projectAccumulator = new Map<
+    string,
+    { costUsd: number; totalTokens: number; records: number }
+  >();
+  let unfilteredCostUsd = 0;
   const dailyAccumulator = new Map<
     string,
     {
@@ -273,21 +309,39 @@ export function mergeUsage(
     const { buckets, sessionsByProvider } = ownedContribution(environment, ownerByFingerprint);
     if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);
 
-    for (const [providerKind, providerSessions] of sessionsByProvider) {
-      sessions += providerSessions;
-      if (providerSessions === 0) continue;
-      const provider = providerAccumulator.get(providerKind) ?? {
-        costUsd: 0,
-        totalTokens: 0,
-        records: 0,
-        sessions: 0,
-      };
-      provider.sessions += providerSessions;
-      providerAccumulator.set(providerKind, provider);
+    // Session counts are per source directory; a project filter cannot split
+    // them, so a filtered merge leaves every session figure at 0.
+    if (projectFilter === undefined) {
+      for (const [providerKind, providerSessions] of sessionsByProvider) {
+        sessions += providerSessions;
+        if (providerSessions === 0) continue;
+        const provider = providerAccumulator.get(providerKind) ?? {
+          costUsd: 0,
+          totalTokens: 0,
+          records: 0,
+          sessions: 0,
+        };
+        provider.sessions += providerSessions;
+        providerAccumulator.set(providerKind, provider);
+      }
     }
 
     for (const bucket of buckets) {
       const tokens = bucketTokens(bucket);
+
+      unfilteredCostUsd += bucket.costUsd;
+      const projectKey = bucket.project ?? "\0";
+      const project = projectAccumulator.get(projectKey) ?? {
+        costUsd: 0,
+        totalTokens: 0,
+        records: 0,
+      };
+      project.costUsd += bucket.costUsd;
+      project.totalTokens += tokens;
+      project.records += bucket.records;
+      projectAccumulator.set(projectKey, project);
+
+      if (projectFilter !== undefined && (bucket.project ?? null) !== projectFilter) continue;
 
       costUsd += bucket.costUsd;
       cacheSavingsUsd += bucket.cacheSavingsUsd;
@@ -383,6 +437,16 @@ export function mergeUsage(
     }))
     .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
 
+  const projects: ProjectTotals[] = [...projectAccumulator.entries()]
+    .map(([key, totals]) => ({
+      project: key === "\0" ? null : key,
+      costUsd: totals.costUsd,
+      totalTokens: totals.totalTokens,
+      records: totals.records,
+      costShare: unfilteredCostUsd === 0 ? 0 : totals.costUsd / unfilteredCostUsd,
+    }))
+    .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
+
   const daily: DailyTotals[] = [...dailyAccumulator.entries()]
     .map(([day, totals]) => ({
       day,
@@ -408,6 +472,7 @@ export function mergeUsage(
     sessions,
     providers,
     models,
+    projects,
     daily,
     hourly,
     costQuality: {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -38,7 +38,7 @@ export interface ModelTotals {
   readonly costUsd: number;
   readonly totalTokens: number;
   readonly cacheWriteTokens: number;
-  readonly cacheWriteUsd: number;
+  readonly cacheWriteUsd: number | null;
   readonly records: number;
   readonly costShare: number;
 }
@@ -52,7 +52,7 @@ export interface ProjectTotals {
   readonly costUsd: number;
   readonly totalTokens: number;
   readonly cacheWriteTokens: number;
-  readonly cacheWriteUsd: number;
+  readonly cacheWriteUsd: number | null;
   readonly records: number;
   readonly costShare: number;
 }
@@ -78,7 +78,7 @@ export interface CostQuality {
   readonly unpricedShare: number;
   readonly cacheSavingsUsd: number;
   /** Estimated cost of reported cache-creation tokens at cache-write rates. */
-  readonly cacheWriteUsd: number;
+  readonly cacheWriteUsd: number | null;
 }
 
 export interface EnvironmentProviderContribution {
@@ -320,6 +320,7 @@ export function mergeUsage(
   let sessions = 0;
   let cacheSavingsUsd = 0;
   let cacheWriteUsd = 0;
+  let cacheWriteComplete = true;
   let providerReportedRecords = 0;
   let unpricedRecords = 0;
 
@@ -335,6 +336,7 @@ export function mergeUsage(
       totalTokens: number;
       cacheWriteTokens: number;
       cacheWriteUsd: number;
+      cacheWriteComplete: boolean;
       records: number;
     }
   >();
@@ -350,6 +352,7 @@ export function mergeUsage(
       totalTokens: number;
       cacheWriteTokens: number;
       cacheWriteUsd: number;
+      cacheWriteComplete: boolean;
       records: number;
     }
   >();
@@ -405,6 +408,8 @@ export function mergeUsage(
 
     for (const bucket of buckets) {
       const tokens = bucketTokens(bucket);
+      const bucketCacheWriteComplete =
+        bucket.totals.cacheCreationTokens === 0 || bucket.cacheWriteUsd !== undefined;
 
       unfilteredCostUsd += bucket.costUsd;
       const localProjectKey = localBucketProjectKey(bucket);
@@ -426,12 +431,14 @@ export function mergeUsage(
           totalTokens: 0,
           cacheWriteTokens: 0,
           cacheWriteUsd: 0,
+          cacheWriteComplete: true,
           records: 0,
         };
         project.costUsd += bucket.costUsd;
         project.totalTokens += tokens;
         project.cacheWriteTokens += bucket.totals.cacheCreationTokens;
         project.cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
+        project.cacheWriteComplete &&= bucketCacheWriteComplete;
         project.records += bucket.records;
         projectAccumulator.set(accumulatorKey, project);
 
@@ -441,6 +448,7 @@ export function mergeUsage(
       costUsd += bucket.costUsd;
       cacheSavingsUsd += bucket.cacheSavingsUsd;
       cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
+      cacheWriteComplete &&= bucketCacheWriteComplete;
       uncachedInputTokens += bucket.totals.uncachedInputTokens;
       cachedInputTokens += bucket.totals.cachedInputTokens;
       cacheCreationTokens += bucket.totals.cacheCreationTokens;
@@ -468,12 +476,14 @@ export function mergeUsage(
         totalTokens: 0,
         cacheWriteTokens: 0,
         cacheWriteUsd: 0,
+        cacheWriteComplete: true,
         records: 0,
       };
       model.costUsd += bucket.costUsd;
       model.totalTokens += tokens;
       model.cacheWriteTokens += bucket.totals.cacheCreationTokens;
       model.cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
+      model.cacheWriteComplete &&= bucketCacheWriteComplete;
       model.records += bucket.records;
       modelAccumulator.set(modelKey, model);
 
@@ -533,7 +543,7 @@ export function mergeUsage(
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
       cacheWriteTokens: totals.cacheWriteTokens,
-      cacheWriteUsd: totals.cacheWriteUsd,
+      cacheWriteUsd: totals.cacheWriteComplete ? totals.cacheWriteUsd : null,
       records: totals.records,
       costShare: costUsd === 0 ? 0 : totals.costUsd / costUsd,
     }))
@@ -547,7 +557,7 @@ export function mergeUsage(
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
       cacheWriteTokens: totals.cacheWriteTokens,
-      cacheWriteUsd: totals.cacheWriteUsd,
+      cacheWriteUsd: totals.cacheWriteComplete ? totals.cacheWriteUsd : null,
       records: totals.records,
       costShare: unfilteredCostUsd === 0 ? 0 : totals.costUsd / unfilteredCostUsd,
     }))
@@ -587,7 +597,7 @@ export function mergeUsage(
       modelPricedShare:
         records === 0 ? 0 : (records - providerReportedRecords - unpricedRecords) / records,
       cacheSavingsUsd,
-      cacheWriteUsd,
+      cacheWriteUsd: cacheWriteComplete ? cacheWriteUsd : null,
     },
     duplicateSources: duplicates,
     contributingEnvironments,

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -37,6 +37,8 @@ export interface ModelTotals {
   readonly provider: UsageProviderKind;
   readonly costUsd: number;
   readonly totalTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly cacheWriteUsd: number;
   readonly records: number;
   readonly costShare: number;
 }
@@ -49,6 +51,8 @@ export interface ProjectTotals {
   readonly project: string | null;
   readonly costUsd: number;
   readonly totalTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly cacheWriteUsd: number;
   readonly records: number;
   readonly costShare: number;
 }
@@ -73,6 +77,8 @@ export interface CostQuality {
   readonly modelPricedShare: number;
   readonly unpricedShare: number;
   readonly cacheSavingsUsd: number;
+  /** Estimated cost of reported cache-creation tokens at cache-write rates. */
+  readonly cacheWriteUsd: number;
 }
 
 export interface EnvironmentProviderContribution {
@@ -223,6 +229,7 @@ const EMPTY_MERGED: MergedUsage = {
     modelPricedShare: 0,
     unpricedShare: 0,
     cacheSavingsUsd: 0,
+    cacheWriteUsd: 0,
   },
   duplicateSources: [],
   contributingEnvironments: [],
@@ -312,6 +319,7 @@ export function mergeUsage(
   let records = 0;
   let sessions = 0;
   let cacheSavingsUsd = 0;
+  let cacheWriteUsd = 0;
   let providerReportedRecords = 0;
   let unpricedRecords = 0;
 
@@ -321,7 +329,14 @@ export function mergeUsage(
   >();
   const modelAccumulator = new Map<
     string,
-    { provider: UsageProviderKind; costUsd: number; totalTokens: number; records: number }
+    {
+      provider: UsageProviderKind;
+      costUsd: number;
+      totalTokens: number;
+      cacheWriteTokens: number;
+      cacheWriteUsd: number;
+      records: number;
+    }
   >();
   // Keyed by stable project id where available, with a namespaced title
   // fallback for pre-v7 summaries. Accumulated before the project filter.
@@ -333,6 +348,8 @@ export function mergeUsage(
       project: string | null;
       costUsd: number;
       totalTokens: number;
+      cacheWriteTokens: number;
+      cacheWriteUsd: number;
       records: number;
     }
   >();
@@ -407,10 +424,14 @@ export function mergeUsage(
           project: bucket.project ?? null,
           costUsd: 0,
           totalTokens: 0,
+          cacheWriteTokens: 0,
+          cacheWriteUsd: 0,
           records: 0,
         };
         project.costUsd += bucket.costUsd;
         project.totalTokens += tokens;
+        project.cacheWriteTokens += bucket.totals.cacheCreationTokens;
+        project.cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
         project.records += bucket.records;
         projectAccumulator.set(accumulatorKey, project);
 
@@ -419,6 +440,7 @@ export function mergeUsage(
 
       costUsd += bucket.costUsd;
       cacheSavingsUsd += bucket.cacheSavingsUsd;
+      cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
       uncachedInputTokens += bucket.totals.uncachedInputTokens;
       cachedInputTokens += bucket.totals.cachedInputTokens;
       cacheCreationTokens += bucket.totals.cacheCreationTokens;
@@ -444,10 +466,14 @@ export function mergeUsage(
         provider: bucket.provider,
         costUsd: 0,
         totalTokens: 0,
+        cacheWriteTokens: 0,
+        cacheWriteUsd: 0,
         records: 0,
       };
       model.costUsd += bucket.costUsd;
       model.totalTokens += tokens;
+      model.cacheWriteTokens += bucket.totals.cacheCreationTokens;
+      model.cacheWriteUsd += bucket.cacheWriteUsd ?? 0;
       model.records += bucket.records;
       modelAccumulator.set(modelKey, model);
 
@@ -506,6 +532,8 @@ export function mergeUsage(
       provider: totals.provider,
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
+      cacheWriteTokens: totals.cacheWriteTokens,
+      cacheWriteUsd: totals.cacheWriteUsd,
       records: totals.records,
       costShare: costUsd === 0 ? 0 : totals.costUsd / costUsd,
     }))
@@ -518,6 +546,8 @@ export function mergeUsage(
       project: totals.project,
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
+      cacheWriteTokens: totals.cacheWriteTokens,
+      cacheWriteUsd: totals.cacheWriteUsd,
       records: totals.records,
       costShare: unfilteredCostUsd === 0 ? 0 : totals.costUsd / unfilteredCostUsd,
     }))
@@ -557,6 +587,7 @@ export function mergeUsage(
       modelPricedShare:
         records === 0 ? 0 : (records - providerReportedRecords - unpricedRecords) / records,
       cacheSavingsUsd,
+      cacheWriteUsd,
     },
     duplicateSources: duplicates,
     contributingEnvironments,

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -8,7 +8,6 @@
  */
 import {
   USAGE_MERGE_COMPATIBLE_SINCE,
-  USAGE_PROJECT_ATTRIBUTION_SINCE,
   type EnvironmentId,
   type ProjectId,
   type UsageBucket,
@@ -234,10 +233,10 @@ export interface MergeUsageOptions {
   readonly projectFilter?: string | null;
 }
 
-function localBucketProjectKey(bucket: UsageBucket): string | null {
+function localBucketProjectKey(bucket: UsageBucket): string | null | undefined {
   if (bucket.projectId !== undefined) return `id:${bucket.projectId}`;
   if (bucket.project !== undefined) return `title:${bucket.project}`;
-  return null;
+  return bucket.projectAttribution === "outside" ? null : undefined;
 }
 
 function namespacedProjectKey(environmentId: EnvironmentId, localKey: string): string {
@@ -376,14 +375,11 @@ export function mergeUsage(
       unfilteredCostUsd += bucket.costUsd;
       const localProjectKey = localBucketProjectKey(bucket);
       const projectKey =
-        localProjectKey === null
-          ? environment.summary.contractVersion >= USAGE_PROJECT_ATTRIBUTION_SINCE
-            ? null
-            : undefined
-          : namespacedProjectKey(environment.environmentId, localProjectKey);
-      // Pre-project contracts cannot distinguish an outside-project bucket
-      // from one whose attribution is simply unavailable. Keep its usage in
-      // unfiltered totals, but never claim it belongs to the Outside slice.
+        typeof localProjectKey === "string"
+          ? namespacedProjectKey(environment.environmentId, localProjectKey)
+          : localProjectKey;
+      // Unknown attribution stays in unfiltered totals but never claims to be
+      // part of the explicit Outside projects slice.
       if (projectKey === undefined) {
         if (projectFilter !== undefined) continue;
       } else {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -9,6 +9,7 @@
 import {
   USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
+  type ProjectId,
   type UsageBucket,
   type UsageProviderKind,
   type UsageSourceFingerprint,
@@ -42,6 +43,9 @@ export interface ModelTotals {
 
 /** One project's slice of the window. `project` is null for buckets that ran outside every project. */
 export interface ProjectTotals {
+  readonly projectId: ProjectId | null;
+  /** Stable, namespaced value accepted by `MergeUsageOptions.projectFilter`. */
+  readonly projectKey: string | null;
   readonly project: string | null;
   readonly costUsd: number;
   readonly totalTokens: number;
@@ -220,13 +224,19 @@ const EMPTY_MERGED: MergedUsage = {
 export interface MergeUsageOptions {
   /**
    * Restrict every figure except `projects` to buckets from one project:
-   * a title selects that project, `null` selects buckets that ran outside
-   * every project, and `undefined` applies no filter.
+   * a project's namespaced key selects that project, `null` selects buckets
+   * that ran outside every project, and `undefined` applies no filter.
    *
    * Sessions are counted per source directory, not per project, so a filtered
    * merge reports `sessions` as 0 rather than a number it cannot know.
    */
   readonly projectFilter?: string | null;
+}
+
+function bucketProjectKey(bucket: UsageBucket): string | null {
+  if (bucket.projectId !== undefined) return `id:${bucket.projectId}`;
+  if (bucket.project !== undefined) return `title:${bucket.project}`;
+  return null;
 }
 
 /**
@@ -278,11 +288,18 @@ export function mergeUsage(
     string,
     { provider: UsageProviderKind; costUsd: number; totalTokens: number; records: number }
   >();
-  // Keyed by title, with null (outside every project) under a NUL sentinel no
-  // title can contain. Accumulated before the project filter applies.
+  // Keyed by stable project id where available, with a namespaced title
+  // fallback for pre-v7 summaries. Accumulated before the project filter.
   const projectAccumulator = new Map<
     string,
-    { costUsd: number; totalTokens: number; records: number }
+    {
+      projectId: ProjectId | null;
+      projectKey: string | null;
+      project: string | null;
+      costUsd: number;
+      totalTokens: number;
+      records: number;
+    }
   >();
   let unfilteredCostUsd = 0;
   const dailyAccumulator = new Map<
@@ -330,8 +347,12 @@ export function mergeUsage(
       const tokens = bucketTokens(bucket);
 
       unfilteredCostUsd += bucket.costUsd;
-      const projectKey = bucket.project ?? "\0";
-      const project = projectAccumulator.get(projectKey) ?? {
+      const projectKey = bucketProjectKey(bucket);
+      const accumulatorKey = projectKey ?? "\0";
+      const project = projectAccumulator.get(accumulatorKey) ?? {
+        projectId: bucket.projectId ?? null,
+        projectKey,
+        project: bucket.project ?? null,
         costUsd: 0,
         totalTokens: 0,
         records: 0,
@@ -339,9 +360,9 @@ export function mergeUsage(
       project.costUsd += bucket.costUsd;
       project.totalTokens += tokens;
       project.records += bucket.records;
-      projectAccumulator.set(projectKey, project);
+      projectAccumulator.set(accumulatorKey, project);
 
-      if (projectFilter !== undefined && (bucket.project ?? null) !== projectFilter) continue;
+      if (projectFilter !== undefined && projectKey !== projectFilter) continue;
 
       costUsd += bucket.costUsd;
       cacheSavingsUsd += bucket.cacheSavingsUsd;
@@ -438,8 +459,10 @@ export function mergeUsage(
     .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);
 
   const projects: ProjectTotals[] = [...projectAccumulator.entries()]
-    .map(([key, totals]) => ({
-      project: key === "\0" ? null : key,
+    .map(([, totals]) => ({
+      projectId: totals.projectId,
+      projectKey: totals.projectKey,
+      project: totals.project,
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
       records: totals.records,

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -75,6 +75,11 @@ export interface CostQuality {
   readonly cacheSavingsUsd: number;
 }
 
+export interface EnvironmentProviderContribution {
+  readonly environmentId: EnvironmentId;
+  readonly providers: readonly UsageProviderKind[];
+}
+
 export interface MergedUsage {
   readonly costUsd: number;
   readonly uncachedInputTokens: number;
@@ -98,6 +103,8 @@ export interface MergedUsage {
   /** Environments whose data was dropped as a duplicate of another's. */
   readonly duplicateSources: readonly string[];
   readonly contributingEnvironments: readonly EnvironmentId[];
+  /** Provider rows this environment owns after physical-source de-duplication. */
+  readonly providerContributions: readonly EnvironmentProviderContribution[];
   readonly staleEnvironments: readonly EnvironmentId[];
 }
 
@@ -218,6 +225,7 @@ const EMPTY_MERGED: MergedUsage = {
   },
   duplicateSources: [],
   contributingEnvironments: [],
+  providerContributions: [],
   staleEnvironments: [],
 };
 
@@ -347,10 +355,17 @@ export function mergeUsage(
     }
   >();
   const contributingEnvironments: EnvironmentId[] = [];
+  const providerContributions: EnvironmentProviderContribution[] = [];
 
   for (const environment of current) {
     const { buckets, sessionsByProvider } = ownedContribution(environment, ownerByFingerprint);
-    if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);
+    if (buckets.length > 0) {
+      contributingEnvironments.push(environment.environmentId);
+      providerContributions.push({
+        environmentId: environment.environmentId,
+        providers: [...new Set(buckets.map((bucket) => bucket.provider))].sort(),
+      });
+    }
 
     // Session counts are per source directory; a project filter cannot split
     // them, so a filtered merge leaves every session figure at 0.
@@ -543,6 +558,9 @@ export function mergeUsage(
     },
     duplicateSources: duplicates,
     contributingEnvironments,
+    providerContributions: providerContributions.sort((a, b) =>
+      a.environmentId.localeCompare(b.environmentId),
+    ),
     staleEnvironments,
   };
 }

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -8,6 +8,7 @@
  */
 import {
   USAGE_MERGE_COMPATIBLE_SINCE,
+  USAGE_PROJECT_ATTRIBUTION_SINCE,
   type EnvironmentId,
   type ProjectId,
   type UsageBucket,
@@ -233,10 +234,36 @@ export interface MergeUsageOptions {
   readonly projectFilter?: string | null;
 }
 
-function bucketProjectKey(bucket: UsageBucket): string | null {
+function localBucketProjectKey(bucket: UsageBucket): string | null {
   if (bucket.projectId !== undefined) return `id:${bucket.projectId}`;
   if (bucket.project !== undefined) return `title:${bucket.project}`;
   return null;
+}
+
+function namespacedProjectKey(environmentId: EnvironmentId, localKey: string): string {
+  return JSON.stringify([environmentId, localKey]);
+}
+
+/** Converts a merged project key back to the key understood by one server. */
+export function projectFilterForEnvironment(
+  filter: string | null | undefined,
+  environmentId: EnvironmentId,
+): string | null | undefined {
+  if (filter === undefined || filter === null) return filter;
+  try {
+    const parsed: unknown = JSON.parse(filter);
+    if (
+      Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      parsed[0] === environmentId &&
+      typeof parsed[1] === "string"
+    ) {
+      return parsed[1];
+    }
+  } catch {
+    // A malformed or foreign key must select nothing in this environment.
+  }
+  return "environment-mismatch:";
 }
 
 /**
@@ -347,22 +374,35 @@ export function mergeUsage(
       const tokens = bucketTokens(bucket);
 
       unfilteredCostUsd += bucket.costUsd;
-      const projectKey = bucketProjectKey(bucket);
-      const accumulatorKey = projectKey ?? "\0";
-      const project = projectAccumulator.get(accumulatorKey) ?? {
-        projectId: bucket.projectId ?? null,
-        projectKey,
-        project: bucket.project ?? null,
-        costUsd: 0,
-        totalTokens: 0,
-        records: 0,
-      };
-      project.costUsd += bucket.costUsd;
-      project.totalTokens += tokens;
-      project.records += bucket.records;
-      projectAccumulator.set(accumulatorKey, project);
+      const localProjectKey = localBucketProjectKey(bucket);
+      const projectKey =
+        localProjectKey === null
+          ? environment.summary.contractVersion >= USAGE_PROJECT_ATTRIBUTION_SINCE
+            ? null
+            : undefined
+          : namespacedProjectKey(environment.environmentId, localProjectKey);
+      // Pre-project contracts cannot distinguish an outside-project bucket
+      // from one whose attribution is simply unavailable. Keep its usage in
+      // unfiltered totals, but never claim it belongs to the Outside slice.
+      if (projectKey === undefined) {
+        if (projectFilter !== undefined) continue;
+      } else {
+        const accumulatorKey = projectKey ?? "\0";
+        const project = projectAccumulator.get(accumulatorKey) ?? {
+          projectId: bucket.projectId ?? null,
+          projectKey,
+          project: bucket.project ?? null,
+          costUsd: 0,
+          totalTokens: 0,
+          records: 0,
+        };
+        project.costUsd += bucket.costUsd;
+        project.totalTokens += tokens;
+        project.records += bucket.records;
+        projectAccumulator.set(accumulatorKey, project);
 
-      if (projectFilter !== undefined && projectKey !== projectFilter) continue;
+        if (projectFilter !== undefined && projectKey !== projectFilter) continue;
+      }
 
       costUsd += bucket.costUsd;
       cacheSavingsUsd += bucket.cacheSavingsUsd;

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -77,6 +77,7 @@ export interface CostQuality {
 
 export interface EnvironmentProviderContribution {
   readonly environmentId: EnvironmentId;
+  readonly contractVersion: number;
   readonly providers: readonly UsageProviderKind[];
 }
 
@@ -363,6 +364,7 @@ export function mergeUsage(
       contributingEnvironments.push(environment.environmentId);
       providerContributions.push({
         environmentId: environment.environmentId,
+        contractVersion: environment.summary.contractVersion,
         providers: [...new Set(buckets.map((bucket) => bucket.provider))].sort(),
       });
     }

--- a/packages/shared/src/usageRefresh.test.ts
+++ b/packages/shared/src/usageRefresh.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { startUsageAutoRefresh, USAGE_AUTO_REFRESH_MS } from "./usageRefresh.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("startUsageAutoRefresh", () => {
+  it("refreshes immediately, repeats every thirty minutes, and stops after cleanup", () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const stop = startUsageAutoRefresh(refresh);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(USAGE_AUTO_REFRESH_MS - 1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(USAGE_AUTO_REFRESH_MS);
+    expect(refresh).toHaveBeenCalledTimes(3);
+
+    stop();
+    vi.advanceTimersByTime(USAGE_AUTO_REFRESH_MS);
+    expect(refresh).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/shared/src/usageRefresh.ts
+++ b/packages/shared/src/usageRefresh.ts
@@ -1,0 +1,12 @@
+// @effect-diagnostics globalTimers:off -- React owns this page-lifetime timer outside an Effect runtime.
+/** Refresh cadence for a usage page that remains mounted. */
+export const USAGE_AUTO_REFRESH_MS = 30 * 60 * 1000;
+
+/**
+ * Refreshes on page mount, then starts the page-lifetime refresh timer.
+ */
+export function startUsageAutoRefresh(refresh: () => void): () => void {
+  refresh();
+  const timer = globalThis.setInterval(refresh, USAGE_AUTO_REFRESH_MS);
+  return () => globalThis.clearInterval(timer);
+}


### PR DESCRIPTION
## Stack Note

This is logic series 3 of 3 and the final PR. The refresh-specific commit is `e08958f269`.

## What Changed

The usage page reads on load and refreshes every 30 minutes while mounted on web and mobile. An open thread breakdown refreshes on the same cadence, and manual refresh remains available.

Transcript parsing is incremental per file. Stable device, inode, byte size, and nanosecond mtime reuse cached parsed records. Metadata-changed candidates receive a full SHA-256 over the exact observed byte snapshot; identical content reuses its parse, and changed content is reparsed only through the observed size. Each request uses one fixed cutoff, stable path order, global deduplication, a shared scan semaphore, and an atomically replaced durable cache.

## Why

The previous cache trusted millisecond metadata, wrote directly to the final cache path, allowed overlapping scans, and had no page-lifetime refresh. The new flow makes warm and cold totals follow the same deterministic aggregation path without reparsing unchanged transcripts.

## Performance

On the current 30-day corpus, unchanged discovery covered 16,960 files in about 1.9 seconds. Metadata-changed files add their full hash and parse time. A diagnostic full hash of all 19.71 GiB took about 11.7 seconds, but the production incremental path does not do that for unchanged files.

## Verification

- 81 focused refresh/accounting tests passed on current upstream.
- Exact replay onto Nightly `v0.0.38-nightly.20260901.1244` passed 80 server, 24 web, and 25 shared tests.
- Contracts, client-runtime, shared, server, web, and mobile typechecks passed on that replay.

## Checklist

- [x] This PR has one refresh/cache concern
- [x] I explained what changed and why
- [x] No visual layout change requires screenshots
- [x] No motion is introduced

Built by gpt-5.6-sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thread breakdown, project attribution, and 30-minute auto-refresh to usage
> - Adds a per-thread usage breakdown view with lazy data fetching, expandable rows, and a new `serverGetUsageThreadBreakdown` WS RPC endpoint
> - Adds project-based attribution: usage buckets carry a `project` field, `mergeUsage` computes per-project totals, and the UI supports filtering the Usage page by project
> - Adds estimated cache-write cost metrics with TTL-specific pricing (5m vs 1h) and expands Claude transcript parsing so lines with `iterations` produce per-attempt records with per-model attribution and stable dedupe keys
> - Adds 30-minute auto-refresh via `startUsageAutoRefresh` in web and mobile usage hooks
> - Risk: `USAGE_SCAN_CACHE_VERSION` bumped to v5 and `USAGE_CONTRACT_VERSION` to v9, invalidating prior cache entries and contract responses; `dedupeWithinFile` now keeps the final snapshot per dedupe key instead of the first
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 54f79cd. 22 files reviewed, 22 issues evaluated, 10 issues filtered, 12 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/usage/usageThreads.ts — 2 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 120](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/apps/server/src/usage/usageThreads.ts#L120): When a duplicate is replaced with a record from a different session transcript, this returns `false` even though the retained record/context has changed. The caller registers title files only when `add()` returns `true`, so a copied/resumed message can move the folded row to the later `sessionKey` without registering that main transcript; an unattributed row then falls back to a short session id instead of its transcript title. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/usage/usageTranscriptReader.ts — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 224](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/apps/server/src/usage/usageTranscriptReader.ts#L224): `cleanTitle` truncates by UTF-16 code units with `slice`, so a title whose 80-character cutoff falls between the high and low halves of an emoji/non-BMP character returns a lone surrogate followed by the ellipsis. For example, a prompt with 78 BMP code units followed by an emoji is rendered with a replacement glyph rather than a valid truncated Unicode prefix. Title text is normal user input and can contain such characters. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/usage/UsagePage.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 447](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/apps/web/src/components/usage/UsagePage.tsx#L447): The Thread breakdown is enabled for the rolling `Past 24h` preset, but its input drops `window.sinceTime`/`untilTime` and sends only inclusive calendar-day bounds. When the 24-hour interval spans two dates, the thread RPC returns both full days while the summary/chart cover only the exact rolling 24 hours, so thread costs and tokens include out-of-window activity. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/usage/UsageThreadTable.tsx — 3 comments posted, 4 evaluated, 1 filtered</summary>
>
> - [line 262](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/apps/web/src/components/usage/UsageThreadTable.tsx#L262): The empty-state message says `No priced usage in this window` whenever the model-rate component total is zero. A row can instead have a nonzero `costUsd` from provider-reported pricing for an unknown model: `usageComponentCosts` returns all zeros when no rate exists, so this branch is taken despite priced usage being shown in the row. The message should say that no model-priced/component breakdown is available. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>docs/user/usage.md — 0 comments posted, 5 evaluated, 5 filtered</summary>
>
> - [line 15](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/docs/user/usage.md#L15): The statement that **any** daily chart can be dragged to zoom and double-clicked to reset is false for expanded Thread rows. Those rows render `UsageThreadDailyChart`, whose SVG is static and has no brush or double-click handlers, so users following this instruction cannot change its date window. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 16](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/docs/user/usage.md#L16): The custom-range instruction is not available on mobile-sized layouts: `UsageDateRangeInputs` is hidden below `lg`, and the compact period selector contains only the four presets (no Custom option). Consequently users on those layouts cannot enter the documented custom date range directly. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 18](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/docs/user/usage.md#L18): The Thread-view description implies one row per T3 Code thread, but the implementation deliberately keys a thread row by `threadId`, provider, and project. A thread with activity from (for example) both Codex and Claude is displayed as separate rows, so the added documentation needs to disclose that scope rather than claiming its sessions simply group into its thread. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 21](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/docs/user/usage.md#L21): The claim that an expanded thread shows any Claude subagents it spawned is too broad. Subagents are attached only when their session key matches a current runtime or their `cwd` uniquely matches a dedicated worktree; `loadThreadAttribution` explicitly excludes a thread using the project root from the worktree map. Subagents run from such a thread therefore remain unattributed standalone rows rather than appearing under the thread. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 22](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/docs/user/usage.md#L22): The 40-row limit is not page-wide as documented. Each server environment applies `THREAD_ROW_CAP` before the web client concatenates its rows, so a user with two connected environments can see up to 80 named rows (and the retained rows are not necessarily the global 40 highest-cost rows). <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>packages/shared/src/usageFormat.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 184](https://github.com/pingdotgg/t3code/blob/54f79cd89f0c8ab202462df2cf15c62d05fa5f18/packages/shared/src/usageFormat.ts#L184): `makeCustomWindow` always returns `resolution: "day"`, but the web caller preserves its prior `days` selection and derives `isPast24Hours` solely from `days === 1`. Thus, after selecting the 1-day rolling preset, changing either date input creates a daily custom window while the page still renders it as a 24-hour view (`merged.hourly` and hourly chart labels). The daily response has no hourly buckets, so the custom range appears empty/broken until a different preset is selected. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->