### PR TITLE
fix(clients): allow slash skills inside messages

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -85,6 +85,8 @@ export function useComposerCommandMenu({
 
     if (trigger.kind === "slash-command") {
       const q = trigger.query.toLowerCase();
+      const isAtLineStart =
+        trigger.rangeStart === 0 || draftMessage[trigger.rangeStart - 1] === "\n";
       const allBuiltIn = [
         {
           id: "cmd:model",
@@ -108,14 +110,16 @@ export function useComposerCommandMenu({
           description: "Switch to default mode",
         },
       ];
-      const builtIn = allBuiltIn.filter(
-        (item) =>
-          item.command.includes(q) &&
-          (item.command === "model" || onUpdateInteractionMode !== undefined),
-      );
+      const builtIn = isAtLineStart
+        ? allBuiltIn.filter(
+            (item) =>
+              item.command.includes(q) &&
+              (item.command === "model" || onUpdateInteractionMode !== undefined),
+          )
+        : [];
 
       const providerCommands: ComposerCommandItem[] = [];
-      for (const command of selectedProviderStatus?.slashCommands ?? []) {
+      for (const command of isAtLineStart ? (selectedProviderStatus?.slashCommands ?? []) : []) {
         if (!command.name.toLowerCase().includes(q)) continue;
         // Codex feedback uploads an existing thread's session and logs.
         if (

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1362,7 +1362,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }));
       const slashCommandItems = slashCommandItemsForPromptPosition(
         [...builtInSlashCommandItems, ...providerSlashCommandItems, ...skillItems],
-        composerTrigger.rangeStart === 0,
+        composerTrigger.rangeStart === 0 || prompt[composerTrigger.rangeStart - 1] === "\n",
       );
       return searchSlashCommandItems(slashCommandItems, query);
     }

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -177,7 +177,7 @@ describe("searchSlashCommandItems", () => {
     ]);
   });
 
-  it("hides skills from slash completion after the first message line", () => {
+  it("keeps only skills in slash completion away from a line start", () => {
     const items = [
       {
         id: "slash:model",
@@ -203,7 +203,7 @@ describe("searchSlashCommandItems", () => {
     >;
 
     expect(slashCommandItemsForPromptPosition(items, false).map((item) => item.id)).toEqual([
-      "slash:model",
+      "skill:claudeAgent:unslop",
     ]);
     expect(slashCommandItemsForPromptPosition(items, true).map((item) => item.id)).toEqual([
       "slash:model",

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -14,12 +14,12 @@ type SlashSearchItem = Extract<
 
 export function slashCommandItemsForPromptPosition(
   items: ReadonlyArray<SlashSearchItem>,
-  isAtPromptStart: boolean,
+  isAtLineStart: boolean,
 ): SlashSearchItem[] {
-  if (isAtPromptStart) {
+  if (isAtLineStart) {
     return [...items];
   }
-  return items.filter((item) => item.type !== "skill");
+  return items.filter((item) => item.type === "skill");
 }
 
 function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -137,6 +137,18 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("detects a slash skill token in the middle of a message", () => {
+    const text = "Use /skill:unslop";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "skill:unslop",
+      rangeStart: "Use ".length,
+      rangeEnd: text.length,
+    });
+  });
+
   it("detects $skill trigger at cursor", () => {
     const text = "Use $gh-fi";
     const trigger = detectComposerTrigger(text, text.length);

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -149,6 +149,26 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it.each(["/", "/sk", "/skill:"])("detects partial inline slash skill token %s", (token) => {
+    const text = `Use ${token}`;
+
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "slash-command",
+      query: token.slice(1),
+      rangeStart: "Use ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it.each(["/tmp/build.sh", "/etc/hosts", "/unslop"])(
+    "keeps ordinary inline slash token %s as text",
+    (token) => {
+      const text = `Use ${token}`;
+
+      expect(detectComposerTrigger(text, text.length)).toBeNull();
+    },
+  );
+
   it("detects $skill trigger at cursor", () => {
     const text = "Use $gh-fi";
     const trigger = detectComposerTrigger(text, text.length);

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -248,7 +248,7 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
 
   const tokenStart = tokenStartForCursor(text, cursor);
   const token = text.slice(tokenStart, cursor);
-  if (token.startsWith("/")) {
+  if (token.startsWith("/") && (token.startsWith("/skill:") || "/skill:".startsWith(token))) {
     return {
       kind: "slash-command",
       query: token.slice(1),

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -248,6 +248,14 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
 
   const tokenStart = tokenStartForCursor(text, cursor);
   const token = text.slice(tokenStart, cursor);
+  if (token.startsWith("/")) {
+    return {
+      kind: "slash-command",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
   if (token.startsWith("$")) {
     return {
       kind: "skill",

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { serializeComposerFileLink, serializeComposerMentionPath } from "./composerTrigger.ts";
+import {
+  detectComposerTrigger,
+  serializeComposerFileLink,
+  serializeComposerMentionPath,
+} from "./composerTrigger.ts";
+
+describe("detectComposerTrigger", () => {
+  it("detects a slash skill token in the middle of a message", () => {
+    const text = "Use /skill:unslop";
+
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "slash-command",
+      query: "skill:unslop",
+      rangeStart: "Use ".length,
+      rangeEnd: text.length,
+    });
+  });
+});
 
 describe("serializeComposerMentionPath", () => {
   it("keeps simple mention paths unquoted", () => {

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -17,6 +17,26 @@ describe("detectComposerTrigger", () => {
       rangeEnd: text.length,
     });
   });
+
+  it.each(["/", "/sk", "/skill:"])("detects partial inline slash skill token %s", (token) => {
+    const text = `Use ${token}`;
+
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "slash-command",
+      query: token.slice(1),
+      rangeStart: "Use ".length,
+      rangeEnd: text.length,
+    });
+  });
+
+  it.each(["/tmp/build.sh", "/etc/hosts", "/unslop"])(
+    "keeps ordinary inline slash token %s as text",
+    (token) => {
+      const text = `Use ${token}`;
+
+      expect(detectComposerTrigger(text, text.length)).toBeNull();
+    },
+  );
 });
 
 describe("serializeComposerMentionPath", () => {

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -104,6 +104,14 @@ export function detectComposerTrigger(
   const tokenStart = tokenIdx + 1;
 
   const token = text.slice(tokenStart, cursor);
+  if (token.startsWith("/")) {
+    return {
+      kind: "slash-command",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
   if (token.startsWith("$")) {
     return {
       kind: "skill",

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -104,7 +104,7 @@ export function detectComposerTrigger(
   const tokenStart = tokenIdx + 1;
 
   const token = text.slice(tokenStart, cursor);
-  if (token.startsWith("/")) {
+  if (token.startsWith("/") && (token.startsWith("/skill:") || "/skill:".startsWith(token))) {
     return {
       kind: "slash-command",
       query: token.slice(1),


### PR DESCRIPTION
## What Changed

Slash skill completion now works in the middle of a composer message on web, desktop, and mobile. At a line start, the slash menu still includes built-in and provider commands. Within prose, it includes skills only and inserts the existing `$skill` token after selection.

## Why

The composer only detected slash commands when `/` started the current line. It also removed skills from slash results after the first message line. Users could invoke a skill with `$` inside a message, but the equivalent slash flow only worked at the start.

## UI Changes

This changes composer interaction without changing its visual styling. An isolated browser pass verified that `Use /skill:cloud` opens matching skills and selecting Cloudflare inserts the skill chip.

Verification:

- 56 focused composer and trigger tests passed
- Web, mobile, and shared typechecks passed
- Targeted lint and formatting passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Made with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer autocomplete behavior only; no auth, data, or API changes. Risk is limited to false-positive slash triggers or wrong menu items in edge cases.
> 
> **Overview**
> **Mid-message `/skill:` completion** is now supported on web, mobile, and shared trigger detection. `detectComposerTrigger` treats inline tokens that match `/skill:` or a partial prefix (e.g. `/`, `/sk`) as slash-command triggers, while paths like `/tmp/foo` stay plain text.
> 
> **Slash menu contents depend on line position.** At a line start (including right after a newline), the menu still lists built-in commands, provider slash commands, and skills. Away from a line start, only **skill** items are offered—built-in and provider commands are hidden—so inline `/` does not surface `/model` or similar inside prose.
> 
> Web `ChatComposer` and mobile `useComposerCommandMenu` align with `slashCommandItemsForPromptPosition`, which renames the flag to `isAtLineStart` and inverts off-line-start filtering accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d0d1f43888808e90cf2d245693d9f534ccfffeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `detectComposerTrigger` to allow inline `/skill:` slash commands in messages
> - `detectComposerTrigger` now returns a `slash-command` trigger when an inline token starts with `/skill:` or is a prefix of it; other inline slash tokens (e.g. `/tmp/build.sh`, `/etc/hosts`) are ignored
> - `slashCommandItemsForPromptPosition` renames its flag to `isAtLineStart` and inverts its filter: at line start it returns all slash items, away from line start it returns only `skill`-type items
> - Web and mobile composers pass the new `isAtLineStart` flag, so slash completion applies at the start of any new line, not just the start of the prompt
> - Risk: callers relying on the old behavior where non-skill slash commands appeared mid-line (or skills appeared mid-line at prompt start) will see different completion results; review usages of `slashCommandItemsForPromptPosition` in [composerSlashCommandSearch.ts](https://github.com/pingdotgg/t3code/pull/9053/files#diff-a81f587c9b12a9a903e8f20bc37bca999eeb757e6d9e08f8a6afd0b9ef2541d9) and [use-composer-command-menu.ts](https://github.com/pingdotgg/t3code/pull/9053/files#diff-765bb6c8049500163389336a7a5e0c83873e041f5b14c72e5f5804359e6492d9)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d0d1f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->