### PR TITLE
fix(server): preserve index during commit generation

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2259,6 +2259,51 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("preserves the exact index when commit message generation fails", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "README.md"), "staged before commit flow\n");
+      yield* runGit(repoDir, ["add", "README.md"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "new-file.txt"), "new\n");
+
+      const indexPath = NodePath.join(repoDir, ".git", "index");
+      const originalIndex = NodeFS.readFileSync(indexPath);
+      const headBefore = yield* runGit(repoDir, ["rev-parse", "HEAD"]).pipe(
+        Effect.map((result) => result.stdout.trim()),
+      );
+      const { manager } = yield* makeManager({
+        textGeneration: {
+          generateCommitMessage: () =>
+            Effect.fail(
+              new TextGenerationError({
+                operation: "generateCommitMessage",
+                detail: "API key is not configured",
+              }),
+            ),
+        },
+      });
+
+      const error = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit",
+      }).pipe(Effect.flip);
+
+      expect(error._tag).toBe("TextGenerationError");
+      expect(NodeFS.readFileSync(indexPath).equals(originalIndex)).toBe(true);
+      expect(
+        yield* runGit(repoDir, ["rev-parse", "HEAD"]).pipe(
+          Effect.map((result) => result.stdout.trim()),
+        ),
+      ).toBe(headBefore);
+      const status = yield* runGit(repoDir, ["status", "--porcelain"]).pipe(
+        Effect.map((result) => result.stdout),
+      );
+      expect(status).toContain("M  README.md");
+      expect(status).toContain("?? new-file.txt");
+    }),
+  );
+
   it.effect("creates a commit when working tree is dirty", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1761,6 +1761,7 @@ export const make = Effect.gen(function* () {
     const { commitSha } = yield* gitCore.commit(cwd, suggestion.subject, suggestion.body, {
       timeoutMs: COMMIT_TIMEOUT_MS,
       ...(commitProgress ? { progress: commitProgress } : {}),
+      stage: filePaths ? { filePaths } : {},
     });
     if (currentHookName !== null) {
       yield* emit({

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -114,6 +114,9 @@ export interface GitCommitProgress {
 export interface GitCommitOptions {
   readonly timeoutMs?: number;
   readonly progress?: GitCommitProgress;
+  readonly stage?: {
+    readonly filePaths?: readonly string[];
+  };
 }
 
 export interface GitPushResult {

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1597,44 +1597,132 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("commit context", () => {
-    it.effect("stages selected files and commits only those files", () =>
+    it.effect(
+      "prepares selected files without changing the index and commits only those files",
+      () =>
+        Effect.gen(function* () {
+          const cwd = yield* makeTmpDir();
+          yield* initRepoWithCommit(cwd);
+          const driver = yield* GitVcsDriver.GitVcsDriver;
+
+          yield* writeTextFile(cwd, "a.txt", "a\n");
+          yield* writeTextFile(cwd, "b.txt", "b\n");
+
+          const context = yield* driver.prepareCommitContext(cwd, ["a.txt"]);
+          assert.include(context?.stagedSummary ?? "", "a.txt");
+          assert.notInclude(context?.stagedSummary ?? "", "b.txt");
+          assert.equal(yield* git(cwd, ["diff", "--cached", "--name-only"]), "");
+
+          const commit = yield* driver.commit(cwd, "Add a", "", {
+            stage: { filePaths: ["a.txt"] },
+          });
+          assert.match(commit.commitSha, /^[a-f0-9]{40}$/);
+          assert.equal(yield* git(cwd, ["log", "-1", "--pretty=%s"]), "Add a");
+
+          const status = yield* git(cwd, ["status", "--porcelain"]);
+          assert.include(status, "?? b.txt");
+          assert.notInclude(status, "a.txt");
+        }),
+    );
+
+    it.effect("prepares selected files without clearing merge state", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();
-        yield* initRepoWithCommit(cwd);
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
         const driver = yield* GitVcsDriver.GitVcsDriver;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
 
-        yield* writeTextFile(cwd, "a.txt", "a\n");
-        yield* writeTextFile(cwd, "b.txt", "b\n");
+        yield* git(cwd, ["checkout", "-b", "merge-source"]);
+        yield* writeTextFile(cwd, "merge-source.txt", "source\n");
+        yield* git(cwd, ["add", "merge-source.txt"]);
+        yield* git(cwd, ["commit", "-m", "Add merge source"]);
+        yield* git(cwd, ["checkout", initialBranch]);
+        yield* writeTextFile(cwd, "main.txt", "main\n");
+        yield* git(cwd, ["add", "main.txt"]);
+        yield* git(cwd, ["commit", "-m", "Advance main"]);
+        yield* git(cwd, ["merge", "--no-commit", "--no-ff", "merge-source"]);
+        yield* writeTextFile(cwd, "selected.txt", "selected\n");
 
-        const context = yield* driver.prepareCommitContext(cwd, ["a.txt"]);
-        assert.include(context?.stagedSummary ?? "", "a.txt");
-        assert.notInclude(context?.stagedSummary ?? "", "b.txt");
+        const indexPath = pathService.join(cwd, ".git", "index");
+        const mergeHeadPath = pathService.join(cwd, ".git", "MERGE_HEAD");
+        const originalIndex = yield* fileSystem.readFile(indexPath);
+        const originalMergeHead = yield* fileSystem.readFile(mergeHeadPath);
 
-        const commit = yield* driver.commit(cwd, "Add a", "");
-        assert.match(commit.commitSha, /^[a-f0-9]{40}$/);
-        assert.equal(yield* git(cwd, ["log", "-1", "--pretty=%s"]), "Add a");
+        const context = yield* driver.prepareCommitContext(cwd, ["selected.txt"]);
 
-        const status = yield* git(cwd, ["status", "--porcelain"]);
-        assert.include(status, "?? b.txt");
-        assert.notInclude(status, "a.txt");
+        assert.include(context?.stagedSummary ?? "", "selected.txt");
+        assert.deepEqual(
+          Array.from(yield* fileSystem.readFile(indexPath)),
+          Array.from(originalIndex),
+        );
+        assert.deepEqual(
+          Array.from(yield* fileSystem.readFile(mergeHeadPath)),
+          Array.from(originalMergeHead),
+        );
       }),
     );
 
     it.effect("treats selected file paths literally", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();
-        yield* initRepoWithCommit(cwd);
+        yield* git(cwd, ["init", "--initial-branch=main"]);
+        yield* git(cwd, ["config", "user.email", "test@test.com"]);
+        yield* git(cwd, ["config", "user.name", "Test"]);
         const driver = yield* GitVcsDriver.GitVcsDriver;
 
         yield* writeTextFile(cwd, "selected[1].txt", "literal\n");
         yield* writeTextFile(cwd, "selected1.txt", "pattern match\n");
+        yield* git(cwd, ["add", "selected1.txt"]);
 
         yield* driver.prepareCommitContext(cwd, ["selected[1].txt"]);
 
-        assert.equal(yield* git(cwd, ["diff", "--cached", "--name-only"]), "selected[1].txt");
+        assert.equal(yield* git(cwd, ["diff", "--cached", "--name-only"]), "selected1.txt");
+        yield* driver.commit(cwd, "Add literal path", "", {
+          stage: { filePaths: ["selected[1].txt"] },
+        });
+        assert.equal(
+          yield* git(cwd, ["diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "HEAD"]),
+          "selected[1].txt",
+        );
 
         const status = yield* git(cwd, ["status", "--porcelain"]);
         assert.include(status, "?? selected1.txt");
+      }),
+    );
+
+    it.effect("includes force-added ignored files without changing the index", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+
+        yield* writeTextFile(cwd, ".gitignore", "*.generated\n");
+        yield* git(cwd, ["add", ".gitignore"]);
+        yield* git(cwd, ["commit", "-m", "Ignore generated files"]);
+        yield* writeTextFile(cwd, "included.generated", "included\n");
+        yield* git(cwd, ["add", "-f", "included.generated"]);
+        const indexPath = pathService.join(cwd, ".git", "index");
+        const originalIndex = yield* fileSystem.readFile(indexPath);
+
+        const allFilesContext = yield* driver.prepareCommitContext(cwd);
+        const selectedFileContext = yield* driver.prepareCommitContext(cwd, ["included.generated"]);
+
+        assert.include(allFilesContext?.stagedSummary ?? "", "included.generated");
+        assert.include(selectedFileContext?.stagedSummary ?? "", "included.generated");
+        assert.deepEqual(
+          Array.from(yield* fileSystem.readFile(indexPath)),
+          Array.from(originalIndex),
+        );
+        yield* driver.commit(cwd, "Add generated file", "", {
+          stage: { filePaths: ["included.generated"] },
+        });
+        assert.equal(
+          yield* git(cwd, ["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"]),
+          "included.generated",
+        );
       }),
     );
   });
@@ -1727,7 +1815,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           refName: "feature/push",
         });
         yield* writeTextFile(cwd, "feature.txt", "feature\n");
-        yield* (yield* GitVcsDriver.GitVcsDriver).prepareCommitContext(cwd);
+        yield* git(cwd, ["add", "-A"]);
         yield* (yield* GitVcsDriver.GitVcsDriver).commit(cwd, "Add feature", "");
 
         const pushed = yield* (yield* GitVcsDriver.GitVcsDriver).pushCurrentBranch(cwd, null);
@@ -1799,7 +1887,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           yield* git(cwd, ["remote", "add", "origin", remote]);
           yield* git(cwd, ["push", "-u", "origin", "main"]);
           yield* writeTextFile(cwd, "upstream.txt", "upstream\n");
-          yield* driver.prepareCommitContext(cwd);
+          yield* git(cwd, ["add", "-A"]);
           yield* driver.commit(cwd, "Add upstream update", "");
 
           const pushed = yield* driver.pushCurrentBranch(cwd, null);
@@ -1840,7 +1928,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         const devSha = yield* git(cwd, ["rev-parse", "HEAD"]);
         yield* git(cwd, ["checkout", "-b", "feature/x", "origin/dev"]);
         yield* writeTextFile(cwd, "feature.txt", "feature\n");
-        yield* driver.prepareCommitContext(cwd);
+        yield* git(cwd, ["add", "-A"]);
         yield* driver.commit(cwd, "Add feature", "");
 
         const pushed = yield* driver.pushCurrentBranch(cwd, null);
@@ -1874,7 +1962,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         yield* git(cwd, ["checkout", "-b", "feature/y", "origin/main"]);
         yield* git(cwd, ["config", "branch.feature/y.gh-merge-base", "release/v2"]);
         yield* writeTextFile(cwd, "feature.txt", "feature\n");
-        yield* driver.prepareCommitContext(cwd);
+        yield* git(cwd, ["add", "-A"]);
         yield* driver.commit(cwd, "Add feature", "");
 
         const pushed = yield* driver.pushCurrentBranch(cwd, null);
@@ -1912,7 +2000,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           "upstream/effect-atom",
         );
         yield* writeTextFile(cwd, "alias.txt", "alias\n");
-        yield* driver.prepareCommitContext(cwd);
+        yield* git(cwd, ["add", "-A"]);
         yield* driver.commit(cwd, "Add alias update", "");
 
         const pushed = yield* driver.pushCurrentBranch(cwd, null);

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1831,48 +1831,128 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       })),
     );
 
+  const stageCommitChanges = Effect.fn("stageCommitChanges")(function* (
+    cwd: string,
+    filePaths: readonly string[] | undefined,
+    env: NodeJS.ProcessEnv | undefined,
+  ) {
+    if (filePaths && filePaths.length > 0) {
+      const head = yield* executeGit(
+        "GitVcsDriver.stageCommitChanges.resolveHead",
+        cwd,
+        ["rev-parse", "--verify", "HEAD"],
+        { allowNonZeroExit: true },
+      );
+      yield* runGit(
+        "GitVcsDriver.stageCommitChanges.reset",
+        cwd,
+        head.exitCode === 0
+          ? env?.GIT_INDEX_FILE
+            ? ["read-tree", "HEAD"]
+            : ["reset"]
+          : ["read-tree", "--empty"],
+        { env },
+      );
+      yield* runGit(
+        "GitVcsDriver.stageCommitChanges.addSelected",
+        cwd,
+        ["--literal-pathspecs", "add", "-A", "--force", "--", ...filePaths],
+        { env },
+      );
+    } else {
+      yield* runGit("GitVcsDriver.stageCommitChanges.addAll", cwd, ["add", "-A"], { env });
+    }
+  });
+
   const prepareCommitContext: GitVcsDriver.GitVcsDriver["Service"]["prepareCommitContext"] =
     Effect.fn("prepareCommitContext")(function* (cwd, filePaths) {
-      if (filePaths && filePaths.length > 0) {
-        yield* runGit("GitVcsDriver.prepareCommitContext.reset", cwd, ["reset"]).pipe(
-          Effect.catchTags({
-            GitCommandError: () => Effect.void,
-          }),
-        );
-        yield* runGit("GitVcsDriver.prepareCommitContext.addSelected", cwd, [
-          "--literal-pathspecs",
-          "add",
-          "-A",
-          "--",
-          ...filePaths,
-        ]);
-      } else {
-        yield* runGit("GitVcsDriver.prepareCommitContext.addAll", cwd, ["add", "-A"]);
-      }
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          const tempDirectory = yield* fileSystem
+            .makeTempDirectoryScoped({ prefix: "t3code-git-index-" })
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new GitCommandError({
+                    ...gitCommandContext({
+                      operation: "GitVcsDriver.prepareCommitContext.createTemporaryIndex",
+                      cwd,
+                      args: ["diff", "--cached"],
+                    }),
+                    detail: "Failed to create a temporary Git index.",
+                    cause,
+                  }),
+              ),
+            );
+          const temporaryIndexPath = path.join(tempDirectory, "index");
+          const env = { GIT_INDEX_FILE: temporaryIndexPath } satisfies NodeJS.ProcessEnv;
+          const rawIndexPath = yield* runGitStdout(
+            "GitVcsDriver.prepareCommitContext.resolveIndex",
+            cwd,
+            ["rev-parse", "--git-path", "index"],
+          ).pipe(Effect.map((stdout) => stdout.trim()));
+          const indexPath = path.isAbsolute(rawIndexPath)
+            ? rawIndexPath
+            : path.resolve(cwd, rawIndexPath);
+          const mapIndexFileError = (cause: PlatformError.PlatformError) =>
+            new GitCommandError({
+              ...gitCommandContext({
+                operation: "GitVcsDriver.prepareCommitContext.copyIndex",
+                cwd,
+                args: ["rev-parse", "--git-path", "index"],
+              }),
+              detail: "Failed to copy the Git index for commit message generation.",
+              cause,
+            });
+          const indexExists = yield* fileSystem
+            .exists(indexPath)
+            .pipe(Effect.mapError(mapIndexFileError));
+          if (indexExists) {
+            yield* fileSystem
+              .copyFile(indexPath, temporaryIndexPath)
+              .pipe(Effect.mapError(mapIndexFileError));
+          } else {
+            const head = yield* executeGit(
+              "GitVcsDriver.prepareCommitContext.resolveHead",
+              cwd,
+              ["rev-parse", "--verify", "HEAD"],
+              { allowNonZeroExit: true },
+            );
+            yield* runGit(
+              "GitVcsDriver.prepareCommitContext.readTree",
+              cwd,
+              head.exitCode === 0 ? ["read-tree", "HEAD"] : ["read-tree", "--empty"],
+              { env },
+            );
+          }
+          yield* stageCommitChanges(cwd, filePaths, env);
 
-      const stagedSummary = yield* runGitStdout(
-        "GitVcsDriver.prepareCommitContext.stagedSummary",
-        cwd,
-        ["diff", "--cached", "--name-status"],
-      ).pipe(Effect.map((stdout) => stdout.trim()));
-      if (stagedSummary.length === 0) {
-        return null;
-      }
+          const stagedSummary = yield* runGitStdoutWithOptions(
+            "GitVcsDriver.prepareCommitContext.stagedSummary",
+            cwd,
+            ["diff", "--cached", "--name-status"],
+            { env },
+          ).pipe(Effect.map((stdout) => stdout.trim()));
+          if (stagedSummary.length === 0) {
+            return null;
+          }
 
-      const stagedPatch = yield* runGitStdoutWithOptions(
-        "GitVcsDriver.prepareCommitContext.stagedPatch",
-        cwd,
-        ["diff", "--no-ext-diff", "--cached", "--patch", "--minimal"],
-        {
-          maxOutputBytes: PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES,
-          appendTruncationMarker: true,
-        },
+          const stagedPatch = yield* runGitStdoutWithOptions(
+            "GitVcsDriver.prepareCommitContext.stagedPatch",
+            cwd,
+            ["diff", "--no-ext-diff", "--cached", "--patch", "--minimal"],
+            {
+              env,
+              maxOutputBytes: PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES,
+              appendTruncationMarker: true,
+            },
+          );
+          return {
+            stagedSummary,
+            stagedPatch,
+          };
+        }),
       );
-
-      return {
-        stagedSummary,
-        stagedPatch,
-      };
     });
 
   const commit: GitVcsDriver.GitVcsDriver["Service"]["commit"] = Effect.fn("commit")(function* (
@@ -1896,6 +1976,10 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             onStderrLine: (line: string) =>
               options.progress?.onOutputLine?.({ stream: "stderr", text: line }) ?? Effect.void,
           };
+    if (options?.stage) {
+      yield* stageCommitChanges(cwd, options.stage.filePaths, undefined);
+    }
+
     yield* executeGit("GitVcsDriver.commit.commit", cwd, args, {
       ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
       ...(progress ? { progress } : {}),


### PR DESCRIPTION
Commit-message generation currently stages changes in the real Git index before calling the provider. If generation fails or is cancelled, no commit is created but the user’s prior staging is lost.

This prepares the message context against a temporary index, then stages the requested paths immediately before the existing Git commit. Literal and ignored selections, initial commits, hooks, signing, and ordinary commit-failure behavior stay intact; staging is intentionally not rolled back after a commit or hook failure.

Fixes #9070

Made with GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Git commit/staging behavior in the VCS driver; incorrect index handling could affect merges, partial commits, or hook failures, though behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes a bug where **AI commit message generation** staged changes in the real Git index; if generation failed or was cancelled, users lost their prior staging even though no commit was created.
> 
> **`prepareCommitContext`** now builds staged diffs on a **temporary index** (copy of the real index via `GIT_INDEX_FILE`) instead of mutating the repository index or merge state. **`commit`** gains optional **`stage.filePaths`** on `GitCommitOptions`; `GitManager` passes selected paths there so staging happens immediately before `git commit`, not during message prep.
> 
> A shared **`stageCommitChanges`** helper handles full or selective staging with literal pathspecs and `--force` for ignored files. Callers that previously relied on `prepareCommitContext` to stage must **`git add`** explicitly before commit (tests and push flows updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80c3328d7ba214030bdc5c52693fa2feea25e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve Git index during commit message generation in `GitVcsDriverCore`
> - `prepareCommitContext` now copies the real index to a temporary file and computes diffs against that, so generating a commit message no longer mutates the repository's real index or merge state
> - Adds `stage.filePaths` to `GitCommitOptions`; when provided, `commit` stages only those files before committing, enabling selective commits without external staging
> - New internal `stageCommitChanges` helper handles staging into either the real index or a temporary one, using `--literal-pathspecs` for selected files
> - Behavioral Change: `prepareCommitContext` no longer stages into the real index; existing tests and remote-operation flows in [GitVcsDriverCore.test.ts](https://github.com/pingdotgg/t3code/pull/9072/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) now use explicit `git add -A` where they previously relied on `prepareCommitContext` side effects
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a80c332.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->