### PR TITLE
fix(server): cache project favicon resolution

### DIFF
--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -1,10 +1,12 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, describe, expect } from "@effect/vitest";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import { TestClock } from "effect/testing";
 
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 import * as ProjectFaviconResolver from "./ProjectFaviconResolver.ts";
@@ -49,6 +51,64 @@ const makeResolverWithFileSystem = (fileSystem: FileSystem.FileSystem) =>
 
 it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
   describe("resolvePath", () => {
+    it.effect("serves repeated resolves from cache instead of re-walking candidates", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "public/favicon.svg", "<svg>public</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+        expect(resolved?.endsWith("public/favicon.svg")).toBe(true);
+
+        // `favicon.svg` outranks `public/favicon.svg`, so a resolver that walked
+        // the candidate list again would switch to it. Staying on the original
+        // answer is only possible from cache.
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>root</svg>");
+
+        for (const _attempt of [1, 2, 3]) {
+          expect(yield* resolver.resolvePath(cwd)).toBe(resolved);
+        }
+
+        yield* TestClock.adjust(Duration.minutes(11));
+
+        expect((yield* resolver.resolvePath(cwd))?.endsWith("/favicon.svg")).toBe(true);
+        expect(yield* resolver.resolvePath(cwd)).not.toBe(resolved);
+      }).pipe(Effect.provide(TestClock.layer())),
+    );
+
+    it.effect("falls back at once when a cached favicon is deleted", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+
+        expect(yield* resolver.resolvePath(cwd)).not.toBeNull();
+
+        yield* fileSystem.remove(path.join(cwd, "favicon.svg")).pipe(Effect.orDie);
+
+        // Still inside the positive TTL: the cached path must not be served.
+        expect(yield* resolver.resolvePath(cwd)).toBeNull();
+      }).pipe(Effect.provide(TestClock.layer())),
+    );
+
+    it.effect("re-probes for a favicon added after a miss once the negative TTL expires", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+
+        expect(yield* resolver.resolvePath(cwd)).toBeNull();
+
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+        expect(yield* resolver.resolvePath(cwd)).toBeNull();
+
+        yield* TestClock.adjust(Duration.minutes(2));
+
+        expect(yield* resolver.resolvePath(cwd)).not.toBeNull();
+      }).pipe(Effect.provide(TestClock.layer())),
+    );
+
     it.effect("prefers well-known favicon files", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -6,8 +6,11 @@
  *
  * @module ProjectFaviconResolver
  */
+import * as Cache from "effect/Cache";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -17,6 +20,30 @@ import * as Schema from "effect/Schema";
 
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 import * as T3ProjectFileLoader from "./T3ProjectFileLoader.ts";
+
+// Resolution walks up to 12 well-known paths plus 7 source files, so a miss
+// costs ~20 filesystem probes. AssetAccess resolves on every project-favicon
+// asset URL, and a project's icon does not move, so the answer is cached.
+const FAVICON_CACHE_CAPACITY = 512;
+const FAVICON_POSITIVE_CACHE_TTL = Duration.minutes(10);
+const FAVICON_NEGATIVE_CACHE_TTL = Duration.minutes(1);
+
+function faviconCacheKey(cwd: string, faviconPath?: string): string {
+  return `${faviconPath ?? ""}\0${cwd}`;
+}
+
+function parseFaviconCacheKey(key: string): {
+  readonly cwd: string;
+  readonly faviconPath?: string;
+} {
+  const separatorIndex = key.indexOf("\0");
+  if (separatorIndex === -1) {
+    return { cwd: key };
+  }
+  const faviconPath = key.slice(0, separatorIndex);
+  const cwd = key.slice(separatorIndex + 1);
+  return faviconPath.length === 0 ? { cwd } : { cwd, faviconPath };
+}
 
 // Well-known favicon paths checked in order.
 const FAVICON_CANDIDATES = [
@@ -178,9 +205,10 @@ export const make = Effect.gen(function* () {
     return null;
   });
 
-  const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
-    "ProjectFaviconResolver.resolvePath",
-  )(function* (cwd, faviconPath) {
+  const resolvePathUncached = Effect.fn("ProjectFaviconResolver.resolvePathUncached")(function* (
+    cwd: string,
+    faviconPath?: string,
+  ): Effect.fn.Return<string | null, ProjectFaviconResolutionError> {
     const projectCwd = yield* workspacePaths.normalizeWorkspaceRoot(cwd).pipe(
       Effect.mapError(
         (cause) =>
@@ -265,6 +293,52 @@ export const make = Effect.gen(function* () {
     }
 
     return null;
+  });
+
+  const faviconCache = yield* Cache.makeWith<string, string | null, ProjectFaviconResolutionError>(
+    (key) => {
+      const { cwd, faviconPath } = parseFaviconCacheKey(key);
+      return resolvePathUncached(cwd, faviconPath);
+    },
+    {
+      capacity: FAVICON_CACHE_CAPACITY,
+      timeToLive: Exit.match({
+        onSuccess: (value: string | null) =>
+          value === null ? FAVICON_NEGATIVE_CACHE_TTL : FAVICON_POSITIVE_CACHE_TTL,
+        onFailure: () => Duration.zero,
+      }),
+    },
+  );
+
+  const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
+    "ProjectFaviconResolver.resolvePath",
+  )(function* (cwd, faviconPath) {
+    const key = faviconCacheKey(cwd, faviconPath);
+    const cached = yield* Cache.get(faviconCache, key);
+    if (cached === null) {
+      return null;
+    }
+
+    // A hit still confirms the file with one stat rather than the ~20 probes a
+    // full walk costs, so a deleted icon falls back at once instead of after
+    // the TTL.
+    const stats = yield* optionOnNotFound(fileSystem.stat(cached)).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProjectFaviconResolutionError({
+            operation: "stat-candidate",
+            workspaceRoot: cwd,
+            absolutePath: cached,
+            cause,
+          }),
+      ),
+    );
+    if (Option.isSome(stats) && stats.value.type === "File") {
+      return cached;
+    }
+
+    yield* Cache.invalidate(faviconCache, key);
+    return yield* Cache.get(faviconCache, key);
   });
 
   return ProjectFaviconResolver.of({ resolvePath });


### PR DESCRIPTION
Refs #8949.

## Problem

`ProjectFaviconResolver.resolvePath` is uncached. Each call normalizes the workspace root, optionally loads `t3.json`, walks up to 12 entries in `FAVICON_CANDIDATES`, and then reads up to 7 `ICON_SOURCE_FILES` and regex-scans them for icon metadata. A miss costs roughly 20 filesystem probes.

`AssetAccess` calls it on every `project-favicon` asset URL:

https://github.com/pingdotgg/t3code/blob/31c1c5996/apps/server/src/assets/AssetAccess.ts#L323-L335

A project's icon does not move, so that work is repeated for an answer that was already known.

Traced over 100 minutes on one install:

```
n=490   total 422s   AssetAccess.issueAssetUrl
n=451   total 313s     ProjectFaviconResolver.resolvePath
n=9106  total 226s       ProjectFaviconResolver.findExistingFile
```

9,106 filesystem probes for 451 resolutions. `ws.rpc.assets.createUrl` had a p95 of 4,357 ms and a max of 67,818 ms, of which 65,582 ms was inside `resolvePath`.

This is cheap when the page cache is warm and the machine is idle. It stops being cheap when it is not, and it is on an RPC the client calls hundreds of times.

## Fix

Cache the resolved path, keyed by workspace root plus the project's saved favicon path. 10 minutes for a hit, 1 minute for a miss, matching the TTLs used by the caches in `GitVcsDriverCore.ts`.

A cache hit still confirms the file with a single `stat` before returning it. That is 1 probe instead of ~20, and it keeps the existing behaviour that deleting an icon falls back immediately rather than serving a stale path until the entry expires. `AssetAccess.test.ts` covers that fallback and caught it when an earlier version of this change skipped the re-check.

## Verification

- `vp test run apps/server/src/project/ProjectFaviconResolver.test.ts` — 23 passed
- `vp test run apps/server/src/project apps/server/src/assets` — 61 passed
- `vp test run apps/server/src/server.test.ts` — 139 passed
- `tsgo --noEmit` in `apps/server` — clean

Two of the three added tests fail on `main`. The third asserts the deletion fallback that the cache must not break.

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path asset URL issuance with caching semantics; deletion re-check limits stale-icon risk but TTL and invalidation behavior affect many RPC calls.
> 
> **Overview**
> **Project favicon resolution is now cached** so repeated `project-favicon` asset URL work no longer re-runs the full candidate walk (~20 filesystem probes per call).
> 
> `ProjectFaviconResolver.resolvePath` wraps the existing discovery logic in an Effect `Cache` keyed by workspace root plus optional saved favicon path, with **10-minute TTL for hits** and **1-minute TTL for misses** (512 entries). Cache hits still **`stat` the resolved file once**; if it is gone, the entry is invalidated and resolution runs again immediately instead of serving a stale path until expiry.
> 
> Three tests use **`TestClock`** to cover stable cached answers across repeated calls, immediate fallback after deletion inside the positive TTL, and re-probing after a miss once the negative TTL passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3667f081166af1f5a281bcb4deffea5d6d6bc951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache project favicon resolution in `ProjectFaviconResolver.make` with 10m positive and 1m negative TTL
> - Extracts the existing resolution logic into `resolvePathUncached` and wraps it in a `Cache.makeWith` keyed by a composite string of `faviconPath` and `cwd`.
> - Cached hits (non-null path) are re-verified with a single `stat` call; if the file no longer exists, the cache entry is invalidated and re-fetched immediately.
> - Cache misses (null) are retried after a 1-minute negative TTL; hits use a 10-minute positive TTL.
> - Adds tests using `TestClock` to verify positive-TTL caching, deleted-file fallback, and negative-TTL discovery.
> - Behavioral Change: `resolvePath` now returns cached answers for up to 10 minutes without re-walking candidates; a deleted favicon file triggers immediate re-resolution rather than waiting for TTL expiry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3667f08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->