### PR TITLE
fix(provider): drop removed custom models from the model picker

### DIFF
--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -620,6 +620,44 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         );
       });
 
+      it("drops custom models the refreshed snapshot no longer carries", () => {
+        const previousProvider = {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          driver: ProviderDriverKind.make("claudeAgent"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-14T00:00:00.000Z",
+          version: "2.1.0",
+          models: [
+            {
+              slug: "claude-sonnet-4-6",
+              name: "Sonnet 4.6",
+              isCustom: false,
+              capabilities: null,
+            },
+            {
+              slug: "removed-custom",
+              name: "removed-custom",
+              isCustom: true,
+              capabilities: null,
+            },
+          ],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-04-14T00:01:00.000Z",
+          models: [previousProvider.models[0]],
+        } satisfies ServerProvider;
+
+        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
+          ...refreshedProvider.models,
+        ]);
+      });
+
       it("drops stale OpenCode models missing from a successful refresh", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("opencode"),

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -105,9 +105,13 @@ const mergeProviderModels = (
   nextModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const shouldRetainMissingModels = shouldRetainMissingProviderModels(provider);
+  // Custom rows are derived from settings and every snapshot carries the full
+  // current list, so a custom model missing from `nextModels` was removed by
+  // the user and must not be resurrected from the previous snapshot.
+  const retainablePreviousModels = previousModels.filter((model) => !model.isCustom);
 
-  if (shouldRetainMissingModels && nextModels.length === 0 && previousModels.length > 0) {
-    return previousModels;
+  if (shouldRetainMissingModels && nextModels.length === 0 && retainablePreviousModels.length > 0) {
+    return retainablePreviousModels;
   }
 
   const previousBySlug = new Map(previousModels.map((model) => [model.slug, model] as const));
@@ -123,7 +127,7 @@ const mergeProviderModels = (
   });
   const nextSlugs = new Set(nextModels.map((model) => model.slug));
   return shouldRetainMissingModels
-    ? [...mergedModels, ...previousModels.filter((model) => !nextSlugs.has(model.slug))]
+    ? [...mergedModels, ...retainablePreviousModels.filter((model) => !nextSlugs.has(model.slug))]
     : mergedModels;
 };
 

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -182,6 +182,35 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
     );
   });
 
+  it("does not resurrect cached custom models that settings no longer declare", () => {
+    const builtIn = {
+      slug: "gpt-5.4",
+      name: "GPT-5.4",
+      isCustom: false,
+      capabilities: emptyCapabilities,
+    } as const;
+    const cachedCodex = makeProvider(CODEX_DRIVER, {
+      models: [
+        builtIn,
+        {
+          slug: "removed-custom",
+          name: "removed-custom",
+          isCustom: true,
+          capabilities: emptyCapabilities,
+        },
+      ],
+    });
+    const fallbackCodex = makeProvider(CODEX_DRIVER, { models: [builtIn] });
+
+    assert.deepStrictEqual(
+      hydrateCachedProvider({
+        cachedProvider: cachedCodex,
+        fallbackProvider: fallbackCodex,
+      }).models,
+      [builtIn],
+    );
+  });
+
   it("ignores stale cached enabled state when the provider is now disabled", () => {
     const cachedCodex = makeProvider(CODEX_DRIVER, {
       checkedAt: "2026-04-10T12:00:00.000Z",

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -21,7 +21,13 @@ const mergeProviderModels = (
   cachedModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const fallbackSlugs = new Set(fallbackModels.map((model) => model.slug));
-  return [...fallbackModels, ...cachedModels.filter((model) => !fallbackSlugs.has(model.slug))];
+  // The fallback snapshot is built from current settings and already carries
+  // every custom model, so cached custom rows that are not in it were removed
+  // while the cache was stale and must not come back.
+  return [
+    ...fallbackModels,
+    ...cachedModels.filter((model) => !model.isCustom && !fallbackSlugs.has(model.slug)),
+  ];
 };
 
 export const orderProviderSnapshots = (

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -226,6 +226,29 @@ describe("instance-scoped model selection", () => {
     ]);
   });
 
+  it("drops server-reported custom rows that are no longer in settings", () => {
+    const baseProvider = provider({
+      instanceId: "claude_openrouter",
+      models: ["claude-sonnet-4-6"],
+    });
+    const providers = [
+      {
+        ...baseProvider,
+        models: [
+          ...baseProvider.models,
+          { slug: "removed/custom", name: "removed/custom", isCustom: true, capabilities: {} },
+        ],
+      },
+    ];
+    const openrouter = deriveProviderInstanceEntries(providers)[0]!;
+
+    expect(
+      getAppModelOptionsForInstance(settingsWithProviderInstances(), openrouter).map(
+        (option) => option.slug,
+      ),
+    ).toEqual(["claude-sonnet-4-6", "openai/gpt-5.5"]);
+  });
+
   it("applies persisted per-instance model ordering", () => {
     const providers = [
       provider({

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -175,7 +175,12 @@ export function getAppModelOptions(
   selectedModel?: string | null,
 ): AppModelOption[] {
   const rawModels = getProviderModels(providers, provider);
-  const options: AppModelOption[] = rawModels.map(toAppModelOption);
+  // Server-reported custom rows mirror settings and can lag a removal, so
+  // only built-ins are taken from the snapshot; custom rows are rebuilt from
+  // settings below.
+  const options: AppModelOption[] = rawModels
+    .filter((model) => !model.isCustom)
+    .map(toAppModelOption);
   const seen = new Set(options.map((option) => option.slug));
   const builtInModelSlugs = new Set(
     Arr.filterMap(getProviderModels(providers, provider), (model) =>
@@ -221,14 +226,18 @@ export function getAppModelOptions(
  * when present, falling back to the legacy per-kind
  * `settings.providers[driverKind].customModels` bucket for default
  * instances only. This keeps two instances of the same kind from leaking
- * custom slugs into each other.
+ * custom slugs into each other. Custom rows reported by the server are
+ * ignored so a slug removed in Settings disappears without waiting for the
+ * next provider probe.
  */
 export function getAppModelOptionsForInstance(
   settings: UnifiedSettings,
   entry: ProviderInstanceEntry,
   selectedModel?: string | null,
 ): AppModelOption[] {
-  const options: AppModelOption[] = entry.models.map(toAppModelOption);
+  const options: AppModelOption[] = entry.models
+    .filter((model) => !model.isCustom)
+    .map(toAppModelOption);
   const seen = new Set(options.map((option) => option.slug));
   const builtInModelSlugs = new Set(
     Arr.filterMap(entry.models, (model) =>


### PR DESCRIPTION
Removing a custom model in Settings did not remove it from the model picker. The row stayed in the composer picker and in every settings picker, and it survived server restarts.

The server's provider aggregator merges each refreshed snapshot with the previous one and, for every driver except OpenCode, keeps any model that the new snapshot no longer reports. Custom models are built from settings on every probe, so the removed slug was missing from the new snapshot and got re-added from the old one on every refresh, then persisted to the boot cache. The web option builder also took custom rows straight from the server snapshot instead of settings.

Custom rows are owned by settings and every snapshot already carries the full current list, so the aggregator and boot-cache merges now never retain previous custom rows. The web option builders only take built-ins from the snapshot and rebuild custom rows from settings, so a removal disappears immediately instead of waiting for the next probe. Mobile reads the server list directly and is fixed by the server change.

Focused tests cover the aggregator merge, the boot-cache hydrate, and the web option list.

Made with Claude Fable 5.1 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider snapshot merging and model-picker assembly, which could affect model lists at runtime, but scope is limited to custom-model retention with targeted tests.
> 
> **Overview**
> Fixes **removed custom models sticking around** in the composer and settings pickers (and across restarts) by treating custom model rows as **settings-owned** instead of mergeable snapshot history.
> 
> On the **server**, `mergeProviderSnapshot` and boot **cache hydration** no longer carry forward previous or cached `isCustom` models when the current settings-derived snapshot omits them; **built-in** models still get the existing “retain on empty/partial refresh” behavior. On **web**, `getAppModelOptions` / `getAppModelOptionsForInstance` take **built-ins only** from the provider snapshot and **rebuild custom options from settings**, so a deletion shows up immediately even if the server list is stale.
> 
> Adds regression tests for registry merge, cache hydrate, and web option lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f05db6c334f5dd10bd71ae9dc1128ea1108eef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop removed custom models from provider snapshots, status cache, and model picker
> - Filters custom models out of the retained set in `mergeProviderModels` so a refreshed provider snapshot no longer resurrects custom models that were removed from settings
> - Excludes custom cached models during `hydrateCachedProvider` hydration so the status cache does not bring back custom models absent from the settings-derived fallback snapshot
> - Ignores server-reported custom models in `getAppModelOptions` and `getAppModelOptionsForInstance`, rebuilding custom rows solely from user settings so removals take effect immediately
> - Risk: any code path that relied on server-reported or cached custom models surviving a refresh will no longer see them; check `mergeProviderModels` in [ProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/9075/files#diff-5c33694fd7889294ecb21a88beafee2debe92f779baab4629651d4c8be8a9a97) and `hydrateCachedProvider` in [providerStatusCache.ts](https://github.com/pingdotgg/t3code/pull/9075/files#diff-6de08e2cd95df6ffd1cc93a059448e8a80f0392091e10e0d7aabd9b6b01dbb07) for downstream consumers
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f05db6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->