### PR TITLE
perf(web): halve the cold-start bundle by splitting Clerk and cold routes

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,6 +1,8 @@
 import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
+  lazy,
+  Suspense,
   useEffect,
   useState,
   useSyncExternalStore,
@@ -17,7 +19,6 @@ import { primaryServerKeybindingsAtom } from "../state/server";
 import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
-import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
 import { SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import {
   resolveSidebarStageFocusRingOffsetClass,
@@ -42,6 +43,14 @@ import {
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
+
+// The settings nav (and the Clerk profile surfaces behind it) only renders on
+// settings routes; lazy-loading it keeps that subtree out of the startup chunk.
+const SettingsSidebarNav = lazy(() =>
+  import("./settings/SettingsSidebarNav").then((module) => ({
+    default: module.SettingsSidebarNav,
+  })),
+);
 
 function subscribeToViewportWidth(onChange: () => void): () => void {
   window.addEventListener("resize", onChange);
@@ -229,7 +238,9 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         {isOnSettings ? (
           <>
             <SidebarChromeHeader isElectron={isElectron} />
-            <SettingsSidebarNav pathname={pathname} />
+            <Suspense fallback={null}>
+              <SettingsSidebarNav pathname={pathname} />
+            </Suspense>
           </>
         ) : legacySidebarEnabled ? (
           <LegacyThreadSidebar />

--- a/apps/web/src/components/clerk/BrowserManagedAuthShell.tsx
+++ b/apps/web/src/components/clerk/BrowserManagedAuthShell.tsx
@@ -1,0 +1,25 @@
+import { ClerkProvider } from "@clerk/react";
+import type { ReactNode } from "react";
+
+import { ManagedRelayAuthProvider } from "../../cloud/managedAuth";
+import { clerkAppearance } from "./clerkAppearance";
+
+/**
+ * Browser half of the managed-auth boundary, loaded lazily from the entry so
+ * cloudless local mode never downloads a Clerk runtime. The browser provider
+ * stays small on its own: it hotloads clerk-js at runtime instead of bundling
+ * it.
+ */
+export default function BrowserManagedAuthShell({
+  publishableKey,
+  children,
+}: {
+  readonly publishableKey: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <ClerkProvider appearance={clerkAppearance} publishableKey={publishableKey}>
+      <ManagedRelayAuthProvider>{children}</ManagedRelayAuthProvider>
+    </ClerkProvider>
+  );
+}

--- a/apps/web/src/components/clerk/ElectronManagedAuthShell.tsx
+++ b/apps/web/src/components/clerk/ElectronManagedAuthShell.tsx
@@ -1,0 +1,26 @@
+import { passkeys } from "@clerk/electron/passkeys";
+import { ClerkProvider } from "@clerk/electron/react";
+import type { ReactNode } from "react";
+
+import { ManagedRelayAuthProvider } from "../../cloud/managedAuth";
+import { clerkAppearance } from "./clerkAppearance";
+
+/**
+ * Electron half of the managed-auth boundary. The Electron provider statically
+ * bundles the full clerk-js runtime, so this module must only ever load
+ * lazily, and only inside the desktop shell — importing it eagerly would put
+ * clerk-js back into every client's startup graph.
+ */
+export default function ElectronManagedAuthShell({
+  publishableKey,
+  children,
+}: {
+  readonly publishableKey: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <ClerkProvider appearance={clerkAppearance} publishableKey={publishableKey} passkeys={passkeys}>
+      <ManagedRelayAuthProvider>{children}</ManagedRelayAuthProvider>
+    </ClerkProvider>
+  );
+}

--- a/apps/web/src/components/settings/ThemeEditorHost.tsx
+++ b/apps/web/src/components/settings/ThemeEditorHost.tsx
@@ -1,10 +1,16 @@
-import { useCallback } from "react";
+import { lazy, Suspense, useCallback } from "react";
 
 import { useTheme } from "../../hooks/useTheme";
 import { getThemeDefinition, type ThemeAppearance, type ThemeDefinition } from "../../themePalette";
 import { stackedThreadToast, toastManager } from "../ui/toast";
-import { ThemeEditorPanel } from "./ThemeEditorPanel";
 import { useThemeEditorStore } from "./themeEditorStore";
+
+// The host mounts above the router on every page, but the editor body only
+// renders once a session opens; lazy-loading it keeps the editor UI out of
+// the startup chunk.
+const ThemeEditorPanel = lazy(() =>
+  import("./ThemeEditorPanel").then((module) => ({ default: module.ThemeEditorPanel })),
+);
 
 /**
  * Renders the theme editor above the router. The editor paints its draft on
@@ -97,18 +103,20 @@ export function ThemeEditorHost() {
   const seedTheme = session.seedThemeId ? (getThemeDefinition(session.seedThemeId) ?? null) : null;
 
   return (
-    <ThemeEditorPanel
-      editingTheme={editingTheme}
-      initialAppearance={session.initialAppearance}
-      key={session.id}
-      onOpenChange={(open) => {
-        if (!open) closeThemeEditor();
-      }}
-      onSaved={handleSaved}
-      open
-      restoreTheme={refreshTheme}
-      seedName={session.seedName ?? undefined}
-      seedTheme={seedTheme}
-    />
+    <Suspense fallback={null}>
+      <ThemeEditorPanel
+        editingTheme={editingTheme}
+        initialAppearance={session.initialAppearance}
+        key={session.id}
+        onOpenChange={(open) => {
+          if (!open) closeThemeEditor();
+        }}
+        onSaved={handleSaved}
+        open
+        restoreTheme={refreshTheme}
+        seedName={session.seedName ?? undefined}
+        seedTheme={seedTheme}
+      />
+    </Suspense>
   );
 }

--- a/apps/web/src/lib/chunkReloadGuard.test.ts
+++ b/apps/web/src/lib/chunkReloadGuard.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { clearChunkReloadGuard, reloadOnceForChunkLoadError } from "./chunkReloadGuard";
+
+function createStorageStub(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+    key: (index) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+describe("reloadOnceForChunkLoadError", () => {
+  it("reloads on the first failure and lets the second one surface", () => {
+    const storage = createStorageStub();
+    const reload = vi.fn();
+
+    expect(reloadOnceForChunkLoadError(() => storage, reload)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    expect(reloadOnceForChunkLoadError(() => storage, reload)).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads again after a successful boot cleared the guard", () => {
+    const storage = createStorageStub();
+    const reload = vi.fn();
+
+    reloadOnceForChunkLoadError(() => storage, reload);
+    clearChunkReloadGuard(() => storage);
+
+    expect(reloadOnceForChunkLoadError(() => storage, reload)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it("never reloads when storage is blocked, so a persistent failure cannot loop", () => {
+    const reload = vi.fn();
+    const blocked = () => {
+      throw new DOMException("blocked", "SecurityError");
+    };
+
+    expect(reloadOnceForChunkLoadError(blocked, reload)).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+    expect(() => clearChunkReloadGuard(blocked)).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/chunkReloadGuard.ts
+++ b/apps/web/src/lib/chunkReloadGuard.ts
@@ -1,0 +1,39 @@
+// Split chunks are fetched lazily, so a deploy (or desktop server swap)
+// between page load and a later fetch can 404 the old hashed assets. One
+// reload picks up the fresh index.html. A sessionStorage flag keeps a
+// persistent failure from becoming a reload loop, and a successful boot clears
+// it so the next stale deploy gets its own single reload.
+const CHUNK_RELOAD_GUARD_KEY = "t3code:chunk-load-reloaded";
+
+/**
+ * Called from the `vite:preloadError` listener. Reloads at most once per
+ * failure streak and returns whether it did, so the caller knows whether to
+ * swallow the event or let the error surface through the normal paths.
+ */
+export function reloadOnceForChunkLoadError(
+  getStorage: () => Storage = () => window.sessionStorage,
+  reload: () => void = () => window.location.reload(),
+): boolean {
+  let alreadyReloaded: boolean;
+  try {
+    const storage = getStorage();
+    alreadyReloaded = storage.getItem(CHUNK_RELOAD_GUARD_KEY) === "1";
+    if (!alreadyReloaded) storage.setItem(CHUNK_RELOAD_GUARD_KEY, "1");
+  } catch {
+    // Without storage the guard cannot survive a reload, so a persistent
+    // failure would loop forever. Let the error surface instead.
+    return false;
+  }
+  if (alreadyReloaded) return false;
+  reload();
+  return true;
+}
+
+/** Clears the guard after a successful boot so a later stale deploy can reload again. */
+export function clearChunkReloadGuard(getStorage: () => Storage = () => window.sessionStorage) {
+  try {
+    getStorage().removeItem(CHUNK_RELOAD_GUARD_KEY);
+  } catch {
+    // Blocked storage never held the flag.
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -25,6 +25,40 @@ if (isElectron) {
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 
+// With split chunks, a deploy (or desktop server swap) between page load and a
+// lazy fetch can 404 the old hashed assets. Reload once to pick up the fresh
+// index.html; the guard keeps a persistent failure from becoming a reload loop
+// and instead lets the error surface through the normal paths.
+const CHUNK_RELOAD_GUARD_KEY = "t3code:chunk-load-reloaded";
+const readChunkReloadGuard = () => {
+  // Blocked storage degrades to reloading on every chunk failure, which is
+  // still better than stranding the page.
+  try {
+    return window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY) === "1";
+  } catch {
+    return false;
+  }
+};
+const writeChunkReloadGuard = (reloaded: boolean) => {
+  try {
+    if (reloaded) {
+      window.sessionStorage.setItem(CHUNK_RELOAD_GUARD_KEY, "1");
+    } else {
+      window.sessionStorage.removeItem(CHUNK_RELOAD_GUARD_KEY);
+    }
+  } catch {
+    // See readChunkReloadGuard.
+  }
+};
+window.addEventListener("vite:preloadError", (event) => {
+  if (readChunkReloadGuard()) {
+    return;
+  }
+  writeChunkReloadGuard(true);
+  event.preventDefault();
+  window.location.reload();
+});
+
 const app = <AppRoot router={router} />;
 
 // Managed auth is cloud-only, and the Electron Clerk provider bundles the full
@@ -47,6 +81,7 @@ void Promise.all([
   managedAuthShellModule?.then((module) => module.default) ?? null,
   router.load(),
 ]).then(([ManagedAuthShell]) => {
+  writeChunkReloadGuard(false);
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
       {ManagedAuthShell && clerkPublishableKey ? (

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { ClerkProvider } from "@clerk/react";
-import { passkeys } from "@clerk/electron/passkeys";
-import { ClerkProvider as ElectronClerkProvider } from "@clerk/electron/react";
 import { createHashHistory, createBrowserHistory } from "@tanstack/react-router";
 
 import "./index.css";
 
 import { isElectron } from "./env";
-import { ManagedRelayAuthProvider } from "./cloud/managedAuth";
 import { hasCloudPublicConfig } from "./cloud/publicConfig";
 import { getRouter } from "./router";
 import {
@@ -16,7 +12,6 @@ import {
   syncDocumentWindowControlsOverlayClass,
 } from "./lib/windowControlsOverlay";
 import { AppRoot } from "./AppRoot";
-import { clerkAppearance } from "./components/clerk/clerkAppearance";
 
 // Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();
@@ -32,22 +27,22 @@ const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string
 
 const app = <AppRoot router={router} />;
 
+// Managed auth is cloud-only, and the Electron Clerk provider bundles the full
+// clerk-js runtime. Lazily loading only the selected runtime keeps every Clerk
+// byte out of the startup graph for local-mode users, and keeps the bundled
+// clerk-js out of the browser build entirely.
+const ManagedAuthShell = React.lazy(() =>
+  isElectron
+    ? import("./components/clerk/ElectronManagedAuthShell")
+    : import("./components/clerk/BrowserManagedAuthShell"),
+);
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     {clerkPublishableKey && hasCloudPublicConfig() ? (
-      isElectron ? (
-        <ElectronClerkProvider
-          appearance={clerkAppearance}
-          publishableKey={clerkPublishableKey}
-          passkeys={passkeys}
-        >
-          <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
-        </ElectronClerkProvider>
-      ) : (
-        <ClerkProvider appearance={clerkAppearance} publishableKey={clerkPublishableKey}>
-          <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
-        </ClerkProvider>
-      )
+      <React.Suspense fallback={null}>
+        <ManagedAuthShell publishableKey={clerkPublishableKey}>{app}</ManagedAuthShell>
+      </React.Suspense>
     ) : (
       app
     )}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,6 +12,7 @@ import {
   syncDocumentWindowControlsOverlayClass,
 } from "./lib/windowControlsOverlay";
 import { AppRoot } from "./AppRoot";
+import { clearChunkReloadGuard, reloadOnceForChunkLoadError } from "./lib/chunkReloadGuard";
 
 // Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();
@@ -25,38 +26,16 @@ if (isElectron) {
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 
-// With split chunks, a deploy (or desktop server swap) between page load and a
-// lazy fetch can 404 the old hashed assets. Reload once to pick up the fresh
-// index.html; the guard keeps a persistent failure from becoming a reload loop
-// and instead lets the error surface through the normal paths.
-const CHUNK_RELOAD_GUARD_KEY = "t3code:chunk-load-reloaded";
-const readChunkReloadGuard = () => {
-  // Blocked storage degrades to reloading on every chunk failure, which is
-  // still better than stranding the page.
-  try {
-    return window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY) === "1";
-  } catch {
-    return false;
-  }
-};
-const writeChunkReloadGuard = (reloaded: boolean) => {
-  try {
-    if (reloaded) {
-      window.sessionStorage.setItem(CHUNK_RELOAD_GUARD_KEY, "1");
-    } else {
-      window.sessionStorage.removeItem(CHUNK_RELOAD_GUARD_KEY);
-    }
-  } catch {
-    // See readChunkReloadGuard.
-  }
-};
+// A failed split-chunk fetch usually means the hashed assets went stale under
+// a deploy; one guarded reload picks up the fresh index.html.
+let chunkLoadFailed = false;
+let reloadScheduled = false;
 window.addEventListener("vite:preloadError", (event) => {
-  if (readChunkReloadGuard()) {
-    return;
+  chunkLoadFailed = true;
+  if (reloadOnceForChunkLoadError()) {
+    reloadScheduled = true;
+    event.preventDefault();
   }
-  writeChunkReloadGuard(true);
-  event.preventDefault();
-  window.location.reload();
 });
 
 const app = <AppRoot router={router} />;
@@ -73,22 +52,33 @@ const managedAuthShellModule =
     : null;
 
 // The index.html boot splash lives inside #root, and React's first commit
-// clears it. Resolve everything that first commit needs — the selected
-// managed-auth runtime and the initial route's split chunks — before
+// clears it. Resolve everything that first commit needs, the selected
+// managed-auth runtime and the initial route's split chunks, before
 // rendering, so the splash holds until real UI paints instead of dropping to
 // a blank window while chunks download.
-void Promise.all([
-  managedAuthShellModule?.then((module) => module.default) ?? null,
-  router.load(),
-]).then(([ManagedAuthShell]) => {
-  writeChunkReloadGuard(false);
-  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-    <React.StrictMode>
-      {ManagedAuthShell && clerkPublishableKey ? (
-        <ManagedAuthShell publishableKey={clerkPublishableKey}>{app}</ManagedAuthShell>
-      ) : (
-        app
-      )}
-    </React.StrictMode>,
-  );
-});
+void Promise.all([managedAuthShellModule?.then((module) => module.default) ?? null, router.load()])
+  .then(([ManagedAuthShell]) => {
+    // A route chunk failure still resolves router.load(): the error is parked in
+    // the lazy component and surfaces through the route error boundary. Skip the
+    // paint when a reload is on its way, and only re-arm the guard after a boot
+    // that fetched every chunk it asked for.
+    if (reloadScheduled) return;
+    if (!chunkLoadFailed) clearChunkReloadGuard();
+    ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+      <React.StrictMode>
+        {ManagedAuthShell && clerkPublishableKey ? (
+          <ManagedAuthShell publishableKey={clerkPublishableKey}>{app}</ManagedAuthShell>
+        ) : (
+          app
+        )}
+      </React.StrictMode>,
+    );
+  })
+  .catch((error: unknown) => {
+    // The auth shell chunk failed and the guarded reload is spent. Say so
+    // instead of leaving the splash up forever.
+    if (reloadScheduled) return;
+    console.error("T3 Code failed to load its startup chunks.", error);
+    const bootShell = document.getElementById("boot-shell");
+    if (bootShell) bootShell.textContent = "T3 Code could not load. Reload to try again.";
+  });

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -28,23 +28,32 @@ const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string
 const app = <AppRoot router={router} />;
 
 // Managed auth is cloud-only, and the Electron Clerk provider bundles the full
-// clerk-js runtime. Lazily loading only the selected runtime keeps every Clerk
-// byte out of the startup graph for local-mode users, and keeps the bundled
-// clerk-js out of the browser build entirely.
-const ManagedAuthShell = React.lazy(() =>
-  isElectron
-    ? import("./components/clerk/ElectronManagedAuthShell")
-    : import("./components/clerk/BrowserManagedAuthShell"),
-);
+// clerk-js runtime. Loading only the selected runtime as a split chunk keeps
+// every Clerk byte out of the startup graph for local-mode users, and keeps
+// the bundled clerk-js out of the browser build entirely.
+const managedAuthShellModule =
+  clerkPublishableKey && hasCloudPublicConfig()
+    ? isElectron
+      ? import("./components/clerk/ElectronManagedAuthShell")
+      : import("./components/clerk/BrowserManagedAuthShell")
+    : null;
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    {clerkPublishableKey && hasCloudPublicConfig() ? (
-      <React.Suspense fallback={null}>
+// The index.html boot splash lives inside #root, and React's first commit
+// clears it. Resolve everything that first commit needs — the selected
+// managed-auth runtime and the initial route's split chunks — before
+// rendering, so the splash holds until real UI paints instead of dropping to
+// a blank window while chunks download.
+void Promise.all([
+  managedAuthShellModule?.then((module) => module.default) ?? null,
+  router.load(),
+]).then(([ManagedAuthShell]) => {
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      {ManagedAuthShell && clerkPublishableKey ? (
         <ManagedAuthShell publishableKey={clerkPublishableKey}>{app}</ManagedAuthShell>
-      </React.Suspense>
-    ) : (
-      app
-    )}
-  </React.StrictMode>,
-);
+      ) : (
+        app
+      )}
+    </React.StrictMode>,
+  );
+});

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -7,6 +7,10 @@ export function getRouter(history: RouterHistory) {
     routeTree,
     history,
     context: {},
+    // Route components are split chunks (autoCodeSplitting in vite.config);
+    // fetching them on hover/focus intent hides the load from the first
+    // settings or pull-request navigation.
+    defaultPreload: "intent",
   });
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -156,7 +156,10 @@ export default defineConfig(() => {
     assetsInclude: ["**/*.wasm"],
     plugins: [
       devCompressionPlugin(),
-      tanstackRouter(),
+      // Route components load as split chunks so settings, pull-request, and
+      // usage code stay out of the cold-start payload; the router prefetches
+      // them on navigation intent (see getRouter's defaultPreload).
+      tanstackRouter({ autoCodeSplitting: true }),
       react(),
       babel({
         // We need to be explicit about the parser options after moving to @vitejs/plugin-react v6.0.0


### PR DESCRIPTION
Every web and desktop client downloads ~2.15 MB gzip of JavaScript before first paint, and ~565 KB of that is the bundled clerk-js runtime that local-mode users never run: the entry statically imports the Electron Clerk provider (which bundles clerk-js) even in the browser, where Clerk hotloads its runtime from CDN anyway. The generated route tree also eagerly pulls settings, pull-request, and usage code into the entry, and the root route pins the theme editor and settings sidebar nav there too.

This splits the cold-start graph along its existing runtime conditionals:

- Managed auth lazy-loads only the selected Clerk runtime (browser or Electron shell) behind the existing `clerkPublishableKey && hasCloudPublicConfig()` gate. Local mode downloads no Clerk at all; the browser build no longer bundles clerk-js.
- Route components become split chunks (`autoCodeSplitting` on the TanStack Router plugin), prefetched on navigation intent (`defaultPreload: "intent"`) so first settings/PR navigation does not pay the load.
- The theme editor panel and settings sidebar nav lazy-load behind their existing "only renders when active" conditions, since the root route keeps them out of route splitting's reach.

Measured on a production build (gzip -6, entry + modulepreloads + CSS from index.html): **2.15 MB → 0.89 MB (−59%)**. The Electron Clerk runtime is now a 555 KB chunk loaded only in the desktop shell with cloud config; only the small `@clerk/react`/`@clerk/shared` hook layer (~86 KB) remains entry-resident for always-mounted consumers. Desktop chunk loading goes through the existing `t3code://` protocol proxy, which forwards arbitrary `/assets/*` paths, so split chunks resolve the same way the entry does.

Verified with the web unit tests around the touched areas (routes titlebar, Clerk profile pages, Electron passkeys, managed auth, AppRoot), targeted lint, and a web typecheck, plus the before/after bundle measurement above.

---
Change authored by Claude Fable 5 running in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup and auth wiring changed (deferred render, lazy Clerk shells, chunk-load reload), so regressions could affect first paint, cloud login, or behavior after deploys—though local mode and error paths are explicitly handled.
> 
> **Overview**
> **Cuts cold-start JavaScript by splitting the entry graph** (~2.15 MB gzip → ~0.89 MB in the PR’s measurement) by moving Clerk, route pages, and a few always-mounted-but-rarely-used UI behind lazy chunks instead of static imports.
> 
> **Managed auth** no longer loads at startup: `main.tsx` dynamically imports `BrowserManagedAuthShell` or `ElectronManagedAuthShell` only when cloud config and a Clerk publishable key are present, so local mode skips Clerk entirely and the browser build avoids bundling the Electron `clerk-js` payload on the critical path.
> 
> **Route code** is code-split via TanStack Router `autoCodeSplitting` in Vite, with `defaultPreload: "intent"` so settings/PR-style routes prefetch on hover/focus rather than on first paint. **Settings sidebar nav** and **theme editor panel** are `React.lazy` + `Suspense` where they only mount when settings or an editor session is active.
> 
> **Boot behavior** changes: first paint waits on `router.load()` and the optional auth shell chunk so the HTML boot splash stays visible until real UI can render; `vite:preloadError` triggers a **one-shot reload** (`chunkReloadGuard`) when stale hashed assets 404 after deploy, with tests for the guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbaa3944487b92f5e5b9aa8b80749d8c46a5ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split Clerk and cold routes to halve web cold-start bundle
> - Moves Clerk browser and Electron provider implementations into separate dynamically loaded auth-shell modules; startup loads only the one selected by the environment, or neither when cloud config is absent
> - Enables TanStack Router automatic route code splitting in [vite.config.ts](https://github.com/pingdotgg/t3code/pull/9058/files#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786) and configures the router to preload route chunks on hover/focus intent
> - Lazily loads the settings navigation in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/9058/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) and the theme editor panel in [ThemeEditorHost.tsx](https://github.com/pingdotgg/t3code/pull/9058/files#diff-bd01345d750f11440089beb858a464e5f96c2898c0ed249069705111bfd01943), each wrapped in a `Suspense` boundary with an empty fallback
> - Adds a chunk-reload guard in [chunkReloadGuard.ts](https://github.com/pingdotgg/t3code/pull/9058/files#diff-c95bd9d1e5560a65b556d8dd073806bc58ea337e915914a23a06396cac032fe1) that reloads once on the first split-chunk load failure using a session-storage marker, and surfaces subsequent failures without reloading
> - Startup in [main.tsx](https://github.com/pingdotgg/t3code/pull/9058/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) now awaits the selected auth shell and router before the first React render, and writes a load-failure message to the boot shell if startup rejects without a scheduled reload
> - Risk: if a user's session storage is blocked, the chunk-reload guard will not attempt a reload and the raw chunk-load error surfaces to the boot shell instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bbaa39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->