### PR TITLE
perf(server): parallelize worktree checkout and narrow the bootstrap fetch

### DIFF
--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -68,6 +68,7 @@ export class GitWorkflowService extends Context.Service<
     readonly fetchRemote: (input: {
       readonly cwd: string;
       readonly remoteName: string;
+      readonly refName: string;
     }) => Effect.Effect<void, GitCommandError>;
     readonly remoteExists: (input: {
       readonly cwd: string;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -8446,6 +8446,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         assert.deepEqual(fetchRemote.mock.calls[0]?.[0], {
           cwd: "/tmp/project",
           remoteName: "origin",
+          refName: "main",
         });
         assert.deepEqual(resolveRemoteTrackingCommit.mock.calls[0]?.[0], {
           cwd: "/tmp/project",

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -197,6 +197,8 @@ export interface GitFetchRemoteTrackingBranchInput {
 export interface GitFetchRemoteInput {
   cwd: string;
   remoteName: string;
+  // Branch to narrow the fetch to, in either `main` or `<remote>/main` form.
+  refName: string;
 }
 
 export interface GitRemoteExistsInput {

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1663,7 +1663,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.notEqual(beforeFetch, remoteHead);
 
         const driver = yield* GitVcsDriver.GitVcsDriver;
-        yield* driver.fetchRemote({ cwd, remoteName: "origin" });
+        yield* driver.fetchRemote({ cwd, remoteName: "origin", refName: initialBranch });
 
         const resolvedBase = yield* driver.resolveRemoteTrackingCommit({
           cwd,
@@ -1708,6 +1708,62 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         const status = yield* driver.statusDetails(worktreePath);
         assert.equal(status.aheadCount, 0);
         assert.equal(status.aheadOfDefaultCount, 0);
+      }),
+    );
+
+    it.effect("fetches only the requested branch, skipping other heads and tags", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-remote-");
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "origin", initialBranch]);
+        yield* git(cwd, ["branch", "other-branch"]);
+        yield* git(cwd, ["tag", "v1"]);
+        yield* git(cwd, ["push", "origin", "other-branch", "v1"]);
+        // Forget everything the pushes recorded locally so the fetch is the
+        // only thing that can bring refs back.
+        yield* git(cwd, ["update-ref", "-d", `refs/remotes/origin/${initialBranch}`]);
+        yield* git(cwd, ["update-ref", "-d", "refs/remotes/origin/other-branch"]);
+        yield* git(cwd, ["tag", "-d", "v1"]);
+
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* driver.fetchRemote({ cwd, remoteName: "origin", refName: initialBranch });
+
+        assert.equal(
+          yield* git(cwd, ["rev-parse", `refs/remotes/origin/${initialBranch}`]),
+          yield* git(cwd, ["rev-parse", initialBranch]),
+        );
+        assert.equal(yield* git(cwd, ["for-each-ref", "refs/remotes/origin/other-branch"]), "");
+        assert.equal(yield* git(cwd, ["tag", "--list"]), "");
+      }),
+    );
+
+    it.effect("fetches from the remote named by a remote-qualified refName", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const origin = yield* makeTmpDir("git-remote-origin-");
+        const upstream = yield* makeTmpDir("git-remote-upstream-");
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        yield* git(origin, ["init", "--bare"]);
+        yield* git(upstream, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", origin]);
+        yield* git(cwd, ["remote", "add", "upstream", upstream]);
+        yield* git(cwd, ["push", "upstream", initialBranch]);
+        yield* git(cwd, ["update-ref", "-d", `refs/remotes/upstream/${initialBranch}`]);
+
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* driver.fetchRemote({
+          cwd,
+          remoteName: "origin",
+          refName: `upstream/${initialBranch}`,
+        });
+
+        assert.equal(
+          yield* git(cwd, ["rev-parse", `refs/remotes/upstream/${initialBranch}`]),
+          yield* git(cwd, ["rev-parse", initialBranch]),
+        );
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -41,7 +41,9 @@ import { ServerConfig } from "../config.ts";
 const DEFAULT_TIMEOUT_MS = 30_000;
 // `git worktree add` checks out the full tree, so on large repositories it can
 // take well beyond the default 30s (e.g. a 375k-file repo takes ~40s on an idle
-// machine). Give it generous headroom while still bounding a genuinely hung git.
+// machine with a sequential checkout, and still tens of seconds with the
+// parallel checkout createWorktree requests). Give it generous headroom while
+// still bounding a genuinely hung git.
 const WORKTREE_ADD_TIMEOUT_MS = 300_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
@@ -2828,9 +2830,20 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const sanitizedBranch = targetBranch.replace(/\//g, "-");
     const repoName = path.basename(input.cwd);
     const worktreePath = input.path ?? path.join(worktreesDir, repoName, sanitizedBranch);
+    // Git checks the tree out on a single thread by default; `checkout.workers`
+    // below 1 means one worker per logical core, which roughly halves worktree
+    // creation on large trees. Only applied when the user has not configured a
+    // value themselves, since `-c` would silently override an intentional one.
+    const checkoutWorkersConfigured = yield* executeGit(
+      "GitVcsDriver.createWorktree.checkoutWorkersConfigured",
+      input.cwd,
+      ["config", "--get", "checkout.workers"],
+      { allowNonZeroExit: true },
+    ).pipe(Effect.map((result) => result.exitCode === 0));
+    const checkoutArgs = checkoutWorkersConfigured ? [] : ["-c", "checkout.workers=0"];
     const args = input.newRefName
-      ? ["worktree", "add", "-b", input.newRefName, worktreePath, input.refName]
-      : ["worktree", "add", worktreePath, input.refName];
+      ? [...checkoutArgs, "worktree", "add", "-b", input.newRefName, worktreePath, input.refName]
+      : [...checkoutArgs, "worktree", "add", worktreePath, input.refName];
 
     yield* executeGit("GitVcsDriver.createWorktree", input.cwd, args, {
       fallbackErrorDetail: "git worktree add failed",
@@ -2993,13 +3006,31 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
 
   const fetchRemote: GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"] = Effect.fn("fetchRemote")(
     function* (input) {
+      // The fetch is narrowed to the one branch the caller is about to resolve
+      // instead of every head plus tags. The ref is parsed the same way
+      // resolveRemoteTrackingCommit parses it, and the explicit refspec targets
+      // the parsed remote, so the tracking ref resolved next is exactly the one
+      // made current (including a base like `upstream/main` naming another remote).
+      const remoteNames = yield* listRemoteNames(input.cwd).pipe(Effect.orElseSucceed(() => []));
+      const parsedRef = parseRemoteRefWithRemoteNames(
+        input.refName,
+        remoteNames.toSorted((left, right) => right.length - left.length),
+      );
+      const remoteName = parsedRef?.remoteName ?? input.remoteName;
+      const branchName = parsedRef?.branchName ?? input.refName;
       yield* executeGit(
         "GitVcsDriver.fetchRemote",
         input.cwd,
-        ["fetch", "--quiet", input.remoteName],
+        [
+          "fetch",
+          "--quiet",
+          "--no-tags",
+          remoteName,
+          `+refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`,
+        ],
         {
           env: STATUS_UPSTREAM_REFRESH_ENV,
-          fallbackErrorDetail: `git fetch ${input.remoteName} failed`,
+          fallbackErrorDetail: `git fetch ${remoteName} failed`,
         },
       );
     },

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1067,6 +1067,7 @@ const makeWsRpcLayer = (
                 yield* gitWorkflow.fetchRemote({
                   cwd: bootstrap.prepareWorktree.projectCwd,
                   remoteName: "origin",
+                  refName: bootstrap.prepareWorktree.baseBranch,
                 });
                 const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
                   cwd: bootstrap.prepareWorktree.projectCwd,


### PR DESCRIPTION
Creating a worktree thread on a large repository makes the user sit through a slow "Setting up worktree..." step: `git worktree add` checks the tree out on a single thread, and the "start from origin" bootstrap runs a full `git fetch origin` (every head plus tags) when the only ref it ever reads is `origin/<baseBranch>`.

Two changes to the worktree bootstrap path:

- `createWorktree` now passes `-c checkout.workers=0` (one worker per logical core) to `git worktree add`, unless the user configured `checkout.workers` themselves. Raw git benchmarks: 2.2-2.9s to 1.2-1.5s on a 16k-file repo, 12.8-20.3s to 9.4-11.5s on a 150k-file tree.
- `fetchRemote` now fetches only the requested base branch with `--no-tags`, using an explicit refspec parsed the same way `resolveRemoteTrackingCommit` parses the ref, so the tracking ref resolved next is exactly the one made current. This also fixes the latent case where a base branch naming another remote (`upstream/main`) fetched `origin` but resolved `upstream/*` stale.

End-to-end proof, driven with Playwright against a 129,600-file fixture repo: both sides send the same message at t=0 on the same warm machine, one frame per second. Before needs 19.7s until the worktree is ready; after this commit it takes 11.4s (repeat runs: before 15.9s/17.9s, after 11.7s/11.1s).

![worktree creation, before vs after, one frame per second](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/f68c0c64-9626-4fa5-91c1-0b24918eb34e/t3code-worktree-creation-before-after.gif)

Verified with `vp test run apps/server/src/vcs/GitVcsDriverCore.test.ts` (58 passed, including two new narrow-fetch behavior tests) and the bootstrap seam tests in `server.test.ts`; server typecheck is clean.

Written by Claude Fable 5 via Claude Code.
