### PR TITLE
perf(server): skip full-message reads while streaming

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1462,6 +1462,8 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       const eventStore = yield* OrchestrationEventStore;
       const sql = yield* SqlClient.SqlClient;
       const now = "2026-01-01T00:00:00.000Z";
+      const streamingAt = "2026-01-01T00:00:01.000Z";
+      const completedAt = "2026-01-01T00:00:02.000Z";
 
       yield* eventStore.append({
         type: "project.created",
@@ -1526,7 +1528,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           role: "assistant",
           text: "hello",
           turnId: null,
-          streaming: false,
+          streaming: true,
           createdAt: now,
           updatedAt: now,
         },
@@ -1539,7 +1541,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         eventId: EventId.make("evt-a4"),
         aggregateKind: "thread",
         aggregateId: ThreadId.make("thread-a"),
-        occurredAt: now,
+        occurredAt: streamingAt,
         commandId: CommandId.make("cmd-a4"),
         causationEventId: null,
         correlationId: CorrelationId.make("cmd-a4"),
@@ -1551,18 +1553,61 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           text: " world",
           turnId: null,
           streaming: true,
-          createdAt: now,
-          updatedAt: now,
+          createdAt: streamingAt,
+          updatedAt: streamingAt,
         },
       });
 
       yield* projectionPipeline.bootstrap;
       yield* projectionPipeline.bootstrap;
 
-      const messageRows = yield* sql<{ readonly text: string }>`
-        SELECT text FROM projection_thread_messages WHERE message_id = 'message-a'
+      yield* eventStore.append({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-a5"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-a"),
+        occurredAt: completedAt,
+        commandId: CommandId.make("cmd-a5"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-a5"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-a"),
+          messageId: MessageId.make("message-a"),
+          role: "assistant",
+          text: "",
+          turnId: null,
+          streaming: false,
+          createdAt: completedAt,
+          updatedAt: completedAt,
+        },
+      });
+
+      yield* projectionPipeline.bootstrap;
+      yield* projectionPipeline.bootstrap;
+
+      const messageRows = yield* sql<{
+        readonly text: string;
+        readonly isStreaming: number;
+        readonly createdAt: string;
+        readonly updatedAt: string;
+      }>`
+        SELECT
+          text,
+          is_streaming AS "isStreaming",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM projection_thread_messages
+        WHERE message_id = 'message-a'
       `;
-      assert.deepEqual(messageRows, [{ text: "hello world" }]);
+      assert.deepEqual(messageRows, [
+        {
+          text: "hello world",
+          isStreaming: 0,
+          createdAt: now,
+          updatedAt: completedAt,
+        },
+      ]);
 
       const stateRows = yield* sql<{
         readonly projector: string;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1008,21 +1008,34 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
 
         case "thread.message-sent": {
+          if (event.payload.streaming) {
+            const attachments =
+              event.payload.attachments !== undefined
+                ? yield* materializeAttachmentsForProjection({
+                    attachments: event.payload.attachments,
+                  })
+                : undefined;
+            yield* projectionThreadMessageRepository.appendStreaming({
+              messageId: event.payload.messageId,
+              threadId: event.payload.threadId,
+              turnId: event.payload.turnId,
+              role: event.payload.role,
+              text: event.payload.text,
+              ...(attachments !== undefined ? { attachments: [...attachments] } : {}),
+              createdAt: event.payload.createdAt,
+              updatedAt: event.payload.updatedAt,
+            });
+            return;
+          }
+
           const existingMessage = yield* projectionThreadMessageRepository.getByMessageId({
             messageId: event.payload.messageId,
           });
           const previousMessage = Option.getOrUndefined(existingMessage);
           const nextText = Option.match(existingMessage, {
             onNone: () => event.payload.text,
-            onSome: (message) => {
-              if (event.payload.streaming) {
-                return `${message.text}${event.payload.text}`;
-              }
-              if (event.payload.text.length === 0) {
-                return message.text;
-              }
-              return event.payload.text;
-            },
+            onSome: (message) =>
+              event.payload.text.length === 0 ? message.text : event.payload.text,
           });
           const nextAttachments =
             event.payload.attachments !== undefined
@@ -1037,7 +1050,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             role: event.payload.role,
             text: nextText,
             ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
-            isStreaming: event.payload.streaming,
+            isStreaming: false,
             createdAt: previousMessage?.createdAt ?? event.payload.createdAt,
             updatedAt: event.payload.updatedAt,
           });

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
@@ -12,6 +12,71 @@ const layer = it.layer(
 );
 
 layer("ProjectionThreadMessageRepository", (it) => {
+  it.effect("appends streaming text and applies attachment updates", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadMessageRepository;
+      const threadId = ThreadId.make("thread-streaming-append");
+      const messageId = MessageId.make("message-streaming-append");
+      const createdAt = "2026-02-28T19:05:00.000Z";
+      const attachments = [
+        {
+          type: "image" as const,
+          id: "thread-streaming-append-att-1",
+          name: "example.png",
+          mimeType: "image/png",
+          sizeBytes: 5,
+        },
+      ];
+
+      yield* repository.appendStreaming({
+        messageId,
+        threadId,
+        turnId: null,
+        role: "assistant",
+        text: "hello",
+        attachments,
+        createdAt,
+        updatedAt: createdAt,
+      });
+      yield* repository.appendStreaming({
+        messageId,
+        threadId,
+        turnId: null,
+        role: "assistant",
+        text: " world",
+        createdAt: "2026-02-28T19:05:01.000Z",
+        updatedAt: "2026-02-28T19:05:01.000Z",
+      });
+
+      const rowWithPreservedAttachments = yield* repository.getByMessageId({ messageId });
+      assert.equal(rowWithPreservedAttachments._tag, "Some");
+      if (rowWithPreservedAttachments._tag === "Some") {
+        assert.deepEqual(rowWithPreservedAttachments.value.attachments, attachments);
+      }
+
+      yield* repository.appendStreaming({
+        messageId,
+        threadId,
+        turnId: null,
+        role: "assistant",
+        text: "",
+        attachments: [],
+        createdAt: "2026-02-28T19:05:02.000Z",
+        updatedAt: "2026-02-28T19:05:02.000Z",
+      });
+
+      const row = yield* repository.getByMessageId({ messageId });
+      assert.equal(row._tag, "Some");
+      if (row._tag === "Some") {
+        assert.equal(row.value.text, "hello world");
+        assert.deepEqual(row.value.attachments, []);
+        assert.equal(row.value.createdAt, createdAt);
+        assert.equal(row.value.updatedAt, "2026-02-28T19:05:02.000Z");
+        assert.isTrue(row.value.isStreaming);
+      }
+    }),
+  );
+
   it.effect("preserves existing attachments when upsert omits attachments", () =>
     Effect.gen(function* () {
       const repository = yield* ProjectionThreadMessageRepository;

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -9,6 +9,7 @@ import { ChatAttachment } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
+  AppendStreamingProjectionThreadMessage,
   GetProjectionThreadMessageInput,
   ProjectionThreadMessageRepository,
   type ProjectionThreadMessageRepositoryShape,
@@ -95,6 +96,50 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
     },
   });
 
+  const appendStreamingProjectionThreadMessageRow = SqlSchema.void({
+    Request: AppendStreamingProjectionThreadMessage,
+    execute: (row) => {
+      const nextAttachmentsJson =
+        row.attachments !== undefined ? JSON.stringify(row.attachments) : null;
+      return sql`
+        INSERT INTO projection_thread_messages (
+          message_id,
+          thread_id,
+          turn_id,
+          role,
+          text,
+          attachments_json,
+          is_streaming,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          ${row.messageId},
+          ${row.threadId},
+          ${row.turnId},
+          ${row.role},
+          ${row.text},
+          ${nextAttachmentsJson},
+          1,
+          ${row.createdAt},
+          ${row.updatedAt}
+        )
+        ON CONFLICT (message_id)
+        DO UPDATE SET
+          thread_id = excluded.thread_id,
+          turn_id = excluded.turn_id,
+          role = excluded.role,
+          text = projection_thread_messages.text || excluded.text,
+          attachments_json = COALESCE(
+            excluded.attachments_json,
+            projection_thread_messages.attachments_json
+          ),
+          is_streaming = 1,
+          updated_at = excluded.updated_at
+      `;
+    },
+  });
+
   const getProjectionThreadMessageRow = SqlSchema.findOneOption({
     Request: GetProjectionThreadMessageInput,
     Result: ProjectionThreadMessageDbRowSchema,
@@ -151,6 +196,13 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
       Effect.mapError(toPersistenceSqlError("ProjectionThreadMessageRepository.upsert:query")),
     );
 
+  const appendStreaming: ProjectionThreadMessageRepositoryShape["appendStreaming"] = (row) =>
+    appendStreamingProjectionThreadMessageRow(row).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionThreadMessageRepository.appendStreaming:query"),
+      ),
+    );
+
   const getByMessageId: ProjectionThreadMessageRepositoryShape["getByMessageId"] = (input) =>
     getProjectionThreadMessageRow(input).pipe(
       Effect.mapError(
@@ -176,6 +228,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
 
   return {
     upsert,
+    appendStreaming,
     getByMessageId,
     listByThreadId,
     deleteByThreadId,

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -16,6 +16,7 @@ import {
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 import * as Context from "effect/Context";
+import * as Struct from "effect/Struct";
 import type * as Option from "effect/Option";
 import type * as Effect from "effect/Effect";
 
@@ -33,6 +34,12 @@ export const ProjectionThreadMessage = Schema.Struct({
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadMessage = typeof ProjectionThreadMessage.Type;
+
+export const AppendStreamingProjectionThreadMessage = Schema.Struct(
+  Struct.omit(ProjectionThreadMessage.fields, ["isStreaming"]),
+);
+export type AppendStreamingProjectionThreadMessage =
+  typeof AppendStreamingProjectionThreadMessage.Type;
 
 export const ListProjectionThreadMessagesInput = Schema.Struct({
   threadId: ThreadId,
@@ -60,6 +67,11 @@ export interface ProjectionThreadMessageRepositoryShape {
    */
   readonly upsert: (
     message: ProjectionThreadMessage,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  /** Insert a streaming message or append text to its existing row. */
+  readonly appendStreaming: (
+    message: AppendStreamingProjectionThreadMessage,
   ) => Effect.Effect<void, ProjectionRepositoryError>;
 
   /**


### PR DESCRIPTION
Each streaming message chunk read the current projected message into Node, joined the text, and wrote the full accumulated message back to SQLite. This added one query per chunk and copied more text as the message grew.

This change gives streaming messages a dedicated repository operation. SQLite appends each delta during the upsert. It preserves the original creation time and keeps existing attachments when the event omits attachment data. Empty attachment arrays still clear attachments. Completed messages keep the existing replace-or-preserve behavior.

Buffered delivery remains the default, so most turns do not use this path often. The change mainly helps configurations that still emit many message deltas.

This only changes the shared server projector. It does not change clients, providers, contracts, migrations, or transport.

## Related work

| PR | Credit and outcome |
| --- | --- |
| [#5651](https://github.com/pingdotgg/t3code/pull/5651) by the T3 Code bot | This PR uses its atomic SQLite append idea. It does not include the transaction, startup, thread, or turn changes from that PR. |
| [#6608](https://github.com/pingdotgg/t3code/pull/6608) by @x1xhlol | Its server shell-summary scan idea is already on `main`. Its client activity cache is separate from this change. |
| [#6613](https://github.com/pingdotgg/t3code/pull/6613) by @patroza | Its selective activity-read idea is already on `main`. |
| [#8993](https://github.com/pingdotgg/t3code/pull/8993) and [#8995](https://github.com/pingdotgg/t3code/pull/8995) by @rcawston | We reviewed both proposals. The SQL count rewrite is not needed here, and `main` no longer reads all activities on this path. |

The related server scan fixes landed through [#8150](https://github.com/pingdotgg/t3code/pull/8150) and [#8988](https://github.com/pingdotgg/t3code/pull/8988).

We also reviewed adjacent stream work in [#5344](https://github.com/pingdotgg/t3code/pull/5344) by @danvernon, [#8309](https://github.com/pingdotgg/t3code/pull/8309) by @lnieuwenhuis, [#6004](https://github.com/pingdotgg/t3code/pull/6004) by @cheruvian, [#4349](https://github.com/pingdotgg/t3code/pull/4349) by @nateEc, and [#4794](https://github.com/pingdotgg/t3code/pull/4794) by @t3dotgg. Those PRs change client batching, provider progress events, Markdown render timing, or native iOS transport, so they stay separate.

## Verification

- 98 tests passed across the message repository, projection pipeline, provider ingestion, and orchestration engine test files
- server typecheck passed
- targeted lint and format checks passed
- `git diff --check` passed

Made with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core projection persistence for assistant streaming messages; incorrect append or completion logic could corrupt message text or attachment state, but scope is limited to the server projector and is well covered by tests.
> 
> **Overview**
> Streaming `thread.message-sent` events no longer load the full projected message into Node to concatenate text on each chunk. The thread-messages projector now calls a new **`appendStreaming`** repository path that upserts with SQLite `text || excluded.text`, keeps **`is_streaming`** set, and uses **`COALESCE`** so omitted attachment payloads preserve existing JSON while an explicit empty array still clears attachments.
> 
> **Non-streaming** completion events still **`upsert`**: text is replaced unless the payload text is empty (then prior text is kept), and **`is_streaming`** is always written as false with **`created_at`** taken from the existing row when present.
> 
> Tests cover repository append behavior and extend the projection-pipeline resume scenario with streaming chunks plus a final completion event (asserting merged text, timestamps, and **`is_streaming`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36124a05b72b9426393735514d850f83b327825e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip full-message upserts during streaming via `appendStreaming` in projection pipeline
> - Adds `appendStreaming` to the `ProjectionThreadMessageRepository` that inserts with `is_streaming=1` and, on conflict, concatenates incoming text to existing text while preserving `created_at` and prior attachments.
> - Routes `thread.message-sent` events with `streaming=true` in `ProjectionPipeline` to `appendStreaming` instead of `upsert`, avoiding full-message overwrites on every chunk.
> - On non-streaming (final) events, the projector finalizes the row via `upsert` with `isStreaming=false`, replacing text unless the incoming text is empty, and preserving `createdAt` from the prior row.
> - Behavioral Change: streaming events no longer overwrite the full message row — text is appended incrementally and `isStreaming` stays `1` until the completion event arrives; existing tests in [ProjectionPipeline.test.ts](https://github.com/pingdotgg/t3code/pull/9032/files#diff-929eb6fd844fad565d5af8faa7348834ab85ad5457f22d71861e6ee886a18fda) and [ProjectionThreadMessages.test.ts](https://github.com/pingdotgg/t3code/pull/9032/files#diff-2581f96350e123d3eb6bb5ba2e637fb414f5be16e2a5f878e6b0941d88b0123c) are updated to cover this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36124a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->