### PR TITLE
fix(web): keep start-from-origin setting visible

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2282,36 +2282,34 @@ export function GeneralSettingsPanel() {
           }
         />
 
-        {settings.defaultThreadEnvMode === "worktree" ? (
-          <SettingsRow
-            className="bg-muted/20 sm:pl-9"
-            title={searchableSetting("start-from-origin").title}
-            description="Creates the worktree from the latest matching branch on origin instead of your local branch."
-            resetAction={
-              settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
-                <SettingResetButton
-                  label="new worktrees start from origin"
-                  onClick={() =>
-                    updateSettings({
-                      newWorktreesStartFromOrigin:
-                        DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-                    })
-                  }
-                />
-              ) : null
-            }
-            control={
-              <Switch
-                checked={settings.newWorktreesStartFromOrigin}
-                onCheckedChange={(checked) =>
-                  updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
+        <SettingsRow
+          className="bg-muted/20 sm:pl-9"
+          title={searchableSetting("start-from-origin").title}
+          description="Creates the worktree from the latest matching branch on origin instead of your local branch."
+          resetAction={
+            settings.newWorktreesStartFromOrigin !==
+            DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+              <SettingResetButton
+                label="new worktrees start from origin"
+                onClick={() =>
+                  updateSettings({
+                    newWorktreesStartFromOrigin:
+                      DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                  })
                 }
-                aria-label="Start new worktrees from origin by default"
               />
-            }
-          />
-        ) : null}
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.newWorktreesStartFromOrigin}
+              onCheckedChange={(checked) =>
+                updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
+              }
+              aria-label="Start new worktrees from origin by default"
+            />
+          }
+        />
 
         <SettingsRow
           {...searchableSetting("add-project-starts-in")}


### PR DESCRIPTION
## What Changed

The General settings page now keeps **Start from origin** visible below **New threads** for both **Local** and **New worktree** defaults.

The existing setting behavior is unchanged. This removes only the visibility condition.

## Why

The option controls every new worktree, including one created manually when **Local** is the default. Hiding it in that mode made an active setting impossible to inspect or change.

Fixes #8876

## UI Changes

| Before | After |
| --- | --- |
| ![Before: Local hides Start from origin](https://github.com/user-attachments/assets/39ec5359-b688-45eb-b527-c7e0f26660f3) | ![After: Local shows Start from origin directly below it](https://github.com/user-attachments/assets/bd9614ed-b828-41de-8559-d3a8c03aa71d) |

## Verification

- `vp test run apps/web/src/components/settings/SettingsPanels.logic.test.ts apps/web/src/components/settings/settingsSearch.test.ts` (34 tests passed)
- `vp run --filter @t3tools/web typecheck`
- `vp lint --report-unused-disable-directives apps/web/src/components/settings/SettingsPanels.tsx`
- `vp fmt --check apps/web/src/components/settings/SettingsPanels.tsx`
- Chromium at 1440×900 with **New threads** set to **Local**

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable; there is no motion or timing change)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in settings UI; persisted setting and worktree behavior are unchanged.
> 
> **Overview**
> **Start from origin** under General settings is no longer hidden when **New threads** is set to **Local**.
> 
> The row stays nested under **New threads** (same switch, reset, and `newWorktreesStartFromOrigin` wiring); only the `defaultThreadEnvMode === "worktree"` guard was removed so users can view and edit the preference whenever worktrees might be created, not only when worktree is the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8035413fc8b5dd8ecab400db0471574c7d84cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep 'start-from-origin' setting row visible in `GeneralSettingsPanel`
> Removes the conditional guard that hid the 'start-from-origin' SettingsRow unless `defaultThreadEnvMode === 'worktree'`. The row and its Switch (bound to `newWorktreesStartFromOrigin`) now always render.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b803541.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Built with GPT-5.6-Sol in T3 Code through the Codex harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Start new worktrees from origin” setting is now always visible in General Settings, regardless of the selected default thread mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->