### PR TITLE
fix(server): settle threads at startup without waiting on GitHub

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -380,6 +380,7 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(
         Layer.succeed(ThreadSettlementReactor.ThreadSettlementReactor, {
           start: () => Effect.void,
+          ready: Effect.void,
           drain: Effect.void,
         }),
       ),

--- a/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
+++ b/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
@@ -71,6 +71,7 @@ const startupDependencies = Layer.mergeAll(
   ServerSettings.layerTest(),
   Layer.succeed(OrchestrationReactor.OrchestrationReactor, {
     start: () => Effect.void,
+    ready: Effect.void,
   }),
   Layer.succeed(ProviderSessionReaper.ProviderSessionReaper, {
     start: () => Effect.void,

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -47,6 +47,7 @@ export interface ServerDerivedPaths {
   readonly anonymousIdPath: string;
   readonly environmentIdPath: string;
   readonly serverRuntimeStatePath: string;
+  readonly settlementLookupsPath: string;
   readonly secretsDir: string;
 }
 
@@ -134,6 +135,7 @@ export const deriveServerPaths = Effect.fn(function* (
     anonymousIdPath: join(stateDir, "anonymous-id"),
     environmentIdPath: join(stateDir, "environment-id"),
     serverRuntimeStatePath: join(stateDir, "server-runtime.json"),
+    settlementLookupsPath: join(stateDir, "settlement-lookups.json"),
     secretsDir: join(stateDir, "secrets"),
   };
 });

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
@@ -71,6 +71,7 @@ describe("OrchestrationReactor", () => {
               started.push("thread-settlement-reactor");
               return Effect.void;
             },
+            ready: Effect.void,
             drain: Effect.void,
           }),
         ),

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
@@ -31,6 +31,7 @@ export const makeOrchestrationReactor = Effect.gen(function* () {
 
   return {
     start,
+    ready: threadSettlementReactor.ready,
   } satisfies OrchestrationReactorShape;
 });
 

--- a/apps/server/src/orchestration/Services/OrchestrationReactor.ts
+++ b/apps/server/src/orchestration/Services/OrchestrationReactor.ts
@@ -22,7 +22,10 @@ export interface OrchestrationReactorShape {
    */
   readonly start: () => Effect.Effect<void, never, Scope.Scope>;
 
-  /** Resolves after startup reactors have established their initial state. */
+  /**
+   * Resolves once startup reactors have applied everything they can decide
+   * locally. Network-backed refreshes keep running in the background.
+   */
   readonly ready: Effect.Effect<void>;
 }
 

--- a/apps/server/src/orchestration/Services/OrchestrationReactor.ts
+++ b/apps/server/src/orchestration/Services/OrchestrationReactor.ts
@@ -21,6 +21,9 @@ export interface OrchestrationReactorShape {
    * finalized on shutdown.
    */
   readonly start: () => Effect.Effect<void, never, Scope.Scope>;
+
+  /** Resolves after startup reactors have established their initial state. */
+  readonly ready: Effect.Effect<void>;
 }
 
 /**

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -280,6 +280,41 @@ const startHarness = Effect.fn("startThreadSettlementHarness")(function* (
 });
 
 describe("ThreadSettlementReactor", () => {
+  it.effect("becomes ready only after the initial settlement sweep", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const lookupStarted = yield* Deferred.make<void>();
+        const releaseLookup = yield* Deferred.make<void>();
+        const readyObserved = yield* Deferred.make<void>();
+        const fixture = yield* makeHarness({
+          snapshot: makeSnapshot([makeThread("startup-thread", { branch: "saved-feature" })]),
+          branchPullRequest: () =>
+            Deferred.succeed(lookupStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseLookup)),
+              Effect.as(null),
+            ),
+        });
+
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* reactor.start();
+          yield* reactor.ready.pipe(
+            Effect.andThen(Deferred.succeed(readyObserved, undefined)),
+            Effect.forkScoped,
+          );
+          yield* Deferred.succeed(fixture.activation, undefined);
+          yield* Deferred.await(lookupStarted);
+
+          assert.isFalse(yield* Deferred.isDone(readyObserved));
+
+          yield* Deferred.succeed(releaseLookup, undefined);
+          yield* Deferred.await(readyObserved);
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
   it.effect("starts without clients and skips protected threads before pull request lookup", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -14,9 +14,11 @@ import {
 } from "@t3tools/contracts";
 import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 import { assert, describe, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Crypto from "effect/Crypto";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as PubSub from "effect/PubSub";
 import * as Queue from "effect/Queue";
@@ -24,6 +26,7 @@ import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
 
+import * as ServerConfig from "../config.ts";
 import { GitManager } from "../git/GitManager.ts";
 import { PullRequestService } from "../pullRequest/PullRequestService.ts";
 import { ServerActivation } from "../serverActivation.ts";
@@ -160,6 +163,9 @@ function makePullRequestDetail(input: {
 
 interface HarnessOptions {
   readonly snapshot: OrchestrationShellSnapshot;
+  /** Share one state directory between harnesses to simulate a restart. */
+  readonly baseDir?: string;
+  readonly readSnapshot?: ProjectionSnapshotQuery["Service"]["getShellSnapshot"];
   readonly settings?: ServerSettings;
   readonly branchPullRequest?: GitManager["Service"]["branchPullRequest"];
   readonly pullRequestDetail?: PullRequestService["Service"]["detail"];
@@ -170,6 +176,12 @@ interface HarnessOptions {
 
 const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options: HarnessOptions) {
   const activation = yield* Deferred.make<void>();
+  const baseDir =
+    options.baseDir ??
+    (yield* Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      return yield* fs.makeTempDirectoryScoped({ prefix: "t3code-thread-settlement-test-" });
+    }).pipe(Effect.provide(NodeServices.layer)));
   const snapshots = yield* Ref.make(options.snapshot);
   const snapshotReadCount = yield* Ref.make(0);
   const snapshotReads = yield* Queue.unbounded<number>();
@@ -239,7 +251,7 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
       getShellSnapshot: () =>
         Ref.updateAndGet(snapshotReadCount, (count) => count + 1).pipe(
           Effect.tap((count) => Queue.offer(snapshotReads, count)),
-          Effect.andThen(Ref.get(snapshots)),
+          Effect.andThen(options.readSnapshot?.() ?? Ref.get(snapshots)),
         ),
     }),
     Layer.mock(GitManager)({ branchPullRequest }),
@@ -253,10 +265,15 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
     Layer.succeed(ServerSettingsService, serverSettings),
     Layer.succeed(ServerActivation, Deferred.await(activation)),
     Layer.succeed(Crypto.Crypto, testCrypto),
+    NodeServices.layer,
+  );
+  const configLayer = ServerConfig.layerTest(process.cwd(), baseDir).pipe(
+    Layer.provide(NodeServices.layer),
   );
 
   return {
     activation,
+    baseDir,
     snapshots,
     snapshotReadCount,
     snapshotReads,
@@ -264,7 +281,10 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
     branchCalls,
     detailCalls,
     updateSettings,
-    layer: ThreadSettlementReactor.layer.pipe(Layer.provide(dependencies)),
+    layer: ThreadSettlementReactor.layer.pipe(
+      Layer.provide(dependencies),
+      Layer.provideMerge(configLayer),
+    ),
   };
 });
 
@@ -280,15 +300,17 @@ const startHarness = Effect.fn("startThreadSettlementHarness")(function* (
 });
 
 describe("ThreadSettlementReactor", () => {
-  it.effect("becomes ready only after the initial settlement sweep", () =>
+  it.effect("becomes ready before the first pull request lookup completes", () =>
     Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(NOW));
         const lookupStarted = yield* Deferred.make<void>();
         const releaseLookup = yield* Deferred.make<void>();
-        const readyObserved = yield* Deferred.make<void>();
         const fixture = yield* makeHarness({
-          snapshot: makeSnapshot([makeThread("startup-thread", { branch: "saved-feature" })]),
+          snapshot: makeSnapshot([
+            makeThread("startup-thread", { branch: "saved-feature" }),
+            makeThread("branchless"),
+          ]),
           branchPullRequest: () =>
             Deferred.succeed(lookupStarted, undefined).pipe(
               Effect.andThen(Deferred.await(releaseLookup)),
@@ -299,17 +321,90 @@ describe("ThreadSettlementReactor", () => {
         yield* Effect.gen(function* () {
           const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
           yield* reactor.start();
-          yield* reactor.ready.pipe(
-            Effect.andThen(Deferred.succeed(readyObserved, undefined)),
-            Effect.forkScoped,
-          );
           yield* Deferred.succeed(fixture.activation, undefined);
           yield* Deferred.await(lookupStarted);
+          yield* reactor.ready;
 
-          assert.isFalse(yield* Deferred.isDone(readyObserved));
+          // Branchless threads settle before the network answers.
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
+            [ThreadId.make("branchless")],
+          );
 
           yield* Deferred.succeed(releaseLookup, undefined);
-          yield* Deferred.await(readyObserved);
+          yield* reactor.drain;
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
+            [ThreadId.make("branchless"), ThreadId.make("startup-thread")],
+          );
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
+  it.effect("settles from the persisted pull request answer after a restart", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const thread = makeThread("merged-thread", { branch: "saved-feature" });
+        const first = yield* makeHarness({
+          snapshot: makeSnapshot([thread]),
+          branchPullRequest: () => Effect.succeed({ state: "merged", updatedAt: NOW }),
+        });
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* startHarness(reactor, first.activation, first.snapshotReads);
+          assert.deepStrictEqual(
+            (yield* Ref.get(first.commands)).map((command) => command.threadId),
+            [thread.id],
+          );
+        }).pipe(Effect.provide(first.layer));
+
+        const lookupStarted = yield* Deferred.make<void>();
+        const releaseLookup = yield* Deferred.make<void>();
+        const restarted = yield* makeHarness({
+          baseDir: first.baseDir,
+          snapshot: makeSnapshot([thread]),
+          branchPullRequest: () =>
+            Deferred.succeed(lookupStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseLookup)),
+              Effect.as({ state: "merged" as const, updatedAt: NOW }),
+            ),
+        });
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* reactor.start();
+          yield* Deferred.succeed(restarted.activation, undefined);
+          yield* Deferred.await(lookupStarted);
+          yield* reactor.ready;
+          assert.deepStrictEqual(
+            (yield* Ref.get(restarted.commands)).map((command) => command.threadId),
+            [thread.id],
+          );
+
+          // An unchanged network answer does not settle the thread twice.
+          yield* Deferred.succeed(releaseLookup, undefined);
+          yield* reactor.drain;
+          assert.strictEqual((yield* Ref.get(restarted.commands)).length, 1);
+        }).pipe(Effect.provide(restarted.layer));
+      }),
+    ),
+  );
+
+  it.effect("becomes ready when the first sweep fails before deciding anything", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeHarness({
+          snapshot: makeSnapshot([]),
+          readSnapshot: () => Effect.die(new Error("projection unavailable")),
+        });
+
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* reactor.start();
+          yield* Deferred.succeed(fixture.activation, undefined);
+          yield* reactor.ready;
+          assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
         }).pipe(Effect.provide(fixture.layer));
       }),
     ),

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -1,4 +1,4 @@
-import { CommandId } from "@t3tools/contracts";
+import { CommandId, type ThreadId } from "@t3tools/contracts";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
@@ -6,11 +6,15 @@ import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 
+import { writeFileStringAtomically } from "../atomicWrite.ts";
+import * as ServerConfig from "../config.ts";
 import * as GitManager from "../git/GitManager.ts";
 import * as PullRequestService from "../pullRequest/PullRequestService.ts";
 import * as ServerSettings from "../serverSettings.ts";
@@ -27,10 +31,49 @@ export class ThreadSettlementReactor extends Context.Service<
   ThreadSettlementReactor,
   {
     readonly start: () => Effect.Effect<void, never, Scope.Scope>;
+    /**
+     * Resolves once the first sweep has applied every settlement it can decide
+     * without the network: branchless threads and threads whose pull request
+     * answer was persisted by an earlier sweep. Startup waits on this so the
+     * first snapshot carries those decisions while pull request lookups keep
+     * running in the background.
+     */
     readonly ready: Effect.Effect<void>;
     readonly drain: Effect.Effect<void>;
   }
 >()("t3/orchestration/ThreadSettlementReactor") {}
+
+/**
+ * The last pull request answer per lookup key, kept on disk so a restart can
+ * settle threads before GitHub answers. Keys match the sweep's grouping key
+ * (linked pull request, or workspace root plus branch).
+ */
+const PersistedLookups = Schema.Struct({
+  version: Schema.Literal(1),
+  lookups: Schema.Record(
+    Schema.String,
+    Schema.NullOr(
+      Schema.Struct({
+        state: Schema.Literals(["open", "closed", "merged"]),
+        updatedAt: Schema.NullOr(Schema.String),
+      }),
+    ),
+  ),
+});
+
+const PersistedLookupsJson = Schema.fromJsonString(PersistedLookups);
+const decodePersistedLookups = Schema.decodeUnknownEffect(PersistedLookupsJson);
+const encodePersistedLookups = Schema.encodeEffect(PersistedLookupsJson);
+
+const samePullRequest = (
+  left: SettlementPullRequest | null,
+  right: SettlementPullRequest | null,
+): boolean =>
+  left === right ||
+  (left !== null &&
+    right !== null &&
+    left.state === right.state &&
+    left.updatedAt === right.updatedAt);
 
 export const make = Effect.gen(function* () {
   const engine = yield* OrchestrationEngine.OrchestrationEngineService;
@@ -39,14 +82,59 @@ export const make = Effect.gen(function* () {
   const git = yield* GitManager.GitManager;
   const pullRequests = yield* PullRequestService.PullRequestService;
   const crypto = yield* Crypto.Crypto;
+  const fs = yield* FileSystem.FileSystem;
+  const { settlementLookupsPath } = yield* ServerConfig.ServerConfig;
   const ready = yield* Deferred.make<void>();
+  const lookups = new Map<string, SettlementPullRequest | null>();
+
+  const loadLookups = Effect.gen(function* () {
+    if (!(yield* fs.exists(settlementLookupsPath))) return;
+    const persisted = yield* fs
+      .readFileString(settlementLookupsPath)
+      .pipe(Effect.flatMap(decodePersistedLookups));
+    for (const [key, pullRequest] of Object.entries(persisted.lookups)) {
+      lookups.set(key, pullRequest);
+    }
+  }).pipe(
+    Effect.catch((cause) =>
+      Effect.logWarning("settlement lookups unavailable, starting without them", {
+        path: settlementLookupsPath,
+        cause,
+      }),
+    ),
+  );
+
+  const saveLookups = (retain: ReadonlySet<string>) =>
+    Effect.gen(function* () {
+      for (const key of lookups.keys()) {
+        if (!retain.has(key)) lookups.delete(key);
+      }
+      const contents = yield* encodePersistedLookups({
+        version: 1,
+        lookups: Object.fromEntries(lookups),
+      });
+      yield* writeFileStringAtomically({
+        filePath: settlementLookupsPath,
+        contents: `${contents}\n`,
+      });
+    }).pipe(
+      Effect.catch((cause) =>
+        Effect.logWarning("settlement lookups not persisted", {
+          path: settlementLookupsPath,
+          cause,
+        }),
+      ),
+    );
 
   const sweep = Effect.fn("ThreadSettlementReactor.sweep")(function* () {
     const snapshot = yield* snapshots.getShellSnapshot();
     const now = DateTime.formatIso(yield* DateTime.now);
     const projects = new Map(snapshot.projects.map((project) => [project.id, project]));
     const candidates = snapshot.threads.filter((thread) => isAutoSettlementCandidate(thread, now));
-    const lookupKey = (thread: (typeof candidates)[number]) => {
+    type Thread = (typeof snapshot.threads)[number];
+    const needsLookup = (thread: Thread) =>
+      thread.linkedPullRequest != null || thread.branch !== null;
+    const lookupKey = (thread: Thread) => {
       if (thread.linkedPullRequest != null) {
         return JSON.stringify([
           "linked",
@@ -64,9 +152,10 @@ export const make = Effect.gen(function* () {
       );
     };
     const groups = Map.groupBy(candidates, lookupKey);
+    const settled = new Set<ThreadId>();
 
     const pullRequestFor = Effect.fn("ThreadSettlementReactor.pullRequestFor")(function* (
-      thread: (typeof candidates)[number],
+      thread: Thread,
     ) {
       if (thread.linkedPullRequest != null) {
         if (!projects.has(thread.linkedPullRequest.projectId)) {
@@ -87,47 +176,69 @@ export const make = Effect.gen(function* () {
       return yield* git.branchPullRequest({ cwd: project.workspaceRoot, branch: thread.branch });
     });
 
+    const decideGroup = (group: ReadonlyArray<Thread>, pullRequest: SettlementPullRequest | null) =>
+      Effect.forEach(
+        group,
+        (thread) =>
+          Effect.gen(function* () {
+            if (settled.has(thread.id)) return;
+            const settings = yield* settingsService.getSettings;
+            const decisionNow = DateTime.formatIso(yield* DateTime.now);
+            if (
+              !shouldAutoSettleThread({
+                thread,
+                pullRequest,
+                now: decisionNow,
+                autoSettleAfterDays: settings.sidebarAutoSettleAfterDays,
+                autoSettleOnMerge: settings.sidebarAutoSettleOnMerge,
+              })
+            ) {
+              return;
+            }
+            const uuid = yield* crypto.randomUUIDv4;
+            yield* engine.dispatch({
+              type: "thread.auto-settle",
+              commandId: CommandId.make(`server:auto-settle:${thread.id}:${uuid}`),
+              threadId: thread.id,
+              snapshotSequence: snapshot.snapshotSequence,
+            });
+            settled.add(thread.id);
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Cause.hasInterruptsOnly(cause)
+                ? Effect.failCause(cause)
+                : Effect.logWarning("automatic thread settlement skipped", {
+                    threadId: thread.id,
+                    cause: Cause.pretty(cause),
+                  }),
+            ),
+          ),
+        { discard: true },
+      );
+
+    // Local phase: everything decidable without the network, so startup can
+    // continue before any pull request lookup returns.
+    for (const [key, group] of groups) {
+      const pullRequest = needsLookup(group[0]!) ? lookups.get(key) : null;
+      if (pullRequest === undefined) continue;
+      yield* decideGroup(group, pullRequest);
+    }
+    yield* Deferred.succeed(ready, undefined);
+
+    // Network phase: refresh every lookup and only re-decide groups whose
+    // answer is new or changed since the local phase.
+    let changed = false;
     yield* Effect.forEach(
-      groups.values(),
-      (group) =>
+      groups,
+      ([key, group]) =>
         Effect.gen(function* () {
+          if (!needsLookup(group[0]!)) return;
           const pullRequest = yield* pullRequestFor(group[0]!);
-          yield* Effect.forEach(
-            group,
-            (thread) =>
-              Effect.gen(function* () {
-                const settings = yield* settingsService.getSettings;
-                const decisionNow = DateTime.formatIso(yield* DateTime.now);
-                if (
-                  !shouldAutoSettleThread({
-                    thread,
-                    pullRequest,
-                    now: decisionNow,
-                    autoSettleAfterDays: settings.sidebarAutoSettleAfterDays,
-                    autoSettleOnMerge: settings.sidebarAutoSettleOnMerge,
-                  })
-                ) {
-                  return;
-                }
-                const uuid = yield* crypto.randomUUIDv4;
-                yield* engine.dispatch({
-                  type: "thread.auto-settle",
-                  commandId: CommandId.make(`server:auto-settle:${thread.id}:${uuid}`),
-                  threadId: thread.id,
-                  snapshotSequence: snapshot.snapshotSequence,
-                });
-              }).pipe(
-                Effect.catchCause((cause) =>
-                  Cause.hasInterruptsOnly(cause)
-                    ? Effect.failCause(cause)
-                    : Effect.logWarning("automatic thread settlement skipped", {
-                        threadId: thread.id,
-                        cause: Cause.pretty(cause),
-                      }),
-                ),
-              ),
-            { discard: true },
-          );
+          const previous = lookups.get(key);
+          lookups.set(key, pullRequest);
+          if (previous !== undefined && samePullRequest(previous, pullRequest)) return;
+          changed = true;
+          yield* decideGroup(group, pullRequest);
         }).pipe(
           Effect.catchCause((cause) =>
             Cause.hasInterruptsOnly(cause)
@@ -140,6 +251,10 @@ export const make = Effect.gen(function* () {
         ),
       { concurrency: 8, discard: true },
     );
+
+    const retain = new Set(snapshot.threads.map(lookupKey));
+    const stale = [...lookups.keys()].some((key) => !retain.has(key));
+    if (changed || stale) yield* saveLookups(retain);
   });
 
   const worker = yield* makeDrainableWorker(() =>
@@ -151,12 +266,15 @@ export const make = Effect.gen(function* () {
               cause: Cause.pretty(cause),
             }),
       ),
+      // A sweep that dies before its local phase must not hold startup.
+      Effect.ensuring(Deferred.succeed(ready, undefined)),
     ),
   );
 
   const start: ThreadSettlementReactor["Service"]["start"] = Effect.fn(
     "ThreadSettlementReactor.start",
   )(function* () {
+    yield* loadLookups;
     const settingsChanges = yield* settingsService.subscribeChanges;
     const initialSettings = yield* settingsService.getSettings.pipe(Effect.orDie);
     let lastAfterDays = initialSettings.sidebarAutoSettleAfterDays;
@@ -165,7 +283,6 @@ export const make = Effect.gen(function* () {
       Effect.gen(function* () {
         yield* worker.enqueue(undefined);
         yield* worker.drain;
-        yield* Deferred.succeed(ready, undefined);
       }).pipe(Effect.repeat(Schedule.spaced("1 minute")), Effect.asVoid),
     );
     yield* forkParked(

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -86,6 +86,8 @@ export const make = Effect.gen(function* () {
   const { settlementLookupsPath } = yield* ServerConfig.ServerConfig;
   const ready = yield* Deferred.make<void>();
   const lookups = new Map<string, SettlementPullRequest | null>();
+  // Answers waiting to reach disk. Stays set across sweeps until a write lands.
+  let unsaved = false;
 
   const loadLookups = Effect.gen(function* () {
     if (!(yield* fs.exists(settlementLookupsPath))) return;
@@ -117,6 +119,7 @@ export const make = Effect.gen(function* () {
         filePath: settlementLookupsPath,
         contents: `${contents}\n`,
       });
+      unsaved = false;
     }).pipe(
       Effect.catch((cause) =>
         Effect.logWarning("settlement lookups not persisted", {
@@ -254,7 +257,8 @@ export const make = Effect.gen(function* () {
 
     const retain = new Set(snapshot.threads.map(lookupKey));
     const stale = [...lookups.keys()].some((key) => !retain.has(key));
-    if (changed || stale) yield* saveLookups(retain);
+    if (changed || stale) unsaved = true;
+    if (unsaved) yield* saveLookups(retain);
   });
 
   const worker = yield* makeDrainableWorker(() =>

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -4,6 +4,7 @@ import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
@@ -26,6 +27,7 @@ export class ThreadSettlementReactor extends Context.Service<
   ThreadSettlementReactor,
   {
     readonly start: () => Effect.Effect<void, never, Scope.Scope>;
+    readonly ready: Effect.Effect<void>;
     readonly drain: Effect.Effect<void>;
   }
 >()("t3/orchestration/ThreadSettlementReactor") {}
@@ -37,6 +39,7 @@ export const make = Effect.gen(function* () {
   const git = yield* GitManager.GitManager;
   const pullRequests = yield* PullRequestService.PullRequestService;
   const crypto = yield* Crypto.Crypto;
+  const ready = yield* Deferred.make<void>();
 
   const sweep = Effect.fn("ThreadSettlementReactor.sweep")(function* () {
     const snapshot = yield* snapshots.getShellSnapshot();
@@ -162,6 +165,7 @@ export const make = Effect.gen(function* () {
       Effect.gen(function* () {
         yield* worker.enqueue(undefined);
         yield* worker.drain;
+        yield* Deferred.succeed(ready, undefined);
       }).pipe(Effect.repeat(Schedule.spaced("1 minute")), Effect.asVoid),
     );
     yield* forkParked(
@@ -179,7 +183,11 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  return { start, drain: worker.drain } satisfies ThreadSettlementReactor["Service"];
+  return {
+    start,
+    ready: Deferred.await(ready),
+    drain: worker.drain,
+  } satisfies ThreadSettlementReactor["Service"];
 });
 
 export const layer = Layer.effect(ThreadSettlementReactor, make);

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -530,6 +530,7 @@ export const make = (options?: StartupOptions) =>
         }),
       );
       yield* options?.activate ?? Effect.void;
+      yield* runStartupPhase("reactors.ready", orchestrationReactor.ready);
 
       yield* Effect.logDebug("Accepting commands");
       yield* commandGate.signalCommandReady;

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -94,6 +94,10 @@ once per minute, including when no client is connected. It dispatches the guarde
 `thread.auto-settle` command, which uses the existing settlement event lifecycle. Automatic
 settlement excludes live background work and requires a comparable PR timestamp for immediate PR
 settlement. The command also rejects any later event for its thread after the reactor's snapshot.
+Each sweep first applies what it can decide locally (branchless threads and the pull request
+answers persisted by earlier sweeps in `settlement-lookups.json`), then refreshes from the network.
+Startup waits only for that local phase, so the first snapshot already carries those decisions
+without putting a GitHub round trip on the startup path.
 Clients render the persisted settlement state and do not derive settlement from PR or inactivity
 state. A committed `thread.settled` event also lets `ProviderCommandReactor` stop an idle provider
 session.


### PR DESCRIPTION
Since #8600 made settlement server-owned, the first snapshot after a restart could show threads as active until the initial settlement sweep landed. The earlier version of this PR fixed that by holding startup until the sweep finished, which put a GitHub round trip per branch on the startup path.

The sweep now persists its last pull request answer per lookup key in `settlement-lookups.json` and runs in two phases. The local phase decides branchless threads and threads with a persisted answer, then signals readiness so startup can accept commands. The network phase refreshes every lookup in the background and only re-decides groups whose answer is new or changed. A sweep that dies before its local phase still signals readiness, so startup can never hang on it.

Verified with the settlement reactor, orchestration reactor, and startup tests, server typecheck, lint, and formatting.

Changes and PR text by Claude Fable 5.1 in T3 Code with the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration startup ordering and introduces on-disk settlement cache that affects auto-settle behavior across restarts; failures degrade to warnings but incorrect cache could delay or skew settlement until network refresh.
> 
> **Overview**
> **Thread settlement no longer blocks startup on GitHub.** The first sweep runs in two phases: a **local phase** settles branchless threads and any thread whose PR state was cached from a prior run, then signals `ready`; a **network phase** refreshes lookups in the background and only re-settles when answers change.
> 
> PR lookup results are **persisted** under `settlement-lookups.json` (new `settlementLookupsPath` in server config), loaded at reactor start and written atomically after sweeps with stale keys pruned.
> 
> **Startup** gains a `reactors.ready` phase that awaits `OrchestrationReactor.ready` (delegated from `ThreadSettlementReactor.ready`) before opening the command gate, so the first client snapshot reflects local settlements without waiting on network. Failed sweeps still unblock `ready` via `Effect.ensuring`.
> 
> Tests and integration mocks were updated for `ready`; new reactor tests cover early readiness, restart from cache, and readiness when projection read fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395ccffd44fa2e439c1bac2a0e5d6eec096d0bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local-phase thread settlement to 'ThreadSettlementReactor' at startup
> - Splits the [ThreadSettlementReactor.ts](https://github.com/pingdotgg/t3code/pull/9043/files#diff-d1d0434f1c82cb762eac14e3238e44d97e93fde6be3f5120c34057a355a0b6fb) sweep into a local phase and a network phase. The local phase settles branchless threads and threads with persisted pull request lookups before resolving a new `ready` effect.
> - Persists pull request lookup answers to `settlement-lookups.json` via the new `settlementLookupsPath` config field, so settlements survive restarts.
> - Server startup in [serverRuntimeStartup.ts](https://github.com/pingdotgg/t3code/pull/9043/files#diff-1930335d6e319fc5766e0578303e19f9d788e9990f87604b77f9f768e61d7118) now awaits `orchestrationReactor.ready` before accepting commands.
> - Behavioral Change: Server startup blocks on the local settlement phase instead of network lookups. `ready` always resolves via `Effect.ensuring`, even if the sweep fails before the local phase.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 395ccff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->