### PR TITLE
feat(claude): add Claude Fable 5.1 model

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -525,6 +525,29 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("preserves xhigh effort for Claude Fable 5.1", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-fable-5-1",
+          [{ id: "effort", value: "xhigh" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.effort, "xhigh");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("preserves xhigh effort for Claude Fable 5", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -51,12 +51,48 @@ const CLAUDE_PRESENTATION = {
   displayName: "Claude",
   showInteractionModeToggle: true,
 } as const;
+const MINIMUM_CLAUDE_FABLE_5_1_VERSION = "2.1.257";
 const MINIMUM_CLAUDE_OPUS_5_VERSION = "2.1.219";
 const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";
 
 const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "claude-fable-5-1",
+    name: "Claude Fable 5.1",
+    isCustom: false,
+    capabilities: createModelCapabilities({
+      optionDescriptors: [
+        buildSelectOptionDescriptor({
+          id: "effort",
+          label: "Reasoning",
+          options: [
+            { value: "low", label: "Low" },
+            { value: "medium", label: "Medium" },
+            { value: "high", label: "High", isDefault: true },
+            { value: "xhigh", label: "Extra High" },
+            { value: "max", label: "Max" },
+            {
+              value: "ultracode",
+              label: "Ultracode",
+              description: "xhigh effort plus multi-agent workflow orchestration",
+            },
+            { value: "ultrathink", label: "Ultrathink" },
+          ],
+          promptInjectedValues: ["ultrathink"],
+        }),
+        buildSelectOptionDescriptor({
+          id: "contextWindow",
+          label: "Context Window",
+          options: [
+            { value: "200k", label: "200k" },
+            { value: "1m", label: "1M", isDefault: true },
+          ],
+        }),
+      ],
+    }),
+  },
   {
     slug: "claude-fable-5",
     name: "Claude Fable 5",
@@ -325,6 +361,10 @@ const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
 // so the catalog itself carries no `isLegacy` flags.
 const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = CLAUDE_MODEL_CATALOG;
 
+function supportsClaudeFable51(version: string | null | undefined): boolean {
+  return version ? compareSemverVersions(version, MINIMUM_CLAUDE_FABLE_5_1_VERSION) >= 0 : false;
+}
+
 function supportsClaudeOpus5(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0 : false;
 }
@@ -345,6 +385,9 @@ function getBuiltInClaudeModelsForVersion(
   version: string | null | undefined,
 ): ReadonlyArray<ServerProviderModel> {
   return BUILT_IN_MODELS.filter((model) => {
+    if (model.slug === "claude-fable-5-1") {
+      return supportsClaudeFable51(version);
+    }
     if (model.slug === "claude-opus-5") {
       return supportsClaudeOpus5(version);
     }
@@ -359,6 +402,11 @@ function getBuiltInClaudeModelsForVersion(
     }
     return true;
   });
+}
+
+function formatClaudeFable51UpgradeMessage(version: string | null): string {
+  const versionLabel = version ? `v${version}` : "the installed version";
+  return `Claude Code ${versionLabel} is too old for Claude Fable 5.1. Upgrade to v${MINIMUM_CLAUDE_FABLE_5_1_VERSION} or newer to access it.`;
 }
 
 function formatClaudeOpus5UpgradeMessage(version: string | null): string {
@@ -424,6 +472,7 @@ export function normalizeClaudeCliEffort(
   }
   if (
     effort === "xhigh" &&
+    model !== "claude-fable-5-1" &&
     model !== "claude-fable-5" &&
     model !== "claude-opus-5" &&
     model !== "claude-opus-4-8" &&
@@ -913,15 +962,17 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
   );
-  const versionUpgradeMessage = supportsClaudeOpus5(parsedVersion)
+  const versionUpgradeMessage = supportsClaudeFable51(parsedVersion)
     ? undefined
-    : supportsClaudeFable5(parsedVersion)
-      ? formatClaudeOpus5UpgradeMessage(parsedVersion)
-      : supportsClaudeOpus48(parsedVersion)
-        ? formatClaudeFable5UpgradeMessage(parsedVersion)
-        : supportsClaudeOpus47(parsedVersion)
-          ? formatClaudeOpus48UpgradeMessage(parsedVersion)
-          : formatClaudeOpus47UpgradeMessage(parsedVersion);
+    : supportsClaudeOpus5(parsedVersion)
+      ? formatClaudeFable51UpgradeMessage(parsedVersion)
+      : supportsClaudeFable5(parsedVersion)
+        ? formatClaudeOpus5UpgradeMessage(parsedVersion)
+        : supportsClaudeOpus48(parsedVersion)
+          ? formatClaudeFable5UpgradeMessage(parsedVersion)
+          : supportsClaudeOpus47(parsedVersion)
+            ? formatClaudeOpus48UpgradeMessage(parsedVersion)
+            : formatClaudeOpus47UpgradeMessage(parsedVersion);
 
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -2132,6 +2132,62 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
+      it.effect("includes Claude Fable 5.1 on supported Claude Code versions", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities(),
+          );
+          const fable51 = status.models.find((model) => model.slug === "claude-fable-5-1");
+          assert.strictEqual(fable51?.name, "Claude Fable 5.1");
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.257\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("hides Claude Fable 5.1 on older Claude Code versions", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities(),
+          );
+          assert.strictEqual(
+            status.models.some((model) => model.slug === "claude-fable-5-1"),
+            false,
+          );
+          assert.strictEqual(
+            status.message,
+            "Claude Code v2.1.256 is too old for Claude Fable 5.1. Upgrade to v2.1.257 or newer to access it.",
+          );
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.256\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("hides Claude Fable 5 on older Claude Code versions", () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(

--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -43,11 +43,15 @@ describe("isLegacyModel (bundled manifest)", () => {
 
   it("keeps only the Claude 5 family out of legacy models", () => {
     assert.deepStrictEqual(
-      ["claude-fable-5", "claude-opus-5", "claude-sonnet-5", "claude-opus-4-8"].map((model) => [
-        model,
-        isLegacyModel(BUNDLED_MODEL_MANIFEST, CLAUDE, model),
-      ]),
       [
+        "claude-fable-5-1",
+        "claude-fable-5",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+      ].map((model) => [model, isLegacyModel(BUNDLED_MODEL_MANIFEST, CLAUDE, model)]),
+      [
+        ["claude-fable-5-1", false],
         ["claude-fable-5", false],
         ["claude-opus-5", false],
         ["claude-sonnet-5", false],

--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -52,7 +52,7 @@ describe("isLegacyModel (bundled manifest)", () => {
       ].map((model) => [model, isLegacyModel(BUNDLED_MODEL_MANIFEST, CLAUDE, model)]),
       [
         ["claude-fable-5-1", false],
-        ["claude-fable-5", false],
+        ["claude-fable-5", true],
         ["claude-opus-5", false],
         ["claude-sonnet-5", false],
         ["claude-opus-4-8", true],

--- a/apps/server/src/provider/model-manifest.json
+++ b/apps/server/src/provider/model-manifest.json
@@ -8,6 +8,6 @@
       "gpt-daybreak-blue-latest",
       "gpt-daybreak-red-latest"
     ],
-    "claudeAgent": ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"]
+    "claudeAgent": ["claude-fable-5-1", "claude-fable-5", "claude-opus-5", "claude-sonnet-5"]
   }
 }

--- a/apps/server/src/provider/model-manifest.json
+++ b/apps/server/src/provider/model-manifest.json
@@ -8,6 +8,6 @@
       "gpt-daybreak-blue-latest",
       "gpt-daybreak-red-latest"
     ],
-    "claudeAgent": ["claude-fable-5-1", "claude-fable-5", "claude-opus-5", "claude-sonnet-5"]
+    "claudeAgent": ["claude-fable-5-1", "claude-opus-5", "claude-sonnet-5"]
   }
 }

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -177,6 +177,9 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   [CLAUDE_DRIVER_KIND]: {
+    fable: "claude-fable-5-1",
+    "fable-5.1": "claude-fable-5-1",
+    "claude-fable-5.1": "claude-fable-5-1",
     opus: "claude-opus-5",
     "opus-5": "claude-opus-5",
     "claude-opus-5.0": "claude-opus-5",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -152,6 +152,7 @@ describe("model slug normalization", () => {
   it("preserves exact custom slugs instead of expanding provider aliases", () => {
     const claude = ProviderDriverKind.make("claudeAgent");
 
+    expect(normalizeModelSlug("fable", claude)).toBe("claude-fable-5-1");
     expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
   });


### PR DESCRIPTION
Supersedes #9077 (closed by @juliusmarminge). The catalog commit here is #9077's verbatim, with his authorship; the follow-up commits add what it left for later.

## What Changed

- **Catalog entry** `claude-fable-5-1` ("Claude Fable 5.1") above Fable 5, gated on Claude Code **v2.1.257** — the first published build with Fable 5.1 (the changelog entry is under 2.1.257; the docs' "2.1.255" never shipped to npm, releases jump 2.1.252 → 2.1.257). Same Fable-style effort ladder (low → `max`, `ultracode`, `ultrathink`, default `high`) and 200k / 1M context option (1M default). No `fastMode` — fast mode is Opus 5 / 4.8 only. `xhigh` is not downgraded to `max`. Older CLIs get the usual "too old, upgrade to v2.1.257" nudge first in the upgrade-message chain.
- **Model manifest:** `claude-fable-5-1` is current and `claude-fable-5` moves to legacy (per review — it is superseded, same treatment as Opus 4.8). Legacy classification is manifest-driven, so without this line the new model would render under "Legacy models". Note the remote manifest on `main` propagates to every install immediately, so between merge and a release that carries the catalog entry, installs without Fable 5.1 will see Fable 5 in the legacy section (still selectable).
- **Slug aliases** `fable`, `fable-5.1`, `claude-fable-5.1` → `claude-fable-5-1`, matching Claude Code's own `fable` alias (`/model fable` resolves to Fable 5.1 as of 2.1.257). Existing aliases untouched.

No SDK bump: Claude Code is spawned from the user's install, and the pinned `@anthropic-ai/claude-agent-sdk` 0.3.170 drives 2.1.257 fine (verified below). Default model is unchanged: the picker's fallback order (`isDefault` → first listed → `DEFAULT_MODEL_BY_PROVIDER`) already had Fable 5 first, so the first-listed slot moving from Fable 5 to 5.1 is the same behavior as when Opus 5 / Fable 5 landed.

## Why

Claude Code 2.1.257 makes Fable 5.1 the default Fable model. Without a catalog entry it cannot be selected from T3 Code, and users on a current CLI have no way to get to it. Fable 5.1 keeps Fable 5's per-token price with cache reads at $0.25/MTok, 1M context by default (Claude Code strips the `[1m]` suffix for it, so `resolveClaudeApiModelId` works unchanged), and the same effort ladder.

## Testing

- `ProviderRegistry.test.ts`: shown at v2.1.257, hidden with the Fable 5.1 upgrade message at v2.1.256; existing Opus 5 / Fable 5 gating tests still pass.
- `ClaudeAdapter.test.ts`: `xhigh` reaches the SDK unchanged for `claude-fable-5-1`.
- `ModelManifest.test.ts` (5.1 current, 5 legacy) and `packages/shared/src/model.test.ts` (`fable` alias).
- `tsgo --noEmit` for `apps/server`, `packages/contracts`, `packages/shared`; `vp lint` and `vp fmt --check` clean on the touched files. CI green on the previous push.
- End to end on macOS with Claude Code 2.1.257 (Claude Max): booted the dev server from this branch against a scratch home, confirmed `server.getConfig` lists `claude-fable-5-1` as non-legacy with status `ready` and no upgrade message, created a thread on it with `effort: low` / `contextWindow: 1m`, and ran a turn. The turn completed, the assistant replied, `context-window.updated` reported `maxTokens: 1000000`, and the Claude Code transcript records `"model":"claude-fable-5-1"`.

## Notes

- **Pricing:** usage cost for Fable 5.1 reads as unpriced until LiteLLM's `model_prices_and_context_window.json` gains `claude-fable-5-1` (open: BerriAI/litellm#39148, BerriAI/litellm#39151; $10 / $50 per MTok, cache read $0.25, cache write $12.50 per the model page). The table is fetched at runtime, so nothing to change here.
- No UI screenshots — data-only entries that render through the existing model picker rows.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a — no UI code changed)
- [x] I included a video for animation/interaction changes (n/a)

Claude Fable 5.1 via Claude Code (catalog commit: gpt-5.6-sol via Codex, from #9077).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog, manifest, and alias changes only; no auth or session logic. Remote manifest may label Fable 5 legacy before releases ship the new catalog entry.
> 
> **Overview**
> Adds **Claude Fable 5.1** (`claude-fable-5-1`) to the Claude agent catalog so users on Claude Code **v2.1.257+** can select it from the model picker, with the same reasoning ladder and 200k/1M context options as Fable 5. **`xhigh`** effort is passed through for this model (via `normalizeClaudeCliEffort`), and older CLIs see a Fable 5.1 upgrade nudge at the top of the existing version-message chain.
> 
> The bundled **model manifest** treats Fable 5.1 as current and **Fable 5 as legacy** (superseded). **Slug aliases** `fable`, `fable-5.1`, and `claude-fable-5.1` resolve to `claude-fable-5-1`, aligned with Claude Code’s `/model fable` behavior.
> 
> Tests cover version gating, manifest legacy flags, alias normalization, and SDK effort forwarding for Fable 5.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267b0905aa0cb17bcd42f656120c05291764d6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `claude-fable-5-1` model to Claude provider with version gating
> - Registers a new built-in model `claude-fable-5-1` in `CLAUDE_MODEL_CATALOG` with `effort` and `contextWindow` option descriptors, gated to CLI version >= `2.1.257` via `supportsClaudeFable51`.
> - Extends `normalizeClaudeCliEffort` to preserve `xhigh` effort for `claude-fable-5-1` instead of mapping it to `max`.
> - Adds slug aliases `fable`, `fable-5.1`, and `claude-fable-5.1` mapping to `claude-fable-5-1` in `MODEL_SLUG_ALIASES_BY_PROVIDER`.
> - Replaces `claude-fable-5` with `claude-fable-5-1` in the non-legacy models list in [model-manifest.json](https://github.com/pingdotgg/t3code/pull/9078/files#diff-fdf6ac0d1183f70794b15b8034d7d7405e3a3d35139c12a62e154b44322ea175), and `checkClaudeProviderStatus` emits an upgrade message when the CLI is too old.
> - Behavioral Change: `claude-fable-5` is no longer listed as a current model in the bundled manifest; `claude-fable-5-1` takes its place, so systems relying on that manifest will treat `claude-fable-5` as legacy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 267b090.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->