### PR TITLE
fix(server): preserve newer runtime state on shutdown

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -495,7 +495,7 @@ export const makeServerLayer = Layer.unwrap(
           const server = yield* HttpServer.HttpServer;
           const address = server.address;
           if (typeof address === "string" || !("port" in address)) {
-            return;
+            return null;
           }
 
           const state = yield* makePersistedServerRuntimeState({
@@ -510,13 +510,16 @@ export const makeServerLayer = Layer.unwrap(
               Effect.logWarning("Failed to persist server runtime state", { cause }),
             ),
           );
+          return state;
         }),
-        () =>
-          clearPersistedServerRuntimeState(config.serverRuntimeStatePath).pipe(
-            Effect.catchCause((cause) =>
-              Effect.logWarning("Failed to clear server runtime state", { cause }),
-            ),
-          ),
+        (state) =>
+          state === null
+            ? Effect.void
+            : clearPersistedServerRuntimeState(config.serverRuntimeStatePath, state).pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logWarning("Failed to clear server runtime state", { cause }),
+                ),
+              ),
       ),
     );
     const tailscaleServeLayer = config.tailscaleServeEnabled

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -78,6 +78,64 @@ describe("serverRuntimeState", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("clears runtime state owned by the stopping server", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      const state: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 123,
+        port: 4_971,
+        origin: "http://127.0.0.1:4971",
+        startedAt: "2026-06-20T00:00:00.000Z",
+      };
+      yield* ServerRuntimeState.persistServerRuntimeState({ path: statePath, state });
+
+      yield* ServerRuntimeState.clearPersistedServerRuntimeState(statePath, state);
+
+      const restored = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+      assert.isTrue(Option.isNone(restored));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("does not clear runtime state replaced by a newer server", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      const oldState: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 123,
+        port: 4_971,
+        origin: "http://127.0.0.1:4971",
+        startedAt: "2026-06-20T00:00:00.000Z",
+      };
+      const currentState: ServerRuntimeState.PersistedServerRuntimeState = {
+        ...oldState,
+        pid: 456,
+        port: 4_972,
+        origin: "http://127.0.0.1:4972",
+        startedAt: "2026-06-20T00:01:00.000Z",
+      };
+      yield* ServerRuntimeState.persistServerRuntimeState({
+        path: statePath,
+        state: currentState,
+      });
+
+      yield* ServerRuntimeState.clearPersistedServerRuntimeState(statePath, oldState);
+
+      const restored = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+      assert.deepEqual(Option.getOrThrow(restored), currentState);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("preserves malformed state decode failures", () => {
     const logs: CapturedLog[] = [];
     const logger = Logger.make(({ fiber, message }) => {

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -79,8 +79,19 @@ export const persistServerRuntimeState = (input: {
     ),
   );
 
-export const clearPersistedServerRuntimeState = (path: string) =>
-  Effect.gen(function* () {
+export const clearPersistedServerRuntimeState = Effect.fn("clearPersistedServerRuntimeState")(
+  function* (path: string, expectedOwner?: Pick<PersistedServerRuntimeState, "pid" | "startedAt">) {
+    if (expectedOwner) {
+      const current = yield* readPersistedServerRuntimeState(path);
+      if (
+        Option.isNone(current) ||
+        current.value.pid !== expectedOwner.pid ||
+        current.value.startedAt !== expectedOwner.startedAt
+      ) {
+        return;
+      }
+    }
+
     const fs = yield* FileSystem.FileSystem;
     yield* fs.remove(path, { force: true }).pipe(
       Effect.mapError(
@@ -102,7 +113,8 @@ export const clearPersistedServerRuntimeState = (path: string) =>
           ),
       }),
     );
-  });
+  },
+);
 
 export const readPersistedServerRuntimeState = (path: string) =>
   Effect.gen(function* () {


### PR DESCRIPTION
## What Changed

- Return the persisted runtime owner from the server resource acquisition.
- Remove runtime state only when `pid` and `startedAt` still match that owner.
- Keep unconditional cleanup for callers that deliberately clear confirmed stale state.
- Add tests for matching-owner cleanup and newer-owner preservation.

## Why

Two T3 servers can overlap briefly during an SSH reconnect. An older server previously removed the shared `server-runtime.json` during shutdown, even after a newer server replaced it. This left endpoint discovery without the current server record.

The owner check keeps the newer record while preserving existing stale-state cleanup behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] Animation or interaction video is not applicable

Validation:

- `vp test run apps/server/src/serverRuntimeState.test.ts`: 8 tests passed.
- `vp run --filter t3 typecheck`: passed with existing suggestions in unrelated files.
- Focused lint passed.
- Context documentation is not needed. This change does not add domain language or a durable product decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared runtime-state lifecycle on shutdown; incorrect owner matching could leave stale files or skip needed cleanup, though behavior is covered by new tests and CLI paths stay unconditional.
> 
> **Overview**
> Fixes a race where an **older** server process could delete `server-runtime.json` on shutdown after a **newer** server had already written it (e.g. brief overlap on SSH reconnect), breaking endpoint discovery.
> 
> **`clearPersistedServerRuntimeState`** now accepts an optional owner (`pid` + `startedAt`). When provided, it reads the file and **skips** removal unless the on-disk record still matches that owner. Callers that omit the owner (e.g. CLI stale cleanup) still delete unconditionally.
> 
> The server **`acquireRelease`** hook returns the persisted state (or `null` when no port was written) and passes it into shutdown cleanup so only the stopping instance clears its own record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d22f861cb077626a674832964ece795ac3a2d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `clearPersistedServerRuntimeState` to skip clearing newer server state on shutdown
> - On shutdown the server now passes the state it acquired at startup as an `expectedOwner` to `clearPersistedServerRuntimeState(path, expectedOwner)` so it only deletes the persisted file when `pid` and `startedAt` still match the current instance
> - If the server had no numeric port/address, the release phase receives `null` and skips the clear entirely
> - Adds tests verifying the file is removed on owner match and preserved when the stored state belongs to a different/newer server
> - Behavioral Change: `clearPersistedServerRuntimeState` signature gains a second optional `expectedOwner` parameter; callers that omit it keep the old unconditional-delete behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0d22f86. 2 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/serverRuntimeState.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 96](https://github.com/pingdotgg/t3code/blob/0d22f861cb077626a674832964ece795ac3a2d3e/apps/server/src/serverRuntimeState.ts#L96): The owner check is a time-of-check/time-of-use race: after `readPersistedServerRuntimeState(path)` confirms that the old instance owns the file, a newer server can atomically replace the state before `fs.remove(path)` runs. The old shutdown then unlinks the newer server's record, recreating the endpoint-discovery failure this guard is intended to prevent. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->