### PR TITLE
feat: add Clauded and Dodex provider aliases

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -80,6 +80,12 @@ export class ServerConfig extends Context.Service<
     readonly devAllowedOrigins: ReadonlyArray<string>;
     readonly noBrowser: boolean;
     readonly startupPresentation: StartupPresentation;
+    /**
+     * Load the first-party Clauded/Dodex alternate CLI instances. Production
+     * configs default this on; test configs turn it off to keep provider
+     * fixtures hermetic.
+     */
+    readonly enableHarnessProviderAliases?: boolean | undefined;
     readonly desktopBootstrapToken: string | undefined;
     readonly desktopTelemetryFd?: number | undefined;
     readonly desktopTelemetryControlFd?: number | undefined;
@@ -211,6 +217,7 @@ const makeTest = Effect.fn("ServerConfig.makeTest")(function* (
     devAllowedOrigins: [],
     noBrowser: false,
     startupPresentation: "browser",
+    enableHarnessProviderAliases: false,
   });
 });
 

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -32,6 +32,7 @@ import { makeClaudeAdapter } from "../Layers/ClaudeAdapter.ts";
 import {
   checkClaudeProviderStatus,
   makePendingClaudeProvider,
+  readClaudeHarnessModelCatalog,
   probeClaudeCapabilities,
 } from "../Layers/ClaudeProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
@@ -60,6 +61,11 @@ const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CAPABILITIES_PROBE_TTL = Duration.minutes(5);
+
+function isClaudeHarnessBinary(binaryPath: string): boolean {
+  const normalized = normalizeCommandPath(binaryPath);
+  return normalized === "clauded" || normalized.endsWith("/clauded");
+}
 
 function isClaudeNativeCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
@@ -134,6 +140,20 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         instanceId,
       });
       const effectiveConfig = { ...config, enabled } satisfies ClaudeSettings;
+      // Clauded writes a replacement model picker in its isolated config.
+      // Load it once per instance so T3 can expose one model row with the
+      // model's effort levels as traits (never one row per effort alias).
+      const harnessModelCatalog = yield* readClaudeHarnessModelCatalog(effectiveConfig).pipe(
+        Effect.orElseSucceed(() => undefined),
+      );
+      // The harness launcher refreshes its OpenCode catalog before every
+      // invocation. T3's periodic health probe must stay lightweight, so use
+      // the native Claude executable against the already-synced isolated
+      // CLAUDE_CONFIG_DIR for probes while keeping the harness binary for all
+      // real sessions and text generation.
+      const healthConfig = isClaudeHarnessBinary(effectiveConfig.binaryPath)
+        ? { ...effectiveConfig, binaryPath: "claude" }
+        : effectiveConfig;
       const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,
@@ -160,23 +180,29 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         capacity: 1,
         timeToLive: CAPABILITIES_PROBE_TTL,
         lookup: () =>
-          probeClaudeCapabilities(effectiveConfig, processEnv, cwd).pipe(
+          probeClaudeCapabilities(healthConfig, processEnv, cwd).pipe(
             Effect.provideService(Path.Path, path),
           ),
       });
-      const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
+      const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(healthConfig, cwd);
 
       // Kick the TTL-gated manifest refresh in the background and classify
       // with the in-memory manifest, so a slow or hung fetch never delays the
       // provider check. A refresh that lands mid-probe applies on the next one.
       const checkProvider = modelManifest.refreshInBackground.pipe(
         Effect.andThen(
+          readClaudeHarnessModelCatalog(effectiveConfig).pipe(
+            Effect.orElseSucceed(() => harnessModelCatalog),
+          ),
+        ),
+        Effect.flatMap((latestHarnessModelCatalog) =>
           Effect.zipWith(
             checkClaudeProviderStatus(
-              effectiveConfig,
+              healthConfig,
               () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
               processEnv,
               cwd,
+              latestHarnessModelCatalog,
             ),
             modelManifest.current,
             (draft, manifest) =>
@@ -197,7 +223,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
         initialSnapshot: (settings) =>
           Effect.zipWith(
-            makePendingClaudeProvider(settings.provider),
+            makePendingClaudeProvider(settings.provider, harnessModelCatalog),
             modelManifest.current,
             (draft, manifest) =>
               stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -12,13 +12,19 @@
  *
  * @module provider/Drivers/ClaudeDriver
  */
-import { ClaudeSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import {
+  ClaudeSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Duration from "effect/Duration";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -146,6 +152,10 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const harnessModelCatalog = yield* readClaudeHarnessModelCatalog(effectiveConfig).pipe(
         Effect.orElseSucceed(() => undefined),
       );
+      const harnessModelCatalogRef = yield* Ref.make<
+        ReadonlyArray<ServerProviderModel> | undefined
+      >(harnessModelCatalog);
+      const getHarnessModelCatalog = () => Ref.get(harnessModelCatalogRef);
       // The harness launcher refreshes its OpenCode catalog before every
       // invocation. T3's periodic health probe must stay lightweight, so use
       // the native Claude executable against the already-synced isolated
@@ -169,10 +179,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const adapterOptions = {
         instanceId,
         environment: processEnv,
+        getHarnessModelCatalog,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       };
       const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);
-      const textGeneration = yield* makeClaudeTextGeneration(effectiveConfig, processEnv);
+      const textGeneration = yield* makeClaudeTextGeneration(
+        effectiveConfig,
+        processEnv,
+        getHarnessModelCatalog,
+      );
 
       // Per-instance capabilities cache: keyed on binary + resolved HOME so
       // account-specific probes never share auth metadata across instances.
@@ -196,18 +211,22 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
           ),
         ),
         Effect.flatMap((latestHarnessModelCatalog) =>
-          Effect.zipWith(
-            checkClaudeProviderStatus(
-              healthConfig,
-              () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
-              processEnv,
-              cwd,
-              latestHarnessModelCatalog,
+          Ref.set(harnessModelCatalogRef, latestHarnessModelCatalog).pipe(
+            Effect.andThen(
+              Effect.zipWith(
+                checkClaudeProviderStatus(
+                  healthConfig,
+                  () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
+                  processEnv,
+                  cwd,
+                  latestHarnessModelCatalog,
+                ),
+                modelManifest.current,
+                (draft, manifest) =>
+                  stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
+                { concurrent: true },
+              ),
             ),
-            modelManifest.current,
-            (draft, manifest) =>
-              stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
-            { concurrent: true },
           ),
         ),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -35,6 +35,7 @@ import {
   type ProviderRuntimeTurnStatus,
   type ProviderSendTurnInput,
   type ProviderSession,
+  type ServerProviderModel,
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   type RuntimeContentStreamKind,
@@ -333,6 +334,10 @@ export interface ClaudeAdapterLiveOptions {
   }) => ClaudeQueryRuntime;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
+  /** Read the current per-instance Clauded catalog without module-global state. */
+  readonly getHarnessModelCatalog?: () => Effect.Effect<
+    ReadonlyArray<ServerProviderModel> | undefined
+  >;
 }
 
 function isUuid(value: string): boolean {
@@ -383,8 +388,9 @@ function normalizeClaudeStreamMessages(
 function getEffectiveClaudeAgentEffort(
   effort: string | null | undefined,
   model: string | null | undefined,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
 ): ClaudeSdkEffort | null {
-  const normalized = normalizeClaudeCliEffort(effort, model);
+  const normalized = normalizeClaudeCliEffort(effort, model, harnessModelCatalog);
   return normalized ? (normalized as ClaudeSdkEffort) : null;
 }
 
@@ -471,6 +477,7 @@ function maxClaudeContextWindowFromModelUsage(
 
 function selectedClaudeContextWindow(
   modelSelection: ModelSelection | undefined,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
 ): number | undefined {
   switch (modelSelection?.model) {
     case "claude-opus-4-8":
@@ -479,7 +486,7 @@ function selectedClaudeContextWindow(
       return 1_000_000;
   }
 
-  switch (resolveClaudeContextWindow(modelSelection)) {
+  switch (resolveClaudeContextWindow(modelSelection, harnessModelCatalog)) {
     case "1m":
       return 1_000_000;
     case "200k":
@@ -1234,6 +1241,7 @@ const CLAUDE_SETTING_SOURCES = [
 function buildPromptText(
   input: ProviderSendTurnInput,
   boundInstanceId: ProviderInstanceId,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
 ): string {
   const rawEffort =
     input.modelSelection?.instanceId === boundInstanceId
@@ -1241,7 +1249,7 @@ function buildPromptText(
       : null;
   const claudeModel =
     input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection.model : undefined;
-  const caps = getClaudeModelCapabilities(claudeModel);
+  const caps = getClaudeModelCapabilities(claudeModel, harnessModelCatalog);
 
   const promptEffort = resolvePromptInjectedEffort(caps, rawEffort);
   return applyClaudePromptEffortPrefix(input.input?.trim() ?? "", promptEffort);
@@ -1281,9 +1289,14 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
     readonly fileSystem: FileSystem.FileSystem;
     readonly attachmentsDir: string;
     readonly boundInstanceId: ProviderInstanceId;
+    readonly harnessModelCatalog: ReadonlyArray<ServerProviderModel> | undefined;
   },
 ) {
-  const text = buildPromptText(input, dependencies.boundInstanceId);
+  const text = buildPromptText(
+    input,
+    dependencies.boundInstanceId,
+    dependencies.harnessModelCatalog,
+  );
   const sdkContent: Array<Record<string, unknown>> = [];
 
   if (text.length > 0) {
@@ -1682,6 +1695,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   options?: ClaudeAdapterLiveOptions,
 ) {
   const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("claudeAgent");
+  const readHarnessModelCatalog =
+    options?.getHarnessModelCatalog ??
+    (() => Effect.succeed<ReadonlyArray<ServerProviderModel> | undefined>(undefined));
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig;
@@ -4245,10 +4261,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const extraArgs = parseCliArgs(claudeSettings.launchArgs).flags;
       const modelSelection =
         input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
-      const caps = getClaudeModelCapabilities(modelSelection?.model);
+      const harnessModelCatalog = yield* readHarnessModelCatalog();
+      const caps = getClaudeModelCapabilities(modelSelection?.model, harnessModelCatalog);
       const descriptors = getProviderOptionDescriptors({ caps });
-      const apiModelId = modelSelection ? resolveClaudeApiModelId(modelSelection) : undefined;
-      const initialContextWindow = selectedClaudeContextWindow(modelSelection);
+      const apiModelId = modelSelection
+        ? resolveClaudeApiModelId(modelSelection, harnessModelCatalog)
+        : undefined;
+      const initialContextWindow = selectedClaudeContextWindow(modelSelection, harnessModelCatalog);
       const rawEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
       const effort = resolveClaudeEffort(caps, rawEffort) ?? null;
       const fastModeSupported = descriptors.some(
@@ -4264,7 +4283,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ? getModelSelectionBooleanOptionValue(modelSelection, "thinking")
         : undefined;
       const ultracode = isClaudeUltracodeEffort(effort);
-      const effectiveEffort = getEffectiveClaudeAgentEffort(effort, modelSelection?.model);
+      const effectiveEffort = getEffectiveClaudeAgentEffort(
+        effort,
+        modelSelection?.model,
+        harnessModelCatalog,
+      );
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
         auto: "auto",
@@ -4511,8 +4534,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       yield* completeTurn(context, "completed");
     }
 
+    const harnessModelCatalog = yield* readHarnessModelCatalog();
     if (modelSelection?.model) {
-      const apiModelId = resolveClaudeApiModelId(modelSelection);
+      const apiModelId = resolveClaudeApiModelId(modelSelection, harnessModelCatalog);
       if (context.currentApiModelId !== apiModelId) {
         yield* Effect.tryPromise({
           try: () => context.query.setModel(apiModelId),
@@ -4524,13 +4548,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...context.session,
         model: modelSelection.model,
       };
-      const turnCaps = getClaudeModelCapabilities(modelSelection.model);
+      const turnCaps = getClaudeModelCapabilities(modelSelection.model, harnessModelCatalog);
       const turnEffort = resolveClaudeEffort(
         turnCaps,
         getModelSelectionStringOptionValue(modelSelection, "effort"),
       );
       context.currentEffort =
-        getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model) ?? undefined;
+        getEffectiveClaudeAgentEffort(
+          turnEffort ?? null,
+          modelSelection.model,
+          harnessModelCatalog,
+        ) ?? undefined;
     }
 
     // Apply interaction mode by switching the SDK's permission mode.
@@ -4589,6 +4617,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       fileSystem,
       attachmentsDir: serverConfig.attachmentsDir,
       boundInstanceId,
+      harnessModelCatalog,
     });
 
     yield* Queue.offer(context.promptQueue, {

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -66,9 +66,9 @@ it("collapses Clauded effort aliases into one T3 model row", () => {
   const commandCode = models[2];
   assert.ok(commandCode);
   assert.ok(commandCode.capabilities);
-  assert.equal(normalizeClaudeCliEffort("ultracode", muse.slug), "xhigh");
-  assert.equal(normalizeClaudeCliEffort("ultracode", ling.slug), "high");
-  assert.equal(normalizeClaudeCliEffort("xhigh", ling.slug), "high");
+  assert.equal(normalizeClaudeCliEffort("ultracode", muse.slug, models), "xhigh");
+  assert.equal(normalizeClaudeCliEffort("ultracode", ling.slug, models), "high");
+  assert.equal(normalizeClaudeCliEffort("xhigh", ling.slug, models), "high");
   assert.equal(commandCode.capabilities.optionDescriptors?.length, 0);
 });
 

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -9,10 +9,68 @@ import * as Schema from "effect/Schema";
 import {
   buildClaudeCapabilitiesProbeQueryOptions,
   CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES,
+  normalizeClaudeCliEffort,
+  parseClaudeHarnessModelPicker,
   probeClaudeCapabilities,
 } from "./ClaudeProvider.ts";
 
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
+
+it("collapses Clauded effort aliases into one T3 model row", () => {
+  const models = parseClaudeHarnessModelPicker({
+    options: [
+      {
+        model: "claude-opus-4-7-oc-zen--muse-free",
+        label: "OpenCode Zen · Muse Free",
+        description: "Effort: minimal, low, medium, high, xhigh",
+      },
+      {
+        model: "claude-opus-4-7-oc-zen--muse-free--effort-minimal",
+        label: "OpenCode Zen · Muse Free · Minimal",
+        description: "Pinned to OpenCode's minimal effort",
+      },
+      {
+        model: "claude-sonnet-4-6-oc-zen--ling-free",
+        label: "OpenCode Zen · Ling Free",
+        description: "Effort: low, medium, high",
+      },
+      {
+        model: "claude-haiku-4-5-cc-commandcode--laguna-free",
+        label: "Command Code · Laguna Free",
+        description: "No reasoning-effort variants",
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    models.map((model) => model.slug),
+    [
+      "claude-opus-4-7-oc-zen--muse-free",
+      "claude-sonnet-4-6-oc-zen--ling-free",
+      "claude-haiku-4-5-cc-commandcode--laguna-free",
+    ],
+  );
+  const muse = models[0];
+  assert.ok(muse);
+  assert.ok(muse.capabilities);
+  const museEffort = muse.capabilities.optionDescriptors?.[0];
+  assert.equal(museEffort?.type, "select");
+  if (museEffort?.type === "select") {
+    assert.deepEqual(
+      museEffort.options.map((option) => option.id),
+      ["minimal", "low", "medium", "high", "xhigh", "ultracode"],
+    );
+  }
+  const ling = models[1];
+  assert.ok(ling);
+  const commandCode = models[2];
+  assert.ok(commandCode);
+  assert.ok(commandCode.capabilities);
+  assert.equal(normalizeClaudeCliEffort("ultracode", muse.slug), "xhigh");
+  assert.equal(normalizeClaudeCliEffort("ultracode", ling.slug), "high");
+  assert.equal(normalizeClaudeCliEffort("xhigh", ling.slug), "high");
+  assert.equal(commandCode.capabilities.optionDescriptors?.length, 0);
+});
 
 it("isolates Claude capability probes without dropping workspace setting sources", () => {
   const abortController = new AbortController();

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -2,6 +2,7 @@ import {
   type ClaudeSettings,
   type ModelCapabilities,
   type ModelSelection,
+  type SelectProviderOptionDescriptor,
   type ServerProviderModel,
   type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
@@ -11,6 +12,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import {
   createModelCapabilities,
@@ -40,12 +42,15 @@ import {
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
-import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
+import { makeClaudeEnvironment, resolveClaudeHomePath } from "../Drivers/ClaudeHome.ts";
 import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
+const decodeClaudeHarnessSettings = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(Schema.Unknown),
+);
 
 const CLAUDE_PRESENTATION = {
   displayName: "Claude",
@@ -325,6 +330,159 @@ const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
 // so the catalog itself carries no `isLegacy` flags.
 const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = CLAUDE_MODEL_CATALOG;
 
+/** Model capabilities discovered from a Clauded modelPicker configuration. */
+const CLAUDED_MODEL_CAPABILITIES = new Map<string, ModelCapabilities>();
+const CLAUDED_MODEL_SUFFIX = /--effort-[a-z0-9-]+$/iu;
+const CLAUDED_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max"]);
+const CLAUDED_EFFORT_RANK = new Map([
+  ["minimal", 0],
+  ["low", 1],
+  ["medium", 2],
+  ["high", 3],
+  ["xhigh", 4],
+  ["max", 5],
+]);
+
+function titleCaseEffort(value: string): string {
+  return value.length === 0 ? value : `${value[0]!.toUpperCase()}${value.slice(1)}`;
+}
+
+function parseClaudeHarnessEfforts(description: string | undefined): ReadonlyArray<string> {
+  const match = description?.match(/^\s*Effort:\s*(.+)$/iu);
+  if (!match) return [];
+  return [
+    ...new Set(
+      match[1]!
+        .split(",")
+        .map((value) => value.trim().toLowerCase())
+        .filter((value) => CLAUDED_EFFORTS.has(value)),
+    ),
+  ];
+}
+
+function highestClaudeHarnessEffort(
+  descriptor: SelectProviderOptionDescriptor,
+): string | undefined {
+  return descriptor.options
+    .map((option) => option.id)
+    .filter((value) => value !== "ultracode")
+    .toSorted(
+      (left, right) =>
+        (CLAUDED_EFFORT_RANK.get(right) ?? -1) - (CLAUDED_EFFORT_RANK.get(left) ?? -1),
+    )[0];
+}
+
+function isClaudeHarnessModelAlias(value: string): boolean {
+  return value.startsWith("claude-") && value.includes("--") && !value.includes("[1m]");
+}
+
+/**
+ * Parse the replacement model picker written by the Clauded wrapper. The
+ * canonical row is the model; effort variants remain traits on that row. A
+ * pinned `--effort-*` row is deliberately ignored so T3 never renders one
+ * model entry per reasoning level.
+ */
+export function parseClaudeHarnessModelPicker(input: unknown): ReadonlyArray<ServerProviderModel> {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) return [];
+  const options = (input as { readonly options?: unknown }).options;
+  if (!Array.isArray(options)) return [];
+
+  const models: ServerProviderModel[] = [];
+  const seen = new Set<string>();
+  for (const rawOption of options) {
+    if (rawOption === null || typeof rawOption !== "object" || Array.isArray(rawOption)) continue;
+    const option = rawOption as {
+      readonly model?: unknown;
+      readonly label?: unknown;
+      readonly description?: unknown;
+    };
+    if (typeof option.model !== "string") continue;
+    const slug = option.model.trim();
+    if (!isClaudeHarnessModelAlias(slug) || CLAUDED_MODEL_SUFFIX.test(slug) || seen.has(slug)) {
+      continue;
+    }
+    const efforts = parseClaudeHarnessEfforts(
+      typeof option.description === "string" ? option.description : undefined,
+    );
+    const effortOptions = efforts.length
+      ? [
+          ...efforts,
+          {
+            value: "ultracode",
+            label: "Ultracode",
+            description:
+              "Use this model's highest available reasoning level with workflow orchestration",
+          },
+        ]
+      : [];
+    const capabilities = effortOptions.length
+      ? createModelCapabilities({
+          optionDescriptors: [
+            buildSelectOptionDescriptor({
+              id: "effort",
+              label: "Reasoning",
+              options: effortOptions.map((effort) =>
+                typeof effort === "string"
+                  ? {
+                      value: effort,
+                      label: titleCaseEffort(effort),
+                      ...(effort === (efforts.includes("medium") ? "medium" : efforts.at(-1))
+                        ? { isDefault: true }
+                        : {}),
+                    }
+                  : effort,
+              ),
+            }),
+          ],
+        })
+      : DEFAULT_CLAUDE_MODEL_CAPABILITIES;
+    CLAUDED_MODEL_CAPABILITIES.set(slug, capabilities);
+    seen.add(slug);
+    models.push({
+      slug,
+      name: typeof option.label === "string" && option.label.trim() ? option.label.trim() : slug,
+      isCustom: false,
+      capabilities,
+    });
+  }
+  return models;
+}
+
+/** Load a Clauded model picker from its isolated config directory. */
+export const readClaudeHarnessModelCatalog = (
+  settings: ClaudeSettings,
+): Effect.Effect<
+  ReadonlyArray<ServerProviderModel> | undefined,
+  never,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function* () {
+    const binaryPath = settings.binaryPath.trim();
+    if (binaryPath !== "clauded" && !binaryPath.endsWith("/clauded")) {
+      return undefined;
+    }
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const homePath = yield* resolveClaudeHomePath(settings);
+    const raw = yield* fileSystem
+      .readFileString(path.join(homePath, "settings.json"))
+      .pipe(Effect.orElseSucceed(() => ""));
+    if (!raw.trim()) return undefined;
+    const parsed = yield* decodeClaudeHarnessSettings(raw).pipe(
+      Effect.orElseSucceed(() => undefined),
+    );
+    const settingsObject =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as { readonly model?: unknown; readonly modelPicker?: unknown })
+        : undefined;
+    const models = parseClaudeHarnessModelPicker(settingsObject?.modelPicker);
+    const defaultModel =
+      typeof settingsObject?.model === "string" ? settingsObject.model.trim() : "";
+    return models.length > 0
+      ? models.map((model) => (model.slug === defaultModel ? { ...model, isDefault: true } : model))
+      : undefined;
+  });
+
 function supportsClaudeOpus5(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0 : false;
 }
@@ -384,6 +542,7 @@ function formatClaudeOpus47UpgradeMessage(version: string | null): string {
 export function getClaudeModelCapabilities(model: string | null | undefined): ModelCapabilities {
   const slug = model?.trim();
   return (
+    (slug ? CLAUDED_MODEL_CAPABILITIES.get(slug) : undefined) ??
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
     DEFAULT_CLAUDE_MODEL_CAPABILITIES
   );
@@ -419,8 +578,37 @@ export function normalizeClaudeCliEffort(
   if (!effort || effort === "ultrathink") {
     return undefined;
   }
+  const dynamicEfforts = (
+    model ? CLAUDED_MODEL_CAPABILITIES.get(model) : undefined
+  )?.optionDescriptors?.find(
+    (descriptor) => descriptor.id === "effort" && descriptor.type === "select",
+  );
   if (effort === "ultracode") {
-    return "xhigh";
+    return dynamicEfforts?.type === "select" ? highestClaudeHarnessEffort(dynamicEfforts) : "xhigh";
+  }
+  if (
+    dynamicEfforts?.type === "select" &&
+    dynamicEfforts.options.some((option) => option.id === effort)
+  ) {
+    return effort;
+  }
+  if (dynamicEfforts?.type === "select") {
+    const requestedRank = CLAUDED_EFFORT_RANK.get(effort);
+    const available = dynamicEfforts.options
+      .map((option) => option.id)
+      .filter((value) => value !== "ultracode");
+    if (available.length > 0) {
+      const sorted = available.toSorted(
+        (left, right) =>
+          (CLAUDED_EFFORT_RANK.get(right) ?? -1) - (CLAUDED_EFFORT_RANK.get(left) ?? -1),
+      );
+      return (
+        sorted.find(
+          (value) =>
+            requestedRank !== undefined && (CLAUDED_EFFORT_RANK.get(value) ?? -1) <= requestedRank,
+        ) ?? sorted.at(-1)
+      );
+    }
   }
   if (
     effort === "xhigh" &&
@@ -811,6 +999,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   ) => Effect.Effect<ClaudeCapabilitiesProbe | undefined>,
   environment?: NodeJS.ProcessEnv,
   cwd?: string,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -818,8 +1007,14 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
 > {
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const configuredModels =
+    harnessModelCatalog ??
+    (yield* readClaudeHarnessModelCatalog(claudeSettings).pipe(
+      Effect.orElseSucceed(() => undefined),
+    )) ??
+    BUILT_IN_MODELS;
   const allModels = providerModelsFromSettings(
-    BUILT_IN_MODELS,
+    configuredModels,
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
   );
@@ -909,19 +1104,25 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   }
 
   const models = providerModelsFromSettings(
-    getBuiltInClaudeModelsForVersion(parsedVersion),
+    harnessModelCatalog ??
+      (yield* readClaudeHarnessModelCatalog(claudeSettings).pipe(
+        Effect.orElseSucceed(() => undefined),
+      )) ??
+      getBuiltInClaudeModelsForVersion(parsedVersion),
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
   );
-  const versionUpgradeMessage = supportsClaudeOpus5(parsedVersion)
+  const versionUpgradeMessage = harnessModelCatalog
     ? undefined
-    : supportsClaudeFable5(parsedVersion)
-      ? formatClaudeOpus5UpgradeMessage(parsedVersion)
-      : supportsClaudeOpus48(parsedVersion)
-        ? formatClaudeFable5UpgradeMessage(parsedVersion)
-        : supportsClaudeOpus47(parsedVersion)
-          ? formatClaudeOpus48UpgradeMessage(parsedVersion)
-          : formatClaudeOpus47UpgradeMessage(parsedVersion);
+    : supportsClaudeOpus5(parsedVersion)
+      ? undefined
+      : supportsClaudeFable5(parsedVersion)
+        ? formatClaudeOpus5UpgradeMessage(parsedVersion)
+        : supportsClaudeOpus48(parsedVersion)
+          ? formatClaudeFable5UpgradeMessage(parsedVersion)
+          : supportsClaudeOpus47(parsedVersion)
+            ? formatClaudeOpus48UpgradeMessage(parsedVersion)
+            : formatClaudeOpus47UpgradeMessage(parsedVersion);
 
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
@@ -984,11 +1185,12 @@ const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 
 export const makePendingClaudeProvider = (
   claudeSettings: ClaudeSettings,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
 ): Effect.Effect<ServerProviderDraft> =>
   Effect.gen(function* () {
     const checkedAt = yield* nowIso;
     const models = providerModelsFromSettings(
-      BUILT_IN_MODELS,
+      harnessModelCatalog ?? BUILT_IN_MODELS,
       claudeSettings.customModels,
       DEFAULT_CLAUDE_MODEL_CAPABILITIES,
     );

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -330,8 +330,6 @@ const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
 // so the catalog itself carries no `isLegacy` flags.
 const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = CLAUDE_MODEL_CATALOG;
 
-/** Model capabilities discovered from a Clauded modelPicker configuration. */
-const CLAUDED_MODEL_CAPABILITIES = new Map<string, ModelCapabilities>();
 const CLAUDED_MODEL_SUFFIX = /--effort-[a-z0-9-]+$/iu;
 const CLAUDED_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max"]);
 const CLAUDED_EFFORT_RANK = new Map([
@@ -436,7 +434,6 @@ export function parseClaudeHarnessModelPicker(input: unknown): ReadonlyArray<Ser
           ],
         })
       : DEFAULT_CLAUDE_MODEL_CAPABILITIES;
-    CLAUDED_MODEL_CAPABILITIES.set(slug, capabilities);
     seen.add(slug);
     models.push({
       slug,
@@ -539,10 +536,15 @@ function formatClaudeOpus47UpgradeMessage(version: string | null): string {
   return `Claude Code ${versionLabel} is too old for Claude Opus 4.7. Upgrade to v${MINIMUM_CLAUDE_OPUS_4_7_VERSION} or newer to access it.`;
 }
 
-export function getClaudeModelCapabilities(model: string | null | undefined): ModelCapabilities {
+export function getClaudeModelCapabilities(
+  model: string | null | undefined,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
+): ModelCapabilities {
   const slug = model?.trim();
   return (
-    (slug ? CLAUDED_MODEL_CAPABILITIES.get(slug) : undefined) ??
+    (slug
+      ? harnessModelCatalog?.find((candidate) => candidate.slug === slug)?.capabilities
+      : undefined) ??
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
     DEFAULT_CLAUDE_MODEL_CAPABILITIES
   );
@@ -574,13 +576,15 @@ export function resolveClaudeEffort(
 export function normalizeClaudeCliEffort(
   effort: string | null | undefined,
   model: string | null | undefined,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
 ): string | undefined {
   if (!effort || effort === "ultrathink") {
     return undefined;
   }
-  const dynamicEfforts = (
-    model ? CLAUDED_MODEL_CAPABILITIES.get(model) : undefined
-  )?.optionDescriptors?.find(
+  const dynamicModel = model
+    ? harnessModelCatalog?.find((candidate) => candidate.slug === model)
+    : undefined;
+  const dynamicEfforts = dynamicModel?.capabilities?.optionDescriptors?.find(
     (descriptor) => descriptor.id === "effort" && descriptor.type === "select",
   );
   if (effort === "ultracode") {
@@ -631,8 +635,9 @@ export function isClaudeUltracodeEffort(effort: string | null | undefined): bool
 
 export function resolveClaudeContextWindow(
   modelSelection: ModelSelection | undefined,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
 ): string | undefined {
-  const caps = getClaudeModelCapabilities(modelSelection?.model);
+  const caps = getClaudeModelCapabilities(modelSelection?.model, harnessModelCatalog);
   const raw = getModelSelectionStringOptionValue(modelSelection, "contextWindow");
   const descriptors = getProviderOptionDescriptors({
     caps,
@@ -643,8 +648,11 @@ export function resolveClaudeContextWindow(
   return typeof value === "string" ? value : undefined;
 }
 
-export function resolveClaudeApiModelId(modelSelection: ModelSelection): string {
-  switch (resolveClaudeContextWindow(modelSelection)) {
+export function resolveClaudeApiModelId(
+  modelSelection: ModelSelection,
+  harnessModelCatalog?: ReadonlyArray<ServerProviderModel>,
+): string {
+  switch (resolveClaudeContextWindow(modelSelection, harnessModelCatalog)) {
     case "1m":
       return `${modelSelection.model}[1m]`;
     default:

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.test.ts
@@ -1,0 +1,51 @@
+import {
+  DEFAULT_SERVER_SETTINGS,
+  ProviderDriverKind,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+
+import { deriveProviderInstanceConfigMap } from "./ProviderInstanceRegistryHydration.ts";
+
+const claudedId = ProviderInstanceId.make("clauded");
+const dodexId = ProviderInstanceId.make("dodex");
+
+it("adds Clauded and Dodex aliases only when requested", () => {
+  const settings = DEFAULT_SERVER_SETTINGS;
+  const withoutAliases = deriveProviderInstanceConfigMap(settings);
+  assert.equal(withoutAliases[claudedId], undefined);
+  assert.equal(withoutAliases[dodexId], undefined);
+
+  const withAliases = deriveProviderInstanceConfigMap(settings, {
+    includeHarnessAliases: true,
+  });
+  assert.deepEqual(withAliases[claudedId], {
+    driver: ProviderDriverKind.make("claudeAgent"),
+    displayName: "Clauded",
+    config: { binaryPath: "clauded", homePath: "~/.clauded" },
+  });
+  assert.deepEqual(withAliases[dodexId], {
+    driver: ProviderDriverKind.make("codex"),
+    displayName: "Dodex",
+    config: { binaryPath: "dodex", homePath: "~/.dodex" },
+  });
+});
+
+it("preserves explicit alias configuration", () => {
+  const explicitClauded = {
+    driver: ProviderDriverKind.make("claudeAgent"),
+    displayName: "My Clauded",
+    enabled: false,
+    config: { binaryPath: "/custom/clauded", homePath: "/custom/home" },
+  } as const;
+  const settings = {
+    ...DEFAULT_SERVER_SETTINGS,
+    providerInstances: {
+      ...DEFAULT_SERVER_SETTINGS.providerInstances,
+      clauded: explicitClauded,
+    },
+  };
+  const map = deriveProviderInstanceConfigMap(settings, { includeHarnessAliases: true });
+  assert.deepEqual(map[claudedId], explicitClauded);
+  assert.deepEqual(map[dodexId]?.config, { binaryPath: "dodex", homePath: "~/.dodex" });
+});

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -42,6 +42,7 @@
  * @module provider/Layers/ProviderInstanceRegistryHydration
  */
 import {
+  BUILT_IN_HARNESS_PROVIDER_INSTANCES,
   defaultInstanceIdForDriver,
   type ProviderInstanceConfig,
   type ProviderInstanceConfigMap,
@@ -51,6 +52,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
 
+import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { BUILT_IN_DRIVERS, type BuiltInDriversEnv } from "../builtInDrivers.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
@@ -72,8 +74,19 @@ import { ProviderInstanceRegistryMutableLayer } from "./ProviderInstanceRegistry
  */
 export const deriveProviderInstanceConfigMap = (
   settings: ServerSettings,
+  options: { readonly includeHarnessAliases?: boolean } = {},
 ): ProviderInstanceConfigMap => {
   const merged: Record<string, ProviderInstanceConfig> = { ...settings.providerInstances };
+
+  if (options.includeHarnessAliases === true) {
+    for (const [instanceId, instance] of Object.entries(BUILT_IN_HARNESS_PROVIDER_INSTANCES)) {
+      // Explicit settings always win, including an explicit disable or a
+      // user-edited binary/home path.
+      if (!(instanceId in merged)) {
+        merged[instanceId] = instance;
+      }
+    }
+  }
 
   for (const driver of BUILT_IN_DRIVERS) {
     const instanceId = defaultInstanceIdForDriver(driver.driverKind);
@@ -118,10 +131,12 @@ const SettingsWatcherLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const mutator = yield* ProviderInstanceRegistryMutator;
     const serverSettings = yield* ServerSettingsService;
+    const serverConfig = yield* ServerConfig;
+    const includeHarnessAliases = serverConfig.enableHarnessProviderAliases !== false;
     yield* serverSettings.streamChanges.pipe(
       Stream.runForEach((next) =>
         mutator
-          .reconcile(deriveProviderInstanceConfigMap(next))
+          .reconcile(deriveProviderInstanceConfigMap(next, { includeHarnessAliases }))
           .pipe(
             Effect.catchCause((cause) =>
               Effect.logError("ProviderInstanceRegistry reconcile failed", cause),
@@ -152,17 +167,19 @@ const SettingsWatcherLive = Layer.effectDiscard(
 export const ProviderInstanceRegistryHydrationLive: Layer.Layer<
   ProviderInstanceRegistry,
   never,
-  BuiltInDriversEnv | ServerSettingsService
+  BuiltInDriversEnv | ServerSettingsService | ServerConfig
 > = Layer.unwrap(
   Effect.gen(function* () {
     const serverSettings = yield* ServerSettingsService;
+    const serverConfig = yield* ServerConfig;
+    const includeHarnessAliases = serverConfig.enableHarnessProviderAliases !== false;
     const initialSettings: ServerSettings | undefined = yield* serverSettings.getSettings.pipe(
       Effect.orElseSucceed(() => undefined),
     );
     const initialConfigMap =
       initialSettings === undefined
         ? ({} as ProviderInstanceConfigMap)
-        : deriveProviderInstanceConfigMap(initialSettings);
+        : deriveProviderInstanceConfigMap(initialSettings, { includeHarnessAliases });
 
     const mutableLayer = ProviderInstanceRegistryMutableLayer({
       drivers: BUILT_IN_DRIVERS,
@@ -171,4 +188,8 @@ export const ProviderInstanceRegistryHydrationLive: Layer.Layer<
 
     return SettingsWatcherLive.pipe(Layer.provideMerge(mutableLayer));
   }),
-) as Layer.Layer<ProviderInstanceRegistry, never, BuiltInDriversEnv | ServerSettingsService>;
+) as Layer.Layer<
+  ProviderInstanceRegistry,
+  never,
+  BuiltInDriversEnv | ServerSettingsService | ServerConfig
+>;

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -13,7 +13,11 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
-import { type ClaudeSettings, type ModelSelection } from "@t3tools/contracts";
+import {
+  type ClaudeSettings,
+  type ModelSelection,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
@@ -61,9 +65,13 @@ const decodeClaudeOutputEnvelope = Schema.decodeEffect(Schema.fromJsonString(Cla
 export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(function* (
   claudeSettings: ClaudeSettings,
   environment?: NodeJS.ProcessEnv,
+  getHarnessModelCatalog?: () => Effect.Effect<ReadonlyArray<ServerProviderModel> | undefined>,
 ) {
   const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
+  const readHarnessModelCatalog =
+    getHarnessModelCatalog ??
+    (() => Effect.succeed<ReadonlyArray<ServerProviderModel> | undefined>(undefined));
 
   const readStreamAsString = <E>(
     operation: string,
@@ -126,7 +134,8 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       toJsonSchemaObject(outputSchemaJson),
       "Failed to encode structured output schema.",
     );
-    const caps = getClaudeModelCapabilities(modelSelection.model);
+    const harnessModelCatalog = yield* readHarnessModelCatalog();
+    const caps = getClaudeModelCapabilities(modelSelection.model, harnessModelCatalog);
     const descriptors = getProviderOptionDescriptors({
       caps,
       selections: modelSelection.options,
@@ -134,7 +143,11 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     const findDescriptor = (id: string) => descriptors.find((descriptor) => descriptor.id === id);
     const rawEffortSelection = getModelSelectionStringOptionValue(modelSelection, "effort");
     const resolvedEffort = resolveClaudeEffort(caps, rawEffortSelection);
-    const cliEffort = normalizeClaudeCliEffort(resolvedEffort, modelSelection.model);
+    const cliEffort = normalizeClaudeCliEffort(
+      resolvedEffort,
+      modelSelection.model,
+      harnessModelCatalog,
+    );
     const ultracode = isClaudeUltracodeEffort(resolvedEffort);
     const thinkingDescriptor = findDescriptor("thinking");
     const fastModeDescriptor = findDescriptor("fastMode");
@@ -166,7 +179,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
           "--json-schema",
           jsonSchemaStr,
           "--model",
-          resolveClaudeApiModelId(modelSelection),
+          resolveClaudeApiModelId(modelSelection, harnessModelCatalog),
           ...(cliEffort ? ["--effort", cliEffort] : []),
           ...(settingsJson ? ["--settings", settingsJson] : []),
           "--dangerously-skip-permissions",

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -6,7 +6,9 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import {
+  BUILT_IN_HARNESS_PROVIDER_INSTANCES,
   defaultInstanceIdForDriver,
+  isBuiltInHarnessProviderInstance,
   type EnvironmentId,
   PROVIDER_DISPLAY_NAMES,
   ProviderDriverKind,
@@ -577,6 +579,7 @@ export function EnvironmentProviderSettings({
     readonly instance: ProviderInstanceConfig;
     readonly driver: ProviderDriverKind;
     readonly isDefault: boolean;
+    readonly isHarnessAlias?: boolean;
     readonly isDirty?: boolean;
   }
 
@@ -589,6 +592,19 @@ export function EnvironmentProviderSettings({
     const list = instancesByDriver.get(driver) ?? [];
     list.push([rawId as ProviderInstanceId, instance]);
     instancesByDriver.set(driver, list);
+  }
+
+  // The server hydrates these aliases from the built-in catalog, so an older
+  // settings file can still render them before the first edit persists an
+  // explicit `providerInstances` entry. Only add them when the connected
+  // server advertises the corresponding snapshot (remote servers may predate
+  // this feature).
+  for (const [rawId, instance] of Object.entries(BUILT_IN_HARNESS_PROVIDER_INSTANCES)) {
+    if (settings.providerInstances?.[rawId as ProviderInstanceId] !== undefined) continue;
+    if (!serverProviders.some((provider) => provider.instanceId === rawId)) continue;
+    const list = instancesByDriver.get(instance.driver) ?? [];
+    list.push([rawId as ProviderInstanceId, instance]);
+    instancesByDriver.set(instance.driver, list);
   }
 
   const defaultSlotIdsBySource = new Set<string>(
@@ -649,7 +665,13 @@ export function EnvironmentProviderSettings({
     }
     for (const [id, instance] of instancesByDriver.get(providerSettings.provider) ?? []) {
       if (id === defaultInstanceId) continue;
-      rows.push({ instanceId: id, instance, driver: instance.driver, isDefault: false });
+      rows.push({
+        instanceId: id,
+        instance,
+        driver: instance.driver,
+        isDefault: false,
+        isHarnessAlias: isBuiltInHarnessProviderInstance(String(id)),
+      });
     }
   }
   for (const [driver, list] of instancesByDriver) {
@@ -660,6 +682,7 @@ export function EnvironmentProviderSettings({
         instance,
         driver: instance.driver,
         isDefault: defaultSlotIdsBySource.has(String(id)),
+        isHarnessAlias: isBuiltInHarnessProviderInstance(String(id)),
       });
     }
   }
@@ -813,7 +836,7 @@ export function EnvironmentProviderSettings({
           );
         }}
         onDelete={
-          mode === "editor" && !row.isDefault
+          mode === "editor" && !row.isDefault && !row.isHarnessAlias
             ? () => deleteProviderInstance(row.instanceId)
             : undefined
         }

--- a/packages/contracts/src/providerInstance.ts
+++ b/packages/contracts/src/providerInstance.ts
@@ -132,6 +132,39 @@ export const ProviderInstanceConfig = Schema.Struct({
 export type ProviderInstanceConfig = typeof ProviderInstanceConfig.Type;
 
 /**
+ * First-party alternate CLI instances that ship with the local harness plane.
+ *
+ * These are intentionally instances of the existing Claude/Codex drivers,
+ * rather than new driver kinds. That keeps the native model picker, traits
+ * (reasoning/effort), commands, skills, MCP, approvals, and continuation
+ * behaviour identical to Claude Code and Codex while the wrapper binaries
+ * provide their independent model/provider catalogs.
+ */
+export const BUILT_IN_HARNESS_PROVIDER_INSTANCES: Readonly<Record<string, ProviderInstanceConfig>> =
+  {
+    clauded: {
+      driver: ProviderDriverKind.make("claudeAgent"),
+      displayName: "Clauded",
+      config: {
+        binaryPath: "clauded",
+        homePath: "~/.clauded",
+      },
+    },
+    dodex: {
+      driver: ProviderDriverKind.make("codex"),
+      displayName: "Dodex",
+      config: {
+        binaryPath: "dodex",
+        homePath: "~/.dodex",
+      },
+    },
+  };
+
+/** Alias ids are stable routing keys, so saved threads continue to resolve. */
+export const isBuiltInHarnessProviderInstance = (instanceId: string): boolean =>
+  Object.hasOwn(BUILT_IN_HARNESS_PROVIDER_INSTANCES, instanceId);
+
+/**
  * Map shape for `ServerSettings.providerInstances`. Keyed by
  * `ProviderInstanceId`, values are envelopes the registry feeds to drivers.
  */


### PR DESCRIPTION
## Summary
- register Clauded and Dodex as first-party instances of the native Claude/Codex drivers
- keep model rows instance-native while exposing reasoning levels as traits
- read Clauded's synced catalog dynamically and map Ultracode to each model's highest available effort
- preserve native commands, skills, MCP, approvals, continuation, and provider settings behavior

## Validation
- focused provider tests: 84 passed
- full monorepo typecheck: passed
- desktop bundle: passed
- full server suite: 3,046 passed, 10 skipped; one pre-existing environment-only symlink assertion fails in `src/entrypoint.test.ts`

The harness-plane branch separately owns the clauded/dodex wrappers and Command Code provider integration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `clauded` and `dodex` built-in provider aliases
> - Adds `BUILT_IN_HARNESS_PROVIDER_INSTANCES` to contracts and an `enableHarnessProviderAliases` flag to `ServerConfig`.
> - `ProviderInstanceRegistryHydration` injects `clauded` and `dodex` aliases when enabled, and the settings UI lists them with delete disabled.
> - `ClaudeDriver` reads the `clauded` model catalog from `settings.json` for provider snapshots and pending states. Health probes run against the native `claude` binary.
> - Dynamically parses harness effort capabilities, collapsing effort variants into single model rows.
> - Behavioral Change: `ProviderInstanceRegistryHydration` auto-includes `clauded` and `dodex` instances when `enableHarnessProviderAliases` is not explicitly false.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7f9e484. 6 files reviewed, 5 issues evaluated, 2 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Drivers/ClaudeDriver.ts — 2 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 146](https://github.com/pingdotgg/t3code/blob/7f9e48488ca13ad2ed6e37f067d7d66c3b1be808/apps/server/src/provider/Drivers/ClaudeDriver.ts#L146): Loading a catalog here mutates the module-global `CLAUDED_MODEL_CAPABILITIES`, which is keyed only by model slug. With two Clauded instances whose catalogs contain the same slug but different supported effort levels, the later instance overwrites the first instance's capabilities; subsequent turns for the first instance resolve/normalize effort using the other instance's catalog and can send an unsupported effort to its wrapper. <b>[ Already posted ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/Layers/ClaudeProvider.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 334](https://github.com/pingdotgg/t3code/blob/7f9e48488ca13ad2ed6e37f067d7d66c3b1be808/apps/server/src/provider/Layers/ClaudeProvider.ts#L334): `CLAUDED_MODEL_CAPABILITIES` is process-global and keyed only by model slug, although Claude supports multiple independently configured instances. Loading or refreshing a second Clauded instance whose picker contains the same alias with different effort levels overwrites the first instance's capabilities; subsequent generation/adapter calls look up only the slug and can validate/map that first instance's selected effort using the other instance's catalog (including sending an unsupported `--effort`). <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->