### PR TITLE
feat(desktop): add SSH environment variables

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -25,6 +25,22 @@ describe("parseSshEnvironmentVariables", () => {
     expect(Object.hasOwn(environment ?? {}, "__proto__")).toBe(true);
   });
 
+  it("does not count blank rows toward the variable limit", () => {
+    const blankRows = Array.from({ length: 129 }, () => ({ name: "", value: "" }));
+
+    expect(parseSshEnvironmentVariables([...blankRows, { name: "TOKEN", value: "value" }])).toEqual(
+      { TOKEN: "value" },
+    );
+    expect(() =>
+      parseSshEnvironmentVariables(
+        Array.from({ length: 129 }, (_, index) => ({
+          name: `VARIABLE_${index}`,
+          value: "value",
+        })),
+      ),
+    ).toThrow("limited to 128");
+  });
+
   it("rejects missing, invalid, and duplicate names", () => {
     expect(() => parseSshEnvironmentVariables([{ name: "", value: "secret" }])).toThrow(
       "needs a name",

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -19,10 +19,10 @@ describe("parseSshEnvironmentVariables", () => {
     ).toEqual({ AWS_PROFILE: "production", TOKEN: "  keep spaces  " });
   });
 
-  it("preserves names that overlap with object prototype properties", () => {
-    const environment = parseSshEnvironmentVariables([{ name: "__proto__", value: "value" }]);
-    expect(environment?.["__proto__"]).toBe("value");
-    expect(Object.hasOwn(environment ?? {}, "__proto__")).toBe(true);
+  it("rejects names that overlap with object prototype properties", () => {
+    expect(() => parseSshEnvironmentVariables([{ name: "__proto__", value: "value" }])).toThrow(
+      "local SSH process",
+    );
   });
 
   it("does not count blank rows toward the variable limit", () => {
@@ -63,6 +63,12 @@ describe("parseSshEnvironmentVariables", () => {
       parseSshEnvironmentVariables([
         { name: "TOKEN", value: "one" },
         { name: " TOKEN ", value: "two" },
+      ]),
+    ).toThrow("listed more than once");
+    expect(() =>
+      parseSshEnvironmentVariables([
+        { name: "TOKEN", value: "one" },
+        { name: "token", value: "two" },
       ]),
     ).toThrow("listed more than once");
     expect(() => parseSshEnvironmentVariables([{ name: "TOKEN", value: "bad\0value" }])).toThrow(

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -4,8 +4,54 @@ import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
   isWslSettingsRowVisible,
+  parseSshEnvironmentVariables,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
+
+describe("parseSshEnvironmentVariables", () => {
+  it("trims names, preserves values, and ignores empty rows", () => {
+    expect(
+      parseSshEnvironmentVariables([
+        { name: " AWS_PROFILE ", value: "production" },
+        { name: "", value: "" },
+        { name: "TOKEN", value: "  keep spaces  " },
+      ]),
+    ).toEqual({ AWS_PROFILE: "production", TOKEN: "  keep spaces  " });
+  });
+
+  it("preserves names that overlap with object prototype properties", () => {
+    const environment = parseSshEnvironmentVariables([{ name: "__proto__", value: "value" }]);
+    expect(environment?.["__proto__"]).toBe("value");
+    expect(Object.hasOwn(environment ?? {}, "__proto__")).toBe(true);
+  });
+
+  it("rejects missing, invalid, and duplicate names", () => {
+    expect(() => parseSshEnvironmentVariables([{ name: "", value: "secret" }])).toThrow(
+      "needs a name",
+    );
+    expect(() => parseSshEnvironmentVariables([{ name: "BAD-NAME", value: "value" }])).toThrow(
+      "invalid name",
+    );
+    expect(() =>
+      parseSshEnvironmentVariables([
+        { name: "TOKEN", value: "one" },
+        { name: " TOKEN ", value: "two" },
+      ]),
+    ).toThrow("listed more than once");
+    expect(() => parseSshEnvironmentVariables([{ name: "TOKEN", value: "bad\0value" }])).toThrow(
+      "NUL character",
+    );
+  });
+
+  it("rejects names that can alter the local SSH process", () => {
+    expect(() => parseSshEnvironmentVariables([{ name: "path", value: "/tmp/bin" }])).toThrow(
+      "local SSH process",
+    );
+    expect(() =>
+      parseSshEnvironmentVariables([{ name: "DYLD_INSERT_LIBRARIES", value: "/tmp/payload" }]),
+    ).toThrow("local SSH process");
+  });
+});
 
 const baseWslState: DesktopWslState = {
   enabled: false,

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -41,6 +41,17 @@ describe("parseSshEnvironmentVariables", () => {
     ).toThrow("limited to 128");
   });
 
+  it("rejects variables above the combined encoded size limit", () => {
+    expect(() =>
+      parseSshEnvironmentVariables(
+        Array.from({ length: 9 }, (_, index) => ({
+          name: `TOKEN_${index}`,
+          value: "€".repeat(8_192),
+        })),
+      ),
+    ).toThrow("limited to 16 KiB in total");
+  });
+
   it("rejects missing, invalid, and duplicate names", () => {
     expect(() => parseSshEnvironmentVariables([{ name: "", value: "secret" }])).toThrow(
       "needs a name",

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -24,6 +24,7 @@ export function parseSshEnvironmentVariables(
     string,
     string
   >;
+  const normalizedNames = new Set<string>();
   let nonEmptyDraftCount = 0;
   let encodedBytes = 0;
 
@@ -59,9 +60,11 @@ export function parseSshEnvironmentVariables(
     if (draft.value.includes("\0")) {
       throw new Error(`SSH environment variable '${name}' contains a NUL character.`);
     }
-    if (Object.hasOwn(environmentVariables, name)) {
+    const normalizedName = name.toUpperCase();
+    if (normalizedNames.has(normalizedName)) {
       throw new Error(`SSH environment variable '${name}' is listed more than once.`);
     }
+    normalizedNames.add(normalizedName);
     encodedBytes +=
       sshEnvironmentTextEncoder.encode(name).byteLength +
       1 +

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -1,4 +1,5 @@
 import {
+  DESKTOP_SSH_ENVIRONMENT_VARIABLES_MAX_ENCODED_BYTES,
   isSafeDesktopSshEnvironmentVariableName,
   type AdvertisedEndpoint,
   type DesktopBridge,
@@ -14,6 +15,7 @@ const SSH_ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const SSH_ENVIRONMENT_VARIABLE_MAX_COUNT = 128;
 const SSH_ENVIRONMENT_VARIABLE_NAME_MAX_LENGTH = 128;
 const SSH_ENVIRONMENT_VARIABLE_VALUE_MAX_LENGTH = 8_192;
+const sshEnvironmentTextEncoder = new TextEncoder();
 
 export function parseSshEnvironmentVariables(
   drafts: ReadonlyArray<SshEnvironmentVariableDraft>,
@@ -23,6 +25,7 @@ export function parseSshEnvironmentVariables(
     string
   >;
   let nonEmptyDraftCount = 0;
+  let encodedBytes = 0;
 
   for (const draft of drafts) {
     const name = draft.name.trim();
@@ -58,6 +61,14 @@ export function parseSshEnvironmentVariables(
     }
     if (Object.hasOwn(environmentVariables, name)) {
       throw new Error(`SSH environment variable '${name}' is listed more than once.`);
+    }
+    encodedBytes +=
+      sshEnvironmentTextEncoder.encode(name).byteLength +
+      1 +
+      sshEnvironmentTextEncoder.encode(draft.value).byteLength +
+      1;
+    if (encodedBytes > DESKTOP_SSH_ENVIRONMENT_VARIABLES_MAX_ENCODED_BYTES) {
+      throw new Error("SSH environment variables are limited to 16 KiB in total.");
     }
     environmentVariables[name] = draft.value;
   }

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -18,20 +18,22 @@ const SSH_ENVIRONMENT_VARIABLE_VALUE_MAX_LENGTH = 8_192;
 export function parseSshEnvironmentVariables(
   drafts: ReadonlyArray<SshEnvironmentVariableDraft>,
 ): Readonly<Record<string, string>> | undefined {
-  if (drafts.length > SSH_ENVIRONMENT_VARIABLE_MAX_COUNT) {
-    throw new Error(
-      `SSH environment variables are limited to ${SSH_ENVIRONMENT_VARIABLE_MAX_COUNT}.`,
-    );
-  }
   const environmentVariables: Record<string, string> = Object.create(null) as Record<
     string,
     string
   >;
+  let nonEmptyDraftCount = 0;
 
   for (const draft of drafts) {
     const name = draft.name.trim();
     if (name.length === 0 && draft.value.length === 0) {
       continue;
+    }
+    nonEmptyDraftCount += 1;
+    if (nonEmptyDraftCount > SSH_ENVIRONMENT_VARIABLE_MAX_COUNT) {
+      throw new Error(
+        `SSH environment variables are limited to ${SSH_ENVIRONMENT_VARIABLE_MAX_COUNT}.`,
+      );
     }
     if (!SSH_ENVIRONMENT_VARIABLE_NAME_PATTERN.test(name)) {
       throw new Error(

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -1,4 +1,67 @@
-import type { AdvertisedEndpoint, DesktopBridge, DesktopWslState } from "@t3tools/contracts";
+import {
+  isSafeDesktopSshEnvironmentVariableName,
+  type AdvertisedEndpoint,
+  type DesktopBridge,
+  type DesktopWslState,
+} from "@t3tools/contracts";
+
+export interface SshEnvironmentVariableDraft {
+  readonly name: string;
+  readonly value: string;
+}
+
+const SSH_ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const SSH_ENVIRONMENT_VARIABLE_MAX_COUNT = 128;
+const SSH_ENVIRONMENT_VARIABLE_NAME_MAX_LENGTH = 128;
+const SSH_ENVIRONMENT_VARIABLE_VALUE_MAX_LENGTH = 8_192;
+
+export function parseSshEnvironmentVariables(
+  drafts: ReadonlyArray<SshEnvironmentVariableDraft>,
+): Readonly<Record<string, string>> | undefined {
+  if (drafts.length > SSH_ENVIRONMENT_VARIABLE_MAX_COUNT) {
+    throw new Error(
+      `SSH environment variables are limited to ${SSH_ENVIRONMENT_VARIABLE_MAX_COUNT}.`,
+    );
+  }
+  const environmentVariables: Record<string, string> = Object.create(null) as Record<
+    string,
+    string
+  >;
+
+  for (const draft of drafts) {
+    const name = draft.name.trim();
+    if (name.length === 0 && draft.value.length === 0) {
+      continue;
+    }
+    if (!SSH_ENVIRONMENT_VARIABLE_NAME_PATTERN.test(name)) {
+      throw new Error(
+        name.length === 0
+          ? "Each SSH environment variable needs a name."
+          : `SSH environment variable '${name}' has an invalid name.`,
+      );
+    }
+    if (name.length > SSH_ENVIRONMENT_VARIABLE_NAME_MAX_LENGTH) {
+      throw new Error(`SSH environment variable '${name}' has a name longer than 128 characters.`);
+    }
+    if (!isSafeDesktopSshEnvironmentVariableName(name)) {
+      throw new Error(
+        `SSH environment variable '${name}' can affect the local SSH process and is not allowed.`,
+      );
+    }
+    if (draft.value.length > SSH_ENVIRONMENT_VARIABLE_VALUE_MAX_LENGTH) {
+      throw new Error(`SSH environment variable '${name}' has a value larger than 8 KiB.`);
+    }
+    if (draft.value.includes("\0")) {
+      throw new Error(`SSH environment variable '${name}' contains a NUL character.`);
+    }
+    if (Object.hasOwn(environmentVariables, name)) {
+      throw new Error(`SSH environment variable '${name}' is listed more than once.`);
+    }
+    environmentVariables[name] = draft.value;
+  }
+
+  return Object.keys(environmentVariables).length === 0 ? undefined : environmentVariables;
+}
 
 type WslEnableBridge = Pick<DesktopBridge, "setWslBackendEnabled" | "setWslDistro" | "setWslOnly">;
 

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -2441,7 +2441,6 @@ export function ConnectionsSettings() {
     savedBackendMode,
     savedBackendPairingCode,
     savedBackendSshHost,
-    savedBackendSshEnvironmentVariables,
     savedBackendSshPort,
     savedBackendSshUsername,
   ]);

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1,8 +1,18 @@
-import { ChevronsLeftRightEllipsisIcon, PlusIcon, QrCodeIcon, TerminalIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  ChevronsLeftRightEllipsisIcon,
+  PlusIcon,
+  QrCodeIcon,
+  RefreshCwIcon,
+  TerminalIcon,
+  XIcon,
+} from "lucide-react";
 import { useAtomValue } from "@effect/atom-react";
 import {
+  type Dispatch,
   type KeyboardEvent,
   type ReactNode,
+  type SetStateAction,
   memo,
   useCallback,
   useEffect,
@@ -50,7 +60,9 @@ import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
   isWslSettingsRowVisible,
+  parseSshEnvironmentVariables,
   selectQrEndpointOption,
+  type SshEnvironmentVariableDraft,
 } from "./ConnectionsSettings.logic";
 import {
   SettingsPageContainer,
@@ -103,6 +115,7 @@ import { Button } from "../ui/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
 import { AnimatedHeight } from "../AnimatedHeight";
 import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import { Textarea } from "../ui/textarea";
 import { getPairingTokenFromUrl, setPairingTokenOnUrl } from "../../pairingUrl";
 import { readHostedPairingRequest } from "../../hostedPairing";
@@ -131,6 +144,7 @@ import { environmentCatalog } from "~/connection/catalog";
 import {
   connectPairing as connectPairingAtom,
   connectSshEnvironment as connectSshEnvironmentAtom,
+  updateSshEnvironmentVariables as updateSshEnvironmentVariablesAtom,
 } from "~/connection/onboarding";
 import { useEnvironmentQuery } from "~/state/query";
 import {
@@ -160,6 +174,102 @@ import {
 const DEFAULT_TAILSCALE_SERVE_PORT = 443;
 const EMPTY_ADVERTISED_ENDPOINTS: ReadonlyArray<AdvertisedEndpoint> = [];
 const EMPTY_DISCOVERED_SSH_HOSTS: ReadonlyArray<DesktopDiscoveredSshHost> = [];
+
+type SshEnvironmentVariableDraftRow = SshEnvironmentVariableDraft & { readonly id: number };
+
+function SshEnvironmentVariableEditor({
+  rows,
+  setRows,
+  disabled,
+}: {
+  readonly rows: ReadonlyArray<SshEnvironmentVariableDraftRow>;
+  readonly setRows: Dispatch<SetStateAction<ReadonlyArray<SshEnvironmentVariableDraftRow>>>;
+  readonly disabled: boolean;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Added to the local SSH process and inherited by the remote T3 server. Each name must match
+        <code> SendEnv</code> for this host in your SSH config. Only add variables you trust; they
+        can affect advanced SSH config such as <code>Match exec</code>. Values are saved in
+        Desktop's protected connection storage.
+      </p>
+      <div className="space-y-2">
+        {rows.map((entry, index) => (
+          <div
+            key={entry.id}
+            className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_2rem] gap-2"
+          >
+            <Input
+              value={entry.name}
+              onChange={(event) => {
+                const name = event.target.value;
+                setRows((current) =>
+                  current.map((item, itemIndex) =>
+                    itemIndex === index ? { ...item, name } : item,
+                  ),
+                );
+              }}
+              placeholder="VARIABLE_NAME"
+              aria-label={`SSH environment variable ${index + 1} name`}
+              disabled={disabled}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              maxLength={128}
+            />
+            <Input
+              type="password"
+              value={entry.value}
+              onChange={(event) => {
+                const value = event.target.value;
+                setRows((current) =>
+                  current.map((item, itemIndex) =>
+                    itemIndex === index ? { ...item, value } : item,
+                  ),
+                );
+              }}
+              placeholder="Value"
+              aria-label={`SSH environment variable ${index + 1} value`}
+              disabled={disabled}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              maxLength={8_192}
+            />
+            <Button
+              type="button"
+              size="icon-xs"
+              variant="ghost"
+              aria-label={`Remove SSH environment variable ${index + 1}`}
+              disabled={disabled}
+              onClick={() =>
+                setRows((current) => current.filter((_, itemIndex) => itemIndex !== index))
+              }
+            >
+              <XIcon className="size-3.5" />
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        type="button"
+        size="xs"
+        variant="ghost"
+        disabled={disabled}
+        onClick={() =>
+          setRows((current) => {
+            const nextId = current.reduce((highest, entry) => Math.max(highest, entry.id), -1) + 1;
+            return [...current, { id: nextId, name: "", value: "" }];
+          })
+        }
+      >
+        <PlusIcon className="size-3.5" />
+        Add variable
+      </Button>
+    </div>
+  );
+}
 
 // Sentinels for the consolidated WSL backend picker. The colon is
 // rejected by DISTRO_NAME_PATTERN (validated on the desktop side) so
@@ -1396,6 +1506,11 @@ type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
   removingEnvironmentId: EnvironmentId | null;
   onConnect: (environmentId: EnvironmentId) => void;
+  onEditSshEnvironment: (input: {
+    readonly environmentId: EnvironmentId;
+    readonly label: string;
+    readonly target: DesktopSshEnvironmentTarget;
+  }) => void;
   onRemove: (environmentId: EnvironmentId) => void;
 };
 
@@ -1403,6 +1518,7 @@ function SavedBackendListRow({
   environment,
   removingEnvironmentId,
   onConnect,
+  onEditSshEnvironment,
   onRemove,
 }: SavedBackendListRowProps) {
   const environmentId = environment.environmentId;
@@ -1567,6 +1683,22 @@ function SavedBackendListRow({
             </Tooltip>
           ) : (
             <>
+              {sshTarget ? (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  disabled={removingEnvironmentId === environmentId}
+                  onClick={() =>
+                    onEditSshEnvironment({
+                      environmentId,
+                      label: environment.label,
+                      target: sshTarget,
+                    })
+                  }
+                >
+                  Edit SSH env
+                </Button>
+              ) : null}
               {!isConnected ? (
                 <Button
                   size="xs"
@@ -1776,6 +1908,9 @@ export function ConnectionsSettings() {
   const connectSshEnvironment = useAtomCommand(connectSshEnvironmentAtom, {
     reportFailure: false,
   });
+  const updateSshEnvironmentVariables = useAtomCommand(updateSshEnvironmentVariablesAtom, {
+    reportFailure: false,
+  });
   const removeEnvironment = useAtomCommand(environmentCatalog.remove, { reportFailure: false });
   const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
@@ -1840,6 +1975,20 @@ export function ConnectionsSettings() {
   const [sshHostSuggestionsOpen, setSshHostSuggestionsOpen] = useState(false);
   // Tracks the arrow-key/hover highlight so Enter selects it instead of submitting the typed text.
   const highlightedSshHostRef = useRef<DesktopDiscoveredSshHost | undefined>(undefined);
+  const [savedBackendSshEnvironmentOpen, setSavedBackendSshEnvironmentOpen] = useState(false);
+  const [savedBackendSshEnvironmentVariables, setSavedBackendSshEnvironmentVariables] = useState<
+    ReadonlyArray<SshEnvironmentVariableDraftRow>
+  >([]);
+  const [editingSshEnvironment, setEditingSshEnvironment] = useState<{
+    readonly environmentId: EnvironmentId;
+    readonly label: string;
+    readonly target: DesktopSshEnvironmentTarget;
+  } | null>(null);
+  const [editingSshEnvironmentVariables, setEditingSshEnvironmentVariables] = useState<
+    ReadonlyArray<SshEnvironmentVariableDraftRow>
+  >([]);
+  const [editingSshEnvironmentError, setEditingSshEnvironmentError] = useState<string | null>(null);
+  const [isSavingSshEnvironment, setIsSavingSshEnvironment] = useState(false);
   const [savedBackendError, setSavedBackendError] = useState<string | null>(null);
   const [isAddingSavedBackend, setIsAddingSavedBackend] = useState(false);
   const [removingSavedEnvironmentId, setRemovingSavedEnvironmentId] =
@@ -2185,6 +2334,8 @@ export function ConnectionsSettings() {
       setSavedBackendSshHost("");
       setSavedBackendSshUsername("");
       setSavedBackendSshPort("");
+      setSavedBackendSshEnvironmentOpen(false);
+      setSavedBackendSshEnvironmentVariables([]);
       setAddBackendDialogOpen(false);
       toastManager.add({
         type: "success",
@@ -2273,6 +2424,7 @@ export function ConnectionsSettings() {
     savedBackendMode,
     savedBackendPairingCode,
     savedBackendSshHost,
+    savedBackendSshEnvironmentVariables,
     savedBackendSshPort,
     savedBackendSshUsername,
   ]);
@@ -2403,6 +2555,123 @@ export function ConnectionsSettings() {
       }
     },
     [removeEnvironment],
+  );
+
+  const handleOpenEditSshEnvironment = useCallback(
+    (input: {
+      readonly environmentId: EnvironmentId;
+      readonly label: string;
+      readonly target: DesktopSshEnvironmentTarget;
+    }) => {
+      const rows = Object.entries(input.target.environmentVariables ?? {}).map(
+        ([name, value], id) => ({ id, name, value }),
+      );
+      setEditingSshEnvironment(input);
+      setEditingSshEnvironmentVariables(rows.length > 0 ? rows : [{ id: 0, name: "", value: "" }]);
+      setEditingSshEnvironmentError(null);
+    },
+    [],
+  );
+
+  const handleSaveSshEnvironment = useCallback(async () => {
+    if (editingSshEnvironment === null) {
+      return;
+    }
+
+    let environmentVariables: Readonly<Record<string, string>> | undefined;
+    try {
+      environmentVariables = parseSshEnvironmentVariables(editingSshEnvironmentVariables);
+    } catch (error) {
+      setEditingSshEnvironmentError(formatDesktopSshConnectionError(error));
+      return;
+    }
+
+    setIsSavingSshEnvironment(true);
+    setEditingSshEnvironmentError(null);
+    const result = await updateSshEnvironmentVariables({
+      environmentId: editingSshEnvironment.environmentId,
+      ...(environmentVariables === undefined ? {} : { environmentVariables }),
+    });
+    setIsSavingSshEnvironment(false);
+
+    if (result._tag === "Failure") {
+      if (!isAtomCommandInterrupted(result)) {
+        setEditingSshEnvironmentError(
+          formatDesktopSshConnectionError(squashAtomCommandFailure(result)),
+        );
+      }
+      return;
+    }
+
+    setEditingSshEnvironment(null);
+    setEditingSshEnvironmentVariables([]);
+    toastManager.add({
+      type: "success",
+      title: "SSH environment saved",
+      description: `${editingSshEnvironment.label} is reconnecting with the updated local environment.`,
+    });
+  }, [editingSshEnvironment, editingSshEnvironmentVariables, updateSshEnvironmentVariables]);
+
+  const handleConnectSshHost = useCallback(
+    async (target: DesktopSshEnvironmentTarget, label?: string) => {
+      let targetWithEnvironment = target;
+      if (savedBackendMode === "ssh") {
+        try {
+          const environmentVariables = parseSshEnvironmentVariables(
+            savedBackendSshEnvironmentVariables,
+          );
+          targetWithEnvironment = {
+            ...target,
+            ...(environmentVariables === undefined ? {} : { environmentVariables }),
+          };
+        } catch (error) {
+          setSavedBackendError(formatDesktopSshConnectionError(error));
+          return;
+        }
+      }
+      setConnectingSshHostAlias(target.alias);
+      if (savedBackendMode === "ssh") {
+        setSavedBackendError(null);
+      } else {
+        setSshConnectionError(null);
+      }
+      const result = await connectSshEnvironment({
+        target: targetWithEnvironment,
+        ...(label === undefined ? {} : { label }),
+      });
+      setConnectingSshHostAlias(null);
+      if (result._tag === "Success") {
+        setSavedBackendSshHost("");
+        setSavedBackendSshUsername("");
+        setSavedBackendSshPort("");
+        setSavedBackendSshEnvironmentOpen(false);
+        setSavedBackendSshEnvironmentVariables([]);
+        setAddBackendDialogOpen(false);
+        toastManager.add({
+          type: "success",
+          title: savedDesktopSshEnvironmentsByAlias[target.alias]
+            ? "Environment reconnected"
+            : "Environment connected",
+          description: `${label?.trim() || target.alias} is ready over an SSH-managed tunnel.`,
+        });
+        return;
+      }
+      if (!isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        const message = formatDesktopSshConnectionError(error);
+        if (savedBackendMode === "ssh") {
+          setSavedBackendError(message);
+        } else {
+          setSshConnectionError(message);
+        }
+      }
+    },
+    [
+      connectSshEnvironment,
+      savedBackendMode,
+      savedBackendSshEnvironmentVariables,
+      savedDesktopSshEnvironmentsByAlias,
+    ],
   );
 
   const visibleDesktopPairingLinks = desktopPairingLinks;
@@ -2652,6 +2921,45 @@ export function ConnectionsSettings() {
             />
           </label>
         </div>
+        <Collapsible
+          open={savedBackendSshEnvironmentOpen}
+          onOpenChange={(open) => {
+            setSavedBackendSshEnvironmentOpen(open);
+            if (open && savedBackendSshEnvironmentVariables.length === 0) {
+              setSavedBackendSshEnvironmentVariables([{ id: 0, name: "", value: "" }]);
+            }
+          }}
+          className="overflow-hidden rounded-lg border border-border/60"
+        >
+          <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-xs text-muted-foreground hover:bg-muted/30 hover:text-foreground">
+            <ChevronDownIcon
+              className={cn(
+                "size-3.5 shrink-0 transition-transform",
+                savedBackendSshEnvironmentOpen && "rotate-180",
+              )}
+            />
+            <span className="font-medium">Local SSH environment</span>
+            {savedBackendSshEnvironmentVariables.some((entry) => entry.name.trim().length > 0) ? (
+              <span className="ml-auto text-[11px] tabular-nums">
+                {
+                  savedBackendSshEnvironmentVariables.filter(
+                    (entry) => entry.name.trim().length > 0,
+                  ).length
+                }{" "}
+                configured
+              </span>
+            ) : null}
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="border-t border-border/60 px-3 py-3">
+              <SshEnvironmentVariableEditor
+                rows={savedBackendSshEnvironmentVariables}
+                setRows={setSavedBackendSshEnvironmentVariables}
+                disabled={isAddingSavedBackend}
+              />
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
         {savedBackendError || discoveredSshHostsError ? (
           <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
             {savedBackendError ?? discoveredSshHostsError}
@@ -3127,6 +3435,58 @@ export function ConnectionsSettings() {
 
   return (
     <SettingsPageContainer>
+      <Dialog
+        open={editingSshEnvironment !== null}
+        onOpenChange={(open) => {
+          if (!open && !isSavingSshEnvironment) {
+            setEditingSshEnvironment(null);
+            setEditingSshEnvironmentVariables([]);
+            setEditingSshEnvironmentError(null);
+          }
+        }}
+      >
+        <DialogPopup className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Edit local SSH environment</DialogTitle>
+            <DialogDescription>
+              {editingSshEnvironment
+                ? `Update variables for ${editingSshEnvironment.label}. Saving restarts this SSH connection so new values reach the local SSH process.`
+                : "Update variables for this saved SSH connection."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <SshEnvironmentVariableEditor
+              rows={editingSshEnvironmentVariables}
+              setRows={setEditingSshEnvironmentVariables}
+              disabled={isSavingSshEnvironment}
+            />
+            {editingSshEnvironmentError ? (
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                {editingSshEnvironmentError}
+              </div>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter variant="bare">
+            <Button
+              variant="outline"
+              disabled={isSavingSshEnvironment}
+              onClick={() => {
+                setEditingSshEnvironment(null);
+                setEditingSshEnvironmentVariables([]);
+                setEditingSshEnvironmentError(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={isSavingSshEnvironment}
+              onClick={() => void handleSaveSshEnvironment()}
+            >
+              {isSavingSshEnvironment ? "Saving…" : "Save and reconnect"}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
       {canManageLocalBackend ? (
         <>
           <SettingsSection {...searchableSetting("connections-environment")}>
@@ -3583,6 +3943,7 @@ export function ConnectionsSettings() {
             environment={environment}
             removingEnvironmentId={removingSavedEnvironmentId}
             onConnect={handleConnectSavedBackend}
+            onEditSshEnvironment={handleOpenEditSshEnvironment}
             onRemove={handleRemoveSavedBackend}
           />
         ))}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -2412,6 +2412,8 @@ export function ConnectionsSettings() {
     setSavedBackendSshHost("");
     setSavedBackendSshUsername("");
     setSavedBackendSshPort("");
+    setSavedBackendSshEnvironmentOpen(false);
+    setSavedBackendSshEnvironmentVariables([]);
     setAddBackendDialogOpen(false);
     toastManager.add({
       type: "success",

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -3,7 +3,6 @@ import {
   ChevronsLeftRightEllipsisIcon,
   PlusIcon,
   QrCodeIcon,
-  RefreshCwIcon,
   TerminalIcon,
   XIcon,
 } from "lucide-react";
@@ -2322,7 +2321,21 @@ export function ConnectionsSettings() {
     async (target: DesktopSshEnvironmentTarget) => {
       setIsAddingSavedBackend(true);
       setSavedBackendError(null);
-      const result = await connectSshEnvironment({ target, label: "" });
+      let targetWithEnvironment: DesktopSshEnvironmentTarget;
+      try {
+        const environmentVariables = parseSshEnvironmentVariables(
+          savedBackendSshEnvironmentVariables,
+        );
+        targetWithEnvironment = {
+          ...target,
+          ...(environmentVariables === undefined ? {} : { environmentVariables }),
+        };
+      } catch (error) {
+        setSavedBackendError(formatDesktopSshConnectionError(error));
+        setIsAddingSavedBackend(false);
+        return;
+      }
+      const result = await connectSshEnvironment({ target: targetWithEnvironment, label: "" });
       if (result._tag === "Failure") {
         if (!isAtomCommandInterrupted(result)) {
           setSavedBackendError(formatDesktopSshConnectionError(squashAtomCommandFailure(result)));
@@ -2346,7 +2359,7 @@ export function ConnectionsSettings() {
       });
       setIsAddingSavedBackend(false);
     },
-    [connectSshEnvironment],
+    [connectSshEnvironment, savedBackendSshEnvironmentVariables],
   );
 
   const handleAddSavedBackend = useCallback(async () => {
@@ -2615,68 +2628,6 @@ export function ConnectionsSettings() {
       description: `${editingSshEnvironment.label} is reconnecting with the updated local environment.`,
     });
   }, [editingSshEnvironment, editingSshEnvironmentVariables, updateSshEnvironmentVariables]);
-
-  const handleConnectSshHost = useCallback(
-    async (target: DesktopSshEnvironmentTarget, label?: string) => {
-      let targetWithEnvironment = target;
-      if (savedBackendMode === "ssh") {
-        try {
-          const environmentVariables = parseSshEnvironmentVariables(
-            savedBackendSshEnvironmentVariables,
-          );
-          targetWithEnvironment = {
-            ...target,
-            ...(environmentVariables === undefined ? {} : { environmentVariables }),
-          };
-        } catch (error) {
-          setSavedBackendError(formatDesktopSshConnectionError(error));
-          return;
-        }
-      }
-      setConnectingSshHostAlias(target.alias);
-      if (savedBackendMode === "ssh") {
-        setSavedBackendError(null);
-      } else {
-        setSshConnectionError(null);
-      }
-      const result = await connectSshEnvironment({
-        target: targetWithEnvironment,
-        ...(label === undefined ? {} : { label }),
-      });
-      setConnectingSshHostAlias(null);
-      if (result._tag === "Success") {
-        setSavedBackendSshHost("");
-        setSavedBackendSshUsername("");
-        setSavedBackendSshPort("");
-        setSavedBackendSshEnvironmentOpen(false);
-        setSavedBackendSshEnvironmentVariables([]);
-        setAddBackendDialogOpen(false);
-        toastManager.add({
-          type: "success",
-          title: savedDesktopSshEnvironmentsByAlias[target.alias]
-            ? "Environment reconnected"
-            : "Environment connected",
-          description: `${label?.trim() || target.alias} is ready over an SSH-managed tunnel.`,
-        });
-        return;
-      }
-      if (!isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        const message = formatDesktopSshConnectionError(error);
-        if (savedBackendMode === "ssh") {
-          setSavedBackendError(message);
-        } else {
-          setSshConnectionError(message);
-        }
-      }
-    },
-    [
-      connectSshEnvironment,
-      savedBackendMode,
-      savedBackendSshEnvironmentVariables,
-      savedDesktopSshEnvironmentsByAlias,
-    ],
-  );
 
   const visibleDesktopPairingLinks = desktopPairingLinks;
   const tailscaleHttpsEndpoint = useMemo(

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -198,7 +198,7 @@ function SshEnvironmentVariableEditor({
         {rows.map((entry, index) => (
           <div
             key={entry.id}
-            className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_2rem] gap-2"
+            className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_2rem] items-center gap-2"
           >
             <Input
               value={entry.name}
@@ -214,6 +214,7 @@ function SshEnvironmentVariableEditor({
               aria-label={`SSH environment variable ${index + 1} name`}
               disabled={disabled}
               autoCapitalize="none"
+              autoComplete="off"
               autoCorrect="off"
               spellCheck={false}
               maxLength={128}
@@ -233,6 +234,7 @@ function SshEnvironmentVariableEditor({
               aria-label={`SSH environment variable ${index + 1} value`}
               disabled={disabled}
               autoCapitalize="none"
+              autoComplete="off"
               autoCorrect="off"
               spellCheck={false}
               maxLength={8_192}

--- a/apps/web/src/connection/onboarding.ts
+++ b/apps/web/src/connection/onboarding.ts
@@ -3,7 +3,7 @@ import {
   createAtomCommandScheduler,
   createRuntimeCommand,
 } from "@t3tools/client-runtime/state/runtime";
-import type { DesktopSshEnvironmentTarget } from "@t3tools/contracts";
+import type { DesktopSshEnvironmentTarget, EnvironmentId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 
 import { connectionAtomRuntime } from "./runtime";
@@ -35,4 +35,20 @@ export const connectSshEnvironment = createRuntimeCommand(connectionAtomRuntime,
   },
   execute: (input: { readonly target: DesktopSshEnvironmentTarget; readonly label?: string }) =>
     ConnectionOnboarding.pipe(Effect.flatMap((onboarding) => onboarding.registerSsh(input))),
+});
+
+export const updateSshEnvironmentVariables = createRuntimeCommand(connectionAtomRuntime, {
+  label: "web:connection:update-ssh-environment-variables",
+  scheduler: onboardingScheduler,
+  concurrency: {
+    mode: "serial",
+    key: (input: { readonly environmentId: EnvironmentId }) => input.environmentId,
+  },
+  execute: (input: {
+    readonly environmentId: EnvironmentId;
+    readonly environmentVariables?: DesktopSshEnvironmentTarget["environmentVariables"];
+  }) =>
+    ConnectionOnboarding.pipe(
+      Effect.flatMap((onboarding) => onboarding.updateSshEnvironmentVariables(input)),
+    ),
 });

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -110,7 +110,8 @@ The SSH form's **Local SSH environment** section adds variables to the local
 `ssh` process. This is useful when SSH config uses `SendEnv` but the desktop app
 was opened outside a shell and did not inherit the variable. Each saved name
 must match `SendEnv` for that host, and the SSH server must allow it with
-`AcceptEnv`. Values are kept in protected desktop connection storage. Use
+`AcceptEnv`. Values are kept in protected desktop connection storage. The
+editor accepts up to 128 variables with a combined encoded size of 16 KiB. Use
 **Edit SSH env** on a saved environment to update or clear them and reconnect.
 Saving restarts a remote T3 server managed by Desktop. If Desktop attached to a
 server started independently, restart that server yourself so it can inherit

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -106,6 +106,15 @@ In the desktop app, open **Settings → Connections → Add environment**, choos
 or reuses a server there and opens the port forward for you. Projects, provider
 credentials, and agent work stay on the remote machine.
 
+The SSH form's **Local SSH environment** section adds variables to the local
+`ssh` process. This is useful when SSH config uses `SendEnv` but the desktop app
+was opened outside a shell and did not inherit the variable. Each saved name
+must match `SendEnv` for that host, and the SSH server must allow it with
+`AcceptEnv`. Values are kept in protected desktop connection storage. Use
+**Edit SSH env** on a saved environment to update or clear them and reconnect.
+Accepted values remain in process memory; T3 Code does not write a remote
+environment file.
+
 The remote host needs a compatible [Node.js installation](./install.md#requirements)
 and [provider setup](./install.md#providers). If launch cannot find Node or reports
 an incompatible version, check it through a non-interactive SSH session:

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -114,9 +114,10 @@ must match `SendEnv` for that host, and the SSH server must allow it with
 editor accepts up to 128 variables with a combined encoded size of 16 KiB. Use
 **Edit SSH env** on a saved environment to update or clear them and reconnect.
 Saving restarts a remote T3 server managed by Desktop. If Desktop attached to a
-server started independently, restart that server yourself so it can inherit
-the new values. Accepted values remain in process memory; T3 Code does not write
-a remote environment file.
+server started independently, stop it and let Desktop launch a managed server,
+or restart it from a session that already has the saved variables. Its normal
+supervisor does not inherit values from Desktop. Accepted values remain in
+process memory; T3 Code does not write a remote environment file.
 
 The remote host needs a compatible [Node.js installation](./install.md#requirements)
 and [provider setup](./install.md#providers). If launch cannot find Node or reports

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -112,8 +112,10 @@ was opened outside a shell and did not inherit the variable. Each saved name
 must match `SendEnv` for that host, and the SSH server must allow it with
 `AcceptEnv`. Values are kept in protected desktop connection storage. Use
 **Edit SSH env** on a saved environment to update or clear them and reconnect.
-Accepted values remain in process memory; T3 Code does not write a remote
-environment file.
+Saving restarts a remote T3 server managed by Desktop. If Desktop attached to a
+server started independently, restart that server yourself so it can inherit
+the new values. Accepted values remain in process memory; T3 Code does not write
+a remote environment file.
 
 The remote host needs a compatible [Node.js installation](./install.md#requirements)
 and [provider setup](./install.md#providers). If launch cannot find Node or reports

--- a/packages/client-runtime/src/connection/index.ts
+++ b/packages/client-runtime/src/connection/index.ts
@@ -14,12 +14,15 @@ export {
   ConnectionOnboarding,
   type PairingConnectionInput,
   type SshConnectionInput,
+  type SshEnvironmentVariablesUpdateInput,
   prepareBearerConnectionUpdate,
   preparePairingRegistration,
+  prepareSshEnvironmentVariablesUpdate,
   prepareSshRegistration,
   registerPairingConnection,
   registerSshConnection,
   updateBearerConnection,
+  updateSshEnvironmentVariables,
 } from "./onboarding.ts";
 export * from "./presentation.ts";
 export * as ProfileStore from "./profileStore.ts";

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -384,16 +384,12 @@ describe("connection onboarding", () => {
                       detail: "TOKEN is not selected by SendEnv.",
                     }),
                   )
-                : Effect.succeed({
-                    bootstrap: {
-                      target: input.target,
-                      httpBaseUrl: "http://127.0.0.1:3773/",
-                      wsBaseUrl: "ws://127.0.0.1:3773/",
-                      pairingToken: "pairing-token",
-                      remotePort: 3773,
-                    },
-                    bearerToken: "bearer-token",
-                  }),
+                : Effect.fail(
+                    new ConnectionBlockedError({
+                      reason: "configuration",
+                      detail: "The previous SSH environment could not be restored.",
+                    }),
+                  ),
             ),
           ),
         disconnect: () => Effect.void,
@@ -411,6 +407,9 @@ describe("connection onboarding", () => {
       expect(error).toMatchObject({
         _tag: "ConnectionBlockedError",
         reason: "configuration",
+        detail: expect.stringContaining(
+          "TOKEN is not selected by SendEnv. The saved settings are unchanged, but the previous SSH runtime could not be restored.",
+        ),
       });
       expect(preparedTargets).toEqual([
         {

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -353,26 +353,41 @@ describe("connection onboarding", () => {
         new Map([[environmentId, { target, profile: Option.some(profile) }]]),
       );
       let registerCount = 0;
-      let preparedTarget: typeof profile.target | null = null;
+      const preparedTargets = new Array<typeof profile.target>();
+      const disconnectedTargets = new Array<typeof profile.target>();
+      const registerIfCurrent: EnvironmentRegistry.EnvironmentRegistry["Service"]["registerIfCurrent"] =
+        (_expectedEntry, _registration, options) =>
+          (options?.beforeRegister ?? Effect.void).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                registerCount += 1;
+              }),
+            ),
+            Effect.tapError(() => options?.onFailure ?? Effect.void),
+          );
       const registry = EnvironmentRegistry.EnvironmentRegistry.of({
         entries,
-        registerIfCurrent: () =>
-          Effect.sync(() => {
-            registerCount += 1;
-          }),
+        registerIfCurrent,
       } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
       const gateway = SshEnvironmentGateway.of({
         provision: () => Effect.die("unused"),
-        prepare: (input) => {
-          preparedTarget = input.target;
-          return Effect.fail(
-            new ConnectionBlockedError({
-              reason: "configuration",
-              detail: "TOKEN is not selected by SendEnv.",
-            }),
-          );
-        },
-        disconnect: () => Effect.die("unused"),
+        prepare: (input) =>
+          Effect.sync(() => {
+            preparedTargets.push(input.target);
+          }).pipe(
+            Effect.andThen(
+              Effect.fail(
+                new ConnectionBlockedError({
+                  reason: "configuration",
+                  detail: "TOKEN is not selected by SendEnv.",
+                }),
+              ),
+            ),
+          ),
+        disconnect: (preparedTarget) =>
+          Effect.sync(() => {
+            disconnectedTargets.push(preparedTarget);
+          }),
       });
 
       const error = yield* updateSshEnvironmentVariables({
@@ -388,7 +403,19 @@ describe("connection onboarding", () => {
         _tag: "ConnectionBlockedError",
         reason: "configuration",
       });
-      expect(preparedTarget).toMatchObject({ environmentVariables: { TOKEN: "new-value" } });
+      expect(preparedTargets).toEqual([
+        {
+          ...profile.target,
+          environmentVariables: { TOKEN: "new-value" },
+        },
+        profile.target,
+      ]);
+      expect(disconnectedTargets).toEqual([
+        {
+          ...profile.target,
+          environmentVariables: { TOKEN: "new-value" },
+        },
+      ]);
       expect(registerCount).toBe(0);
     }),
   );
@@ -416,30 +443,42 @@ describe("connection onboarding", () => {
       const entries = yield* SubscriptionRef.make(
         new Map([[environmentId, { target, profile: Option.some(profile) }]]),
       );
+      const preparedTargets = new Array<typeof profile.target>();
       const disconnectedTargets = new Array<typeof profile.target>();
+      const registerIfCurrent: EnvironmentRegistry.EnvironmentRegistry["Service"]["registerIfCurrent"] =
+        (_expectedEntry, _registration, options) =>
+          (options?.beforeRegister ?? Effect.void).pipe(
+            Effect.andThen(
+              Effect.fail(
+                new Persistence.ConnectionPersistenceError({
+                  operation: "register-connection",
+                  message: "Storage is unavailable.",
+                }),
+              ),
+            ),
+            Effect.tapError(() => options?.onFailure ?? Effect.void),
+          );
       const registry = EnvironmentRegistry.EnvironmentRegistry.of({
         entries,
-        registerIfCurrent: () =>
-          Effect.fail(
-            new Persistence.ConnectionPersistenceError({
-              operation: "register-connection",
-              message: "Storage is unavailable.",
-            }),
-          ),
+        registerIfCurrent,
       } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
       const gateway = SshEnvironmentGateway.of({
         provision: () => Effect.die("unused"),
         prepare: (input) =>
-          Effect.succeed({
-            bootstrap: {
-              target: input.target,
-              httpBaseUrl: "http://127.0.0.1:3773/",
-              wsBaseUrl: "ws://127.0.0.1:3773/",
-              pairingToken: "pairing-token",
-              remotePort: 3773,
-            },
-            bearerToken: "bearer-token",
-          }),
+          Effect.sync(() => {
+            preparedTargets.push(input.target);
+          }).pipe(
+            Effect.as({
+              bootstrap: {
+                target: input.target,
+                httpBaseUrl: "http://127.0.0.1:3773/",
+                wsBaseUrl: "ws://127.0.0.1:3773/",
+                pairingToken: "pairing-token",
+                remotePort: 3773,
+              },
+              bearerToken: "bearer-token",
+            }),
+          ),
         disconnect: (preparedTarget) =>
           Effect.sync(() => {
             disconnectedTargets.push(preparedTarget);
@@ -456,6 +495,13 @@ describe("connection onboarding", () => {
       );
 
       expect(error._tag).toBe("ConnectionPersistenceError");
+      expect(preparedTargets).toEqual([
+        {
+          ...profile.target,
+          environmentVariables: { TOKEN: "new-value" },
+        },
+        profile.target,
+      ]);
       expect(disconnectedTargets).toEqual([
         {
           ...profile.target,

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -7,6 +7,7 @@ import * as SubscriptionRef from "effect/SubscriptionRef";
 
 import { remoteHttpClientLayer } from "../rpc/http.ts";
 import { ClientPresentation, SshEnvironmentGateway } from "../platform/capabilities.ts";
+import * as Persistence from "../platform/persistence.ts";
 import {
   BearerConnectionCredential,
   BearerConnectionProfile,
@@ -355,7 +356,7 @@ describe("connection onboarding", () => {
       let preparedTarget: typeof profile.target | null = null;
       const registry = EnvironmentRegistry.EnvironmentRegistry.of({
         entries,
-        register: () =>
+        registerIfCurrent: () =>
           Effect.sync(() => {
             registerCount += 1;
           }),
@@ -389,6 +390,78 @@ describe("connection onboarding", () => {
       });
       expect(preparedTarget).toMatchObject({ environmentVariables: { TOKEN: "new-value" } });
       expect(registerCount).toBe(0);
+    }),
+  );
+
+  it.effect("cleans up the prepared SSH environment when persistence fails", () =>
+    Effect.gen(function* () {
+      const environmentId = EnvironmentId.make("environment-ssh");
+      const target = new SshConnectionTarget({
+        environmentId,
+        label: "Remote development box",
+        connectionId: "ssh:environment-ssh",
+      });
+      const profile = new SshConnectionProfile({
+        connectionId: target.connectionId,
+        environmentId,
+        label: target.label,
+        target: {
+          alias: "devbox",
+          hostname: "devbox.example.test",
+          username: "developer",
+          port: 22,
+          environmentVariables: { TOKEN: "old-value" },
+        },
+      });
+      const entries = yield* SubscriptionRef.make(
+        new Map([[environmentId, { target, profile: Option.some(profile) }]]),
+      );
+      const disconnectedTargets = new Array<typeof profile.target>();
+      const registry = EnvironmentRegistry.EnvironmentRegistry.of({
+        entries,
+        registerIfCurrent: () =>
+          Effect.fail(
+            new Persistence.ConnectionPersistenceError({
+              operation: "register-connection",
+              message: "Storage is unavailable.",
+            }),
+          ),
+      } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+      const gateway = SshEnvironmentGateway.of({
+        provision: () => Effect.die("unused"),
+        prepare: (input) =>
+          Effect.succeed({
+            bootstrap: {
+              target: input.target,
+              httpBaseUrl: "http://127.0.0.1:3773/",
+              wsBaseUrl: "ws://127.0.0.1:3773/",
+              pairingToken: "pairing-token",
+              remotePort: 3773,
+            },
+            bearerToken: "bearer-token",
+          }),
+        disconnect: (preparedTarget) =>
+          Effect.sync(() => {
+            disconnectedTargets.push(preparedTarget);
+          }),
+      });
+
+      const error = yield* updateSshEnvironmentVariables({
+        environmentId,
+        environmentVariables: { TOKEN: "new-value" },
+      }).pipe(
+        Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
+        Effect.provideService(SshEnvironmentGateway, gateway),
+        Effect.flip,
+      );
+
+      expect(error._tag).toBe("ConnectionPersistenceError");
+      expect(disconnectedTargets).toEqual([
+        {
+          ...profile.target,
+          environmentVariables: { TOKEN: "new-value" },
+        },
+      ]);
     }),
   );
 });

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -6,11 +6,16 @@ import * as Option from "effect/Option";
 
 import { remoteHttpClientLayer } from "../rpc/http.ts";
 import { ClientPresentation, SshEnvironmentGateway } from "../platform/capabilities.ts";
-import { BearerConnectionCredential, BearerConnectionProfile } from "./catalog.ts";
-import { BearerConnectionTarget } from "./model.ts";
+import {
+  BearerConnectionCredential,
+  BearerConnectionProfile,
+  SshConnectionProfile,
+} from "./catalog.ts";
+import { BearerConnectionTarget, SshConnectionTarget } from "./model.ts";
 import {
   prepareBearerConnectionUpdate,
   preparePairingRegistration,
+  prepareSshEnvironmentVariablesUpdate,
   prepareSshRegistration,
 } from "./onboarding.ts";
 
@@ -251,6 +256,71 @@ describe("connection onboarding", () => {
           connectionId: "ssh:environment-ssh",
           target,
         },
+      });
+    }),
+  );
+
+  it.effect("updates and clears saved SSH environment variables without changing identity", () =>
+    Effect.gen(function* () {
+      const environmentId = EnvironmentId.make("environment-ssh");
+      const entry = Option.some({
+        target: new SshConnectionTarget({
+          environmentId,
+          label: "Remote development box",
+          connectionId: "ssh:environment-ssh",
+        }),
+        profile: Option.some(
+          new SshConnectionProfile({
+            connectionId: "ssh:environment-ssh",
+            environmentId,
+            label: "Remote development box",
+            target: {
+              alias: "devbox",
+              hostname: "devbox.example.test",
+              username: "developer",
+              port: 22,
+              environmentVariables: { TOKEN: "old-value" },
+            },
+          }),
+        ),
+      });
+
+      const updated = yield* prepareSshEnvironmentVariablesUpdate({
+        input: {
+          environmentId,
+          environmentVariables: { TOKEN: "new-value", EMPTY: "" },
+        },
+        entry,
+      });
+      expect(updated).toMatchObject({
+        target: {
+          environmentId,
+          label: "Remote development box",
+          connectionId: "ssh:environment-ssh",
+        },
+        profile: {
+          connectionId: "ssh:environment-ssh",
+          environmentId,
+          label: "Remote development box",
+          target: {
+            alias: "devbox",
+            hostname: "devbox.example.test",
+            username: "developer",
+            port: 22,
+            environmentVariables: { TOKEN: "new-value", EMPTY: "" },
+          },
+        },
+      });
+
+      const cleared = yield* prepareSshEnvironmentVariablesUpdate({
+        input: { environmentId },
+        entry: Option.some({ target: updated.target, profile: Option.some(updated.profile) }),
+      });
+      expect(cleared.profile.target).toEqual({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: "developer",
+        port: 22,
       });
     }),
   );

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -354,7 +354,7 @@ describe("connection onboarding", () => {
       );
       let registerCount = 0;
       const preparedTargets = new Array<typeof profile.target>();
-      const disconnectedTargets = new Array<typeof profile.target>();
+      let prepareCount = 0;
       const registerIfCurrent: EnvironmentRegistry.EnvironmentRegistry["Service"]["registerIfCurrent"] =
         (_expectedEntry, _registration, options) =>
           (options?.beforeRegister ?? Effect.void).pipe(
@@ -374,20 +374,29 @@ describe("connection onboarding", () => {
         prepare: (input) =>
           Effect.sync(() => {
             preparedTargets.push(input.target);
+            prepareCount += 1;
           }).pipe(
-            Effect.andThen(
-              Effect.fail(
-                new ConnectionBlockedError({
-                  reason: "configuration",
-                  detail: "TOKEN is not selected by SendEnv.",
-                }),
-              ),
+            Effect.andThen(() =>
+              prepareCount === 1
+                ? Effect.fail(
+                    new ConnectionBlockedError({
+                      reason: "configuration",
+                      detail: "TOKEN is not selected by SendEnv.",
+                    }),
+                  )
+                : Effect.succeed({
+                    bootstrap: {
+                      target: input.target,
+                      httpBaseUrl: "http://127.0.0.1:3773/",
+                      wsBaseUrl: "ws://127.0.0.1:3773/",
+                      pairingToken: "pairing-token",
+                      remotePort: 3773,
+                    },
+                    bearerToken: "bearer-token",
+                  }),
             ),
           ),
-        disconnect: (preparedTarget) =>
-          Effect.sync(() => {
-            disconnectedTargets.push(preparedTarget);
-          }),
+        disconnect: () => Effect.void,
       });
 
       const error = yield* updateSshEnvironmentVariables({
@@ -409,12 +418,6 @@ describe("connection onboarding", () => {
           environmentVariables: { TOKEN: "new-value" },
         },
         profile.target,
-      ]);
-      expect(disconnectedTargets).toEqual([
-        {
-          ...profile.target,
-          environmentVariables: { TOKEN: "new-value" },
-        },
       ]);
       expect(registerCount).toBe(0);
     }),
@@ -444,7 +447,6 @@ describe("connection onboarding", () => {
         new Map([[environmentId, { target, profile: Option.some(profile) }]]),
       );
       const preparedTargets = new Array<typeof profile.target>();
-      const disconnectedTargets = new Array<typeof profile.target>();
       const registerIfCurrent: EnvironmentRegistry.EnvironmentRegistry["Service"]["registerIfCurrent"] =
         (_expectedEntry, _registration, options) =>
           (options?.beforeRegister ?? Effect.void).pipe(
@@ -479,10 +481,7 @@ describe("connection onboarding", () => {
               bearerToken: "bearer-token",
             }),
           ),
-        disconnect: (preparedTarget) =>
-          Effect.sync(() => {
-            disconnectedTargets.push(preparedTarget);
-          }),
+        disconnect: () => Effect.void,
       });
 
       const error = yield* updateSshEnvironmentVariables({
@@ -501,12 +500,6 @@ describe("connection onboarding", () => {
           environmentVariables: { TOKEN: "new-value" },
         },
         profile.target,
-      ]);
-      expect(disconnectedTargets).toEqual([
-        {
-          ...profile.target,
-          environmentVariables: { TOKEN: "new-value" },
-        },
       ]);
     }),
   );

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as SubscriptionRef from "effect/SubscriptionRef";
 
 import { remoteHttpClientLayer } from "../rpc/http.ts";
 import { ClientPresentation, SshEnvironmentGateway } from "../platform/capabilities.ts";
@@ -11,13 +12,15 @@ import {
   BearerConnectionProfile,
   SshConnectionProfile,
 } from "./catalog.ts";
-import { BearerConnectionTarget, SshConnectionTarget } from "./model.ts";
+import { BearerConnectionTarget, ConnectionBlockedError, SshConnectionTarget } from "./model.ts";
 import {
   prepareBearerConnectionUpdate,
   preparePairingRegistration,
   prepareSshEnvironmentVariablesUpdate,
   prepareSshRegistration,
+  updateSshEnvironmentVariables,
 } from "./onboarding.ts";
+import * as EnvironmentRegistry from "./registry.ts";
 
 const CLIENT_PRESENTATION_LAYER = Layer.succeed(
   ClientPresentation,
@@ -322,6 +325,70 @@ describe("connection onboarding", () => {
         username: "developer",
         port: 22,
       });
+    }),
+  );
+
+  it.effect("validates updated SSH environment variables before persisting them", () =>
+    Effect.gen(function* () {
+      const environmentId = EnvironmentId.make("environment-ssh");
+      const target = new SshConnectionTarget({
+        environmentId,
+        label: "Remote development box",
+        connectionId: "ssh:environment-ssh",
+      });
+      const profile = new SshConnectionProfile({
+        connectionId: target.connectionId,
+        environmentId,
+        label: target.label,
+        target: {
+          alias: "devbox",
+          hostname: "devbox.example.test",
+          username: "developer",
+          port: 22,
+          environmentVariables: { TOKEN: "old-value" },
+        },
+      });
+      const entries = yield* SubscriptionRef.make(
+        new Map([[environmentId, { target, profile: Option.some(profile) }]]),
+      );
+      let registerCount = 0;
+      let preparedTarget: typeof profile.target | null = null;
+      const registry = EnvironmentRegistry.EnvironmentRegistry.of({
+        entries,
+        register: () =>
+          Effect.sync(() => {
+            registerCount += 1;
+          }),
+      } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+      const gateway = SshEnvironmentGateway.of({
+        provision: () => Effect.die("unused"),
+        prepare: (input) => {
+          preparedTarget = input.target;
+          return Effect.fail(
+            new ConnectionBlockedError({
+              reason: "configuration",
+              detail: "TOKEN is not selected by SendEnv.",
+            }),
+          );
+        },
+        disconnect: () => Effect.die("unused"),
+      });
+
+      const error = yield* updateSshEnvironmentVariables({
+        environmentId,
+        environmentVariables: { TOKEN: "new-value" },
+      }).pipe(
+        Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
+        Effect.provideService(SshEnvironmentGateway, gateway),
+        Effect.flip,
+      );
+
+      expect(error).toMatchObject({
+        _tag: "ConnectionBlockedError",
+        reason: "configuration",
+      });
+      expect(preparedTarget).toMatchObject({ environmentVariables: { TOKEN: "new-value" } });
+      expect(registerCount).toBe(0);
     }),
   );
 });

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -323,14 +323,13 @@ export const updateSshEnvironmentVariables = Effect.fn(
         Effect.ignore,
       ),
     ),
-    Effect.catchTag(
-      "EnvironmentNotRegisteredError",
-      () =>
+    Effect.catchTags({
+      EnvironmentNotRegisteredError: () =>
         new ConnectionBlockedError({
           reason: "configuration",
           detail: "The SSH environment was removed before the update could be saved.",
         }),
-    ),
+    }),
   );
 });
 

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -26,6 +26,7 @@ import { mapRemoteEnvironmentError } from "./errors.ts";
 import {
   BearerConnectionTarget,
   ConnectionBlockedError,
+  ConnectionTransientError,
   SshConnectionTarget,
   type ConnectionAttemptError,
 } from "./model.ts";
@@ -321,13 +322,55 @@ export const updateSshEnvironmentVariables = Effect.fn(
         target,
       })
       .pipe(Effect.asVoid);
-  const restorePreviousTarget = prepareTarget(previousProfile.target);
+  let restoreError: ConnectionAttemptError | null = null;
+  const restorePreviousTarget = prepareTarget(previousProfile.target).pipe(
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        restoreError = error;
+      }).pipe(
+        Effect.andThen(
+          Effect.logWarning("Could not restore the previous SSH environment after save failed.", {
+            environmentId: input.environmentId,
+            error,
+          }),
+        ),
+      ),
+    ),
+  );
   yield* registry
     .registerIfCurrent(entry, registration, {
       beforeRegister: prepareTarget(registration.profile.target),
       onFailure: restorePreviousTarget,
     })
     .pipe(
+      Effect.mapError((error) => {
+        if (restoreError === null) {
+          return error;
+        }
+        const recovery =
+          "The saved settings are unchanged, but the previous SSH runtime could not be restored. Disconnect and reconnect this environment before continuing.";
+        switch (error._tag) {
+          case "ConnectionPersistenceError":
+            return new Persistence.ConnectionPersistenceError({
+              operation: error.operation,
+              message: `${error.message} ${recovery}`,
+            });
+          case "ConnectionBlockedError":
+            return new ConnectionBlockedError({
+              reason: error.reason,
+              detail: `${error.detail} ${recovery}`,
+              ...(error.traceId === undefined ? {} : { traceId: error.traceId }),
+            });
+          case "ConnectionTransientError":
+            return new ConnectionTransientError({
+              reason: error.reason,
+              detail: `${error.detail} ${recovery}`,
+              ...(error.traceId === undefined ? {} : { traceId: error.traceId }),
+            });
+          case "EnvironmentNotRegisteredError":
+            return error;
+        }
+      }),
       Effect.catchTags({
         EnvironmentNotRegisteredError: () =>
           new ConnectionBlockedError({

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -294,10 +294,16 @@ export const updateSshEnvironmentVariables = Effect.fn(
   "clientRuntime.connection.onboarding.updateSshEnvironmentVariables",
 )(function* (input: SshEnvironmentVariablesUpdateInput) {
   const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+  const gateway = yield* ClientCapabilities.SshEnvironmentGateway;
   const entry = (yield* SubscriptionRef.get(registry.entries)).get(input.environmentId);
   const registration = yield* prepareSshEnvironmentVariablesUpdate({
     input,
     entry: Option.fromUndefinedOr(entry),
+  });
+  yield* gateway.prepare({
+    connectionId: registration.profile.connectionId,
+    expectedEnvironmentId: registration.profile.environmentId,
+    target: registration.profile.target,
   });
   yield* registry.register(registration);
 });
@@ -324,6 +330,7 @@ export const make = Effect.gen(function* () {
     updateSshEnvironmentVariables: (input) =>
       updateSshEnvironmentVariables(input).pipe(
         Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
+        Effect.provideService(ClientCapabilities.SshEnvironmentGateway, ssh),
       ),
     updateBearer: (input) =>
       updateBearerConnection(input).pipe(

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -306,31 +306,45 @@ export const updateSshEnvironmentVariables = Effect.fn(
     input,
     entry: Option.some(entry),
   });
-  yield* gateway.prepare({
-    connectionId: registration.profile.connectionId,
-    expectedEnvironmentId: registration.profile.environmentId,
-    target: registration.profile.target,
-  });
-  yield* registry.registerIfCurrent(entry, registration).pipe(
-    Effect.tapError(() =>
-      gateway.disconnect(registration.profile.target).pipe(
-        Effect.tapError((error) =>
-          Effect.logWarning("Could not clean up a prepared SSH environment after save failed.", {
-            environmentId: input.environmentId,
-            error,
-          }),
-        ),
-        Effect.ignore,
-      ),
+  const previousProfile = Option.getOrNull(entry.profile);
+  if (previousProfile === null || !isSshProfile(previousProfile)) {
+    return yield* new ConnectionBlockedError({
+      reason: "configuration",
+      detail: "Only saved SSH environments can update their local environment variables.",
+    });
+  }
+  const prepareTarget = (target: DesktopSshEnvironmentTarget) =>
+    gateway
+      .prepare({
+        connectionId: registration.profile.connectionId,
+        expectedEnvironmentId: registration.profile.environmentId,
+        target,
+      })
+      .pipe(Effect.asVoid);
+  const restorePreviousTarget = gateway.disconnect(registration.profile.target).pipe(
+    Effect.ignore,
+    Effect.andThen(prepareTarget(previousProfile.target)),
+    Effect.catch((error) =>
+      Effect.logWarning("Could not restore the previous SSH environment after save failed.", {
+        environmentId: input.environmentId,
+        error,
+      }),
     ),
-    Effect.catchTags({
-      EnvironmentNotRegisteredError: () =>
-        new ConnectionBlockedError({
-          reason: "configuration",
-          detail: "The SSH environment was removed before the update could be saved.",
-        }),
-    }),
   );
+  yield* registry
+    .registerIfCurrent(entry, registration, {
+      beforeRegister: prepareTarget(registration.profile.target),
+      onFailure: restorePreviousTarget,
+    })
+    .pipe(
+      Effect.catchTags({
+        EnvironmentNotRegisteredError: () =>
+          new ConnectionBlockedError({
+            reason: "configuration",
+            detail: "The SSH environment was removed before the update could be saved.",
+          }),
+      }),
+    );
 });
 
 export const make = Effect.gen(function* () {

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -43,6 +43,11 @@ export interface SshConnectionInput {
   readonly label?: string;
 }
 
+export interface SshEnvironmentVariablesUpdateInput {
+  readonly environmentId: EnvironmentId;
+  readonly environmentVariables?: DesktopSshEnvironmentTarget["environmentVariables"];
+}
+
 export interface BearerConnectionUpdateInput {
   readonly environmentId: EnvironmentId;
   readonly label: string;
@@ -64,6 +69,9 @@ export class ConnectionOnboarding extends Context.Service<
       EnvironmentId,
       ConnectionAttemptError | Persistence.ConnectionPersistenceError
     >;
+    readonly updateSshEnvironmentVariables: (
+      input: SshEnvironmentVariablesUpdateInput,
+    ) => Effect.Effect<void, ConnectionAttemptError | Persistence.ConnectionPersistenceError>;
     readonly updateBearer: (
       input: BearerConnectionUpdateInput,
     ) => Effect.Effect<void, ConnectionAttemptError | Persistence.ConnectionPersistenceError>;
@@ -129,6 +137,7 @@ export const registerPairingConnection = Effect.fn(
 
 const isBearerCredential = Schema.is(BearerConnectionCredential);
 const isBearerProfile = Schema.is(BearerConnectionProfile);
+const isSshProfile = Schema.is(SshConnectionProfile);
 
 export const updateBearerConnection = Effect.fn(
   "clientRuntime.connection.onboarding.updateBearerConnection",
@@ -242,6 +251,57 @@ export const registerSshConnection = Effect.fn(
   return registration.target.environmentId;
 });
 
+export const prepareSshEnvironmentVariablesUpdate = Effect.fn(
+  "clientRuntime.connection.onboarding.prepareSshEnvironmentVariablesUpdate",
+)(function* (options: {
+  readonly input: SshEnvironmentVariablesUpdateInput;
+  readonly entry: Option.Option<ConnectionCatalogEntry>;
+}) {
+  const entry = Option.getOrNull(options.entry);
+  if (
+    entry === null ||
+    entry.target._tag !== "SshConnectionTarget" ||
+    Option.isNone(entry.profile) ||
+    !isSshProfile(entry.profile.value)
+  ) {
+    return yield* new ConnectionBlockedError({
+      reason: "configuration",
+      detail: "Only saved SSH environments can update their local environment variables.",
+    });
+  }
+
+  const profile = entry.profile.value;
+  const { environmentVariables: _currentEnvironmentVariables, ...baseTarget } = profile.target;
+  const target: DesktopSshEnvironmentTarget = {
+    ...baseTarget,
+    ...(options.input.environmentVariables === undefined
+      ? {}
+      : { environmentVariables: options.input.environmentVariables }),
+  };
+
+  return new SshConnectionRegistration({
+    target: entry.target,
+    profile: new SshConnectionProfile({
+      connectionId: profile.connectionId,
+      environmentId: profile.environmentId,
+      label: profile.label,
+      target,
+    }),
+  });
+});
+
+export const updateSshEnvironmentVariables = Effect.fn(
+  "clientRuntime.connection.onboarding.updateSshEnvironmentVariables",
+)(function* (input: SshEnvironmentVariablesUpdateInput) {
+  const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+  const entry = (yield* SubscriptionRef.get(registry.entries)).get(input.environmentId);
+  const registration = yield* prepareSshEnvironmentVariablesUpdate({
+    input,
+    entry: Option.fromUndefinedOr(entry),
+  });
+  yield* registry.register(registration);
+});
+
 export const make = Effect.gen(function* () {
   const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
   const presentation = yield* ClientCapabilities.ClientPresentation;
@@ -260,6 +320,10 @@ export const make = Effect.gen(function* () {
       registerSshConnection(input).pipe(
         Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
         Effect.provideService(ClientCapabilities.SshEnvironmentGateway, ssh),
+      ),
+    updateSshEnvironmentVariables: (input) =>
+      updateSshEnvironmentVariables(input).pipe(
+        Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
       ),
     updateBearer: (input) =>
       updateBearerConnection(input).pipe(

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -296,16 +296,42 @@ export const updateSshEnvironmentVariables = Effect.fn(
   const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
   const gateway = yield* ClientCapabilities.SshEnvironmentGateway;
   const entry = (yield* SubscriptionRef.get(registry.entries)).get(input.environmentId);
+  if (entry === undefined) {
+    return yield* new ConnectionBlockedError({
+      reason: "configuration",
+      detail: "Only saved SSH environments can update their local environment variables.",
+    });
+  }
   const registration = yield* prepareSshEnvironmentVariablesUpdate({
     input,
-    entry: Option.fromUndefinedOr(entry),
+    entry: Option.some(entry),
   });
   yield* gateway.prepare({
     connectionId: registration.profile.connectionId,
     expectedEnvironmentId: registration.profile.environmentId,
     target: registration.profile.target,
   });
-  yield* registry.register(registration);
+  yield* registry.registerIfCurrent(entry, registration).pipe(
+    Effect.tapError(() =>
+      gateway.disconnect(registration.profile.target).pipe(
+        Effect.tapError((error) =>
+          Effect.logWarning("Could not clean up a prepared SSH environment after save failed.", {
+            environmentId: input.environmentId,
+            error,
+          }),
+        ),
+        Effect.ignore,
+      ),
+    ),
+    Effect.catchTag(
+      "EnvironmentNotRegisteredError",
+      () =>
+        new ConnectionBlockedError({
+          reason: "configuration",
+          detail: "The SSH environment was removed before the update could be saved.",
+        }),
+    ),
+  );
 });
 
 export const make = Effect.gen(function* () {

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -321,16 +321,7 @@ export const updateSshEnvironmentVariables = Effect.fn(
         target,
       })
       .pipe(Effect.asVoid);
-  const restorePreviousTarget = gateway.disconnect(registration.profile.target).pipe(
-    Effect.ignore,
-    Effect.andThen(prepareTarget(previousProfile.target)),
-    Effect.catch((error) =>
-      Effect.logWarning("Could not restore the previous SSH environment after save failed.", {
-        environmentId: input.environmentId,
-        error,
-      }),
-    ),
-  );
+  const restorePreviousTarget = prepareTarget(previousProfile.target);
   yield* registry
     .registerIfCurrent(entry, registration, {
       beforeRegister: prepareTarget(registration.profile.target),

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -135,6 +135,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   initialCredentials: ReadonlyArray<readonly [string, ConnectionCredential]> = [],
   options?: {
     readonly beforeSessionConnect?: (environmentId: EnvironmentId) => Effect.Effect<void>;
+    readonly beforeSessionRelease?: () => Effect.Effect<void>;
     readonly beforeRegistrationRegister?: (
       registration: ConnectionRegistration,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
@@ -364,7 +365,10 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
             probe: Effect.void,
             closed: Deferred.await(closed),
           } satisfies RpcSession.RpcSession),
-          () => Ref.update(releasedSessions, (count) => count + 1),
+          () =>
+            (options?.beforeSessionRelease?.() ?? Effect.void).pipe(
+              Effect.andThen(Ref.update(releasedSessions, (count) => count + 1)),
+            ),
         );
         yield* reportProgress({ stage: "synchronizing", prepared });
         yield* session.ready;
@@ -836,6 +840,63 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
+  it.effect("lets removal win when it starts during update preparation", () =>
+    Effect.gen(function* () {
+      const preparationStarted = yield* Deferred.make<void>();
+      const continuePreparation = yield* Deferred.make<void>();
+      const removalStarted = yield* Deferred.make<void>();
+      const harness = yield* makeHarness([SSH_CONNECTION], [SSH_PROFILE]);
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const expectedEntry = Option.getOrThrow(
+          Option.fromUndefinedOr(
+            (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId),
+          ),
+        );
+        const update = yield* registry
+          .registerIfCurrent(
+            expectedEntry,
+            new SshConnectionRegistration({
+              target: SSH_CONNECTION,
+              profile: new SshConnectionProfile({
+                connectionId: SSH_PROFILE.connectionId,
+                environmentId: SSH_PROFILE.environmentId,
+                label: SSH_PROFILE.label,
+                target: {
+                  ...SSH_PROFILE.target,
+                  environmentVariables: { TOKEN: "new-value" },
+                },
+              }),
+            }),
+            {
+              beforeRegister: Deferred.succeed(preparationStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(continuePreparation)),
+              ),
+            },
+          )
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(preparationStarted);
+        const removal = yield* Effect.gen(function* () {
+          yield* Deferred.succeed(removalStarted, undefined);
+          yield* registry.remove(SSH_CONNECTION.environmentId);
+        }).pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(removalStarted);
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(continuePreparation, undefined);
+        yield* Fiber.join(update);
+        yield* Fiber.join(removal);
+
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).has(SSH_CONNECTION.environmentId),
+        ).toBe(false);
+        expect((yield* Ref.get(harness.storedTargets)).has(SSH_CONNECTION.environmentId)).toBe(
+          false,
+        );
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
   it.effect("rolls back a prepared update when durable registration fails", () =>
     Effect.gen(function* () {
       const lifecycle = new Array<string>();
@@ -893,6 +954,106 @@ describe("EnvironmentRegistry", () => {
         expect(yield* Ref.get(harness.storedProfiles)).toEqual(
           new Map([[SSH_PROFILE.connectionId, SSH_PROFILE]]),
         );
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("rolls back a prepared update when durable registration defects", () =>
+    Effect.gen(function* () {
+      const lifecycle = new Array<string>();
+      const harness = yield* makeHarness([SSH_CONNECTION], [SSH_PROFILE], [], {
+        beforeRegistrationRegister: () => Effect.die("storage defect"),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const expectedEntry = Option.getOrThrow(
+          Option.fromUndefinedOr(
+            (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId),
+          ),
+        );
+        const exit = yield* Effect.exit(
+          registry.registerIfCurrent(
+            expectedEntry,
+            new SshConnectionRegistration({
+              target: SSH_CONNECTION,
+              profile: SSH_PROFILE,
+            }),
+            {
+              beforeRegister: Effect.sync(() => {
+                lifecycle.push("prepare");
+              }),
+              onFailure: Effect.sync(() => {
+                lifecycle.push("rollback");
+              }),
+            },
+          ),
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(lifecycle).toEqual(["prepare", "rollback"]);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("keeps the committed update when previous runtime cleanup defects", () =>
+    Effect.gen(function* () {
+      let cleanupCount = 0;
+      let rollbackCount = 0;
+      const harness = yield* makeHarness([SSH_CONNECTION], [SSH_PROFILE], [], {
+        beforeSessionRelease: () =>
+          Effect.sync(() => {
+            cleanupCount += 1;
+          }).pipe(Effect.andThen(Effect.die("cleanup defect"))),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* awaitConnectionState(
+          registry,
+          SSH_CONNECTION.environmentId,
+          (state) => state.phase === "connected",
+        );
+        const expectedEntry = Option.getOrThrow(
+          Option.fromUndefinedOr(
+            (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId),
+          ),
+        );
+        const updatedProfile = new SshConnectionProfile({
+          connectionId: SSH_PROFILE.connectionId,
+          environmentId: SSH_PROFILE.environmentId,
+          label: SSH_PROFILE.label,
+          target: {
+            ...SSH_PROFILE.target,
+            environmentVariables: { TOKEN: "new-value" },
+          },
+        });
+
+        yield* registry.registerIfCurrent(
+          expectedEntry,
+          new SshConnectionRegistration({
+            target: SSH_CONNECTION,
+            profile: updatedProfile,
+          }),
+          {
+            onFailure: Effect.sync(() => {
+              rollbackCount += 1;
+            }),
+          },
+        );
+
+        expect(cleanupCount).toBe(1);
+        expect(rollbackCount).toBe(0);
+        expect(yield* Ref.get(harness.storedProfiles)).toEqual(
+          new Map([[updatedProfile.connectionId, updatedProfile]]),
+        );
+        expect(
+          Option.getOrThrow(
+            (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId)
+              ?.profile ?? Option.none(),
+          ),
+        ).toEqual(updatedProfile);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -27,6 +27,7 @@ import {
   type ConnectionRegistration,
   PrimaryConnectionRegistration,
   RelayConnectionRegistration,
+  SshConnectionRegistration,
   SshConnectionProfile,
   type ConnectionCredential,
   type ConnectionProfile,
@@ -780,6 +781,45 @@ describe("EnvironmentRegistry", () => {
         expect((yield* Ref.get(harness.storedTargets)).has(RELAY_TARGET.environmentId)).toBe(true);
         expect(yield* Ref.get(harness.cacheClears)).toEqual([]);
         expect(yield* Ref.get(harness.ownedDataClears)).toEqual([]);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("does not register an update after its environment was removed", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([SSH_CONNECTION], [SSH_PROFILE]);
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const expectedEntry = Option.getOrThrow(
+          Option.fromUndefinedOr(
+            (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId),
+          ),
+        );
+
+        yield* registry.remove(SSH_CONNECTION.environmentId);
+        const error = yield* registry
+          .registerIfCurrent(
+            expectedEntry,
+            new SshConnectionRegistration({
+              target: SSH_CONNECTION,
+              profile: new SshConnectionProfile({
+                connectionId: SSH_PROFILE.connectionId,
+                environmentId: SSH_PROFILE.environmentId,
+                label: SSH_PROFILE.label,
+                target: {
+                  ...SSH_PROFILE.target,
+                  environmentVariables: { TOKEN: "new-value" },
+                },
+              }),
+            }),
+          )
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("EnvironmentNotRegisteredError");
+        expect((yield* Ref.get(harness.storedTargets)).has(SSH_CONNECTION.environmentId)).toBe(
+          false,
+        );
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -798,6 +798,8 @@ describe("EnvironmentRegistry", () => {
         );
 
         yield* registry.remove(SSH_CONNECTION.environmentId);
+        let prepared = false;
+        let rolledBack = false;
         const error = yield* registry
           .registerIfCurrent(
             expectedEntry,
@@ -813,12 +815,83 @@ describe("EnvironmentRegistry", () => {
                 },
               }),
             }),
+            {
+              beforeRegister: Effect.sync(() => {
+                prepared = true;
+              }),
+              onFailure: Effect.sync(() => {
+                rolledBack = true;
+              }),
+            },
           )
           .pipe(Effect.flip);
 
         expect(error._tag).toBe("EnvironmentNotRegisteredError");
+        expect(prepared).toBe(false);
+        expect(rolledBack).toBe(false);
         expect((yield* Ref.get(harness.storedTargets)).has(SSH_CONNECTION.environmentId)).toBe(
           false,
+        );
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("rolls back a prepared update when durable registration fails", () =>
+    Effect.gen(function* () {
+      const lifecycle = new Array<string>();
+      const harness = yield* makeHarness([SSH_CONNECTION], [SSH_PROFILE], [], {
+        beforeRegistrationRegister: () =>
+          Effect.sync(() => {
+            lifecycle.push("persist");
+          }).pipe(
+            Effect.andThen(
+              Effect.fail(
+                new Persistence.ConnectionPersistenceError({
+                  operation: "register-connection",
+                  message: "Storage is unavailable.",
+                }),
+              ),
+            ),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const expectedEntry = Option.getOrThrow(
+          Option.fromUndefinedOr(
+            (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId),
+          ),
+        );
+        const error = yield* registry
+          .registerIfCurrent(
+            expectedEntry,
+            new SshConnectionRegistration({
+              target: SSH_CONNECTION,
+              profile: new SshConnectionProfile({
+                connectionId: SSH_PROFILE.connectionId,
+                environmentId: SSH_PROFILE.environmentId,
+                label: SSH_PROFILE.label,
+                target: {
+                  ...SSH_PROFILE.target,
+                  environmentVariables: { TOKEN: "new-value" },
+                },
+              }),
+            }),
+            {
+              beforeRegister: Effect.sync(() => {
+                lifecycle.push("prepare");
+              }),
+              onFailure: Effect.sync(() => {
+                lifecycle.push("rollback");
+              }),
+            },
+          )
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("ConnectionPersistenceError");
+        expect(lifecycle).toEqual(["prepare", "persist", "rollback"]);
+        expect(yield* Ref.get(harness.storedProfiles)).toEqual(
+          new Map([[SSH_PROFILE.connectionId, SSH_PROFILE]]),
         );
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -70,6 +70,13 @@ export class EnvironmentRegistry extends Context.Service<
     readonly register: (
       registration: ConnectionRegistration,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly registerIfCurrent: (
+      expectedEntry: ConnectionCatalogEntry,
+      registration: ConnectionRegistration,
+    ) => Effect.Effect<
+      void,
+      Persistence.ConnectionPersistenceError | EnvironmentNotRegisteredError
+    >;
     readonly registerPlatform: (registration: PrimaryConnectionRegistration) => Effect.Effect<void>;
     readonly reconcilePlatform: (
       registrations: ReadonlyArray<PlatformConnectionRegistration>,
@@ -387,24 +394,48 @@ export const make = Effect.gen(function* () {
     yield* createServiceScope(entry);
   });
 
-  const register = Effect.fn("EnvironmentRegistry.register")(function* (
+  const registerLocked = Effect.fn("EnvironmentRegistry.registerLocked")(function* (
     registration: ConnectionRegistration,
   ) {
     const entry = connectionRegistrationCatalogEntry(registration);
     const environmentId = entry.target.environmentId;
+    yield* registrations.register(registration);
+    yield* Ref.update(persistedTargetsByEnvironment, (current) => {
+      const next = new Map(current);
+      next.set(environmentId, registration.target);
+      return next;
+    });
+    yield* installEntryLocked(entry);
+  });
+
+  const register = Effect.fn("EnvironmentRegistry.register")(function* (
+    registration: ConnectionRegistration,
+  ) {
+    const environmentId = registration.target.environmentId;
     yield* withLeaseLock(
       environmentId,
       Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
           return;
         }
-        yield* registrations.register(registration);
-        yield* Ref.update(persistedTargetsByEnvironment, (current) => {
-          const next = new Map(current);
-          next.set(environmentId, registration.target);
-          return next;
-        });
-        yield* installEntryLocked(entry);
+        yield* registerLocked(registration);
+      }),
+    );
+  });
+
+  const registerIfCurrent = Effect.fn("EnvironmentRegistry.registerIfCurrent")(function* (
+    expectedEntry: ConnectionCatalogEntry,
+    registration: ConnectionRegistration,
+  ) {
+    const environmentId = registration.target.environmentId;
+    yield* withLeaseLock(
+      environmentId,
+      Effect.gen(function* () {
+        const currentEntry = (yield* SubscriptionRef.get(entries)).get(environmentId);
+        if (currentEntry === undefined || !Equal.equals(currentEntry, expectedEntry)) {
+          return yield* new EnvironmentNotRegisteredError({ environmentId });
+        }
+        yield* registerLocked(registration);
       }),
     );
   });
@@ -663,6 +694,7 @@ export const make = Effect.gen(function* () {
     networkStatus,
     start,
     register,
+    registerIfCurrent,
     registerPlatform,
     reconcilePlatform,
     remove,

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -75,7 +75,7 @@ export class EnvironmentRegistry extends Context.Service<
       registration: ConnectionRegistration,
       options?: {
         readonly beforeRegister?: Effect.Effect<void, ConnectionAttemptError>;
-        readonly onFailure?: Effect.Effect<void, ConnectionAttemptError>;
+        readonly onFailure?: Effect.Effect<void>;
       },
     ) => Effect.Effect<
       void,
@@ -446,7 +446,7 @@ export const make = Effect.gen(function* () {
     registration: ConnectionRegistration,
     options?: {
       readonly beforeRegister?: Effect.Effect<void, ConnectionAttemptError>;
-      readonly onFailure?: Effect.Effect<void, ConnectionAttemptError>;
+      readonly onFailure?: Effect.Effect<void>;
     },
   ) {
     const environmentId = registration.target.environmentId;

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -73,9 +73,15 @@ export class EnvironmentRegistry extends Context.Service<
     readonly registerIfCurrent: (
       expectedEntry: ConnectionCatalogEntry,
       registration: ConnectionRegistration,
+      options?: {
+        readonly beforeRegister?: Effect.Effect<void, ConnectionAttemptError>;
+        readonly onFailure?: Effect.Effect<void>;
+      },
     ) => Effect.Effect<
       void,
-      Persistence.ConnectionPersistenceError | EnvironmentNotRegisteredError
+      | ConnectionAttemptError
+      | Persistence.ConnectionPersistenceError
+      | EnvironmentNotRegisteredError
     >;
     readonly registerPlatform: (registration: PrimaryConnectionRegistration) => Effect.Effect<void>;
     readonly reconcilePlatform: (
@@ -426,6 +432,10 @@ export const make = Effect.gen(function* () {
   const registerIfCurrent = Effect.fn("EnvironmentRegistry.registerIfCurrent")(function* (
     expectedEntry: ConnectionCatalogEntry,
     registration: ConnectionRegistration,
+    options?: {
+      readonly beforeRegister?: Effect.Effect<void, ConnectionAttemptError>;
+      readonly onFailure?: Effect.Effect<void>;
+    },
   ) {
     const environmentId = registration.target.environmentId;
     yield* withLeaseLock(
@@ -435,7 +445,10 @@ export const make = Effect.gen(function* () {
         if (currentEntry === undefined || !Equal.equals(currentEntry, expectedEntry)) {
           return yield* new EnvironmentNotRegisteredError({ environmentId });
         }
-        yield* registerLocked(registration);
+        yield* (options?.beforeRegister ?? Effect.void).pipe(
+          Effect.andThen(registerLocked(registration)),
+          Effect.tapError(() => options?.onFailure ?? Effect.void),
+        );
       }),
     );
   });

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -75,7 +75,7 @@ export class EnvironmentRegistry extends Context.Service<
       registration: ConnectionRegistration,
       options?: {
         readonly beforeRegister?: Effect.Effect<void, ConnectionAttemptError>;
-        readonly onFailure?: Effect.Effect<void>;
+        readonly onFailure?: Effect.Effect<void, ConnectionAttemptError>;
       },
     ) => Effect.Effect<
       void,
@@ -255,7 +255,14 @@ export const make = Effect.gen(function* () {
     const next = new Map(current);
     next.delete(environmentId);
     yield* SubscriptionRef.set(serviceScopes, next);
-    yield* Scope.close(lease.scope, Exit.void);
+    yield* Scope.close(lease.scope, Exit.void).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("Connection supervisor cleanup failed after its lease was removed.", {
+          environmentId,
+          cause,
+        }),
+      ),
+    );
   });
 
   const createServiceScope = Effect.fn("EnvironmentRegistry.createServiceScope")(
@@ -400,17 +407,22 @@ export const make = Effect.gen(function* () {
     yield* createServiceScope(entry);
   });
 
+  const persistRegistrationLocked = Effect.fn("EnvironmentRegistry.persistRegistrationLocked")(
+    function* (registration: ConnectionRegistration) {
+      yield* registrations.register(registration);
+      yield* Ref.update(persistedTargetsByEnvironment, (current) => {
+        const next = new Map(current);
+        next.set(registration.target.environmentId, registration.target);
+        return next;
+      });
+    },
+  );
+
   const registerLocked = Effect.fn("EnvironmentRegistry.registerLocked")(function* (
     registration: ConnectionRegistration,
   ) {
     const entry = connectionRegistrationCatalogEntry(registration);
-    const environmentId = entry.target.environmentId;
-    yield* registrations.register(registration);
-    yield* Ref.update(persistedTargetsByEnvironment, (current) => {
-      const next = new Map(current);
-      next.set(environmentId, registration.target);
-      return next;
-    });
+    yield* persistRegistrationLocked(registration);
     yield* installEntryLocked(entry);
   });
 
@@ -434,7 +446,7 @@ export const make = Effect.gen(function* () {
     registration: ConnectionRegistration,
     options?: {
       readonly beforeRegister?: Effect.Effect<void, ConnectionAttemptError>;
-      readonly onFailure?: Effect.Effect<void>;
+      readonly onFailure?: Effect.Effect<void, ConnectionAttemptError>;
     },
   ) {
     const environmentId = registration.target.environmentId;
@@ -445,9 +457,19 @@ export const make = Effect.gen(function* () {
         if (currentEntry === undefined || !Equal.equals(currentEntry, expectedEntry)) {
           return yield* new EnvironmentNotRegisteredError({ environmentId });
         }
-        yield* (options?.beforeRegister ?? Effect.void).pipe(
-          Effect.andThen(registerLocked(registration)),
-          Effect.tapError(() => options?.onFailure ?? Effect.void),
+        yield* Effect.uninterruptible(
+          Effect.gen(function* () {
+            const exit = yield* Effect.exit(
+              (options?.beforeRegister ?? Effect.void).pipe(
+                Effect.andThen(persistRegistrationLocked(registration)),
+              ),
+            );
+            if (Exit.isFailure(exit)) {
+              yield* options?.onFailure ?? Effect.void;
+              return yield* Effect.failCause(exit.cause);
+            }
+            yield* installEntryLocked(connectionRegistrationCatalogEntry(registration));
+          }),
         );
       }),
     );

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -218,6 +218,10 @@ describe("ConnectionCatalogDocument", () => {
         hostname: "devbox.example.test",
         username: "developer",
         port: 22,
+        environmentVariables: {
+          AWS_PROFILE: "production",
+          FORWARDED_SECRET: "secret-value",
+        },
       },
     });
     const document = registerConnectionInCatalog(

--- a/packages/client-runtime/src/state/threads-atoms.test.ts
+++ b/packages/client-runtime/src/state/threads-atoms.test.ts
@@ -163,6 +163,7 @@ const makeHarness = Effect.fn("TestThreadAtoms.makeHarness")(function* (options?
     networkStatus: yield* SubscriptionRef.make<NetworkStatus>("online"),
     start: Effect.void,
     register: () => Effect.die("Unexpected environment registration"),
+    registerIfCurrent: () => Effect.die("Unexpected environment registration"),
     registerPlatform: () => Effect.die("Unexpected environment registration"),
     reconcilePlatform: () => Effect.die("Unexpected environment reconciliation"),
     remove: () => Effect.die("Unexpected environment removal"),

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { DesktopEnvironmentBootstrapSchema } from "./ipc.ts";
+import { DesktopEnvironmentBootstrapSchema, DesktopSshEnvironmentTargetSchema } from "./ipc.ts";
 
 describe("DesktopEnvironmentBootstrapSchema", () => {
   const decode = Schema.decodeUnknownSync(DesktopEnvironmentBootstrapSchema);
@@ -34,5 +34,79 @@ describe("DesktopEnvironmentBootstrapSchema", () => {
         wsBaseUrl: null,
       }).runningDistro,
     ).toBeNull();
+  });
+});
+
+describe("DesktopSshEnvironmentTargetSchema", () => {
+  const decode = Schema.decodeUnknownSync(DesktopSshEnvironmentTargetSchema);
+
+  it("preserves bounded local SSH environment variables", () => {
+    expect(
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: "developer",
+        port: 22,
+        environmentVariables: {
+          AWS_PROFILE: "production",
+          EMPTY_VALUE: "",
+        },
+      }).environmentVariables,
+    ).toEqual({ AWS_PROFILE: "production", EMPTY_VALUE: "" });
+  });
+
+  it("rejects names that cannot be process environment keys", () => {
+    expect(() =>
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: null,
+        port: null,
+        environmentVariables: { "BAD-NAME": "value" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects NUL bytes before values reach process spawning", () => {
+    expect(() =>
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: null,
+        port: null,
+        environmentVariables: { TOKEN: "bad\0value" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects variables that can alter local process execution", () => {
+    for (const name of [
+      "PATH",
+      "path",
+      "LD_PRELOAD",
+      "ld_audit",
+      "DYLD_INSERT_LIBRARIES",
+      "GSS_MECH_CONFIG",
+      "KRB5_CONFIG",
+      "KRB5_KTNAME",
+      "KRB5_PLUGIN_DIR",
+      "OpenSSL_CONF",
+      "PROGRAMDATA",
+      "SSH_ASKPASS",
+      "SSH_SK_HELPER",
+      "ssh_sk_provider",
+      "SSH_PKCS11_HELPER",
+      "T3_SSH_AUTH_SECRET",
+    ]) {
+      expect(() =>
+        decode({
+          alias: "devbox",
+          hostname: "devbox.example.test",
+          username: null,
+          port: null,
+          environmentVariables: { [name]: "value" },
+        }),
+      ).toThrow();
+    }
   });
 });

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -79,6 +79,18 @@ describe("DesktopSshEnvironmentTargetSchema", () => {
     ).toThrow();
   });
 
+  it("rejects names that differ only by case", () => {
+    expect(() =>
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: null,
+        port: null,
+        environmentVariables: { TOKEN: "first", token: "second" },
+      }),
+    ).toThrow();
+  });
+
   it("rejects environment maps above the encoded process environment budget", () => {
     expect(() =>
       decode({

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -67,6 +67,37 @@ describe("DesktopSshEnvironmentTargetSchema", () => {
     ).toThrow();
   });
 
+  it("rejects oversized SSH target fields", () => {
+    expect(() =>
+      decode({
+        alias: "a".repeat(1_025),
+        hostname: "devbox.example.test",
+        username: null,
+        port: null,
+      }),
+    ).toThrow();
+    expect(() =>
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: "u".repeat(257),
+        port: null,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects option-like hosts, unsafe usernames, and invalid ports", () => {
+    for (const input of [
+      { alias: "-oProxyCommand=bad", hostname: "devbox.example.test", username: null, port: null },
+      { alias: "devbox", hostname: "devbox.example.test", username: "bad@user", port: null },
+      { alias: "devbox", hostname: "devbox.example.test", username: null, port: 0 },
+      { alias: "devbox", hostname: "devbox.example.test", username: null, port: 65_536 },
+      { alias: "devbox", hostname: "devbox.example.test", username: null, port: 22.5 },
+    ]) {
+      expect(() => decode(input)).toThrow();
+    }
+  });
+
   it("rejects NUL bytes before values reach process spawning", () => {
     expect(() =>
       decode({

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -96,6 +96,14 @@ describe("DesktopSshEnvironmentTargetSchema", () => {
     ]) {
       expect(() => decode(input)).toThrow();
     }
+    expect(
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: "build$",
+        port: 22,
+      }).username,
+    ).toBe("build$");
   });
 
   it("rejects NUL bytes before values reach process spawning", () => {

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -79,6 +79,20 @@ describe("DesktopSshEnvironmentTargetSchema", () => {
     ).toThrow();
   });
 
+  it("rejects environment maps above the encoded process environment budget", () => {
+    expect(() =>
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: null,
+        port: null,
+        environmentVariables: Object.fromEntries(
+          Array.from({ length: 9 }, (_, index) => [`TOKEN_${index}`, "€".repeat(8_192)]),
+        ),
+      }),
+    ).toThrow();
+  });
+
   it("rejects variables that can alter local process execution", () => {
     for (const name of [
       "PATH",

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -65,6 +65,15 @@ describe("DesktopSshEnvironmentTargetSchema", () => {
         environmentVariables: { "BAD-NAME": "value" },
       }),
     ).toThrow();
+    expect(() =>
+      decode({
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: null,
+        port: null,
+        environmentVariables: JSON.parse('{"__proto__":"value"}'),
+      }),
+    ).toThrow();
   });
 
   it("rejects oversized SSH target fields", () => {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -390,6 +390,17 @@ export const DesktopSshEnvironmentVariablesSchema = Schema.Record(
         : [{ path: [name], issue: "Invalid SSH environment variable name" }],
     ),
   ),
+  Schema.makeFilter((environmentVariables) => {
+    const normalizedNames = new Set<string>();
+    return Object.keys(environmentVariables).flatMap((name) => {
+      const normalizedName = name.toUpperCase();
+      if (normalizedNames.has(normalizedName)) {
+        return [{ path: [name], issue: "SSH environment variable names must be unique by case" }];
+      }
+      normalizedNames.add(normalizedName);
+      return [];
+    });
+  }),
   Schema.isMaxProperties(128),
   Schema.makeFilter((environmentVariables) =>
     desktopSshEnvironmentVariablesEncodedBytes(environmentVariables) <=

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -422,7 +422,7 @@ const DesktopSshHostTextSchema = Schema.String.check(
 const DesktopSshUsernameSchema = Schema.String.check(
   Schema.isMaxLength(256),
   Schema.makeFilter((value) =>
-    /^[A-Za-z0-9._\\-]+$/u.test(value) ? undefined : "Invalid SSH username",
+    /^[A-Za-z0-9._\\-]+\$?$/u.test(value) ? undefined : "Invalid SSH username",
   ),
 );
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -350,6 +350,23 @@ export function isSafeDesktopSshEnvironmentVariableName(name: string): boolean {
   );
 }
 
+export const DESKTOP_SSH_ENVIRONMENT_VARIABLES_MAX_ENCODED_BYTES = 16 * 1_024;
+const sshEnvironmentTextEncoder = new TextEncoder();
+
+function desktopSshEnvironmentVariablesEncodedBytes(
+  environmentVariables: Readonly<Record<string, string>>,
+): number {
+  return Object.entries(environmentVariables).reduce(
+    (total, [name, value]) =>
+      total +
+      sshEnvironmentTextEncoder.encode(name).byteLength +
+      1 +
+      sshEnvironmentTextEncoder.encode(value).byteLength +
+      1,
+    0,
+  );
+}
+
 export const DesktopSshEnvironmentVariablesSchema = Schema.Record(
   Schema.String,
   Schema.String.check(
@@ -374,6 +391,12 @@ export const DesktopSshEnvironmentVariablesSchema = Schema.Record(
     ),
   ),
   Schema.isMaxProperties(128),
+  Schema.makeFilter((environmentVariables) =>
+    desktopSshEnvironmentVariablesEncodedBytes(environmentVariables) <=
+    DESKTOP_SSH_ENVIRONMENT_VARIABLES_MAX_ENCODED_BYTES
+      ? undefined
+      : "SSH environment variables exceed the 16 KiB encoded size limit",
+  ),
 );
 export type DesktopSshEnvironmentVariables = typeof DesktopSshEnvironmentVariablesSchema.Type;
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -87,7 +87,7 @@ import type {
   OrchestrationSubscribeThreadInput,
   OrchestrationThreadStreamItem,
 } from "./orchestration.ts";
-import { EnvironmentId } from "./baseSchemas.ts";
+import { EnvironmentId, PortSchema } from "./baseSchemas.ts";
 import { BrowserProfileId } from "./browserProfile.ts";
 import type {
   BrowserImportResult,
@@ -411,11 +411,26 @@ export const DesktopSshEnvironmentVariablesSchema = Schema.Record(
 );
 export type DesktopSshEnvironmentVariables = typeof DesktopSshEnvironmentVariablesSchema.Type;
 
+const DesktopSshHostTextSchema = Schema.String.check(
+  Schema.isMaxLength(1_024),
+  Schema.makeFilter((value) =>
+    value.trim().length > 0 && !value.trimStart().startsWith("-")
+      ? undefined
+      : "SSH hosts must be non-empty and cannot begin with a hyphen",
+  ),
+);
+const DesktopSshUsernameSchema = Schema.String.check(
+  Schema.isMaxLength(256),
+  Schema.makeFilter((value) =>
+    /^[A-Za-z0-9._\\-]+$/u.test(value) ? undefined : "Invalid SSH username",
+  ),
+);
+
 export const DesktopSshEnvironmentTargetSchema = Schema.Struct({
-  alias: Schema.String,
-  hostname: Schema.String,
-  username: Schema.NullOr(Schema.String),
-  port: Schema.NullOr(Schema.Number),
+  alias: DesktopSshHostTextSchema,
+  hostname: DesktopSshHostTextSchema,
+  username: Schema.NullOr(DesktopSshUsernameSchema),
+  port: Schema.NullOr(PortSchema),
   environmentVariables: Schema.optionalKey(DesktopSshEnvironmentVariablesSchema),
 });
 export type DesktopSshEnvironmentTarget = typeof DesktopSshEnvironmentTargetSchema.Type;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -336,6 +336,7 @@ const UNSAFE_DESKTOP_SSH_ENVIRONMENT_VARIABLE_NAMES = new Set([
   "SHLIB_PATH",
   "T3_SSH_AUTH_SECRET",
   "USERPROFILE",
+  "__PROTO__",
 ]);
 
 /** Block high-risk process overrides before target-specific SendEnv validation. */

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -306,11 +306,83 @@ export const DesktopEnvironmentBootstrapSchema = Schema.Struct({
   bootstrapToken: Schema.optionalKey(Schema.String),
 });
 
+const UNSAFE_DESKTOP_SSH_ENVIRONMENT_VARIABLE_NAMES = new Set([
+  "BASH_ENV",
+  "CDPATH",
+  "COMSPEC",
+  "ENV",
+  "GCONV_PATH",
+  "GSS_MECH_CONFIG",
+  "HOME",
+  "KRB5_CONFIG",
+  "KRB5_KTNAME",
+  "KRB5_PLUGIN_DIR",
+  "LIBPATH",
+  "LOCPATH",
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "PATH",
+  "PATHEXT",
+  "PERL5LIB",
+  "PERL5OPT",
+  "PYTHONHOME",
+  "PYTHONINSPECT",
+  "PYTHONPATH",
+  "PYTHONSTARTUP",
+  "PROGRAMDATA",
+  "RUBYLIB",
+  "RUBYOPT",
+  "SHELLOPTS",
+  "SHLIB_PATH",
+  "T3_SSH_AUTH_SECRET",
+  "USERPROFILE",
+]);
+
+/** Block high-risk process overrides before target-specific SendEnv validation. */
+export function isSafeDesktopSshEnvironmentVariableName(name: string): boolean {
+  const normalized = name.toUpperCase();
+  return (
+    !UNSAFE_DESKTOP_SSH_ENVIRONMENT_VARIABLE_NAMES.has(normalized) &&
+    !normalized.startsWith("DYLD_") &&
+    !normalized.startsWith("LD_") &&
+    !normalized.startsWith("OPENSSL_") &&
+    !normalized.startsWith("SSH_")
+  );
+}
+
+export const DesktopSshEnvironmentVariablesSchema = Schema.Record(
+  Schema.String,
+  Schema.String.check(
+    Schema.isMaxLength(8_192),
+    Schema.makeFilter((value) =>
+      value.includes("\0") ? "SSH environment variable values cannot contain NUL" : undefined,
+    ),
+  ),
+).check(
+  Schema.makeFilter((environmentVariables) =>
+    Object.keys(environmentVariables).flatMap((name) =>
+      /^[A-Za-z_][A-Za-z0-9_]*$/u.test(name) && name.length <= 128
+        ? isSafeDesktopSshEnvironmentVariableName(name)
+          ? []
+          : [
+              {
+                path: [name],
+                issue: "SSH environment variable can affect the local SSH process",
+              },
+            ]
+        : [{ path: [name], issue: "Invalid SSH environment variable name" }],
+    ),
+  ),
+  Schema.isMaxProperties(128),
+);
+export type DesktopSshEnvironmentVariables = typeof DesktopSshEnvironmentVariablesSchema.Type;
+
 export const DesktopSshEnvironmentTargetSchema = Schema.Struct({
   alias: Schema.String,
   hostname: Schema.String,
   username: Schema.NullOr(Schema.String),
   port: Schema.NullOr(Schema.Number),
+  environmentVariables: Schema.optionalKey(DesktopSshEnvironmentVariablesSchema),
 });
 export type DesktopSshEnvironmentTarget = typeof DesktopSshEnvironmentTargetSchema.Type;
 

--- a/packages/ssh/src/auth.test.ts
+++ b/packages/ssh/src/auth.test.ts
@@ -5,7 +5,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import {
   buildSshAskpassHelperDescriptor,
@@ -71,5 +71,23 @@ describe("ssh auth", () => {
         ["ssh-askpass.cmd", "ssh-askpass.ps1"],
       );
     }),
+  );
+
+  it.effect("removes inherited Windows keys that collide with the overlay by case", () =>
+    Effect.gen(function* () {
+      const env = yield* buildSshChildEnvironment({ baseEnv: { token: "new-value" } });
+
+      assert.equal(env.token, "new-value");
+      assert.notProperty(env, "TOKEN");
+      assert.equal(env.KEEP, "inherited");
+    }).pipe(
+      Effect.provideService(HostProcessPlatform, "win32"),
+      Effect.provideService(HostProcessEnvironment, {
+        TOKEN: "old-value",
+        KEEP: "inherited",
+      }),
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
   );
 });

--- a/packages/ssh/src/auth.ts
+++ b/packages/ssh/src/auth.ts
@@ -1,4 +1,4 @@
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -179,12 +179,24 @@ export const buildSshChildEnvironment = Effect.fn("ssh/auth.buildSshChildEnviron
   PlatformError.PlatformError,
   FileSystem.FileSystem | Path.Path
 > {
-  const baseEnv = { ...input.baseEnv };
+  const platform = yield* HostProcessPlatform;
+  const hostEnvironment = yield* HostProcessEnvironment;
+  const baseEnv: NodeJS.ProcessEnv = { ...hostEnvironment };
+  if (platform === "win32") {
+    const overlayNames = new Set(
+      Object.keys(input.baseEnv ?? {}).map((name) => name.toUpperCase()),
+    );
+    for (const name of Object.keys(baseEnv)) {
+      if (overlayNames.has(name.toUpperCase())) {
+        delete baseEnv[name];
+      }
+    }
+  }
+  Object.assign(baseEnv, input.baseEnv);
   if (!input.interactiveAuth) {
     return baseEnv;
   }
 
-  const platform = yield* HostProcessPlatform;
   const hostDisplay = input.baseEnv
     ? input.baseEnv.DISPLAY
     : yield* Config.string("DISPLAY").pipe(

--- a/packages/ssh/src/auth.ts
+++ b/packages/ssh/src/auth.ts
@@ -56,6 +56,7 @@ export class SshPasswordPrompt extends Context.Service<SshPasswordPrompt, SshPas
 export interface SshChildEnvironmentOptions {
   readonly interactiveAuth?: boolean;
   readonly baseEnv?: NodeJS.ProcessEnv;
+  readonly unsetEnv?: ReadonlyArray<string>;
   readonly askpassDirectory?: string;
   readonly authSecret?: string | null;
 }
@@ -182,14 +183,16 @@ export const buildSshChildEnvironment = Effect.fn("ssh/auth.buildSshChildEnviron
   const platform = yield* HostProcessPlatform;
   const hostEnvironment = yield* HostProcessEnvironment;
   const baseEnv: NodeJS.ProcessEnv = { ...hostEnvironment };
-  if (platform === "win32") {
-    const overlayNames = new Set(
-      Object.keys(input.baseEnv ?? {}).map((name) => name.toUpperCase()),
-    );
-    for (const name of Object.keys(baseEnv)) {
-      if (overlayNames.has(name.toUpperCase())) {
-        delete baseEnv[name];
-      }
+  const normalizeName = (name: string) => (platform === "win32" ? name.toUpperCase() : name);
+  const namesToRemove = new Set(
+    [
+      ...(input.unsetEnv ?? []),
+      ...(platform === "win32" ? Object.keys(input.baseEnv ?? {}) : []),
+    ].map(normalizeName),
+  );
+  for (const name of Object.keys(baseEnv)) {
+    if (namesToRemove.has(normalizeName(name))) {
+      delete baseEnv[name];
     }
   }
   Object.assign(baseEnv, input.baseEnv);

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -283,7 +283,8 @@ describe("ssh command", () => {
       const target = yield* resolveSshTarget("devbox", { TOKEN: "forwarded-value" });
 
       assert.isUndefined(spawnedEnvironments[0]?.TOKEN);
-      assert.equal(spawnedEnvironments[1]?.TOKEN, "forwarded-value");
+      assert.isUndefined(spawnedEnvironments[1]?.TOKEN);
+      assert.equal(spawnedEnvironments[2]?.TOKEN, "forwarded-value");
       assert.deepEqual(target, {
         alias: "devbox",
         hostname: "devbox.example.com",
@@ -291,6 +292,40 @@ describe("ssh command", () => {
         port: 2222,
         environmentVariables: { TOKEN: "forwarded-value" },
       });
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("validates SendEnv with the managed remote command", () => {
+    const spawnedArgs: Array<ReadonlyArray<string>> = [];
+    const spawner = ChildProcessSpawner.make((command) => {
+      const args = command._tag === "StandardCommand" ? command.args : [];
+      spawnedArgs.push(args);
+      const commandSpecificConfig = args.includes("sh");
+      return Effect.succeed(
+        makeSuccessfulProcess(
+          [
+            "hostname devbox.example.com",
+            "user julius",
+            "port 2222",
+            ...(commandSpecificConfig ? ["sendenv TOKEN"] : []),
+            "",
+          ].join("\n"),
+        ),
+      );
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const target = yield* resolveSshTarget("devbox", { TOKEN: "forwarded-value" });
+
+      assert.equal(spawnedArgs.length, 3);
+      assert.notInclude(spawnedArgs[0] ?? [], "sh");
+      assert.include(spawnedArgs[1] ?? [], "sh");
+      assert.include(spawnedArgs[2] ?? [], "sh");
+      assert.equal(target.environmentVariables?.TOKEN, "forwarded-value");
     }).pipe(Effect.provide(processLayer));
   });
 
@@ -322,7 +357,7 @@ describe("ssh command", () => {
       resolveCount += 1;
       return Effect.succeed(
         makeSuccessfulProcess(
-          resolveCount === 1
+          resolveCount <= 2
             ? "hostname devbox.example.com\nsendenv TOKEN\n"
             : "hostname devbox.example.com\n",
         ),

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -262,6 +263,34 @@ describe("ssh command", () => {
     }).pipe(Effect.provide(processLayer));
   });
 
+  it.effect("terminates SSH options before the host argument", () => {
+    let spawnedArgs: ReadonlyArray<string> = [];
+    const spawner = ChildProcessSpawner.make((command) => {
+      spawnedArgs = command._tag === "StandardCommand" ? command.args : [];
+      return Effect.succeed(makeSuccessfulProcess(""));
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      yield* runSshCommand(
+        {
+          alias: "-oProxyCommand=bad",
+          hostname: "ignored.example.com",
+          username: null,
+          port: null,
+        },
+        { remoteCommandArgs: ["true"] },
+      );
+
+      const separatorIndex = spawnedArgs.indexOf("--");
+      assert.isAtLeast(separatorIndex, 0);
+      assert.equal(spawnedArgs[separatorIndex + 1], "-oProxyCommand=bad");
+    }).pipe(Effect.provide(processLayer));
+  });
+
   it.effect("validates SendEnv before resolving SSH config with the forwarded variables", () => {
     const spawnedEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> = [];
     const spawner = ChildProcessSpawner.make((command) => {
@@ -294,6 +323,38 @@ describe("ssh command", () => {
         port: 2222,
         environmentVariables: { TOKEN: "forwarded-value" },
       });
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("removes ambient managed values from baseline SSH config probes", () => {
+    const probeValues = new Array<string | undefined>();
+    const spawner = ChildProcessSpawner.make((command) => {
+      const environment = command._tag === "StandardCommand" ? command.options.env : undefined;
+      probeValues.push(environment?.TOKEN);
+      const sendEnvironment = environment?.TOKEN !== "ambient-blocked";
+      return Effect.succeed(
+        makeSuccessfulProcess(
+          [
+            "hostname devbox.example.com",
+            "user julius",
+            "port 2222",
+            ...(sendEnvironment ? ["sendenv TOKEN"] : []),
+            "",
+          ].join("\n"),
+        ),
+      );
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HostProcessEnvironment, { TOKEN: "ambient-blocked" }),
+    );
+
+    return Effect.gen(function* () {
+      const target = yield* resolveSshTarget("devbox", { TOKEN: "saved-allowed" });
+
+      assert.deepEqual(probeValues, [undefined, undefined, "saved-allowed"]);
+      assert.equal(target.environmentVariables?.TOKEN, "saved-allowed");
     }).pipe(Effect.provide(processLayer));
   });
 

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -16,6 +16,7 @@ import {
   isSshEnvironmentNameConfiguredForSend,
   parseSshResolveOutput,
   parseSshSendEnvironmentPatterns,
+  redactSshOutput,
   resolveRemoteT3CliPackageSpec,
   resolveSshTarget,
   runSshCommand,
@@ -329,6 +330,49 @@ describe("ssh command", () => {
     }).pipe(Effect.provide(processLayer));
   });
 
+  it.effect("validates SendEnv with the requested SSH username and port", () => {
+    const spawnedArgs = new Array<ReadonlyArray<string>>();
+    const spawner = ChildProcessSpawner.make((command) => {
+      const args = command._tag === "StandardCommand" ? command.args : [];
+      spawnedArgs.push(args);
+      const usesRequestedIdentity =
+        args.includes("developer@devbox") &&
+        args.some((value, index) => value === "-p" && args[index + 1] === "2200");
+      return Effect.succeed(
+        makeSuccessfulProcess(
+          [
+            "hostname devbox.example.com",
+            "user developer",
+            "port 2200",
+            ...(usesRequestedIdentity && args.includes("sh") ? ["sendenv TOKEN"] : []),
+            "",
+          ].join("\n"),
+        ),
+      );
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const target = yield* resolveSshTarget(
+        "devbox",
+        { TOKEN: "forwarded-value" },
+        { username: "developer", port: 2200 },
+      );
+
+      assert.equal(spawnedArgs.length, 3);
+      for (const args of spawnedArgs) {
+        assert.include(args, "developer@devbox");
+        assert.isTrue(args.some((value, index) => value === "-p" && args[index + 1] === "2200"));
+      }
+      assert.equal(target.username, "developer");
+      assert.equal(target.port, 2200);
+      assert.equal(target.environmentVariables?.TOKEN, "forwarded-value");
+    }).pipe(Effect.provide(processLayer));
+  });
+
   it.effect("rejects variables not selected by SendEnv", () => {
     const spawner = ChildProcessSpawner.make(() =>
       Effect.succeed(
@@ -375,9 +419,14 @@ describe("ssh command", () => {
     }).pipe(Effect.provide(processLayer));
   });
 
-  it.effect("redacts credentials from stdout in non-zero command failures", () => {
+  it.effect("redacts credentials and forwarded values in non-zero command failures", () => {
     const spawner = ChildProcessSpawner.make(() =>
-      Effect.succeed(makeFailedProcess({ stdout: '{"credential":"pairing-secret"}\n' })),
+      Effect.succeed(
+        makeFailedProcess({
+          stdout: '{"credential":"pairing-secret"}\n',
+          stderr: "Authentication failed for forwarded-secret\n",
+        }),
+      ),
     );
     const spawnerLayer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner);
     const processLayer = Layer.mergeAll(NodeServices.layer, spawnerLayer);
@@ -390,6 +439,7 @@ describe("ssh command", () => {
             hostname: "devbox.example.com",
             username: "julius",
             port: 2222,
+            environmentVariables: { TOKEN: "forwarded-secret" },
           },
           { remoteCommandArgs: ["sh", "-s"] },
         ),
@@ -398,11 +448,27 @@ describe("ssh command", () => {
       assert.isTrue(Result.isFailure(result));
       if (Result.isFailure(result)) {
         assert.instanceOf(result.failure, SshCommandError);
-        assert.equal(result.failure.message, '{"credential":"[redacted]"}');
+        assert.equal(result.failure.message, "Authentication failed for [redacted]");
         assert.equal(result.failure.stdout, '{"credential":"[redacted]"}\n');
+        assert.equal(result.failure.stderr, "Authentication failed for [redacted]\n");
+        assert.notInclude(result.failure.message, "forwarded-secret");
+        assert.notInclude(result.failure.stdout ?? "", "forwarded-secret");
+        assert.notInclude(result.failure.stderr, "forwarded-secret");
       }
     }).pipe(Effect.provide(processLayer));
   });
+
+  it.effect("redacts longer overlapping SSH environment values first", () =>
+    Effect.sync(() => {
+      assert.equal(
+        redactSshOutput("token-long token", {
+          SHORT: "token",
+          LONG: "token-long",
+        }),
+        "[redacted] [redacted]",
+      );
+    }),
+  );
 
   it.effect("fails commands that never finish", () => {
     const spawner = ChildProcessSpawner.make(() => Effect.succeed(makeNeverFinishingProcess()));

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -13,11 +13,15 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import {
   baseSshArgs,
   getLastNonEmptyOutputLine,
+  isSshEnvironmentNameConfiguredForSend,
   parseSshResolveOutput,
+  parseSshSendEnvironmentPatterns,
   resolveRemoteT3CliPackageSpec,
+  resolveSshTarget,
   runSshCommand,
+  sshEnvironmentVariablesEqual,
 } from "./command.ts";
-import { SshCommandError } from "./errors.ts";
+import { SshCommandError, SshInvalidTargetError } from "./errors.ts";
 
 const encoder = new TextEncoder();
 
@@ -30,6 +34,23 @@ const makeFailedProcess = (input: { readonly stdout: string; readonly stderr?: s
     stderr: stderrStream,
     all: Stream.empty,
     exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    stdin: Sink.drain,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    unref: Effect.succeed(Effect.void),
+  });
+};
+
+const makeSuccessfulProcess = (stdout: string) => {
+  const stdoutStream = Stream.make(encoder.encode(stdout));
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(123),
+    stdout: stdoutStream,
+    stderr: Stream.empty,
+    all: stdoutStream,
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
     isRunning: Effect.succeed(false),
     kill: () => Effect.void,
     stdin: Sink.drain,
@@ -65,6 +86,19 @@ const makeNeverFinishingProcess = () => {
 };
 
 describe("ssh command", () => {
+  it.effect("compares SSH environment overlays without exposing them in connection keys", () =>
+    Effect.sync(() => {
+      assert.isTrue(
+        sshEnvironmentVariablesEqual(
+          { AWS_PROFILE: "production", TOKEN: "secret" },
+          { TOKEN: "secret", AWS_PROFILE: "production" },
+        ),
+      );
+      assert.isFalse(sshEnvironmentVariablesEqual({ TOKEN: "old" }, { TOKEN: "replacement" }));
+      assert.isFalse(sshEnvironmentVariablesEqual(undefined, { EMPTY_VALUE: "" }));
+    }),
+  );
+
   it.effect("parses resolved ssh config output into a target", () =>
     Effect.sync(() => {
       assert.deepEqual(
@@ -79,6 +113,19 @@ describe("ssh command", () => {
           port: 2222,
         },
       );
+    }),
+  );
+
+  it.effect("matches exact and wildcard SendEnv entries, including removals", () =>
+    Effect.sync(() => {
+      const patterns = parseSshSendEnvironmentPatterns(
+        ["sendenv TOKEN", "sendenv LC_*", "sendenv -LC_SECRET", ""].join("\n"),
+      );
+      assert.deepEqual(patterns, ["TOKEN", "LC_*", "-LC_SECRET"]);
+      assert.isTrue(isSshEnvironmentNameConfiguredForSend("TOKEN", patterns));
+      assert.isTrue(isSshEnvironmentNameConfiguredForSend("LC_ALL", patterns));
+      assert.isFalse(isSshEnvironmentNameConfiguredForSend("LC_SECRET", patterns));
+      assert.isFalse(isSshEnvironmentNameConfiguredForSend("OTHER", patterns));
     }),
   );
 
@@ -172,6 +219,124 @@ describe("ssh command", () => {
         assert.equal(result.failure.stdout, "Pairing token creation failed\n");
         assert.equal(result.failure.stderr, "");
       }
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("adds target environment variables to the local ssh process", () => {
+    let spawnedEnvironment: Readonly<Record<string, string | undefined>> | undefined;
+    const spawner = ChildProcessSpawner.make((command) => {
+      const childProcess = command as unknown as {
+        readonly options: {
+          readonly env?: Readonly<Record<string, string | undefined>>;
+          readonly extendEnv?: boolean;
+        };
+      };
+      spawnedEnvironment = childProcess.options.env;
+      assert.equal(childProcess.options.extendEnv, true);
+      return Effect.succeed(makeFailedProcess({ stdout: "", stderr: "expected failure" }));
+    });
+    const spawnerLayer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner);
+    const processLayer = Layer.mergeAll(NodeServices.layer, spawnerLayer);
+
+    return Effect.gen(function* () {
+      yield* Effect.result(
+        runSshCommand(
+          {
+            alias: "devbox",
+            hostname: "devbox.example.com",
+            username: "julius",
+            port: 2222,
+            environmentVariables: {
+              AWS_PROFILE: "production",
+              EMPTY_VALUE: "",
+            },
+          },
+          { remoteCommandArgs: ["true"] },
+        ),
+      );
+
+      assert.equal(spawnedEnvironment?.AWS_PROFILE, "production");
+      assert.equal(spawnedEnvironment?.EMPTY_VALUE, "");
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("validates SendEnv before resolving SSH config with the forwarded variables", () => {
+    const spawnedEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> = [];
+    const spawner = ChildProcessSpawner.make((command) => {
+      spawnedEnvironments.push(
+        command._tag === "StandardCommand" ? command.options.env : undefined,
+      );
+      return Effect.succeed(
+        makeSuccessfulProcess(
+          ["hostname devbox.example.com", "user julius", "port 2222", "sendenv TOKEN", ""].join(
+            "\n",
+          ),
+        ),
+      );
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const target = yield* resolveSshTarget("devbox", { TOKEN: "forwarded-value" });
+
+      assert.isUndefined(spawnedEnvironments[0]?.TOKEN);
+      assert.equal(spawnedEnvironments[1]?.TOKEN, "forwarded-value");
+      assert.deepEqual(target, {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+        environmentVariables: { TOKEN: "forwarded-value" },
+      });
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("rejects variables not selected by SendEnv", () => {
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(
+        makeSuccessfulProcess(
+          ["hostname devbox.example.com", "user julius", "port 2222", "sendenv LANG", ""].join(
+            "\n",
+          ),
+        ),
+      ),
+    );
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const error = yield* resolveSshTarget("devbox", { TOKEN: "value" }).pipe(Effect.flip);
+      assert.instanceOf(error, SshInvalidTargetError);
+      assert.include(error.message, "Add TOKEN to SendEnv for devbox");
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("rejects a variable removed from SendEnv by the forwarded environment", () => {
+    let resolveCount = 0;
+    const spawner = ChildProcessSpawner.make(() => {
+      resolveCount += 1;
+      return Effect.succeed(
+        makeSuccessfulProcess(
+          resolveCount === 1
+            ? "hostname devbox.example.com\nsendenv TOKEN\n"
+            : "hostname devbox.example.com\n",
+        ),
+      );
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const error = yield* resolveSshTarget("devbox", { TOKEN: "value" }).pipe(Effect.flip);
+      assert.instanceOf(error, SshInvalidTargetError);
+      assert.include(error.message, "no longer selects TOKEN");
     }).pipe(Effect.provide(processLayer));
   });
 

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -14,6 +14,7 @@ import {
   baseSshArgs,
   getLastNonEmptyOutputLine,
   isSshEnvironmentNameConfiguredForSend,
+  managedRemoteLaunchCommandArgs,
   parseSshResolveOutput,
   parseSshSendEnvironmentPatterns,
   redactSshOutput,
@@ -233,7 +234,7 @@ describe("ssh command", () => {
         };
       };
       spawnedEnvironment = childProcess.options.env;
-      assert.equal(childProcess.options.extendEnv, true);
+      assert.isUndefined(childProcess.options.extendEnv);
       return Effect.succeed(makeFailedProcess({ stdout: "", stderr: "expected failure" }));
     });
     const spawnerLayer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner);
@@ -327,6 +328,34 @@ describe("ssh command", () => {
       assert.include(spawnedArgs[1] ?? [], "sh");
       assert.include(spawnedArgs[2] ?? [], "sh");
       assert.equal(target.environmentVariables?.TOKEN, "forwarded-value");
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("revalidates with the managed command for the final resolved target", () => {
+    const spawnedArgs = new Array<ReadonlyArray<string>>();
+    let commandProbeCount = 0;
+    const spawner = ChildProcessSpawner.make((command) => {
+      const args = command._tag === "StandardCommand" ? command.args : [];
+      spawnedArgs.push(args);
+      if (!args.includes("sh")) {
+        return Effect.succeed(makeSuccessfulProcess("hostname first.example.com\nsendenv TOKEN\n"));
+      }
+      commandProbeCount += 1;
+      const hostname = commandProbeCount <= 2 ? "second.example.com" : "final.example.com";
+      return Effect.succeed(makeSuccessfulProcess(`hostname ${hostname}\nsendenv TOKEN\n`));
+    });
+    const processLayer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const target = yield* resolveSshTarget("devbox", { TOKEN: "forwarded-value" });
+
+      assert.equal(spawnedArgs.length, 7);
+      assert.deepEqual(spawnedArgs[5]?.slice(-5), managedRemoteLaunchCommandArgs(target));
+      assert.deepEqual(spawnedArgs[6]?.slice(-5), managedRemoteLaunchCommandArgs(target));
+      assert.equal(target.hostname, "final.example.com");
     }).pipe(Effect.provide(processLayer));
   });
 

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -292,7 +292,6 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
     .spawn(
       ChildProcess.make(sshCommand, args, {
         env: environment,
-        extendEnv: true,
         stdin: {
           stream: stdinStream(input.stdin),
           endOnDone: true,
@@ -438,32 +437,33 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
   }
 
   const identityTarget = parseSshResolveOutput(trimmedAlias, identityResult.stdout);
-  const managedRemoteCommand = managedRemoteLaunchCommandArgs(identityTarget);
-  const resolvedResult =
-    environmentVariables === undefined
-      ? identityResult
-      : yield* Effect.gen(function* () {
-          const baselineResult = yield* runSshCommand(unresolvedTarget, {
-            preHostArgs: ["-G"],
-            remoteCommandArgs: managedRemoteCommand,
-          });
-          const unsupportedBaselineNames = unsupportedSshEnvironmentNames(
-            environmentVariables,
-            baselineResult.stdout,
-          );
-          if (unsupportedBaselineNames.length > 0) {
-            return yield* new SshInvalidTargetError({
-              message: `Add ${unsupportedBaselineNames.join(", ")} to SendEnv for ${trimmedAlias} in your SSH config before forwarding ${unsupportedBaselineNames.length === 1 ? "it" : "them"}.`,
-            });
-          }
+  if (environmentVariables === undefined) {
+    yield* Effect.logDebug("ssh.target.resolve.succeeded", sshTargetLogFields(identityTarget));
+    return identityTarget;
+  }
 
-          return yield* runSshCommand(
-            { ...unresolvedTarget, environmentVariables },
-            { preHostArgs: ["-G"], remoteCommandArgs: managedRemoteCommand },
-          );
-        });
+  let commandTarget = identityTarget;
+  let resolvedTarget: DesktopSshEnvironmentTarget | null = null;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const managedRemoteCommand = managedRemoteLaunchCommandArgs(commandTarget);
+    const baselineResult = yield* runSshCommand(unresolvedTarget, {
+      preHostArgs: ["-G"],
+      remoteCommandArgs: managedRemoteCommand,
+    });
+    const unsupportedBaselineNames = unsupportedSshEnvironmentNames(
+      environmentVariables,
+      baselineResult.stdout,
+    );
+    if (unsupportedBaselineNames.length > 0) {
+      return yield* new SshInvalidTargetError({
+        message: `Add ${unsupportedBaselineNames.join(", ")} to SendEnv for ${trimmedAlias} in your SSH config before forwarding ${unsupportedBaselineNames.length === 1 ? "it" : "them"}.`,
+      });
+    }
 
-  if (environmentVariables !== undefined) {
+    const resolvedResult = yield* runSshCommand(
+      { ...unresolvedTarget, environmentVariables },
+      { preHostArgs: ["-G"], remoteCommandArgs: managedRemoteCommand },
+    );
     const unsupportedNames = unsupportedSshEnvironmentNames(
       environmentVariables,
       resolvedResult.stdout,
@@ -473,11 +473,22 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
         message: `SendEnv for ${trimmedAlias} no longer selects ${unsupportedNames.join(", ")} after applying the saved local SSH environment.`,
       });
     }
+
+    resolvedTarget = {
+      ...parseSshResolveOutput(trimmedAlias, resolvedResult.stdout),
+      environmentVariables,
+    };
+    if (remoteStateKey(resolvedTarget) === remoteStateKey(commandTarget)) {
+      break;
+    }
+    commandTarget = resolvedTarget;
+    resolvedTarget = null;
   }
-  const resolvedTarget = {
-    ...parseSshResolveOutput(trimmedAlias, resolvedResult.stdout),
-    ...(environmentVariables === undefined ? {} : { environmentVariables }),
-  };
+  if (resolvedTarget === null) {
+    return yield* new SshInvalidTargetError({
+      message: `SSH Match command rules for ${trimmedAlias} did not resolve to a stable target. Check command-specific HostName, User, and Port settings.`,
+    });
+  }
   yield* Effect.logDebug("ssh.target.resolve.succeeded", sshTargetLogFields(resolvedTarget));
   return resolvedTarget;
 });

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -38,6 +38,7 @@ export interface SshCommandResult {
 export interface RunSshCommandOptions extends SshAuthOptions {
   readonly preHostArgs?: ReadonlyArray<string>;
   readonly remoteCommandArgs?: ReadonlyArray<string>;
+  readonly unsetEnvironmentVariables?: ReadonlyArray<string>;
   readonly stdin?: string;
   readonly timeoutMs?: number;
 }
@@ -258,6 +259,9 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
   const hostSpec = yield* buildSshHostSpecEffect(target);
   const environment = yield* buildSshChildEnvironment({
     ...(target.environmentVariables === undefined ? {} : { baseEnv: target.environmentVariables }),
+    ...(input.unsetEnvironmentVariables === undefined
+      ? {}
+      : { unsetEnv: input.unsetEnvironmentVariables }),
     ...(input.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),
     ...(input.authSecret === undefined ? {} : { authSecret: input.authSecret }),
   }).pipe(
@@ -277,6 +281,7 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
       batchMode: input.batchMode ?? (input.interactiveAuth ? "no" : "yes"),
     }),
     ...(input.preHostArgs ?? []),
+    "--",
     hostSpec,
     ...(input.remoteCommandArgs ?? []),
   ];
@@ -423,7 +428,11 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
     username: overrides?.username ?? null,
     port: overrides?.port ?? null,
   };
-  const identityResult = yield* runSshCommand(unresolvedTarget, { preHostArgs: ["-G"] }).pipe(
+  const managedEnvironmentNames = Object.keys(environmentVariables ?? {});
+  const identityResult = yield* runSshCommand(unresolvedTarget, {
+    preHostArgs: ["-G"],
+    unsetEnvironmentVariables: managedEnvironmentNames,
+  }).pipe(
     Effect.catch((cause) =>
       environmentVariables === undefined
         ? Effect.logDebug("ssh.target.resolve.fallback", { alias: trimmedAlias, cause }).pipe(
@@ -449,6 +458,7 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
     const baselineResult = yield* runSshCommand(unresolvedTarget, {
       preHostArgs: ["-G"],
       remoteCommandArgs: managedRemoteCommand,
+      unsetEnvironmentVariables: managedEnvironmentNames,
     });
     const unsupportedBaselineNames = unsupportedSshEnvironmentNames(
       environmentVariables,

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -137,6 +137,12 @@ export function remoteStateKey(target: DesktopSshEnvironmentTarget): string {
     .slice(0, 16);
 }
 
+export function managedRemoteLaunchCommandArgs(
+  target: DesktopSshEnvironmentTarget,
+): ReadonlyArray<string> {
+  return ["sh", "-l", "-s", "--", remoteStateKey(target)];
+}
+
 export function buildSshHostSpec(target: DesktopSshEnvironmentTarget): string {
   const destination = target.alias.trim() || target.hostname.trim();
   if (destination.length === 0) {
@@ -403,7 +409,7 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
     username: null,
     port: null,
   };
-  const baselineResult = yield* runSshCommand(unresolvedTarget, { preHostArgs: ["-G"] }).pipe(
+  const identityResult = yield* runSshCommand(unresolvedTarget, { preHostArgs: ["-G"] }).pipe(
     Effect.catch((cause) =>
       environmentVariables === undefined
         ? Effect.logDebug("ssh.target.resolve.fallback", { alias: trimmedAlias, cause }).pipe(
@@ -412,29 +418,36 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
         : Effect.fail(cause),
     ),
   );
-  if (baselineResult === null) {
+  if (identityResult === null) {
     return unresolvedTarget;
   }
 
-  if (environmentVariables !== undefined) {
-    const unsupportedNames = unsupportedSshEnvironmentNames(
-      environmentVariables,
-      baselineResult.stdout,
-    );
-    if (unsupportedNames.length > 0) {
-      return yield* new SshInvalidTargetError({
-        message: `Add ${unsupportedNames.join(", ")} to SendEnv for ${trimmedAlias} in your SSH config before forwarding ${unsupportedNames.length === 1 ? "it" : "them"}.`,
-      });
-    }
-  }
-
+  const identityTarget = parseSshResolveOutput(trimmedAlias, identityResult.stdout);
+  const managedRemoteCommand = managedRemoteLaunchCommandArgs(identityTarget);
   const resolvedResult =
     environmentVariables === undefined
-      ? baselineResult
-      : yield* runSshCommand(
-          { ...unresolvedTarget, environmentVariables },
-          { preHostArgs: ["-G"] },
-        );
+      ? identityResult
+      : yield* Effect.gen(function* () {
+          const baselineResult = yield* runSshCommand(unresolvedTarget, {
+            preHostArgs: ["-G"],
+            remoteCommandArgs: managedRemoteCommand,
+          });
+          const unsupportedBaselineNames = unsupportedSshEnvironmentNames(
+            environmentVariables,
+            baselineResult.stdout,
+          );
+          if (unsupportedBaselineNames.length > 0) {
+            return yield* new SshInvalidTargetError({
+              message: `Add ${unsupportedBaselineNames.join(", ")} to SendEnv for ${trimmedAlias} in your SSH config before forwarding ${unsupportedBaselineNames.length === 1 ? "it" : "them"}.`,
+            });
+          }
+
+          return yield* runSshCommand(
+            { ...unresolvedTarget, environmentVariables },
+            { preHostArgs: ["-G"], remoteCommandArgs: managedRemoteCommand },
+          );
+        });
+
   if (environmentVariables !== undefined) {
     const unsupportedNames = unsupportedSshEnvironmentNames(
       environmentVariables,

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -69,8 +69,65 @@ export function parseSshResolveOutput(alias: string, stdout: string): DesktopSsh
   };
 }
 
+export function parseSshSendEnvironmentPatterns(stdout: string): ReadonlyArray<string> {
+  return stdout.split(/\r?\n/u).flatMap((line) => {
+    const trimmed = line.trim();
+    if (!trimmed.toLowerCase().startsWith("sendenv ")) {
+      return [];
+    }
+    return trimmed.slice("sendenv ".length).trim().split(/\s+/u).filter(Boolean);
+  });
+}
+
+function sshEnvironmentNameMatchesPattern(name: string, pattern: string): boolean {
+  const source = pattern
+    .replace(/[.+^${}()|[\]\\]/gu, "\\$&")
+    .replace(/\*/gu, ".*")
+    .replace(/\?/gu, ".");
+  return new RegExp(`^${source}$`, "u").test(name);
+}
+
+export function isSshEnvironmentNameConfiguredForSend(
+  name: string,
+  patterns: ReadonlyArray<string>,
+): boolean {
+  let configured = false;
+  for (const rawPattern of patterns) {
+    const removesPattern = rawPattern.startsWith("-");
+    const pattern = removesPattern ? rawPattern.slice(1) : rawPattern;
+    if (pattern.length > 0 && sshEnvironmentNameMatchesPattern(name, pattern)) {
+      configured = !removesPattern;
+    }
+  }
+  return configured;
+}
+
+function unsupportedSshEnvironmentNames(
+  environmentVariables: NonNullable<DesktopSshEnvironmentTarget["environmentVariables"]>,
+  resolvedConfigOutput: string,
+): ReadonlyArray<string> {
+  const patterns = parseSshSendEnvironmentPatterns(resolvedConfigOutput);
+  return Object.keys(environmentVariables).filter(
+    (name) => !isSshEnvironmentNameConfiguredForSend(name, patterns),
+  );
+}
+
 export function targetConnectionKey(target: DesktopSshEnvironmentTarget): string {
   return `${target.alias}\u0000${target.hostname}\u0000${target.username ?? ""}\u0000${target.port ?? ""}`;
+}
+
+export function sshEnvironmentVariablesEqual(
+  left: DesktopSshEnvironmentTarget["environmentVariables"],
+  right: DesktopSshEnvironmentTarget["environmentVariables"],
+): boolean {
+  const leftEntries = Object.entries(left ?? {});
+  const rightEnvironment = right ?? {};
+  return (
+    leftEntries.length === Object.keys(rightEnvironment).length &&
+    leftEntries.every(
+      ([name, value]) => Object.hasOwn(rightEnvironment, name) && rightEnvironment[name] === value,
+    )
+  );
 }
 
 export function remoteStateKey(target: DesktopSshEnvironmentTarget): string {
@@ -181,6 +238,7 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
 > {
   const hostSpec = yield* buildSshHostSpecEffect(target);
   const environment = yield* buildSshChildEnvironment({
+    ...(target.environmentVariables === undefined ? {} : { baseEnv: target.environmentVariables }),
     ...(input.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),
     ...(input.authSecret === undefined ? {} : { authSecret: input.authSecret }),
   }).pipe(
@@ -327,6 +385,7 @@ export const runSshCommand = Effect.fn("ssh/command.runSshCommand")(function* (
 
 export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(function* (
   alias: string,
+  environmentVariables?: DesktopSshEnvironmentTarget["environmentVariables"],
 ): Effect.fn.Return<
   DesktopSshEnvironmentTarget,
   SshCommandError | SshInvalidTargetError,
@@ -338,30 +397,61 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
   }
 
   yield* Effect.logDebug("ssh.target.resolve.start", { alias: trimmedAlias });
-  return yield* runSshCommand(
-    {
-      alias: trimmedAlias,
-      hostname: trimmedAlias,
-      username: null,
-      port: null,
-    },
-    { preHostArgs: ["-G"] },
-  ).pipe(
-    Effect.map((result) => parseSshResolveOutput(trimmedAlias, result.stdout)),
-    Effect.tap((target) =>
-      Effect.logDebug("ssh.target.resolve.succeeded", sshTargetLogFields(target)),
-    ),
+  const unresolvedTarget: DesktopSshEnvironmentTarget = {
+    alias: trimmedAlias,
+    hostname: trimmedAlias,
+    username: null,
+    port: null,
+  };
+  const baselineResult = yield* runSshCommand(unresolvedTarget, { preHostArgs: ["-G"] }).pipe(
     Effect.catch((cause) =>
-      Effect.logDebug("ssh.target.resolve.fallback", { alias: trimmedAlias, cause }).pipe(
-        Effect.as({
-          alias: trimmedAlias,
-          hostname: trimmedAlias,
-          username: null,
-          port: null,
-        }),
-      ),
+      environmentVariables === undefined
+        ? Effect.logDebug("ssh.target.resolve.fallback", { alias: trimmedAlias, cause }).pipe(
+            Effect.as(null),
+          )
+        : Effect.fail(cause),
     ),
   );
+  if (baselineResult === null) {
+    return unresolvedTarget;
+  }
+
+  if (environmentVariables !== undefined) {
+    const unsupportedNames = unsupportedSshEnvironmentNames(
+      environmentVariables,
+      baselineResult.stdout,
+    );
+    if (unsupportedNames.length > 0) {
+      return yield* new SshInvalidTargetError({
+        message: `Add ${unsupportedNames.join(", ")} to SendEnv for ${trimmedAlias} in your SSH config before forwarding ${unsupportedNames.length === 1 ? "it" : "them"}.`,
+      });
+    }
+  }
+
+  const resolvedResult =
+    environmentVariables === undefined
+      ? baselineResult
+      : yield* runSshCommand(
+          { ...unresolvedTarget, environmentVariables },
+          { preHostArgs: ["-G"] },
+        );
+  if (environmentVariables !== undefined) {
+    const unsupportedNames = unsupportedSshEnvironmentNames(
+      environmentVariables,
+      resolvedResult.stdout,
+    );
+    if (unsupportedNames.length > 0) {
+      return yield* new SshInvalidTargetError({
+        message: `SendEnv for ${trimmedAlias} no longer selects ${unsupportedNames.join(", ")} after applying the saved local SSH environment.`,
+      });
+    }
+  }
+  const resolvedTarget = {
+    ...parseSshResolveOutput(trimmedAlias, resolvedResult.stdout),
+    ...(environmentVariables === undefined ? {} : { environmentVariables }),
+  };
+  yield* Effect.logDebug("ssh.target.resolve.succeeded", sshTargetLogFields(resolvedTarget));
+  return resolvedTarget;
 });
 
 export function resolveRemoteT3CliPackageSpec(input: {

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -196,11 +196,24 @@ export const collectProcessOutput = <E>(
     ),
   );
 
-function redactSshErrorOutput(output: string): string {
-  const redacted = output.replace(
+export function redactSshOutput(
+  output: string,
+  environmentVariables?: Readonly<Record<string, string | undefined>>,
+): string {
+  let redacted = output.replace(
     /("(?:access_token|bearerToken|credential|pairingToken|token)"\s*:\s*")[^"]+(")/giu,
     "$1[redacted]$2",
   );
+  const environmentValues = [
+    ...new Set(
+      Object.values(environmentVariables ?? {}).filter(
+        (value): value is string => value !== undefined && value.length > 0,
+      ),
+    ),
+  ].sort((left, right) => right.length - left.length);
+  for (const value of environmentValues) {
+    redacted = redacted.replaceAll(value, "[redacted]");
+  }
   return redacted.length > MAX_SSH_ERROR_OUTPUT_LENGTH
     ? `${redacted.slice(0, MAX_SSH_ERROR_OUTPUT_LENGTH)}\n[truncated]`
     : redacted;
@@ -325,22 +338,23 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
   );
 
   if (exitCode !== 0) {
-    const diagnosticStdout = redactSshErrorOutput(stdout);
+    const diagnosticStdout = redactSshOutput(stdout, target.environmentVariables);
+    const diagnosticStderr = redactSshOutput(stderr, target.environmentVariables);
     yield* Effect.logWarning("ssh.command.failed", {
       ...sshTargetLogFields(target),
       command: ["ssh", ...args],
       exitCode,
       stdout: diagnosticStdout,
-      stderr,
+      stderr: diagnosticStderr,
     });
     return yield* new SshCommandError({
       command: ["ssh", ...args],
       exitCode,
       stdout: diagnosticStdout,
-      stderr,
+      stderr: diagnosticStderr,
       message: normalizeSshErrorMessage({
         stdout: diagnosticStdout,
-        stderr,
+        stderr: diagnosticStderr,
         fallbackMessage: `SSH command failed for ${hostSpec} (exit ${exitCode}).`,
       }),
     });
@@ -392,6 +406,7 @@ export const runSshCommand = Effect.fn("ssh/command.runSshCommand")(function* (
 export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(function* (
   alias: string,
   environmentVariables?: DesktopSshEnvironmentTarget["environmentVariables"],
+  overrides?: Pick<DesktopSshEnvironmentTarget, "username" | "port">,
 ): Effect.fn.Return<
   DesktopSshEnvironmentTarget,
   SshCommandError | SshInvalidTargetError,
@@ -406,8 +421,8 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
   const unresolvedTarget: DesktopSshEnvironmentTarget = {
     alias: trimmedAlias,
     hostname: trimmedAlias,
-    username: null,
-    port: null,
+    username: overrides?.username ?? null,
+    port: overrides?.port ?? null,
   };
   const identityResult = yield* runSshCommand(unresolvedTarget, { preHostArgs: ["-G"] }).pipe(
     Effect.catch((cause) =>

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -15,6 +15,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { SshPasswordPrompt } from "./auth.ts";
+import { SshCommandError } from "./errors.ts";
 import {
   buildRemoteLaunchScript,
   buildRemotePairingScript,
@@ -573,11 +574,17 @@ describe("ssh tunnel scripts", () => {
         const args = commandArgs(command);
         if (args.includes("-G")) {
           return makeSuccessfulProcess(
-            ["hostname resolved.example.com", "user resolved-user", "port 2200", ""].join("\n"),
+            [
+              "hostname resolved.example.com",
+              "user resolved-user",
+              "port 2200",
+              "sendenv TOKEN",
+              "",
+            ].join("\n"),
           );
         }
         if (args.includes("-N")) {
-          return makeFailedProcess("tunnel failed\n");
+          return makeFailedProcess("tunnel failed for forwarded-secret\n");
         }
         if (args.includes("sh") && args.includes("--")) {
           return makeSuccessfulProcess('{"remotePort":3773}\n');
@@ -602,12 +609,17 @@ describe("ssh tunnel scripts", () => {
       hostname: "devbox",
       username: null,
       port: null,
+      environmentVariables: { TOKEN: "forwarded-secret" },
     } as const;
 
     return Effect.gen(function* () {
       const manager = yield* SshEnvironmentManager;
-      const ensureExit = yield* Effect.exit(manager.ensureEnvironment(target));
-      assert.isTrue(Exit.isFailure(ensureExit));
+      const ensureResult = yield* Effect.result(manager.ensureEnvironment(target));
+      assert.isTrue(Result.isFailure(ensureResult));
+      if (Result.isFailure(ensureResult)) {
+        assert.instanceOf(ensureResult.failure, SshCommandError);
+        assert.equal(ensureResult.failure.stderr, "tunnel failed for [redacted]\n");
+      }
       assert.equal(postLaunchCommands.length, 2);
       const failedLaunchStopArgs = postLaunchCommands[1] ?? [];
       assert.include(failedLaunchStopArgs, "2200");
@@ -683,7 +695,7 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
-  it.effect("keeps the old tunnel when its managed server cannot be stopped", () => {
+  it.effect("closes the old tunnel and retries its failed remote stop before replacement", () => {
     let launchCount = 0;
     let stopAttemptCount = 0;
     let tunnelKillCount = 0;
@@ -704,7 +716,7 @@ describe("ssh tunnel scripts", () => {
         }
         if (args.includes("sh")) {
           stopAttemptCount += 1;
-          return stopAttemptCount === 1
+          return stopAttemptCount <= 2
             ? makeFailedProcess("stop failed\n")
             : makeSuccessfulProcess('{"stopped":true}\n');
         }
@@ -741,13 +753,14 @@ describe("ssh tunnel scripts", () => {
 
       assert.isTrue(Exit.isFailure(replaceExit));
       assert.equal(launchCount, 1);
-      assert.equal(tunnelKillCount, 0);
+      assert.equal(stopAttemptCount, 2);
+      assert.equal(tunnelKillCount, 1);
 
       yield* manager.ensureEnvironment({
         ...target,
         environmentVariables: { TOKEN: "new-value" },
       });
-      assert.equal(stopAttemptCount, 2);
+      assert.equal(stopAttemptCount, 3);
       assert.equal(launchCount, 2);
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -222,7 +222,10 @@ describe("ssh tunnel scripts", () => {
       "does not satisfy required range ",
     );
     assert.include(buildRemoteLaunchScript(), "wait_ready");
-    assert.include(buildRemoteLaunchScript(), '"$RUNNER_FILE" serve --host 127.0.0.1');
+    assert.include(
+      buildRemoteLaunchScript(),
+      '"$MANAGED_WRAPPER_FILE" "$RUNNER_FILE" "$REMOTE_NONCE" "$WRAPPER_READY_FILE" serve --host 127.0.0.1',
+    );
     assert.include(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
     assert.notInclude(buildRemoteLaunchScript(), "server-home");
     assert.include(buildRemoteLaunchScript(), "Remote T3 server did not become ready");
@@ -258,6 +261,13 @@ describe("ssh tunnel scripts", () => {
     );
     assert.include(buildRemoteLaunchScript(), "port > 65535");
     assert.include(buildRemoteLaunchScript(), 'PID_START_FILE="$STATE_DIR/pid-start"');
+    assert.include(buildRemoteLaunchScript(), 'MANAGED_WRAPPER_FILE="$STATE_DIR/run-managed.sh"');
+    assert.include(buildRemoteLaunchScript(), 'randomBytes(24).toString("hex")');
+    assert.include(
+      buildRemoteLaunchScript(),
+      'proc:*|ps:*"$MANAGED_WRAPPER_FILE"*"$REMOTE_NONCE"*',
+    );
+    assert.include(buildRemoteLaunchScript(), "printf 'ready\\n' >\"$WRAPPER_READY_FILE\"");
     assert.include(buildRemoteLaunchScript(), '[ "$DEFAULT_RUNTIME_PID" = "$REMOTE_PID" ]');
     assert.include(buildRemoteLaunchScript(), 'Number(origin.port || "80") !== port');
     assert.include(
@@ -340,6 +350,43 @@ describe("ssh tunnel scripts", () => {
       assert.isTrue(yield* fs.exists(path.join(stateDir, "pid")));
       assert.isTrue(yield* fs.exists(path.join(stateDir, "port")));
       assert.isTrue(yield* fs.exists(path.join(stateDir, "managed")));
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("clears managed state after the verified process stops", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") {
+        return;
+      }
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const homeDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-stop-success-test-" });
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+      const stateDir = path.join(homeDir, ".t3", "ssh-launch", remoteStateKey(target));
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "pid"), "123\n");
+      yield* fs.writeFileString(path.join(stateDir, "pid-start"), "ps:start\n");
+      yield* fs.writeFileString(path.join(stateDir, "port"), "3773\n");
+      yield* fs.writeFileString(path.join(stateDir, "managed"), "managed\n");
+      const script = `kill() { if [ "$1" = "-0" ]; then [ -f "$HOME/alive" ]; else rm -f "$HOME/alive"; touch "$HOME/signalled"; fi; }\nps() { [ -f "$HOME/alive" ] && printf 'start\\n'; }\ntouch "$HOME/alive"\n${buildRemoteStopScript(target)}`;
+      const child = yield* spawner.spawn(
+        ChildProcess.make("sh", ["-c", script], {
+          env: { HOME: homeDir },
+          extendEnv: true,
+        }),
+      );
+      const exitCode = yield* child.exitCode.pipe(Effect.map(Number));
+
+      assert.equal(exitCode, 0);
+      assert.isTrue(yield* fs.exists(path.join(homeDir, "signalled")));
+      assert.isFalse(yield* fs.exists(path.join(stateDir, "pid")));
+      assert.isFalse(yield* fs.exists(path.join(stateDir, "pid-start")));
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
 

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -4,6 +4,7 @@ import * as NetService from "@t3tools/shared/Net";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
@@ -75,6 +76,23 @@ const makeRunningProcess = (onKill: () => void) => {
         onKill();
         finish?.(ChildProcessSpawner.ExitCode(143));
       }),
+    stdin: Sink.drain,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    unref: Effect.succeed(Effect.void),
+  });
+};
+
+const makeFailedProcess = (stderr: string) => {
+  const stderrStream = Stream.make(new TextEncoder().encode(stderr));
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(123),
+    stdout: Stream.empty,
+    stderr: stderrStream,
+    all: stderrStream,
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
     stdin: Sink.drain,
     getInputFd: () => Sink.drain,
     getOutputFd: () => Stream.empty,
@@ -506,6 +524,59 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.effect("disconnects the resolved target after tunnel creation fails", () => {
+    const postLaunchCommands: Array<ReadonlyArray<string>> = [];
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          return makeSuccessfulProcess(
+            ["hostname resolved.example.com", "user resolved-user", "port 2200", ""].join("\n"),
+          );
+        }
+        if (args.includes("-N")) {
+          return makeFailedProcess("tunnel failed\n");
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          postLaunchCommands.push(args);
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, hangingHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox",
+      username: null,
+      port: null,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      const ensureExit = yield* Effect.exit(manager.ensureEnvironment(target));
+      assert.isTrue(Exit.isFailure(ensureExit));
+      assert.equal(postLaunchCommands.length, 1);
+
+      yield* manager.disconnectEnvironment(target);
+
+      assert.equal(postLaunchCommands.length, 2);
+      const stopArgs = postLaunchCommands[1] ?? [];
+      assert.include(stopArgs, "2200");
+      assert.include(stopArgs, "resolved-user@devbox");
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.effect("replaces a live tunnel when its local SSH environment changes", () => {
     const tunnelEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> = [];
     const remoteLifecycle: Array<"launch" | "stop"> = [];
@@ -715,6 +786,66 @@ describe("ssh tunnel scripts", () => {
 
       assert.equal(first.target.hostname, "devbox-1.example.com");
       assert.equal(second.target.hostname, "devbox-2.example.com");
+      assert.equal(tunnelKillCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("prefers an existing resolved tunnel over a stale requested mapping", () => {
+    let resolveCount = 0;
+    let tunnelCount = 0;
+    let tunnelKillCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          resolveCount += 1;
+          const hostname = resolveCount === 1 ? "old.example.com" : "new.example.com";
+          return makeSuccessfulProcess(
+            [`hostname ${hostname}`, "user julius", "port 2222", ""].join("\n"),
+          );
+        }
+        if (args.includes("-N")) {
+          tunnelCount += 1;
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const initialTarget = {
+      alias: "devbox",
+      hostname: "devbox",
+      username: null,
+      port: null,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      const oldEnvironment = yield* manager.ensureEnvironment(initialTarget);
+      yield* manager.ensureEnvironment({
+        alias: "devbox",
+        hostname: "new.example.com",
+        username: "julius",
+        port: 2222,
+      });
+      yield* manager.ensureEnvironment(oldEnvironment.target);
+
+      assert.equal(tunnelCount, 2);
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -515,10 +515,10 @@ describe("ssh tunnel scripts", () => {
       const manager = yield* SshEnvironmentManager;
       yield* manager.ensureEnvironment(target);
 
-      assert.equal(resolveCount, 2);
+      assert.equal(resolveCount, 3);
       yield* manager.disconnectEnvironment(target);
 
-      assert.equal(resolveCount, 2);
+      assert.equal(resolveCount, 3);
       assert.equal(tunnelKillCount, 1);
       assert.equal(stopCommandCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
@@ -683,6 +683,76 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.effect("keeps the old tunnel when its managed server cannot be stopped", () => {
+    let launchCount = 0;
+    let stopAttemptCount = 0;
+    let tunnelKillCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          return makeSuccessfulProcess("sendenv TOKEN\n");
+        }
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          launchCount += 1;
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          stopAttemptCount += 1;
+          return stopAttemptCount === 1
+            ? makeFailedProcess("stop failed\n")
+            : makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.ensureEnvironment({
+        ...target,
+        environmentVariables: { TOKEN: "old-value" },
+      });
+      const replaceExit = yield* Effect.exit(
+        manager.ensureEnvironment({
+          ...target,
+          environmentVariables: { TOKEN: "new-value" },
+        }),
+      );
+
+      assert.isTrue(Exit.isFailure(replaceExit));
+      assert.equal(launchCount, 1);
+      assert.equal(tunnelKillCount, 0);
+
+      yield* manager.ensureEnvironment({
+        ...target,
+        environmentVariables: { TOKEN: "new-value" },
+      });
+      assert.equal(stopAttemptCount, 2);
+      assert.equal(launchCount, 2);
+      assert.equal(tunnelKillCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.effect("waits for an in-flight ensure before replacing its environment", () =>
     Effect.gen(function* () {
       const pairingStarted = yield* Deferred.make<void>();
@@ -699,12 +769,12 @@ describe("ssh tunnel scripts", () => {
           const environment = commandEnvironment(command);
           if (args.includes("-G")) {
             resolveCount += 1;
-            if (resolveCount % 2 === 1) {
-              assert.isUndefined(environment?.TOKEN);
-            } else {
+            if (resolveCount % 3 === 0) {
               assert.isDefined(environment?.TOKEN);
+            } else {
+              assert.isUndefined(environment?.TOKEN);
             }
-            if (resolveCount === 3) {
+            if (resolveCount === 4) {
               yield* Deferred.succeed(secondResolveStarted, undefined).pipe(Effect.ignore);
             }
             return makeSuccessfulProcess("sendenv TOKEN\n");

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -766,11 +766,10 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
-  it.effect("waits for an in-flight ensure before replacing its environment", () =>
+  it.effect("serializes resolution and replacement for the same requested target", () =>
     Effect.gen(function* () {
       const pairingStarted = yield* Deferred.make<void>();
       const releasePairing = yield* Deferred.make<void>();
-      const secondResolveStarted = yield* Deferred.make<void>();
       const tunnelEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> =
         [];
       let tunnelKillCount = 0;
@@ -787,10 +786,8 @@ describe("ssh tunnel scripts", () => {
             } else {
               assert.isUndefined(environment?.TOKEN);
             }
-            if (resolveCount === 4) {
-              yield* Deferred.succeed(secondResolveStarted, undefined).pipe(Effect.ignore);
-            }
-            return makeSuccessfulProcess("sendenv TOKEN\n");
+            const resolvedHost = resolveCount <= 3 ? "first.example.com" : "second.example.com";
+            return makeSuccessfulProcess(`hostname ${resolvedHost}\nsendenv TOKEN\n`);
           }
           if (args.includes("-N")) {
             tunnelEnvironments.push(environment);
@@ -849,15 +846,16 @@ describe("ssh tunnel scripts", () => {
             environmentVariables: { TOKEN: "new-value" },
           }),
         );
-        yield* Deferred.await(secondResolveStarted);
         yield* Effect.yieldNow;
 
+        assert.equal(resolveCount, 3);
         assert.equal(tunnelKillCount, 0);
         yield* Deferred.succeed(releasePairing, undefined);
 
         const first = yield* Fiber.join(firstFiber);
         yield* Fiber.join(secondFiber);
         assert.equal(first.pairingToken, "PAIRING-CODE");
+        assert.equal(resolveCount, 6);
         assert.equal(tunnelKillCount, 1);
         assert.equal(tunnelEnvironments.length, 2);
       }).pipe(Effect.provide(layer), Effect.scoped);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -224,7 +224,7 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript(), "wait_ready");
     assert.include(
       buildRemoteLaunchScript(),
-      '"$MANAGED_WRAPPER_FILE" "$RUNNER_FILE" "$REMOTE_NONCE" "$WRAPPER_READY_FILE" serve --host 127.0.0.1',
+      '"$MANAGED_WRAPPER_FILE" "$RUNNER_FILE" "$REMOTE_NONCE" "$WRAPPER_READY_FILE" "$CHILD_PID_FILE" serve --host 127.0.0.1',
     );
     assert.include(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
     assert.notInclude(buildRemoteLaunchScript(), "server-home");
@@ -245,10 +245,10 @@ describe("ssh tunnel scripts", () => {
       'if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$EXPECTED_PID_START" ]',
     );
     assert.include(buildRemoteStopScript(target), 'if ! kill "$REMOTE_PID" 2>/dev/null');
-    assert.include(buildRemoteStopScript(target), 'PS_IDENTITY="$(LC_ALL=C ps -o lstart=');
+    assert.include(buildRemoteStopScript(target), 'PS_IDENTITY="$(LC_ALL=C ps -ww -o lstart=');
     assert.include(
       buildRemoteStopScript(target),
-      'rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"',
+      'rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE" "$PORT_FILE" "$MANAGED_FILE"',
     );
     assert.include(
       buildRemoteLaunchScript(),
@@ -262,11 +262,13 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript(), "port > 65535");
     assert.include(buildRemoteLaunchScript(), 'PID_START_FILE="$STATE_DIR/pid-start"');
     assert.include(buildRemoteLaunchScript(), 'MANAGED_WRAPPER_FILE="$STATE_DIR/run-managed.sh"');
+    assert.include(buildRemoteLaunchScript(), 'REMOTE_CHILD_PID="$(cat "$CHILD_PID_FILE"');
+    assert.include(buildRemoteLaunchScript(), '[ "$DEFAULT_RUNTIME_PID" = "$REMOTE_CHILD_PID" ]');
+    assert.include(buildRemoteLaunchScript(), 'createHash("sha256").update(commandLine)');
+    assert.include(buildRemoteLaunchScript(), "process_is_expected_wrapper()");
+    assert.include(buildRemoteLaunchScript(), "entries.includes(process.argv[3])");
     assert.include(buildRemoteLaunchScript(), 'randomBytes(24).toString("hex")');
-    assert.include(
-      buildRemoteLaunchScript(),
-      'proc:*|ps:*"$MANAGED_WRAPPER_FILE"*"$REMOTE_NONCE"*',
-    );
+    assert.include(buildRemoteLaunchScript(), 'ps:*"$MANAGED_WRAPPER_FILE"*"$REMOTE_NONCE"*');
     assert.include(buildRemoteLaunchScript(), "printf 'ready\\n' >\"$WRAPPER_READY_FILE\"");
     assert.include(buildRemoteLaunchScript(), '[ "$DEFAULT_RUNTIME_PID" = "$REMOTE_PID" ]');
     assert.include(buildRemoteLaunchScript(), 'Number(origin.port || "80") !== port');
@@ -283,10 +285,6 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript(), 'rm -f "$PID_FILE"');
     assert.include(buildRemoteLaunchScript(), "printf 'external\\n' >\"$MANAGED_FILE\"");
     assert.include(buildRemoteLaunchScript(), 'if [ -z "$REMOTE_PORT" ]; then');
-    assert.isBelow(
-      buildRemoteLaunchScript().indexOf('if [ "$REMOTE_MANAGED" = "managed" ]'),
-      buildRemoteLaunchScript().indexOf("printf 'external\\n' >\"$MANAGED_FILE\""),
-    );
     assert.isBelow(
       buildRemoteLaunchScript().indexOf('DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port'),
       buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PORT" ]; then'),

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -453,6 +453,7 @@ describe("ssh tunnel scripts", () => {
 
   it.effect("replaces a live tunnel when its local SSH environment changes", () => {
     const tunnelEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> = [];
+    const remoteLifecycle: Array<"launch" | "stop"> = [];
     let tunnelKillCount = 0;
     const spawner = ChildProcessSpawner.make((command) =>
       Effect.sync(() => {
@@ -467,9 +468,11 @@ describe("ssh tunnel scripts", () => {
           });
         }
         if (args.includes("sh") && args.includes("--")) {
+          remoteLifecycle.push("launch");
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
         if (args.includes("sh")) {
+          remoteLifecycle.push("stop");
           return makeSuccessfulProcess('{"stopped":true}\n');
         }
         return makeSuccessfulProcess("\n");
@@ -505,6 +508,7 @@ describe("ssh tunnel scripts", () => {
       assert.equal(tunnelEnvironments[0]?.TOKEN, "old-value");
       assert.equal(tunnelEnvironments[1]?.TOKEN, "new-value");
       assert.equal(tunnelKillCount, 1);
+      assert.deepEqual(remoteLifecycle, ["launch", "stop", "launch"]);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -524,6 +524,48 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.effect("disconnects a saved target without a tracked tunnel or SendEnv validation", () => {
+    let resolveCount = 0;
+    let stopCommandCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          resolveCount += 1;
+          return makeFailedProcess("SSH config is unavailable\n");
+        }
+        if (args.includes("sh")) {
+          stopCommandCount += 1;
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const savedTarget = {
+      alias: "devbox",
+      hostname: "resolved.example.com",
+      username: "resolved-user",
+      port: 2200,
+      environmentVariables: { TOKEN: "forwarded-value" },
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.disconnectEnvironment(savedTarget);
+
+      assert.equal(resolveCount, 0);
+      assert.equal(stopCommandCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.effect("stops the resolved target after tunnel creation fails", () => {
     const postLaunchCommands: Array<ReadonlyArray<string>> = [];
     const spawner = ChildProcessSpawner.make((command) =>

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -524,7 +524,7 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
-  it.effect("disconnects the resolved target after tunnel creation fails", () => {
+  it.effect("stops the resolved target after tunnel creation fails", () => {
     const postLaunchCommands: Array<ReadonlyArray<string>> = [];
     const spawner = ChildProcessSpawner.make((command) =>
       Effect.sync(() => {
@@ -566,14 +566,17 @@ describe("ssh tunnel scripts", () => {
       const manager = yield* SshEnvironmentManager;
       const ensureExit = yield* Effect.exit(manager.ensureEnvironment(target));
       assert.isTrue(Exit.isFailure(ensureExit));
-      assert.equal(postLaunchCommands.length, 1);
+      assert.equal(postLaunchCommands.length, 2);
+      const failedLaunchStopArgs = postLaunchCommands[1] ?? [];
+      assert.include(failedLaunchStopArgs, "2200");
+      assert.include(failedLaunchStopArgs, "resolved-user@devbox");
 
       yield* manager.disconnectEnvironment(target);
 
-      assert.equal(postLaunchCommands.length, 2);
-      const stopArgs = postLaunchCommands[1] ?? [];
-      assert.include(stopArgs, "2200");
-      assert.include(stopArgs, "resolved-user@devbox");
+      assert.equal(postLaunchCommands.length, 3);
+      const disconnectStopArgs = postLaunchCommands[2] ?? [];
+      assert.include(disconnectStopArgs, "2200");
+      assert.include(disconnectStopArgs, "resolved-user@devbox");
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
@@ -849,6 +852,93 @@ describe("ssh tunnel scripts", () => {
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
+
+  it.effect("does not stop the selected target for a stale conflicting key", () =>
+    Effect.gen(function* () {
+      const stopStarted = yield* Deferred.make<void>();
+      const releaseStop = yield* Deferred.make<void>();
+      const conflictingResolveStarted = yield* Deferred.make<void>();
+      let resolveCount = 0;
+      let stopCount = 0;
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          const args = commandArgs(command);
+          if (args.includes("-G")) {
+            resolveCount += 1;
+            const hostname = resolveCount === 1 ? "old.example.com" : "new.example.com";
+            if (resolveCount === 3) {
+              yield* Deferred.succeed(conflictingResolveStarted, undefined).pipe(Effect.ignore);
+            }
+            return makeSuccessfulProcess(
+              [`hostname ${hostname}`, "user julius", "port 2222", ""].join("\n"),
+            );
+          }
+          if (args.includes("-N")) {
+            return makeRunningProcess(() => undefined);
+          }
+          if (args.includes("sh") && args.includes("--")) {
+            return makeSuccessfulProcess('{"remotePort":3773}\n');
+          }
+          if (args.includes("sh")) {
+            stopCount += 1;
+            yield* Deferred.succeed(stopStarted, undefined).pipe(Effect.ignore);
+            const process = makeSuccessfulProcess('{"stopped":true}\n');
+            return {
+              ...process,
+              exitCode: Deferred.await(releaseStop).pipe(
+                Effect.as(ChildProcessSpawner.ExitCode(0)),
+              ),
+            };
+          }
+          return makeSuccessfulProcess("\n");
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+      const requestedTarget = {
+        alias: "devbox",
+        hostname: "devbox",
+        username: null,
+        port: null,
+      } as const;
+
+      yield* Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        const oldEnvironment = yield* manager.ensureEnvironment(requestedTarget);
+        yield* manager.ensureEnvironment({
+          alias: "devbox",
+          hostname: "new.example.com",
+          username: "julius",
+          port: 2222,
+        });
+
+        const disconnectFiber = yield* Effect.forkChild(
+          manager.disconnectEnvironment(requestedTarget),
+        );
+        yield* Deferred.await(stopStarted);
+        const ensureFiber = yield* Effect.forkChild(
+          manager.ensureEnvironment(oldEnvironment.target),
+        );
+        yield* Deferred.await(conflictingResolveStarted);
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(releaseStop, undefined);
+
+        yield* Fiber.join(disconnectFiber);
+        yield* Fiber.join(ensureFiber);
+        assert.equal(stopCount, 1);
+      }).pipe(
+        Effect.ensuring(Deferred.succeed(releaseStop, undefined).pipe(Effect.ignore)),
+        Effect.provide(layer),
+        Effect.scoped,
+      );
+    }),
+  );
 
   it.effect("does not block unrelated hosts behind an in-flight ensure", () =>
     Effect.gen(function* () {

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -97,6 +98,12 @@ const testNetService = NetService.NetService.of({
 
 function commandArgs(command: ChildProcess.Command): ReadonlyArray<string> {
   return command._tag === "StandardCommand" ? command.args : [];
+}
+
+function commandEnvironment(
+  command: ChildProcess.Command,
+): Readonly<Record<string, string | undefined>> | undefined {
+  return command._tag === "StandardCommand" ? command.options.env : undefined;
 }
 
 describe("ssh tunnel scripts", () => {
@@ -443,4 +450,292 @@ describe("ssh tunnel scripts", () => {
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
+
+  it.effect("replaces a live tunnel when its local SSH environment changes", () => {
+    const tunnelEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> = [];
+    let tunnelKillCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          return makeSuccessfulProcess("sendenv TOKEN\n");
+        }
+        if (args.includes("-N")) {
+          tunnelEnvironments.push(commandEnvironment(command));
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.ensureEnvironment({
+        ...target,
+        environmentVariables: { TOKEN: "old-value" },
+      });
+      yield* manager.ensureEnvironment({
+        ...target,
+        environmentVariables: { TOKEN: "new-value" },
+      });
+
+      assert.equal(tunnelEnvironments.length, 2);
+      assert.equal(tunnelEnvironments[0]?.TOKEN, "old-value");
+      assert.equal(tunnelEnvironments[1]?.TOKEN, "new-value");
+      assert.equal(tunnelKillCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("waits for an in-flight ensure before replacing its environment", () =>
+    Effect.gen(function* () {
+      const pairingStarted = yield* Deferred.make<void>();
+      const releasePairing = yield* Deferred.make<void>();
+      const secondResolveStarted = yield* Deferred.make<void>();
+      const tunnelEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> =
+        [];
+      let tunnelKillCount = 0;
+      let shellCommandCount = 0;
+      let resolveCount = 0;
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          const args = commandArgs(command);
+          const environment = commandEnvironment(command);
+          if (args.includes("-G")) {
+            resolveCount += 1;
+            if (resolveCount % 2 === 1) {
+              assert.isUndefined(environment?.TOKEN);
+            } else {
+              assert.isDefined(environment?.TOKEN);
+            }
+            if (resolveCount === 3) {
+              yield* Deferred.succeed(secondResolveStarted, undefined).pipe(Effect.ignore);
+            }
+            return makeSuccessfulProcess("sendenv TOKEN\n");
+          }
+          if (args.includes("-N")) {
+            tunnelEnvironments.push(environment);
+            return makeRunningProcess(() => {
+              tunnelKillCount += 1;
+            });
+          }
+          if (args.includes("sh") && args.includes("--")) {
+            return makeSuccessfulProcess('{"remotePort":3773}\n');
+          }
+          if (args.includes("sh")) {
+            shellCommandCount += 1;
+            if (shellCommandCount === 1) {
+              yield* Deferred.succeed(pairingStarted, undefined).pipe(Effect.ignore);
+              const process = makeSuccessfulProcess('{"credential":"PAIRING-CODE"}\n');
+              return {
+                ...process,
+                exitCode: Deferred.await(releasePairing).pipe(
+                  Effect.as(ChildProcessSpawner.ExitCode(0)),
+                ),
+              };
+            }
+            return makeSuccessfulProcess('{"stopped":true}\n');
+          }
+          return makeSuccessfulProcess("\n");
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+
+      yield* Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        const firstFiber = yield* Effect.forkChild(
+          manager.ensureEnvironment(
+            { ...target, environmentVariables: { TOKEN: "old-value" } },
+            { issuePairingToken: true },
+          ),
+        );
+        yield* Deferred.await(pairingStarted);
+
+        const secondFiber = yield* Effect.forkChild(
+          manager.ensureEnvironment({
+            ...target,
+            environmentVariables: { TOKEN: "new-value" },
+          }),
+        );
+        yield* Deferred.await(secondResolveStarted);
+        yield* Effect.yieldNow;
+
+        assert.equal(tunnelKillCount, 0);
+        yield* Deferred.succeed(releasePairing, undefined);
+
+        const first = yield* Fiber.join(firstFiber);
+        yield* Fiber.join(secondFiber);
+        assert.equal(first.pairingToken, "PAIRING-CODE");
+        assert.equal(tunnelKillCount, 1);
+        assert.equal(tunnelEnvironments.length, 2);
+      }).pipe(Effect.provide(layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("replaces the existing profile tunnel when SSH config resolves differently", () => {
+    let resolveCount = 0;
+    let tunnelKillCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          resolveCount += 1;
+          return makeSuccessfulProcess(
+            [`hostname devbox-${resolveCount}.example.com`, "user julius", "port 2222", ""].join(
+              "\n",
+            ),
+          );
+        }
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const requestedTarget = {
+      alias: "devbox",
+      hostname: "devbox",
+      username: null,
+      port: null,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      const first = yield* manager.ensureEnvironment(requestedTarget);
+      const second = yield* manager.ensureEnvironment(first.target);
+
+      assert.equal(first.target.hostname, "devbox-1.example.com");
+      assert.equal(second.target.hostname, "devbox-2.example.com");
+      assert.equal(tunnelKillCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("does not block unrelated hosts behind an in-flight ensure", () =>
+    Effect.gen(function* () {
+      const pairingStarted = yield* Deferred.make<void>();
+      const releasePairing = yield* Deferred.make<void>();
+      const tunnelAliases: Array<string> = [];
+      let shellCommandCount = 0;
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          const args = commandArgs(command);
+          if (args.includes("-G")) {
+            return makeSuccessfulProcess("\n");
+          }
+          if (args.includes("-N")) {
+            tunnelAliases.push(args.at(-1) ?? "");
+            return makeRunningProcess(() => undefined);
+          }
+          if (args.includes("sh") && args.includes("--")) {
+            return makeSuccessfulProcess('{"remotePort":3773}\n');
+          }
+          if (args.includes("sh")) {
+            shellCommandCount += 1;
+            if (shellCommandCount === 1) {
+              yield* Deferred.succeed(pairingStarted, undefined).pipe(Effect.ignore);
+              const process = makeSuccessfulProcess('{"credential":"PAIRING-CODE"}\n');
+              return {
+                ...process,
+                exitCode: Deferred.await(releasePairing).pipe(
+                  Effect.as(ChildProcessSpawner.ExitCode(0)),
+                ),
+              };
+            }
+          }
+          return makeSuccessfulProcess("\n");
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+
+      yield* Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        const firstFiber = yield* Effect.forkChild(
+          manager.ensureEnvironment(
+            {
+              alias: "first-host",
+              hostname: "first.example.com",
+              username: "julius",
+              port: 2222,
+            },
+            { issuePairingToken: true },
+          ),
+        );
+        yield* Deferred.await(pairingStarted);
+
+        const second = yield* manager.ensureEnvironment({
+          alias: "second-host",
+          hostname: "second.example.com",
+          username: "julius",
+          port: 2222,
+        });
+        assert.equal(second.target.alias, "second-host");
+        assert.isTrue(tunnelAliases.some((alias) => alias.endsWith("@second-host")));
+
+        yield* Deferred.succeed(releasePairing, undefined);
+        const first = yield* Fiber.join(firstFiber);
+        assert.equal(first.pairingToken, "PAIRING-CODE");
+      }).pipe(
+        Effect.ensuring(Deferred.succeed(releasePairing, undefined).pipe(Effect.ignore)),
+        Effect.provide(layer),
+        Effect.scoped,
+      );
+    }),
+  );
 });

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessExecutablePath, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -129,12 +129,18 @@ function commandEnvironment(
   return command._tag === "StandardCommand" ? command.options.env : undefined;
 }
 
+function isManagedLaunchCommand(args: ReadonlyArray<string>): boolean {
+  return args.includes("sh") && args.filter((arg) => arg === "--").length === 2;
+}
+
 describe("ssh tunnel scripts", () => {
   it("builds the remote t3 runner with npx and npm fallbacks", () => {
     const script = buildRemoteT3RunnerScript({ nodeEngineRange: TEST_NODE_ENGINE_RANGE });
 
     assert.include(script, "T3_NODE_SCRIPT_PATH=''");
     assert.include(script, 'exec t3 "$@"');
+    assert.notInclude(script, "exec npx --yes 't3@latest' \"$@\"");
+    assert.notInclude(script, "exec npm exec --yes 't3@latest' -- \"$@\"");
     assert.include(script, 'exec "$T3_CLI_PATH" "$@"');
     assert.include(script, "could not install 't3@latest'");
     assert.include(script, "require_installed_t3_cli npx --yes --package 't3@latest'");
@@ -170,10 +176,13 @@ describe("ssh tunnel scripts", () => {
       packageSpec: "t3@nightly; touch /tmp/t3-owned",
     });
 
+    assert.notInclude(script, "exec npx --yes 't3@nightly; touch /tmp/t3-owned' \"$@\"");
+    assert.notInclude(script, "exec npm exec --yes 't3@nightly; touch /tmp/t3-owned' -- \"$@\"");
     assert.include(
       script,
       "require_installed_t3_cli npx --yes --package 't3@nightly; touch /tmp/t3-owned'",
     );
+    assert.include(script, 'exec "$T3_CLI_PATH" "$@"');
     assert.notInclude(script, "exec npx --yes t3@nightly; touch /tmp/t3-owned");
   });
 
@@ -199,7 +208,7 @@ describe("ssh tunnel scripts", () => {
 
     assert.include(
       buildRemoteLaunchScript({ nodeEngineRange: TEST_NODE_ENGINE_RANGE }),
-      '[ -n "$REMOTE_PID" ] && [ -n "$REMOTE_PORT" ] && kill -0 "$REMOTE_PID" 2>/dev/null',
+      "managed_pid_is_owned()",
     );
     assert.include(buildRemoteLaunchScript(), "RUNNER_CHANGED=1");
     assert.include(buildRemoteLaunchScript(), "ensure_remote_node_path()");
@@ -212,7 +221,6 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript({ nodeEngineRange: TEST_NODE_ENGINE_RANGE }),
       "does not satisfy required range ",
     );
-    assert.include(buildRemoteLaunchScript(), 'kill "$REMOTE_PID" 2>/dev/null || true');
     assert.include(buildRemoteLaunchScript(), "wait_ready");
     assert.include(buildRemoteLaunchScript(), '"$RUNNER_FILE" serve --host 127.0.0.1');
     assert.include(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
@@ -231,11 +239,14 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemotePairingScript(target, { packageSpec: "t3@nightly" }), "t3@nightly");
     assert.include(
       buildRemoteStopScript(target),
-      'if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ]',
+      'if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$EXPECTED_PID_START" ]',
     );
     assert.include(buildRemoteStopScript(target), 'if ! kill "$REMOTE_PID" 2>/dev/null');
-    assert.include(buildRemoteStopScript(target), 'if kill -0 "$REMOTE_PID" 2>/dev/null; then');
-    assert.include(buildRemoteStopScript(target), 'rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"');
+    assert.include(buildRemoteStopScript(target), 'PS_IDENTITY="$(LC_ALL=C ps -o lstart=');
+    assert.include(
+      buildRemoteStopScript(target),
+      'rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"',
+    );
     assert.include(
       buildRemoteLaunchScript(),
       'DEFAULT_RUNTIME_FILE="$DEFAULT_SERVER_HOME/userdata/server-runtime.json"',
@@ -245,11 +256,19 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript(),
       'DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port',
     );
+    assert.include(buildRemoteLaunchScript(), "port > 65535");
+    assert.include(buildRemoteLaunchScript(), 'PID_START_FILE="$STATE_DIR/pid-start"');
+    assert.include(buildRemoteLaunchScript(), '[ "$DEFAULT_RUNTIME_PID" = "$REMOTE_PID" ]');
+    assert.include(buildRemoteLaunchScript(), 'Number(origin.port || "80") !== port');
     assert.include(
       buildRemoteLaunchScript(),
-      "if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(port))",
+      'if [ "$REMOTE_MANAGED" = "managed" ] && ! stop_managed_pid; then',
     );
-    assert.include(buildRemoteLaunchScript(), 'PID_TO_STOP="${REMOTE_PID:-$DEFAULT_RUNTIME_PID}"');
+    assert.include(buildRemoteLaunchScript(), 'path: "/.well-known/t3/environment"');
+    assert.notInclude(
+      buildRemoteLaunchScript(),
+      'else\n    kill "$REMOTE_PID" 2>/dev/null || true',
+    );
     assert.include(buildRemoteLaunchScript(), 'REMOTE_PORT="$DEFAULT_REMOTE_PORT"');
     assert.include(buildRemoteLaunchScript(), 'rm -f "$PID_FILE"');
     assert.include(buildRemoteLaunchScript(), "printf 'external\\n' >\"$MANAGED_FILE\"");
@@ -260,9 +279,28 @@ describe("ssh tunnel scripts", () => {
     );
     assert.isBelow(
       buildRemoteLaunchScript().indexOf('DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port'),
-      buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PID" ]'),
+      buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PORT" ]; then'),
     );
   });
+
+  it.effect("generates valid POSIX remote lifecycle scripts", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") {
+        return;
+      }
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+      for (const script of [buildRemoteLaunchScript(), buildRemoteStopScript(target)]) {
+        const child = yield* spawner.spawn(ChildProcess.make("sh", ["-n", "-c", script]));
+        assert.equal(Number(yield* child.exitCode), 0);
+      }
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
 
   it.effect("keeps remote state when the managed process survives stop", () =>
     Effect.gen(function* () {
@@ -282,9 +320,10 @@ describe("ssh tunnel scripts", () => {
       const stateDir = path.join(homeDir, ".t3", "ssh-launch", remoteStateKey(target));
       yield* fs.makeDirectory(stateDir, { recursive: true });
       yield* fs.writeFileString(path.join(stateDir, "pid"), "123\n");
+      yield* fs.writeFileString(path.join(stateDir, "pid-start"), "ps:start\n");
       yield* fs.writeFileString(path.join(stateDir, "port"), "3773\n");
       yield* fs.writeFileString(path.join(stateDir, "managed"), "managed\n");
-      const script = `kill() { return 0; }\nsleep() { return 0; }\n${buildRemoteStopScript(target)}`;
+      const script = `kill() { return 0; }\nps() { printf 'start\\n'; }\nsleep() { return 0; }\n${buildRemoteStopScript(target)}`;
       const child = yield* spawner.spawn(
         ChildProcess.make("sh", ["-c", script], {
           env: { HOME: homeDir },
@@ -300,6 +339,116 @@ describe("ssh tunnel scripts", () => {
       assert.include(stderr, "did not stop");
       assert.isTrue(yield* fs.exists(path.join(stateDir, "pid")));
       assert.isTrue(yield* fs.exists(path.join(stateDir, "port")));
+      assert.isTrue(yield* fs.exists(path.join(stateDir, "managed")));
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("does not signal a process that reused a stale managed PID", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") {
+        return;
+      }
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const homeDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-stale-pid-test-" });
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+      const stateDir = path.join(homeDir, ".t3", "ssh-launch", remoteStateKey(target));
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "pid"), "123\n");
+      yield* fs.writeFileString(path.join(stateDir, "pid-start"), "ps:old-start\n");
+      yield* fs.writeFileString(path.join(stateDir, "port"), "3773\n");
+      yield* fs.writeFileString(path.join(stateDir, "managed"), "managed\n");
+      const script = `kill() { if [ "$1" != "-0" ]; then touch "$HOME/signalled"; fi; return 0; }\nps() { printf 'new-start\\n'; }\n${buildRemoteStopScript(target)}`;
+      const child = yield* spawner.spawn(
+        ChildProcess.make("sh", ["-c", script], {
+          env: { HOME: homeDir },
+          extendEnv: true,
+        }),
+      );
+      const exitCode = yield* child.exitCode.pipe(Effect.map(Number));
+
+      assert.equal(exitCode, 0);
+      assert.isFalse(yield* fs.exists(path.join(homeDir, "signalled")));
+      assert.isFalse(yield* fs.exists(path.join(stateDir, "pid")));
+      assert.isFalse(yield* fs.exists(path.join(stateDir, "pid-start")));
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("retains managed state when process identity cannot be verified", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") {
+        return;
+      }
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const homeDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-pid-probe-test-" });
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+      const stateDir = path.join(homeDir, ".t3", "ssh-launch", remoteStateKey(target));
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "pid"), "123\n");
+      yield* fs.writeFileString(path.join(stateDir, "pid-start"), "ps:start\n");
+      yield* fs.writeFileString(path.join(stateDir, "port"), "3773\n");
+      yield* fs.writeFileString(path.join(stateDir, "managed"), "managed\n");
+      const script = `kill() { if [ "$1" != "-0" ]; then touch "$HOME/signalled"; fi; return 0; }\nps() { return 1; }\n${buildRemoteStopScript(target)}`;
+      const child = yield* spawner.spawn(
+        ChildProcess.make("sh", ["-c", script], {
+          env: { HOME: homeDir, PATH: "/usr/bin:/bin" },
+          extendEnv: true,
+        }),
+      );
+      const exitCode = yield* child.exitCode.pipe(Effect.map(Number));
+
+      assert.equal(exitCode, 1);
+      assert.isFalse(yield* fs.exists(path.join(homeDir, "signalled")));
+      assert.isTrue(yield* fs.exists(path.join(stateDir, "pid")));
+      assert.isTrue(yield* fs.exists(path.join(stateDir, "pid-start")));
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("retains live managed state when its identity file is missing", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") {
+        return;
+      }
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const homeDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-partial-state-test-" });
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+      const stateDir = path.join(homeDir, ".t3", "ssh-launch", remoteStateKey(target));
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "pid"), "123\n");
+      yield* fs.writeFileString(path.join(stateDir, "port"), "3773\n");
+      yield* fs.writeFileString(path.join(stateDir, "managed"), "managed\n");
+      const script = `kill() { if [ "$1" != "-0" ]; then touch "$HOME/signalled"; fi; return 0; }\nps() { printf 'start\\n'; }\n${buildRemoteStopScript(target)}`;
+      const child = yield* spawner.spawn(
+        ChildProcess.make("sh", ["-c", script], {
+          env: { HOME: homeDir },
+          extendEnv: true,
+        }),
+      );
+      const exitCode = yield* child.exitCode.pipe(Effect.map(Number));
+
+      assert.equal(exitCode, 1);
+      assert.isFalse(yield* fs.exists(path.join(homeDir, "signalled")));
+      assert.isTrue(yield* fs.exists(path.join(stateDir, "pid")));
       assert.isTrue(yield* fs.exists(path.join(stateDir, "managed")));
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
@@ -325,6 +474,61 @@ describe("ssh tunnel scripts", () => {
       const result = yield* launchOrReuseRemoteServer(target);
       assert.equal(result.remotePort, 3774);
       assert.deepEqual(spawnedCommands[0]?.slice(-5, -1), ["sh", "-l", "-s", "--"]);
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("redacts forwarded values from malformed successful launch output", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+      environmentVariables: { TOKEN: "forwarded-secret" },
+    } as const;
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(makeSuccessfulProcess("startup forwarded-secret without launch JSON\n")),
+    );
+    const processLayer = Layer.merge(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const result = yield* Effect.result(launchOrReuseRemoteServer(target));
+
+      assert.isTrue(Result.isFailure(result));
+      if (Result.isFailure(result)) {
+        assert.equal(result.failure._tag, "SshLaunchError");
+        if (result.failure._tag === "SshLaunchError") {
+          assert.notInclude(result.failure.stdout, "forwarded-secret");
+          assert.include(result.failure.stdout, "[redacted]");
+        }
+      }
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("rejects out-of-range remote launch ports", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(makeSuccessfulProcess('{"remotePort":65536}\n')),
+    );
+    const processLayer = Layer.merge(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const result = yield* Effect.result(launchOrReuseRemoteServer(target));
+
+      assert.isTrue(Result.isFailure(result));
+      if (Result.isFailure(result)) {
+        assert.equal(result.failure._tag, "SshLaunchError");
+      }
     }).pipe(Effect.provide(processLayer));
   });
 
@@ -354,6 +558,37 @@ describe("ssh tunnel scripts", () => {
   it("allows the remote port picker to run without a state file path", () => {
     assert.include(REMOTE_PICK_PORT_SCRIPT, 'const filePath = process.argv[2] ?? "";');
   });
+
+  it.effect("ignores an out-of-range preferred port from remote state", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const nodePath = yield* HostProcessExecutablePath;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-port-test-" });
+      const portFile = path.join(directory, "port");
+      yield* fs.writeFileString(portFile, "70000\n");
+      const child = yield* spawner.spawn(
+        ChildProcess.make(nodePath, [
+          "-e",
+          REMOTE_PICK_PORT_SCRIPT,
+          "unused",
+          portFile,
+          "49152",
+          "100",
+        ]),
+      );
+      const [stdout, exitCode] = yield* Effect.all([
+        collectProcessOutput(child.stdout),
+        child.exitCode.pipe(Effect.map(Number)),
+      ]);
+      const selectedPort = Number(stdout);
+
+      assert.equal(exitCode, 0);
+      assert.isAtLeast(selectedPort, 49_152);
+      assert.isAtMost(selectedPort, 49_251);
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
 
   it.effect("bounds each HTTP readiness probe so retries cannot hang on one request", () =>
     Effect.gen(function* () {
@@ -455,6 +690,35 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(processLayer));
   });
 
+  it.effect("redacts credentials from malformed successful pairing output", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(makeSuccessfulProcess('{"credential":"pairing-secret"\n')),
+    );
+    const processLayer = Layer.merge(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+
+    return Effect.gen(function* () {
+      const result = yield* Effect.result(issueRemotePairingToken(target));
+
+      assert.isTrue(Result.isFailure(result));
+      if (Result.isFailure(result)) {
+        assert.equal(result.failure._tag, "SshPairingError");
+        if (result.failure._tag === "SshPairingError") {
+          assert.notInclude(result.failure.stdout, "pairing-secret");
+          assert.equal(result.failure.stdout, "");
+        }
+      }
+    }).pipe(Effect.provide(processLayer));
+  });
+
   it.effect("closes the tunnel scope and starts fresh after disconnect", () => {
     const spawnedCommands: Array<ReadonlyArray<string>> = [];
     let tunnelKillCount = 0;
@@ -468,7 +732,7 @@ describe("ssh tunnel scripts", () => {
             tunnelKillCount += 1;
           });
         }
-        if (args.includes("sh") && args.includes("--")) {
+        if (isManagedLaunchCommand(args)) {
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
         if (args.includes("sh")) {
@@ -531,7 +795,7 @@ describe("ssh tunnel scripts", () => {
             tunnelKillCount += 1;
           });
         }
-        if (args.includes("sh") && args.includes("--")) {
+        if (isManagedLaunchCommand(args)) {
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
         if (args.includes("sh")) {
@@ -631,7 +895,7 @@ describe("ssh tunnel scripts", () => {
         if (args.includes("-N")) {
           return makeFailedProcess("tunnel failed for forwarded-secret\n");
         }
-        if (args.includes("sh") && args.includes("--")) {
+        if (isManagedLaunchCommand(args)) {
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
         if (args.includes("sh")) {
@@ -695,7 +959,7 @@ describe("ssh tunnel scripts", () => {
             tunnelKillCount += 1;
           });
         }
-        if (args.includes("sh") && args.includes("--")) {
+        if (isManagedLaunchCommand(args)) {
           remoteLifecycle.push("launch");
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
@@ -755,7 +1019,7 @@ describe("ssh tunnel scripts", () => {
             tunnelKillCount += 1;
           });
         }
-        if (args.includes("sh") && args.includes("--")) {
+        if (isManagedLaunchCommand(args)) {
           launchCount += 1;
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
@@ -840,7 +1104,7 @@ describe("ssh tunnel scripts", () => {
               tunnelKillCount += 1;
             });
           }
-          if (args.includes("sh") && args.includes("--")) {
+          if (isManagedLaunchCommand(args)) {
             return makeSuccessfulProcess('{"remotePort":3773}\n');
           }
           if (args.includes("sh")) {
@@ -926,7 +1190,7 @@ describe("ssh tunnel scripts", () => {
             tunnelKillCount += 1;
           });
         }
-        if (args.includes("sh") && args.includes("--")) {
+        if (isManagedLaunchCommand(args)) {
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
         if (args.includes("sh")) {
@@ -961,6 +1225,78 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.effect("keeps a failed old-host stop pending after SSH config drift", () => {
+    let resolveCount = 0;
+    let launchCount = 0;
+    let oldHostStopCount = 0;
+    let newHostStopCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          resolveCount += 1;
+          const oldHost = resolveCount === 1;
+          return makeSuccessfulProcess(
+            [
+              `hostname ${oldHost ? "old" : "new"}.example.com`,
+              `user ${oldHost ? "old-user" : "new-user"}`,
+              "port 2222",
+              "",
+            ].join("\n"),
+          );
+        }
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {});
+        }
+        if (isManagedLaunchCommand(args)) {
+          launchCount += 1;
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          if (args.includes("old-user@devbox")) {
+            oldHostStopCount += 1;
+            return oldHostStopCount <= 3
+              ? makeFailedProcess("old host stop failed\n")
+              : makeSuccessfulProcess('{"stopped":true}\n');
+          }
+          newHostStopCount += 1;
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const requestedTarget = {
+      alias: "devbox",
+      hostname: "devbox",
+      username: null,
+      port: null,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.ensureEnvironment(requestedTarget);
+      const replacementExit = yield* Effect.exit(manager.ensureEnvironment(requestedTarget));
+      const disconnectExit = yield* Effect.exit(manager.disconnectEnvironment(requestedTarget));
+
+      assert.isTrue(Exit.isFailure(replacementExit));
+      assert.isTrue(Exit.isFailure(disconnectExit));
+      assert.equal(oldHostStopCount, 3);
+      assert.equal(newHostStopCount, 0);
+
+      yield* manager.ensureEnvironment(requestedTarget);
+      assert.equal(oldHostStopCount, 4);
+      assert.equal(launchCount, 2);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.effect("prefers an existing resolved tunnel over a stale requested mapping", () => {
     let resolveCount = 0;
     let tunnelCount = 0;
@@ -981,7 +1317,7 @@ describe("ssh tunnel scripts", () => {
             tunnelKillCount += 1;
           });
         }
-        if (args.includes("sh") && args.includes("--")) {
+        if (isManagedLaunchCommand(args)) {
           return makeSuccessfulProcess('{"remotePort":3773}\n');
         }
         if (args.includes("sh")) {
@@ -1044,7 +1380,7 @@ describe("ssh tunnel scripts", () => {
           if (args.includes("-N")) {
             return makeRunningProcess(() => undefined);
           }
-          if (args.includes("sh") && args.includes("--")) {
+          if (isManagedLaunchCommand(args)) {
             return makeSuccessfulProcess('{"remotePort":3773}\n');
           }
           if (args.includes("sh")) {
@@ -1124,7 +1460,7 @@ describe("ssh tunnel scripts", () => {
             tunnelAliases.push(args.at(-1) ?? "");
             return makeRunningProcess(() => undefined);
           }
-          if (args.includes("sh") && args.includes("--")) {
+          if (isManagedLaunchCommand(args)) {
             return makeSuccessfulProcess('{"remotePort":3773}\n');
           }
           if (args.includes("sh")) {
@@ -1166,6 +1502,17 @@ describe("ssh tunnel scripts", () => {
           ),
         );
         yield* Deferred.await(pairingStarted);
+        const queuedSameTarget = yield* Effect.forEach(Array.from({ length: 3 }), () =>
+          Effect.forkChild(
+            manager.ensureEnvironment({
+              alias: "first-host",
+              hostname: "first.example.com",
+              username: "julius",
+              port: 2222,
+            }),
+          ),
+        );
+        yield* Effect.yieldNow;
 
         const second = yield* manager.ensureEnvironment({
           alias: "second-host",
@@ -1178,9 +1525,79 @@ describe("ssh tunnel scripts", () => {
 
         yield* Deferred.succeed(releasePairing, undefined);
         const first = yield* Fiber.join(firstFiber);
+        yield* Effect.forEach(queuedSameTarget, Fiber.join, { discard: true });
         assert.equal(first.pairingToken, "PAIRING-CODE");
       }).pipe(
         Effect.ensuring(Deferred.succeed(releasePairing, undefined).pipe(Effect.ignore)),
+        Effect.provide(layer),
+        Effect.scoped,
+      );
+    }),
+  );
+
+  it.effect("limits concurrent SSH work across unrelated hosts", () =>
+    Effect.gen(function* () {
+      const fourResolutionsStarted = yield* Deferred.make<void>();
+      const releaseResolutions = yield* Deferred.make<void>();
+      let activeResolutions = 0;
+      let maximumActiveResolutions = 0;
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          const args = commandArgs(command);
+          if (args.includes("-G")) {
+            activeResolutions += 1;
+            maximumActiveResolutions = Math.max(maximumActiveResolutions, activeResolutions);
+            if (activeResolutions === 4) {
+              yield* Deferred.succeed(fourResolutionsStarted, undefined).pipe(Effect.ignore);
+            }
+            yield* Deferred.await(releaseResolutions);
+            activeResolutions -= 1;
+            return makeSuccessfulProcess("\n");
+          }
+          if (args.includes("-N")) {
+            return makeRunningProcess(() => undefined);
+          }
+          if (isManagedLaunchCommand(args)) {
+            return makeSuccessfulProcess('{"remotePort":3773}\n');
+          }
+          if (args.includes("sh")) {
+            return makeSuccessfulProcess('{"stopped":true}\n');
+          }
+          return makeSuccessfulProcess("\n");
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+
+      yield* Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        const fibers = yield* Effect.forEach(
+          Array.from({ length: 5 }, (_, index) => index),
+          (index) =>
+            Effect.forkChild(
+              manager.ensureEnvironment({
+                alias: `host-${index}`,
+                hostname: `host-${index}.example.com`,
+                username: "julius",
+                port: 2222,
+              }),
+            ),
+        );
+        yield* Deferred.await(fourResolutionsStarted);
+        yield* Effect.yieldNow;
+
+        assert.equal(maximumActiveResolutions, 4);
+        yield* Deferred.succeed(releaseResolutions, undefined);
+        yield* Effect.forEach(fibers, Fiber.join, { discard: true });
+        assert.equal(maximumActiveResolutions, 4);
+      }).pipe(
+        Effect.ensuring(Deferred.succeed(releaseResolutions, undefined).pipe(Effect.ignore)),
         Effect.provide(layer),
         Effect.scoped,
       );

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -451,6 +451,61 @@ describe("ssh tunnel scripts", () => {
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 
+  it.effect("disconnects a live tunnel without revalidating its saved SendEnv", () => {
+    let resolveCount = 0;
+    let tunnelKillCount = 0;
+    let stopCommandCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-G")) {
+          resolveCount += 1;
+          return makeSuccessfulProcess("sendenv TOKEN\n");
+        }
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          stopCommandCount += 1;
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+      environmentVariables: { TOKEN: "forwarded-value" },
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.ensureEnvironment(target);
+
+      assert.equal(resolveCount, 2);
+      yield* manager.disconnectEnvironment(target);
+
+      assert.equal(resolveCount, 2);
+      assert.equal(tunnelKillCount, 1);
+      assert.equal(stopCommandCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
   it.effect("replaces a live tunnel when its local SSH environment changes", () => {
     const tunnelEnvironments: Array<Readonly<Record<string, string | undefined>> | undefined> = [];
     const remoteLifecycle: Array<"launch" | "stop"> = [];

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,12 +1,15 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -28,6 +31,7 @@ import {
   SshEnvironmentManager,
   waitForHttpReady,
 } from "./tunnel.ts";
+import { collectProcessOutput, remoteStateKey } from "./command.ts";
 
 const TEST_NODE_ENGINE_RANGE = "^22.16 || ^23.11 || >=24.10";
 
@@ -229,7 +233,8 @@ describe("ssh tunnel scripts", () => {
       buildRemoteStopScript(target),
       'if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ]',
     );
-    assert.include(buildRemoteStopScript(target), 'kill "$REMOTE_PID" 2>/dev/null || true');
+    assert.include(buildRemoteStopScript(target), 'if ! kill "$REMOTE_PID" 2>/dev/null');
+    assert.include(buildRemoteStopScript(target), 'if kill -0 "$REMOTE_PID" 2>/dev/null; then');
     assert.include(buildRemoteStopScript(target), 'rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"');
     assert.include(
       buildRemoteLaunchScript(),
@@ -258,6 +263,46 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PID" ]'),
     );
   });
+
+  it.effect("keeps remote state when the managed process survives stop", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") {
+        return;
+      }
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const homeDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-stop-test-" });
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+      const stateDir = path.join(homeDir, ".t3", "ssh-launch", remoteStateKey(target));
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "pid"), "123\n");
+      yield* fs.writeFileString(path.join(stateDir, "port"), "3773\n");
+      yield* fs.writeFileString(path.join(stateDir, "managed"), "managed\n");
+      const script = `kill() { return 0; }\nsleep() { return 0; }\n${buildRemoteStopScript(target)}`;
+      const child = yield* spawner.spawn(
+        ChildProcess.make("sh", ["-c", script], {
+          env: { HOME: homeDir },
+          extendEnv: true,
+        }),
+      );
+      const [stderr, exitCode] = yield* Effect.all([
+        collectProcessOutput(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ]);
+
+      assert.equal(exitCode, 1);
+      assert.include(stderr, "did not stop");
+      assert.isTrue(yield* fs.exists(path.join(stateDir, "pid")));
+      assert.isTrue(yield* fs.exists(path.join(stateDir, "port")));
+      assert.isTrue(yield* fs.exists(path.join(stateDir, "managed")));
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
 
   it.effect("accepts launch JSON after remote shell startup noise", () => {
     const target = {

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -35,6 +35,7 @@ import {
   collectProcessOutput,
   getLastNonEmptyOutputLine,
   managedRemoteLaunchCommandArgs,
+  redactSshOutput,
   remoteStateKey,
   resolveSshCommand,
   resolveSshTarget,
@@ -1085,12 +1086,13 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
         }),
     ),
     Effect.flatMap(([stderr, exitCode]) => {
+      const diagnosticStderr = redactSshOutput(stderr, input.resolvedTarget.environmentVariables);
       const error = new SshCommandError({
         command: tunnelCommand,
         exitCode,
-        stderr,
+        stderr: diagnosticStderr,
         message: normalizeSshErrorMessage(
-          stderr,
+          diagnosticStderr,
           `SSH tunnel exited unexpectedly for ${input.resolvedTarget.alias} (exit ${exitCode}).`,
         ),
       });
@@ -1102,7 +1104,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
         remotePort: input.remotePort,
         httpBaseUrl: input.httpBaseUrl,
         exitCode,
-        stderr,
+        stderr: diagnosticStderr,
       }).pipe(Effect.andThen(Effect.fail(error)));
     }),
   );
@@ -1138,7 +1140,8 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
           ? localPortAvailableExit.value
           : null;
         const remoteLogTail = Exit.isSuccess(remoteLogTailExit)
-          ? remoteLogTailExit.value || null
+          ? redactSshOutput(remoteLogTailExit.value, input.resolvedTarget.environmentVariables) ||
+            null
           : null;
         yield* Effect.logWarning("ssh.tunnel.ready.failed", {
           ...sshTargetLogFields(input.resolvedTarget),
@@ -1191,6 +1194,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const tunnelKeysByTarget = new Map<string, string>();
   const resolvedTargetsByTunnelKey = new Map<string, DesktopSshEnvironmentTarget>();
   const stoppedRemoteEntries = new WeakSet<SshTunnelEntry>();
+  const remoteStopRequiredTargets = new Map<string, DesktopSshEnvironmentTarget>();
   const withTunnelMutationLock = <A, E, R>(
     key: string,
     effect: Effect.Effect<A, E, R>,
@@ -1400,16 +1404,39 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     });
   });
 
+  const stopRemoteForKey = Effect.fn("ssh/tunnel.stopRemoteForKey")(function* (
+    key: string,
+    target: DesktopSshEnvironmentTarget,
+  ) {
+    yield* runWithSshAuth({
+      key,
+      target,
+      operation: (authOptions) => stopRemoteServer(target, authOptions),
+    }).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          remoteStopRequiredTargets.delete(key);
+        }),
+      ),
+      Effect.tapError(() =>
+        Effect.sync(() => {
+          remoteStopRequiredTargets.set(key, target);
+        }),
+      ),
+    );
+  });
+
   const stopAndCloseTunnelEntry = Effect.fn("ssh/tunnel.stopAndCloseTunnelEntry")(function* (
     entry: SshTunnelEntry,
   ) {
-    yield* runWithSshAuth({
-      key: entry.key,
-      target: entry.target,
-      operation: (authOptions) => stopRemoteServer(entry.target, authOptions),
-    });
-    stoppedRemoteEntries.add(entry);
-    yield* closeTunnelEntry(entry);
+    yield* stopRemoteForKey(entry.key, entry.target).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          stoppedRemoteEntries.add(entry);
+        }),
+      ),
+      Effect.ensuring(closeTunnelEntry(entry)),
+    );
   });
 
   yield* Scope.addFinalizer(
@@ -1435,11 +1462,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     }
     yield* cancelPendingTunnelEntry(key, cleanupTarget);
     if (entry === null && (trackedTarget !== undefined || stopFallbackTarget)) {
-      yield* runWithSshAuth({
-        key,
-        target: cleanupTarget,
-        operation: (authOptions) => stopRemoteServer(cleanupTarget, authOptions),
-      });
+      yield* stopRemoteForKey(key, cleanupTarget);
     }
     forgetTunnelTargetKeys(key);
     authSecrets.delete(key);
@@ -1497,11 +1520,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
       ),
       Effect.tapError((cause) =>
-        runWithSshAuth({
-          key: input.key,
-          target: input.resolvedTarget,
-          operation: (authOptions) => stopRemoteServer(input.resolvedTarget, authOptions),
-        }).pipe(
+        stopRemoteForKey(input.key, input.resolvedTarget).pipe(
           Effect.tapError((cleanupCause) =>
             Effect.logWarning("ssh.environment.remoteServer.cleanup.failed", {
               ...sshTargetLogFields(input.resolvedTarget),
@@ -1549,6 +1568,16 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
                   Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
                   Effect.provideService(FileSystem.FileSystem, fileSystemService),
                   Effect.provideService(Path.Path, pathService),
+                  Effect.tap(() =>
+                    Effect.sync(() => {
+                      remoteStopRequiredTargets.delete(tunnelEntry.key);
+                    }),
+                  ),
+                  Effect.tapError(() =>
+                    Effect.sync(() => {
+                      remoteStopRequiredTargets.set(tunnelEntry.key, tunnelEntry.target);
+                    }),
+                  ),
                 ),
           ],
           { concurrency: "unbounded" },
@@ -1645,6 +1674,11 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       return yield* ensureTunnelEntry(key, resolvedTarget, runner);
     }
 
+    const remoteStopRequiredTarget = remoteStopRequiredTargets.get(key);
+    if (remoteStopRequiredTarget !== undefined) {
+      yield* stopRemoteForKey(key, remoteStopRequiredTarget);
+    }
+
     const deferred = yield* Deferred.make<SshTunnelEntry, SshEnvironmentEffectError>();
     pendingTunnelEntries.set(key, deferred);
 
@@ -1685,6 +1719,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const baseResolved = yield* resolveSshTarget(
       target.alias || target.hostname,
       target.environmentVariables,
+      { username: target.username, port: target.port },
     );
     const resolvedTarget: DesktopSshEnvironmentTarget = {
       ...baseResolved,

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1188,6 +1188,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const authSecrets = new Map<string, string>();
   const tunnelMutationLocks = new Map<string, Semaphore.Semaphore>();
   const tunnelKeysByTarget = new Map<string, string>();
+  const resolvedTargetsByTunnelKey = new Map<string, DesktopSshEnvironmentTarget>();
   const withTunnelMutationLock = <A, E, R>(
     key: string,
     effect: Effect.Effect<A, E, R>,
@@ -1200,18 +1201,39 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     tunnelMutationLocks.set(key, lock);
     return lock.withPermit(effect);
   };
+  const withTunnelMutationLocks = <A, E, R>(
+    keys: ReadonlyArray<string>,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const uniqueKeys = [...new Set(keys)].sort();
+    const acquire = (index: number): Effect.Effect<A, E, R> => {
+      const key = uniqueKeys[index];
+      return key === undefined ? effect : withTunnelMutationLock(key, acquire(index + 1));
+    };
+    return acquire(0);
+  };
 
   const resolveTunnelKey = (
     requestedTarget: DesktopSshEnvironmentTarget,
     resolvedTarget: DesktopSshEnvironmentTarget,
-  ): { readonly key: string; readonly requestedKey: string; readonly resolvedKey: string } => {
+  ): {
+    readonly key: string;
+    readonly requestedKey: string;
+    readonly resolvedKey: string;
+    readonly conflictingKeys: ReadonlyArray<string>;
+  } => {
     const requestedKey = targetConnectionKey(requestedTarget);
     const resolvedKey = targetConnectionKey(resolvedTarget);
+    const requestedMapping = tunnelKeysByTarget.get(requestedKey);
+    const resolvedMapping = tunnelKeysByTarget.get(resolvedKey);
+    const key = resolvedMapping ?? requestedMapping ?? resolvedKey;
     return {
-      key:
-        tunnelKeysByTarget.get(requestedKey) ?? tunnelKeysByTarget.get(resolvedKey) ?? resolvedKey,
+      key,
       requestedKey,
       resolvedKey,
+      conflictingKeys: [requestedMapping, resolvedMapping].filter(
+        (mappedKey): mappedKey is string => mappedKey !== undefined && mappedKey !== key,
+      ),
     };
   };
 
@@ -1219,9 +1241,11 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     key: string,
     requestedKey: string,
     resolvedKey: string,
+    resolvedTarget: DesktopSshEnvironmentTarget,
   ): void => {
     tunnelKeysByTarget.set(requestedKey, key);
     tunnelKeysByTarget.set(resolvedKey, key);
+    resolvedTargetsByTunnelKey.set(key, resolvedTarget);
   };
 
   const forgetTunnelTargetKeys = (key: string): void => {
@@ -1230,6 +1254,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         tunnelKeysByTarget.delete(targetKey);
       }
     }
+    resolvedTargetsByTunnelKey.delete(key);
   };
 
   const closeTunnelEntry = Effect.fn("ssh/tunnel.closeTunnelEntry")(function* (
@@ -1381,6 +1406,27 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       promptCount: 0,
       authSecret: authSecrets.get(input.key) ?? null,
     });
+  });
+
+  const cleanupTunnelKey = Effect.fn("ssh/tunnel.cleanupTunnelKey")(function* (
+    key: string,
+    fallbackTarget: DesktopSshEnvironmentTarget,
+  ) {
+    const entry = tunnels.get(key) ?? null;
+    const cleanupTarget = entry?.target ?? resolvedTargetsByTunnelKey.get(key) ?? fallbackTarget;
+    if (entry !== null) {
+      yield* closeTunnelEntry(entry);
+    }
+    yield* cancelPendingTunnelEntry(key, cleanupTarget);
+    if (entry === null) {
+      yield* runWithSshAuth({
+        key,
+        target: cleanupTarget,
+        operation: (authOptions) => stopRemoteServer(cleanupTarget, authOptions),
+      });
+    }
+    forgetTunnelTargetKeys(key);
+    authSecrets.delete(key);
   });
 
   const createTunnelEntry = Effect.fn("ssh/tunnel.ensureTunnelEntry.create")(function* (input: {
@@ -1620,11 +1666,19 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         ? {}
         : { environmentVariables: target.environmentVariables }),
     };
-    const { key, requestedKey, resolvedKey } = resolveTunnelKey(target, resolvedTarget);
-    return yield* withTunnelMutationLock(
-      key,
+    const { key, requestedKey, resolvedKey, conflictingKeys } = resolveTunnelKey(
+      target,
+      resolvedTarget,
+    );
+    return yield* withTunnelMutationLocks(
+      [key, ...conflictingKeys],
       Effect.gen(function* () {
-        rememberTunnelTargetKeys(key, requestedKey, resolvedKey);
+        yield* Effect.forEach(
+          conflictingKeys,
+          (conflictingKey) => cleanupTunnelKey(conflictingKey, resolvedTarget),
+          { discard: true },
+        );
+        rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
         yield* Effect.logDebug("ssh.environment.target.resolved", {
           ...sshTargetLogFields(resolvedTarget),
           key,
@@ -1684,27 +1738,17 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         existingKey,
         Effect.gen(function* () {
           const entry = tunnels.get(existingKey) ?? null;
+          const cleanupTarget =
+            entry?.target ?? resolvedTargetsByTunnelKey.get(existingKey) ?? target;
           yield* Effect.logDebug("ssh.environment.disconnect.knownTarget", {
-            ...sshTargetLogFields(target),
+            ...sshTargetLogFields(cleanupTarget),
             key: existingKey,
             hasTunnel: entry !== null,
             hasPendingTunnel: pendingTunnelEntries.has(existingKey),
           });
-          if (entry !== null) {
-            yield* closeTunnelEntry(entry);
-          }
-          yield* cancelPendingTunnelEntry(existingKey, target);
-          if (entry === null) {
-            yield* runWithSshAuth({
-              key: existingKey,
-              target,
-              operation: (authOptions) => stopRemoteServer(target, authOptions),
-            });
-          }
-          forgetTunnelTargetKeys(existingKey);
-          authSecrets.delete(existingKey);
+          yield* cleanupTunnelKey(existingKey, target);
           yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {
-            ...sshTargetLogFields(target),
+            ...sshTargetLogFields(cleanupTarget),
             key: existingKey,
           });
         }),
@@ -1726,7 +1770,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     yield* withTunnelMutationLock(
       key,
       Effect.gen(function* () {
-        rememberTunnelTargetKeys(key, requestedKey, resolvedKey);
+        rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
         const entry = tunnels.get(key) ?? null;
         yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
           ...sshTargetLogFields(resolvedTarget),

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -34,6 +34,7 @@ import {
   buildSshHostSpecEffect,
   collectProcessOutput,
   getLastNonEmptyOutputLine,
+  managedRemoteLaunchCommandArgs,
   remoteStateKey,
   resolveSshCommand,
   resolveSshTarget,
@@ -730,7 +731,7 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
       stateKey: remoteStateKey(target),
     });
     const result = yield* runSshCommand(target, {
-      remoteCommandArgs: ["sh", "-l", "-s", "--", remoteStateKey(target)],
+      remoteCommandArgs: managedRemoteLaunchCommandArgs(target),
       stdin: buildRemoteLaunchScript(runner),
       timeoutMs: REMOTE_LAUNCH_TIMEOUT_MS,
       ...(input?.authSecret === undefined ? {} : { authSecret: input.authSecret }),
@@ -1189,6 +1190,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const tunnelMutationLocks = new Map<string, Semaphore.Semaphore>();
   const tunnelKeysByTarget = new Map<string, string>();
   const resolvedTargetsByTunnelKey = new Map<string, DesktopSshEnvironmentTarget>();
+  const stoppedRemoteEntries = new WeakSet<SshTunnelEntry>();
   const withTunnelMutationLock = <A, E, R>(
     key: string,
     effect: Effect.Effect<A, E, R>,
@@ -1286,16 +1288,6 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     pendingTunnelEntries.delete(key);
     yield* Deferred.fail(pending, makeSshTunnelCancelledError(target)).pipe(Effect.ignore);
   });
-
-  yield* Scope.addFinalizer(
-    managerScope,
-    Effect.sync(() => [...tunnels.values()]).pipe(
-      Effect.flatMap((entries) =>
-        Effect.forEach(entries, closeTunnelEntry, { concurrency: "unbounded" }),
-      ),
-      Effect.ignore,
-    ),
-  );
 
   const promptForPassword = Effect.fn("ssh/tunnel.promptForPassword")(function* (
     target: DesktopSshEnvironmentTarget,
@@ -1408,6 +1400,28 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     });
   });
 
+  const stopAndCloseTunnelEntry = Effect.fn("ssh/tunnel.stopAndCloseTunnelEntry")(function* (
+    entry: SshTunnelEntry,
+  ) {
+    yield* runWithSshAuth({
+      key: entry.key,
+      target: entry.target,
+      operation: (authOptions) => stopRemoteServer(entry.target, authOptions),
+    });
+    stoppedRemoteEntries.add(entry);
+    yield* closeTunnelEntry(entry);
+  });
+
+  yield* Scope.addFinalizer(
+    managerScope,
+    Effect.sync(() => [...tunnels.values()]).pipe(
+      Effect.flatMap((entries) =>
+        Effect.forEach(entries, closeTunnelEntry, { concurrency: "unbounded" }),
+      ),
+      Effect.ignore,
+    ),
+  );
+
   const cleanupTunnelKey = Effect.fn("ssh/tunnel.cleanupTunnelKey")(function* (
     key: string,
     fallbackTarget: DesktopSshEnvironmentTarget,
@@ -1417,7 +1431,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const trackedTarget = entry?.target ?? resolvedTargetsByTunnelKey.get(key);
     const cleanupTarget = trackedTarget ?? fallbackTarget;
     if (entry !== null) {
-      yield* closeTunnelEntry(entry);
+      yield* stopAndCloseTunnelEntry(entry);
     }
     yield* cancelPendingTunnelEntry(key, cleanupTarget);
     if (entry === null && (trackedTarget !== undefined || stopFallbackTarget)) {
@@ -1524,23 +1538,18 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
               killSignal: "SIGTERM",
               forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
             }),
-            stopRemoteServer(
-              tunnelEntry.target,
-              authSecret === null
-                ? {
-                    batchMode: "yes",
-                    interactiveAuth: false,
-                  }
-                : {
-                    authSecret,
-                    batchMode: "no",
-                    interactiveAuth: true,
-                  },
-            ).pipe(
-              Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
-              Effect.provideService(FileSystem.FileSystem, fileSystemService),
-              Effect.provideService(Path.Path, pathService),
-            ),
+            stoppedRemoteEntries.has(tunnelEntry)
+              ? Effect.void
+              : stopRemoteServer(
+                  tunnelEntry.target,
+                  authSecret === null
+                    ? { batchMode: "yes", interactiveAuth: false }
+                    : { authSecret, batchMode: "no", interactiveAuth: true },
+                ).pipe(
+                  Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
+                  Effect.provideService(FileSystem.FileSystem, fileSystemService),
+                  Effect.provideService(Path.Path, pathService),
+                ),
           ],
           { concurrency: "unbounded" },
         ).pipe(Effect.ignore);
@@ -1611,7 +1620,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
           reason: targetChanged ? "target-changed" : "environment-changed",
         });
       }
-      yield* closeTunnelEntry(entry);
+      yield* stopAndCloseTunnelEntry(entry);
       yield* cancelPendingTunnelEntry(key, resolvedTarget);
       entry = null;
     }
@@ -1632,7 +1641,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ) {
         return pendingEntry;
       }
-      yield* closeTunnelEntry(pendingEntry);
+      yield* stopAndCloseTunnelEntry(pendingEntry);
       return yield* ensureTunnelEntry(key, resolvedTarget, runner);
     }
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -640,12 +640,19 @@ MANAGED_FILE="$STATE_DIR/managed"
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
 if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
-  kill "$REMOTE_PID" 2>/dev/null || true
+  if ! kill "$REMOTE_PID" 2>/dev/null && kill -0 "$REMOTE_PID" 2>/dev/null; then
+    printf 'Failed to stop managed remote T3 server process %s.\n' "$REMOTE_PID" >&2
+    exit 1
+  fi
   WAIT_COUNT=0
   while kill -0 "$REMOTE_PID" 2>/dev/null && [ "$WAIT_COUNT" -lt 20 ]; do
     WAIT_COUNT=$((WAIT_COUNT + 1))
     sleep 0.1
   done
+  if kill -0 "$REMOTE_PID" 2>/dev/null; then
+    printf 'Managed remote T3 server process %s did not stop.\n' "$REMOTE_PID" >&2
+    exit 1
+  fi
 fi
 rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
 printf '{"stopped":true}\\n'
@@ -1027,7 +1034,6 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     .spawn(
       ChildProcess.make(sshCommand, args, {
         env: childEnvironment,
-        extendEnv: true,
         stdin: {
           stream: Stream.empty,
           endOnDone: true,

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -471,6 +471,7 @@ DEFAULT_RUNTIME_FILE="$DEFAULT_SERVER_HOME/userdata/server-runtime.json"
 PORT_FILE="$STATE_DIR/port"
 PID_FILE="$STATE_DIR/pid"
 PID_START_FILE="$STATE_DIR/pid-start"
+CHILD_PID_FILE="$STATE_DIR/child-pid"
 MANAGED_FILE="$STATE_DIR/managed"
 LOG_FILE="$STATE_DIR/server.log"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
@@ -521,11 +522,14 @@ process_identity() {
   if [ -r "/proc/$PID_TO_IDENTIFY/stat" ] && command -v node >/dev/null 2>&1; then
     PROC_IDENTITY="$(node - "/proc/$PID_TO_IDENTIFY/stat" <<'NODE' 2>/dev/null || true
 const fs = require("node:fs");
+const crypto = require("node:crypto");
 const raw = fs.readFileSync(process.argv[2], "utf8");
 const commandEnd = raw.lastIndexOf(")");
 const fields = commandEnd < 0 ? [] : raw.slice(commandEnd + 2).trim().split(/\\s+/);
 const startTicks = fields[19] ?? "";
-if (/^\\d+$/.test(startTicks)) process.stdout.write("proc:" + startTicks);
+const commandLine = fs.readFileSync(process.argv[2].replace(/stat$/, "cmdline"));
+const commandHash = crypto.createHash("sha256").update(commandLine).digest("hex");
+if (/^\\d+$/.test(startTicks)) process.stdout.write("proc:" + startTicks + ":" + commandHash);
 NODE
 )"
     if [ -n "$PROC_IDENTITY" ]; then
@@ -533,9 +537,17 @@ NODE
       return 0
     fi
   fi
-  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -o command= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
+  PS_IDENTITY="$(LC_ALL=C ps -ww -o lstart= -o command= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
   [ -n "$PS_IDENTITY" ] || return 2
   printf 'ps:%s' "$PS_IDENTITY"
+}
+process_is_expected_wrapper() {
+  [ -r "/proc/$REMOTE_PID/cmdline" ] || return 1
+  node - "/proc/$REMOTE_PID/cmdline" "$MANAGED_WRAPPER_FILE" "$REMOTE_NONCE" <<'NODE' 2>/dev/null
+const fs = require("node:fs");
+const entries = fs.readFileSync(process.argv[2], "utf8").split("\\0").filter(Boolean);
+process.exit(entries.includes(process.argv[3]) && entries.includes(process.argv[4]) ? 0 : 1);
+NODE
 }
 managed_pid_is_owned() {
   [ "$REMOTE_MANAGED" = "managed" ] || return 1
@@ -636,6 +648,7 @@ valid_port() {
   [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
 }
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
+REMOTE_CHILD_PID="$(cat "$CHILD_PID_FILE" 2>/dev/null || true)"
 REMOTE_PORT="$(cat "$PORT_FILE" 2>/dev/null || true)"
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
 if ! valid_port "$REMOTE_PORT"; then
@@ -650,6 +663,22 @@ if [ -n "$DEFAULT_RUNTIME_INFO" ]; then
 fi
 if [ -n "$DEFAULT_REMOTE_PORT" ] && [ "$DEFAULT_RUNTIME_PID" = "$REMOTE_PID" ]; then
   REMOTE_PORT="$DEFAULT_REMOTE_PORT"
+elif [ -n "$DEFAULT_REMOTE_PORT" ] && [ "$DEFAULT_RUNTIME_PID" = "$REMOTE_CHILD_PID" ]; then
+  if managed_pid_is_owned; then
+    REMOTE_PORT="$DEFAULT_REMOTE_PORT"
+  else
+    OWNERSHIP_STATUS=$?
+    if [ "$OWNERSHIP_STATUS" -eq 2 ]; then
+      printf 'Could not verify managed remote T3 wrapper process %s. State was retained.\\n' "$REMOTE_PID" >&2
+      exit 1
+    fi
+    REMOTE_PID=""
+    REMOTE_PORT="$DEFAULT_REMOTE_PORT"
+    REMOTE_MANAGED="external"
+    rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE"
+    printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
+    printf 'external\\n' >"$MANAGED_FILE"
+  fi
 elif [ -n "$DEFAULT_REMOTE_PORT" ]; then
   REMOTE_PORT="$DEFAULT_REMOTE_PORT"
   if wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
@@ -665,7 +694,7 @@ elif [ -n "$DEFAULT_REMOTE_PORT" ]; then
       REMOTE_PID=""
       REMOTE_PORT="$DEFAULT_REMOTE_PORT"
       REMOTE_MANAGED="external"
-      rm -f "$PID_FILE" "$PID_START_FILE"
+      rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE"
       printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
       printf 'external\\n' >"$MANAGED_FILE"
     else
@@ -703,7 +732,7 @@ elif [ -n "$REMOTE_PORT" ]; then
       printf 'Could not verify managed remote T3 server process %s. State was retained.\\n' "$REMOTE_PID" >&2
       exit 1
     fi
-    rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
+    rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
     REMOTE_PID=""
     REMOTE_PORT=""
     REMOTE_MANAGED=""
@@ -713,7 +742,7 @@ else
     printf 'Managed remote T3 server process %s could not be safely stopped. State was retained.\\n' "$REMOTE_PID" >&2
     exit 1
   fi
-  rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
+  rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
   REMOTE_PID=""
   REMOTE_PORT=""
   REMOTE_MANAGED=""
@@ -730,10 +759,12 @@ set -eu
 RUNNER_FILE="$1"
 LAUNCH_NONCE="$2"
 WRAPPER_READY_FILE="$3"
-shift 3
+CHILD_PID_FILE="$4"
+shift 4
 CHILD_PID=""
 stop_child() {
   rm -f "$WRAPPER_READY_FILE"
+  rm -f "$CHILD_PID_FILE"
   if [ -n "$CHILD_PID" ] && kill -0 "$CHILD_PID" 2>/dev/null; then
     kill "$CHILD_PID" 2>/dev/null || true
     wait "$CHILD_PID" 2>/dev/null || true
@@ -745,16 +776,18 @@ trap stop_child TERM INT HUP
 printf 'ready\\n' >"$WRAPPER_READY_FILE"
 env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" "$@" &
 CHILD_PID="$!"
+printf '%s\\n' "$CHILD_PID" >"$CHILD_PID_FILE"
 CHILD_EXIT=0
 wait "$CHILD_PID" || CHILD_EXIT="$?"
 rm -f "$WRAPPER_READY_FILE"
+rm -f "$CHILD_PID_FILE"
 exit "$CHILD_EXIT"
 SH
   chmod 700 "$MANAGED_WRAPPER_FILE"
   REMOTE_NONCE="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(24).toString("hex"))')"
   WRAPPER_READY_FILE="$STATE_DIR/wrapper-ready.$REMOTE_NONCE"
   rm -f "$WRAPPER_READY_FILE"
-  nohup "$MANAGED_WRAPPER_FILE" "$RUNNER_FILE" "$REMOTE_NONCE" "$WRAPPER_READY_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
+  nohup "$MANAGED_WRAPPER_FILE" "$RUNNER_FILE" "$REMOTE_NONCE" "$WRAPPER_READY_FILE" "$CHILD_PID_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
   REMOTE_PID="$!"
   REMOTE_MANAGED="managed"
   READY_ATTEMPT=0
@@ -775,7 +808,13 @@ SH
     IDENTITY_ATTEMPT=$((IDENTITY_ATTEMPT + 1))
     if PID_IDENTITY="$(process_identity "$REMOTE_PID")"; then
       case "$PID_IDENTITY" in
-        proc:*|ps:*"$MANAGED_WRAPPER_FILE"*"$REMOTE_NONCE"*) REMOTE_PID_START="$PID_IDENTITY"; break ;;
+        proc:*)
+          if process_is_expected_wrapper; then
+            REMOTE_PID_START="$PID_IDENTITY"
+            break
+          fi
+          ;;
+        ps:*"$MANAGED_WRAPPER_FILE"*"$REMOTE_NONCE"*) REMOTE_PID_START="$PID_IDENTITY"; break ;;
       esac
     fi
     sleep 0.05
@@ -800,7 +839,7 @@ SH
       printf 'It wrote nothing to %s, so it exited before producing any output.\\n' "$LOG_FILE" >&2
     fi
     if stop_managed_pid; then
-      rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
+      rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
     fi
     exit 1
   fi
@@ -825,6 +864,7 @@ export const REMOTE_STOP_SCRIPT = `set -eu
 STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
 PID_FILE="$STATE_DIR/pid"
 PID_START_FILE="$STATE_DIR/pid-start"
+CHILD_PID_FILE="$STATE_DIR/child-pid"
 PORT_FILE="$STATE_DIR/port"
 MANAGED_FILE="$STATE_DIR/managed"
 process_identity() {
@@ -836,11 +876,14 @@ process_identity() {
   if [ -r "/proc/$PID_TO_IDENTIFY/stat" ] && command -v node >/dev/null 2>&1; then
     PROC_IDENTITY="$(node - "/proc/$PID_TO_IDENTIFY/stat" <<'NODE' 2>/dev/null || true
 const fs = require("node:fs");
+const crypto = require("node:crypto");
 const raw = fs.readFileSync(process.argv[2], "utf8");
 const commandEnd = raw.lastIndexOf(")");
 const fields = commandEnd < 0 ? [] : raw.slice(commandEnd + 2).trim().split(/\\s+/);
 const startTicks = fields[19] ?? "";
-if (/^\\d+$/.test(startTicks)) process.stdout.write("proc:" + startTicks);
+const commandLine = fs.readFileSync(process.argv[2].replace(/stat$/, "cmdline"));
+const commandHash = crypto.createHash("sha256").update(commandLine).digest("hex");
+if (/^\\d+$/.test(startTicks)) process.stdout.write("proc:" + startTicks + ":" + commandHash);
 NODE
 )"
     if [ -n "$PROC_IDENTITY" ]; then
@@ -848,7 +891,7 @@ NODE
       return 0
     fi
   fi
-  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -o command= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
+  PS_IDENTITY="$(LC_ALL=C ps -ww -o lstart= -o command= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
   [ -n "$PS_IDENTITY" ] || return 2
   printf 'ps:%s' "$PS_IDENTITY"
 }
@@ -880,7 +923,7 @@ if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$EXPECTED_PID_START" ]; then
       printf 'Could not verify managed remote T3 server process %s. State was retained.\\n' "$REMOTE_PID" >&2
       exit 1
     fi
-    rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
+    rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
     printf '{"stopped":true}\\n'
     exit 0
   fi
@@ -904,7 +947,7 @@ if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$EXPECTED_PID_START" ]; then
     fi
   fi
 fi
-rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
+rm -f "$PID_FILE" "$PID_START_FILE" "$CHILD_PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
 printf '{"stopped":true}\\n'
 `;
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -18,6 +18,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -37,6 +38,7 @@ import {
   resolveSshCommand,
   resolveSshTarget,
   runSshCommand,
+  sshEnvironmentVariablesEqual,
   targetConnectionKey,
 } from "./command.ts";
 import {
@@ -964,6 +966,9 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
 > {
   const hostSpec = yield* buildSshHostSpecEffect(input.resolvedTarget);
   const childEnvironment = yield* buildSshChildEnvironment({
+    ...(input.resolvedTarget.environmentVariables === undefined
+      ? {}
+      : { baseEnv: input.resolvedTarget.environmentVariables }),
     ...(input.authOptions.authSecret === undefined
       ? {}
       : { authSecret: input.authOptions.authSecret }),
@@ -1181,6 +1186,51 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>
   >();
   const authSecrets = new Map<string, string>();
+  const tunnelMutationLocks = new Map<string, Semaphore.Semaphore>();
+  const tunnelKeysByTarget = new Map<string, string>();
+  const withTunnelMutationLock = <A, E, R>(
+    key: string,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const existing = tunnelMutationLocks.get(key);
+    if (existing !== undefined) {
+      return existing.withPermit(effect);
+    }
+    const lock = Semaphore.makeUnsafe(1);
+    tunnelMutationLocks.set(key, lock);
+    return lock.withPermit(effect);
+  };
+
+  const resolveTunnelKey = (
+    requestedTarget: DesktopSshEnvironmentTarget,
+    resolvedTarget: DesktopSshEnvironmentTarget,
+  ): { readonly key: string; readonly requestedKey: string; readonly resolvedKey: string } => {
+    const requestedKey = targetConnectionKey(requestedTarget);
+    const resolvedKey = targetConnectionKey(resolvedTarget);
+    return {
+      key:
+        tunnelKeysByTarget.get(requestedKey) ?? tunnelKeysByTarget.get(resolvedKey) ?? resolvedKey,
+      requestedKey,
+      resolvedKey,
+    };
+  };
+
+  const rememberTunnelTargetKeys = (
+    key: string,
+    requestedKey: string,
+    resolvedKey: string,
+  ): void => {
+    tunnelKeysByTarget.set(requestedKey, key);
+    tunnelKeysByTarget.set(resolvedKey, key);
+  };
+
+  const forgetTunnelTargetKeys = (key: string): void => {
+    for (const [targetKey, tunnelKey] of tunnelKeysByTarget) {
+      if (tunnelKey === key) {
+        tunnelKeysByTarget.delete(targetKey);
+      }
+    }
+  };
 
   const closeTunnelEntry = Effect.fn("ssh/tunnel.closeTunnelEntry")(function* (
     entry: SshTunnelEntry,
@@ -1460,25 +1510,42 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         localPort: entry.localPort,
         remotePort: entry.remotePort,
       });
-      const readinessExit = yield* Effect.exit(
-        waitForHttpReady({ baseUrl: entry.httpBaseUrl, timeoutMs: 2_000 }),
+      const targetChanged =
+        targetConnectionKey(entry.target) !== targetConnectionKey(resolvedTarget);
+      const environmentChanged = !sshEnvironmentVariablesEqual(
+        entry.target.environmentVariables,
+        resolvedTarget.environmentVariables,
       );
-      if (Exit.isSuccess(readinessExit)) {
-        yield* Effect.logDebug("ssh.environment.tunnel.reused", {
+      if (!targetChanged && !environmentChanged) {
+        const readinessExit = yield* Effect.exit(
+          waitForHttpReady({ baseUrl: entry.httpBaseUrl, timeoutMs: 2_000 }),
+        );
+        if (Exit.isSuccess(readinessExit)) {
+          yield* Effect.logDebug("ssh.environment.tunnel.reused", {
+            ...sshTargetLogFields(resolvedTarget),
+            key,
+            localPort: entry.localPort,
+            remotePort: entry.remotePort,
+          });
+          return entry;
+        }
+        yield* Effect.logWarning("ssh.environment.tunnel.existing.replace", {
           ...sshTargetLogFields(resolvedTarget),
           key,
           localPort: entry.localPort,
           remotePort: entry.remotePort,
+          reason: "readiness-failed",
+          cause: readinessExit.cause,
         });
-        return entry;
+      } else {
+        yield* Effect.logInfo("ssh.environment.tunnel.existing.replace", {
+          ...sshTargetLogFields(resolvedTarget),
+          key,
+          localPort: entry.localPort,
+          remotePort: entry.remotePort,
+          reason: targetChanged ? "target-changed" : "environment-changed",
+        });
       }
-      yield* Effect.logWarning("ssh.environment.tunnel.existing.stale", {
-        ...sshTargetLogFields(resolvedTarget),
-        key,
-        localPort: entry.localPort,
-        remotePort: entry.remotePort,
-        cause: readinessExit.cause,
-      });
       yield* closeTunnelEntry(entry);
       yield* cancelPendingTunnelEntry(key, resolvedTarget);
       entry = null;
@@ -1490,7 +1557,18 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         ...sshTargetLogFields(resolvedTarget),
         key,
       });
-      return yield* Deferred.await(pending);
+      const pendingEntry = yield* Deferred.await(pending);
+      if (
+        targetConnectionKey(pendingEntry.target) === targetConnectionKey(resolvedTarget) &&
+        sshEnvironmentVariablesEqual(
+          pendingEntry.target.environmentVariables,
+          resolvedTarget.environmentVariables,
+        )
+      ) {
+        return pendingEntry;
+      }
+      yield* closeTunnelEntry(pendingEntry);
+      return yield* ensureTunnelEntry(key, resolvedTarget, runner);
     }
 
     const deferred = yield* Deferred.make<SshTunnelEntry, SshEnvironmentEffectError>();
@@ -1530,91 +1608,118 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...sshTargetLogFields(target),
       issuePairingToken: requestOptions?.issuePairingToken === true,
     });
-    const baseResolved = yield* resolveSshTarget(target.alias || target.hostname);
+    const baseResolved = yield* resolveSshTarget(
+      target.alias || target.hostname,
+      target.environmentVariables,
+    );
     const resolvedTarget: DesktopSshEnvironmentTarget = {
       ...baseResolved,
       ...(target.username !== null ? { username: target.username } : {}),
       ...(target.port !== null ? { port: target.port } : {}),
+      ...(target.environmentVariables === undefined
+        ? {}
+        : { environmentVariables: target.environmentVariables }),
     };
-    const key = targetConnectionKey(resolvedTarget);
-    yield* Effect.logDebug("ssh.environment.target.resolved", {
-      ...sshTargetLogFields(resolvedTarget),
+    const { key, requestedKey, resolvedKey } = resolveTunnelKey(target, resolvedTarget);
+    return yield* withTunnelMutationLock(
       key,
-    });
-    const packageSpec = options.resolveCliPackageSpec?.();
-    const runner =
-      options.resolveCliRunner === undefined
-        ? packageSpec === undefined
-          ? undefined
-          : { packageSpec }
-        : yield* options.resolveCliRunner;
-    yield* Effect.logDebug("ssh.environment.runner.resolved", {
-      ...sshTargetLogFields(resolvedTarget),
-      ...sshRunnerLogFields(runner),
-      key,
-    });
-    const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
-
-    const pairingResult = requestOptions?.issuePairingToken
-      ? yield* runWithSshAuth({
+      Effect.gen(function* () {
+        rememberTunnelTargetKeys(key, requestedKey, resolvedKey);
+        yield* Effect.logDebug("ssh.environment.target.resolved", {
+          ...sshTargetLogFields(resolvedTarget),
           key,
-          target: entry.target,
-          operation: (authOptions) => issueRemotePairingToken(entry.target, authOptions, runner),
-        })
-      : null;
-    const pairingToken = pairingResult?.credential ?? null;
+        });
+        const packageSpec = options.resolveCliPackageSpec?.();
+        const runner =
+          options.resolveCliRunner === undefined
+            ? packageSpec === undefined
+              ? undefined
+              : { packageSpec }
+            : yield* options.resolveCliRunner;
+        yield* Effect.logDebug("ssh.environment.runner.resolved", {
+          ...sshTargetLogFields(resolvedTarget),
+          ...sshRunnerLogFields(runner),
+          key,
+        });
+        const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
 
-    yield* Effect.logInfo("ssh.environment.ensure.succeeded", {
-      ...sshTargetLogFields(entry.target),
-      key,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-      remoteServerKind: entry.remoteServerKind,
-      issuedPairingToken: pairingToken !== null,
-    });
-    return {
-      target: entry.target,
-      httpBaseUrl: entry.httpBaseUrl,
-      wsBaseUrl: entry.wsBaseUrl,
-      pairingToken,
-      remotePort: entry.remotePort,
-      ...(entry.remoteServerKind ? { remoteServerKind: entry.remoteServerKind } : {}),
-    };
+        const pairingResult = requestOptions?.issuePairingToken
+          ? yield* runWithSshAuth({
+              key,
+              target: entry.target,
+              operation: (authOptions) =>
+                issueRemotePairingToken(entry.target, authOptions, runner),
+            })
+          : null;
+        const pairingToken = pairingResult?.credential ?? null;
+
+        yield* Effect.logInfo("ssh.environment.ensure.succeeded", {
+          ...sshTargetLogFields(entry.target),
+          key,
+          localPort: entry.localPort,
+          remotePort: entry.remotePort,
+          remoteServerKind: entry.remoteServerKind,
+          issuedPairingToken: pairingToken !== null,
+        });
+        return {
+          target: entry.target,
+          httpBaseUrl: entry.httpBaseUrl,
+          wsBaseUrl: entry.wsBaseUrl,
+          pairingToken,
+          remotePort: entry.remotePort,
+          ...(entry.remoteServerKind ? { remoteServerKind: entry.remoteServerKind } : {}),
+        };
+      }),
+    );
   });
 
   const disconnectEnvironment = Effect.fn("ssh/tunnel.disconnectEnvironment")(function* (
     target: DesktopSshEnvironmentTarget,
   ): Effect.fn.Return<void, SshEnvironmentEffectError, SshEnvironmentEffectContext> {
     yield* Effect.logInfo("ssh.environment.disconnect.start", sshTargetLogFields(target));
-    const baseResolved = yield* resolveSshTarget(target.alias || target.hostname);
+    const baseResolved = yield* resolveSshTarget(
+      target.alias || target.hostname,
+      target.environmentVariables,
+    );
     const resolvedTarget: DesktopSshEnvironmentTarget = {
       ...baseResolved,
       ...(target.username !== null ? { username: target.username } : {}),
       ...(target.port !== null ? { port: target.port } : {}),
+      ...(target.environmentVariables === undefined
+        ? {}
+        : { environmentVariables: target.environmentVariables }),
     };
-    const key = targetConnectionKey(resolvedTarget);
-    const entry = tunnels.get(key) ?? null;
-    yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
-      ...sshTargetLogFields(resolvedTarget),
+    const { key, requestedKey, resolvedKey } = resolveTunnelKey(target, resolvedTarget);
+    yield* withTunnelMutationLock(
       key,
-      hasTunnel: entry !== null,
-      hasPendingTunnel: pendingTunnelEntries.has(key),
-    });
-    if (entry !== null) {
-      yield* closeTunnelEntry(entry);
-    }
-    yield* cancelPendingTunnelEntry(key, resolvedTarget);
-    if (entry === null) {
-      yield* runWithSshAuth({
-        key,
-        target: resolvedTarget,
-        operation: (authOptions) => stopRemoteServer(resolvedTarget, authOptions),
-      });
-    }
-    yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {
-      ...sshTargetLogFields(resolvedTarget),
-      key,
-    });
+      Effect.gen(function* () {
+        rememberTunnelTargetKeys(key, requestedKey, resolvedKey);
+        const entry = tunnels.get(key) ?? null;
+        yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
+          ...sshTargetLogFields(resolvedTarget),
+          key,
+          hasTunnel: entry !== null,
+          hasPendingTunnel: pendingTunnelEntries.has(key),
+        });
+        if (entry !== null) {
+          yield* closeTunnelEntry(entry);
+        }
+        yield* cancelPendingTunnelEntry(key, resolvedTarget);
+        if (entry === null) {
+          yield* runWithSshAuth({
+            key,
+            target: resolvedTarget,
+            operation: (authOptions) => stopRemoteServer(resolvedTarget, authOptions),
+          });
+        }
+        forgetTunnelTargetKeys(key);
+        authSecrets.delete(key);
+        yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {
+          ...sshTargetLogFields(resolvedTarget),
+          key,
+        });
+      }),
+    );
   });
 
   return SshEnvironmentManager.of({ ensureEnvironment, disconnectEnvironment });

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -474,6 +474,7 @@ PID_START_FILE="$STATE_DIR/pid-start"
 MANAGED_FILE="$STATE_DIR/managed"
 LOG_FILE="$STATE_DIR/server.log"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
+MANAGED_WRAPPER_FILE="$STATE_DIR/run-managed.sh"
 RUNNER_NEXT="$STATE_DIR/run-t3.next.$$"
 mkdir -p "$STATE_DIR"
 cleanup_runner_next() {
@@ -532,7 +533,7 @@ NODE
       return 0
     fi
   fi
-  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
+  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -o command= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
   [ -n "$PS_IDENTITY" ] || return 2
   printf 'ps:%s' "$PS_IDENTITY"
 }
@@ -543,8 +544,9 @@ managed_pid_is_owned() {
   if [ -z "$EXPECTED_PID_START" ]; then
     if process_identity "$REMOTE_PID" >/dev/null; then
       return 2
+    else
+      IDENTITY_STATUS=$?
     fi
-    IDENTITY_STATUS=$?
     [ "$IDENTITY_STATUS" -eq 1 ] && return 1
     return 2
   fi
@@ -562,8 +564,9 @@ stop_managed_pid() {
   if ! kill "$REMOTE_PID" 2>/dev/null; then
     if managed_pid_is_owned; then
       return 1
+    else
+      OWNERSHIP_STATUS=$?
     fi
-    OWNERSHIP_STATUS=$?
     [ "$OWNERSHIP_STATUS" -eq 1 ] && return 0
     return 2
   fi
@@ -574,8 +577,9 @@ stop_managed_pid() {
   done
   if managed_pid_is_owned; then
     return 1
+  else
+    OWNERSHIP_STATUS=$?
   fi
-  OWNERSHIP_STATUS=$?
   [ "$OWNERSHIP_STATUS" -eq 1 ] && return 0
   return 2
 }
@@ -720,18 +724,70 @@ if [ -z "$REMOTE_PORT" ]; then
     printf 'Failed to find an available port on the remote host. Ensure node is available on PATH.\\n' >&2
     exit 1
   fi
-  nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
+  cat >"$MANAGED_WRAPPER_FILE" <<'SH'
+#!/bin/sh
+set -eu
+RUNNER_FILE="$1"
+LAUNCH_NONCE="$2"
+WRAPPER_READY_FILE="$3"
+shift 3
+CHILD_PID=""
+stop_child() {
+  rm -f "$WRAPPER_READY_FILE"
+  if [ -n "$CHILD_PID" ] && kill -0 "$CHILD_PID" 2>/dev/null; then
+    kill "$CHILD_PID" 2>/dev/null || true
+    wait "$CHILD_PID" 2>/dev/null || true
+  fi
+  exit 143
+}
+trap stop_child TERM INT HUP
+: "$LAUNCH_NONCE"
+printf 'ready\\n' >"$WRAPPER_READY_FILE"
+env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" "$@" &
+CHILD_PID="$!"
+CHILD_EXIT=0
+wait "$CHILD_PID" || CHILD_EXIT="$?"
+rm -f "$WRAPPER_READY_FILE"
+exit "$CHILD_EXIT"
+SH
+  chmod 700 "$MANAGED_WRAPPER_FILE"
+  REMOTE_NONCE="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(24).toString("hex"))')"
+  WRAPPER_READY_FILE="$STATE_DIR/wrapper-ready.$REMOTE_NONCE"
+  rm -f "$WRAPPER_READY_FILE"
+  nohup "$MANAGED_WRAPPER_FILE" "$RUNNER_FILE" "$REMOTE_NONCE" "$WRAPPER_READY_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
   REMOTE_PID="$!"
   REMOTE_MANAGED="managed"
-  if REMOTE_PID_START="$(process_identity "$REMOTE_PID")"; then
-    :
-  else
+  READY_ATTEMPT=0
+  while [ ! -f "$WRAPPER_READY_FILE" ] && [ "$READY_ATTEMPT" -lt 20 ]; do
+    READY_ATTEMPT=$((READY_ATTEMPT + 1))
+    sleep 0.05
+  done
+  if [ ! -f "$WRAPPER_READY_FILE" ]; then
+    printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"
+    printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
+    printf 'managed\\n' >"$MANAGED_FILE"
+    printf 'Managed remote T3 server wrapper did not become ready. State was retained.\\n' >&2
+    exit 1
+  fi
+  REMOTE_PID_START=""
+  IDENTITY_ATTEMPT=0
+  while [ "$IDENTITY_ATTEMPT" -lt 20 ]; do
+    IDENTITY_ATTEMPT=$((IDENTITY_ATTEMPT + 1))
+    if PID_IDENTITY="$(process_identity "$REMOTE_PID")"; then
+      case "$PID_IDENTITY" in
+        proc:*|ps:*"$MANAGED_WRAPPER_FILE"*"$REMOTE_NONCE"*) REMOTE_PID_START="$PID_IDENTITY"; break ;;
+      esac
+    fi
+    sleep 0.05
+  done
+  if [ -z "$REMOTE_PID_START" ]; then
     printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"
     printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
     printf 'managed\\n' >"$MANAGED_FILE"
     printf 'Could not verify the managed remote T3 server process identity.\\n' >&2
     exit 1
   fi
+  rm -f "$WRAPPER_READY_FILE"
   printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"
   printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
   printf '%s\\n' "$REMOTE_PID_START" >"$PID_START_FILE"
@@ -792,7 +848,7 @@ NODE
       return 0
     fi
   fi
-  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
+  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -o command= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
   [ -n "$PS_IDENTITY" ] || return 2
   printf 'ps:%s' "$PS_IDENTITY"
 }
@@ -807,8 +863,9 @@ if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$REMOTE_PID" ] && [ -z "$EXPECTED_
   if process_identity "$REMOTE_PID" >/dev/null; then
     printf 'Managed remote T3 server process %s has no ownership identity. State was retained.\\n' "$REMOTE_PID" >&2
     exit 1
+  else
+    IDENTITY_STATUS=$?
   fi
-  IDENTITY_STATUS=$?
   if [ "$IDENTITY_STATUS" -eq 2 ]; then
     printf 'Could not verify managed remote T3 server process %s. State was retained.\\n' "$REMOTE_PID" >&2
     exit 1

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -248,8 +248,10 @@ const defaultPort = Number.parseInt(process.argv[3] ?? "", 10);
 const scanWindow = Number.parseInt(process.argv[4] ?? "", 10);
 const raw = fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8").trim() : "";
 const preferred = Number.parseInt(raw, 10);
-const start = Number.isInteger(preferred) ? preferred : defaultPort;
-const end = start + scanWindow;
+const validPort = (port) => Number.isInteger(port) && port >= 1 && port <= 65535;
+if (!validPort(defaultPort) || !Number.isInteger(scanWindow) || scanWindow < 1) process.exit(1);
+const start = validPort(preferred) ? preferred : defaultPort;
+const end = Math.min(start + scanWindow, 65536);
 
 function tryPort(port) {
   return new Promise((resolve) => {
@@ -293,7 +295,7 @@ function probe() {
       {
         hostname: "127.0.0.1",
         port,
-        path: "/",
+        path: "/.well-known/t3/environment",
         timeout: probeTimeoutMs,
       },
       (response) => {
@@ -468,6 +470,7 @@ DEFAULT_SERVER_HOME="$HOME/.t3"
 DEFAULT_RUNTIME_FILE="$DEFAULT_SERVER_HOME/userdata/server-runtime.json"
 PORT_FILE="$STATE_DIR/port"
 PID_FILE="$STATE_DIR/pid"
+PID_START_FILE="$STATE_DIR/pid-start"
 MANAGED_FILE="$STATE_DIR/managed"
 LOG_FILE="$STATE_DIR/server.log"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
@@ -508,19 +511,111 @@ wait_for_pid_exit() {
     sleep 0.1
   done
 }
+process_identity() {
+  PID_TO_IDENTIFY="$1"
+  case "$PID_TO_IDENTIFY" in
+    ''|*[!0-9]*|0) return 1 ;;
+  esac
+  kill -0 "$PID_TO_IDENTIFY" 2>/dev/null || return 1
+  if [ -r "/proc/$PID_TO_IDENTIFY/stat" ] && command -v node >/dev/null 2>&1; then
+    PROC_IDENTITY="$(node - "/proc/$PID_TO_IDENTIFY/stat" <<'NODE' 2>/dev/null || true
+const fs = require("node:fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const commandEnd = raw.lastIndexOf(")");
+const fields = commandEnd < 0 ? [] : raw.slice(commandEnd + 2).trim().split(/\\s+/);
+const startTicks = fields[19] ?? "";
+if (/^\\d+$/.test(startTicks)) process.stdout.write("proc:" + startTicks);
+NODE
+)"
+    if [ -n "$PROC_IDENTITY" ]; then
+      printf '%s' "$PROC_IDENTITY"
+      return 0
+    fi
+  fi
+  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
+  [ -n "$PS_IDENTITY" ] || return 2
+  printf 'ps:%s' "$PS_IDENTITY"
+}
+managed_pid_is_owned() {
+  [ "$REMOTE_MANAGED" = "managed" ] || return 1
+  [ -n "$REMOTE_PID" ] || return 1
+  EXPECTED_PID_START="$(cat "$PID_START_FILE" 2>/dev/null || true)"
+  if [ -z "$EXPECTED_PID_START" ]; then
+    if process_identity "$REMOTE_PID" >/dev/null; then
+      return 2
+    fi
+    IDENTITY_STATUS=$?
+    [ "$IDENTITY_STATUS" -eq 1 ] && return 1
+    return 2
+  fi
+  CURRENT_PID_START="$(process_identity "$REMOTE_PID")" || return $?
+  [ -n "$CURRENT_PID_START" ] && [ "$CURRENT_PID_START" = "$EXPECTED_PID_START" ]
+}
+stop_managed_pid() {
+  if managed_pid_is_owned; then
+    :
+  else
+    OWNERSHIP_STATUS=$?
+    [ "$OWNERSHIP_STATUS" -eq 1 ] && return 0
+    return 2
+  fi
+  if ! kill "$REMOTE_PID" 2>/dev/null; then
+    if managed_pid_is_owned; then
+      return 1
+    fi
+    OWNERSHIP_STATUS=$?
+    [ "$OWNERSHIP_STATUS" -eq 1 ] && return 0
+    return 2
+  fi
+  WAIT_COUNT=0
+  while managed_pid_is_owned && [ "$WAIT_COUNT" -lt 20 ]; do
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+    sleep 0.1
+  done
+  if managed_pid_is_owned; then
+    return 1
+  fi
+  OWNERSHIP_STATUS=$?
+  [ "$OWNERSHIP_STATUS" -eq 1 ] && return 0
+  return 2
+}
 resolve_default_runtime_port() {
   node - "$DEFAULT_RUNTIME_FILE" <<'NODE'
 const fs = require("node:fs");
+const childProcess = require("node:child_process");
 const runtimePath = process.argv[2] ?? "";
 try {
 	  const runtime = JSON.parse(fs.readFileSync(runtimePath, "utf8"));
 	  const pid = Number(runtime.pid);
 	  const port = Number(runtime.port);
-	  if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(port)) {
+	  if (
+	    runtime.version !== 1 ||
+	    !Number.isInteger(pid) ||
+	    pid <= 0 ||
+	    !Number.isInteger(port) ||
+	    port < 1 ||
+	    port > 65535
+	  ) {
 	    process.exit(1);
 	  }
   const origin = new URL(String(runtime.origin ?? ""));
-  if (origin.protocol !== "http:" || !["127.0.0.1", "localhost"].includes(origin.hostname)) {
+  const runtimeStartedAt = Date.parse(String(runtime.startedAt ?? ""));
+  const processStartedAt = Date.parse(
+    childProcess.execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      env: { ...process.env, LC_ALL: "C" },
+      timeout: 2000,
+    }).trim(),
+  );
+  if (
+    origin.protocol !== "http:" ||
+    !["127.0.0.1", "localhost"].includes(origin.hostname) ||
+    Number(origin.port || "80") !== port ||
+    !Number.isFinite(runtimeStartedAt) ||
+    !Number.isFinite(processStartedAt) ||
+    runtimeStartedAt < processStartedAt ||
+    runtimeStartedAt - processStartedAt > 300000
+  ) {
     process.exit(1);
   }
   process.kill(pid, 0);
@@ -530,9 +625,18 @@ try {
 }
 NODE
 }
+valid_port() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
 REMOTE_PORT="$(cat "$PORT_FILE" 2>/dev/null || true)"
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
+if ! valid_port "$REMOTE_PORT"; then
+  REMOTE_PORT=""
+fi
 DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port 2>/dev/null || true)"
 DEFAULT_RUNTIME_PID=""
 DEFAULT_REMOTE_PORT=""
@@ -540,19 +644,24 @@ if [ -n "$DEFAULT_RUNTIME_INFO" ]; then
   DEFAULT_RUNTIME_PID="\${DEFAULT_RUNTIME_INFO%% *}"
   DEFAULT_REMOTE_PORT="\${DEFAULT_RUNTIME_INFO#* }"
 fi
-if [ -n "$DEFAULT_REMOTE_PORT" ]; then
+if [ -n "$DEFAULT_REMOTE_PORT" ] && [ "$DEFAULT_RUNTIME_PID" = "$REMOTE_PID" ]; then
+  REMOTE_PORT="$DEFAULT_REMOTE_PORT"
+elif [ -n "$DEFAULT_REMOTE_PORT" ]; then
   REMOTE_PORT="$DEFAULT_REMOTE_PORT"
   if wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
     if [ "$REMOTE_MANAGED" = "managed" ]; then
-      PID_TO_STOP="\${REMOTE_PID:-$DEFAULT_RUNTIME_PID}"
-      if [ -n "$PID_TO_STOP" ] && kill -0 "$PID_TO_STOP" 2>/dev/null; then
-        kill "$PID_TO_STOP" 2>/dev/null || true
-        wait_for_pid_exit "$PID_TO_STOP"
+      if ! stop_managed_pid; then
+        printf 'Managed remote T3 server process %s did not stop.\\n' "$REMOTE_PID" >&2
+        exit 1
+      fi
+      if ! wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
+        printf 'The discovered external T3 server stopped responding during managed cleanup.\\n' >&2
+        exit 1
       fi
       REMOTE_PID=""
       REMOTE_PORT="$DEFAULT_REMOTE_PORT"
       REMOTE_MANAGED="external"
-      rm -f "$PID_FILE"
+      rm -f "$PID_FILE" "$PID_START_FILE"
       printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
       printf 'external\\n' >"$MANAGED_FILE"
     else
@@ -573,21 +682,34 @@ if [ "$REMOTE_MANAGED" = "external" ]; then
     REMOTE_PORT=""
     REMOTE_MANAGED=""
   fi
-elif [ -n "$REMOTE_PID" ] && [ -n "$REMOTE_PORT" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
-  if [ "$RUNNER_CHANGED" -eq 1 ]; then
-    kill "$REMOTE_PID" 2>/dev/null || true
-    wait_for_pid_exit "$REMOTE_PID"
-    REMOTE_PID=""
-    REMOTE_PORT=""
-    REMOTE_MANAGED=""
-  elif ! wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
-    kill "$REMOTE_PID" 2>/dev/null || true
-    wait_for_pid_exit "$REMOTE_PID"
+elif [ -n "$REMOTE_PORT" ]; then
+  if managed_pid_is_owned; then
+    if [ "$RUNNER_CHANGED" -eq 1 ] || ! wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
+      if ! stop_managed_pid; then
+        printf 'Managed remote T3 server process %s could not be safely stopped.\\n' "$REMOTE_PID" >&2
+        exit 1
+      fi
+      REMOTE_PID=""
+      REMOTE_PORT=""
+      REMOTE_MANAGED=""
+    fi
+  else
+    OWNERSHIP_STATUS=$?
+    if [ "$OWNERSHIP_STATUS" -eq 2 ]; then
+      printf 'Could not verify managed remote T3 server process %s. State was retained.\\n' "$REMOTE_PID" >&2
+      exit 1
+    fi
+    rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
     REMOTE_PID=""
     REMOTE_PORT=""
     REMOTE_MANAGED=""
   fi
 else
+  if [ "$REMOTE_MANAGED" = "managed" ] && ! stop_managed_pid; then
+    printf 'Managed remote T3 server process %s could not be safely stopped. State was retained.\\n' "$REMOTE_PID" >&2
+    exit 1
+  fi
+  rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
   REMOTE_PID=""
   REMOTE_PORT=""
   REMOTE_MANAGED=""
@@ -600,8 +722,19 @@ if [ -z "$REMOTE_PORT" ]; then
   fi
   nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
   REMOTE_PID="$!"
+  REMOTE_MANAGED="managed"
+  if REMOTE_PID_START="$(process_identity "$REMOTE_PID")"; then
+    :
+  else
+    printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"
+    printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
+    printf 'managed\\n' >"$MANAGED_FILE"
+    printf 'Could not verify the managed remote T3 server process identity.\\n' >&2
+    exit 1
+  fi
   printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"
   printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
+  printf '%s\\n' "$REMOTE_PID_START" >"$PID_START_FILE"
   printf 'managed\\n' >"$MANAGED_FILE"
   if ! wait_ready "@@T3_READY_TIMEOUT_MS@@"; then
     printf 'Remote T3 server did not become ready on 127.0.0.1:%s.\\n' "$REMOTE_PORT" >&2
@@ -610,9 +743,9 @@ if [ -z "$REMOTE_PORT" ]; then
     else
       printf 'It wrote nothing to %s, so it exited before producing any output.\\n' "$LOG_FILE" >&2
     fi
-    kill "$REMOTE_PID" 2>/dev/null || true
-    wait_for_pid_exit "$REMOTE_PID"
-    rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
+    if stop_managed_pid; then
+      rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
+    fi
     exit 1
   fi
 fi
@@ -635,26 +768,86 @@ PAIRING_BASE_DIR="$DEFAULT_SERVER_HOME"
 export const REMOTE_STOP_SCRIPT = `set -eu
 STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
 PID_FILE="$STATE_DIR/pid"
+PID_START_FILE="$STATE_DIR/pid-start"
 PORT_FILE="$STATE_DIR/port"
 MANAGED_FILE="$STATE_DIR/managed"
+process_identity() {
+  PID_TO_IDENTIFY="$1"
+  case "$PID_TO_IDENTIFY" in
+    ''|*[!0-9]*|0) return 1 ;;
+  esac
+  kill -0 "$PID_TO_IDENTIFY" 2>/dev/null || return 1
+  if [ -r "/proc/$PID_TO_IDENTIFY/stat" ] && command -v node >/dev/null 2>&1; then
+    PROC_IDENTITY="$(node - "/proc/$PID_TO_IDENTIFY/stat" <<'NODE' 2>/dev/null || true
+const fs = require("node:fs");
+const raw = fs.readFileSync(process.argv[2], "utf8");
+const commandEnd = raw.lastIndexOf(")");
+const fields = commandEnd < 0 ? [] : raw.slice(commandEnd + 2).trim().split(/\\s+/);
+const startTicks = fields[19] ?? "";
+if (/^\\d+$/.test(startTicks)) process.stdout.write("proc:" + startTicks);
+NODE
+)"
+    if [ -n "$PROC_IDENTITY" ]; then
+      printf '%s' "$PROC_IDENTITY"
+      return 0
+    fi
+  fi
+  PS_IDENTITY="$(LC_ALL=C ps -o lstart= -p "$PID_TO_IDENTIFY" 2>/dev/null || true)"
+  [ -n "$PS_IDENTITY" ] || return 2
+  printf 'ps:%s' "$PS_IDENTITY"
+}
+pid_matches_expected() {
+  CURRENT_PID_START="$(process_identity "$REMOTE_PID")" || return $?
+  [ "$CURRENT_PID_START" = "$EXPECTED_PID_START" ]
+}
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
-if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
-  if ! kill "$REMOTE_PID" 2>/dev/null && kill -0 "$REMOTE_PID" 2>/dev/null; then
-    printf 'Failed to stop managed remote T3 server process %s.\n' "$REMOTE_PID" >&2
+EXPECTED_PID_START="$(cat "$PID_START_FILE" 2>/dev/null || true)"
+if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$REMOTE_PID" ] && [ -z "$EXPECTED_PID_START" ]; then
+  if process_identity "$REMOTE_PID" >/dev/null; then
+    printf 'Managed remote T3 server process %s has no ownership identity. State was retained.\\n' "$REMOTE_PID" >&2
     exit 1
   fi
-  WAIT_COUNT=0
-  while kill -0 "$REMOTE_PID" 2>/dev/null && [ "$WAIT_COUNT" -lt 20 ]; do
-    WAIT_COUNT=$((WAIT_COUNT + 1))
-    sleep 0.1
-  done
-  if kill -0 "$REMOTE_PID" 2>/dev/null; then
-    printf 'Managed remote T3 server process %s did not stop.\n' "$REMOTE_PID" >&2
+  IDENTITY_STATUS=$?
+  if [ "$IDENTITY_STATUS" -eq 2 ]; then
+    printf 'Could not verify managed remote T3 server process %s. State was retained.\\n' "$REMOTE_PID" >&2
     exit 1
   fi
 fi
-rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
+if [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$EXPECTED_PID_START" ]; then
+  if pid_matches_expected; then
+    :
+  else
+    OWNERSHIP_STATUS=$?
+    if [ "$OWNERSHIP_STATUS" -eq 2 ]; then
+      printf 'Could not verify managed remote T3 server process %s. State was retained.\\n' "$REMOTE_PID" >&2
+      exit 1
+    fi
+    rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
+    printf '{"stopped":true}\\n'
+    exit 0
+  fi
+  if ! kill "$REMOTE_PID" 2>/dev/null && kill -0 "$REMOTE_PID" 2>/dev/null; then
+    printf 'Failed to stop managed remote T3 server process %s.\\n' "$REMOTE_PID" >&2
+    exit 1
+  fi
+  WAIT_COUNT=0
+  while pid_matches_expected && [ "$WAIT_COUNT" -lt 20 ]; do
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+    sleep 0.1
+  done
+  if pid_matches_expected; then
+    printf 'Managed remote T3 server process %s did not stop.\\n' "$REMOTE_PID" >&2
+    exit 1
+  else
+    OWNERSHIP_STATUS=$?
+    if [ "$OWNERSHIP_STATUS" -eq 2 ]; then
+      printf 'Could not verify whether managed remote T3 server process %s stopped. State was retained.\\n' "$REMOTE_PID" >&2
+      exit 1
+    fi
+  fi
+fi
+rm -f "$PID_FILE" "$PID_START_FILE" "$PORT_FILE" "$MANAGED_FILE"
 printf '{"stopped":true}\\n'
 `;
 
@@ -746,10 +939,11 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
       ...(input?.batchMode === undefined ? {} : { batchMode: input.batchMode }),
       ...(input?.interactiveAuth === undefined ? {} : { interactiveAuth: input.interactiveAuth }),
     });
+    const diagnosticStdout = redactSshOutput(result.stdout, target.environmentVariables);
     if (!getLastNonEmptyOutputLine(result.stdout)) {
       return yield* new SshLaunchError({
         message: "SSH launch did not return a remote port.",
-        stdout: result.stdout,
+        stdout: diagnosticStdout,
       });
     }
     const parsed = yield* decodeRemoteLaunchOutput(result.stdout).pipe(
@@ -757,15 +951,19 @@ export const launchOrReuseRemoteServer = Effect.fn("ssh/tunnel.launchOrReuseRemo
         (cause) =>
           new SshLaunchError({
             message: "SSH launch returned unparseable output.",
-            stdout: result.stdout,
+            stdout: diagnosticStdout,
             cause,
           }),
       ),
     );
-    if (!Number.isInteger(parsed.remotePort)) {
+    if (
+      !Number.isInteger(parsed.remotePort) ||
+      parsed.remotePort < 1 ||
+      parsed.remotePort > 65_535
+    ) {
       return yield* new SshLaunchError({
         message: `SSH launch returned an invalid remote port: ${String(parsed.remotePort)}.`,
-        stdout: result.stdout,
+        stdout: diagnosticStdout,
       });
     }
     yield* Effect.logInfo("ssh.remoteServer.launch.ready", {
@@ -806,7 +1004,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
   if (!getLastNonEmptyOutputLine(result.stdout)) {
     return yield* new SshPairingError({
       message: "SSH pairing did not return a credential.",
-      stdout: result.stdout,
+      stdout: "",
     });
   }
   const parsed = yield* decodeRemotePairingOutput(result.stdout).pipe(
@@ -814,7 +1012,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
       (cause) =>
         new SshPairingError({
           message: "SSH pairing returned unparseable output.",
-          stdout: result.stdout,
+          stdout: "",
           cause,
         }),
     ),
@@ -822,7 +1020,7 @@ export const issueRemotePairingToken = Effect.fn("ssh/tunnel.issueRemotePairingT
   if (parsed.credential.trim().length === 0) {
     return yield* new SshPairingError({
       message: "SSH pairing command returned an invalid credential.",
-      stdout: result.stdout,
+      stdout: "",
     });
   }
   yield* Effect.logDebug("ssh.remoteServer.pairingToken.created", {
@@ -1016,6 +1214,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     "-N",
     "-L",
     `${input.localPort}:127.0.0.1:${input.remotePort}`,
+    "--",
     hostSpec,
   ];
   const sshCommand = yield* resolveSshCommand;
@@ -1196,36 +1395,64 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>
   >();
   const authSecrets = new Map<string, string>();
-  const targetResolutionLocks = new Map<string, Semaphore.Semaphore>();
-  const tunnelMutationLocks = new Map<string, Semaphore.Semaphore>();
+  const sshEnsureSemaphore = Semaphore.makeUnsafe(4);
+  const targetResolutionLocks = new Map<
+    string,
+    { readonly semaphore: Semaphore.Semaphore; users: number }
+  >();
+  const tunnelMutationLocks = new Map<
+    string,
+    { readonly semaphore: Semaphore.Semaphore; users: number }
+  >();
   const tunnelKeysByTarget = new Map<string, string>();
   const resolvedTargetsByTunnelKey = new Map<string, DesktopSshEnvironmentTarget>();
   const stoppedRemoteEntries = new WeakSet<SshTunnelEntry>();
-  const remoteStopRequiredTargets = new Map<string, DesktopSshEnvironmentTarget>();
+  const remoteStopRequiredTargets = new Map<string, Map<string, DesktopSshEnvironmentTarget>>();
+
+  const rememberRequiredRemoteStop = (key: string, target: DesktopSshEnvironmentTarget): void => {
+    const targets = remoteStopRequiredTargets.get(key) ?? new Map();
+    targets.set(remoteStateKey(target), target);
+    remoteStopRequiredTargets.set(key, targets);
+  };
+
+  const forgetRequiredRemoteStop = (key: string, target: DesktopSshEnvironmentTarget): void => {
+    const targets = remoteStopRequiredTargets.get(key);
+    if (targets === undefined) {
+      return;
+    }
+    targets.delete(remoteStateKey(target));
+    if (targets.size === 0) {
+      remoteStopRequiredTargets.delete(key);
+    }
+  };
+  const withKeyedLock = <A, E, R>(
+    locks: Map<string, { readonly semaphore: Semaphore.Semaphore; users: number }>,
+    key: string,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> =>
+    Effect.suspend(() => {
+      const lock = locks.get(key) ?? { semaphore: Semaphore.makeUnsafe(1), users: 0 };
+      lock.users += 1;
+      locks.set(key, lock);
+      return lock.semaphore.withPermit(effect).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            lock.users -= 1;
+            if (lock.users === 0 && locks.get(key) === lock) {
+              locks.delete(key);
+            }
+          }),
+        ),
+      );
+    });
   const withTargetResolutionLock = <A, E, R>(
     key: string,
     effect: Effect.Effect<A, E, R>,
-  ): Effect.Effect<A, E, R> => {
-    const existing = targetResolutionLocks.get(key);
-    if (existing !== undefined) {
-      return existing.withPermit(effect);
-    }
-    const lock = Semaphore.makeUnsafe(1);
-    targetResolutionLocks.set(key, lock);
-    return lock.withPermit(effect);
-  };
+  ): Effect.Effect<A, E, R> => withKeyedLock(targetResolutionLocks, key, effect);
   const withTunnelMutationLock = <A, E, R>(
     key: string,
     effect: Effect.Effect<A, E, R>,
-  ): Effect.Effect<A, E, R> => {
-    const existing = tunnelMutationLocks.get(key);
-    if (existing !== undefined) {
-      return existing.withPermit(effect);
-    }
-    const lock = Semaphore.makeUnsafe(1);
-    tunnelMutationLocks.set(key, lock);
-    return lock.withPermit(effect);
-  };
+  ): Effect.Effect<A, E, R> => withKeyedLock(tunnelMutationLocks, key, effect);
   const withTunnelMutationLocks = <A, E, R>(
     keys: ReadonlyArray<string>,
     effect: Effect.Effect<A, E, R>,
@@ -1434,12 +1661,12 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     }).pipe(
       Effect.tap(() =>
         Effect.sync(() => {
-          remoteStopRequiredTargets.delete(key);
+          forgetRequiredRemoteStop(key, target);
         }),
       ),
       Effect.tapError(() =>
         Effect.sync(() => {
-          remoteStopRequiredTargets.set(key, target);
+          rememberRequiredRemoteStop(key, target);
         }),
       ),
     );
@@ -1476,11 +1703,22 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const entry = tunnels.get(key) ?? null;
     const trackedTarget = entry?.target ?? resolvedTargetsByTunnelKey.get(key);
     const cleanupTarget = trackedTarget ?? fallbackTarget;
+    const stoppedRequiredStateKeys = new Set<string>();
     if (entry !== null) {
       yield* stopAndCloseTunnelEntry(entry);
     }
     yield* cancelPendingTunnelEntry(key, cleanupTarget);
-    if (entry === null && (trackedTarget !== undefined || stopFallbackTarget)) {
+    if (entry === null) {
+      for (const requiredTarget of remoteStopRequiredTargets.get(key)?.values() ?? []) {
+        yield* stopRemoteForKey(key, requiredTarget);
+        stoppedRequiredStateKeys.add(remoteStateKey(requiredTarget));
+      }
+    }
+    if (
+      entry === null &&
+      (trackedTarget !== undefined || stopFallbackTarget) &&
+      !stoppedRequiredStateKeys.has(remoteStateKey(cleanupTarget))
+    ) {
       yield* stopRemoteForKey(key, cleanupTarget);
     }
     forgetTunnelTargetKeys(key);
@@ -1589,12 +1827,12 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
                   Effect.provideService(Path.Path, pathService),
                   Effect.tap(() =>
                     Effect.sync(() => {
-                      remoteStopRequiredTargets.delete(tunnelEntry.key);
+                      forgetRequiredRemoteStop(tunnelEntry.key, tunnelEntry.target);
                     }),
                   ),
                   Effect.tapError(() =>
                     Effect.sync(() => {
-                      remoteStopRequiredTargets.set(tunnelEntry.key, tunnelEntry.target);
+                      rememberRequiredRemoteStop(tunnelEntry.key, tunnelEntry.target);
                     }),
                   ),
                 ),
@@ -1693,8 +1931,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       return yield* ensureTunnelEntry(key, resolvedTarget, runner);
     }
 
-    const remoteStopRequiredTarget = remoteStopRequiredTargets.get(key);
-    if (remoteStopRequiredTarget !== undefined) {
+    for (const remoteStopRequiredTarget of remoteStopRequiredTargets.get(key)?.values() ?? []) {
       yield* stopRemoteForKey(key, remoteStopRequiredTarget);
     }
 
@@ -1738,87 +1975,89 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const requestedTargetKey = (target.alias || target.hostname).trim();
     return yield* withTargetResolutionLock(
       requestedTargetKey,
-      Effect.gen(function* () {
-        const baseResolved = yield* resolveSshTarget(
-          target.alias || target.hostname,
-          target.environmentVariables,
-          { username: target.username, port: target.port },
-        );
-        const resolvedTarget: DesktopSshEnvironmentTarget = {
-          ...baseResolved,
-          ...(target.username !== null ? { username: target.username } : {}),
-          ...(target.port !== null ? { port: target.port } : {}),
-          ...(target.environmentVariables === undefined
-            ? {}
-            : { environmentVariables: target.environmentVariables }),
-        };
-        const { key, requestedKey, resolvedKey, conflictingKeys } = resolveTunnelKey(
-          target,
-          resolvedTarget,
-        );
-        return yield* withTunnelMutationLocks(
-          [key, ...conflictingKeys],
-          Effect.gen(function* () {
-            yield* Effect.forEach(
-              conflictingKeys,
-              (conflictingKey) => {
-                const isStillMapped =
-                  tunnelKeysByTarget.get(requestedKey) === conflictingKey ||
-                  tunnelKeysByTarget.get(resolvedKey) === conflictingKey;
-                return isStillMapped
-                  ? cleanupTunnelKey(conflictingKey, resolvedTarget)
-                  : Effect.void;
-              },
-              { discard: true },
-            );
-            rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
-            yield* Effect.logDebug("ssh.environment.target.resolved", {
-              ...sshTargetLogFields(resolvedTarget),
-              key,
-            });
-            const packageSpec = options.resolveCliPackageSpec?.();
-            const runner =
-              options.resolveCliRunner === undefined
-                ? packageSpec === undefined
-                  ? undefined
-                  : { packageSpec }
-                : yield* options.resolveCliRunner;
-            yield* Effect.logDebug("ssh.environment.runner.resolved", {
-              ...sshTargetLogFields(resolvedTarget),
-              ...sshRunnerLogFields(runner),
-              key,
-            });
-            const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
+      sshEnsureSemaphore.withPermit(
+        Effect.gen(function* () {
+          const baseResolved = yield* resolveSshTarget(
+            target.alias || target.hostname,
+            target.environmentVariables,
+            { username: target.username, port: target.port },
+          );
+          const resolvedTarget: DesktopSshEnvironmentTarget = {
+            ...baseResolved,
+            ...(target.username !== null ? { username: target.username } : {}),
+            ...(target.port !== null ? { port: target.port } : {}),
+            ...(target.environmentVariables === undefined
+              ? {}
+              : { environmentVariables: target.environmentVariables }),
+          };
+          const { key, requestedKey, resolvedKey, conflictingKeys } = resolveTunnelKey(
+            target,
+            resolvedTarget,
+          );
+          return yield* withTunnelMutationLocks(
+            [key, ...conflictingKeys],
+            Effect.gen(function* () {
+              yield* Effect.forEach(
+                conflictingKeys,
+                (conflictingKey) => {
+                  const isStillMapped =
+                    tunnelKeysByTarget.get(requestedKey) === conflictingKey ||
+                    tunnelKeysByTarget.get(resolvedKey) === conflictingKey;
+                  return isStillMapped
+                    ? cleanupTunnelKey(conflictingKey, resolvedTarget)
+                    : Effect.void;
+                },
+                { discard: true },
+              );
+              rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
+              yield* Effect.logDebug("ssh.environment.target.resolved", {
+                ...sshTargetLogFields(resolvedTarget),
+                key,
+              });
+              const packageSpec = options.resolveCliPackageSpec?.();
+              const runner =
+                options.resolveCliRunner === undefined
+                  ? packageSpec === undefined
+                    ? undefined
+                    : { packageSpec }
+                  : yield* options.resolveCliRunner;
+              yield* Effect.logDebug("ssh.environment.runner.resolved", {
+                ...sshTargetLogFields(resolvedTarget),
+                ...sshRunnerLogFields(runner),
+                key,
+              });
+              const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
 
-            const pairingResult = requestOptions?.issuePairingToken
-              ? yield* runWithSshAuth({
-                  key,
-                  target: entry.target,
-                  operation: (authOptions) =>
-                    issueRemotePairingToken(entry.target, authOptions, runner),
-                })
-              : null;
-            const pairingToken = pairingResult?.credential ?? null;
+              const pairingResult = requestOptions?.issuePairingToken
+                ? yield* runWithSshAuth({
+                    key,
+                    target: entry.target,
+                    operation: (authOptions) =>
+                      issueRemotePairingToken(entry.target, authOptions, runner),
+                  })
+                : null;
+              const pairingToken = pairingResult?.credential ?? null;
 
-            yield* Effect.logInfo("ssh.environment.ensure.succeeded", {
-              ...sshTargetLogFields(entry.target),
-              key,
-              localPort: entry.localPort,
-              remotePort: entry.remotePort,
-              remoteServerKind: entry.remoteServerKind,
-              issuedPairingToken: pairingToken !== null,
-            });
-            return {
-              target: entry.target,
-              httpBaseUrl: entry.httpBaseUrl,
-              wsBaseUrl: entry.wsBaseUrl,
-              pairingToken,
-              remotePort: entry.remotePort,
-              ...(entry.remoteServerKind ? { remoteServerKind: entry.remoteServerKind } : {}),
-            };
-          }),
-        );
-      }),
+              yield* Effect.logInfo("ssh.environment.ensure.succeeded", {
+                ...sshTargetLogFields(entry.target),
+                key,
+                localPort: entry.localPort,
+                remotePort: entry.remotePort,
+                remoteServerKind: entry.remoteServerKind,
+                issuedPairingToken: pairingToken !== null,
+              });
+              return {
+                target: entry.target,
+                httpBaseUrl: entry.httpBaseUrl,
+                wsBaseUrl: entry.wsBaseUrl,
+                pairingToken,
+                remotePort: entry.remotePort,
+                ...(entry.remoteServerKind ? { remoteServerKind: entry.remoteServerKind } : {}),
+              };
+            }),
+          );
+        }),
+      ),
     );
   });
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1677,6 +1677,39 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     target: DesktopSshEnvironmentTarget,
   ): Effect.fn.Return<void, SshEnvironmentEffectError, SshEnvironmentEffectContext> {
     yield* Effect.logInfo("ssh.environment.disconnect.start", sshTargetLogFields(target));
+    const knownRequestedKey = targetConnectionKey(target);
+    const existingKey = tunnelKeysByTarget.get(knownRequestedKey);
+    if (existingKey !== undefined) {
+      return yield* withTunnelMutationLock(
+        existingKey,
+        Effect.gen(function* () {
+          const entry = tunnels.get(existingKey) ?? null;
+          yield* Effect.logDebug("ssh.environment.disconnect.knownTarget", {
+            ...sshTargetLogFields(target),
+            key: existingKey,
+            hasTunnel: entry !== null,
+            hasPendingTunnel: pendingTunnelEntries.has(existingKey),
+          });
+          if (entry !== null) {
+            yield* closeTunnelEntry(entry);
+          }
+          yield* cancelPendingTunnelEntry(existingKey, target);
+          if (entry === null) {
+            yield* runWithSshAuth({
+              key: existingKey,
+              target,
+              operation: (authOptions) => stopRemoteServer(target, authOptions),
+            });
+          }
+          forgetTunnelTargetKeys(existingKey);
+          authSecrets.delete(existingKey);
+          yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {
+            ...sshTargetLogFields(target),
+            key: existingKey,
+          });
+        }),
+      );
+    }
     const baseResolved = yield* resolveSshTarget(
       target.alias || target.hostname,
       target.environmentVariables,

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1411,14 +1411,16 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const cleanupTunnelKey = Effect.fn("ssh/tunnel.cleanupTunnelKey")(function* (
     key: string,
     fallbackTarget: DesktopSshEnvironmentTarget,
+    stopFallbackTarget = false,
   ) {
     const entry = tunnels.get(key) ?? null;
-    const cleanupTarget = entry?.target ?? resolvedTargetsByTunnelKey.get(key) ?? fallbackTarget;
+    const trackedTarget = entry?.target ?? resolvedTargetsByTunnelKey.get(key);
+    const cleanupTarget = trackedTarget ?? fallbackTarget;
     if (entry !== null) {
       yield* closeTunnelEntry(entry);
     }
     yield* cancelPendingTunnelEntry(key, cleanupTarget);
-    if (entry === null) {
+    if (entry === null && (trackedTarget !== undefined || stopFallbackTarget)) {
       yield* runWithSshAuth({
         key,
         target: cleanupTarget,
@@ -1479,6 +1481,23 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     }).pipe(
       Effect.onExit((exit) =>
         Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
+      ),
+      Effect.tapError((cause) =>
+        runWithSshAuth({
+          key: input.key,
+          target: input.resolvedTarget,
+          operation: (authOptions) => stopRemoteServer(input.resolvedTarget, authOptions),
+        }).pipe(
+          Effect.tapError((cleanupCause) =>
+            Effect.logWarning("ssh.environment.remoteServer.cleanup.failed", {
+              ...sshTargetLogFields(input.resolvedTarget),
+              key: input.key,
+              cause,
+              cleanupCause,
+            }),
+          ),
+          Effect.ignore,
+        ),
       ),
     );
     tunnels.set(input.key, tunnelEntry);
@@ -1675,7 +1694,12 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       Effect.gen(function* () {
         yield* Effect.forEach(
           conflictingKeys,
-          (conflictingKey) => cleanupTunnelKey(conflictingKey, resolvedTarget),
+          (conflictingKey) => {
+            const isStillMapped =
+              tunnelKeysByTarget.get(requestedKey) === conflictingKey ||
+              tunnelKeysByTarget.get(resolvedKey) === conflictingKey;
+            return isStillMapped ? cleanupTunnelKey(conflictingKey, resolvedTarget) : Effect.void;
+          },
           { discard: true },
         );
         rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
@@ -1746,7 +1770,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
             hasTunnel: entry !== null,
             hasPendingTunnel: pendingTunnelEntries.has(existingKey),
           });
-          yield* cleanupTunnelKey(existingKey, target);
+          yield* cleanupTunnelKey(existingKey, target, true);
           yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {
             ...sshTargetLogFields(cleanupTarget),
             key: existingKey,

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1778,45 +1778,21 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         }),
       );
     }
-    const baseResolved = yield* resolveSshTarget(
-      target.alias || target.hostname,
-      target.environmentVariables,
-    );
-    const resolvedTarget: DesktopSshEnvironmentTarget = {
-      ...baseResolved,
-      ...(target.username !== null ? { username: target.username } : {}),
-      ...(target.port !== null ? { port: target.port } : {}),
-      ...(target.environmentVariables === undefined
-        ? {}
-        : { environmentVariables: target.environmentVariables }),
-    };
-    const { key, requestedKey, resolvedKey } = resolveTunnelKey(target, resolvedTarget);
+    const { environmentVariables: _environmentVariables, ...cleanupTarget } = target;
+    const key = targetConnectionKey(cleanupTarget);
     yield* withTunnelMutationLock(
       key,
       Effect.gen(function* () {
-        rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
         const entry = tunnels.get(key) ?? null;
-        yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
-          ...sshTargetLogFields(resolvedTarget),
+        yield* Effect.logDebug("ssh.environment.disconnect.savedTarget", {
+          ...sshTargetLogFields(cleanupTarget),
           key,
           hasTunnel: entry !== null,
           hasPendingTunnel: pendingTunnelEntries.has(key),
         });
-        if (entry !== null) {
-          yield* closeTunnelEntry(entry);
-        }
-        yield* cancelPendingTunnelEntry(key, resolvedTarget);
-        if (entry === null) {
-          yield* runWithSshAuth({
-            key,
-            target: resolvedTarget,
-            operation: (authOptions) => stopRemoteServer(resolvedTarget, authOptions),
-          });
-        }
-        forgetTunnelTargetKeys(key);
-        authSecrets.delete(key);
+        yield* cleanupTunnelKey(key, cleanupTarget, true);
         yield* Effect.logInfo("ssh.environment.disconnect.succeeded", {
-          ...sshTargetLogFields(resolvedTarget),
+          ...sshTargetLogFields(cleanupTarget),
           key,
         });
       }),

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1190,11 +1190,24 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>
   >();
   const authSecrets = new Map<string, string>();
+  const targetResolutionLocks = new Map<string, Semaphore.Semaphore>();
   const tunnelMutationLocks = new Map<string, Semaphore.Semaphore>();
   const tunnelKeysByTarget = new Map<string, string>();
   const resolvedTargetsByTunnelKey = new Map<string, DesktopSshEnvironmentTarget>();
   const stoppedRemoteEntries = new WeakSet<SshTunnelEntry>();
   const remoteStopRequiredTargets = new Map<string, DesktopSshEnvironmentTarget>();
+  const withTargetResolutionLock = <A, E, R>(
+    key: string,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const existing = targetResolutionLocks.get(key);
+    if (existing !== undefined) {
+      return existing.withPermit(effect);
+    }
+    const lock = Semaphore.makeUnsafe(1);
+    targetResolutionLocks.set(key, lock);
+    return lock.withPermit(effect);
+  };
   const withTunnelMutationLock = <A, E, R>(
     key: string,
     effect: Effect.Effect<A, E, R>,
@@ -1716,81 +1729,89 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...sshTargetLogFields(target),
       issuePairingToken: requestOptions?.issuePairingToken === true,
     });
-    const baseResolved = yield* resolveSshTarget(
-      target.alias || target.hostname,
-      target.environmentVariables,
-      { username: target.username, port: target.port },
-    );
-    const resolvedTarget: DesktopSshEnvironmentTarget = {
-      ...baseResolved,
-      ...(target.username !== null ? { username: target.username } : {}),
-      ...(target.port !== null ? { port: target.port } : {}),
-      ...(target.environmentVariables === undefined
-        ? {}
-        : { environmentVariables: target.environmentVariables }),
-    };
-    const { key, requestedKey, resolvedKey, conflictingKeys } = resolveTunnelKey(
-      target,
-      resolvedTarget,
-    );
-    return yield* withTunnelMutationLocks(
-      [key, ...conflictingKeys],
+    const requestedTargetKey = (target.alias || target.hostname).trim();
+    return yield* withTargetResolutionLock(
+      requestedTargetKey,
       Effect.gen(function* () {
-        yield* Effect.forEach(
-          conflictingKeys,
-          (conflictingKey) => {
-            const isStillMapped =
-              tunnelKeysByTarget.get(requestedKey) === conflictingKey ||
-              tunnelKeysByTarget.get(resolvedKey) === conflictingKey;
-            return isStillMapped ? cleanupTunnelKey(conflictingKey, resolvedTarget) : Effect.void;
-          },
-          { discard: true },
+        const baseResolved = yield* resolveSshTarget(
+          target.alias || target.hostname,
+          target.environmentVariables,
+          { username: target.username, port: target.port },
         );
-        rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
-        yield* Effect.logDebug("ssh.environment.target.resolved", {
-          ...sshTargetLogFields(resolvedTarget),
-          key,
-        });
-        const packageSpec = options.resolveCliPackageSpec?.();
-        const runner =
-          options.resolveCliRunner === undefined
-            ? packageSpec === undefined
-              ? undefined
-              : { packageSpec }
-            : yield* options.resolveCliRunner;
-        yield* Effect.logDebug("ssh.environment.runner.resolved", {
-          ...sshTargetLogFields(resolvedTarget),
-          ...sshRunnerLogFields(runner),
-          key,
-        });
-        const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
-
-        const pairingResult = requestOptions?.issuePairingToken
-          ? yield* runWithSshAuth({
-              key,
-              target: entry.target,
-              operation: (authOptions) =>
-                issueRemotePairingToken(entry.target, authOptions, runner),
-            })
-          : null;
-        const pairingToken = pairingResult?.credential ?? null;
-
-        yield* Effect.logInfo("ssh.environment.ensure.succeeded", {
-          ...sshTargetLogFields(entry.target),
-          key,
-          localPort: entry.localPort,
-          remotePort: entry.remotePort,
-          remoteServerKind: entry.remoteServerKind,
-          issuedPairingToken: pairingToken !== null,
-        });
-        return {
-          target: entry.target,
-          httpBaseUrl: entry.httpBaseUrl,
-          wsBaseUrl: entry.wsBaseUrl,
-          pairingToken,
-          remotePort: entry.remotePort,
-          ...(entry.remoteServerKind ? { remoteServerKind: entry.remoteServerKind } : {}),
+        const resolvedTarget: DesktopSshEnvironmentTarget = {
+          ...baseResolved,
+          ...(target.username !== null ? { username: target.username } : {}),
+          ...(target.port !== null ? { port: target.port } : {}),
+          ...(target.environmentVariables === undefined
+            ? {}
+            : { environmentVariables: target.environmentVariables }),
         };
+        const { key, requestedKey, resolvedKey, conflictingKeys } = resolveTunnelKey(
+          target,
+          resolvedTarget,
+        );
+        return yield* withTunnelMutationLocks(
+          [key, ...conflictingKeys],
+          Effect.gen(function* () {
+            yield* Effect.forEach(
+              conflictingKeys,
+              (conflictingKey) => {
+                const isStillMapped =
+                  tunnelKeysByTarget.get(requestedKey) === conflictingKey ||
+                  tunnelKeysByTarget.get(resolvedKey) === conflictingKey;
+                return isStillMapped
+                  ? cleanupTunnelKey(conflictingKey, resolvedTarget)
+                  : Effect.void;
+              },
+              { discard: true },
+            );
+            rememberTunnelTargetKeys(key, requestedKey, resolvedKey, resolvedTarget);
+            yield* Effect.logDebug("ssh.environment.target.resolved", {
+              ...sshTargetLogFields(resolvedTarget),
+              key,
+            });
+            const packageSpec = options.resolveCliPackageSpec?.();
+            const runner =
+              options.resolveCliRunner === undefined
+                ? packageSpec === undefined
+                  ? undefined
+                  : { packageSpec }
+                : yield* options.resolveCliRunner;
+            yield* Effect.logDebug("ssh.environment.runner.resolved", {
+              ...sshTargetLogFields(resolvedTarget),
+              ...sshRunnerLogFields(runner),
+              key,
+            });
+            const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
+
+            const pairingResult = requestOptions?.issuePairingToken
+              ? yield* runWithSshAuth({
+                  key,
+                  target: entry.target,
+                  operation: (authOptions) =>
+                    issueRemotePairingToken(entry.target, authOptions, runner),
+                })
+              : null;
+            const pairingToken = pairingResult?.credential ?? null;
+
+            yield* Effect.logInfo("ssh.environment.ensure.succeeded", {
+              ...sshTargetLogFields(entry.target),
+              key,
+              localPort: entry.localPort,
+              remotePort: entry.remotePort,
+              remoteServerKind: entry.remoteServerKind,
+              issuedPairingToken: pairingToken !== null,
+            });
+            return {
+              target: entry.target,
+              httpBaseUrl: entry.httpBaseUrl,
+              wsBaseUrl: entry.wsBaseUrl,
+              pairingToken,
+              remotePort: entry.remotePort,
+              ...(entry.remoteServerKind ? { remoteServerKind: entry.remoteServerKind } : {}),
+            };
+          }),
+        );
       }),
     );
   });


### PR DESCRIPTION
## Why

Desktop SSH connections already support SSH-agent authentication and agent forwarding, but an app launched from Finder does not inherit variables sourced in a shell. OpenSSH SendEnv can only forward values present in the local ssh process environment, so remote T3 servers launched by Desktop can otherwise miss API keys and other required session configuration.

## What changed

- add a collapsed **Local SSH environment** editor to the desktop SSH connection flow
- persist variables per saved SSH connection in protected desktop connection storage
- let saved connections update or clear their variables through **Edit SSH env**, then reconnect automatically
- require every name to match the effective SendEnv configuration for the final managed launch command
- replace live tunnels when their saved environment or resolved SSH target changes
- roll back failed edits without allowing a concurrent removal to recreate the environment
- fail replacement when the old managed process cannot be confirmed stopped
- cap the encoded environment size and reject Windows case collisions
- block high-risk local process overrides and avoid logging variable values

## SSH configuration

The SSH client still needs to select each variable for forwarding:

```sshconfig
Host devbox
  SendEnv OPENAI_API_KEY ANTHROPIC_API_KEY
```

The SSH server must explicitly accept the same names, for example in `/etc/ssh/sshd_config`:

```sshconfig
AcceptEnv OPENAI_API_KEY ANTHROPIC_API_KEY
```

After changing `sshd_config`, reload or restart `sshd`. Accepted values exist in the remote session and process environment. This feature does not create an environment file on the remote host.

Saving changes restarts a remote T3 server managed by Desktop so the replacement process inherits the new values. A T3 server started independently must be stopped so Desktop can launch a managed server, or restarted from a session that already contains the variables.

## Screenshots

### Add SSH environment variables

<img width="1972" height="1330" alt="Expanded Local SSH environment editor in the Add Environment modal" src="https://github.com/user-attachments/assets/684c656d-b0b3-4fed-bc11-c15e8b19a946" />

### Edit a saved SSH environment

<img width="585" height="156" alt="Edit SSH env action on a saved remote environment" src="https://github.com/user-attachments/assets/0ae6af1f-9803-440a-9398-679930734dd2" />

## Verification

- 136 focused tests across nine affected suites covering contracts, SSH authentication and lifecycle, connection onboarding, persistence, registry concurrency, and settings logic
- affected contracts, SSH, client-runtime, and web typechecks
- targeted lint, formatting, and `git diff --check`
- desktop dev build launched against isolated state and reconnected an existing SSH environment
- independent final code review completed with no material findings

## Surfaces

Creation and editing are desktop-only because they require access to the local SSH process and protected desktop storage. Once saved, the remote environment continues to use the shared environment and connection model.

Built with GPT-5.6-sol in T3 Code through the OpenCode harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SSH environment variables to desktop connections
> - Adds UI, contracts, and onboarding support for configuring local SSH environment variables on saved SSH connections, including creation, editing, and reconnect behavior
> - Introduces `DesktopSshEnvironmentVariablesSchema` with safety checks (rejects `DYLD_`, `LD_`, `OPENSSL_`, `SSH_` prefixes), 128-variable limit, 16 KiB encoded limit, and NUL/value-length validation in [ipc.ts](https://github.com/pingdotgg/t3code/pull/9042/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a)
> - Adds `EnvironmentRegistry.registerIfCurrent` for conditional compare-and-register with preparation and failure-cleanup hooks in [registry.ts](https://github.com/pingdotgg/t3code/pull/9042/files#diff-ee90d1d763db46ddbfa1b641685acf6071253fc055b4abca6edaee99a0c536b8)
> - Reworks SSH target resolution and tunnel lifecycle to validate `SendEnv` against baseline and overlay config, redact forwarded values in diagnostics, and run managed remote servers behind a tracked wrapper with process-identity verification in [command.ts](https://github.com/pingdotgg/t3code/pull/9042/files#diff-4f1aef4b11679d8551404a853942f04f47c3a80c050bc25b784d2b0c48ec9e5e) and [tunnel.ts](https://github.com/pingdotgg/t3code/pull/9042/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072)
> - Risk: `DesktopSshEnvironmentTargetSchema` now rejects unconstrained aliases, hostnames, usernames, and ports; existing callers passing invalid values will receive decode errors. Tunnel ensures are capped at four concurrent operations and remote stop now requires identity verification before killing a managed PID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f20a639.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes local SSH process environment, SendEnv validation, and remote server launch/stop semantics—areas where misconfiguration or bugs could affect authentication, secret handling, or unintended process termination.
> 
> **Overview**
> Desktop users can configure **local SSH environment** variables when adding or editing saved SSH remote environments, so values reach the local `ssh` process even when the app was not launched from a shell. Variables are stored in protected desktop connection storage, validated in the UI via `parseSshEnvironmentVariables`, and enforced again on the wire through `DesktopSshEnvironmentVariablesSchema` (128-name cap, 16 KiB encoded budget, case-unique names, and a blocklist for variables that could hijack the local SSH process).
> 
> The SSH stack forwards saved variables into the child environment, validates each name against effective **SendEnv** (including `Match exec` / command-specific config) before connect, redacts forwarded values in diagnostics, and terminates SSH options with `--` before the host argument. **Edit SSH env** persists changes through `updateSshEnvironmentVariables` and `registerIfCurrent`, preparing the new SSH runtime before durable registration and attempting to restore the previous runtime if save or validation fails.
> 
> Tunnel management is tightened alongside this: live tunnels are replaced when environment overlays or resolved targets change, remote launch/stop scripts verify managed process identity instead of blindly killing PIDs, and concurrency limits serialize per-host SSH work. User docs describe SendEnv/AcceptEnv requirements and that saving restarts Desktop-managed remote T3 servers so new values apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c26ae6387f89f154cd60fc556fed3023c21d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->