### PR TITLE
feat(swift-ios): show skill invocations as pills

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerPowerFeatures.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerPowerFeatures.swift
@@ -27,6 +27,10 @@ struct FeatureComposerPowerFeatures {
     }
 
     static var disabled: FeatureComposerPowerFeatures { FeatureComposerPowerFeatures() }
+
+    var enabledSkills: [FeatureProviderSkill] {
+        skills.filter(\.isEnabled)
+    }
 }
 
 enum FeatureContextCompaction {

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -17,6 +17,7 @@ struct FeatureComposerTextInput: UIViewRepresentable {
     let placeholder: String
     let acceptsImages: Bool
     let isReadOnly: Bool
+    let skills: [FeatureProviderSkill]
     let selectionRequest: FeatureComposerTextSelectionRequest?
     let onSelectionChange: (NSRange) -> Void
     let onPasteImages: ([NSItemProvider]) -> Void
@@ -65,36 +66,57 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         textView.onDismissKeyboard = onDismissKeyboard
         textView.isReadOnly = isReadOnly
 
+        let previousAttributedText = textView.attributedText ?? NSAttributedString()
+        let previousText = FeatureInlineSkillProjection.plainText(from: previousAttributedText)
+        let previousSelection = FeatureInlineSkillProjection.plainRange(
+            for: textView.selectedRange,
+            in: previousAttributedText
+        )
         let shouldApplySelection = selectionRequest.map {
             context.coordinator.lastAppliedSelectionRequestID != $0.id
         } ?? false
         context.coordinator.isApplyingProgrammaticUpdate = true
         defer {
             context.coordinator.isApplyingProgrammaticUpdate = false
-            onSelectionChange(textView.selectedRange)
+            onSelectionChange(FeatureInlineSkillProjection.plainRange(
+                for: textView.selectedRange,
+                in: textView.attributedText
+            ))
         }
-        if textView.text != text {
-            let previousText = textView.text ?? ""
-            let selectedRange = textView.selectedRange
-            textView.text = text
-            if !shouldApplySelection {
-                let location = FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
-                    previousText: previousText,
-                    newText: text,
-                    selectedLocation: selectedRange.location
-                )
-                let length = previousText.isEmpty
-                    ? 0
-                    : min(selectedRange.length, text.utf16.count - location)
-                textView.selectedRange = NSRange(location: location, length: length)
-                textView.scrollSelectionIntoView()
-            }
-        }
+        let targetSelection: NSRange
         if shouldApplySelection, let selectionRequest {
-            let location = min(selectionRequest.location, textView.text.utf16.count)
-            textView.selectedRange = NSRange(location: location, length: 0)
+            targetSelection = NSRange(
+                location: min(selectionRequest.location, text.utf16.count),
+                length: 0
+            )
+        } else if previousText != text {
+            let location = FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
+                previousText: previousText,
+                newText: text,
+                selectedLocation: previousSelection.location
+            )
+            let length = previousText.isEmpty
+                ? 0
+                : min(previousSelection.length, text.utf16.count - location)
+            targetSelection = NSRange(location: location, length: length)
+        } else {
+            targetSelection = previousSelection
+        }
+
+        let rebuiltText = context.coordinator.synchronizeInlineSkills(
+            in: textView,
+            source: text,
+            selection: targetSelection
+        )
+        if shouldApplySelection, let selectionRequest {
+            textView.selectedRange = FeatureInlineSkillProjection.displayRange(
+                for: targetSelection,
+                in: textView.attributedText
+            )
             textView.scrollSelectionIntoView()
             context.coordinator.lastAppliedSelectionRequestID = selectionRequest.id
+        } else if rebuiltText {
+            textView.scrollSelectionIntoView()
         }
         updateAccessibility(textView)
 
@@ -143,6 +165,7 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         var lastAppliedFocus: Bool?
         var lastAppliedSelectionRequestID: UUID?
         var isApplyingProgrammaticUpdate = false
+        private var isSynchronizingInlineSkills = false
 
         init(_ parent: FeatureComposerTextInput) {
             self.parent = parent
@@ -158,14 +181,83 @@ struct FeatureComposerTextInput: UIViewRepresentable {
 
         func textViewDidChange(_ textView: UITextView) {
             guard !isApplyingProgrammaticUpdate else { return }
-            guard parent.text != textView.text else { return }
-            parent.text = textView.text
-            (textView as? FeatureComposerUITextView)?.scrollSelectionIntoView()
+            guard !isSynchronizingInlineSkills else { return }
+            let source = FeatureInlineSkillProjection.plainText(from: textView.attributedText)
+            if parent.text != source {
+                parent.text = source
+            }
+            guard textView.markedTextRange == nil,
+                  let composerTextView = textView as? FeatureComposerUITextView else {
+                return
+            }
+            let selection = FeatureInlineSkillProjection.plainRange(
+                for: textView.selectedRange,
+                in: textView.attributedText
+            )
+            _ = synchronizeInlineSkills(
+                in: composerTextView,
+                source: source,
+                selection: selection
+            )
+            composerTextView.scrollSelectionIntoView()
+        }
+
+        @discardableResult
+        func synchronizeInlineSkills(
+            in textView: FeatureComposerUITextView,
+            source: String,
+            selection: NSRange
+        ) -> Bool {
+            let currentText = textView.attributedText ?? NSAttributedString()
+            let currentSource = FeatureInlineSkillProjection.plainText(from: currentText)
+            let currentSignatures = FeatureInlineSkillProjection.signatures(in: currentText)
+            let preservedTrailing = currentSource == source
+                ? currentSignatures.last?.descriptor
+                : nil
+            let descriptors = FeatureInlineSkillParser.descriptors(
+                in: source,
+                skills: parent.skills,
+                allowsEndBoundary: false,
+                preservingTrailing: preservedTrailing
+            )
+            let font = textView.font ?? UIFont.preferredFont(forTextStyle: .body)
+            let desiredSignatures = FeatureInlineSkillPillRenderer.signatures(
+                for: descriptors,
+                font: font,
+                traits: textView.traitCollection
+            )
+            guard currentSource != source || currentSignatures != desiredSignatures else {
+                return false
+            }
+
+            let baseAttributes: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: T3Colors.uiTextPrimary,
+            ]
+            let attributedText = FeatureInlineSkillPillRenderer.attributedText(
+                source: source,
+                descriptors: descriptors,
+                baseAttributes: baseAttributes,
+                font: font,
+                traits: textView.traitCollection
+            )
+            isSynchronizingInlineSkills = true
+            textView.attributedText = attributedText
+            textView.typingAttributes = baseAttributes
+            textView.selectedRange = FeatureInlineSkillProjection.displayRange(
+                for: selection,
+                in: attributedText
+            )
+            isSynchronizingInlineSkills = false
+            return true
         }
 
         func textViewDidChangeSelection(_ textView: UITextView) {
-            guard !isApplyingProgrammaticUpdate else { return }
-            parent.onSelectionChange(textView.selectedRange)
+            guard !isApplyingProgrammaticUpdate, !isSynchronizingInlineSkills else { return }
+            parent.onSelectionChange(FeatureInlineSkillProjection.plainRange(
+                for: textView.selectedRange,
+                in: textView.attributedText
+            ))
         }
 
         func textViewDidBeginEditing(_ textView: UITextView) {
@@ -186,7 +278,7 @@ struct FeatureComposerTextInput: UIViewRepresentable {
 
 /// Advertises image support to the paste menu and routes image pastes out to
 /// the attachment pipeline. Text-only pastes fall through to UIKit untouched.
-final class FeatureComposerUITextView: UITextView {
+final class FeatureComposerUITextView: FeatureInlineSkillTextView {
     private static let bottomEditingInset: CGFloat = 10
     private var lastLaidOutBoundsSize = CGSize.zero
 

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -243,11 +243,11 @@ struct FeatureComposerTextInput: UIViewRepresentable {
             )
             isSynchronizingInlineSkills = true
             textView.attributedText = attributedText
-            textView.typingAttributes = baseAttributes
             textView.selectedRange = FeatureInlineSkillProjection.displayRange(
                 for: selection,
                 in: attributedText
             )
+            textView.typingAttributes = baseAttributes
             isSynchronizingInlineSkills = false
             return true
         }

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -164,6 +164,7 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         private struct UndoSnapshot: Equatable {
             let source: String
             let selection: NSRange
+            let trailingSkill: FeatureInlineSkillDescriptor?
         }
 
         var parent: FeatureComposerTextInput
@@ -220,7 +221,7 @@ struct FeatureComposerTextInput: UIViewRepresentable {
                 source: source,
                 selection: selection
             )
-            let updatedSnapshot = UndoSnapshot(source: source, selection: selection)
+            let updatedSnapshot = undoSnapshot(in: textView)
             if let pendingUndoSnapshot, pendingUndoSnapshot != updatedSnapshot {
                 registerUndo(
                     restoring: pendingUndoSnapshot,
@@ -236,14 +237,15 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         func synchronizeInlineSkills(
             in textView: FeatureComposerUITextView,
             source: String,
-            selection: NSRange
+            selection: NSRange,
+            preservingTrailing restoredTrailingSkill: FeatureInlineSkillDescriptor? = nil
         ) -> Bool {
             let currentText = textView.attributedText ?? NSAttributedString()
             let currentSource = FeatureInlineSkillProjection.plainText(from: currentText)
             let currentSignatures = FeatureInlineSkillProjection.signatures(in: currentText)
-            let preservedTrailing = currentSource == source
-                ? currentSignatures.last?.descriptor
-                : nil
+            let preservedTrailing = restoredTrailingSkill ?? (
+                currentSource == source ? currentSignatures.last?.descriptor : nil
+            )
             let descriptors = FeatureInlineSkillParser.descriptors(
                 in: source,
                 skills: parent.skills,
@@ -308,12 +310,18 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         }
 
         private func undoSnapshot(in textView: UITextView) -> UndoSnapshot {
-            UndoSnapshot(
-                source: FeatureInlineSkillProjection.plainText(from: textView.attributedText),
+            let source = FeatureInlineSkillProjection.plainText(from: textView.attributedText)
+            let trailingSkill = FeatureInlineSkillProjection.signatures(in: textView.attributedText)
+                .last?.descriptor
+            return UndoSnapshot(
+                source: source,
                 selection: FeatureInlineSkillProjection.plainRange(
                     for: textView.selectedRange,
                     in: textView.attributedText
-                )
+                ),
+                trailingSkill: trailingSkill.flatMap {
+                    NSMaxRange($0.range) == source.utf16.count ? $0 : nil
+                }
             )
         }
 
@@ -359,7 +367,8 @@ struct FeatureComposerTextInput: UIViewRepresentable {
             _ = synchronizeInlineSkills(
                 in: textView,
                 source: snapshot.source,
-                selection: snapshot.selection
+                selection: snapshot.selection,
+                preservingTrailing: snapshot.trailingSkill
             )
             parent.text = snapshot.source
             parent.onSelectionChange(snapshot.selection)

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -161,11 +161,18 @@ struct FeatureComposerTextInput: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, UITextViewDelegate {
+        private struct UndoSnapshot: Equatable {
+            let source: String
+            let selection: NSRange
+        }
+
         var parent: FeatureComposerTextInput
         var lastAppliedFocus: Bool?
         var lastAppliedSelectionRequestID: UUID?
         var isApplyingProgrammaticUpdate = false
         private var isSynchronizingInlineSkills = false
+        private var pendingUndoSnapshot: UndoSnapshot?
+        private weak var disabledUndoManager: UndoManager?
 
         init(_ parent: FeatureComposerTextInput) {
             self.parent = parent
@@ -176,10 +183,24 @@ struct FeatureComposerTextInput: UIViewRepresentable {
             shouldChangeTextIn range: NSRange,
             replacementText text: String
         ) -> Bool {
-            !parent.isReadOnly
+            guard !parent.isReadOnly else { return false }
+            guard !isApplyingProgrammaticUpdate, !isSynchronizingInlineSkills else {
+                return true
+            }
+            if pendingUndoSnapshot == nil {
+                pendingUndoSnapshot = undoSnapshot(in: textView)
+            }
+            if disabledUndoManager == nil,
+               let undoManager = textView.undoManager,
+               undoManager.isUndoRegistrationEnabled {
+                undoManager.disableUndoRegistration()
+                disabledUndoManager = undoManager
+            }
+            return true
         }
 
         func textViewDidChange(_ textView: UITextView) {
+            restoreUndoRegistration()
             guard !isApplyingProgrammaticUpdate else { return }
             guard !isSynchronizingInlineSkills else { return }
             let source = FeatureInlineSkillProjection.plainText(from: textView.attributedText)
@@ -199,6 +220,15 @@ struct FeatureComposerTextInput: UIViewRepresentable {
                 source: source,
                 selection: selection
             )
+            let updatedSnapshot = UndoSnapshot(source: source, selection: selection)
+            if let pendingUndoSnapshot, pendingUndoSnapshot != updatedSnapshot {
+                registerUndo(
+                    restoring: pendingUndoSnapshot,
+                    inverse: updatedSnapshot,
+                    in: composerTextView
+                )
+            }
+            pendingUndoSnapshot = nil
             composerTextView.scrollSelectionIntoView()
         }
 
@@ -242,22 +272,31 @@ struct FeatureComposerTextInput: UIViewRepresentable {
                 traits: textView.traitCollection
             )
             isSynchronizingInlineSkills = true
+            let undoManager = textView.undoManager
+            let shouldRestoreUndoRegistration = undoManager?.isUndoRegistrationEnabled == true
+            if shouldRestoreUndoRegistration {
+                undoManager?.disableUndoRegistration()
+            }
             textView.attributedText = attributedText
             textView.selectedRange = FeatureInlineSkillProjection.displayRange(
                 for: selection,
                 in: attributedText
             )
             textView.typingAttributes = baseAttributes
+            if shouldRestoreUndoRegistration {
+                undoManager?.enableUndoRegistration()
+            }
             isSynchronizingInlineSkills = false
             return true
         }
 
         func textViewDidChangeSelection(_ textView: UITextView) {
             guard !isApplyingProgrammaticUpdate, !isSynchronizingInlineSkills else { return }
-            parent.onSelectionChange(FeatureInlineSkillProjection.plainRange(
+            let selection = FeatureInlineSkillProjection.plainRange(
                 for: textView.selectedRange,
                 in: textView.attributedText
-            ))
+            )
+            parent.onSelectionChange(selection)
         }
 
         func textViewDidBeginEditing(_ textView: UITextView) {
@@ -268,10 +307,72 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         }
 
         func textViewDidEndEditing(_ textView: UITextView) {
+            restoreUndoRegistration()
+            pendingUndoSnapshot = nil
             lastAppliedFocus = false
             if parent.focused {
                 parent.focused = false
             }
+        }
+
+        private func undoSnapshot(in textView: UITextView) -> UndoSnapshot {
+            UndoSnapshot(
+                source: FeatureInlineSkillProjection.plainText(from: textView.attributedText),
+                selection: FeatureInlineSkillProjection.plainRange(
+                    for: textView.selectedRange,
+                    in: textView.attributedText
+                )
+            )
+        }
+
+        private func restoreUndoRegistration() {
+            if let disabledUndoManager,
+               !disabledUndoManager.isUndoRegistrationEnabled {
+                disabledUndoManager.enableUndoRegistration()
+            }
+            disabledUndoManager = nil
+        }
+
+        private func registerUndo(
+            restoring snapshot: UndoSnapshot,
+            inverse: UndoSnapshot,
+            in textView: FeatureComposerUITextView
+        ) {
+            guard let undoManager = textView.undoManager else { return }
+            let opensUndoGroup = undoManager.groupingLevel == 0
+            if opensUndoGroup {
+                undoManager.beginUndoGrouping()
+            }
+            undoManager.registerUndo(withTarget: self) { [weak textView] coordinator in
+                guard let textView else { return }
+                coordinator.restore(
+                    snapshot,
+                    inverse: inverse,
+                    in: textView
+                )
+            }
+            undoManager.setActionName("Typing")
+            if opensUndoGroup {
+                undoManager.endUndoGrouping()
+            }
+        }
+
+        private func restore(
+            _ snapshot: UndoSnapshot,
+            inverse: UndoSnapshot,
+            in textView: FeatureComposerUITextView
+        ) {
+            registerUndo(restoring: inverse, inverse: snapshot, in: textView)
+            isApplyingProgrammaticUpdate = true
+            _ = synchronizeInlineSkills(
+                in: textView,
+                source: snapshot.source,
+                selection: snapshot.selection
+            )
+            parent.text = snapshot.source
+            parent.onSelectionChange(snapshot.selection)
+            isApplyingProgrammaticUpdate = false
+            textView.scrollSelectionIntoView()
         }
     }
 }

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -272,20 +272,12 @@ struct FeatureComposerTextInput: UIViewRepresentable {
                 traits: textView.traitCollection
             )
             isSynchronizingInlineSkills = true
-            let undoManager = textView.undoManager
-            let shouldRestoreUndoRegistration = undoManager?.isUndoRegistrationEnabled == true
-            if shouldRestoreUndoRegistration {
-                undoManager?.disableUndoRegistration()
-            }
             textView.attributedText = attributedText
             textView.selectedRange = FeatureInlineSkillProjection.displayRange(
                 for: selection,
                 in: attributedText
             )
             textView.typingAttributes = baseAttributes
-            if shouldRestoreUndoRegistration {
-                undoManager?.enableUndoRegistration()
-            }
             isSynchronizingInlineSkills = false
             return true
         }

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -240,6 +240,8 @@ struct FeatureComposerTextInput: UIViewRepresentable {
             selection: NSRange,
             preservingTrailing restoredTrailingSkill: FeatureInlineSkillDescriptor? = nil
         ) -> Bool {
+            // Replacing attributed text would commit or discard active IME composition.
+            guard textView.markedTextRange == nil else { return false }
             let currentText = textView.attributedText ?? NSAttributedString()
             let currentSource = FeatureInlineSkillProjection.plainText(from: currentText)
             let currentSignatures = FeatureInlineSkillProjection.signatures(in: currentText)

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -330,7 +330,7 @@ struct FeatureComposerView: View {
                     placeholder: composerPlaceholder,
                     acceptsImages: imagesAllowed,
                     isReadOnly: voiceInputController.isBusy,
-                    skills: powerFeatures.skills,
+                    skills: powerFeatures.enabledSkills,
                     selectionRequest: textSelectionRequest,
                     onSelectionChange: handleTextSelectionChange,
                     onPasteImages: attachImageProviders,

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -330,6 +330,7 @@ struct FeatureComposerView: View {
                     placeholder: composerPlaceholder,
                     acceptsImages: imagesAllowed,
                     isReadOnly: voiceInputController.isBusy,
+                    skills: powerFeatures.skills,
                     selectionRequest: textSelectionRequest,
                     onSelectionChange: handleTextSelectionChange,
                     onPasteImages: attachImageProviders,

--- a/apps/swift-ios/Features/Chat/FeatureInlineSkillPill.swift
+++ b/apps/swift-ios/Features/Chat/FeatureInlineSkillPill.swift
@@ -169,18 +169,28 @@ enum FeatureInlineSkillProjection {
     private static func runs(in attributedText: NSAttributedString) -> [Run] {
         var result: [Run] = []
         var plainOffset = 0
+        let source = attributedText.string as NSString
         attributedText.enumerateAttributes(
             in: NSRange(location: 0, length: attributedText.length)
         ) { attributes, displayRange, _ in
-            let rawText = attributes[.featureInlineSkillRawText] as? String
+            let isSkillAttachment = displayRange.length == 1
+                && source.character(at: displayRange.location) == 0xFFFC
+                && attributes[.attachment] is NSTextAttachment
+            let rawText = isSkillAttachment
+                ? attributes[.featureInlineSkillRawText] as? String
+                : nil
             let plainLength = rawText.map { ($0 as NSString).length } ?? displayRange.length
             result.append(
                 Run(
                     displayRange: displayRange,
                     plainRange: NSRange(location: plainOffset, length: plainLength),
                     rawText: rawText,
-                    displayName: attributes[.featureInlineSkillDisplayName] as? String,
-                    styleKey: attributes[.featureInlineSkillStyleKey] as? String
+                    displayName: rawText == nil
+                        ? nil
+                        : attributes[.featureInlineSkillDisplayName] as? String,
+                    styleKey: rawText == nil
+                        ? nil
+                        : attributes[.featureInlineSkillStyleKey] as? String
                 )
             )
             plainOffset += plainLength

--- a/apps/swift-ios/Features/Chat/FeatureInlineSkillPill.swift
+++ b/apps/swift-ios/Features/Chat/FeatureInlineSkillPill.swift
@@ -330,7 +330,7 @@ enum FeatureInlineSkillPillRenderer {
             let bounds = CGRect(origin: .zero, size: size).insetBy(dx: 0.5, dy: 0.5)
             let path = UIBezierPath(
                 roundedRect: bounds,
-                cornerRadius: max(7, pillHeight * 0.35)
+                cornerRadius: labelFont.pointSize * 0.5
             )
             fuchsia.withAlphaComponent(0.12).setFill()
             path.fill()

--- a/apps/swift-ios/Features/Chat/FeatureInlineSkillPill.swift
+++ b/apps/swift-ios/Features/Chat/FeatureInlineSkillPill.swift
@@ -1,0 +1,400 @@
+import SwiftUI
+import UIKit
+
+struct FeatureInlineSkillDescriptor: Equatable {
+    let rawText: String
+    let displayName: String
+    let range: NSRange
+}
+
+extension FeatureProviderSkill {
+    var invocationDisplayName: String {
+        if let displayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !displayName.isEmpty {
+            return displayName
+        }
+
+        return name
+            .split { $0.isWhitespace || $0 == ":" || $0 == "_" || $0 == "-" }
+            .map { word in
+                word.prefix(1).uppercased() + word.dropFirst()
+            }
+            .joined(separator: " ")
+    }
+}
+
+enum FeatureInlineSkillParser {
+    private static let tokenExpression = try! NSRegularExpression(
+        pattern: #"(?<!\S)\$([A-Za-z][A-Za-z0-9:_-]*)(?=\s|$)"#
+    )
+
+    static func descriptors(
+        in text: String,
+        skills: [FeatureProviderSkill],
+        allowsEndBoundary: Bool,
+        preservingTrailing preserved: FeatureInlineSkillDescriptor? = nil
+    ) -> [FeatureInlineSkillDescriptor] {
+        guard !text.isEmpty, !skills.isEmpty else { return [] }
+
+        let skillsByName = Dictionary(skills.map { ($0.name, $0) }) { first, _ in first }
+        let source = text as NSString
+        return tokenExpression.matches(
+            in: text,
+            range: NSRange(location: 0, length: source.length)
+        ).compactMap { match in
+            let range = match.range(at: 0)
+            let hasEndBoundary = NSMaxRange(range) == source.length
+            let preservesThisTrailingToken = hasEndBoundary
+                && preserved?.range == range
+                && preserved?.rawText == source.substring(with: range)
+            guard !hasEndBoundary || allowsEndBoundary || preservesThisTrailingToken else {
+                return nil
+            }
+
+            let name = source.substring(with: match.range(at: 1))
+            guard let skill = skillsByName[name] else { return nil }
+            return FeatureInlineSkillDescriptor(
+                rawText: source.substring(with: range),
+                displayName: skill.invocationDisplayName,
+                range: range
+            )
+        }
+    }
+}
+
+struct FeatureInlineSkillAttachmentSignature: Equatable {
+    let descriptor: FeatureInlineSkillDescriptor
+    let styleKey: String
+}
+
+extension NSAttributedString.Key {
+    static let featureInlineSkillRawText = NSAttributedString.Key("t3.inline-skill.raw-text")
+    static let featureInlineSkillDisplayName = NSAttributedString.Key("t3.inline-skill.display-name")
+    static let featureInlineSkillStyleKey = NSAttributedString.Key("t3.inline-skill.style-key")
+}
+
+enum FeatureInlineSkillProjection {
+    private struct Run {
+        let displayRange: NSRange
+        let plainRange: NSRange
+        let rawText: String?
+        let displayName: String?
+        let styleKey: String?
+    }
+
+    static func plainText(from attributedText: NSAttributedString) -> String {
+        let result = NSMutableString()
+        let source = attributedText.string as NSString
+        for run in runs(in: attributedText) {
+            result.append(run.rawText ?? source.substring(with: run.displayRange))
+        }
+        return result as String
+    }
+
+    static func signatures(
+        in attributedText: NSAttributedString
+    ) -> [FeatureInlineSkillAttachmentSignature] {
+        runs(in: attributedText).compactMap { run in
+            guard let rawText = run.rawText,
+                  let displayName = run.displayName,
+                  let styleKey = run.styleKey else { return nil }
+            return FeatureInlineSkillAttachmentSignature(
+                descriptor: FeatureInlineSkillDescriptor(
+                    rawText: rawText,
+                    displayName: displayName,
+                    range: run.plainRange
+                ),
+                styleKey: styleKey
+            )
+        }
+    }
+
+    static func plainRange(
+        for displayRange: NSRange,
+        in attributedText: NSAttributedString
+    ) -> NSRange {
+        guard displayRange.location != NSNotFound else { return NSRange(location: 0, length: 0) }
+        let runs = runs(in: attributedText)
+        let lower = plainOffset(for: displayRange.location, runs: runs, displayLength: attributedText.length)
+        let upper = plainOffset(for: NSMaxRange(displayRange), runs: runs, displayLength: attributedText.length)
+        return NSRange(location: lower, length: max(0, upper - lower))
+    }
+
+    static func displayRange(
+        for plainRange: NSRange,
+        in attributedText: NSAttributedString
+    ) -> NSRange {
+        guard plainRange.location != NSNotFound else { return NSRange(location: 0, length: 0) }
+        let runs = runs(in: attributedText)
+        let plainLength = runs.last.map { NSMaxRange($0.plainRange) } ?? 0
+        let lower = displayOffset(for: plainRange.location, runs: runs, plainLength: plainLength)
+        let upper = displayOffset(for: NSMaxRange(plainRange), runs: runs, plainLength: plainLength)
+        return NSRange(location: lower, length: max(0, upper - lower))
+    }
+
+    private static func plainOffset(
+        for displayOffset: Int,
+        runs: [Run],
+        displayLength: Int
+    ) -> Int {
+        let target = min(max(displayOffset, 0), displayLength)
+        var lengthDelta = 0
+        for run in runs where run.rawText != nil {
+            guard target > run.displayRange.location else { break }
+            if target <= NSMaxRange(run.displayRange) {
+                return NSMaxRange(run.plainRange)
+            }
+            lengthDelta += run.plainRange.length - run.displayRange.length
+        }
+        return target + lengthDelta
+    }
+
+    private static func displayOffset(
+        for plainOffset: Int,
+        runs: [Run],
+        plainLength: Int
+    ) -> Int {
+        let target = min(max(plainOffset, 0), plainLength)
+        var lengthDelta = 0
+        for run in runs where run.rawText != nil {
+            guard target > run.plainRange.location else { break }
+            if target <= NSMaxRange(run.plainRange) {
+                return NSMaxRange(run.displayRange)
+            }
+            lengthDelta += run.plainRange.length - run.displayRange.length
+        }
+        return target - lengthDelta
+    }
+
+    private static func runs(in attributedText: NSAttributedString) -> [Run] {
+        var result: [Run] = []
+        var plainOffset = 0
+        attributedText.enumerateAttributes(
+            in: NSRange(location: 0, length: attributedText.length)
+        ) { attributes, displayRange, _ in
+            let rawText = attributes[.featureInlineSkillRawText] as? String
+            let plainLength = rawText.map { ($0 as NSString).length } ?? displayRange.length
+            result.append(
+                Run(
+                    displayRange: displayRange,
+                    plainRange: NSRange(location: plainOffset, length: plainLength),
+                    rawText: rawText,
+                    displayName: attributes[.featureInlineSkillDisplayName] as? String,
+                    styleKey: attributes[.featureInlineSkillStyleKey] as? String
+                )
+            )
+            plainOffset += plainLength
+        }
+        return result
+    }
+}
+
+@MainActor
+enum FeatureInlineSkillPillRenderer {
+    private static let imageCache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = 128
+        return cache
+    }()
+
+    static func attributedText(
+        source: String,
+        descriptors: [FeatureInlineSkillDescriptor],
+        baseAttributes: [NSAttributedString.Key: Any],
+        font: UIFont,
+        traits: UITraitCollection
+    ) -> NSAttributedString {
+        guard !descriptors.isEmpty else {
+            return NSAttributedString(string: source, attributes: baseAttributes)
+        }
+        let result = NSMutableAttributedString()
+        let sourceText = source as NSString
+        let styleKey = styleKey(font: font, traits: traits)
+        var cursor = 0
+
+        for descriptor in descriptors where descriptor.range.location >= cursor {
+            if descriptor.range.location > cursor {
+                result.append(
+                    NSAttributedString(
+                        string: sourceText.substring(
+                            with: NSRange(location: cursor, length: descriptor.range.location - cursor)
+                        ),
+                        attributes: baseAttributes
+                    )
+                )
+            }
+
+            let attachment = NSTextAttachment()
+            let renderedPill = image(
+                label: descriptor.displayName,
+                font: font,
+                traits: traits
+            )
+            attachment.image = renderedPill
+            attachment.bounds = CGRect(
+                x: 0,
+                y: (font.capHeight - renderedPill.size.height) / 2,
+                width: renderedPill.size.width,
+                height: renderedPill.size.height
+            )
+            let attachmentText = NSMutableAttributedString(attachment: attachment)
+            attachmentText.addAttributes(
+                baseAttributes.merging(
+                    [
+                        .featureInlineSkillRawText: descriptor.rawText,
+                        .featureInlineSkillDisplayName: descriptor.displayName,
+                        .featureInlineSkillStyleKey: styleKey,
+                    ],
+                    uniquingKeysWith: { _, replacement in replacement }
+                ),
+                range: NSRange(location: 0, length: attachmentText.length)
+            )
+            result.append(attachmentText)
+            cursor = NSMaxRange(descriptor.range)
+        }
+
+        if cursor < sourceText.length {
+            result.append(
+                NSAttributedString(
+                    string: sourceText.substring(from: cursor),
+                    attributes: baseAttributes
+                )
+            )
+        }
+        return result
+    }
+
+    static func signatures(
+        for descriptors: [FeatureInlineSkillDescriptor],
+        font: UIFont,
+        traits: UITraitCollection
+    ) -> [FeatureInlineSkillAttachmentSignature] {
+        let styleKey = styleKey(font: font, traits: traits)
+        return descriptors.map {
+            FeatureInlineSkillAttachmentSignature(descriptor: $0, styleKey: styleKey)
+        }
+    }
+
+    private static func styleKey(font: UIFont, traits: UITraitCollection) -> String {
+        [
+            String(format: "%.3f", font.pointSize),
+            String(traits.userInterfaceStyle.rawValue),
+            traits.preferredContentSizeCategory.rawValue,
+            String(format: "%.2f", traits.displayScale),
+        ].joined(separator: ":")
+    }
+
+    private static func image(
+        label: String,
+        font: UIFont,
+        traits: UITraitCollection
+    ) -> UIImage {
+        let cacheKey = "\(styleKey(font: font, traits: traits))\u{0}\(label)" as NSString
+        if let cached = imageCache.object(forKey: cacheKey) {
+            return cached
+        }
+        let labelFont = UIFont.systemFont(ofSize: max(11, font.pointSize * 0.86), weight: .medium)
+        let pillHeight = max(18, font.pointSize * 1.41)
+        let iconSize = max(12, labelFont.pointSize * 1.08)
+        let horizontalPadding = max(6, font.pointSize * 0.5)
+        let gap = max(4, font.pointSize * 0.28)
+        let maximumLabelWidth: CGFloat = 190
+        let measuredLabelWidth = (label as NSString).size(withAttributes: [.font: labelFont]).width
+        let labelWidth = min(maximumLabelWidth, ceil(measuredLabelWidth))
+        let size = CGSize(
+            width: ceil(horizontalPadding * 2 + iconSize + gap + labelWidth),
+            height: ceil(pillHeight)
+        )
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = traits.displayScale > 0 ? traits.displayScale : UIScreen.main.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        let rendered = renderer.image { _ in
+            let foreground = UIColor { currentTraits in
+                currentTraits.userInterfaceStyle == .dark
+                    ? UIColor(red: 240 / 255, green: 171 / 255, blue: 252 / 255, alpha: 1)
+                    : UIColor(red: 162 / 255, green: 28 / 255, blue: 175 / 255, alpha: 1)
+            }.resolvedColor(with: traits)
+            let fuchsia = UIColor(red: 217 / 255, green: 70 / 255, blue: 239 / 255, alpha: 1)
+            let bounds = CGRect(origin: .zero, size: size).insetBy(dx: 0.5, dy: 0.5)
+            let path = UIBezierPath(
+                roundedRect: bounds,
+                cornerRadius: max(7, pillHeight * 0.35)
+            )
+            fuchsia.withAlphaComponent(0.12).setFill()
+            path.fill()
+            fuchsia.withAlphaComponent(0.25).setStroke()
+            path.lineWidth = 1
+            path.stroke()
+
+            let iconOrigin = CGPoint(
+                x: horizontalPadding,
+                y: (size.height - iconSize) / 2
+            )
+            if let icon = UIImage(
+                systemName: "shippingbox",
+                withConfiguration: UIImage.SymbolConfiguration(
+                    pointSize: iconSize,
+                    weight: .regular
+                )
+            )?.withTintColor(foreground, renderingMode: .alwaysOriginal) {
+                icon.draw(in: CGRect(origin: iconOrigin, size: CGSize(width: iconSize, height: iconSize)))
+            }
+
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineBreakMode = .byTruncatingTail
+            let labelRect = CGRect(
+                x: horizontalPadding + iconSize + gap,
+                y: (size.height - labelFont.lineHeight) / 2,
+                width: labelWidth,
+                height: labelFont.lineHeight
+            )
+            (label as NSString).draw(
+                with: labelRect,
+                options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine],
+                attributes: [
+                    .font: labelFont,
+                    .foregroundColor: foreground,
+                    .paragraphStyle: paragraphStyle,
+                ],
+                context: nil
+            )
+        }
+        imageCache.setObject(rendered, forKey: cacheKey)
+        return rendered
+    }
+}
+
+/// Makes selected pill text portable. UIKit otherwise copies an attachment as
+/// rich image data or the object-replacement character instead of `$skill`.
+class FeatureInlineSkillTextView: UITextView {
+    override func copy(_ sender: Any?) {
+        guard let selectedPlainText else {
+            super.copy(sender)
+            return
+        }
+        UIPasteboard.general.string = selectedPlainText
+    }
+
+    override func cut(_ sender: Any?) {
+        guard let selectedPlainText else {
+            super.cut(sender)
+            return
+        }
+        super.cut(sender)
+        UIPasteboard.general.string = selectedPlainText
+    }
+
+    private var selectedPlainText: String? {
+        let range = selectedRange
+        guard range.location != NSNotFound,
+              range.length > 0,
+              NSMaxRange(range) <= attributedText.length else {
+            return nil
+        }
+        let selected = attributedText.attributedSubstring(from: range)
+        guard !FeatureInlineSkillProjection.signatures(in: selected).isEmpty else { return nil }
+        return FeatureInlineSkillProjection.plainText(from: selected)
+    }
+}

--- a/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
@@ -27,6 +27,7 @@ struct MarkdownMessageView: View {
     private let isStreaming: Bool
     private let copyActionTitle: String
     private let imageContext: MarkdownImageContext?
+    private let skills: [FeatureProviderSkill]
     @State private var selectionSource: MarkdownSelectionSource
     @State private var renderedDocument: MarkdownRenderedDocument?
     @State private var streamingRenderer = StreamingMarkdownRenderer()
@@ -35,12 +36,14 @@ struct MarkdownMessageView: View {
         _ source: String,
         isStreaming: Bool = false,
         copyActionTitle: String = "Copy message",
-        imageContext: MarkdownImageContext? = nil
+        imageContext: MarkdownImageContext? = nil,
+        skills: [FeatureProviderSkill] = []
     ) {
         self.source = source
         self.isStreaming = isStreaming
         self.copyActionTitle = copyActionTitle
         self.imageContext = imageContext
+        self.skills = skills
         _selectionSource = State(initialValue: MarkdownSelectionSource(source))
         let revision = MarkdownContentRevision(source)
         self.revision = revision
@@ -129,7 +132,8 @@ struct MarkdownMessageView: View {
         selectionSource.text = source
         return MarkdownSelectionContext(
             source: selectionSource,
-            copyActionTitle: copyActionTitle
+            copyActionTitle: copyActionTitle,
+            skills: skills
         )
     }
 }
@@ -210,9 +214,12 @@ private final class MarkdownSelectionSource: @unchecked Sendable {
 private struct MarkdownSelectionContext: Equatable, Sendable {
     let source: MarkdownSelectionSource
     let copyActionTitle: String
+    let skills: [FeatureProviderSkill]
 
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.source === rhs.source && lhs.copyActionTitle == rhs.copyActionTitle
+        lhs.source === rhs.source
+            && lhs.copyActionTitle == rhs.copyActionTitle
+            && lhs.skills == rhs.skills
     }
 }
 
@@ -796,7 +803,7 @@ private struct MarkdownInlineText: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+        let textView = FeatureInlineSkillTextView()
         textView.backgroundColor = .clear
         textView.isEditable = false
         textView.isSelectable = true
@@ -825,7 +832,9 @@ private struct MarkdownInlineText: UIViewRepresentable {
             lineSpacing: lineSpacing,
             textColor: textColor,
             dynamicTypeSize: dynamicTypeSize,
-            wrapsLines: wrapsLines
+            wrapsLines: wrapsLines,
+            skills: selectionContext.skills,
+            traits: textView.traitCollection
         )
         if context.coordinator.shouldApply(attributedText) {
             let previousText = context.coordinator.lastAppliedText
@@ -871,6 +880,8 @@ private struct MarkdownInlineText: UIViewRepresentable {
             let textColor: MarkdownTextColor
             let dynamicTypeSize: DynamicTypeSize
             let wrapsLines: Bool
+            let skills: [FeatureProviderSkill]
+            let userInterfaceStyle: UIUserInterfaceStyle
         }
 
         private struct SizeKey: Hashable {
@@ -880,7 +891,8 @@ private struct MarkdownInlineText: UIViewRepresentable {
 
         var selectionContext = MarkdownSelectionContext(
             source: MarkdownSelectionSource(""),
-            copyActionTitle: "Copy message"
+            copyActionTitle: "Copy message",
+            skills: []
         )
         var onOpenURL: ((URL) -> Void)?
         private var cacheKey: CacheKey?
@@ -896,13 +908,17 @@ private struct MarkdownInlineText: UIViewRepresentable {
             lineSpacing: CGFloat,
             textColor: MarkdownTextColor,
             dynamicTypeSize: DynamicTypeSize,
-            wrapsLines: Bool
+            wrapsLines: Bool,
+            skills: [FeatureProviderSkill],
+            traits: UITraitCollection
         ) -> NSAttributedString {
             let key = CacheKey(
                 lineSpacing: lineSpacing,
                 textColor: textColor,
                 dynamicTypeSize: dynamicTypeSize,
-                wrapsLines: wrapsLines
+                wrapsLines: wrapsLines,
+                skills: skills,
+                userInterfaceStyle: traits.userInterfaceStyle
             )
             if cachedRendered === rendered, key == cacheKey, let cachedAttributedText {
                 return cachedAttributedText
@@ -912,7 +928,9 @@ private struct MarkdownInlineText: UIViewRepresentable {
                 lineSpacing: lineSpacing,
                 foregroundColor: textColor.uiColor,
                 dynamicTypeSize: dynamicTypeSize,
-                wrapsLines: wrapsLines
+                wrapsLines: wrapsLines,
+                skills: skills,
+                traits: traits
             )
             cacheKey = key
             cachedRendered = rendered
@@ -1047,7 +1065,9 @@ enum MarkdownSelectableTextAttributes {
         lineSpacing: CGFloat,
         foregroundColor: UIColor = T3Colors.uiTextPrimary,
         dynamicTypeSize: DynamicTypeSize = .large,
-        wrapsLines: Bool = true
+        wrapsLines: Bool = true,
+        skills: [FeatureProviderSkill] = [],
+        traits: UITraitCollection = .current
     ) -> NSAttributedString {
         let result = NSMutableAttributedString()
         let paragraphStyle = NSMutableParagraphStyle()
@@ -1074,10 +1094,22 @@ enum MarkdownSelectableTextAttributes {
             if let link = run.link {
                 attributes[.link] = link
             }
+            let runText = String(rendered.attributedText[run.range].characters)
+            let descriptors = intent?.contains(.code) == true || run.link != nil
+                ? []
+                : FeatureInlineSkillParser.descriptors(
+                    in: runText,
+                    skills: skills,
+                    allowsEndBoundary: true
+                )
             result.append(
-                NSAttributedString(
-                    string: String(rendered.attributedText[run.range].characters),
-                    attributes: attributes
+                FeatureInlineSkillPillRenderer.attributedText(
+                    source: runText,
+                    descriptors: descriptors,
+                    baseAttributes: attributes,
+                    font: attributes[.font] as? UIFont
+                        ?? rendered.style.uiFont(dynamicTypeSize: dynamicTypeSize),
+                    traits: traits
                 )
             )
         }

--- a/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
@@ -1095,13 +1095,23 @@ enum MarkdownSelectableTextAttributes {
                 attributes[.link] = link
             }
             let runText = String(rendered.attributedText[run.range].characters)
+            let hasLeadingBoundary = run.range.lowerBound == rendered.attributedText.startIndex
+                || rendered.attributedText.characters[
+                    rendered.attributedText.characters.index(before: run.range.lowerBound)
+                ].isWhitespace
+            let hasTrailingBoundary = run.range.upperBound == rendered.attributedText.endIndex
+                || rendered.attributedText.characters[run.range.upperBound].isWhitespace
+            let runLength = (runText as NSString).length
             let descriptors = intent?.contains(.code) == true || run.link != nil
                 ? []
                 : FeatureInlineSkillParser.descriptors(
                     in: runText,
                     skills: skills,
                     allowsEndBoundary: true
-                )
+                ).filter { descriptor in
+                    (descriptor.range.location > 0 || hasLeadingBoundary)
+                        && (NSMaxRange(descriptor.range) < runLength || hasTrailingBoundary)
+                }
             result.append(
                 FeatureInlineSkillPillRenderer.attributedText(
                     source: runText,

--- a/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
@@ -1102,7 +1102,9 @@ enum MarkdownSelectableTextAttributes {
             let hasTrailingBoundary = run.range.upperBound == rendered.attributedText.endIndex
                 || rendered.attributedText.characters[run.range.upperBound].isWhitespace
             let runLength = (runText as NSString).length
-            let descriptors = intent?.contains(.code) == true || run.link != nil
+            let descriptors = rendered.style == .code
+                || intent?.contains(.code) == true
+                || run.link != nil
                 ? []
                 : FeatureInlineSkillParser.descriptors(
                     in: runText,

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -672,6 +672,7 @@ public struct ThreadDetailView: View {
                     attachmentContext: (model.client as? any FeatureAttachmentAssetResolving).map {
                         FeatureAttachmentContext(threadID: thread.id, resolver: $0)
                     },
+                    skills: threadProviderSkills,
                     renderUpdate: timelineRenderUpdate,
                     dynamicTypeSize: dynamicTypeSize,
                     isWorking: isWorking,
@@ -781,6 +782,11 @@ public struct ThreadDetailView: View {
         guard await model.refreshProviders(environmentID: environmentID) else {
             throw FeatureModelRefreshError()
         }
+    }
+
+    private var threadProviderSkills: [FeatureProviderSkill] {
+        guard let selectedProviderID = currentSelection?.providerID else { return [] }
+        return threadProviders.first { $0.id == selectedProviderID }?.skills ?? []
     }
 
     private var timelineRenderUpdate: FeatureDetailRenderUpdate? {
@@ -1324,6 +1330,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
     let messages: [FeatureMessage]
     let imageContext: MarkdownImageContext?
     let attachmentContext: FeatureAttachmentContext?
+    let skills: [FeatureProviderSkill]
     let renderUpdate: FeatureDetailRenderUpdate?
     let dynamicTypeSize: DynamicTypeSize
     let isWorking: Bool
@@ -1362,6 +1369,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             messages: messages,
             imageContext: imageContext,
             attachmentContext: attachmentContext,
+            skills: skills,
             renderUpdate: renderUpdate,
             dynamicTypeSize: dynamicTypeSize,
             isWorking: isWorking,
@@ -1415,6 +1423,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private var currentThreadID: String?
         private var currentImageContext: MarkdownImageContext?
         private var currentAttachmentContext: FeatureAttachmentContext?
+        private var currentSkills: [FeatureProviderSkill] = []
         private var currentDetailRevision: UInt64?
         private var currentDynamicTypeSize: DynamicTypeSize?
         private var currentIsWorking = false
@@ -1468,8 +1477,10 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
 
                 cell.contentConfiguration = UIHostingConfiguration {
                     FeatureMessageView(
-                        message: message, imageContext: self?.currentImageContext,
-                        attachmentContext: self?.currentAttachmentContext
+                        message: message,
+                        imageContext: self?.currentImageContext,
+                        attachmentContext: self?.currentAttachmentContext,
+                        skills: self?.currentSkills ?? []
                     )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -1496,6 +1507,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             messages: [FeatureMessage],
             imageContext: MarkdownImageContext?,
             attachmentContext: FeatureAttachmentContext?,
+            skills: [FeatureProviderSkill],
             renderUpdate: FeatureDetailRenderUpdate?,
             dynamicTypeSize: DynamicTypeSize,
             isWorking: Bool,
@@ -1516,6 +1528,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             let threadChanged = currentThreadID != threadID
             let imageContextChanged = currentImageContext != imageContext
                 || currentAttachmentContext != attachmentContext
+            let skillsChanged = currentSkills != skills
             let typeSizeChanged = currentDynamicTypeSize != dynamicTypeSize
             let revisionChanged = currentDetailRevision != renderUpdate?.revision
             let workingChanged = currentIsWorking != isWorking
@@ -1525,7 +1538,8 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 || currentIsMonitoring != isMonitoring
             let loadEarlierChanged = currentCanLoadEarlier != canLoadEarlier
                 || currentIsLoadingEarlier != isLoadingEarlier
-            guard threadChanged || imageContextChanged || typeSizeChanged || revisionChanged || workingChanged
+            guard threadChanged || imageContextChanged || skillsChanged || typeSizeChanged
+                || revisionChanged || workingChanged
                 || workingDetailChanged || loadEarlierChanged else { return }
 
             let incremental = !threadChanged
@@ -1534,12 +1548,13 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             let state = incremental ?? fullState(messages: messages)
             let newIDs = state.ids
             let idsChanged = state.idsChanged
-            let changedIDs = typeSizeChanged || imageContextChanged
+            let changedIDs = typeSizeChanged || imageContextChanged || skillsChanged
                 ? newIDs
                 : state.changedIDs
 
             currentImageContext = imageContext
             currentAttachmentContext = attachmentContext
+            currentSkills = skills
             currentDetailRevision = renderUpdate?.revision
             currentDynamicTypeSize = dynamicTypeSize
             currentIsWorking = isWorking
@@ -2449,6 +2464,7 @@ struct FeatureMessageView: View {
     let message: FeatureMessage
     var imageContext: MarkdownImageContext? = nil
     var attachmentContext: FeatureAttachmentContext? = nil
+    var skills: [FeatureProviderSkill] = []
 
     var body: some View {
         switch message.role {
@@ -2461,7 +2477,8 @@ struct FeatureMessageView: View {
                         MarkdownMessageView(
                             message.text,
                             isStreaming: message.state == .streaming,
-                            imageContext: imageContext
+                            imageContext: imageContext,
+                            skills: skills
                         )
                     }
                 }
@@ -2496,7 +2513,8 @@ struct FeatureMessageView: View {
                     MarkdownMessageView(
                         message.text,
                         isStreaming: message.state == .streaming,
-                        imageContext: imageContext
+                        imageContext: imageContext,
+                        skills: skills
                     )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -784,9 +784,10 @@ public struct ThreadDetailView: View {
         }
     }
 
-    private var threadProviderSkills: [FeatureProviderSkill] {
+    var threadProviderSkills: [FeatureProviderSkill] {
         guard let selectedProviderID = currentSelection?.providerID else { return [] }
-        return threadProviders.first { $0.id == selectedProviderID }?.skills ?? []
+        return threadProviders.first { $0.id == selectedProviderID }?
+            .workspaceCatalog(cwd: workspaceCatalogPath).skills ?? []
     }
 
     private var timelineRenderUpdate: FeatureDetailRenderUpdate? {

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -797,6 +797,77 @@ struct FeatureComposerPowerTests {
         )
     }
 
+    @Test @MainActor
+    func inlineSkillSynchronizationPreservesComposerUndoHistory() throws {
+        let input = FeatureComposerTextInput(
+            text: .constant("Use"),
+            focused: .constant(false),
+            placeholder: "",
+            acceptsImages: false,
+            isReadOnly: false,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")],
+            selectionRequest: nil,
+            onSelectionChange: { _ in },
+            onPasteImages: { _ in },
+            onDismissKeyboard: nil
+        )
+        let coordinator = FeatureComposerTextInput.Coordinator(input)
+        let textView = FeatureComposerUITextView()
+        textView.delegate = coordinator
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.attributedText = NSAttributedString(string: "Use")
+        textView.selectedRange = NSRange(location: 3, length: 0)
+
+        let viewController = UIViewController()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        viewController.view.addSubview(textView)
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        #expect(textView.becomeFirstResponder())
+
+        let undoManager = try #require(textView.undoManager)
+        undoManager.removeAllActions()
+        undoManager.groupsByEvent = false
+
+        #expect(coordinator.textView(
+            textView,
+            shouldChangeTextIn: textView.selectedRange,
+            replacementText: " $file-pr"
+        ))
+        textView.insertText(" $file-pr")
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).isEmpty)
+
+        #expect(coordinator.textView(
+            textView,
+            shouldChangeTextIn: textView.selectedRange,
+            replacementText: " "
+        ))
+        textView.insertText(" ")
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).count == 1)
+
+        #expect(undoManager.canUndo)
+        undoManager.undo()
+        #expect(
+            FeatureInlineSkillProjection.plainText(from: textView.attributedText)
+                == "Use $file-pr"
+        )
+        undoManager.undo()
+        #expect(FeatureInlineSkillProjection.plainText(from: textView.attributedText) == "Use")
+
+        undoManager.redo()
+        #expect(
+            FeatureInlineSkillProjection.plainText(from: textView.attributedText)
+                == "Use $file-pr"
+        )
+        undoManager.redo()
+        #expect(
+            FeatureInlineSkillProjection.plainText(from: textView.attributedText)
+                == "Use $file-pr "
+        )
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).count == 1)
+    }
+
     @Test
     func changingInputQuestionsKeepsAValidActiveQuestionAndDropsStaleAnswers() {
         #expect(

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -717,6 +717,24 @@ struct FeatureComposerPowerTests {
         )
     }
 
+    @Test
+    func composerInlineSkillsExcludeDisabledSkills() {
+        let powerFeatures = FeatureComposerPowerFeatures(
+            skills: [
+                FeatureProviderSkill(name: "file-pr", displayName: "File PR"),
+                FeatureProviderSkill(name: "disabled", isEnabled: false),
+            ]
+        )
+
+        let descriptors = FeatureInlineSkillParser.descriptors(
+            in: "$file-pr $disabled ",
+            skills: powerFeatures.enabledSkills,
+            allowsEndBoundary: false
+        )
+
+        #expect(descriptors.map(\.rawText) == ["$file-pr"])
+    }
+
     @Test @MainActor
     func inlineSkillAttachmentsRoundTripPlainTextAndSelectionOffsets() throws {
         let source = "Use $file-pr now"

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -680,6 +680,99 @@ struct FeatureComposerPowerTests {
     }
 
     @Test
+    func inlineSkillTokensUseProviderLabelsAndWebBoundaries() throws {
+        let skills = [
+            FeatureProviderSkill(name: "file-pr", displayName: "File PR"),
+            FeatureProviderSkill(name: "review-follow-up"),
+        ]
+
+        let completed = FeatureInlineSkillParser.descriptors(
+            in: "Use $file-pr then ",
+            skills: skills,
+            allowsEndBoundary: false
+        )
+        #expect(completed.map(\.rawText) == ["$file-pr"])
+        #expect(completed.map(\.displayName) == ["File PR"])
+
+        #expect(
+            FeatureInlineSkillParser.descriptors(
+                in: "$review-follow-up",
+                skills: skills,
+                allowsEndBoundary: true
+            ).map(\.displayName) == ["Review Follow Up"]
+        )
+        #expect(
+            FeatureInlineSkillParser.descriptors(
+                in: "$file-pr",
+                skills: skills,
+                allowsEndBoundary: false
+            ).isEmpty
+        )
+        #expect(
+            FeatureInlineSkillParser.descriptors(
+                in: "prefix$file-pr ",
+                skills: skills,
+                allowsEndBoundary: true
+            ).isEmpty
+        )
+    }
+
+    @Test @MainActor
+    func inlineSkillAttachmentsRoundTripPlainTextAndSelectionOffsets() throws {
+        let source = "Use $file-pr now"
+        let descriptors = FeatureInlineSkillParser.descriptors(
+            in: source,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")],
+            allowsEndBoundary: false
+        )
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let attributed = FeatureInlineSkillPillRenderer.attributedText(
+            source: source,
+            descriptors: descriptors,
+            baseAttributes: [.font: font],
+            font: font,
+            traits: UITraitCollection(userInterfaceStyle: .dark)
+        )
+
+        #expect(FeatureInlineSkillProjection.plainText(from: attributed) == source)
+        #expect(FeatureInlineSkillProjection.signatures(in: attributed).count == 1)
+        #expect(attributed.string == "Use \u{FFFC} now")
+
+        let plainAfterSkill = NSMaxRange(try #require(descriptors.first).range)
+        let displaySelection = FeatureInlineSkillProjection.displayRange(
+            for: NSRange(location: plainAfterSkill, length: 0),
+            in: attributed
+        )
+        #expect(displaySelection == NSRange(location: 5, length: 0))
+        #expect(
+            FeatureInlineSkillProjection.plainRange(
+                for: displaySelection,
+                in: attributed
+            ) == NSRange(location: plainAfterSkill, length: 0)
+        )
+    }
+
+    @Test
+    func completedComposerPillSurvivesDeletingItsTrailingSpace() throws {
+        let skill = FeatureProviderSkill(name: "file-pr", displayName: "File PR")
+        let completed = try #require(
+            FeatureInlineSkillParser.descriptors(
+                in: "$file-pr ",
+                skills: [skill],
+                allowsEndBoundary: false
+            ).first
+        )
+        #expect(
+            FeatureInlineSkillParser.descriptors(
+                in: "$file-pr",
+                skills: [skill],
+                allowsEndBoundary: false,
+                preservingTrailing: completed
+            ) == [completed]
+        )
+    }
+
+    @Test
     func changingInputQuestionsKeepsAValidActiveQuestionAndDropsStaleAnswers() {
         #expect(
             FeatureComposerQuestionReconciliation.index(

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -752,6 +752,31 @@ struct FeatureComposerPowerTests {
         )
     }
 
+    @Test @MainActor
+    func inlineSkillProjectionIgnoresPillMetadataInheritedByTypedText() throws {
+        let source = "$file-pr"
+        let descriptors = FeatureInlineSkillParser.descriptors(
+            in: source,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")],
+            allowsEndBoundary: true
+        )
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let attributed = FeatureInlineSkillPillRenderer.attributedText(
+            source: source,
+            descriptors: descriptors,
+            baseAttributes: [.font: font],
+            font: font,
+            traits: UITraitCollection(userInterfaceStyle: .dark)
+        )
+        let typedTextAttributes = attributed.attributes(at: 0, effectiveRange: nil)
+            .filter { $0.key != .attachment }
+        let afterTyping = NSMutableAttributedString(attributedString: attributed)
+        afterTyping.append(NSAttributedString(string: "x", attributes: typedTextAttributes))
+
+        #expect(FeatureInlineSkillProjection.plainText(from: afterTyping) == "$file-prx")
+        #expect(FeatureInlineSkillProjection.signatures(in: afterTyping).count == 1)
+    }
+
     @Test
     func completedComposerPillSurvivesDeletingItsTrailingSpace() throws {
         let skill = FeatureProviderSkill(name: "file-pr", displayName: "File PR")

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -868,6 +868,62 @@ struct FeatureComposerPowerTests {
         #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).count == 1)
     }
 
+    @Test @MainActor
+    func composerRedoPreservesTrailingSkillPill() throws {
+        let input = FeatureComposerTextInput(
+            text: .constant("$file-pr "),
+            focused: .constant(false),
+            placeholder: "",
+            acceptsImages: false,
+            isReadOnly: false,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")],
+            selectionRequest: nil,
+            onSelectionChange: { _ in },
+            onPasteImages: { _ in },
+            onDismissKeyboard: nil
+        )
+        let coordinator = FeatureComposerTextInput.Coordinator(input)
+        let textView = FeatureComposerUITextView()
+        textView.delegate = coordinator
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        _ = coordinator.synchronizeInlineSkills(
+            in: textView,
+            source: "$file-pr ",
+            selection: NSRange(location: 9, length: 0)
+        )
+
+        let viewController = UIViewController()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        viewController.view.addSubview(textView)
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        #expect(textView.becomeFirstResponder())
+
+        let undoManager = try #require(textView.undoManager)
+        undoManager.removeAllActions()
+        undoManager.groupsByEvent = false
+
+        let trailingSpace = NSRange(location: 1, length: 1)
+        #expect(coordinator.textView(
+            textView,
+            shouldChangeTextIn: trailingSpace,
+            replacementText: ""
+        ))
+        textView.selectedRange = trailingSpace
+        textView.insertText("")
+        #expect(FeatureInlineSkillProjection.plainText(from: textView.attributedText) == "$file-pr")
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).count == 1)
+
+        undoManager.undo()
+        #expect(FeatureInlineSkillProjection.plainText(from: textView.attributedText) == "$file-pr ")
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).count == 1)
+
+        undoManager.redo()
+        #expect(FeatureInlineSkillProjection.plainText(from: textView.attributedText) == "$file-pr")
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).count == 1)
+    }
+
     @Test
     func changingInputQuestionsKeepsAValidActiveQuestionAndDropsStaleAnswers() {
         #expect(

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -816,6 +816,55 @@ struct FeatureComposerPowerTests {
     }
 
     @Test @MainActor
+    func skillCatalogUpdatePreservesMarkedComposerText() throws {
+        let input = FeatureComposerTextInput(
+            text: .constant("Use $file-pr に"),
+            focused: .constant(false),
+            placeholder: "",
+            acceptsImages: false,
+            isReadOnly: false,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")],
+            selectionRequest: nil,
+            onSelectionChange: { _ in },
+            onPasteImages: { _ in },
+            onDismissKeyboard: nil
+        )
+        let coordinator = FeatureComposerTextInput.Coordinator(input)
+        let textView = FeatureComposerUITextView()
+        textView.delegate = coordinator
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.text = "Use $file-pr "
+        textView.selectedRange = NSRange(location: textView.text.utf16.count, length: 0)
+
+        let viewController = UIViewController()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        viewController.view.addSubview(textView)
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        #expect(textView.becomeFirstResponder())
+        textView.setMarkedText("に", selectedRange: NSRange(location: 1, length: 0))
+        let markedRange = try #require(textView.markedTextRange)
+        #expect(textView.text(in: markedRange) == "に")
+        let source = FeatureInlineSkillProjection.plainText(from: textView.attributedText)
+        let selection = textView.selectedRange
+
+        #expect(!coordinator.synchronizeInlineSkills(
+            in: textView,
+            source: source,
+            selection: selection
+        ))
+        #expect(textView.markedTextRange != nil)
+        #expect(textView.selectedRange == selection)
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).isEmpty)
+
+        textView.unmarkText()
+        coordinator.textViewDidChange(textView)
+        #expect(FeatureInlineSkillProjection.plainText(from: textView.attributedText) == source)
+        #expect(FeatureInlineSkillProjection.signatures(in: textView.attributedText).count == 1)
+    }
+
+    @Test @MainActor
     func inlineSkillSynchronizationPreservesComposerUndoHistory() throws {
         let input = FeatureComposerTextInput(
             text: .constant("Use"),

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -10,6 +10,65 @@ import XCTest
 @Suite("Feature root model")
 struct FeatureRootModelTests {
     @Test
+    func transcriptSkillPillsUseTheThreadWorkspaceCatalog() async {
+        let skill = FeatureProviderSkill(name: "project-only", displayName: "Project only")
+        var provider = FeatureProvider(
+            id: "codex", name: "Codex", driver: "codex",
+            models: [.init(id: "test-model", name: "Test model")],
+            skills: [.init(name: "global-only")]
+        )
+        provider.workspaceSnapshots = [
+            .init(cwd: "/workspace", slashCommands: [], skills: [skill]),
+        ]
+        let thread = FeatureThread(
+            id: "workspace-skills", projectID: "project", environmentID: "environment",
+            title: "Workspace skills", worktreePath: "/workspace",
+            providerID: "codex", modelID: "test-model"
+        )
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            threads: [thread], providersByEnvironment: ["environment": [provider]]
+        )
+        let model = testRootModel(client: client)
+        await model.reload()
+        let view = ThreadDetailView(model: model, thread: thread, submitMessage: { _ in true })
+
+        let pills = FeatureInlineSkillParser.descriptors(
+            in: "$project-only", skills: view.threadProviderSkills, allowsEndBoundary: true
+        )
+
+        #expect(pills.map(\.rawText) == ["$project-only"])
+        #expect(pills.map(\.displayName) == ["Project only"])
+
+        let source = "$project-only $new-skill $global-only"
+        provider.workspaceSnapshots = [
+            .init(cwd: "/workspace", slashCommands: [], skills: [
+                .init(name: "project-only", displayName: "Updated name"),
+                .init(name: "new-skill", displayName: "New skill"),
+            ]),
+        ]
+        client.snapshot.providersByEnvironment = ["environment": [provider]]
+        await model.reload()
+        let updated = FeatureInlineSkillParser.descriptors(
+            in: source, skills: view.threadProviderSkills, allowsEndBoundary: true
+        )
+        #expect(updated.map(\.rawText) == ["$project-only", "$new-skill"])
+        #expect(updated.map(\.displayName) == ["Updated name", "New skill"])
+
+        provider.workspaceSnapshots = [
+            .init(cwd: "/other-workspace", slashCommands: [], skills: [
+                .init(name: "project-only"),
+            ]),
+        ]
+        client.snapshot.providersByEnvironment = ["environment": [provider]]
+        await model.reload()
+        let removed = FeatureInlineSkillParser.descriptors(
+            in: source, skills: view.threadProviderSkills, allowsEndBoundary: true
+        )
+        #expect(removed.isEmpty)
+    }
+
+    @Test
     func foregroundRecoveryIgnoresInitialActivationAndReplacesLongSuspendedSockets() async {
         let client = FeatureClientStub()
         let model = testRootModel(client: client)

--- a/apps/swift-ios/Tests/FeatureTests/FeatureVoiceInputTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureVoiceInputTests.swift
@@ -16,6 +16,7 @@ struct FeatureVoiceInputTests {
                 text: Binding(get: { text }, set: { text = $0 }),
                 focused: Binding(get: { focused }, set: { focused = $0 }),
                 placeholder: "Message", acceptsImages: true, isReadOnly: readOnly,
+                skills: [],
                 selectionRequest: nil, onSelectionChange: { _ in },
                 onPasteImages: { _ in Issue.record("Pasted while dictating") },
                 onDismissKeyboard: nil

--- a/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
@@ -713,6 +713,33 @@ struct MarkdownDocumentTests {
     }
 
     @Test @MainActor
+    func selectableTextKeepsSkillBoundariesAcrossFormattedRuns() throws {
+        let document = try #require(
+            MarkdownRenderCache.shared.documentImmediately(
+                for: MarkdownContentRevision(
+                    "prefix.**$file-pr** then **$file-pr** and **$file-pr**suffix"
+                )
+            )
+        )
+        guard case let .paragraph(inline) = document.blocks.first else {
+            Issue.record("Expected a rendered paragraph")
+            return
+        }
+
+        let attributed = MarkdownSelectableTextAttributes.make(
+            from: inline,
+            lineSpacing: 4,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")]
+        )
+
+        #expect(FeatureInlineSkillProjection.signatures(in: attributed).count == 1)
+        #expect(
+            FeatureInlineSkillProjection.plainText(from: attributed)
+                == "prefix.$file-pr then $file-pr and $file-prsuffix"
+        )
+    }
+
+    @Test @MainActor
     func codeBlocksReuseSelectableInlineRendering() throws {
         let literalCode = "x = arr[i](fn)\na **b** c\nprintf(\\\"a\\\\tb\\\");"
         let cache = MarkdownRenderCache()

--- a/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
@@ -713,6 +713,28 @@ struct MarkdownDocumentTests {
     }
 
     @Test @MainActor
+    func selectableTextKeepsSkillsLiteralInsideFencedCode() throws {
+        let document = try #require(
+            MarkdownRenderCache.shared.documentImmediately(
+                for: MarkdownContentRevision("```text\n$file-pr\n```")
+            )
+        )
+        guard case let .codeBlock(_, code, inline) = document.blocks.first else {
+            Issue.record("Expected a rendered code block")
+            return
+        }
+
+        let attributed = MarkdownSelectableTextAttributes.make(
+            from: inline,
+            lineSpacing: 3,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")]
+        )
+
+        #expect(attributed.string == code)
+        #expect(FeatureInlineSkillProjection.signatures(in: attributed).isEmpty)
+    }
+
+    @Test @MainActor
     func selectableTextKeepsSkillBoundariesAcrossFormattedRuns() throws {
         let document = try #require(
             MarkdownRenderCache.shared.documentImmediately(

--- a/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/MarkdownDocumentTests.swift
@@ -686,6 +686,33 @@ struct MarkdownDocumentTests {
     }
 
     @Test @MainActor
+    func selectableTextRendersKnownSkillsAsPillsOutsideCodeAndLinks() throws {
+        let document = try #require(
+            MarkdownRenderCache.shared.documentImmediately(
+                for: MarkdownContentRevision(
+                    "Use $file-pr now, not `$file-pr` or [$file-pr](https://example.com)."
+                )
+            )
+        )
+        guard case let .paragraph(inline) = document.blocks.first else {
+            Issue.record("Expected a rendered paragraph")
+            return
+        }
+
+        let attributed = MarkdownSelectableTextAttributes.make(
+            from: inline,
+            lineSpacing: 4,
+            skills: [FeatureProviderSkill(name: "file-pr", displayName: "File PR")]
+        )
+
+        #expect(FeatureInlineSkillProjection.signatures(in: attributed).count == 1)
+        #expect(
+            FeatureInlineSkillProjection.plainText(from: attributed)
+                == "Use $file-pr now, not $file-pr or $file-pr."
+        )
+    }
+
+    @Test @MainActor
     func codeBlocksReuseSelectableInlineRendering() throws {
         let literalCode = "x = arr[i](fn)\na **b** c\nprintf(\\\"a\\\\tb\\\");"
         let cache = MarkdownRenderCache()


### PR DESCRIPTION
Known `$skill` tokens appear as labeled pills in the SwiftUI composer and sent messages. The draft and sent payload remain plain text. Copy, cut, selection, and undo preserve the original token. Inline code, fenced code, links, and unknown tokens stay literal.

Sent messages now use the thread's workspace skill catalog, matching the composer. Catalog changes update the transcript. Pill conversion waits until active IME text composition ends, so a catalog update does not discard marked text or move its caret.

This version is rebased onto `t3code/rebuild-mobile-app-swift` at `614a7b672a86ee638f284298fe26e8b0194e0eaa`. It preserves current attachment rendering, compaction state, and keyboard dismissal.

Validation:

- 153 focused native tests passed at `07d15466f9f6f9430647ec2ac4a5804d10a9bed7` across the root model, composer, Markdown, and voice suites.
- A new native UITextView test reproduced marked text loss during pill conversion. After the guard, the composer and voice suites passed 48 tests at `511c239f0430879033ec520dc775085a80522c3a`.
- Coverage includes project skill lookup, catalog changes, workspace isolation, raw token preservation, copy, selection, and undo.

Earlier captures of the pill styling:

| Surface | Before | After |
| --- | --- | --- |
| Composer | <img src="https://github.com/mackinleysmith/t3code/releases/download/pr-9071-evidence/composer-before.jpg" alt="Composer with a raw skill token" width="320"> | <img src="https://github.com/mackinleysmith/t3code/releases/download/pr-9071-evidence/pr-9071-composer-after-web-corners.jpg" alt="Composer with a skill pill" width="320"> |
| Sent message | <img src="https://github.com/mackinleysmith/t3code/releases/download/pr-9071-evidence/message-before.jpg" alt="Sent message with a raw skill token" width="320"> | <img src="https://github.com/mackinleysmith/t3code/releases/download/pr-9071-evidence/pr-9071-message-after-web-corners.jpg" alt="Sent message with a skill pill" width="320"> |

Modernized and fixed with GPT-6 in Codex.
