### PR TITLE
perf(clients): fix composer draft persistence boundaries

### DIFF
--- a/apps/mobile/src/components/ComposerAttachmentStrip.tsx
+++ b/apps/mobile/src/components/ComposerAttachmentStrip.tsx
@@ -4,7 +4,13 @@ import { useEffect, useRef, useState } from "react";
 import { Alert, Image, Pressable, ScrollView, View } from "react-native";
 
 import { AppText as Text } from "./AppText";
-import type { DraftComposerAttachment, DraftComposerFileAttachment } from "../lib/composerImages";
+import {
+  isFileBackedComposerAttachment,
+  type DraftComposerAttachment,
+  type DraftComposerFileAttachment,
+  type DraftComposerImageAttachment,
+} from "../lib/composerImages";
+import { resolveOwnedComposerAttachmentFileUri } from "../lib/composerAttachmentFiles";
 import { VideoAttachmentTile } from "./VideoAttachmentTile";
 import { loadLocalAttachmentPreview } from "../lib/localAttachmentPreview";
 import { PresentationSource } from "./NativePresentation";
@@ -87,35 +93,75 @@ export function ComposerAttachmentThumbnail(props: ComposerAttachmentThumbnailPr
   );
 }
 
+/**
+ * Thumbnail URI for a draft image. File-backed previews rebase into the
+ * current iOS data container (its UUID changes across installs); the raw
+ * persisted URI renders meanwhile, which is correct everywhere but after a
+ * container move.
+ */
+function useComposerImagePreviewUri(attachment: DraftComposerImageAttachment): string {
+  const { fileUri, previewUri } = attachment;
+  const [rebased, setRebased] = useState<{ fileUri: string; uri: string } | null>(null);
+  useEffect(() => {
+    if (fileUri === undefined) return;
+    let cancelled = false;
+    void (async () => {
+      const { Paths } = await import("expo-file-system");
+      const owned = resolveOwnedComposerAttachmentFileUri(fileUri, Paths.document.uri);
+      // Re-render only when the container actually moved.
+      if (!cancelled && owned !== null && owned !== previewUri) setRebased({ fileUri, uri: owned });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [fileUri, previewUri]);
+  return fileUri !== undefined && rebased?.fileUri === fileUri ? rebased.uri : previewUri;
+}
+
+function ComposerImageAttachment(
+  props: ComposerAttachmentThumbnailProps & { readonly attachment: DraftComposerImageAttachment },
+) {
+  const { attachment } = props;
+  const style = { width: props.size, height: props.size, borderRadius: props.borderRadius };
+  const previewUri = useComposerImagePreviewUri(attachment);
+  const sourceIdentifier = `draft-image:${attachment.id}`;
+  return (
+    <PresentationSource identifier={sourceIdentifier}>
+      <Pressable
+        accessibilityRole="imagebutton"
+        accessibilityLabel={`Open ${attachment.name}`}
+        disabled={!props.onPressPreview}
+        onPress={() =>
+          props.onPressPreview?.(
+            // File-backed images open through the retain-lease + container
+            // rebase path; legacy drafts still carry their inline bytes.
+            isFileBackedComposerAttachment(attachment)
+              ? { kind: "image", attachment, name: attachment.name, sourceIdentifier }
+              : {
+                  kind: "image",
+                  uri: attachment.dataUrl ?? attachment.previewUri,
+                  name: attachment.name,
+                  sourceIdentifier,
+                },
+          )
+        }
+      >
+        <Image
+          source={{ uri: previewUri }}
+          style={style}
+          className="bg-subtle"
+          resizeMode="cover"
+        />
+      </Pressable>
+    </PresentationSource>
+  );
+}
+
 function ComposerAttachmentContent(props: ComposerAttachmentThumbnailProps) {
   const { attachment } = props;
   const style = { width: props.size, height: props.size, borderRadius: props.borderRadius };
   if (attachment.type === "image") {
-    const sourceIdentifier = `draft-image:${attachment.id}`;
-    return (
-      <PresentationSource identifier={sourceIdentifier}>
-        <Pressable
-          accessibilityRole="imagebutton"
-          accessibilityLabel={`Open ${attachment.name}`}
-          disabled={!props.onPressPreview}
-          onPress={() =>
-            props.onPressPreview?.({
-              kind: "image",
-              uri: attachment.dataUrl,
-              name: attachment.name,
-              sourceIdentifier,
-            })
-          }
-        >
-          <Image
-            source={{ uri: attachment.previewUri }}
-            style={style}
-            className="bg-subtle"
-            resizeMode="cover"
-          />
-        </Pressable>
-      </PresentationSource>
-    );
+    return <ComposerImageAttachment {...props} attachment={attachment} />;
   }
   const onPressVideo = props.onPressVideo;
   if (onPressVideo && videoMimeType(attachment) !== null) {

--- a/apps/mobile/src/components/FilePreviewModal.tsx
+++ b/apps/mobile/src/components/FilePreviewModal.tsx
@@ -3,7 +3,7 @@ import type { AssetResource, EnvironmentId } from "@t3tools/contracts";
 import { useEffect, useEffectEvent, useState } from "react";
 import { Alert, Keyboard } from "react-native";
 
-import type { DraftComposerFileAttachment } from "../lib/composerImages";
+import type { FileBackedComposerAttachment } from "../lib/composerImages";
 import { loadLocalAttachmentPreview } from "../lib/localAttachmentPreview";
 import { useAssetUrlState } from "../state/assets";
 import { usePreparedConnection } from "../state/session";
@@ -19,7 +19,7 @@ export interface ResolvedFilePreviewSource {
 export type FilePreviewSource = Omit<ResolvedFilePreviewSource, "uri"> &
   (
     | { readonly uri: string }
-    | { readonly attachment: DraftComposerFileAttachment }
+    | { readonly attachment: FileBackedComposerAttachment }
     | { readonly environmentId: EnvironmentId; readonly resource: AssetResource }
   );
 

--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -1,7 +1,7 @@
 import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { TextInputWrapper } from "expo-paste-input";
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Platform, Pressable, ScrollView, View, useWindowDimensions } from "react-native";
 import { KeyboardAvoidingView, KeyboardStickyView } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -15,6 +15,7 @@ import { cn } from "../../lib/cn";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { convertPastedImagesToAttachments, pickComposerImages } from "../../lib/composerImages";
 import { useNativePaste } from "../../lib/useNativePaste";
+import { scheduleUnusedComposerAttachmentCleanup } from "../../state/use-composer-drafts";
 import { setPendingConnectionError } from "../../state/use-remote-environment-registry";
 import { appendReviewCommentToDraft } from "../../state/use-thread-composer-state";
 import {
@@ -53,6 +54,21 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
     Record<string, ReadonlyArray<ReviewHighlightedToken>>
   >({});
   const [attachments, setAttachments] = useState<ReadonlyArray<DraftComposerImageAttachment>>([]);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
+  // Attachments live in local state until submit copies them into the thread
+  // draft, but their image bytes already live in the app-owned attachment
+  // directory. Whatever is still here when the sheet unmounts was neither
+  // submitted nor removed; release those copies so dismissal does not leak
+  // storage. Cleanup is reference-checked, so submitted files stay.
+  useEffect(
+    () => () => {
+      if (attachmentsRef.current.length > 0) {
+        scheduleUnusedComposerAttachmentCleanup(attachmentsRef.current);
+      }
+    },
+    [],
+  );
   const [previewFile, setPreviewFile] = useState<FilePreviewSource | null>(null);
 
   const selectedLines = useMemo(
@@ -275,9 +291,13 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
                         onPressPreview={setPreviewFile}
                         removeButtonPlacement="gutter"
                         onRemove={(imageId) => {
+                          const removed = attachments.find((image) => image.id === imageId);
                           setAttachments((current) =>
                             current.filter((image) => image.id !== imageId),
                           );
+                          if (removed) {
+                            scheduleUnusedComposerAttachmentCleanup([removed]);
+                          }
                         }}
                       />
                     </View>

--- a/apps/mobile/src/features/sharing/incoming-share-model.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.test.ts
@@ -36,6 +36,9 @@ describe("incoming native shares", () => {
       originalName: "Screenshot.png",
     };
     const removeOwnedFile = vi.fn(() => Promise.resolve());
+    const readBase64 = vi.fn(async () => "unused");
+    const persistedUri = "file:///documents/t3-composer-attachments/Screenshot.png";
+    const persistFile = vi.fn(async () => persistedUri);
 
     const result = await buildIncomingShareDraft({
       id: "share-1",
@@ -43,7 +46,9 @@ describe("incoming native shares", () => {
       payloads,
       resolvedPayloads: [resolvedImage],
       fileReader: {
-        readBase64: async () => "YWJj",
+        readBase64,
+        persistFile,
+        readSize: async (uri) => (uri === persistedUri ? 3 : null),
         removeOwnedFile,
       },
     });
@@ -60,13 +65,16 @@ describe("incoming native shares", () => {
           name: "Screenshot.png",
           mimeType: "image/png",
           sizeBytes: 3,
-          dataUrl: "data:image/png;base64,YWJj",
-          previewUri: "data:image/png;base64,YWJj",
+          fileUri: persistedUri,
+          previewUri: persistedUri,
         },
       ],
       warnings: [],
     });
+    expect(persistFile).toHaveBeenCalledWith(image.value, "Screenshot.png");
+    expect(readBase64).not.toHaveBeenCalled();
     expect(removeOwnedFile).toHaveBeenCalledWith(image.value);
+    expect(removeOwnedFile).not.toHaveBeenCalledWith(persistedUri);
     expect(hasIncomingShareContent(result)).toBe(true);
   });
 

--- a/apps/mobile/src/features/sharing/incoming-share-model.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.ts
@@ -405,29 +405,61 @@ export async function buildIncomingShareDraft(input: {
       continue;
     }
 
+    const imageName = resolved?.originalName ?? fallbackName(uri, index, mimeType);
+    let persistedImageUri: string | undefined;
     try {
+      if (input.fileReader.persistFile) {
+        // The share provider's file is temporary. Copy it into the durable
+        // attachment directory so the composer stays valid after the source
+        // file and App Group entry are gone, without inlining the bytes.
+        persistedImageUri = await input.fileReader.persistFile(uri, imageName);
+        const sizeBytes =
+          (await input.fileReader.readSize?.(persistedImageUri)) ?? resolved?.contentSize ?? null;
+        if (sizeBytes === null || sizeBytes <= 0) {
+          warnings.push(`'${imageName}' is empty or could not be read.`);
+          await releaseOwnedFiles(input.fileReader, [persistedImageUri]);
+          continue;
+        }
+        if (sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+          warnings.push(`'${imageName}' exceeds the 10 MB attachment limit.`);
+          await releaseOwnedFiles(input.fileReader, [persistedImageUri]);
+          continue;
+        }
+        attachments.push({
+          id: `${input.id}:image:${index}`,
+          type: "image",
+          name: imageName,
+          mimeType,
+          sizeBytes,
+          fileUri: persistedImageUri,
+          previewUri: persistedImageUri,
+        });
+        continue;
+      }
+      // Readers without persistFile keep the legacy inline shape.
       const base64 = await input.fileReader.readBase64(uri);
       const sizeBytes = resolved?.contentSize ?? estimateBase64ByteSize(base64);
       if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-        warnings.push(
-          `'${resolved?.originalName ?? fallbackName(uri, index, mimeType)}' exceeds the 10 MB attachment limit.`,
-        );
+        warnings.push(`'${imageName}' exceeds the 10 MB attachment limit.`);
         continue;
       }
       const dataUrl = `data:${mimeType};base64,${base64}`;
       attachments.push({
         id: `${input.id}:image:${index}`,
         type: "image",
-        name: resolved?.originalName ?? fallbackName(uri, index, mimeType),
+        name: imageName,
         mimeType,
         sizeBytes,
         dataUrl,
-        // The share provider's file is temporary. A data-backed preview keeps
-        // the composer valid after its source file and App Group entry are gone.
         previewUri: dataUrl,
       });
     } catch {
       warnings.push(`Could not read '${fallbackName(uri, index, mimeType)}'.`);
+      // A copy persisted before the failure has no attachment referencing it;
+      // release it or it leaks in the app's attachment directory.
+      if (persistedImageUri !== undefined) {
+        await releaseOwnedFiles(input.fileReader, [persistedImageUri]);
+      }
     } finally {
       await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
     }

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -120,7 +120,6 @@ export function useCreateProjectThread() {
           messageId: metadata.messageId,
           createdAt: metadata.createdAt,
           text: initialMessageText,
-          attachments: input.initialAttachments,
           uploadedAttachments: prepared.attachments,
           modelSelection: input.modelSelection,
           runtimeMode: input.runtimeMode,

--- a/apps/mobile/src/lib/attachmentUpload.test.ts
+++ b/apps/mobile/src/lib/attachmentUpload.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   upload: vi.fn(),
   writeFile: vi.fn(),
   deleteFile: vi.fn(),
+  readBase64: vi.fn(),
 }));
 
 vi.mock("@t3tools/client-runtime/state/runtime", () => ({
@@ -68,6 +69,10 @@ vi.mock("expo-file-system", () => ({
       mocks.deleteFile(this.uri);
     }
 
+    async base64() {
+      return mocks.readBase64(this.uri);
+    }
+
     upload(url: string, options: unknown) {
       return mocks.upload(this.uri, url, options);
     }
@@ -100,6 +105,16 @@ const image = {
   sizeBytes: 3,
   dataUrl: "data:image/png;base64,YWJj",
   previewUri: "file:///images/screenshot.png",
+} as const satisfies DraftComposerAttachment;
+
+const fileBackedImage = {
+  id: "image-2",
+  type: "image",
+  name: "photo.png",
+  mimeType: "image/png",
+  sizeBytes: 3,
+  fileUri: "file:///documents/t3-composer-attachments/photo.png",
+  previewUri: "file:///documents/t3-composer-attachments/photo.png",
 } as const satisfies DraftComposerAttachment;
 
 const file = {
@@ -174,6 +189,8 @@ describe("prepareTurnAttachments", () => {
     mocks.upload.mockReset();
     mocks.writeFile.mockReset();
     mocks.deleteFile.mockReset();
+    mocks.readBase64.mockReset();
+    mocks.readBase64.mockResolvedValue("YWJj");
     mocks.readAtom.mockReturnValue(Option.some({ httpBaseUrl: "https://environment.example/" }));
     mocks.runAtomCommand.mockImplementation(async (_registry: unknown, command: unknown) =>
       command === mocks.createUploadUrl
@@ -206,6 +223,55 @@ describe("prepareTurnAttachments", () => {
     ]);
     expect(prepared.pendingAttachmentIds).toEqual([]);
     expect(mocks.upload).not.toHaveBeenCalled();
+  });
+
+  it("inlines a file-backed image lazily when the server lacks image uploads", async () => {
+    const prepared = await prepareTurnAttachments({
+      environmentId,
+      attachments: [fileBackedImage],
+    });
+
+    expect(prepared.status).toBe("ready");
+    if (prepared.status !== "ready") return;
+    expect(prepared.attachments).toEqual([
+      {
+        type: "image",
+        name: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 3,
+        dataUrl: "data:image/png;base64,YWJj",
+      },
+    ]);
+    expect(mocks.readBase64).toHaveBeenCalledExactlyOnceWith(fileBackedImage.fileUri);
+    expect(mocks.upload).not.toHaveBeenCalled();
+  });
+
+  it("uploads a file-backed image from its owned copy without staging base64", async () => {
+    const prepared = await prepareTurnAttachments({
+      environmentId,
+      attachments: [fileBackedImage],
+      supportsImageUploads: true,
+    });
+
+    expect(mocks.upload).toHaveBeenCalledWith(
+      fileBackedImage.fileUri,
+      "https://environment.example/api/attachments/upload/signed",
+      expect.objectContaining({ headers: { "Content-Type": "image/png" } }),
+    );
+    expect(mocks.readBase64).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+    expect(mocks.deleteFile).not.toHaveBeenCalled();
+    expect(prepared.status).toBe("ready");
+    if (prepared.status !== "ready") return;
+    expect(prepared.attachments).toEqual([
+      {
+        type: "image",
+        id: MINTED_ID,
+        name: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 3,
+      },
+    ]);
   });
 
   it("uploads generic file bytes directly and keeps mixed attachment order", async () => {

--- a/apps/mobile/src/lib/attachmentUpload.ts
+++ b/apps/mobile/src/lib/attachmentUpload.ts
@@ -187,17 +187,21 @@ async function uploadFileBytes(
 ): Promise<void> {
   const { File, Paths, UploadType } = await import("expo-file-system");
   if (signal.aborted) throw new Error("Upload cancelled.");
+  // Legacy image drafts persisted inline bytes and stage them in a temp cache
+  // file for the native uploader. Everything else uploads its owned copy.
+  const fileUri = attachment.fileUri;
+  const inlineDataUrl = attachment.type === "image" ? attachment.dataUrl : undefined;
+  if (fileUri === undefined && inlineDataUrl === undefined) {
+    throw new Error(`'${attachment.name}' is no longer available. Attach the image again.`);
+  }
   const file =
-    attachment.type === "image"
+    fileUri === undefined
       ? new File(Paths.cache, `t3-upload-${uuidv4()}`)
-      : new File(
-          resolveOwnedComposerAttachmentFileUri(attachment.fileUri, Paths.document.uri) ??
-            attachment.fileUri,
-        );
+      : new File(resolveOwnedComposerAttachmentFileUri(fileUri, Paths.document.uri) ?? fileUri);
   try {
-    if (attachment.type === "image") {
+    if (fileUri === undefined && inlineDataUrl !== undefined) {
       file.create();
-      file.write(attachment.dataUrl.slice(attachment.dataUrl.indexOf(",") + 1), {
+      file.write(inlineDataUrl.slice(inlineDataUrl.indexOf(",") + 1), {
         encoding: "base64",
       });
     }
@@ -218,7 +222,7 @@ async function uploadFileBytes(
       throw new Error(`Upload failed for '${attachment.name}' (${result.status}).`);
     }
   } finally {
-    if (attachment.type === "image" && file.exists) file.delete();
+    if (fileUri === undefined && file.exists) file.delete();
   }
 }
 
@@ -260,7 +264,7 @@ export async function prepareTurnAttachments(input: {
 
   if (input.attachments.length === 0 || (files.length === 0 && !input.supportsImageUploads)) {
     return ready(
-      toUploadChatImageAttachments(
+      await toUploadChatImageAttachments(
         input.attachments.filter((attachment) => attachment.type === "image"),
       ),
       [],
@@ -285,7 +289,7 @@ export async function prepareTurnAttachments(input: {
     for (const attachment of input.attachments) {
       if (controller.signal.aborted) throw new Error("Upload cancelled.");
       if (attachment.type === "image" && !input.supportsImageUploads) {
-        uploadedAttachments.push(...toUploadChatImageAttachments([attachment]));
+        uploadedAttachments.push(...(await toUploadChatImageAttachments([attachment])));
         continue;
       }
 

--- a/apps/mobile/src/lib/composer-image-schema.ts
+++ b/apps/mobile/src/lib/composer-image-schema.ts
@@ -8,7 +8,10 @@ export const DraftComposerImageAttachmentSchema = Schema.Struct({
   name: Schema.String,
   mimeType: Schema.String,
   sizeBytes: Schema.Number,
-  dataUrl: Schema.String,
+  // New attachments persist an owned file path; drafts saved by older app
+  // versions carry inline dataUrl bytes instead and must keep decoding.
+  fileUri: Schema.optional(Schema.String),
+  dataUrl: Schema.optional(Schema.String),
   uploadedAttachmentId: Schema.optional(Schema.String),
   uploadEnvironmentId: Schema.optional(EnvironmentId),
 });

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -106,21 +106,29 @@ describe("composer file attachments", () => {
   });
 
   describe("photo library image conversion", () => {
-    const jpeg = "/9j/2Q==";
+    const jpegMagic = () => ({
+      readBytes: () => new Uint8Array([0xff, 0xd8, 0xff]),
+      close: vi.fn(),
+    });
+    const otherMagic = () => ({
+      readBytes: () => new Uint8Array([0x00, 0x11, 0x22]),
+      close: vi.fn(),
+    });
     const photo: ImagePickerAsset = {
       uri: "file:///picker/photo.heic",
       type: "image",
       fileName: "photo.HEIC",
       mimeType: "image/heic",
       fileSize: 20 * 1024 * 1024,
-      base64: jpeg,
+      base64: null,
       width: 1,
       height: 1,
     };
 
     it.each(["image/heic", "image/heif", undefined])(
-      "attaches the native JPEG conversion with matching metadata when the source MIME is %s",
+      "records the picker's silent JPEG transcode when the metadata says %s",
       async (mimeType) => {
+        mocks.open.mockImplementation(() => jpegMagic());
         mocks.pickMedia.mockResolvedValue({
           canceled: false,
           assets: [{ ...photo, mimeType }],
@@ -128,6 +136,8 @@ describe("composer file attachments", () => {
 
         const result = await pickComposerImages({ existingCount: 0 });
 
+        expect(mocks.pickMedia).toHaveBeenCalledWith(expect.not.objectContaining({ base64: true }));
+        const fileUri = "file:///documents/t3-composer-attachments/attachment-id-photo.jpg";
         expect(result).toEqual({
           images: [
             {
@@ -135,73 +145,80 @@ describe("composer file attachments", () => {
               type: "image",
               name: "photo.jpg",
               mimeType: "image/jpeg",
-              sizeBytes: 4,
-              dataUrl: `data:image/jpeg;base64,${jpeg}`,
-              previewUri: `data:image/jpeg;base64,${jpeg}`,
+              sizeBytes: 42,
+              fileUri,
+              previewUri: fileUri,
             },
           ],
           error: null,
         });
+        expect(mocks.copy).toHaveBeenCalledWith(photo.uri, fileUri);
       },
     );
 
     it.each([
-      { extension: "png", mimeType: "image/png", base64: "iVBORw0KGgo=" },
-      { extension: "gif", mimeType: "image/gif", base64: "R0lGODlh" },
-      { extension: "webp", mimeType: "image/webp", base64: "UklGRgQAAABXRUJQ" },
-    ])("preserves original $extension bytes instead of the picker's JPEG", async (original) => {
+      { extension: "png", mimeType: "image/png" },
+      { extension: "gif", mimeType: "image/gif" },
+      { extension: "webp", mimeType: "image/webp" },
+    ])("keeps original $extension files the picker did not transcode", async (original) => {
       const name = `photo.${original.extension}`;
+      mocks.open.mockImplementation(() => otherMagic());
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
         assets: [{ ...photo, fileName: name, mimeType: original.mimeType }],
       });
-      mocks.readBase64.mockResolvedValue(original.base64);
 
       const result = await pickComposerImages({ existingCount: 0 });
 
       expect(result.error).toBeNull();
+      const fileUri = `file:///documents/t3-composer-attachments/attachment-id-${name}`;
       expect(result.images).toEqual([
-        expect.objectContaining({
-          name,
-          mimeType: original.mimeType,
-          dataUrl: `data:${original.mimeType};base64,${original.base64}`,
-          sizeBytes: Buffer.from(original.base64, "base64").byteLength,
-        }),
+        expect.objectContaining({ name, mimeType: original.mimeType, fileUri, sizeBytes: 42 }),
       ]);
+      expect(mocks.readBase64).not.toHaveBeenCalled();
     });
 
-    it("checks the converted JPEG size even when the HEIC source was smaller", async () => {
-      const oversized =
-        jpeg.slice(0, 4) + "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4);
-      mocks.pickMedia.mockResolvedValue({
-        canceled: false,
-        assets: [{ ...photo, fileSize: 42, base64: oversized }],
-      });
+    it("rejects an image whose stored copy exceeds the attachment limit", async () => {
+      mocks.open.mockImplementation(() => jpegMagic());
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [{ ...photo, fileSize: 42 }] });
+      mocks.size.mockImplementation((uri: string) =>
+        uri.startsWith("file:///documents/") ? PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1 : 42,
+      );
 
       await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
         images: [],
-        error: "'photo.HEIC' exceeds the 10 MB attachment limit.",
+        error: "'photo.jpg' exceeds the 10 MB attachment limit.",
       });
+      expect(mocks.delete).toHaveBeenCalledWith(
+        "file:///documents/t3-composer-attachments/attachment-id-photo.jpg",
+      );
     });
 
     it("does not relabel unconverted HEIC bytes as JPEG", async () => {
-      mocks.pickMedia.mockResolvedValue({
-        canceled: false,
-        assets: [{ ...photo, base64: "AAAAGGZ0eXBoZWlj" }],
-      });
+      mocks.open.mockImplementation(() => otherMagic());
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [photo] });
 
       const result = await pickComposerImages({ existingCount: 0 });
 
       expect(result.images).toEqual([]);
       expect(result.error).toContain("not a supported image type");
+      expect(mocks.copy).not.toHaveBeenCalled();
     });
 
-    it("retains a converted photo when another original cannot be read", async () => {
-      mocks.pickMedia.mockResolvedValue({
-        canceled: false,
-        assets: [{ ...photo, fileName: "missing.gif", mimeType: "image/gif" }, photo],
+    it("retains a copied photo when another asset cannot be copied", async () => {
+      const failing = {
+        ...photo,
+        uri: "file:///picker/missing.gif",
+        fileName: "missing.gif",
+        mimeType: "image/gif",
+      };
+      mocks.open.mockImplementation((uri: string) =>
+        uri === photo.uri ? jpegMagic() : otherMagic(),
+      );
+      mocks.copy.mockImplementation((uri: string) => {
+        if (uri === failing.uri) throw new Error("Failed to read 'missing.gif'.");
       });
-      mocks.readBase64.mockRejectedValue(new Error("missing file"));
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [failing, photo] });
 
       const result = await pickComposerImages({ existingCount: 0 });
 
@@ -232,9 +249,9 @@ describe("composer file attachments", () => {
       height: 1080,
     };
 
-    it("retains mixed photos and videos, keeping video bytes in durable file storage", async () => {
+    it("retains mixed photos and videos, keeping both in durable file storage", async () => {
       mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [image, video] });
-      mocks.size.mockReturnValue(video.fileSize);
+      mocks.size.mockImplementation((uri: string) => (uri.includes("clip") ? video.fileSize : 3));
 
       const result = await pickComposerMedia({ existingCount: 0, maxVideoBytes: 50 * 1024 * 1024 });
 
@@ -246,7 +263,13 @@ describe("composer file attachments", () => {
       );
       expect(result).toEqual({
         attachments: [
-          expect.objectContaining({ type: "image", dataUrl: "data:image/png;base64,YWJj" }),
+          expect.objectContaining({
+            type: "image",
+            name: "photo.png",
+            sizeBytes: 3,
+            fileUri: "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+            previewUri: "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+          }),
           {
             id: "attachment-id",
             type: "file",
@@ -277,7 +300,10 @@ describe("composer file attachments", () => {
         expect.objectContaining({ type: "image", name: "photo.png" }),
       ]);
       expect(result.error).toBeNull();
-      expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.copy).toHaveBeenCalledExactlyOnceWith(
+        image.uri,
+        "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+      );
     });
 
     it("does not persist videos when the destination lacks file support", async () => {
@@ -287,7 +313,10 @@ describe("composer file attachments", () => {
 
       expect(result.attachments).toEqual([expect.objectContaining({ type: "image" })]);
       expect(result.error).toBe("Video attachments are unavailable here.");
-      expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.copy).toHaveBeenCalledExactlyOnceWith(
+        image.uri,
+        "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+      );
     });
 
     it("uses local video metadata when the picker omits its name, MIME type, or size", async () => {
@@ -345,7 +374,7 @@ describe("composer file attachments", () => {
           canceled: false,
           assets: [{ ...video, fileSize: reported }, image],
         });
-        mocks.size.mockReturnValue(stored);
+        mocks.size.mockImplementation((uri: string) => (uri.includes("clip") ? stored : 3));
 
         const result = await pickComposerMedia({ existingCount: 0, maxVideoBytes: limit });
 
@@ -369,7 +398,10 @@ describe("composer file attachments", () => {
       expect(result.attachments).toEqual([expect.objectContaining({ type: "image" })]);
       expect(result.error).toBe("You can attach up to 8 attachments per message.");
       expect(mocks.pickMedia).toHaveBeenCalledWith(expect.objectContaining({ selectionLimit: 1 }));
-      expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.copy).toHaveBeenCalledExactlyOnceWith(
+        image.uri,
+        "file:///documents/t3-composer-attachments/attachment-id-photo.png",
+      );
     });
 
     it("reports a native video retrieval error and ends the foreground handoff", async () => {

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -204,9 +204,11 @@ describe("composer file attachments", () => {
 
     it("lands the picker's JPEG export for an unconverted HEIC photo", async () => {
       mocks.open.mockImplementation(() => otherMagic());
+      // "/9j/" is the base64 encoding of the JPEG magic number FF D8 FF.
+      const jpegBase64 = "/9j/heic-as-jpeg";
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
-        assets: [{ ...photo, base64: "aGVpYy1hcy1qcGVn" }],
+        assets: [{ ...photo, base64: jpegBase64 }],
       });
 
       const result = await pickComposerImages({ existingCount: 0 });
@@ -225,21 +227,26 @@ describe("composer file attachments", () => {
         error: null,
       });
       // The JPEG export is written once; the HEIC original is never copied.
-      expect(mocks.write).toHaveBeenCalledWith(fileUri, "aGVpYy1hcy1qcGVn", {
+      expect(mocks.write).toHaveBeenCalledWith(fileUri, jpegBase64, {
         encoding: "base64",
       });
       expect(mocks.copy).not.toHaveBeenCalled();
     });
 
-    it("rejects unconverted HEIC when the picker supplied no JPEG export", async () => {
+    it.each([
+      { label: "no export", base64: null },
+      // Android's quality-1 export is the raw original, not a JPEG transcode.
+      { label: "a non-JPEG export", base64: "AAAAGGZ0eXBoZWlj" },
+    ])("rejects unconverted HEIC with $label", async ({ base64 }) => {
       mocks.open.mockImplementation(() => otherMagic());
-      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [photo] });
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [{ ...photo, base64 }] });
 
       const result = await pickComposerImages({ existingCount: 0 });
 
       expect(result.images).toEqual([]);
       expect(result.error).toContain("not a supported image type");
       expect(mocks.copy).not.toHaveBeenCalled();
+      expect(mocks.write).not.toHaveBeenCalled();
     });
 
     it("retains a copied photo when another asset cannot be copied", async () => {

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   open: vi.fn(),
   size: vi.fn(),
   readBase64: vi.fn(),
+  write: vi.fn(),
 }));
 
 vi.mock("expo-file-system", () => {
@@ -61,6 +62,10 @@ vi.mock("expo-file-system", () => {
       return mocks.readBase64(this.uri);
     }
 
+    async write(data: string, options?: { readonly encoding?: string }): Promise<void> {
+      mocks.write(this.uri, data, options);
+    }
+
     delete(): void {
       mocks.delete(this.uri);
     }
@@ -102,6 +107,7 @@ describe("composer file attachments", () => {
     mocks.open.mockReset();
     mocks.size.mockReset();
     mocks.readBase64.mockReset();
+    mocks.write.mockReset();
     mocks.size.mockImplementation((uri: string) => (uri.startsWith("content:") ? null : 42));
   });
 
@@ -136,7 +142,9 @@ describe("composer file attachments", () => {
 
         const result = await pickComposerImages({ existingCount: 0 });
 
-        expect(mocks.pickMedia).toHaveBeenCalledWith(expect.not.objectContaining({ base64: true }));
+        expect(mocks.pickMedia).toHaveBeenCalledWith(
+          expect.objectContaining({ base64: true, quality: 1 }),
+        );
         const fileUri = "file:///documents/t3-composer-attachments/attachment-id-photo.jpg";
         expect(result).toEqual({
           images: [
@@ -194,7 +202,36 @@ describe("composer file attachments", () => {
       );
     });
 
-    it("does not relabel unconverted HEIC bytes as JPEG", async () => {
+    it("lands the picker's JPEG export for an unconverted HEIC photo", async () => {
+      mocks.open.mockImplementation(() => otherMagic());
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [{ ...photo, base64: "aGVpYy1hcy1qcGVn" }],
+      });
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      const fileUri = "file:///documents/t3-composer-attachments/attachment-id-photo.jpg";
+      expect(result).toEqual({
+        images: [
+          expect.objectContaining({
+            name: "photo.jpg",
+            mimeType: "image/jpeg",
+            fileUri,
+            previewUri: fileUri,
+            sizeBytes: 42,
+          }),
+        ],
+        error: null,
+      });
+      // The JPEG export is written once; the HEIC original is never copied.
+      expect(mocks.write).toHaveBeenCalledWith(fileUri, "aGVpYy1hcy1qcGVn", {
+        encoding: "base64",
+      });
+      expect(mocks.copy).not.toHaveBeenCalled();
+    });
+
+    it("rejects unconverted HEIC when the picker supplied no JPEG export", async () => {
       mocks.open.mockImplementation(() => otherMagic());
       mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [photo] });
 

--- a/apps/mobile/src/lib/composerImages.test.ts
+++ b/apps/mobile/src/lib/composerImages.test.ts
@@ -2,17 +2,46 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@t3tools/contracts";
 
 const files = new Map<string, { base64: string; deleted: boolean }>();
+const paths = { documentUri: "file:///documents" };
 
-vi.mock("expo-file-system", () => ({
-  File: class {
+vi.mock("expo-file-system", () => {
+  class Directory {
     readonly uri: string;
 
-    constructor(uri: string) {
-      this.uri = uri;
+    constructor(root: string | { readonly uri: string }, name: string) {
+      this.uri = `${typeof root === "string" ? root : root.uri}/${name}`;
+    }
+
+    create(): void {}
+  }
+
+  class File {
+    readonly uri: string;
+
+    constructor(source: string | Directory, name?: string) {
+      this.uri = source instanceof Directory ? `${source.uri}/${name}` : source;
     }
 
     get exists(): boolean {
       return files.has(this.uri) && files.get(this.uri)?.deleted === false;
+    }
+
+    get size(): number | null {
+      const entry = files.get(this.uri);
+      if (!entry || entry.deleted) {
+        return null;
+      }
+      return Buffer.from(entry.base64, "base64").byteLength;
+    }
+
+    create(): void {}
+
+    async copy(destination: File): Promise<void> {
+      const entry = files.get(this.uri);
+      if (!entry || entry.deleted) {
+        throw new Error("missing file");
+      }
+      files.set(destination.uri, { base64: entry.base64, deleted: false });
     }
 
     async base64(): Promise<string> {
@@ -29,22 +58,39 @@ vi.mock("expo-file-system", () => ({
         entry.deleted = true;
       }
     }
-  },
-}));
+  }
+
+  return {
+    Directory,
+    File,
+    FileMode: { ReadOnly: "r", WriteOnly: "w" },
+    Paths: {
+      get document() {
+        return { uri: paths.documentUri };
+      },
+    },
+  };
+});
 
 vi.mock("./uuid", () => ({
   uuidv4: () => "attachment-id",
 }));
 
 import {
+  composerImageAttachmentDataUrl,
   convertPastedImagesToAttachments,
   isOwnedPastedImageUri,
   toUploadChatImageAttachments,
 } from "./composerImages";
 
 describe("toUploadChatImageAttachments", () => {
-  it("strips client draft id and previewUri for the startTurn wire shape", () => {
-    expect(
+  beforeEach(() => {
+    files.clear();
+    paths.documentUri = "file:///documents";
+  });
+
+  it("strips client draft id and previewUri for the startTurn wire shape", async () => {
+    await expect(
       toUploadChatImageAttachments([
         {
           id: "client-draft-id",
@@ -56,7 +102,7 @@ describe("toUploadChatImageAttachments", () => {
           previewUri: "file:///tmp/preview.png",
         },
       ]),
-    ).toEqual([
+    ).resolves.toEqual([
       {
         type: "image",
         name: "pasted-image.png",
@@ -65,6 +111,63 @@ describe("toUploadChatImageAttachments", () => {
         dataUrl: "data:image/png;base64,AA==",
       },
     ]);
+  });
+
+  it("reads file-backed image bytes lazily from the owned copy", async () => {
+    const fileUri = "file:///documents/t3-composer-attachments/attachment-id-photo.png";
+    files.set(fileUri, { base64: "aGVsbG8=", deleted: false });
+    const attachment = {
+      id: "client-draft-id",
+      type: "image" as const,
+      name: "photo.png",
+      mimeType: "image/png",
+      sizeBytes: 5,
+      fileUri,
+      previewUri: fileUri,
+    };
+
+    await expect(toUploadChatImageAttachments([attachment])).resolves.toEqual([
+      {
+        type: "image",
+        name: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 5,
+        dataUrl: "data:image/png;base64,aGVsbG8=",
+      },
+    ]);
+  });
+
+  it("resolves a restored image from the current iOS document container", async () => {
+    const fileName = "33333333-3333-4333-8333-333333333333-photo.png";
+    paths.documentUri =
+      "file:///var/mobile/Containers/Data/Application/22222222-2222-4222-8222-222222222222/Documents";
+    const currentUri = `${paths.documentUri}/t3-composer-attachments/${fileName}`;
+    files.set(currentUri, { base64: "aGVsbG8=", deleted: false });
+
+    await expect(
+      composerImageAttachmentDataUrl({
+        id: "client-draft-id",
+        type: "image",
+        name: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 5,
+        fileUri: `file:///var/mobile/Containers/Data/Application/11111111-1111-4111-8111-111111111111/Documents/t3-composer-attachments/${fileName}`,
+        previewUri: currentUri,
+      }),
+    ).resolves.toBe("data:image/png;base64,aGVsbG8=");
+  });
+
+  it("rejects an attachment that lost both its bytes and its file", async () => {
+    await expect(
+      composerImageAttachmentDataUrl({
+        id: "client-draft-id",
+        type: "image",
+        name: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 5,
+        previewUri: "file:///tmp/preview.png",
+      }),
+    ).rejects.toThrow("'photo.png' is no longer available. Attach the image again.");
   });
 });
 
@@ -83,7 +186,7 @@ describe("native pasted image cleanup", () => {
     expect(isOwnedPastedImageUri("https://example.com/t3-composer-paste/id.png")).toBe(false);
   });
 
-  it("converts owned files to data-backed previews and deletes the source", async () => {
+  it("copies owned files into durable storage without inlining bytes, deleting the source", async () => {
     const uri =
       "file:///private/var/mobile/Containers/Data/Application/app/tmp/t3-composer-paste/id.png";
     files.set(uri, { base64: "aGVsbG8=", deleted: false });
@@ -93,13 +196,20 @@ describe("native pasted image cleanup", () => {
       existingCount: 0,
     });
 
+    const fileUri = "file:///documents/t3-composer-attachments/attachment-id-pasted-image.png";
     expect(attachments).toEqual([
-      expect.objectContaining({
-        dataUrl: "data:image/png;base64,aGVsbG8=",
-        previewUri: "data:image/png;base64,aGVsbG8=",
-      }),
+      {
+        id: "attachment-id",
+        type: "image",
+        name: "pasted-image.png",
+        mimeType: "image/png",
+        sizeBytes: 5,
+        fileUri,
+        previewUri: fileUri,
+      },
     ]);
     expect(files.get(uri)?.deleted).toBe(true);
+    expect(files.get(fileUri)?.deleted).toBe(false);
   });
 
   it("deletes rejected and overflow owned files without deleting user-owned files", async () => {
@@ -120,5 +230,10 @@ describe("native pasted image cleanup", () => {
     expect(files.get(rejected)?.deleted).toBe(true);
     expect(files.get(overflow)?.deleted).toBe(true);
     expect(files.get(userOwned)?.deleted).toBe(false);
+    // The rejected paste's partial durable copy must not leak either.
+    expect(
+      files.get("file:///documents/t3-composer-attachments/attachment-id-pasted-image.png")
+        ?.deleted,
+    ).toBe(true);
   });
 });

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -20,9 +20,17 @@ import {
 import { beginForegroundHandoff } from "./foreground-handoff";
 import { uuidv4 } from "./uuid";
 
-export interface DraftComposerImageAttachment extends UploadChatImageAttachment {
+export interface DraftComposerImageAttachment {
   readonly id: string;
+  readonly type: "image";
+  readonly name: string;
+  readonly mimeType: string;
+  readonly sizeBytes: number;
   readonly previewUri: string;
+  /** App-owned copy of the image bytes; every newly created attachment has one. */
+  readonly fileUri?: string;
+  /** Inline bytes persisted by app versions that predate file-backed images. */
+  readonly dataUrl?: string;
   readonly uploadedAttachmentId?: string;
   readonly uploadEnvironmentId?: EnvironmentId;
 }
@@ -40,17 +48,51 @@ export interface DraftComposerFileAttachment {
 
 export type DraftComposerAttachment = DraftComposerImageAttachment | DraftComposerFileAttachment;
 
-/** Wire shape for startTurn: pure uploads without client draft id / previewUri. */
-export function toUploadChatImageAttachments(
+/** Any composer attachment whose bytes live in the app-owned attachment directory. */
+export type FileBackedComposerAttachment = DraftComposerAttachment & { readonly fileUri: string };
+
+/** Files always carry a local copy; images do unless they are legacy inline drafts. */
+export function isFileBackedComposerAttachment(
+  attachment: DraftComposerAttachment,
+): attachment is FileBackedComposerAttachment {
+  return attachment.fileUri !== undefined;
+}
+
+/**
+ * Wire shape for startTurn on servers without attachment uploads: pure inline
+ * uploads without client draft id / previewUri. File-backed images read their
+ * base64 from disk lazily, only when this legacy path is actually taken.
+ */
+export async function toUploadChatImageAttachments(
   attachments: ReadonlyArray<DraftComposerImageAttachment>,
-): ReadonlyArray<UploadChatImageAttachment> {
-  return attachments.map((attachment) => ({
-    type: attachment.type,
-    name: attachment.name,
-    mimeType: attachment.mimeType,
-    sizeBytes: attachment.sizeBytes,
-    dataUrl: attachment.dataUrl,
-  }));
+): Promise<ReadonlyArray<UploadChatImageAttachment>> {
+  return Promise.all(
+    attachments.map(async (attachment) => ({
+      type: attachment.type,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+      dataUrl: await composerImageAttachmentDataUrl(attachment),
+    })),
+  );
+}
+
+/** Inline bytes for one image: legacy drafts carry them, file-backed ones read them from disk. */
+export async function composerImageAttachmentDataUrl(
+  attachment: DraftComposerImageAttachment,
+): Promise<string> {
+  if (attachment.dataUrl !== undefined) {
+    return attachment.dataUrl;
+  }
+  if (attachment.fileUri === undefined) {
+    throw new Error(`'${attachment.name}' is no longer available. Attach the image again.`);
+  }
+  const { File, Paths } = await import("expo-file-system");
+  const uri =
+    resolveOwnedComposerAttachmentFileUri(attachment.fileUri, Paths.document.uri) ??
+    attachment.fileUri;
+  const base64 = await new File(uri).base64();
+  return `data:${attachment.mimeType};base64,${base64}`;
 }
 
 const OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste";
@@ -144,6 +186,29 @@ export async function persistComposerAttachmentFile(
   return destination.uri;
 }
 
+/** Lands in-memory image bytes (clipboard pastes) in the owned attachment directory. */
+async function persistComposerImageBase64(base64: string, name: string): Promise<string> {
+  const { Directory, File, Paths } = await import("expo-file-system");
+  const directory = new Directory(Paths.document, COMPOSER_ATTACHMENT_DIRECTORY);
+  directory.create({ idempotent: true, intermediates: true });
+  const destination = new File(directory, `${uuidv4()}-${name}`);
+  destination.create();
+  try {
+    await destination.write(base64, { encoding: "base64" });
+  } catch (error) {
+    // A failed write must not leave a partial copy no attachment will release.
+    try {
+      if (destination.exists) {
+        destination.delete();
+      }
+    } catch (cleanupError) {
+      console.warn("[composer-attachments] could not remove a partial write", cleanupError);
+    }
+    throw error;
+  }
+  return destination.uri;
+}
+
 export async function removePersistedComposerAttachmentFile(uri: string): Promise<void> {
   try {
     const { File, Paths } = await import("expo-file-system");
@@ -191,6 +256,60 @@ async function createComposerFileAttachment(input: {
   } catch (error) {
     await removePersistedComposerAttachmentFile(fileUri);
     throw error;
+  }
+}
+
+/** Copies a picked or pasted image into app-owned storage, validating the stored bytes. */
+async function createComposerImageAttachment(input: {
+  readonly uri: string;
+  readonly name: string;
+  readonly mimeType: string;
+}): Promise<DraftComposerImageAttachment> {
+  const { File } = await import("expo-file-system");
+  const fileUri = await persistComposerAttachmentFile(
+    input.uri,
+    input.name,
+    PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  );
+  try {
+    const sizeBytes = new File(fileUri).size ?? 0;
+    if (sizeBytes <= 0) {
+      throw new Error(`'${input.name}' is empty or could not be read.`);
+    }
+    if (sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+      throw new Error(
+        fileAttachmentTooLargeMessage(input.name, PROVIDER_SEND_TURN_MAX_IMAGE_BYTES),
+      );
+    }
+    return {
+      id: uuidv4(),
+      type: "image",
+      name: input.name,
+      mimeType: input.mimeType,
+      sizeBytes,
+      fileUri,
+      previewUri: fileUri,
+    };
+  } catch (error) {
+    await removePersistedComposerAttachmentFile(fileUri);
+    throw error;
+  }
+}
+
+/** Reads only the file's magic number; picker exports can be many megabytes. */
+async function hasJpegMagicBytes(uri: string): Promise<boolean> {
+  try {
+    const { File, FileMode } = await import("expo-file-system");
+    const handle = new File(uri).open(FileMode.ReadOnly);
+    try {
+      const bytes = handle.readBytes(3);
+      return bytes.byteLength === 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+    } finally {
+      handle.close();
+    }
+  } catch {
+    // An unreadable file surfaces as a copy failure later; trust the metadata.
+    return false;
   }
 }
 
@@ -325,8 +444,6 @@ export async function pickComposerMedia(input: {
       mediaTypes: input.maxVideoBytes === undefined ? ["images"] : ["images", "videos"],
       allowsMultipleSelection: true,
       selectionLimit: remainingSlots,
-      base64: true,
-      quality: 1,
       shouldDownloadFromNetwork: true,
     });
   } catch (error) {
@@ -382,34 +499,14 @@ export async function pickComposerMedia(input: {
       continue;
     }
 
-    let base64 = asset.base64;
-    if (!base64) {
-      error = `Failed to read '${asset.fileName ?? "image"}'.`;
-      continue;
-    }
-
     let name = asset.fileName?.trim() || "image";
-    // The iOS picker returns JPEG base64 even when its metadata describes HEIC,
-    // PNG, or GIF. Keep supported originals so transparency and animation survive;
-    // use the native JPEG conversion for formats providers cannot accept.
-    if (base64.startsWith("/9j/")) {
-      if (
-        mimeType &&
-        mimeType !== "image/jpeg" &&
-        isProviderSendTurnSupportedImageMimeType(mimeType)
-      ) {
-        try {
-          const { File } = await import("expo-file-system");
-          base64 = await new File(asset.uri).base64();
-        } catch {
-          error = `Failed to read '${name}'.`;
-          continue;
-        }
-      } else {
-        mimeType = "image/jpeg";
-        if (!/\.jpe?g$/i.test(name)) {
-          name = `${name.replace(/\.[^.]+$/, "")}.jpg`;
-        }
+    // The iOS picker can export JPEG bytes while its metadata still describes
+    // the HEIC (or another) original. The file's magic number is the truth:
+    // record JPEG when the picker silently transcoded.
+    if (mimeType !== "image/jpeg" && (await hasJpegMagicBytes(asset.uri))) {
+      mimeType = "image/jpeg";
+      if (!/\.jpe?g$/i.test(name)) {
+        name = `${name.replace(/\.[^.]+$/, "")}.jpg`;
       }
     }
     if (!mimeType || !isProviderSendTurnSupportedImageMimeType(mimeType)) {
@@ -417,22 +514,11 @@ export async function pickComposerMedia(input: {
       continue;
     }
 
-    const sizeBytes = estimateBase64ByteSize(base64);
-    if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-      error = `'${asset.fileName ?? "image"}' exceeds the 10 MB attachment limit.`;
-      continue;
+    try {
+      attachments.push(await createComposerImageAttachment({ uri: asset.uri, name, mimeType }));
+    } catch (cause) {
+      error = cause instanceof Error ? cause.message : `Failed to read '${name}'.`;
     }
-
-    const dataUrl = `data:${mimeType};base64,${base64}`;
-    attachments.push({
-      id: uuidv4(),
-      type: "image",
-      name,
-      mimeType,
-      sizeBytes,
-      dataUrl,
-      previewUri: mimeType === asset.mimeType?.toLowerCase() ? asset.uri : dataUrl,
-    });
   }
 
   return {
@@ -486,6 +572,18 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
       };
     }
 
+    // The clipboard only yields inline bytes; land them in the owned
+    // attachment directory once so drafts persist a path instead of megabytes.
+    let fileUri: string;
+    try {
+      fileUri = await persistComposerImageBase64(base64, "pasted-image.png");
+    } catch (cause) {
+      return {
+        images: [],
+        text: null,
+        error: cause instanceof Error ? cause.message : "Clipboard image could not be saved.",
+      };
+    }
     return {
       images: [
         {
@@ -494,8 +592,8 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
           name: "pasted-image.png",
           mimeType: "image/png",
           sizeBytes,
-          dataUrl: image.data,
-          previewUri: image.data,
+          fileUri,
+          previewUri: fileUri,
         },
       ],
       text: null,
@@ -567,22 +665,14 @@ export async function convertPastedImagesToAttachments(input: {
       if (index >= Math.max(0, remainingSlots)) {
         continue;
       }
-      const file = new File(uri);
-      const base64 = await file.base64();
-      const sizeBytes = estimateBase64ByteSize(base64);
-      if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-        continue;
-      }
       const mimeType = mimeTypeFromUri(uri);
-      results.push({
-        id: uuidv4(),
-        type: "image",
-        name: `pasted-image.${mimeType.split("/")[1] ?? "png"}`,
-        mimeType,
-        sizeBytes,
-        dataUrl: `data:${mimeType};base64,${base64}`,
-        previewUri: ownedTemporaryFile ? `data:${mimeType};base64,${base64}` : uri,
-      });
+      results.push(
+        await createComposerImageAttachment({
+          uri,
+          name: `pasted-image.${mimeType.split("/")[1] ?? "png"}`,
+          mimeType,
+        }),
+      );
     } catch (error) {
       console.warn("Failed to read pasted image", uri, error);
     } finally {

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -527,8 +527,11 @@ export async function pickComposerMedia(input: {
     if (!mimeType || !isProviderSendTurnSupportedImageMimeType(mimeType)) {
       // HEIC and friends: providers cannot accept the original bytes, so land
       // the picker's JPEG export in the owned directory instead of rejecting
-      // the photo. iPhone camera-roll photos are HEIC by default.
-      if (!asset.base64) {
+      // the photo. iPhone camera-roll photos are HEIC by default. iOS always
+      // exports JPEG; Android's quality-1 export is the raw original, so only
+      // accept an export that actually carries the JPEG magic number ("/9j/"
+      // is base64 for FF D8 FF).
+      if (!asset.base64?.startsWith("/9j/")) {
         error = `'${name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
         continue;
       }

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -259,20 +259,15 @@ async function createComposerFileAttachment(input: {
   }
 }
 
-/** Copies a picked or pasted image into app-owned storage, validating the stored bytes. */
-async function createComposerImageAttachment(input: {
-  readonly uri: string;
+/** Validates an already-owned image copy and builds its attachment; deletes the copy on failure. */
+async function ownedComposerImageAttachment(input: {
+  readonly fileUri: string;
   readonly name: string;
   readonly mimeType: string;
 }): Promise<DraftComposerImageAttachment> {
   const { File } = await import("expo-file-system");
-  const fileUri = await persistComposerAttachmentFile(
-    input.uri,
-    input.name,
-    PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
-  );
   try {
-    const sizeBytes = new File(fileUri).size ?? 0;
+    const sizeBytes = new File(input.fileUri).size ?? 0;
     if (sizeBytes <= 0) {
       throw new Error(`'${input.name}' is empty or could not be read.`);
     }
@@ -287,13 +282,27 @@ async function createComposerImageAttachment(input: {
       name: input.name,
       mimeType: input.mimeType,
       sizeBytes,
-      fileUri,
-      previewUri: fileUri,
+      fileUri: input.fileUri,
+      previewUri: input.fileUri,
     };
   } catch (error) {
-    await removePersistedComposerAttachmentFile(fileUri);
+    await removePersistedComposerAttachmentFile(input.fileUri);
     throw error;
   }
+}
+
+/** Copies a picked or pasted image into app-owned storage, validating the stored bytes. */
+async function createComposerImageAttachment(input: {
+  readonly uri: string;
+  readonly name: string;
+  readonly mimeType: string;
+}): Promise<DraftComposerImageAttachment> {
+  const fileUri = await persistComposerAttachmentFile(
+    input.uri,
+    input.name,
+    PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  );
+  return ownedComposerImageAttachment({ fileUri, name: input.name, mimeType: input.mimeType });
 }
 
 /** Reads only the file's magic number; picker exports can be many megabytes. */
@@ -445,6 +454,12 @@ export async function pickComposerMedia(input: {
       allowsMultipleSelection: true,
       selectionLimit: remainingSlots,
       shouldDownloadFromNetwork: true,
+      // The picker's file copy keeps HEIC-family originals as HEIC on every
+      // path, so its JPEG base64 export is the only supported-bytes source
+      // for them. quality 1 keeps the fast original-file copy path; the
+      // base64 string stays transient and is never persisted.
+      base64: true,
+      quality: 1,
     });
   } catch (error) {
     return {
@@ -510,7 +525,26 @@ export async function pickComposerMedia(input: {
       }
     }
     if (!mimeType || !isProviderSendTurnSupportedImageMimeType(mimeType)) {
-      error = `'${name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+      // HEIC and friends: providers cannot accept the original bytes, so land
+      // the picker's JPEG export in the owned directory instead of rejecting
+      // the photo. iPhone camera-roll photos are HEIC by default.
+      if (!asset.base64) {
+        error = `'${name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+        continue;
+      }
+      const jpegName = /\.jpe?g$/i.test(name) ? name : `${name.replace(/\.[^.]+$/, "")}.jpg`;
+      try {
+        const jpegUri = await persistComposerImageBase64(asset.base64, jpegName);
+        attachments.push(
+          await ownedComposerImageAttachment({
+            fileUri: jpegUri,
+            name: jpegName,
+            mimeType: "image/jpeg",
+          }),
+        );
+      } catch (cause) {
+        error = cause instanceof Error ? cause.message : `Failed to read '${name}'.`;
+      }
       continue;
     }
 

--- a/apps/mobile/src/lib/localAttachmentPreview.ts
+++ b/apps/mobile/src/lib/localAttachmentPreview.ts
@@ -1,13 +1,13 @@
 import { videoMimeType } from "@t3tools/shared/video";
 
-import type { DraftComposerFileAttachment } from "./composerImages";
+import type { FileBackedComposerAttachment } from "./composerImages";
 import { resolveOwnedComposerAttachmentFileUri } from "./composerAttachmentFiles";
 import { shareLocalAttachment, type AttachmentPreviewFile } from "./attachmentDownload";
 import { retainComposerAttachmentFileForPreview } from "../state/use-composer-drafts";
 
 /** Retains the draft original for preview and gives each outgoing share its own lease. */
 export async function loadLocalAttachmentPreview(
-  attachment: DraftComposerFileAttachment,
+  attachment: FileBackedComposerAttachment,
   signal: AbortSignal,
 ): Promise<AttachmentPreviewFile | null> {
   if (signal.aborted) return null;

--- a/apps/mobile/src/lib/projectThreadStartTurn.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.ts
@@ -8,7 +8,6 @@ import {
   type RuntimeMode,
 } from "@t3tools/contracts";
 
-import { toUploadChatImageAttachments, type DraftComposerAttachment } from "./composerImages";
 import type { UploadedMobileAttachment } from "./attachmentUpload";
 
 export function deriveThreadTitleFromPrompt(value: string): string {
@@ -29,8 +28,8 @@ export interface ProjectThreadStartTurnSpec {
   readonly messageId: string;
   readonly createdAt: string;
   readonly text: string;
-  readonly attachments: ReadonlyArray<DraftComposerAttachment>;
-  readonly uploadedAttachments?: ReadonlyArray<UploadedMobileAttachment>;
+  /** Wire attachments from `prepareTurnAttachments`, in composer order. */
+  readonly uploadedAttachments: ReadonlyArray<UploadedMobileAttachment>;
   readonly modelSelection: ModelSelection;
   readonly runtimeMode: RuntimeMode;
   readonly interactionMode: ProviderInteractionMode;
@@ -57,11 +56,7 @@ export function buildProjectThreadStartTurnInput(spec: ProjectThreadStartTurnSpe
       messageId: MessageId.make(spec.messageId),
       role: "user" as const,
       text: spec.text,
-      attachments:
-        spec.uploadedAttachments ??
-        toUploadChatImageAttachments(
-          spec.attachments.filter((attachment) => attachment.type === "image"),
-        ),
+      attachments: spec.uploadedAttachments,
     },
     modelSelection: spec.modelSelection,
     titleSeed: title,

--- a/apps/mobile/src/state/composer-attachment-uploads.ts
+++ b/apps/mobile/src/state/composer-attachment-uploads.ts
@@ -4,6 +4,7 @@ import { Atom } from "effect/unstable/reactivity";
 import { useEffect, useRef } from "react";
 
 import { prepareTurnAttachments } from "../lib/attachmentUpload";
+import { isFileBackedComposerAttachment } from "../lib/composerImages";
 import {
   composerAttachmentUploadKey,
   composerDraftEnvironmentId,
@@ -60,10 +61,9 @@ export function useComposerAttachmentUploadWorker() {
     const queue = createComposerAttachmentUploadQueue({
       onChange: (states) => appAtomRegistry.set(composerAttachmentUploadsAtom, states),
       upload: async ({ environmentId, attachment }, signal, onProgress) => {
-        const release =
-          attachment.type === "file"
-            ? retainComposerAttachmentFileForPreview(attachment)
-            : undefined;
+        const release = isFileBackedComposerAttachment(attachment)
+          ? retainComposerAttachmentFileForPreview(attachment)
+          : undefined;
         try {
           const result = await prepareTurnAttachments({
             environmentId,

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -25,7 +25,8 @@ import { DraftComposerAttachmentSchema } from "../lib/composer-image-schema";
 import type { DraftComposerAttachment } from "../lib/composerImages";
 import { scopedThreadKey } from "../lib/scopedEntities";
 
-const THREAD_OUTBOX_SCHEMA_VERSION = 3;
+// v4: image attachments persist an owned fileUri instead of inline dataUrl bytes.
+const THREAD_OUTBOX_SCHEMA_VERSION = 4;
 const THREAD_OUTBOX_MAX_RETRY_DELAY_MS = 16_000;
 
 const QueuedThreadCreationSchema = Schema.Struct({
@@ -41,7 +42,7 @@ const QueuedThreadCreationSchema = Schema.Struct({
 });
 
 export const QueuedThreadMessageSchema = Schema.Struct({
-  schemaVersion: Schema.Literals([1, 2, THREAD_OUTBOX_SCHEMA_VERSION]),
+  schemaVersion: Schema.Literals([1, 2, 3, THREAD_OUTBOX_SCHEMA_VERSION]),
   environmentId: EnvironmentId,
   threadId: ThreadId,
   messageId: MessageId,

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -102,6 +102,32 @@ describe("thread outbox", () => {
     expect(decodeQueuedThreadMessage(encodeQueuedThreadMessage(message))).toEqual(message);
   });
 
+  it("persists image attachment paths without embedding their contents", () => {
+    const message = {
+      ...queuedMessage({
+        messageId: "message-image",
+        createdAt: "2026-06-08T10:00:01.000Z",
+      }),
+      attachments: [
+        {
+          id: "image-1",
+          type: "image" as const,
+          name: "photo.png",
+          mimeType: "image/png",
+          sizeBytes: 3,
+          fileUri: "file:///documents/t3-composer-attachments/photo.png",
+          previewUri: "file:///documents/t3-composer-attachments/photo.png",
+          uploadedAttachmentId: "pending-photo-png",
+          uploadEnvironmentId: EnvironmentId.make("environment-1"),
+        },
+      ],
+    } satisfies QueuedThreadMessage;
+
+    const encoded = encodeQueuedThreadMessage(message);
+    expect(JSON.stringify(encoded)).not.toContain("dataUrl");
+    expect(decodeQueuedThreadMessage(encoded)).toEqual(message);
+  });
+
   it("persists the exact selector snapshot while remaining compatible with v1 messages", () => {
     const legacyMessage = queuedMessage({
       messageId: "message-1",

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -303,6 +303,48 @@ describe("mobile composer drafts", () => {
     expect(composerAttachmentCleanupMocks.remove).toHaveBeenCalledWith(file.fileUri);
   });
 
+  it("retains a referenced file-backed image and releases it once unreferenced", async () => {
+    const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
+    onTestFinished(() => outboxLoad.mockRestore());
+    const image = {
+      id: "image-1",
+      type: "image" as const,
+      name: "photo.png",
+      mimeType: "image/png",
+      sizeBytes: 3,
+      fileUri: "file:///documents/t3-composer-attachments/photo.png",
+      previewUri: "file:///documents/t3-composer-attachments/photo.png",
+    };
+    appAtomRegistry.set(composerDraftsAtom, {
+      "environment-1:thread-1": { text: "look at this", attachments: [image] },
+    });
+
+    await releaseUnusedComposerAttachmentFiles([image]);
+    expect(composerAttachmentCleanupMocks.remove).not.toHaveBeenCalled();
+
+    // A queued outbox message must keep the bytes alive after the draft clears.
+    appAtomRegistry.set(composerDraftsAtom, {});
+    appAtomRegistry.set(threadOutboxManager.queuedMessagesByThreadKeyAtom, {
+      "environment-1:thread-1": [
+        {
+          environmentId: EnvironmentId.make("environment-1"),
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("queued-image"),
+          commandId: CommandId.make("command-image"),
+          text: "look at this",
+          attachments: [image],
+          createdAt: "2026-08-31T12:00:00.000Z",
+        },
+      ],
+    });
+    await releaseUnusedComposerAttachmentFiles([image]);
+    expect(composerAttachmentCleanupMocks.remove).not.toHaveBeenCalled();
+
+    appAtomRegistry.set(threadOutboxManager.queuedMessagesByThreadKeyAtom, {});
+    await releaseUnusedComposerAttachmentFiles([image]);
+    expect(composerAttachmentCleanupMocks.remove).toHaveBeenCalledExactlyOnceWith(image.fileUri);
+  });
+
   it("keeps a failed-send draft's pending upload for retry", async () => {
     const outboxLoad = vi.spyOn(threadOutboxManager, "load").mockResolvedValue(true);
     onTestFinished(() => outboxLoad.mockRestore());

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -20,7 +20,7 @@ import {
   isComposerAttachmentFileRetained,
   retainComposerAttachmentFile,
 } from "../lib/composerAttachmentFiles";
-import type { DraftComposerAttachment, DraftComposerFileAttachment } from "../lib/composerImages";
+import type { DraftComposerAttachment, FileBackedComposerAttachment } from "../lib/composerImages";
 import { SerializedAsyncQueue } from "../lib/serialized-async-queue";
 import { appAtomRegistry } from "./atom-registry";
 import {
@@ -376,7 +376,7 @@ function isComposerAttachmentFileReferenced(fileUri: string): boolean {
   return [...drafts, ...queuedMessages, ...signedOutAttachmentOwners()].some((owner) =>
     owner.attachments.some(
       (attachment) =>
-        attachment.type === "file" &&
+        attachment.fileUri !== undefined &&
         composerAttachmentFileReferenceKey(attachment.fileUri) === referenceKey,
     ),
   );
@@ -403,9 +403,9 @@ export async function releaseUnusedComposerAttachmentFiles(
   attachments: ReadonlyArray<DraftComposerAttachment>,
 ): Promise<void> {
   const candidates = new Set(
-    attachments
-      .filter((attachment) => attachment.type === "file")
-      .map((attachment) => attachment.fileUri),
+    attachments.flatMap((attachment) =>
+      attachment.fileUri !== undefined ? [attachment.fileUri] : [],
+    ),
   );
   const uploadCandidates = new Map<EnvironmentId, Set<string>>();
   for (const attachment of attachments) {
@@ -454,7 +454,7 @@ export async function releaseUnusedComposerAttachmentFiles(
     incomingShareFileUris = new Set(
       incomingShares.flatMap((share) =>
         share.attachments.flatMap((attachment) =>
-          attachment.type === "file"
+          attachment.fileUri !== undefined
             ? [composerAttachmentFileReferenceKey(attachment.fileUri)]
             : [],
         ),
@@ -509,7 +509,8 @@ export function scheduleUnusedComposerAttachmentCleanup(
 ): void {
   if (
     !attachments.some(
-      (attachment) => attachment.type === "file" || attachment.uploadedAttachmentId !== undefined,
+      (attachment) =>
+        attachment.fileUri !== undefined || attachment.uploadedAttachmentId !== undefined,
     )
   ) {
     return;
@@ -521,7 +522,7 @@ export function scheduleUnusedComposerAttachmentCleanup(
 
 /** Keeps a native preview or upload readable until it finishes, then retries ownership cleanup. */
 export function retainComposerAttachmentFileForPreview(
-  attachment: DraftComposerFileAttachment,
+  attachment: FileBackedComposerAttachment,
 ): () => void {
   return retainComposerAttachmentFile(attachment.fileUri, () => {
     scheduleUnusedComposerAttachmentCleanup([attachment]);

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -819,7 +819,6 @@ export function useThreadOutboxDrain(): void {
           messageId: queuedMessage.messageId,
           createdAt: queuedMessage.createdAt,
           text: queuedMessage.text.trim(),
-          attachments: queuedMessage.attachments,
           uploadedAttachments: prepared.attachments,
           modelSelection,
           runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -69,6 +69,7 @@ import {
   type ComposerFileAttachment,
   type ComposerImageAttachment,
   composerFileNeedsReattach,
+  partializeComposerDraftStoreState,
   useComposerDraftStore,
   DraftId,
 } from "./composerDraftStore";
@@ -78,7 +79,7 @@ import {
   insertInlineTerminalContextPlaceholder,
   type TerminalContextDraft,
 } from "./lib/terminalContext";
-import { createDebouncedStorage } from "./lib/storage";
+import { createDeferredStorage } from "./lib/storage";
 
 function makeImage(input: {
   id: string;
@@ -319,7 +320,6 @@ describe("composerDraftStore file attachments", () => {
 
     const persistApi = useComposerDraftStore.persist as unknown as {
       getOptions: () => {
-        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
         merge: (
           persistedState: unknown,
           currentState: ReturnType<typeof useComposerDraftStore.getState>,
@@ -327,9 +327,7 @@ describe("composerDraftStore file attachments", () => {
       };
     };
     const options = persistApi.getOptions();
-    const persisted = options.partialize(useComposerDraftStore.getState()) as {
-      draftsByThreadKey: Record<string, { files?: Array<Record<string, unknown>> }>;
-    };
+    const persisted = partializeComposerDraftStoreState(useComposerDraftStore.getState());
 
     expect(persisted.draftsByThreadKey[threadKeyFor(threadId, TEST_ENVIRONMENT_ID)]?.files).toEqual(
       [
@@ -367,7 +365,6 @@ describe("composerDraftStore file attachments", () => {
 
     const persistApi = useComposerDraftStore.persist as unknown as {
       getOptions: () => {
-        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
         merge: (
           persistedState: unknown,
           currentState: ReturnType<typeof useComposerDraftStore.getState>,
@@ -375,9 +372,7 @@ describe("composerDraftStore file attachments", () => {
       };
     };
     const options = persistApi.getOptions();
-    const persisted = options.partialize(useComposerDraftStore.getState()) as {
-      draftsByThreadKey: Record<string, { files?: Array<Record<string, unknown>> }>;
-    };
+    const persisted = partializeComposerDraftStoreState(useComposerDraftStore.getState());
 
     expect(persisted.draftsByThreadKey[threadKeyFor(threadId, TEST_ENVIRONMENT_ID)]?.files).toEqual(
       [
@@ -927,12 +922,9 @@ describe("composerDraftStore terminal contexts", () => {
       .getState()
       .addTerminalContext(threadRef, makeTerminalContext({ id: "ctx-persist" }));
 
-    const persistApi = useComposerDraftStore.persist as unknown as {
-      getOptions: () => {
-        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
-      };
-    };
-    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+    const persistedState = partializeComposerDraftStoreState(
+      useComposerDraftStore.getState(),
+    ) as unknown as {
       draftsByThreadKey?: Record<string, { terminalContexts?: Array<Record<string, unknown>> }>;
     };
 
@@ -1101,12 +1093,9 @@ describe("composerDraftStore element contexts", () => {
 
   it("persists element contexts via the partializer (round-trippable)", () => {
     useComposerDraftStore.getState().addElementContext(threadRef, baseSelection);
-    const persistApi = useComposerDraftStore.persist as unknown as {
-      getOptions: () => {
-        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
-      };
-    };
-    const persisted = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+    const persisted = partializeComposerDraftStoreState(
+      useComposerDraftStore.getState(),
+    ) as unknown as {
       draftsByThreadKey?: Record<string, { elementContexts?: Array<Record<string, unknown>> }>;
     };
     const entry =
@@ -1159,12 +1148,9 @@ describe("composerDraftStore review comments", () => {
   it("persists review comments and clears them with composer content", () => {
     const store = useComposerDraftStore.getState();
     store.addReviewComment(threadRef, comment);
-    const persistApi = useComposerDraftStore.persist as unknown as {
-      getOptions: () => {
-        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
-      };
-    };
-    const persisted = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+    const persisted = partializeComposerDraftStoreState(
+      useComposerDraftStore.getState(),
+    ) as unknown as {
       draftsByThreadKey?: Record<string, { reviewComments?: Array<Record<string, unknown>> }>;
     };
 
@@ -2571,7 +2557,7 @@ describe("composerDraftStore runtime and interaction settings", () => {
 });
 
 // ---------------------------------------------------------------------------
-// createDebouncedStorage
+// createDeferredStorage
 // ---------------------------------------------------------------------------
 
 function createMockStorage() {
@@ -2587,9 +2573,12 @@ function createMockStorage() {
   };
 }
 
-describe("createDebouncedStorage", () => {
+describe("createDeferredStorage", () => {
+  const serialize = vi.fn((value: string) => `s:${value}`);
+
   beforeEach(() => {
     vi.useFakeTimers();
+    serialize.mockClear();
   });
 
   afterEach(() => {
@@ -2599,69 +2588,74 @@ describe("createDebouncedStorage", () => {
   it("delegates getItem immediately", () => {
     const base = createMockStorage();
     base.getItem.mockReturnValueOnce("value");
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     expect(storage.getItem("key")).toBe("value");
     expect(base.getItem).toHaveBeenCalledWith("key");
   });
 
-  it("does not write to base storage until the debounce fires", () => {
+  it("neither serializes nor writes until the debounce fires", () => {
     const base = createMockStorage();
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     storage.setItem("key", "v1");
+    expect(serialize).not.toHaveBeenCalled();
     expect(base.setItem).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(299);
+    expect(serialize).not.toHaveBeenCalled();
     expect(base.setItem).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(1);
-    expect(base.setItem).toHaveBeenCalledWith("key", "v1");
+    expect(base.setItem).toHaveBeenCalledWith("key", "s:v1");
   });
 
-  it("only writes the last value when setItem is called rapidly", () => {
+  it("serializes and writes only the last value when setItem is called rapidly", () => {
     const base = createMockStorage();
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     storage.setItem("key", "v1");
     storage.setItem("key", "v2");
     storage.setItem("key", "v3");
 
     vi.advanceTimersByTime(300);
+    expect(serialize).toHaveBeenCalledTimes(1);
     expect(base.setItem).toHaveBeenCalledTimes(1);
-    expect(base.setItem).toHaveBeenCalledWith("key", "v3");
+    expect(base.setItem).toHaveBeenCalledWith("key", "s:v3");
   });
 
   it("removeItem cancels a pending setItem write", () => {
     const base = createMockStorage();
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     storage.setItem("key", "v1");
     storage.removeItem("key");
 
     vi.advanceTimersByTime(300);
+    expect(serialize).not.toHaveBeenCalled();
     expect(base.setItem).not.toHaveBeenCalled();
     expect(base.removeItem).toHaveBeenCalledWith("key");
   });
 
-  it("flush writes the pending value immediately", () => {
+  it("flush serializes and writes the pending value immediately", () => {
     const base = createMockStorage();
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     storage.setItem("key", "v1");
     expect(base.setItem).not.toHaveBeenCalled();
 
     storage.flush();
-    expect(base.setItem).toHaveBeenCalledWith("key", "v1");
+    expect(base.setItem).toHaveBeenCalledWith("key", "s:v1");
 
     // Timer should be cancelled; no duplicate write.
     vi.advanceTimersByTime(300);
+    expect(serialize).toHaveBeenCalledTimes(1);
     expect(base.setItem).toHaveBeenCalledTimes(1);
   });
 
   it("flush is a no-op when nothing is pending", () => {
     const base = createMockStorage();
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     storage.flush();
     expect(base.setItem).not.toHaveBeenCalled();
@@ -2669,7 +2663,7 @@ describe("createDebouncedStorage", () => {
 
   it("flush after removeItem is a no-op", () => {
     const base = createMockStorage();
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     storage.setItem("key", "v1");
     storage.removeItem("key");
@@ -2680,7 +2674,7 @@ describe("createDebouncedStorage", () => {
 
   it("setItem works normally after removeItem cancels a pending write", () => {
     const base = createMockStorage();
-    const storage = createDebouncedStorage(base);
+    const storage = createDeferredStorage(base, serialize);
 
     storage.setItem("key", "v1");
     storage.removeItem("key");
@@ -2688,6 +2682,6 @@ describe("createDebouncedStorage", () => {
 
     vi.advanceTimersByTime(300);
     expect(base.setItem).toHaveBeenCalledTimes(1);
-    expect(base.setItem).toHaveBeenCalledWith("key", "v2");
+    expect(base.setItem).toHaveBeenCalledWith("key", "s:v2");
   });
 });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -54,9 +54,9 @@ import {
   newElementContextId,
 } from "./lib/elementContext";
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+import { persist, type PersistStorage, type StorageValue } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
-import { createDebouncedStorage, createMemoryStorage } from "./lib/storage";
+import { createDeferredStorage, createMemoryStorage } from "./lib/storage";
 import { getDefaultServerModel } from "./providerModels";
 import { UnifiedSettings } from "@t3tools/contracts/settings";
 import { ReviewCommentContextSchema, type ReviewCommentContext } from "./reviewCommentContext";
@@ -74,10 +74,46 @@ export type DraftId = typeof DraftId.Type;
 
 const COMPOSER_PERSIST_DEBOUNCE_MS = 300;
 
-const composerDebouncedStorage = createDebouncedStorage(
+/**
+ * What flows from `partialize` into the debounced storage. The persist
+ * pipeline used to run the full draft walk + JSON.stringify on every store
+ * write — every keystroke serialized all persisted drafts, including base64
+ * image attachments. `partialize` now only captures the live state reference,
+ * and the real walk + stringify run once per debounced flush. Already
+ * persisted-shape values (migration seeds written straight to storage) pass
+ * through serialization untouched.
+ */
+type ComposerPersistState =
+  | { capturedState: ComposerDraftStoreState }
+  | PersistedComposerDraftStoreState;
+
+const composerDebouncedStorage = createDeferredStorage<StorageValue<ComposerPersistState>>(
   typeof localStorage !== "undefined" ? localStorage : createMemoryStorage(),
+  (value) =>
+    JSON.stringify({
+      state:
+        "capturedState" in value.state
+          ? partializeComposerDraftStoreState(value.state.capturedState)
+          : value.state,
+      version: value.version,
+    }),
   COMPOSER_PERSIST_DEBOUNCE_MS,
 );
+
+const composerPersistStorage: PersistStorage<ComposerPersistState> = {
+  getItem: (name) => {
+    // The base storage is localStorage (or in-memory), which is synchronous.
+    const raw = composerDebouncedStorage.getItem(name);
+    if (typeof raw !== "string") {
+      return null;
+    }
+    // Parsed persisted JSON. `migrate` and `merge` normalize it from unknown,
+    // so the cast mirrors the one zustand's createJSONStorage performs.
+    return JSON.parse(raw) as StorageValue<ComposerPersistState>;
+  },
+  setItem: (name, value) => composerDebouncedStorage.setItem(name, value),
+  removeItem: (name) => composerDebouncedStorage.removeItem(name),
+};
 
 // Flush pending composer draft writes before page unload to prevent data loss.
 if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
@@ -1982,7 +2018,12 @@ function migratePersistedComposerDraftStoreState(
   };
 }
 
-function partializeComposerDraftStoreState(
+/**
+ * Produces the persisted draft-store shape. Runs once per debounced storage
+ * flush (see ComposerPersistState), not on every store write. Exported so
+ * tests can exercise the persistence round trip directly.
+ */
+export function partializeComposerDraftStoreState(
   state: ComposerDraftStoreState,
 ): PersistedComposerDraftStoreState {
   // Draft sessions worth persisting: mapped (a new-thread flow targets
@@ -3921,9 +3962,11 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
     {
       name: COMPOSER_DRAFT_STORAGE_KEY,
       version: COMPOSER_DRAFT_STORAGE_VERSION,
-      storage: createJSONStorage(() => composerDebouncedStorage),
+      storage: composerPersistStorage,
       migrate: migratePersistedComposerDraftStoreState,
-      partialize: partializeComposerDraftStoreState,
+      // Cheap capture only; the draft walk + stringify happen at flush time
+      // inside composerDebouncedStorage. See ComposerPersistState.
+      partialize: (state): ComposerPersistState => ({ capturedState: state }),
       merge: (persistedState, currentState) => {
         const normalizedPersisted =
           normalizeCurrentPersistedComposerDraftStoreState(persistedState);

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -6,7 +6,10 @@ export interface StateStorage<R = unknown> {
   removeItem: (name: string) => R;
 }
 
-export interface DebouncedStorage<R = unknown> extends StateStorage<R> {
+export interface DeferredStorage<TValue> {
+  getItem: (name: string) => string | null | Promise<string | null>;
+  setItem: (name: string, value: TValue) => void;
+  removeItem: (name: string) => void;
   flush: () => void;
 }
 
@@ -39,14 +42,21 @@ export function resolveStorage(storage: Partial<StateStorage> | null | undefined
   return isStateStorage(storage) ? storage : createMemoryStorage();
 }
 
-export function createDebouncedStorage(
+/**
+ * Debounced storage that also defers serialization: `setItem` only holds the
+ * latest raw value, and `serialize` runs once when the debounce fires (or on
+ * `flush`). This keeps rapid updates — such as composer keystrokes — at
+ * "store a reference" cost instead of serializing the full value every time.
+ */
+export function createDeferredStorage<TValue>(
   baseStorage: Partial<StateStorage> | null | undefined,
+  serialize: (value: TValue) => string,
   debounceMs: number = 300,
-): DebouncedStorage {
+): DeferredStorage<TValue> {
   const resolvedStorage = resolveStorage(baseStorage);
   const debouncedSetItem = new Debouncer(
-    (name: string, value: string) => {
-      resolvedStorage.setItem(name, value);
+    (name: string, value: TValue) => {
+      resolvedStorage.setItem(name, serialize(value));
     },
     { wait: debounceMs },
   );


### PR DESCRIPTION
Typing next to a heavy composer draft was paying for the whole draft store on every keystroke, and mobile image drafts were storing megabytes of base64 in JSON. This is item 03 of the performance opportunity audit.

**Web:** the persist pipeline ran the full draft walk plus `JSON.stringify` on every store write, so each keystroke serialized every persisted draft, including base64 image attachments; only the final `localStorage.setItem` was debounced. `partialize` now captures the live state reference cheaply, and the real walk + stringify run once per idle flush inside the debounced storage (`createDeferredStorage`). Flush-on-unload, flush-before-attachment-verify, migration writeback, and hydration behavior are unchanged.

**Mobile:** picked and pasted images persisted full base64 data URLs into `drafts.json`, `thread-outbox/*.json`, and `incoming-shares/*.json`, re-serialized on every 200 ms draft debounce and re-parsed at cold start. Images are now file-backed the way file attachments already were: bytes are copied once into the app-owned attachment directory and drafts persist metadata plus `fileUri`. Uploads stream from the owned file (no temp base64 staging), and base64 is materialized lazily only for the old-server inline fallback. Legacy `dataUrl` drafts still hydrate, preview, upload, and send; the outbox schema version moves 3 → 4 following the existing pattern.

## Measurements

| Metric | Before | After |
| --- | --- | --- |
| Web: full draft-store serializations per 200 keystrokes | 200 | 1 |
| Web: bytes serialized during those keystrokes | 534.6 MB | 2.7 MB |
| Web: main-thread time in the typing loop | 1693.5 ms | 6.8 ms |
| Mobile: persisted draft JSON for one 8 MB image | 21.4 MB (22,369,796 B) | 322 B |

Web numbers are from a store seeded with 20 drafts, one holding two 1 MB persisted images, driving 200 `setPrompt` calls through the real persist pipeline. Mobile numbers encode one attachment through the actual draft schema (the legacy shape stored the data URL twice: `dataUrl` + `previewUri`).

## Draft persistence still works (type → reload → restored)

![Composer draft typed, page reloaded, draft restored](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/fecebb1a-8ba8-4d8e-8231-1916429f44cb/point-03-draft-persistence.gif)

Recorded against a live dev environment running this branch: the draft is typed, flushed after idle, and restored into the composer and sidebar after a full page reload.

## Verification

- `vp test run` across all 12 touched suites: 333 tests pass (web draft store 105, mobile attachment/draft/outbox/share suites 228).
- Scoped typecheck (`tsgo --noEmit` for web, `tsc --noEmit` for mobile) and `vp lint` on changed files: clean.
- Web verified end to end in a real browser (typing, idle flush to localStorage, reload restore). Mobile verified through tests and typecheck only; no simulator run on this Linux workbench.

Known limitation: downgrading the mobile app to a pre-change build will not decode fileUri-only drafts or v4 outbox entries, the same class of impact as the earlier file-attachment rollout.

Change made by Claude Fable 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to mobile attachment lifecycle, outbox schema v4, and async image upload wiring; legacy paths are preserved but downgrading the mobile app will not read file-only drafts.
> 
> **Overview**
> **Web:** Composer draft persistence no longer runs the full draft walk and `JSON.stringify` on every keystroke. `partialize` only captures a live state reference; `createDeferredStorage` runs normalization and serialization once per debounced flush (flush-on-unload unchanged).
> 
> **Mobile:** New image attachments (picker, clipboard, paste, incoming share) are stored as app-owned files with `fileUri` metadata instead of megabyte-scale `dataUrl` in drafts, thread outbox (schema **v3 → v4**), and share drafts. Uploads stream from the owned file; base64 is read lazily only for servers without image uploads. Legacy inline `dataUrl` drafts still decode and send. Image previews rebase paths when the iOS document container moves; review composer cleans up unreferenced files on dismiss/remove.
> 
> **Send path:** `buildProjectThreadStartTurnInput` now always uses prepared `uploadedAttachments` (raw draft attachments removed from project start/outbox drain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1f781467d651c6d0659612904d2957f1e771d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch composer image attachments to app-owned files
> - Replaces inline base64 `dataUrl` image storage with app-owned file paths (`fileUri`) across composer drafts, outbox, and incoming shares.
> - Adds `FileBackedComposerAttachment` type and `isFileBackedComposerAttachment` guard to narrow attachments with a defined `fileUri`.
> - `toUploadChatImageAttachments` is now async and lazily reads base64 from disk only when the server lacks image uploads.
> - `uploadFileBytes` uploads directly from `fileUri` and only stages temporary files for legacy inline images.
> - Web composer draft persistence uses `createDeferredStorage` with deferred serialization; `partializeComposerDraftStoreState` is now exported.
> - Bumps thread outbox schema to v4; accepts v1-v4 on decode.
> - Behavioral Change: schema accepts `dataUrl` or `fileUri`; old drafts without `fileUri` still work via legacy inline path. Drafts/outbox now persist image paths instead of bytes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c1f781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->