### PR TITLE
fix(server): use Bitbucket workspace permissions endpoint

### DIFF
--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -855,7 +855,7 @@ layer("BitbucketPullRequestApi.layer", (it) => {
 
       assert.isFalse(yield* api.getRepositoryPermission({ repository: "acme/web" }));
 
-      expect(callAt(0).url).toContain("/user/permissions/repositories");
+      expect(callAt(0).url).toContain("/user/workspaces/acme/permissions/repositories");
       assert.strictEqual(filterOfCall(0), 'repository.full_name="acme/web"');
     }),
   );
@@ -874,27 +874,34 @@ layer("BitbucketPullRequestApi.layer", (it) => {
   );
 
   it.effect(
-    "reads a removed permissions endpoint as granted rather than failing the merge on it",
+    "uses the supported workspace permission endpoint when the removed one returns 404",
     () =>
       Effect.gen(function* () {
-        // Bitbucket retired /user/permissions/repositories under CHANGE-2770: every account now
-        // gets HTTP 410 here, whatever it may do.
-        mockedRequest.mockReturnValue(
-          Effect.fail(
-            new BitbucketApi.BitbucketResponseError({
-              operation: "request",
-              status: 410,
-              responseBodyLength: 0,
-            }),
-          ),
+        mockedRequest.mockImplementation((input) =>
+          input.url.startsWith("/user/workspaces/acme/permissions/repositories?")
+            ? Effect.succeed(
+                response(
+                  JSON.stringify({
+                    values: [{ type: "repository_permission", permission: "write" }],
+                  }),
+                ),
+              )
+            : Effect.fail(
+                new BitbucketApi.BitbucketResponseError({
+                  operation: "request",
+                  status: 404,
+                  responseBodyLength: 0,
+                }),
+              ),
         );
         const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
 
         assert.isTrue(yield* api.getRepositoryPermission({ repository: "acme/web" }));
+        expect(callAt(0).url).toContain("/user/workspaces/acme/permissions/repositories");
       }),
   );
 
-  it.effect("still fails the permission read on a failure that is not the removed endpoint", () =>
+  it.effect("fails the permission read on an authentication failure", () =>
     Effect.gen(function* () {
       mockedRequest.mockReturnValue(
         Effect.fail(

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -109,16 +109,6 @@ export type BitbucketPullRequestApiError =
   | BitbucketDiffCommitError;
 
 /**
- * `/user/permissions/repositories` answering CHANGE-2770's removal notice rather than a
- * permission — Bitbucket sends this for every account now, not only ones it would have refused.
- */
-function isRepositoryPermissionRemovedError(
-  error: BitbucketPullRequestApiError,
-): error is BitbucketApi.BitbucketResponseError {
-  return error._tag === "BitbucketResponseError" && error.status === 410;
-}
-
-/**
  * Bitbucket's own ceiling. Asking for more does not fail — it answers with an empty page and no
  * error at all, so this is a number to respect rather than to push against.
  */
@@ -574,26 +564,19 @@ export const make = Effect.gen(function* () {
         }),
       ),
 
-    // Nothing on the repository, the pull request or the workspace states what the credentials
-    // may do, so this endpoint is the one request Bitbucket makes unavoidable. It is asked
-    // alongside the reads the detail was already making, so it costs no round trip of its own.
-    //
-    // Bitbucket permanently removed this endpoint (CHANGE-2770): every account now gets HTTP 410
-    // in place of an answer, whatever it may do. That is the deprecated-endpoint signal, not a
-    // permission being refused, so it is read the same way an unreachable read already is
-    // elsewhere — as a permission that could not be learned, which grants rather than blocks, and
-    // leaves the actual merge or write to say why if the account may not do it. Any other failure
-    // (a bad token, a network fault, an unreadable body) still fails as it did before.
+    // Bitbucket keeps the configured user's effective repository permissions under its workspace.
+    // This request runs alongside the reads the detail was already making, so it costs no round
+    // trip of its own.
     getRepositoryPermission: (input) =>
-      withRepository(input.repository, () =>
+      withRepository(input.repository, (_, workspace) =>
         readPage({
           operation: "getRepositoryPermission",
-          url: `/user/permissions/repositories?q=${encodeURIComponent(
+          url: `/user/workspaces/${encodeURIComponent(workspace)}/permissions/repositories?q=${encodeURIComponent(
             `repository.full_name="${filterLiteral(input.repository.trim())}"`,
           )}`,
           decode: decodeRepositoryPermissionJson,
         }),
-      ).pipe(Effect.catchIf(isRepositoryPermissionRemovedError, () => Effect.succeed(true))),
+      ),
 
     getPullRequestDiff: (input) =>
       input.commit !== undefined && !isCommitSha(input.commit)


### PR DESCRIPTION
## What Changed

Bitbucket pull request permission checks now use the supported, workspace-scoped endpoint:

`GET /2.0/user/workspaces/{workspace}/permissions/repositories`

The server still filters the response to the requested repository and decodes the same effective `admin`, `write`, or `read` permission. The old HTTP 410 fallback was removed with the retired endpoint.

A regression test makes any request to the old endpoint fail with HTTP 404 and verifies that the supported endpoint succeeds. The existing authentication-failure coverage remains in place.

## Why

Before every pull request write, `PullRequestService` asks the provider for the viewer's permissions. T3 Code used Bitbucket's removed `/user/permissions/repositories` endpoint for that preflight. Some Bitbucket accounts now receive HTTP 404 from the endpoint, so `getViewerPermissions` failed and the server never sent the requested comment.

The replacement endpoint reports the authenticated caller's effective repository permissions and accepts the existing `read:repository:bitbucket` API-token scope. Using it fixes the preflight without hiding real HTTP 401, HTTP 403, network, or response-decoding failures.

Closes #9034

## Verification

- `vp test run apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts apps/server/src/pullRequest/BitbucketPullRequestProvider.test.ts` — 47 tests passed
- Targeted formatting check passed
- Targeted lint passed
- Server typecheck passed; it reports only existing suggestions in unrelated files
- `git diff --check` passed

This was not tested by posting a comment to a live Bitbucket Cloud pull request.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable because this is a server-only change
- [x] A video is not applicable because this does not change motion or interaction

Authored with gpt-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preflight permission checks before Bitbucket PR writes; wrong endpoint or decoding could block comments/merges, though scope is limited to Bitbucket integration code with updated tests.
> 
> **Overview**
> **Bitbucket repository permission preflight** now calls `GET /user/workspaces/{workspace}/permissions/repositories` instead of the retired `/user/permissions/repositories` route, using the workspace parsed from `workspace/slug` while keeping the same `repository.full_name` filter and permission decoding.
> 
> The **HTTP 410 “endpoint removed” workaround** is gone: `getRepositoryPermission` no longer treats a deprecated-endpoint response as “permission unknown → allow” and instead surfaces real API outcomes (e.g. **401** still fails the read).
> 
> Tests were updated to assert the new URL, exercise success via the workspace endpoint when other URLs would 404, and rename the auth-failure case accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da055cd51dadb502bf2c2ccbf1bb9f769589cd6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch `BitbucketPullRequestApi.getRepositoryPermission` to workspace permissions endpoint
> Replaces the deprecated `/user/permissions/repositories` call with `/user/workspaces/{workspace}/permissions/repositories` (workspace URL-encoded). The filter query and escaping behavior are unchanged.
> - Removes the `isRepositoryPermissionRemovedError` helper and its special-case catch that treated an HTTP 410 from the old endpoint as an implicit grant.
> - Updates tests to expect the new workspace-scoped URL and verifies that 401 failures still propagate as failures.
> - Risk: errors from the new endpoint now propagate normally instead of a 410 being converted to `true`; callers of `getRepositoryPermission` that relied on the old 410-as-success behavior in [BitbucketPullRequestApi.ts](https://github.com/pingdotgg/t3code/pull/9035/files#diff-b8db316b58d8493059f93e4d1bec9cbf008091ccb14abcf8a88defe4de2fc842) will see different results when the endpoint returns 410.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da055cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->