### PR TITLE
fix(desktop): forward Bitbucket credentials from the login shell

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -152,6 +152,59 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  it.effect("hydrates Bitbucket credentials from the login shell on macOS", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () =>
+          envOutput({
+            PATH: "/opt/homebrew/bin:/usr/bin",
+            T3CODE_BITBUCKET_ACCESS_TOKEN: "access-token",
+            T3CODE_BITBUCKET_EMAIL: "developer@example.com",
+            T3CODE_BITBUCKET_API_TOKEN: "api-token",
+          }),
+      });
+
+      assert.equal(env.T3CODE_BITBUCKET_ACCESS_TOKEN, "access-token");
+      assert.equal(env.T3CODE_BITBUCKET_EMAIL, "developer@example.com");
+      assert.equal(env.T3CODE_BITBUCKET_API_TOKEN, "api-token");
+    }),
+  );
+
+  it.effect("does not mix login-shell Bitbucket credentials into an inherited set", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        T3CODE_BITBUCKET_ACCESS_TOKEN: "inherited-access-token",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () =>
+          envOutput({
+            PATH: "/opt/homebrew/bin:/usr/bin",
+            T3CODE_BITBUCKET_EMAIL: "developer@example.com",
+            T3CODE_BITBUCKET_API_TOKEN: "api-token",
+          }),
+      });
+
+      // An access token outranks email plus API token, so hydrating the pair here
+      // would leave the app authenticating with the inherited token and the shell
+      // credentials silently ignored.
+      assert.equal(env.T3CODE_BITBUCKET_ACCESS_TOKEN, "inherited-access-token");
+      assert.equal(env.T3CODE_BITBUCKET_EMAIL, undefined);
+      assert.equal(env.T3CODE_BITBUCKET_API_TOKEN, undefined);
+    }),
+  );
+
   it.effect("hydrates the locale from the login shell on macOS", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -67,6 +67,16 @@ export class DesktopShellEnvironment extends Context.Service<
   }
 >()("@t3tools/desktop/shell/DesktopShellEnvironment") {}
 
+// The server reads these from plain process env, and we document them as shell
+// exports. A GUI launch inherits nothing from the shell, so without forwarding
+// them the desktop app reports Bitbucket as unauthenticated while the very same
+// credentials work in a terminal-started server.
+const BITBUCKET_CREDENTIAL_ENV_NAMES = [
+  "T3CODE_BITBUCKET_ACCESS_TOKEN",
+  "T3CODE_BITBUCKET_EMAIL",
+  "T3CODE_BITBUCKET_API_TOKEN",
+] as const;
+
 const LOGIN_SHELL_ENV_NAMES = [
   "PATH",
   "DBUS_SESSION_BUS_ADDRESS",
@@ -85,6 +95,7 @@ const LOGIN_SHELL_ENV_NAMES = [
   "XDG_SESSION_DESKTOP",
   "XDG_SESSION_TYPE",
   "WAYLAND_DISPLAY",
+  ...BITBUCKET_CREDENTIAL_ENV_NAMES,
 ] as const;
 const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
 const LOCALE_ENV_NAMES = ["LANG", "LC_ALL", "LC_CTYPE"] as const;
@@ -477,6 +488,18 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     ] as const) {
       if (!config.env[name] && shellEnvironment[name]) {
         config.env[name] = shellEnvironment[name];
+      }
+    }
+
+    // Bitbucket credentials form one precedence group: an access token outranks an
+    // email plus API token, so adding a shell-probed pair next to an inherited
+    // access token would leave the probed values silently unused. Take the whole
+    // set from one source, and prefer whatever the process already carries.
+    if (BITBUCKET_CREDENTIAL_ENV_NAMES.every((name) => !config.env[name])) {
+      for (const name of BITBUCKET_CREDENTIAL_ENV_NAMES) {
+        if (shellEnvironment[name]) {
+          config.env[name] = shellEnvironment[name];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #5840.

## Problem

On macOS and Linux the desktop app is started by the session manager, not a shell, so `T3CODE_BITBUCKET_*` exports in `~/.zshrc` or `~/.profile` never reach it. `docs/user/source-control.md` tells users to set those credentials exactly that way, and the server reads them straight from process env in `apps/server/src/sourceControl/BitbucketApi.ts`. The result is Bitbucket reporting as unauthenticated in the desktop app while the identical credentials work in a server started from a terminal.

The startup login-shell probe is not the problem. It runs, and the credentials are in scope for it. `readLoginShellEnvironment` issues one `printenv` per name in `LOGIN_SHELL_ENV_NAMES`, and that list covers PATH, locale, XDG, Homebrew and `SSH_AUTH_SOCK` only, so the values were never asked for. `extractEnvironment` filters by the same list, so nothing downstream could recover them either.

Reproduced on 0.0.37, macOS 26.6.2, Apple Silicon, with credentials exported from `~/.zshrc`:

```sh
$ ps eww $(python3 -c "import json;print(json.load(open(/Users/michael/.t3/userdata/server-runtime.json))[pid])") \
    | tr " " "\n" | grep -c "^T3CODE_BITBUCKET_API_TOKEN="
0
```

## Fix

Add the three credential names the server reads to the probe list, and hydrate them in `installPosixEnvironment`.

They are hydrated as a single precedence group rather than per name, following the locale group already in that function. An access token outranks an email plus API token, so filling in a shell-probed pair alongside an inherited access token would produce a set that authenticates with the inherited token while the probed values go silently unused. Taking the whole set from one source keeps that from happening, and anything already in the process env still wins.

This is the POSIX path only. Windows GUI processes inherit User-level variables set through `SetEnvironmentVariable`, so there is no gap there, and the `wsl.exe` boundary is handled separately by #7620, whose forwarded set this matches.

## Tests

Two cases alongside the existing probe tests in `DesktopShellEnvironment.test.ts`: hydration of the credentials from the login shell, and the group rule holding when the process already carries an access token. The first fails on `main`. The second is a regression guard against a later switch to per-name hydration; it passes before the fix, since nothing is hydrated at all then.

`apps/desktop` tests (16/16) and typecheck are clean, as are lint and format on the touched files.

---

Written by Claude Opus 5 in Claude Code, reviewed by me before submitting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication-related environment forwarding on desktop startup; behavior is constrained by all-or-nothing hydration and existing process env winning, with regression tests for mixed credential sets.
> 
> **Overview**
> **Fixes Bitbucket showing unauthenticated in the GUI** when credentials are only exported in the user’s shell profile (`~/.zshrc`, etc.), which session-launched desktop apps do not inherit.
> 
> The desktop login-shell probe now requests `T3CODE_BITBUCKET_ACCESS_TOKEN`, `T3CODE_BITBUCKET_EMAIL`, and `T3CODE_BITBUCKET_API_TOKEN` (same names the server reads from `process.env`). On POSIX, those values are copied into the process **only when none of the three are already set**, so an inherited access token is not combined with shell-probed email/API token pairs that would be ignored by precedence rules.
> 
> Tests cover full hydration from the shell and the “no mixing” case when an access token is already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec7039d2865ffc5fb7bef67ff9fbd11765d96b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `T3CODE_BITBUCKET_*` credentials from login shell in `installPosixEnvironment`
> - Adds `BITBUCKET_CREDENTIAL_ENV_NAMES` constant and includes it in `LOGIN_SHELL_ENV_NAMES` so the login shell probe reads `T3CODE_BITBUCKET_ACCESS_TOKEN`, `T3CODE_BITBUCKET_EMAIL`, and `T3CODE_BITBUCKET_API_TOKEN`
> - On POSIX, `installPosixEnvironment` copies these variables from the login shell snapshot into `config.env` only when none are already set in the process environment; if any one is already present, all shell values are skipped to avoid mixing an inherited token with shell-provided email/API token
> - Behavioral Change: a process that sets only `T3CODE_BITBUCKET_ACCESS_TOKEN` will no longer receive `T3CODE_BITBUCKET_EMAIL` or `T3CODE_BITBUCKET_API_TOKEN` from the login shell
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ec7039.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->