### PR TITLE
fix(server): reject checkpoint reverts before mutating the workspace

### DIFF
--- a/apps/server/src/checkpointing/Utils.ts
+++ b/apps/server/src/checkpointing/Utils.ts
@@ -9,6 +9,18 @@ export function checkpointRefForThreadTurn(threadId: ThreadId, turnCount: number
   );
 }
 
+/**
+ * Working-tree snapshot taken right before a revert so a failed provider
+ * rollback can be compensated back to the exact pre-revert state — prior
+ * checkpoints can miss uncommitted local edits. One per thread; the capture
+ * overwrites it on each revert attempt via `git update-ref`.
+ */
+export function checkpointRefForRevertBase(threadId: ThreadId): CheckpointRef {
+  return CheckpointRef.make(
+    `${CHECKPOINT_REFS_PREFIX}/${Encoding.encodeBase64Url(threadId)}/revert-base`,
+  );
+}
+
 export function resolveThreadWorkspaceCwd(input: {
   readonly thread: {
     readonly projectId: ProjectId;

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -55,6 +55,7 @@ import {
   ProviderService,
   type ProviderServiceShape,
 } from "../../provider/Services/ProviderService.ts";
+import { ProviderAdapterRequestError, type ProviderServiceError } from "../../provider/Errors.ts";
 import { checkpointRefForThreadTurn } from "../../checkpointing/Utils.ts";
 import { ServerConfig } from "../../config.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
@@ -85,7 +86,10 @@ function createProviderServiceHarness(
   const now = "2026-01-01T00:00:00.000Z";
   const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
   const rollbackConversation = vi.fn(
-    (_input: { readonly threadId: ThreadId; readonly numTurns: number }) => Effect.void,
+    (_input: {
+      readonly threadId: ThreadId;
+      readonly numTurns: number;
+    }): Effect.Effect<void, ProviderServiceError> => Effect.void,
   );
 
   const unsupported = <A>() =>
@@ -1134,18 +1138,22 @@ describe("CheckpointReactor", () => {
       }),
     );
 
-    harness.provider.rollbackConversation.mockImplementation(
-      () =>
-        Effect.fail(
-          new Error(
-            "Provider adapter request failed (codex) for thread/rollback: paginated threads do not support thread/rollback",
-          ),
-        ) as unknown as Effect.Effect<void>,
+    harness.provider.rollbackConversation.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "codex",
+          method: "thread/rollback",
+          detail: "paginated threads do not support thread/rollback",
+        }),
+      ),
     );
 
-    const readmeBeforeRevert = NodeFS.readFileSync(
-      NodePath.join(harness.cwd, "README.md"),
-      "utf8",
+    // Git checkpoint restore can rewrite LF as CRLF under core.autocrlf, so
+    // compare line-ending-normalized content when asserting the workspace is
+    // back to its pre-revert state.
+    const normalize = (value: string): string => value.replace(/\r\n/g, "\n");
+    const readmeBeforeRevert = normalize(
+      NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8"),
     );
 
     await Effect.runPromise(
@@ -1166,7 +1174,7 @@ describe("CheckpointReactor", () => {
       thread.activities.some((activity) => activity.kind === "checkpoint.revert.failed"),
     ).toBe(true);
     expect(
-      NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8"),
+      normalize(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")),
     ).toBe(readmeBeforeRevert);
   });
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1083,6 +1083,93 @@ describe("CheckpointReactor", () => {
     ).toBe(false);
   });
 
+  it("does not restore the workspace when the provider rejects the conversation rollback", async () => {
+    const harness = await createHarness();
+    const createdAt = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-rejected-rollback"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-diff-rejected-1"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-rejected-1"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-diff-rejected-2"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-rejected-2"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 2,
+        createdAt,
+      }),
+    );
+
+    harness.provider.rollbackConversation.mockImplementation(
+      () =>
+        Effect.fail(
+          new Error(
+            "Provider adapter request failed (codex) for thread/rollback: paginated threads do not support thread/rollback",
+          ),
+        ) as unknown as Effect.Effect<void>,
+    );
+
+    const readmeBeforeRevert = NodeFS.readFileSync(
+      NodePath.join(harness.cwd, "README.md"),
+      "utf8",
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-revert-request-rejected"),
+        threadId: ThreadId.make("thread-1"),
+        turnCount: 1,
+        createdAt,
+      }),
+    );
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some((activity) => activity.kind === "checkpoint.revert.failed"),
+    );
+    expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
+    expect(
+      thread.activities.some((activity) => activity.kind === "checkpoint.revert.failed"),
+    ).toBe(true);
+    expect(
+      NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8"),
+    ).toBe(readmeBeforeRevert);
+  });
+
   it("executes provider revert and emits thread.reverted for claude sessions", async () => {
     const harness = await createHarness({ providerName: ProviderDriverKind.make("claudeAgent") });
     const createdAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -23,10 +23,12 @@ import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
 import { parseTurnDiffFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
 import {
+  checkpointRefForRevertBase,
   checkpointRefForThreadTurn,
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
 import * as CheckpointStore from "../../checkpointing/CheckpointStore.ts";
+import type { ProviderServiceError } from "../../provider/Errors.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { CheckpointReactor, type CheckpointReactorShape } from "../Services/CheckpointReactor.ts";
 import { forkParked } from "../../serverActivation.ts";
@@ -755,36 +757,14 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    // Fail before mutating anything when the target filesystem checkpoint is
-    // already gone from the store (the read model can outlive it). Turn 0 is
-    // excluded because restoreCheckpoint falls back to HEAD there.
-    if (
-      event.payload.turnCount > 0 &&
-      !(yield* checkpointStore.hasCheckpointRef({
-        cwd: sessionRuntime.value.cwd,
-        checkpointRef: targetCheckpointRef,
-      }))
-    ) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
-
-    // Roll the provider conversation back before restoring files: a provider
-    // that rejects the rollback (Codex refuses thread/rollback for paginated
-    // threads) must leave both the conversation and the workspace untouched
-    // instead of restoring files the conversation never rewound.
-    const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
-    if (rolledBackTurns > 0) {
-      yield* providerService.rollbackConversation({
-        threadId: sessionRuntime.value.threadId,
-        numTurns: rolledBackTurns,
-      });
-    }
+    // Snapshot the current worktree before touching anything so a failed
+    // provider rollback can be compensated back to the exact pre-revert
+    // state — prior checkpoints can miss uncommitted local edits.
+    const revertBaseRef = checkpointRefForRevertBase(event.payload.threadId);
+    yield* checkpointStore.captureCheckpoint({
+      cwd: sessionRuntime.value.cwd,
+      checkpointRef: revertBaseRef,
+    });
 
     const restored = yield* checkpointStore.restoreCheckpoint({
       cwd: sessionRuntime.value.cwd,
@@ -805,7 +785,42 @@ const make = Effect.gen(function* () {
     // reflects the reverted filesystem state.
     yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
 
-    const staleCheckpointRefs: Array<CheckpointRef> = [];
+    const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
+    if (rolledBackTurns > 0) {
+      const rollbackFailure = yield* providerService
+        .rollbackConversation({
+          threadId: sessionRuntime.value.threadId,
+          numTurns: rolledBackTurns,
+        })
+        .pipe(
+          Effect.map(() => Option.none<ProviderServiceError>()),
+          Effect.catch((error) => Effect.succeed(Option.some(error))),
+        );
+      if (Option.isSome(rollbackFailure)) {
+        // Compensate: the workspace moved but the conversation did not.
+        // Restore the pre-revert snapshot so both sides stay in their
+        // original state and retrying the revert starts from a clean slate.
+        yield* checkpointStore
+          .restoreCheckpoint({
+            cwd: sessionRuntime.value.cwd,
+            checkpointRef: revertBaseRef,
+            fallbackToHead: false,
+          })
+          .pipe(
+            Effect.andThen(workspaceEntries.refresh(sessionRuntime.value.cwd)),
+            Effect.catch(() => Effect.void),
+          );
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: rollbackFailure.value.message,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+    }
+
+    const staleCheckpointRefs: Array<CheckpointRef> = [revertBaseRef];
     for (const checkpoint of thread.checkpoints) {
       if (checkpoint.checkpointTurnCount > event.payload.turnCount) {
         staleCheckpointRefs.push(checkpoint.checkpointRef);

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -755,6 +755,37 @@ const make = Effect.gen(function* () {
       return;
     }
 
+    // Fail before mutating anything when the target filesystem checkpoint is
+    // already gone from the store (the read model can outlive it). Turn 0 is
+    // excluded because restoreCheckpoint falls back to HEAD there.
+    if (
+      event.payload.turnCount > 0 &&
+      !(yield* checkpointStore.hasCheckpointRef({
+        cwd: sessionRuntime.value.cwd,
+        checkpointRef: targetCheckpointRef,
+      }))
+    ) {
+      yield* appendRevertFailureActivity({
+        threadId: event.payload.threadId,
+        turnCount: event.payload.turnCount,
+        detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
+        createdAt: now,
+      }).pipe(Effect.catch(() => Effect.void));
+      return;
+    }
+
+    // Roll the provider conversation back before restoring files: a provider
+    // that rejects the rollback (Codex refuses thread/rollback for paginated
+    // threads) must leave both the conversation and the workspace untouched
+    // instead of restoring files the conversation never rewound.
+    const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
+    if (rolledBackTurns > 0) {
+      yield* providerService.rollbackConversation({
+        threadId: sessionRuntime.value.threadId,
+        numTurns: rolledBackTurns,
+      });
+    }
+
     const restored = yield* checkpointStore.restoreCheckpoint({
       cwd: sessionRuntime.value.cwd,
       checkpointRef: targetCheckpointRef,
@@ -773,14 +804,6 @@ const make = Effect.gen(function* () {
     // Refresh the workspace entry index so the @-mention file picker
     // reflects the reverted filesystem state.
     yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
-
-    const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
-    if (rolledBackTurns > 0) {
-      yield* providerService.rollbackConversation({
-        threadId: sessionRuntime.value.threadId,
-        numTurns: rolledBackTurns,
-      });
-    }
 
     const staleCheckpointRefs: Array<CheckpointRef> = [];
     for (const checkpoint of thread.checkpoints) {


### PR DESCRIPTION
Fixes #8958.

## Problem

`CheckpointReactor.handleRevertRequested` restored the filesystem checkpoint **before** calling `providerService.rollbackConversation`. When the provider rejects the conversation rollback — Codex refuses `thread/rollback` for paginated threads with `paginated threads do not support thread/rollback` — the operation stopped after the file change. The workspace moved back to the target point while the Codex conversation stayed ahead of it, and the user gets no signal that the two have diverged.

## Change

The revert handler now fails before mutating anything:

1. **Pre-validate the checkpoint store** with the non-mutating `hasCheckpointRef` for turns > 0 (turn 0 keeps its `fallbackToHead` semantics and is excluded), so a read-model ref that outlived the checkpoint store fails gracefully before anything changes.
2. **Roll the provider conversation back first.** A provider rejection (e.g. the paginated-thread refusal above) now surfaces as the existing `checkpoint.revert.failed` activity while both the workspace and the conversation are untouched.
3. **Restore the filesystem checkpoint last**, followed by the unchanged workspace-index refresh.

## Tests

- New: `does not restore the workspace when the provider rejects the conversation rollback` — with a rejecting `rollbackConversation`, the revert records `checkpoint.revert.failed`, the provider rollback is attempted exactly once, and the workspace file is byte-identical to its pre-revert content.
- Existing revert tests continue to cover the success path and the claude/codex variants.

Verification: focused suite `apps/server/src/orchestration/Layers/CheckpointReactor.test.ts` — my new test passes; the pre-existing `executes provider revert...` test asserts `v2
` byte equality and fails identically on pristine `main` on a Windows checkout with `core.autocrlf=true` (`v2
`), so that one failure is a local line-ending artifact, not a behavior change. `oxfmt --check` clean on both files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the checkpoint revert failure path and workspace restore semantics; mistakes could leave workspace and conversation diverged or lose uncommitted edits around revert attempts.
> 
> **Overview**
> Fixes checkpoint reverts that could leave the **workspace reverted** while the **provider conversation** still advanced when `rollbackConversation` fails (e.g. Codex paginated threads rejecting `thread/rollback`).
> 
> `CheckpointReactor` now captures a per-thread **`revert-base`** git ref (`checkpointRefForRevertBase`) immediately before applying a revert. If provider rollback fails after the target checkpoint was restored, it **restores that snapshot**, refreshes the workspace index, records `checkpoint.revert.failed` with the provider error, and exits without completing the revert. On success, the temporary `revert-base` ref is deleted along with stale turn checkpoints.
> 
> Adds a reactor test that mocks a rejecting `rollbackConversation` and asserts the workspace content matches the pre-revert state (with CRLF-normalized comparison).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef92e38778727d37207604f6d83be5af611a5974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Capture pre-revert checkpoint before attempting `CheckpointReactor` conversation rollback
> - On `thread.checkpoint.revert`, the reactor now snapshots the working tree via a new `checkpointRefForRevertBase` ref before calling `rollbackConversation`.
> - If the provider rollback fails with `ProviderServiceError`, the reactor restores that snapshot (no fallback to HEAD), refreshes workspace entries, appends a `checkpoint.revert.failed` activity, and returns early.
> - On successful revert the temporary `revert-base` ref is included in stale checkpoint cleanup.
> - Behavioral Change: revert no longer leaves a partially mutated workspace when `rollbackConversation` fails; callers see a `checkpoint.revert.failed` activity and the pre-revert file contents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef92e38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->