### PR TITLE
perf(clients): lease sidebar status by visibility

### DIFF
--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -15,11 +15,18 @@ import { presentThreadPr, type ThreadPrPresentation } from "./thread-pr-presenta
 import { vcsEnvironment } from "./vcs";
 
 const linkedPullRequestDetailAtom = createLinkedPullRequestDetailAtomFamily(connectionAtomRuntime);
-const threadPrSnapshotAtoms = Atom.family((key: string) =>
-  Atom.make<ThreadPrPresentation | null>(null).pipe(
-    Atom.keepAlive,
-    Atom.withLabel(`mobile:thread-pr-snapshot:${key}`),
-  ),
+const MAX_THREAD_PR_SNAPSHOTS = 500;
+
+interface ThreadPrSnapshot {
+  readonly identity: string;
+  readonly presentation: ThreadPrPresentation;
+}
+
+// One bounded cache survives row virtualization without retaining one live
+// atom for every thread, branch, directory, or linked pull request ever seen.
+const threadPrSnapshotsAtom = Atom.make<ReadonlyMap<string, ThreadPrSnapshot>>(new Map()).pipe(
+  Atom.keepAlive,
+  Atom.withLabel("mobile:thread-pr-snapshots"),
 );
 
 export {
@@ -39,12 +46,13 @@ export function useThreadPr(
   projectCwd: string | null,
 ): ThreadPrPresentation | null {
   const cwd = thread.worktreePath ?? projectCwd;
-  const snapshotKey = JSON.stringify([
-    scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+  const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+  const snapshotIdentity = JSON.stringify(
     thread.linkedPullRequest ?? { branch: thread.branch, cwd },
-  ]);
-  const snapshotAtom = useMemo(() => threadPrSnapshotAtoms(snapshotKey), [snapshotKey]);
-  const snapshot = useAtomValue(snapshotAtom);
+  );
+  const snapshots = useAtomValue(threadPrSnapshotsAtom);
+  const snapshotEntry = snapshots.get(threadKey);
+  const snapshot = snapshotEntry?.identity === snapshotIdentity ? snapshotEntry.presentation : null;
   const gitStatus = useEnvironmentQuery(
     thread.linkedPullRequest == null && thread.branch !== null && cwd !== null
       ? vcsEnvironment.status({
@@ -86,8 +94,29 @@ export function useThreadPr(
   }, [gitStatus.data, linkedPullRequest.data, thread.branch, thread.linkedPullRequest]);
 
   useEffect(() => {
-    if (live !== undefined && snapshot !== live) appAtomRegistry.set(snapshotAtom, live);
-  }, [live, snapshot, snapshotAtom]);
+    if (live === undefined) return;
+    appAtomRegistry.modify(threadPrSnapshotsAtom, (current) => {
+      const existing = current.get(threadKey);
+      if (live === null) {
+        if (existing === undefined) return [false, current];
+        const next = new Map(current);
+        next.delete(threadKey);
+        return [true, next];
+      }
+      if (existing?.identity === snapshotIdentity && existing.presentation === live) {
+        return [false, current];
+      }
+      const next = new Map(current);
+      next.delete(threadKey);
+      next.set(threadKey, { identity: snapshotIdentity, presentation: live });
+      while (next.size > MAX_THREAD_PR_SNAPSHOTS) {
+        const oldestKey = next.keys().next().value;
+        if (oldestKey === undefined) break;
+        next.delete(oldestKey);
+      }
+      return [true, next];
+    });
+  }, [live, snapshotIdentity, threadKey]);
 
   return live === undefined ? snapshot : live;
 }

--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -6,7 +6,7 @@ import {
   pullRequestDetailToVcsStatus,
 } from "@t3tools/client-runtime/state/pull-requests";
 import { Atom } from "effect/unstable/reactivity";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { connectionAtomRuntime } from "../connection/runtime";
 import { appAtomRegistry } from "./atom-registry";
@@ -50,8 +50,14 @@ export function useThreadPr(
   const snapshotIdentity = JSON.stringify(
     thread.linkedPullRequest ?? { branch: thread.branch, cwd },
   );
-  const snapshots = useAtomValue(threadPrSnapshotsAtom);
-  const snapshotEntry = snapshots.get(threadKey);
+  // Select this row's entry so writes for other rows do not re-render it.
+  const snapshotEntry = useAtomValue(
+    threadPrSnapshotsAtom,
+    useCallback(
+      (current: ReadonlyMap<string, ThreadPrSnapshot>) => current.get(threadKey),
+      [threadKey],
+    ),
+  );
   const snapshot = snapshotEntry?.identity === snapshotIdentity ? snapshotEntry.presentation : null;
   const gitStatus = useEnvironmentQuery(
     thread.linkedPullRequest == null && thread.branch !== null && cwd !== null

--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -1,15 +1,26 @@
+import { useAtomValue } from "@effect/atom-react";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import {
   createLinkedPullRequestDetailAtomFamily,
   pullRequestDetailToVcsStatus,
 } from "@t3tools/client-runtime/state/pull-requests";
+import { Atom } from "effect/unstable/reactivity";
+import { useEffect, useMemo } from "react";
 
 import { connectionAtomRuntime } from "../connection/runtime";
+import { appAtomRegistry } from "./atom-registry";
 import { useEnvironmentQuery } from "./query";
 import { presentThreadPr, type ThreadPrPresentation } from "./thread-pr-presentation";
 import { vcsEnvironment } from "./vcs";
 
 const linkedPullRequestDetailAtom = createLinkedPullRequestDetailAtomFamily(connectionAtomRuntime);
+const threadPrSnapshotAtoms = Atom.family((key: string) =>
+  Atom.make<ThreadPrPresentation | null>(null).pipe(
+    Atom.keepAlive,
+    Atom.withLabel(`mobile:thread-pr-snapshot:${key}`),
+  ),
+);
 
 export {
   presentThreadPr,
@@ -28,6 +39,12 @@ export function useThreadPr(
   projectCwd: string | null,
 ): ThreadPrPresentation | null {
   const cwd = thread.worktreePath ?? projectCwd;
+  const snapshotKey = JSON.stringify([
+    scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+    thread.linkedPullRequest ?? { branch: thread.branch, cwd },
+  ]);
+  const snapshotAtom = useMemo(() => threadPrSnapshotAtoms(snapshotKey), [snapshotKey]);
+  const snapshot = useAtomValue(snapshotAtom);
   const gitStatus = useEnvironmentQuery(
     thread.linkedPullRequest == null && thread.branch !== null && cwd !== null
       ? vcsEnvironment.status({
@@ -49,23 +66,28 @@ export function useThreadPr(
         }),
   );
 
-  if (thread.linkedPullRequest != null) {
-    const detail = linkedPullRequest.data;
-    return detail === null
-      ? null
-      : presentThreadPr(pullRequestDetailToVcsStatus(detail), {
-          kind: detail.provider,
-          name: detail.provider,
-          baseUrl: "",
-        });
-  }
+  const live = useMemo<ThreadPrPresentation | null | undefined>(() => {
+    if (thread.linkedPullRequest != null) {
+      const detail = linkedPullRequest.data;
+      return detail === null
+        ? undefined
+        : presentThreadPr(pullRequestDetailToVcsStatus(detail), {
+            kind: detail.provider,
+            name: detail.provider,
+            baseUrl: "",
+          });
+    }
 
-  const status = gitStatus.data;
-  if (status === null || thread.branch === null || status.refName !== thread.branch) {
-    return null;
-  }
-  if (!status.pr) {
-    return null;
-  }
-  return presentThreadPr(status.pr, status.sourceControlProvider);
+    const status = gitStatus.data;
+    if (thread.branch === null) return null;
+    if (status === null) return undefined;
+    if (status.refName !== thread.branch || !status.pr) return null;
+    return presentThreadPr(status.pr, status.sourceControlProvider);
+  }, [gitStatus.data, linkedPullRequest.data, thread.branch, thread.linkedPullRequest]);
+
+  useEffect(() => {
+    if (live !== undefined && snapshot !== live) appAtomRegistry.set(snapshotAtom, live);
+  }, [live, snapshot, snapshotAtom]);
+
+  return live === undefined ? snapshot : live;
 }

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -185,6 +185,7 @@ import {
   orderItemsByPreferredIds,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
+  useSidebarRowSubscriptionLease,
   useThreadJumpHintVisibility,
   ThreadStatusPill,
 } from "./Sidebar.logic";
@@ -376,6 +377,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   } = props;
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
+  const { leaseLiveStatus, rowRef } = useSidebarRowSubscriptionLease(isActive);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const runningTerminalIds = useThreadRunningTerminalIds({
@@ -417,7 +419,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   const threadProjectCwd = threadProject?.workspaceRoot ?? null;
   const gitCwd = thread.worktreePath ?? threadProjectCwd ?? props.projectCwd;
   const gitStatus = useEnvironmentQuery(
-    thread.linkedPullRequest == null && thread.branch != null && gitCwd !== null
+    leaseLiveStatus && thread.linkedPullRequest == null && thread.branch != null && gitCwd !== null
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
@@ -459,16 +461,26 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     },
   });
   const linkedPullRequestStatus = useLinkedThreadPullRequest(
-    thread.environmentId,
-    thread.linkedPullRequest,
+    leaseLiveStatus ? thread.environmentId : null,
+    leaseLiveStatus ? thread.linkedPullRequest : null,
   );
+  const gitStatusSnapshotRef = useRef(gitStatus.data);
+  const linkedPullRequestStatusSnapshotRef = useRef(linkedPullRequestStatus);
+  if (gitStatus.data !== null) gitStatusSnapshotRef.current = gitStatus.data;
+  if (linkedPullRequestStatus !== null) {
+    linkedPullRequestStatusSnapshotRef.current = linkedPullRequestStatus;
+  }
+  const visibleGitStatus = gitStatus.data ?? gitStatusSnapshotRef.current;
+  const visibleLinkedPullRequestStatus =
+    linkedPullRequestStatus ?? linkedPullRequestStatusSnapshotRef.current;
   const pr =
     thread.linkedPullRequest == null
-      ? resolveThreadPr({ threadBranch: thread.branch, gitStatus: gitStatus.data })
-      : (linkedPullRequestStatus?.pr ?? null);
+      ? resolveThreadPr({ threadBranch: thread.branch, gitStatus: visibleGitStatus })
+      : (visibleLinkedPullRequestStatus?.pr ?? null);
   const prStatus = prStatusIndicator(
     pr,
-    linkedPullRequestStatus?.sourceControlProvider ?? gitStatus.data?.sourceControlProvider,
+    visibleLinkedPullRequestStatus?.sourceControlProvider ??
+      visibleGitStatus?.sourceControlProvider,
   );
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = confirmingArchiveThreadKey === threadKey && !isThreadRunning;
@@ -681,6 +693,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
 
   return (
     <SidebarMenuSubItem
+      ref={rowRef}
       className="w-full"
       data-thread-item
       onMouseLeave={handleMouseLeave}

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -185,6 +185,7 @@ import {
   orderItemsByPreferredIds,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
+  useRetainedValue,
   useSidebarRowSubscriptionLease,
   useThreadJumpHintVisibility,
   ThreadStatusPill,
@@ -464,39 +465,16 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     leaseLiveStatus ? thread.environmentId : null,
     leaseLiveStatus ? thread.linkedPullRequest : null,
   );
-  const gitStatusSnapshotKey = JSON.stringify([thread.environmentId, gitCwd]);
-  const gitStatusSnapshotRef = useRef<{
-    readonly key: string;
-    readonly value: NonNullable<typeof gitStatus.data>;
-  } | null>(null);
-  const linkedPullRequestSnapshotKey =
+  const visibleGitStatus = useRetainedValue(
+    JSON.stringify([thread.environmentId, gitCwd]),
+    gitStatus.data,
+  );
+  const visibleLinkedPullRequestStatus = useRetainedValue(
     thread.linkedPullRequest === null
       ? null
-      : JSON.stringify([thread.environmentId, thread.linkedPullRequest]);
-  const linkedPullRequestStatusSnapshotRef = useRef<{
-    readonly key: string;
-    readonly value: NonNullable<typeof linkedPullRequestStatus>;
-  } | null>(null);
-  if (gitStatus.data !== null) {
-    gitStatusSnapshotRef.current = { key: gitStatusSnapshotKey, value: gitStatus.data };
-  }
-  if (linkedPullRequestStatus !== null && linkedPullRequestSnapshotKey !== null) {
-    linkedPullRequestStatusSnapshotRef.current = {
-      key: linkedPullRequestSnapshotKey,
-      value: linkedPullRequestStatus,
-    };
-  }
-  const visibleGitStatus =
-    gitStatus.data ??
-    (gitStatusSnapshotRef.current?.key === gitStatusSnapshotKey
-      ? gitStatusSnapshotRef.current.value
-      : null);
-  const visibleLinkedPullRequestStatus =
-    linkedPullRequestStatus ??
-    (linkedPullRequestSnapshotKey !== null &&
-    linkedPullRequestStatusSnapshotRef.current?.key === linkedPullRequestSnapshotKey
-      ? linkedPullRequestStatusSnapshotRef.current.value
-      : null);
+      : JSON.stringify([thread.environmentId, thread.linkedPullRequest]),
+    linkedPullRequestStatus,
+  );
   const pr =
     thread.linkedPullRequest == null
       ? resolveThreadPr({ threadBranch: thread.branch, gitStatus: visibleGitStatus })

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -464,15 +464,39 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     leaseLiveStatus ? thread.environmentId : null,
     leaseLiveStatus ? thread.linkedPullRequest : null,
   );
-  const gitStatusSnapshotRef = useRef(gitStatus.data);
-  const linkedPullRequestStatusSnapshotRef = useRef(linkedPullRequestStatus);
-  if (gitStatus.data !== null) gitStatusSnapshotRef.current = gitStatus.data;
-  if (linkedPullRequestStatus !== null) {
-    linkedPullRequestStatusSnapshotRef.current = linkedPullRequestStatus;
+  const gitStatusSnapshotKey = JSON.stringify([thread.environmentId, gitCwd]);
+  const gitStatusSnapshotRef = useRef<{
+    readonly key: string;
+    readonly value: NonNullable<typeof gitStatus.data>;
+  } | null>(null);
+  const linkedPullRequestSnapshotKey =
+    thread.linkedPullRequest === null
+      ? null
+      : JSON.stringify([thread.environmentId, thread.linkedPullRequest]);
+  const linkedPullRequestStatusSnapshotRef = useRef<{
+    readonly key: string;
+    readonly value: NonNullable<typeof linkedPullRequestStatus>;
+  } | null>(null);
+  if (gitStatus.data !== null) {
+    gitStatusSnapshotRef.current = { key: gitStatusSnapshotKey, value: gitStatus.data };
   }
-  const visibleGitStatus = gitStatus.data ?? gitStatusSnapshotRef.current;
+  if (linkedPullRequestStatus !== null && linkedPullRequestSnapshotKey !== null) {
+    linkedPullRequestStatusSnapshotRef.current = {
+      key: linkedPullRequestSnapshotKey,
+      value: linkedPullRequestStatus,
+    };
+  }
+  const visibleGitStatus =
+    gitStatus.data ??
+    (gitStatusSnapshotRef.current?.key === gitStatusSnapshotKey
+      ? gitStatusSnapshotRef.current.value
+      : null);
   const visibleLinkedPullRequestStatus =
-    linkedPullRequestStatus ?? linkedPullRequestStatusSnapshotRef.current;
+    linkedPullRequestStatus ??
+    (linkedPullRequestSnapshotKey !== null &&
+    linkedPullRequestStatusSnapshotRef.current?.key === linkedPullRequestSnapshotKey
+      ? linkedPullRequestStatusSnapshotRef.current.value
+      : null);
   const pr =
     thread.linkedPullRequest == null
       ? resolveThreadPr({ threadBranch: thread.branch, gitStatus: visibleGitStatus })

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -63,6 +63,18 @@ export function useSidebarRowSubscriptionLease(isActive: boolean): {
   };
 }
 
+// A row keeps the last live value it rendered so a released lease never
+// blanks its badge. The value is bound to `key`, so a different worktree or
+// linked pull request cannot reuse the previous one.
+export function useRetainedValue<T>(key: string | null, value: T | null): T | null {
+  const retained = React.useRef<{ readonly key: string; readonly value: T } | null>(null);
+  if (key !== null && value !== null) {
+    retained.current = { key, value };
+  }
+  if (value !== null) return value;
+  return key !== null && retained.current?.key === key ? retained.current.value : null;
+}
+
 // The list already reaches its destination through sortable transforms while
 // the pointer is down. dnd-kit's default also animates the committed DOM order
 // after release, replaying the same movement across every affected row.

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -23,6 +23,45 @@ export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 200;
 // so this limit is a direct renderer-heap and server-load multiplier — keep
 // it small; cold opens still render instantly from the cached snapshot.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 3;
+// A small buffer keeps the next few rows warm without leasing every row that
+// content-visibility leaves mounted below the scroll viewport.
+export const SIDEBAR_ROW_SUBSCRIPTION_OVERSCAN_PX = 160;
+
+export function useSidebarRowSubscriptionLease(isActive: boolean): {
+  readonly leaseLiveStatus: boolean;
+  readonly rowRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
+} {
+  const [row, setRow] = React.useState<HTMLElement | null>(null);
+  const [isNearViewport, setIsNearViewport] = React.useState(isActive);
+
+  React.useEffect(() => {
+    if (isActive) {
+      setIsNearViewport(true);
+      return;
+    }
+    if (row === null) return;
+    if (typeof IntersectionObserver === "undefined") {
+      setIsNearViewport(true);
+      return;
+    }
+
+    const scrollRoot = row.closest<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsNearViewport(entry?.isIntersecting === true),
+      {
+        root: scrollRoot,
+        rootMargin: `${SIDEBAR_ROW_SUBSCRIPTION_OVERSCAN_PX}px 0px`,
+      },
+    );
+    observer.observe(row);
+    return () => observer.disconnect();
+  }, [isActive, row]);
+
+  return {
+    leaseLiveStatus: isActive || isNearViewport,
+    rowRef: setRow,
+  };
+}
 
 // The list already reaches its destination through sortable transforms while
 // the pointer is down. dnd-kit's default also animates the committed DOM order

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -813,10 +813,23 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         })
       : null,
   );
+  const gitStatusSnapshotKey = JSON.stringify([thread.environmentId, gitCwd]);
+  const gitStatusSnapshotRef = useRef<{
+    readonly key: string;
+    readonly value: NonNullable<typeof gitStatus.data>;
+  } | null>(null);
+  if (gitStatus.data !== null) {
+    gitStatusSnapshotRef.current = { key: gitStatusSnapshotKey, value: gitStatus.data };
+  }
+  const visibleGitStatus =
+    gitStatus.data ??
+    (gitStatusSnapshotRef.current?.key === gitStatusSnapshotKey
+      ? gitStatusSnapshotRef.current.value
+      : null);
   const retainTerminalOnBranchMismatch = thread.worktreePath === null;
   const pr = resolveDisplayedThreadPr({
     threadBranch: thread.branch,
-    gitStatus: gitStatus.data,
+    gitStatus: visibleGitStatus,
     snapshot: changeRequestSnapshot,
     retainTerminalOnBranchMismatch,
     linkedPullRequest: thread.linkedPullRequest,
@@ -911,11 +924,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
     activeWorktreePath: thread.worktreePath,
     activeThreadBranch: thread.branch,
-    currentGitBranch: gitStatus.data?.refName ?? null,
+    currentGitBranch: visibleGitStatus?.refName ?? null,
   });
   const prProvider = resolveDisplayedThreadPrProvider({
     threadBranch: thread.branch,
-    gitStatus: gitStatus.data,
+    gitStatus: visibleGitStatus,
     snapshot: changeRequestSnapshot,
     retainTerminalOnBranchMismatch,
     linkedPullRequest: thread.linkedPullRequest,
@@ -926,7 +939,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   useEffect(() => {
     const nextSnapshot = nextThreadChangeRequestSnapshot({
       threadBranch: thread.branch,
-      gitStatus: gitStatus.data,
+      gitStatus: visibleGitStatus,
       snapshot: changeRequestSnapshot,
       retainTerminalOnBranchMismatch,
       linkedPullRequest: thread.linkedPullRequest,
@@ -936,7 +949,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     onChangeRequestSnapshot(threadKey, nextSnapshot);
   }, [
     changeRequestSnapshot,
-    gitStatus.data,
+    visibleGitStatus,
     linkedPullRequestStatus,
     onChangeRequestSnapshot,
     retainTerminalOnBranchMismatch,
@@ -1653,11 +1666,24 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
         })
       : null,
   );
+  const gitStatusSnapshotKey = JSON.stringify([thread.environmentId, gitCwd]);
+  const gitStatusSnapshotRef = useRef<{
+    readonly key: string;
+    readonly value: NonNullable<typeof gitStatus.data>;
+  } | null>(null);
+  if (gitStatus.data !== null) {
+    gitStatusSnapshotRef.current = { key: gitStatusSnapshotKey, value: gitStatus.data };
+  }
+  const visibleGitStatus =
+    gitStatus.data ??
+    (gitStatusSnapshotRef.current?.key === gitStatusSnapshotKey
+      ? gitStatusSnapshotRef.current.value
+      : null);
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
     activeWorktreePath: thread.worktreePath,
     activeThreadBranch: thread.branch,
-    currentGitBranch: gitStatus.data?.refName ?? null,
+    currentGitBranch: visibleGitStatus?.refName ?? null,
   });
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -143,6 +143,7 @@ import {
   sortPinnedThreadsForSidebar,
   sortSettledThreadsForSidebar,
   sortThreadsForSidebar,
+  useSidebarRowSubscriptionLease,
   useThreadJumpHintVisibility,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
@@ -787,6 +788,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     [thread.environmentId, thread.id],
   );
   const threadKey = scopedThreadKey(threadRef);
+  const { leaseLiveStatus, rowRef } = useSidebarRowSubscriptionLease(props.isActive);
   const isRegeneratingTitle = thread.titleRegeneration != null;
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
@@ -800,11 +802,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
 
   const gitCwd = thread.worktreePath ?? props.projectCwd;
   const linkedPullRequestStatus = useLinkedThreadPullRequest(
-    thread.environmentId,
-    thread.linkedPullRequest,
+    leaseLiveStatus ? thread.environmentId : null,
+    leaseLiveStatus ? thread.linkedPullRequest : null,
   );
   const gitStatus = useEnvironmentQuery(
-    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
+    leaseLiveStatus && (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
@@ -1246,6 +1248,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
           <TooltipTrigger
             render={
               <div
+                ref={rowRef}
                 role="button"
                 tabIndex={0}
                 data-testid="sidebar-row-slim"
@@ -1407,6 +1410,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         <TooltipTrigger
           render={
             <div
+              ref={rowRef}
               role="button"
               tabIndex={0}
               data-testid="sidebar-row-card"
@@ -1635,11 +1639,14 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   onSelect: () => void;
 }) {
   const { thread } = props;
+  const { leaseLiveStatus, rowRef } = useSidebarRowSubscriptionLease(
+    props.isHighlighted || props.isRouteActive,
+  );
   // Same details tooltip as the regular rows: a search hit is still a thread,
   // and the hover card is how you disambiguate identically-titled results.
   const gitCwd = thread.worktreePath ?? props.projectCwd;
   const gitStatus = useEnvironmentQuery(
-    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
+    leaseLiveStatus && (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
@@ -1674,6 +1681,7 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
         <TooltipTrigger
           render={
             <button
+              ref={rowRef}
               id={props.resultId}
               type="button"
               role="option"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -143,6 +143,7 @@ import {
   sortPinnedThreadsForSidebar,
   sortSettledThreadsForSidebar,
   sortThreadsForSidebar,
+  useRetainedValue,
   useSidebarRowSubscriptionLease,
   useThreadJumpHintVisibility,
 } from "./Sidebar.logic";
@@ -813,19 +814,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         })
       : null,
   );
-  const gitStatusSnapshotKey = JSON.stringify([thread.environmentId, gitCwd]);
-  const gitStatusSnapshotRef = useRef<{
-    readonly key: string;
-    readonly value: NonNullable<typeof gitStatus.data>;
-  } | null>(null);
-  if (gitStatus.data !== null) {
-    gitStatusSnapshotRef.current = { key: gitStatusSnapshotKey, value: gitStatus.data };
-  }
-  const visibleGitStatus =
-    gitStatus.data ??
-    (gitStatusSnapshotRef.current?.key === gitStatusSnapshotKey
-      ? gitStatusSnapshotRef.current.value
-      : null);
+  const visibleGitStatus = useRetainedValue(
+    JSON.stringify([thread.environmentId, gitCwd]),
+    gitStatus.data,
+  );
   const retainTerminalOnBranchMismatch = thread.worktreePath === null;
   const pr = resolveDisplayedThreadPr({
     threadBranch: thread.branch,
@@ -1666,19 +1658,10 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
         })
       : null,
   );
-  const gitStatusSnapshotKey = JSON.stringify([thread.environmentId, gitCwd]);
-  const gitStatusSnapshotRef = useRef<{
-    readonly key: string;
-    readonly value: NonNullable<typeof gitStatus.data>;
-  } | null>(null);
-  if (gitStatus.data !== null) {
-    gitStatusSnapshotRef.current = { key: gitStatusSnapshotKey, value: gitStatus.data };
-  }
-  const visibleGitStatus =
-    gitStatus.data ??
-    (gitStatusSnapshotRef.current?.key === gitStatusSnapshotKey
-      ? gitStatusSnapshotRef.current.value
-      : null);
+  const visibleGitStatus = useRetainedValue(
+    JSON.stringify([thread.environmentId, gitCwd]),
+    gitStatus.data,
+  );
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
     activeWorktreePath: thread.worktreePath,

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -26,6 +26,8 @@ export class EnvironmentHttpConnectionNotReadyError extends Data.TaggedError(
   "EnvironmentHttpConnectionNotReadyError",
 )<{ readonly message: string }> {}
 
+export const LINKED_PULL_REQUEST_DETAIL_IDLE_TTL_MS = 5_000;
+
 /** Refresh a linked PR while its thread is visible so merges update the sidebar. */
 export function createLinkedPullRequestDetailAtomFamily<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
@@ -35,6 +37,7 @@ export function createLinkedPullRequestDetailAtomFamily<R, E>(
     tag: WS_METHODS.pullRequestsDetail,
     staleTimeMs: 15_000,
     refreshIntervalMs: 30_000,
+    idleTtlMs: LINKED_PULL_REQUEST_DETAIL_IDLE_TTL_MS,
   });
 }
 

--- a/packages/client-runtime/src/state/vcs.ts
+++ b/packages/client-runtime/src/state/vcs.ts
@@ -31,6 +31,9 @@ import {
 
 const OFFLINE_BRANCH_LIST_LIMIT = 100;
 const VCS_REFS_IDLE_TTL_MS = 30_000;
+// Rows keep the last status they rendered, so the live stream only needs a
+// short grace period when virtualization or scrolling releases its consumer.
+export const VCS_STATUS_IDLE_TTL_MS = 10_000;
 const VCS_REFS_RETRY_SCHEDULE = Schedule.exponential("1 second").pipe(
   Schedule.modifyDelay(({ duration }) =>
     Effect.succeed(Duration.min(duration, Duration.seconds(30))),
@@ -275,6 +278,7 @@ export function createVcsEnvironmentAtoms<R, E>(
     listRefs,
     status: createEnvironmentSubscriptionAtomFamily(runtime, {
       label: "environment-data:vcs:status",
+      idleTtlMs: VCS_STATUS_IDLE_TTL_MS,
       subscribe: (input: EnvironmentRpcInput<typeof WS_METHODS.subscribeVcsStatus>) =>
         subscribe(WS_METHODS.subscribeVcsStatus, input).pipe(
           Stream.mapAccum(


### PR DESCRIPTION
Mounted sidebar rows kept VCS streams and linked pull request refreshes alive for five minutes, even after the rows left the viewport. With many unique worktrees, idle rows continued doing Git and provider work. This is item 07 of the performance opportunity audit.

Web and desktop rows now lease live status only while active or within 160 px of the sidebar viewport. Active and highlighted search rows always stay live. Mobile keeps its existing list virtualization and now preserves the last pull request badge separately while the shared live atom expires. VCS streams get a 10-second scroll grace and linked pull request detail queries get a 5-second idle TTL.

## Measurements

Measured with the same isolated 50-row, 50-worktree fixture on the pre-change commit (`b883fc066`) and this commit. Scope counts come from the server's background-policy snapshot after the browser settled. The after run scrolled from row 01 to row 50, waited past the grace period, and selected row 50.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Live fixture VCS scopes | 50 | 11 | 78% fewer |
| VCS idle retention | 300 s | 10 s | 96.7% shorter |
| Linked PR detail idle retention | 300 s | 5 s | 98.3% shorter |

In this fixture, the change releases 39 offscreen VCS streams. That removes unnecessary Git status work and server/client subscription bookkeeping, while offscreen linked PR polling can stop after 5 seconds instead of remaining eligible for 5 minutes. The 78% figure is a measured live-scope reduction, not a CPU reduction claim.

## Proof

The native-resolution sidebar GIF drives the real web client through the 50-row fixture, scrolls the full list, and opens row 50.

![50-row sidebar remains interactive with visibility-leased status](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/2e419e12-d14f-4dd2-bf08-6350e476e054/point-07-visibility-leases-crisp.gif)

## Verification

- `pnpm exec vp test run packages/client-runtime/src/state/vcs.test.ts packages/client-runtime/src/state/pullRequests.test.ts apps/web/src/components/Sidebar.logic.test.ts apps/web/src/components/ThreadStatusIndicators.test.ts apps/mobile/src/features/threads/threadListV2.test.ts` (192 tests)
- `pnpm --filter @t3tools/client-runtime typecheck`
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/mobile typecheck`
- targeted lint and diff checks

Changes and PR text by GPT-5.6 Sol in T3 Code with the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused subscription gating with retained UI snapshots; no auth or data-model changes, though off-screen rows may show slightly stale PR/git badges until scrolled back into range.
> 
> **Overview**
> Sidebar thread rows no longer keep **live VCS status** and **linked PR detail** subscriptions for every mounted row. A new **visibility lease** (`useSidebarRowSubscriptionLease`) turns those queries on only when the row is active or within **160px** of the scroll viewport; **`useRetainedValue`** keeps the last git/PR values so PR badges and branch metadata do not flash empty when the lease drops.
> 
> **Client-runtime** shortens idle teardown for off-lease consumers: **VCS status** streams use a **10s** idle TTL (was the default **5 min**), and **linked PR detail** queries use **5s**.
> 
> **Mobile** adds a bounded (**500** entry) **thread PR snapshot** atom so virtualized list rows can show the last PR presentation while shared live atoms expire, without one atom per thread forever.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4faaad45140c178332ca59ca7f07490bb74f7758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lease sidebar VCS and linked-PR status queries by viewport visibility
> - Adds `useSidebarRowSubscriptionLease` to gate VCS status and linked-PR queries on active or near-viewport rows (160px overscan via `IntersectionObserver`, with a fallback that keeps leases alive)
> - Adds `useRetainedValue` so rows continue rendering the last non-null status keyed by environment and checkout identity while their live query is disabled
> - Adds `threadPrSnapshotsAtom`, a 500-entry bounded cache on mobile that persists thread PR presentations across unmount/remount, with eviction of the oldest entries
> - Adds idle TTLs to client-runtime atom families: 10s for VCS status (`createVcsEnvironmentAtoms`) and 5s for linked-PR detail (`createLinkedPullRequestDetailAtomFamily`)
> - Behavioral Change: rows outside the active/near-viewport lease stop polling live git and linked-PR status and display retained snapshots instead; `useThreadPr` on mobile clears cached entries on definitive null results
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4faaad4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->