### PR TITLE
fix(claude): restore plan updates for Claude 5 sessions

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeHome.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.test.ts
@@ -20,13 +20,14 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         const resolved = path.resolve(NodeOS.homedir());
 
         expect(yield* resolveClaudeHomePath({ homePath: "" })).toBe(resolved);
-        expect((yield* makeClaudeEnvironment({ homePath: "" })).CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe(
-          "1",
-        );
+        const environment = yield* makeClaudeEnvironment({ homePath: "" }, { PATH: "/test/bin" });
+
+        expect(environment.PATH).toBe("/test/bin");
+        expect(environment.CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe("1");
       }),
     );
 
-    it.effect("merges the base environment and overrides the todo-tools flag", () =>
+    it.effect("merges the base environment and preserves an explicit todo-tools flag", () =>
       Effect.gen(function* () {
         const environment = yield* makeClaudeEnvironment(
           { homePath: "" },
@@ -34,7 +35,7 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         );
 
         expect(environment.PATH).toBe("/test/bin");
-        expect(environment.CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe("1");
+        expect(environment.CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe("0");
       }),
     );
 
@@ -45,7 +46,8 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         const resolved = path.resolve(NodeOS.homedir(), ".claude-work");
 
         expect(yield* resolveClaudeHomePath({ homePath })).toBe(resolved);
-        const environment = yield* makeClaudeEnvironment({ homePath });
+        const environment = yield* makeClaudeEnvironment({ homePath }, { PATH: "/test/bin" });
+        expect(environment.PATH).toBe("/test/bin");
         expect(environment.CLAUDE_CONFIG_DIR).toBe(resolved);
         expect(environment.CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe("1");
         expect(yield* makeClaudeContinuationGroupKey({ homePath })).toBe(`claude:home:${resolved}`);

--- a/apps/server/src/provider/Drivers/ClaudeHome.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.test.ts
@@ -20,7 +20,21 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         const resolved = path.resolve(NodeOS.homedir());
 
         expect(yield* resolveClaudeHomePath({ homePath: "" })).toBe(resolved);
-        expect(yield* makeClaudeEnvironment({ homePath: "" })).toBe(process.env);
+        expect((yield* makeClaudeEnvironment({ homePath: "" })).CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe(
+          "1",
+        );
+      }),
+    );
+
+    it.effect("merges the base environment and overrides the todo-tools flag", () =>
+      Effect.gen(function* () {
+        const environment = yield* makeClaudeEnvironment(
+          { homePath: "" },
+          { PATH: "/test/bin", CLAUDE_CODE_ENABLE_TODO_TOOLS: "0" },
+        );
+
+        expect(environment.PATH).toBe("/test/bin");
+        expect(environment.CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe("1");
       }),
     );
 
@@ -31,7 +45,9 @@ it.layer(NodeServices.layer)("ClaudeHome", (it) => {
         const resolved = path.resolve(NodeOS.homedir(), ".claude-work");
 
         expect(yield* resolveClaudeHomePath({ homePath })).toBe(resolved);
-        expect((yield* makeClaudeEnvironment({ homePath })).CLAUDE_CONFIG_DIR).toBe(resolved);
+        const environment = yield* makeClaudeEnvironment({ homePath });
+        expect(environment.CLAUDE_CONFIG_DIR).toBe(resolved);
+        expect(environment.CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe("1");
         expect(yield* makeClaudeContinuationGroupKey({ homePath })).toBe(`claude:home:${resolved}`);
         expect(yield* makeClaudeCapabilitiesCacheKey({ binaryPath: "claude", homePath })).toBe(
           `claude\0${resolved}\0`,

--- a/apps/server/src/provider/Drivers/ClaudeHome.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.ts
@@ -18,7 +18,10 @@ export const makeClaudeEnvironment = Effect.fn("makeClaudeEnvironment")(function
   config: Pick<ClaudeSettings, "homePath">,
   baseEnv?: NodeJS.ProcessEnv,
 ): Effect.fn.Return<NodeJS.ProcessEnv, never, Path.Path> {
-  const resolvedBaseEnv = baseEnv ?? process.env;
+  const resolvedBaseEnv = {
+    ...(baseEnv ?? process.env),
+    CLAUDE_CODE_ENABLE_TODO_TOOLS: "1",
+  };
   const homePath = config.homePath.trim();
   if (homePath.length === 0) return resolvedBaseEnv;
   const resolvedHomePath = yield* resolveClaudeHomePath(config);

--- a/apps/server/src/provider/Drivers/ClaudeHome.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.ts
@@ -18,9 +18,10 @@ export const makeClaudeEnvironment = Effect.fn("makeClaudeEnvironment")(function
   config: Pick<ClaudeSettings, "homePath">,
   baseEnv?: NodeJS.ProcessEnv,
 ): Effect.fn.Return<NodeJS.ProcessEnv, never, Path.Path> {
+  const sourceEnv = baseEnv ?? process.env;
   const resolvedBaseEnv = {
-    ...(baseEnv ?? process.env),
-    CLAUDE_CODE_ENABLE_TODO_TOOLS: "1",
+    ...sourceEnv,
+    CLAUDE_CODE_ENABLE_TODO_TOOLS: sourceEnv.CLAUDE_CODE_ENABLE_TODO_TOOLS ?? "1",
   };
   const homePath = config.homePath.trim();
   if (homePath.length === 0) return resolvedBaseEnv;


### PR DESCRIPTION
## Summary

Restore Claude task updates for Claude 5 sessions so T3 Code's existing plan sidebar can receive progress events again.

## Changes

- Enable `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in the shared Claude session environment builder.
- Preserve inherited environment values and the existing configured `CLAUDE_CONFIG_DIR` behavior.
- Add focused tests for default-home, configured-home, environment preservation, and override behavior.
- No UI or plan-event mapping changes.

## Testing

- `git diff --check` — passed.
- Focused `vp` tests, formatting, lint, and typecheck could not run locally because `vp` and `node_modules` are not installed in the checkout.

## Checklist

- [x] Focused backend change
- [x] Regression tests added
- [x] No dependency changes
- [x] No unrelated files changed
- [ ] Local `vp` checks (blocked by missing `vp`/`node_modules`)

Fixes #9029

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to Claude spawn environment defaults with regression tests; no auth, data, or UI changes.
> 
> **Overview**
> Restores Claude 5 plan/progress updates in T3 Code by ensuring spawned Claude CLI sessions get todo/plan tooling enabled when the flag isn’t already set.
> 
> **`makeClaudeEnvironment`** now builds a merged env from the optional `baseEnv` (or `process.env`) and sets **`CLAUDE_CODE_ENABLE_TODO_TOOLS`** to **`"1"`** only when that variable is missing—explicit values (including **`"0"`**) are left unchanged. Configured **`homePath`** behavior is unchanged: **`CLAUDE_CONFIG_DIR`** is still applied when a Claude home override is set.
> 
> Tests were updated to pass a minimal base env, assert the default flag, cover override preservation, and confirm **`PATH`** / **`CLAUDE_CONFIG_DIR`** still merge correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f097059a1c2557db365431af0e14f70dbcd35d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `todo-tools` default in `makeClaudeEnvironment` for Claude 5 sessions
> `makeClaudeEnvironment` in [ClaudeHome.ts](https://github.com/pingdotgg/t3code/pull/9031/files#diff-73ba6e23eba4250edbecbe8239d07a8f0556ddef26400793eb1b7432199ea29d) now shallow-copies the source environment and injects a default `todo-tools` flag when none is present, while preserving any explicit value. Both the no-home and configured-home return paths use this copied environment. Risk: callers that relied on receiving the raw process environment object without the `todo-tools` flag will now see the flag always present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f09705.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->