### PR TITLE
fix(web): mute routine notices and update actions

### DIFF
--- a/apps/web/src/components/ProviderUpdateEnvironmentRows.tsx
+++ b/apps/web/src/components/ProviderUpdateEnvironmentRows.tsx
@@ -133,7 +133,7 @@ function EnvironmentUpdateRow({
       break;
     default:
       trailing = (
-        <Button size="xs" onClick={onUpdate}>
+        <Button size="xs" variant="outline" onClick={onUpdate}>
           Update
         </Button>
       );

--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
@@ -281,7 +281,7 @@ export function ProviderUpdatePrimaryNotification() {
                 children: "Settings",
                 onClick: openSettings,
               },
-        actionVariant: oneClickProviders.length > 0 ? "default" : "outline",
+        actionVariant: "outline",
         data: {
           leadingIcon:
             updateProviders.length === 1 ? (

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -154,7 +154,7 @@ export function ServerUpdateAction({
   }
 
   return (
-    <Button size="xs" onClick={() => void handleUpdate()}>
+    <Button size="xs" variant="outline" onClick={() => void handleUpdate()}>
       {label}
     </Button>
   );

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -27,9 +27,8 @@ const variantColors: Record<ComposerBannerVariant, string> = {
   default: neutralOutline,
   error:
     "[--chat-composer-attached-outline:color-mix(in_srgb,var(--error)_32%,transparent)] [--chat-composer-attached-tint:color-mix(in_srgb,var(--error)_8%,transparent)]",
-  info: "[--chat-composer-attached-outline:color-mix(in_srgb,var(--info)_32%,transparent)] [--chat-composer-attached-tint:color-mix(in_srgb,var(--info)_4%,transparent)]",
-  success:
-    "[--chat-composer-attached-outline:color-mix(in_srgb,var(--success)_32%,transparent)] [--chat-composer-attached-tint:color-mix(in_srgb,var(--success)_4%,transparent)]",
+  info: neutralOutline,
+  success: neutralOutline,
   warning:
     "[--chat-composer-attached-outline:color-mix(in_srgb,var(--warning)_28%,transparent)] [--chat-composer-attached-tint:color-mix(in_srgb,var(--warning)_8%,transparent)]",
 };
@@ -71,8 +70,8 @@ function Surface({
 const peekBorder: Record<ComposerBannerVariant, string> = {
   default: "border-(--chat-composer-attached-outline)",
   error: "border-destructive/24",
-  info: "border-info/24",
-  success: "border-success/24",
+  info: "border-(--chat-composer-attached-outline)",
+  success: "border-(--chat-composer-attached-outline)",
   warning: "border-warning/24",
 };
 

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -660,7 +660,7 @@ export function ProviderInstanceCard({
               {versionCodeNode}
               {versionAdvisory ? (
                 <span role="img" aria-label="Update available" className="inline-flex shrink-0">
-                  <ArrowUpCircleIcon className="size-3.5 text-update-foreground" />
+                  <ArrowUpCircleIcon className="size-3.5 text-muted-foreground" />
                 </span>
               ) : null}
             </span>
@@ -715,7 +715,7 @@ export function ProviderInstanceCard({
                           "size-5 rounded-sm p-0",
                           versionAdvisory.emphasis === "strong"
                             ? "text-warning hover:text-warning"
-                            : "text-update-foreground hover:text-update-foreground",
+                            : "text-muted-foreground hover:text-foreground",
                         )}
                         aria-label="Update available — view details"
                       >
@@ -748,7 +748,7 @@ export function ProviderInstanceCard({
                         <Button
                           type="button"
                           size="xs"
-                          variant="default"
+                          variant="outline"
                           className="w-full"
                           disabled={isUpdating}
                           onClick={onRunUpdate}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -381,7 +381,7 @@ function AboutVersionSection() {
               render={
                 <Button
                   size="xs"
-                  variant={action === "install" ? "default" : "outline"}
+                  variant="outline"
                   disabled={buttonDisabled || isUpdateActionPending}
                   onClick={handleButtonClick}
                 >

--- a/apps/web/src/components/sidebar/DesktopUpdateStatusIcon.tsx
+++ b/apps/web/src/components/sidebar/DesktopUpdateStatusIcon.tsx
@@ -46,7 +46,7 @@ function DesktopUpdateAvailableIcon() {
       <DownloadIcon className="size-4" />
       <span
         aria-hidden="true"
-        className="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-update-foreground ring-2 ring-update-surface"
+        className="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-current ring-2 ring-sidebar-control-surface"
       />
     </span>
   );
@@ -93,7 +93,7 @@ function DesktopUpdateDownloadedIcon() {
   return (
     <span className="relative grid size-4 place-items-center">
       <RotateCwIcon className="size-4" />
-      <span className="absolute -right-1 -bottom-1 grid size-2.5 place-items-center rounded-full bg-update-foreground text-background ring-2 ring-background">
+      <span className="absolute -right-1 -bottom-1 grid size-2.5 place-items-center rounded-full bg-foreground text-background ring-2 ring-background">
         <CheckIcon className="size-2" strokeWidth={3} />
       </span>
     </span>

--- a/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
@@ -14,9 +14,9 @@ import { Button } from "../ui/button";
 
 const PROVIDER_UPDATE_PILL_STYLES = {
   loading:
-    "bg-update-surface text-update-foreground group-has-[button.provider-update-main:hover]/provider-update:bg-update/22",
+    "bg-sidebar-control-surface text-sidebar-foreground group-has-[button.provider-update-main:hover]/provider-update:bg-sidebar-row-hover",
   success:
-    "bg-success/12 text-success group-has-[button.provider-update-main:hover]/provider-update:bg-success/18",
+    "bg-sidebar-control-surface text-sidebar-foreground group-has-[button.provider-update-main:hover]/provider-update:bg-sidebar-row-hover",
   warning:
     "bg-warning/12 text-warning group-has-[button.provider-update-main:hover]/provider-update:bg-warning/18",
   error:
@@ -24,7 +24,7 @@ const PROVIDER_UPDATE_PILL_STYLES = {
 } as const;
 
 const PROVIDER_UPDATE_PILL_PROGRESS_STYLES = {
-  success: "bg-success/18",
+  success: "bg-foreground/8",
   warning: "bg-warning/14",
   error: "bg-destructive/14",
 } as const;

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -84,7 +84,7 @@ function SidebarUpdateReleaseNotesTooltip({
               Update ready to download
             </div>
             {state.availableVersion ? (
-              <div className="mt-0.5 text-xs leading-4 text-update-foreground">
+              <div className="mt-0.5 text-xs leading-4 text-muted-foreground">
                 {state.availableVersion}
               </div>
             ) : null}
@@ -319,8 +319,8 @@ function SidebarUpdateControl() {
                 isInteractionDisabled ? "cursor-not-allowed" : "cursor-pointer",
                 showUpdateIconState
                   ? cn(
-                      "bg-update-surface text-update-foreground",
-                      !isInteractionDisabled && "hover:bg-update/12",
+                      "bg-sidebar-control-surface text-sidebar-foreground",
+                      !isInteractionDisabled && "hover:bg-sidebar-row-hover",
                     )
                   : cn(
                       "text-[var(--sidebar-icon-color)]",
@@ -351,15 +351,6 @@ function SidebarUpdateControl() {
               : undefined
           }
           side="top"
-          style={
-            showUpdateDetails
-              ? {
-                  background:
-                    "color-mix(in srgb, var(--update) 18%, color-mix(in srgb, var(--popover) var(--glass-opacity), transparent))",
-                  borderColor: "var(--update-foreground)",
-                }
-              : undefined
-          }
           variant={showUpdateDetails ? "glass" : "default"}
         >
           {showUpdateDetails && state ? (


### PR DESCRIPTION
This mutes informational and success composer banners so routine thread states sit on neutral app surfaces while warnings and errors keep semantic color. Update indicators and routine update actions now use sidebar neutrals and outline buttons instead of accent fills. Verified with the web typecheck, targeted lint and formatting, and 28 focused unit tests. Built with `gpt-5.6-sol` in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and button-variant changes only; no changes to update logic, auth, or data handling.
> 
> **Overview**
> This PR **quiets routine informational UI** so warnings and errors stay visually distinct. **Composer** `info` and `success` banners now use the same neutral outline/tint as `default`, instead of blue/green semantic styling; **warning** and **error** are unchanged.
> 
> **Update flows** are de-emphasized across the app: primary **Update** actions use **`outline`** buttons (provider rows, server update, settings About, provider popover) instead of filled defaults. Provider update toasts always use an outline primary action.
> 
> **Sidebar and settings** swap **update** accent tokens for **sidebar neutrals** (`sidebar-control-surface`, `sidebar-foreground`, `muted-foreground`, `foreground`): desktop update badge dots, provider update pill loading/success states, and the sidebar update control. Provider **update available** icons in settings use muted icon colors rather than `update-foreground`. The sidebar update tooltip no longer applies custom update-tinted glass styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 352c999cae4d66bd29fdc8b4d8e9b06538a331af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mute routine update notices and switch update actions to neutral outline styling
> Replaces update-themed, info, and success colors with neutral `outline` variant and muted/sidebar tokens across update-related UI components.
>
> - Switches update action buttons (environment rows, server self-update, provider cards, about version, primary notification toast) from `default` to `variant="outline"`
> - Recolors info and success `ComposerBanner` variants to `neutralOutline` and matching peek borders
> - Reworks sidebar update icons and pills (`DesktopUpdateAvailableIcon`, `DesktopUpdateDownloadedIcon`, `SidebarProviderUpdatePill`, `SidebarUpdateControl`) to use `sidebar-control-surface`, `sidebar-foreground`, and `text-muted-foreground` instead of `update-foreground`/`success` tokens
> - Removes custom inline tooltip background/border styling in `SidebarUpdateControl` while keeping `variant="glass"`
> - Risk: components in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/9063/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9) and [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/9063/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf) drop `text-update-foreground` and `bg-update-foreground` usages; any out-of-tree consumers of those theme tokens will no longer match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 352c999.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->