### PR TITLE
fix(web): align un-settle banner action

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4924,7 +4924,6 @@ function ChatViewContent(props: ChatViewProps) {
         : "Sending a message moves it back to Active in the sidebar.",
       actions: (
         <Button
-          className="translate-y-2"
           size="xs"
           variant="outline"
           disabled={isSnoozed ? isUnsnoozing : isUnsettling}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4924,6 +4924,7 @@ function ChatViewContent(props: ChatViewProps) {
         : "Sending a message moves it back to Active in the sidebar.",
       actions: (
         <Button
+          className="translate-y-2"
           size="xs"
           variant="outline"
           disabled={isSnoozed ? isUnsnoozing : isUnsettling}

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -270,7 +270,18 @@ function ComposerBannerStackAlert({
     >
       <ComposerBanner.Row layout="wrap-actions">
         <ComposerBanner.Icon>{item.icon}</ComposerBanner.Icon>
-        <ComposerBanner.Content className="font-medium">{item.title}</ComposerBanner.Content>
+        <ComposerBanner.Content
+          className={item.description ? "flex-col items-start gap-0" : "font-medium"}
+        >
+          {item.description ? (
+            <>
+              <span className="font-medium">{item.title}</span>
+              <span className="text-muted-foreground">{item.description}</span>
+            </>
+          ) : (
+            item.title
+          )}
+        </ComposerBanner.Content>
         {item.actions || item.onDismiss ? (
           <ComposerBanner.Actions>
             {item.actions}
@@ -284,19 +295,7 @@ function ComposerBannerStackAlert({
           </ComposerBanner.Actions>
         ) : null}
       </ComposerBanner.Row>
-      {item.description || item.children ? (
-        <ComposerBanner.Children>
-          {item.description ? (
-            <ComposerBanner.Row>
-              <ComposerBanner.Icon />
-              <ComposerBanner.Content className="text-muted-foreground">
-                {item.description}
-              </ComposerBanner.Content>
-            </ComposerBanner.Row>
-          ) : null}
-          {item.children}
-        </ComposerBanner.Children>
-      ) : null}
+      {item.children ? <ComposerBanner.Children>{item.children}</ComposerBanner.Children> : null}
     </ComposerBanner.Root>
   );
 }

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -269,7 +269,9 @@ function ComposerBannerStackAlert({
       className={item.className}
     >
       <ComposerBanner.Row layout="wrap-actions">
-        <ComposerBanner.Icon>{item.icon}</ComposerBanner.Icon>
+        <ComposerBanner.Icon className={item.description ? "min-h-4 self-start" : undefined}>
+          {item.icon}
+        </ComposerBanner.Icon>
         <ComposerBanner.Content
           className={item.description ? "flex-col items-start gap-0" : "font-medium"}
         >


### PR DESCRIPTION
The Un-settle action was aligned to the title row, which left it visibly too high next to the settled banner's two lines of text.

Render banner titles and descriptions in one content column so actions center against the complete text block through the shared banner layout. Two-line banner icons stay aligned to their title. This also aligns Wake now, Compact, and dismiss actions on other two-line composer banners.

## Before

![Un-settle action aligned too high](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/62493478-011e-4c14-9bce-f8cf4873ad6d/unsettle-before.png)

## After

![Un-settle action centered across the banner text](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/79ac0356-fbbe-408f-9aa0-b24a6cd3542f/unsettle-after-v3.png)

Verified in the web client with Playwright at a 1440 x 900 viewport. The action and combined text block both center at y=684, while the icon and title both begin at y=668. Targeted lint and git diff checks pass.

Created by GPT-5.6 using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in `ComposerBannerStackAlert`; no auth, data, or API behavior.
> 
> **Overview**
> Fixes composer alert banners where **actions sat too high** when a title and description stacked (e.g. the settled **Un-settle** control).
> 
> **Title and description** now render together in one `ComposerBanner.Content` column (bold title, muted description) instead of a second row under `ComposerBanner.Children`. The icon uses **top alignment** when a description is present so it lines up with the text block. `ComposerBanner.Children` is only used for optional `item.children`, not descriptions.
> 
> Actions in the shared `wrap-actions` row **vertically center against the full text block**, so two-line banners (Unsettle, Wake now, Compact, dismiss) align consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0e3475f54682d200f030053227261ff0164cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix banner alignment in `ComposerBannerStackAlert` when description is present
> Renders the title and description inline within the main `Content` block instead of a separate `Children` section, with the title as a bold span and description as a muted span. The `Icon` now conditionally receives alignment/sizing classes when a description exists, and the `Children` section only renders `item.children` if explicitly provided. Risk: banners that relied on the auto-rendered description inside `ComposerBanner.Children` will no longer show it unless passed via `item.children`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a0e347.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->