### PR TITLE
feat(desktop): add configurable quit shortcut confirmation

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -128,9 +128,19 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     };
   },
   onQuitShortcut: (listener) => {
-    const wrappedListener = (_event: Electron.IpcRendererEvent, state: unknown) => {
-      if (state !== "down" && state !== "up") return;
-      listener(state);
+    const wrappedListener = (_event: Electron.IpcRendererEvent, hint: unknown) => {
+      if (typeof hint !== "object" || hint === null || !("state" in hint)) return;
+      if (hint.state === "up") {
+        listener({ state: "up" });
+        return;
+      }
+      if (
+        hint.state === "down" &&
+        "mode" in hint &&
+        (hint.mode === "hold" || hint.mode === "double-click")
+      ) {
+        listener({ state: "down", mode: hint.mode });
+      }
     };
 
     ipcRenderer.on(IpcChannels.QUIT_SHORTCUT_CHANNEL, wrappedListener);

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -19,7 +19,7 @@ const clientSettings: ClientSettings = {
   browserDefaultAppearance: "dark",
   browserRecordingFrameRate: 60,
   browserAutoShowFloatingPreview: false,
-  confirmQuit: true,
+  confirmQuit: "double-click",
   confirmThreadArchive: true,
   confirmThreadDelete: false,
   confirmThreadUnpin: false,

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -565,9 +565,9 @@ export const make = Effect.gen(function* () {
             }),
           ),
         ),
-      notify: (state) => {
+      notify: (hint) => {
         if (!window.isDestroyed()) {
-          window.webContents.send(QUIT_SHORTCUT_CHANNEL, state);
+          window.webContents.send(QUIT_SHORTCUT_CHANNEL, hint);
         }
       },
       quit: () => {

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -27,7 +27,7 @@ import * as PreviewManager from "../preview/Manager.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopClientSettings from "../settings/DesktopClientSettings.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
-import { makeQuitHoldHandler } from "./QuitHold.ts";
+import { makeQuitShortcutHandler } from "./QuitHold.ts";
 
 const TITLEBAR_HEIGHT = 40;
 const TITLEBAR_COLOR = "#01000000"; // #00000000 does not work correctly on Linux
@@ -551,12 +551,11 @@ export const make = Effect.gen(function* () {
     // close-terminal shortcut can outlive the terminal that handled its first
     // press, so reject repeats before they reach the native window accelerator.
     // Deliberate presses still flow through the renderer or native menu.
-    // Chrome-style hold-to-quit: intercept the quit accelerator before the
-    // native menu sees it and only quit after the shortcut is held. The
-    // renderer shows the "Hold to Quit" hint via QUIT_SHORTCUT_CHANNEL.
-    const quitHoldHandler = makeQuitHoldHandler({
+    // Intercept the quit accelerator before the native menu sees it and apply
+    // the configured direct, hold, or double-press behavior.
+    const quitShortcutHandler = makeQuitShortcutHandler({
       platform: environment.platform,
-      isEnabled: () =>
+      getMode: () =>
         runPromise(
           Effect.map(
             clientSettings.get,
@@ -576,7 +575,7 @@ export const make = Effect.gen(function* () {
       },
     });
     window.webContents.on("before-input-event", (event, input) => {
-      quitHoldHandler(event, input);
+      quitShortcutHandler(event, input);
       if (input.type !== "keyDown" || !input.isAutoRepeat) return;
       const modifier = environment.platform === "darwin" ? input.meta : input.control;
       if (modifier && !input.alt && !input.shift && input.key.toLowerCase() === "w") {

--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
-  makeQuitHoldHandler,
-  QUIT_DOUBLE_TAP_MS,
+  makeQuitShortcutHandler,
+  QUIT_DOUBLE_PRESS_MS,
   QUIT_HOLD_DURATION_MS,
   QUIT_HOLD_RELEASE_GRACE_MS,
 } from "./QuitHold.ts";
 import type { QuitHoldKeyInput, QuitHoldState } from "./QuitHold.ts";
+import type { QuitConfirmationMode } from "@t3tools/contracts";
 
 function makeInput(overrides: Partial<QuitHoldKeyInput>): QuitHoldKeyInput {
   return {
@@ -22,22 +23,22 @@ function makeInput(overrides: Partial<QuitHoldKeyInput>): QuitHoldKeyInput {
 }
 
 function makeHarness(options?: {
-  enabled?: boolean;
+  mode?: QuitConfirmationMode;
   platform?: NodeJS.Platform;
-  isEnabled?: () => Promise<boolean>;
+  getMode?: () => Promise<QuitConfirmationMode>;
 }) {
   const notifications: Array<QuitHoldState> = [];
   const quit = vi.fn();
-  const handler = makeQuitHoldHandler({
+  const handler = makeQuitShortcutHandler({
     platform: options?.platform ?? "darwin",
-    isEnabled: options?.isEnabled ?? (() => Promise.resolve(options?.enabled ?? true)),
+    getMode: options?.getMode ?? (() => Promise.resolve(options?.mode ?? "hold")),
     notify: (state) => notifications.push(state),
     quit,
   });
   const preventDefault = vi.fn();
   const send = async (input: QuitHoldKeyInput) => {
     handler({ preventDefault }, input);
-    // Let the isEnabled promise settle.
+    // Let the getMode promise settle.
     await Promise.resolve();
     await Promise.resolve();
   };
@@ -55,7 +56,7 @@ function makeHarness(options?: {
   return { notifications, quit, preventDefault, send, holdFor };
 }
 
-describe("makeQuitHoldHandler", () => {
+describe("makeQuitShortcutHandler", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -122,53 +123,64 @@ describe("makeQuitHoldHandler", () => {
     expect(harness.quit).not.toHaveBeenCalled();
   });
 
-  it("quits without showing a hint when hold-to-quit is disabled", async () => {
-    const harness = makeHarness({ enabled: false });
+  it("quits without showing a hint in direct mode", async () => {
+    const harness = makeHarness({ mode: "direct" });
     await harness.send(makeInput({}));
     expect(harness.quit).toHaveBeenCalledTimes(1);
     expect(harness.notifications).toEqual([]);
   });
 
-  it("discards a stale isEnabled resolution from a superseded press", async () => {
-    // Press #1's isEnabled is still pending when the user releases and
+  it("discards a stale mode resolution from a superseded press", async () => {
+    // Press #1's mode is still pending when the user releases and
     // presses again; its late resolution must not act for press #2.
-    const resolvers: Array<(enabled: boolean) => void> = [];
+    const resolvers: Array<(mode: QuitConfirmationMode) => void> = [];
     const harness = makeHarness({
-      isEnabled: () => new Promise((resolve) => resolvers.push(resolve)),
+      getMode: () => new Promise((resolve) => resolvers.push(resolve)),
     });
     await harness.send(makeInput({}));
     await harness.send(makeInput({ type: "keyUp" }));
-    // Outside the double-tap window, so the second press starts a new hold.
-    vi.advanceTimersByTime(QUIT_DOUBLE_TAP_MS + 100);
+    // Outside the double-press window, so the second press starts a new hold.
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS + 100);
     await harness.send(makeInput({}));
     expect(resolvers).toHaveLength(2);
 
-    // Press #1 resolves late with "disabled" — it must not quit press #2.
-    resolvers[0]?.(false);
+    // Press #1 resolves late with "direct". It must not quit press #2.
+    resolvers[0]?.("direct");
     await Promise.resolve();
     await Promise.resolve();
     expect(harness.quit).not.toHaveBeenCalled();
 
-    // Press #2 resolves enabled and completes a full hold.
-    resolvers[1]?.(true);
+    // Press #2 resolves to hold and completes the gesture.
+    resolvers[1]?.("hold");
     await harness.holdFor(QUIT_HOLD_DURATION_MS + 200);
     await harness.send(makeInput({ type: "keyUp" }));
     expect(harness.quit).toHaveBeenCalledTimes(1);
   });
 
-  it("quits on a quick double tap, even when the first release was never seen", async () => {
-    const harness = makeHarness();
+  it("quits on a quick double press in double-click mode when the first release is unseen", async () => {
+    const harness = makeHarness({ mode: "double-click" });
     await harness.send(makeInput({}));
-    vi.advanceTimersByTime(QUIT_DOUBLE_TAP_MS - 100);
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
     await harness.send(makeInput({}));
     expect(harness.quit).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toEqual(["down", "up"]);
   });
 
-  it("treats two slow taps as separate presses", async () => {
+  it("treats two slow presses as separate attempts in double-click mode", async () => {
+    const harness = makeHarness({ mode: "double-click" });
+    await harness.send(makeInput({}));
+    await harness.send(makeInput({ type: "keyUp" }));
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS + 100);
+    await harness.send(makeInput({}));
+    expect(harness.quit).not.toHaveBeenCalled();
+    expect(harness.notifications).toEqual(["down", "up", "down"]);
+  });
+
+  it("does not treat two quick presses as a quit in hold mode", async () => {
     const harness = makeHarness();
     await harness.send(makeInput({}));
     await harness.send(makeInput({ type: "keyUp" }));
-    vi.advanceTimersByTime(QUIT_DOUBLE_TAP_MS + 100);
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
     await harness.send(makeInput({}));
     expect(harness.quit).not.toHaveBeenCalled();
     expect(harness.notifications).toEqual(["down", "up", "down"]);
@@ -186,12 +198,11 @@ describe("makeQuitHoldHandler", () => {
     expect(harness.quit).not.toHaveBeenCalled();
   });
 
-  it("does not count an interrupted press toward a double tap", async () => {
-    const harness = makeHarness();
+  it("does not count an interrupted press toward a double press", async () => {
+    const harness = makeHarness({ mode: "double-click" });
     await harness.send(makeInput({}));
     await harness.send(makeInput({ shift: true }));
-    // A fresh press right after the interruption starts a new hold, not a
-    // double-tap quit.
+    // A fresh press right after the interruption starts a new attempt.
     await harness.send(makeInput({}));
     expect(harness.quit).not.toHaveBeenCalled();
     expect(harness.notifications).toEqual(["down", "up", "down"]);

--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -6,8 +6,12 @@ import {
   QUIT_HOLD_DURATION_MS,
   QUIT_HOLD_RELEASE_GRACE_MS,
 } from "./QuitHold.ts";
-import type { QuitHoldKeyInput, QuitHoldState } from "./QuitHold.ts";
-import type { QuitConfirmationMode } from "@t3tools/contracts";
+import type { QuitHoldKeyInput } from "./QuitHold.ts";
+import type { QuitConfirmationMode, QuitShortcutHintEvent } from "@t3tools/contracts";
+
+const HOLD_DOWN = { state: "down", mode: "hold" } as const;
+const DOUBLE_CLICK_DOWN = { state: "down", mode: "double-click" } as const;
+const UP = { state: "up" } as const;
 
 function makeInput(overrides: Partial<QuitHoldKeyInput>): QuitHoldKeyInput {
   return {
@@ -27,12 +31,12 @@ function makeHarness(options?: {
   platform?: NodeJS.Platform;
   getMode?: () => Promise<QuitConfirmationMode>;
 }) {
-  const notifications: Array<QuitHoldState> = [];
+  const notifications: Array<QuitShortcutHintEvent> = [];
   const quit = vi.fn();
   const handler = makeQuitShortcutHandler({
     platform: options?.platform ?? "darwin",
     getMode: options?.getMode ?? (() => Promise.resolve(options?.mode ?? "hold")),
-    notify: (state) => notifications.push(state),
+    notify: (event) => notifications.push(event),
     quit,
   });
   const preventDefault = vi.fn();
@@ -70,12 +74,12 @@ describe("makeQuitShortcutHandler", () => {
     const harness = makeHarness();
     await harness.send(makeInput({}));
     expect(harness.preventDefault).toHaveBeenCalledTimes(1);
-    expect(harness.notifications).toEqual(["down"]);
+    expect(harness.notifications).toEqual([HOLD_DOWN]);
 
     vi.advanceTimersByTime(QUIT_HOLD_DURATION_MS + QUIT_HOLD_RELEASE_GRACE_MS);
     expect(harness.quit).not.toHaveBeenCalled();
     // The watchdog dismisses the hint once the press is clearly over.
-    expect(harness.notifications).toEqual(["down", "up"]);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
   });
 
   it("quits after a completed hold is released", async () => {
@@ -87,7 +91,7 @@ describe("makeQuitShortcutHandler", () => {
     expect(harness.quit).not.toHaveBeenCalled();
     vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
     expect(harness.quit).toHaveBeenCalledTimes(1);
-    expect(harness.notifications).toEqual(["down", "up"]);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
   });
 
   it("waits for Q release when Cmd is released first", async () => {
@@ -109,7 +113,7 @@ describe("makeQuitShortcutHandler", () => {
     await harness.send(makeInput({}));
     await harness.holdFor(500);
     await harness.send(makeInput({ type: "keyUp" }));
-    expect(harness.notifications).toEqual(["down", "up"]);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
     vi.advanceTimersByTime((QUIT_HOLD_DURATION_MS + QUIT_HOLD_RELEASE_GRACE_MS) * 2);
     expect(harness.quit).not.toHaveBeenCalled();
   });
@@ -118,7 +122,7 @@ describe("makeQuitShortcutHandler", () => {
     const harness = makeHarness();
     await harness.send(makeInput({}));
     await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
-    expect(harness.notifications).toEqual(["down", "up"]);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
     vi.advanceTimersByTime((QUIT_HOLD_DURATION_MS + QUIT_HOLD_RELEASE_GRACE_MS) * 2);
     expect(harness.quit).not.toHaveBeenCalled();
   });
@@ -126,6 +130,63 @@ describe("makeQuitShortcutHandler", () => {
   it("quits without showing a hint in direct mode", async () => {
     const harness = makeHarness({ mode: "direct" });
     await harness.send(makeInput({}));
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toEqual([]);
+  });
+
+  it("honors direct mode when the key is released before its mode read settles", async () => {
+    let resolveMode: ((mode: QuitConfirmationMode) => void) | undefined;
+    const harness = makeHarness({
+      getMode: () =>
+        new Promise((resolve) => {
+          resolveMode = resolve;
+        }),
+    });
+    await harness.send(makeInput({}));
+    await harness.send(makeInput({ type: "keyUp" }));
+
+    resolveMode?.("direct");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toEqual([]);
+  });
+
+  it("does not arm hold mode after a released key's mode read settles", async () => {
+    let resolveMode: ((mode: QuitConfirmationMode) => void) | undefined;
+    const harness = makeHarness({
+      getMode: () =>
+        new Promise((resolve) => {
+          resolveMode = resolve;
+        }),
+    });
+    await harness.send(makeInput({}));
+    await harness.send(makeInput({ type: "keyUp" }));
+
+    resolveMode?.("hold");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.quit).not.toHaveBeenCalled();
+    expect(harness.notifications).toEqual([]);
+  });
+
+  it("honors a quick double press when both key releases beat their mode reads", async () => {
+    const resolvers: Array<(mode: QuitConfirmationMode) => void> = [];
+    const harness = makeHarness({
+      getMode: () => new Promise((resolve) => resolvers.push(resolve)),
+    });
+    await harness.send(makeInput({}));
+    await harness.send(makeInput({ type: "keyUp" }));
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
+    await harness.send(makeInput({}));
+    await harness.send(makeInput({ type: "keyUp" }));
+
+    resolvers[1]?.("double-click");
+    await Promise.resolve();
+    await Promise.resolve();
+
     expect(harness.quit).toHaveBeenCalledTimes(1);
     expect(harness.notifications).toEqual([]);
   });
@@ -163,7 +224,7 @@ describe("makeQuitShortcutHandler", () => {
     vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
     await harness.send(makeInput({}));
     expect(harness.quit).toHaveBeenCalledTimes(1);
-    expect(harness.notifications).toEqual(["down", "up"]);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP]);
   });
 
   it("treats two slow presses as separate attempts in double-click mode", async () => {
@@ -173,7 +234,7 @@ describe("makeQuitShortcutHandler", () => {
     vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS + 100);
     await harness.send(makeInput({}));
     expect(harness.quit).not.toHaveBeenCalled();
-    expect(harness.notifications).toEqual(["down", "up", "down"]);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP, DOUBLE_CLICK_DOWN]);
   });
 
   it("does not treat two quick presses as a quit in hold mode", async () => {
@@ -183,7 +244,7 @@ describe("makeQuitShortcutHandler", () => {
     vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
     await harness.send(makeInput({}));
     expect(harness.quit).not.toHaveBeenCalled();
-    expect(harness.notifications).toEqual(["down", "up", "down"]);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP, HOLD_DOWN]);
   });
 
   it("cancels the hold when another key interrupts it", async () => {
@@ -192,7 +253,7 @@ describe("makeQuitShortcutHandler", () => {
     await harness.holdFor(500);
     // Shift pressed mid-hold breaks the gesture...
     await harness.send(makeInput({ shift: true }));
-    expect(harness.notifications).toEqual(["down", "up"]);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
     // ...so later repeats past the threshold must not quit.
     await harness.holdFor(QUIT_HOLD_DURATION_MS);
     expect(harness.quit).not.toHaveBeenCalled();
@@ -205,7 +266,7 @@ describe("makeQuitShortcutHandler", () => {
     // A fresh press right after the interruption starts a new attempt.
     await harness.send(makeInput({}));
     expect(harness.quit).not.toHaveBeenCalled();
-    expect(harness.notifications).toEqual(["down", "up", "down"]);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP, DOUBLE_CLICK_DOWN]);
   });
 
   it("ignores other shortcuts", async () => {

--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -227,6 +227,42 @@ describe("makeQuitShortcutHandler", () => {
     expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP]);
   });
 
+  it("keeps the double-press hint visible after key release until the window ends", async () => {
+    const harness = makeHarness({ mode: "double-click" });
+    await harness.send(makeInput({}));
+    vi.advanceTimersByTime(100);
+    await harness.send(makeInput({ type: "keyUp" }));
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN]);
+
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 101);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN]);
+    vi.advanceTimersByTime(1);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP]);
+  });
+
+  it("expires a delayed double-press hint from keydown rather than mode resolution", async () => {
+    let resolveMode: ((mode: QuitConfirmationMode) => void) | undefined;
+    const harness = makeHarness({
+      getMode: () =>
+        new Promise((resolve) => {
+          resolveMode = resolve;
+        }),
+    });
+    await harness.send(makeInput({}));
+    vi.advanceTimersByTime(100);
+    await harness.send(makeInput({ type: "keyUp" }));
+    vi.advanceTimersByTime(100);
+    resolveMode?.("double-click");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN]);
+
+    vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 201);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN]);
+    vi.advanceTimersByTime(1);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP]);
+  });
+
   it("treats two slow presses as separate attempts in double-click mode", async () => {
     const harness = makeHarness({ mode: "double-click" });
     await harness.send(makeInput({}));

--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -240,6 +240,20 @@ describe("makeQuitShortcutHandler", () => {
     expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP]);
   });
 
+  it("accepts a second full shortcut after the modifier is released and pressed again", async () => {
+    const harness = makeHarness({ mode: "double-click" });
+    await harness.send(makeInput({}));
+    await harness.send(makeInput({ type: "keyUp" }));
+    await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
+    vi.advanceTimersByTime(100);
+
+    await harness.send(makeInput({ key: "Meta" }));
+    await harness.send(makeInput({}));
+
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP]);
+  });
+
   it("expires a delayed double-press hint from keydown rather than mode resolution", async () => {
     let resolveMode: ((mode: QuitConfirmationMode) => void) | undefined;
     const harness = makeHarness({

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -1,6 +1,6 @@
 // @effect-diagnostics globalDate:off globalTimers:off -- Synchronous before-input-event handler; key events must be timed and the watchdog scheduled outside any Effect runtime.
 
-import type { QuitConfirmationMode } from "@t3tools/contracts";
+import type { QuitConfirmationMode, QuitShortcutHintEvent } from "@t3tools/contracts";
 
 // The quit accelerator is intercepted in before-input-event, which runs
 // before the native menu accelerator. Quitting from the application menu is
@@ -15,8 +15,6 @@ export const QUIT_DOUBLE_PRESS_MS = 500;
 // auto-repeat disabled fall back to the application menu Quit action.
 export const QUIT_HOLD_RELEASE_GRACE_MS = 600;
 
-export type QuitHoldState = "down" | "up";
-
 export interface QuitHoldKeyInput {
   readonly type: string;
   readonly key: string;
@@ -30,7 +28,7 @@ export interface QuitHoldKeyInput {
 export interface QuitShortcutOptions {
   readonly platform: NodeJS.Platform;
   readonly getMode: () => Promise<QuitConfirmationMode>;
-  readonly notify: (state: QuitHoldState) => void;
+  readonly notify: (event: QuitShortcutHintEvent) => void;
   readonly quit: () => void;
 }
 
@@ -47,9 +45,9 @@ export function makeQuitShortcutHandler(
   let quitOnRelease = false;
   let heldSince = 0;
   let lastPressAt = 0;
-  // Incremented on every new press and every release/quit so a pending
-  // getMode() resolution from a superseded press cannot arm (or quit for)
-  // the current one.
+  // Incremented when a press is superseded or explicitly cancelled. A plain
+  // key release does not invalidate its pending mode read: direct mode and a
+  // completed second press must still be honored after that read settles.
   let generation = 0;
 
   const clearWatchdog = () => {
@@ -59,9 +57,9 @@ export function makeQuitShortcutHandler(
     }
   };
 
-  const release = () => {
+  const release = (cancelPendingMode = true) => {
     if (!holding) return;
-    generation += 1;
+    if (cancelPendingMode) generation += 1;
     holding = false;
     mode = undefined;
     armed = false;
@@ -69,7 +67,7 @@ export function makeQuitShortcutHandler(
     clearWatchdog();
     if (notified) {
       notified = false;
-      options.notify("up");
+      options.notify({ state: "up" });
     }
   };
 
@@ -84,11 +82,11 @@ export function makeQuitShortcutHandler(
     if (input.type === "keyUp") {
       if (key === "q") {
         const shouldQuit = quitOnRelease;
-        release();
+        release(false);
         if (shouldQuit) options.quit();
       } else if (key === modifierKey) {
         if (!quitOnRelease) {
-          release();
+          release(false);
         } else {
           watchdog = setTimeout(quitNow, QUIT_HOLD_RELEASE_GRACE_MS);
         }
@@ -143,7 +141,6 @@ export function makeQuitShortcutHandler(
     void options.getMode().then(
       (resolvedMode) => {
         if (generation !== pressGeneration) return;
-        mode = resolvedMode;
         if (resolvedMode === "direct") {
           quitNow();
           return;
@@ -157,8 +154,14 @@ export function makeQuitShortcutHandler(
           return;
         }
 
+        // The physical press ended while its settings read was pending. Hold
+        // mode has nothing left to arm, while a non-matching double press has
+        // already recorded its timestamp for the next attempt.
+        if (!holding) return;
+
+        mode = resolvedMode;
         notified = true;
-        options.notify("down");
+        options.notify({ state: "down", mode: resolvedMode });
         if (resolvedMode === "double-click") {
           watchdog = setTimeout(release, QUIT_DOUBLE_PRESS_MS);
           return;

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -106,6 +106,10 @@ export function makeQuitShortcutHandler(
 
     const modifierDown = options.platform === "darwin" ? input.meta : input.control;
     if (!modifierDown || input.alt || input.shift || key !== "q") {
+      // Re-pressing the platform modifier is the first half of a second full
+      // quit shortcut, so it must not cancel an active double-press window.
+      if (key === modifierKey && !input.alt && !input.shift) return;
+
       // Any other key (or an extra modifier) pressed mid-hold breaks the
       // gesture; without this the hold timer keeps running through the
       // interruption and the next qualifying repeat would quit early. The

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -1,15 +1,12 @@
 // @effect-diagnostics globalDate:off globalTimers:off -- Synchronous before-input-event handler; key events must be timed and the watchdog scheduled outside any Effect runtime.
 
-// Chrome-style hold-to-quit. The quit accelerator is intercepted in
-// before-input-event (which runs before the native menu accelerator), and the
-// app only quits after the shortcut has been held for QUIT_HOLD_DURATION_MS
-// and released.
-// A quick tap just shows the renderer's "Hold to Quit" hint, and a second tap
-// within QUIT_DOUBLE_TAP_MS quits immediately. Quitting from the application
-// menu itself is untouched and quits immediately.
+import type { QuitConfirmationMode } from "@t3tools/contracts";
+
+// The quit accelerator is intercepted in before-input-event, which runs
+// before the native menu accelerator. Quitting from the application menu is
+// untouched and always quits immediately.
 export const QUIT_HOLD_DURATION_MS = 1200;
-// A second quick tap of the shortcut is the user insisting: quit immediately.
-export const QUIT_DOUBLE_TAP_MS = 500;
+export const QUIT_DOUBLE_PRESS_MS = 500;
 // "Still held" is proven by auto-repeat keydowns, not by the absence of a
 // release: macOS suppresses a letter keyUp while the command key is down, so a
 // tap release can go completely unseen and a release-based timer would quit
@@ -30,26 +27,28 @@ export interface QuitHoldKeyInput {
   readonly isAutoRepeat: boolean;
 }
 
-export interface QuitHoldOptions {
+export interface QuitShortcutOptions {
   readonly platform: NodeJS.Platform;
-  readonly isEnabled: () => Promise<boolean>;
+  readonly getMode: () => Promise<QuitConfirmationMode>;
   readonly notify: (state: QuitHoldState) => void;
   readonly quit: () => void;
 }
 
-export function makeQuitHoldHandler(
-  options: QuitHoldOptions,
+export function makeQuitShortcutHandler(
+  options: QuitShortcutOptions,
 ): (event: { preventDefault: () => void }, input: QuitHoldKeyInput) => void {
   const modifierKey = options.platform === "darwin" ? "meta" : "control";
   let watchdog: NodeJS.Timeout | undefined;
   let holding = false;
-  // Set once isEnabled resolves true; auto-repeats may only complete the hold when armed.
+  let mode: QuitConfirmationMode | undefined;
+  let notified = false;
+  // Set once getMode resolves to hold; auto-repeats may only complete the hold when armed.
   let armed = false;
   let quitOnRelease = false;
   let heldSince = 0;
   let lastPressAt = 0;
   // Incremented on every new press and every release/quit so a pending
-  // isEnabled() resolution from a superseded press cannot arm (or quit for)
+  // getMode() resolution from a superseded press cannot arm (or quit for)
   // the current one.
   let generation = 0;
 
@@ -62,17 +61,19 @@ export function makeQuitHoldHandler(
 
   const release = () => {
     if (!holding) return;
-    const shouldNotify = armed || quitOnRelease;
     generation += 1;
     holding = false;
+    mode = undefined;
     armed = false;
     quitOnRelease = false;
     clearWatchdog();
-    if (shouldNotify) options.notify("up");
+    if (notified) {
+      notified = false;
+      options.notify("up");
+    }
   };
 
-  // Dismisses any overlay first: if the quit is cancelled downstream the
-  // renderer must not be left with a stuck "Hold to Quit" hint.
+  // Dismisses any overlay first so a cancelled quit cannot leave a stale hint.
   const quitNow = () => {
     release();
     options.quit();
@@ -107,7 +108,7 @@ export function makeQuitHoldHandler(
       // Any other key (or an extra modifier) pressed mid-hold breaks the
       // gesture; without this the hold timer keeps running through the
       // interruption and the next qualifying repeat would quit early. The
-      // interrupted press also stops counting toward a double tap — but only
+      // interrupted press also stops counting toward a double press, but only
       // here, not in release(), which runs mid-restart on an unseen-release
       // re-press and must not wipe that press's own tap timestamp.
       if (holding && !input.isAutoRepeat) {
@@ -120,7 +121,7 @@ export function makeQuitHoldHandler(
     event.preventDefault();
 
     if (input.isAutoRepeat) {
-      if (armed && Date.now() - heldSince >= QUIT_HOLD_DURATION_MS) {
+      if (mode === "hold" && armed && Date.now() - heldSince >= QUIT_HOLD_DURATION_MS) {
         armed = false;
         quitOnRelease = true;
         clearWatchdog();
@@ -132,27 +133,38 @@ export function makeQuitHoldHandler(
     const previousPressAt = lastPressAt;
     lastPressAt = now;
     // A fresh keydown while "holding" means the key came back down after a
-    // release macOS never delivered — so both branches below see real taps.
-    if (previousPressAt !== 0 && now - previousPressAt <= QUIT_DOUBLE_TAP_MS) {
-      quitNow();
-      return;
-    }
+    // release macOS never delivered.
     if (holding) release();
 
     generation += 1;
     const pressGeneration = generation;
     holding = true;
     heldSince = now;
-    void options.isEnabled().then(
-      (enabled) => {
+    void options.getMode().then(
+      (resolvedMode) => {
         if (generation !== pressGeneration) return;
-        if (!enabled) {
-          // Hold-to-quit disabled: a single press quits immediately.
+        mode = resolvedMode;
+        if (resolvedMode === "direct") {
           quitNow();
           return;
         }
-        armed = true;
+        if (
+          resolvedMode === "double-click" &&
+          previousPressAt !== 0 &&
+          now - previousPressAt <= QUIT_DOUBLE_PRESS_MS
+        ) {
+          quitNow();
+          return;
+        }
+
+        notified = true;
         options.notify("down");
+        if (resolvedMode === "double-click") {
+          watchdog = setTimeout(release, QUIT_DOUBLE_PRESS_MS);
+          return;
+        }
+
+        armed = true;
         // No auto-repeat by then means the key was released (possibly with a
         // suppressed keyUp) or repeat is disabled; either way, don't quit.
         watchdog = setTimeout(() => {

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -57,13 +57,16 @@ export function makeQuitShortcutHandler(
     }
   };
 
-  const release = (cancelPendingMode = true) => {
-    if (!holding) return;
+  const release = (cancelPendingMode = true, keepDoublePressHint = false) => {
+    if (!holding && !notified) return;
+    const keepHint = keepDoublePressHint && mode === "double-click" && notified;
     if (cancelPendingMode) generation += 1;
     holding = false;
-    mode = undefined;
     armed = false;
     quitOnRelease = false;
+    if (keepHint) return;
+
+    mode = undefined;
     clearWatchdog();
     if (notified) {
       notified = false;
@@ -82,11 +85,11 @@ export function makeQuitShortcutHandler(
     if (input.type === "keyUp") {
       if (key === "q") {
         const shouldQuit = quitOnRelease;
-        release(false);
+        release(false, true);
         if (shouldQuit) options.quit();
       } else if (key === modifierKey) {
         if (!quitOnRelease) {
-          release(false);
+          release(false, true);
         } else {
           watchdog = setTimeout(quitNow, QUIT_HOLD_RELEASE_GRACE_MS);
         }
@@ -109,7 +112,7 @@ export function makeQuitShortcutHandler(
       // interrupted press also stops counting toward a double press, but only
       // here, not in release(), which runs mid-restart on an unseen-release
       // re-press and must not wipe that press's own tap timestamp.
-      if (holding && !input.isAutoRepeat) {
+      if ((holding || notified) && !input.isAutoRepeat) {
         lastPressAt = 0;
         release();
       }
@@ -130,9 +133,9 @@ export function makeQuitShortcutHandler(
     const now = Date.now();
     const previousPressAt = lastPressAt;
     lastPressAt = now;
-    // A fresh keydown while "holding" means the key came back down after a
-    // release macOS never delivered.
-    if (holding) release();
+    // A fresh keydown supersedes the current physical hold or the hint kept
+    // alive after a detected release.
+    if (holding || notified) release();
 
     generation += 1;
     const pressGeneration = generation;
@@ -154,18 +157,25 @@ export function makeQuitShortcutHandler(
           return;
         }
 
-        // The physical press ended while its settings read was pending. Hold
-        // mode has nothing left to arm, while a non-matching double press has
-        // already recorded its timestamp for the next attempt.
+        if (resolvedMode === "double-click") {
+          const remainingMs = QUIT_DOUBLE_PRESS_MS - (Date.now() - now);
+          if (remainingMs <= 0) {
+            release();
+            return;
+          }
+          mode = resolvedMode;
+          notified = true;
+          options.notify({ state: "down", mode: resolvedMode });
+          watchdog = setTimeout(release, remainingMs);
+          return;
+        }
+
+        // A hold cannot be armed after its physical press has ended.
         if (!holding) return;
 
         mode = resolvedMode;
         notified = true;
         options.notify({ state: "down", mode: resolvedMode });
-        if (resolvedMode === "double-click") {
-          watchdog = setTimeout(release, QUIT_DOUBLE_PRESS_MS);
-          return;
-        }
 
         armed = true;
         // No auto-repeat by then means the key was released (possibly with a

--- a/apps/web/src/components/QuitHoldOverlay.tsx
+++ b/apps/web/src/components/QuitHoldOverlay.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
 
-import { getClientSettings } from "../hooks/useSettings";
 import { isMacPlatform } from "../lib/utils";
 
-// Matches the hold duration in apps/desktop/src/window/QuitHold.ts: the hint
-// from a quick tap lingers for as long as a full hold would have taken.
-const HIDE_AFTER_RELEASE_MS = 1200;
+// A released hold hint lingers for the original hold duration. Double-press
+// hints disappear as soon as their acceptance window closes.
+const HOLD_HINT_LINGER_MS = 1200;
 
 /**
  * The desktop main process intercepts the quit accelerator and pushes
@@ -18,14 +17,19 @@ export function QuitHoldOverlay() {
     const subscribe = window.desktopBridge?.onQuitShortcut;
     if (!subscribe) return;
     let hideTimer: number | undefined;
-    const unsubscribe = subscribe((state) => {
+    let pressedMode: "hold" | "double-click" = "hold";
+    const unsubscribe = subscribe((hint) => {
       window.clearTimeout(hideTimer);
-      if (state === "down") {
-        const mode = getClientSettings().confirmQuit;
-        setVisibleMode(mode === "double-click" ? mode : "hold");
+      if (hint.state === "down") {
+        pressedMode = hint.mode;
+        setVisibleMode(hint.mode);
         return;
       }
-      hideTimer = window.setTimeout(() => setVisibleMode(null), HIDE_AFTER_RELEASE_MS);
+      if (pressedMode === "double-click") {
+        setVisibleMode(null);
+        return;
+      }
+      hideTimer = window.setTimeout(() => setVisibleMode(null), HOLD_HINT_LINGER_MS);
     });
     return () => {
       window.clearTimeout(hideTimer);

--- a/apps/web/src/components/QuitHoldOverlay.tsx
+++ b/apps/web/src/components/QuitHoldOverlay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { getClientSettings } from "../hooks/useSettings";
 import { isMacPlatform } from "../lib/utils";
 
 // Matches the hold duration in apps/desktop/src/window/QuitHold.ts: the hint
@@ -7,12 +8,11 @@ import { isMacPlatform } from "../lib/utils";
 const HIDE_AFTER_RELEASE_MS = 1200;
 
 /**
- * Chrome-style "Hold ⌘Q to Quit" hint. The desktop main process intercepts
- * the quit accelerator and pushes press/release states; a quick tap shows
- * this pill while a full hold quits the app.
+ * The desktop main process intercepts the quit accelerator and pushes
+ * press/release states while it waits for a hold or second press.
  */
 export function QuitHoldOverlay() {
-  const [visible, setVisible] = useState(false);
+  const [visibleMode, setVisibleMode] = useState<"hold" | "double-click" | null>(null);
 
   useEffect(() => {
     const subscribe = window.desktopBridge?.onQuitShortcut;
@@ -21,10 +21,11 @@ export function QuitHoldOverlay() {
     const unsubscribe = subscribe((state) => {
       window.clearTimeout(hideTimer);
       if (state === "down") {
-        setVisible(true);
+        const mode = getClientSettings().confirmQuit;
+        setVisibleMode(mode === "double-click" ? mode : "hold");
         return;
       }
-      hideTimer = window.setTimeout(() => setVisible(false), HIDE_AFTER_RELEASE_MS);
+      hideTimer = window.setTimeout(() => setVisibleMode(null), HIDE_AFTER_RELEASE_MS);
     });
     return () => {
       window.clearTimeout(hideTimer);
@@ -32,15 +33,17 @@ export function QuitHoldOverlay() {
     };
   }, []);
 
-  if (!visible) return null;
+  if (!visibleMode) return null;
   const shortcut = isMacPlatform(navigator.platform) ? "⌘Q" : "Ctrl+Q";
+  const message =
+    visibleMode === "hold" ? `Hold ${shortcut} to Quit` : `Press ${shortcut} again to Quit`;
   return (
     <div
       role="status"
       className="pointer-events-none fixed inset-x-0 top-[22%] z-100 flex justify-center"
     >
       <div className="rounded-full bg-neutral-700/95 px-8 py-4 text-2xl font-bold text-white shadow-xl">
-        Hold {shortcut} to Quit
+        {message}
       </div>
     </div>
   );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -34,6 +34,7 @@ import {
   MIN_PROMPT_FONT_SIZE,
   MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
   MIN_TERMINAL_FONT_SIZE,
+  type QuitConfirmationMode,
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
 import { createModelSelection } from "@t3tools/shared/model";
@@ -162,6 +163,12 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const QUIT_CONFIRMATION_MODE_LABELS: Record<QuitConfirmationMode, string> = {
+  direct: "Direct",
+  hold: "Hold",
+  "double-click": "Double press",
+};
 
 const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
   balanced: "Balanced",
@@ -542,9 +549,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
-      ...(settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit
-        ? ["Quit confirmation"]
-        : []),
+      ...(settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit ? ["Quit shortcut"] : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
       ...getChangedBrowserSettingLabels(settings),
       ...(settings.enableAgentBrowserAccess !== DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess
@@ -2422,11 +2427,11 @@ export function GeneralSettingsPanel() {
         {isElectron ? (
           <SettingsRow
             {...searchableSetting("quit-confirmation")}
-            description="Require holding the quit shortcut before the desktop app quits. A quick tap shows a hint instead."
+            description="Choose whether the desktop app quits immediately, after a hold, or after two quick presses."
             resetAction={
               settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit ? (
                 <SettingResetButton
-                  label="quit confirmation"
+                  label="quit shortcut behavior"
                   onClick={() =>
                     updateSettings({ confirmQuit: DEFAULT_UNIFIED_SETTINGS.confirmQuit })
                   }
@@ -2434,11 +2439,25 @@ export function GeneralSettingsPanel() {
               ) : null
             }
             control={
-              <Switch
-                checked={settings.confirmQuit}
-                onCheckedChange={(checked) => updateSettings({ confirmQuit: Boolean(checked) })}
-                aria-label="Hold to quit"
-              />
+              <Select
+                value={settings.confirmQuit}
+                onValueChange={(value) => {
+                  if (value === "direct" || value === "hold" || value === "double-click") {
+                    updateSettings({ confirmQuit: value });
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full sm:w-40" aria-label="Quit shortcut behavior">
+                  <SelectValue>{QUIT_CONFIRMATION_MODE_LABELS[settings.confirmQuit]}</SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  {Object.entries(QUIT_CONFIRMATION_MODE_LABELS).map(([value, label]) => (
+                    <SelectItem hideIndicator key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
             }
           />
         ) : null}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -238,9 +238,9 @@ export const SETTINGS_SEARCH_ITEMS = [
   },
   {
     id: "quit-confirmation",
-    title: "Hold to quit",
+    title: "Quit shortcut",
     to: "/settings/general",
-    searchTerms: ["confirmation shortcut desktop app exit"],
+    searchTerms: ["confirmation desktop app exit direct hold double click press twice"],
     desktopOnly: true,
   },
   {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -91,7 +91,7 @@ import { EnvironmentId } from "./baseSchemas.ts";
 import { AuthAccessTokenResult, AuthSessionState, AuthWebSocketTicketResult } from "./auth.ts";
 import { AdvertisedEndpoint } from "./remoteAccess.ts";
 import { ExecutionEnvironmentDescriptor } from "./environment.ts";
-import type { ClientSettings } from "./settings.ts";
+import type { ClientSettings, QuitConfirmationMode } from "./settings.ts";
 import type { EditorId } from "./editor.ts";
 import type {
   SourceControlCloneRepositoryInput,
@@ -115,6 +115,10 @@ export interface ContextMenuItem<T extends string = string> {
   separatorBefore?: boolean;
   children?: readonly ContextMenuItem<T>[];
 }
+
+export type QuitShortcutHintEvent =
+  | { readonly state: "down"; readonly mode: Exclude<QuitConfirmationMode, "direct"> }
+  | { readonly state: "up" };
 
 export interface ContextMenuItemSchemaType {
   readonly id: string;
@@ -1156,7 +1160,7 @@ export interface DesktopBridge {
    * Quit-confirmation hint pushes. Optional: older desktop builds never emit
    * them.
    */
-  onQuitShortcut?: (listener: (state: "down" | "up") => void) => () => void;
+  onQuitShortcut?: (listener: (event: QuitShortcutHintEvent) => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1153,9 +1153,8 @@ export interface DesktopBridge {
   probeRemoteEditors?: () => Promise<readonly EditorId[]>;
   onMenuAction: (listener: (action: string) => void) => () => void;
   /**
-   * Hold-to-quit hint pushes: "down" when the quit shortcut is first pressed,
-   * "up" when it is released before the hold completes. Optional: older
-   * desktop builds never emit it.
+   * Quit-confirmation hint pushes. Optional: older desktop builds never emit
+   * them.
    */
   onQuitShortcut?: (listener: (state: "down" | "up") => void) => () => void;
   getWindowFullscreenState: () => boolean;

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -15,6 +15,7 @@ import {
 
 const decodeClientSettings = Schema.decodeUnknownSync(ClientSettingsSchema);
 const decodeClientSettingsPatch = Schema.decodeUnknownSync(ClientSettingsPatch);
+const encodeClientSettings = Schema.encodeSync(ClientSettingsSchema);
 const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
@@ -63,6 +64,31 @@ describe("ClientSettings word wrap", () => {
     expect(decoded.wordWrap).toBe(true);
     expect(decoded).not.toHaveProperty("chatWordWrap");
     expect(decoded).not.toHaveProperty("diffWordWrap");
+  });
+});
+
+describe("ClientSettings quit confirmation", () => {
+  it("defaults to hold", () => {
+    expect(decodeClientSettings({}).confirmQuit).toBe("hold");
+  });
+
+  it.each(["direct", "hold", "double-click"] as const)("accepts the %s mode", (mode) => {
+    expect(decodeClientSettings({ confirmQuit: mode }).confirmQuit).toBe(mode);
+    expect(decodeClientSettingsPatch({ confirmQuit: mode }).confirmQuit).toBe(mode);
+  });
+
+  it.each([
+    [true, "hold"],
+    [false, "direct"],
+  ] as const)("migrates the legacy %s value to %s", (legacyValue, mode) => {
+    const settings = decodeClientSettings({ confirmQuit: legacyValue });
+
+    expect(settings.confirmQuit).toBe(mode);
+    expect(encodeClientSettings(settings).confirmQuit).toBe(mode);
+  });
+
+  it("rejects legacy booleans at the patch boundary", () => {
+    expect(() => decodeClientSettingsPatch({ confirmQuit: true })).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -124,6 +124,22 @@ export const EnvironmentIdentificationMode = Schema.Literals(["artwork", "pill",
 export type EnvironmentIdentificationMode = typeof EnvironmentIdentificationMode.Type;
 export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationMode = "artwork";
 
+export const QuitConfirmationMode = Schema.Literals(["direct", "hold", "double-click"]);
+export type QuitConfirmationMode = typeof QuitConfirmationMode.Type;
+export const DEFAULT_QUIT_CONFIRMATION_MODE: QuitConfirmationMode = "hold";
+
+const LegacyConfirmQuit = Schema.Boolean.pipe(
+  Schema.decodeTo(
+    QuitConfirmationMode,
+    SchemaTransformation.transform({
+      decode: (confirmQuit): QuitConfirmationMode => (confirmQuit ? "hold" : "direct"),
+      encode: (mode) => mode === "hold",
+    }),
+  ),
+);
+
+const QuitConfirmationModeSetting = Schema.Union([QuitConfirmationMode, LegacyConfirmQuit]);
+
 /**
  * A user-chosen font family (a single name or a comma-separated list). Empty
  * means "use the app default"; clients compose their own fallback stacks.
@@ -183,9 +199,11 @@ export const ClientSettingsSchema = Schema.Struct({
   browserAutoShowFloatingPreview: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_BROWSER_AUTO_SHOW_FLOATING_PREVIEW)),
   ),
-  // Desktop-only: require holding the quit shortcut (Cmd/Ctrl+Q) before the
-  // app quits; a quick tap only shows a hint. Browser clients ignore it.
-  confirmQuit: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  // Desktop-only. Boolean values from older settings files decode to their
+  // equivalent mode and encode back as the canonical string value.
+  confirmQuit: QuitConfirmationModeSetting.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_QUIT_CONFIRMATION_MODE)),
+  ),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadUnpin: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -938,7 +956,7 @@ export const ClientSettingsPatch = Schema.Struct({
   browserDefaultAppearance: Schema.optionalKey(PreviewAppearancePreference),
   browserRecordingFrameRate: Schema.optionalKey(BrowserRecordingFrameRate),
   browserAutoShowFloatingPreview: Schema.optionalKey(Schema.Boolean),
-  confirmQuit: Schema.optionalKey(Schema.Boolean),
+  confirmQuit: Schema.optionalKey(QuitConfirmationMode),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   confirmThreadUnpin: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
## Before

`confirmQuit` was a boolean. Disabled meant quit immediately. Enabled, which was the default, presented itself as hold to quit but accepted either of two gestures:

- Hold Cmd/Ctrl+Q for 1.2 seconds, then release.
- Press Cmd/Ctrl+Q again within 500 ms to quit immediately.

That second gesture was built into hold mode and was not configurable or explained in Settings. If someone canceled a hold and quickly tried again, the retry counted as the second press and quit the app. This is the behavior reported as a broken hold restart.

The application menu Quit action was separate and always quit immediately.

## After

`confirmQuit` is now an explicit mode:

- **Direct:** quit on the first Cmd/Ctrl+Q press.
- **Hold:** quit only after a completed 1.2-second hold. Canceling and pressing again starts a new hold, even inside the 500 ms window.
- **Double press:** quit when Cmd/Ctrl+Q is pressed twice within 500 ms. One press shows a "Press again to quit" hint until the window expires.

Hold remains the default. Existing stored booleans migrate as `true` to hold and `false` to direct. The application menu Quit action remains immediate.

The desktop shortcut handler, Settings selector, quit hint overlay, preload validation, and IPC contract now use the selected mode. Focused tests cover canceled holds, hold retries, quick and slow double presses, interrupted shortcuts, suppressed key-up events, and delayed settings reads.

## Rationale

The old boolean combined hold and double press into one setting. That made a deliberate hold retry indistinguishable from a double-press confirmation. Separating the gestures fixes that ambiguity and gives users the behavior they expect: immediate quit, hold only, or double press only.

## UI

<img width="1206" height="2622" alt="General settings showing the quit shortcut mode selector" src="https://github.com/user-attachments/assets/4a3f9348-f1b8-45dd-9538-4b93aa755dce" />

Implemented and reviewed with GPT-5.6 Sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the desktop app quits from a global shortcut and alters the IPC contract for quit hints; mistakes could cause accidental quits or stuck overlays, though behavior is heavily tested.
> 
> **Overview**
> Desktop quit via **Cmd/Ctrl+Q** is no longer a single on/off “hold to quit” flag. **`confirmQuit`** becomes **`QuitConfirmationMode`**: **`direct`**, **`hold`**, or **`double-click`**, defaulting to **`hold`**. Stored booleans still decode (**`true` → hold**, **`false` → direct**) and re-encode as strings; **`ClientSettingsPatch`** no longer accepts boolean **`confirmQuit`**.
> 
> The main-process handler is renamed to **`makeQuitShortcutHandler`** and branches on the resolved mode: immediate quit, hold-then-release, or quit on two presses within **`QUIT_DOUBLE_PRESS_MS`**. Hint IPC moves from **`"down"` / `"up"`** strings to **`QuitShortcutHintEvent`** objects (including **`mode`** on press). Preload validates and forwards those shapes; **`QuitHoldOverlay`** shows hold vs “press again” copy with different dismiss timing.
> 
> General settings replace the quit switch with a **select**; search/reset copy refers to “quit shortcut” behavior. Contract and desktop tests cover migration, patch validation, and the expanded gesture edge cases (async mode reads, double-press windows, stale resolutions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edbbb40dbe9a3f0ad23727b0c515dc8d6c2cd49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable quit shortcut modes (`direct`, `hold`, `double-click`) to desktop app
> - Replaces the boolean `confirmQuit` setting with a `QuitConfirmationMode` enum (`direct` | `hold` | `double-click`), defaulting to `hold`. Legacy boolean values are migrated on full decode but rejected in patches.
> - Refactors `makeQuitHoldHandler` into `makeQuitShortcutHandler` in [QuitHold.ts](https://github.com/pingdotgg/t3code/pull/9076/files#diff-c9e580dbc762f19a498b272467ed869973f2fb60fb1765ebbdf7b0d3c2883760), supporting all three modes with generation-tracked timers to prevent stale async resolutions.
> - Changes the `onQuitShortcut` IPC contract to emit structured `QuitShortcutHintEvent` objects (`{ state: 'down', mode }` or `{ state: 'up' }`) instead of plain strings, updated in [ipc.ts](https://github.com/pingdotgg/t3code/pull/9076/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a) and [preload.ts](https://github.com/pingdotgg/t3code/pull/9076/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac).
> - Updates [QuitHoldOverlay.tsx](https://github.com/pingdotgg/t3code/pull/9076/files#diff-0d6c0b150ac2c5add6763dd61120bad7b1c955b39711c88119a1d021bfdb6998) to show mode-specific copy and adjust hint visibility timing per mode.
> - Updates the settings UI in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/9076/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) to use a Select control instead of a boolean toggle.
> - Risk: `onQuitShortcut` listeners must handle structured events instead of strings; any out-of-tree consumers of this IPC channel will break. The `confirmQuit` patch schema rejects legacy booleans, so clients sending `true`/`false` will fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edbbb40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
