### PR TITLE
fix(server): stop stale settlement notifications

### DIFF
--- a/packages/shared/src/agentAwareness.test.ts
+++ b/packages/shared/src/agentAwareness.test.ts
@@ -12,6 +12,7 @@ import { ProviderInstanceId } from "@t3tools/contracts";
 import { projectThreadAwareness } from "./agentAwareness.ts";
 
 const NOW = "2026-05-22T12:00:00.000Z";
+const TERMINAL_AT = "2026-05-21T12:00:00.000Z";
 
 const project = {
   title: "t3code",
@@ -106,15 +107,26 @@ describe("projectThreadAwareness", () => {
     const finishedTurn = {
       turnId: "turn-1" as TurnId,
       state: "interrupted" as const,
-      requestedAt: NOW,
-      startedAt: NOW,
-      completedAt: NOW,
+      requestedAt: TERMINAL_AT,
+      startedAt: TERMINAL_AT,
+      completedAt: TERMINAL_AT,
       assistantMessageId: null,
     };
     const state = projectThreadAwareness({
       environmentId: "env-1" as EnvironmentId,
       project,
-      thread: thread({ latestTurn: finishedTurn }),
+      thread: thread({
+        latestTurn: finishedTurn,
+        session: {
+          threadId: "thread-1" as ThreadId,
+          status: "stopped",
+          providerName: "Codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: NOW,
+        },
+      }),
     });
 
     // Session teardown settles still-running turns by session status, and
@@ -122,6 +134,7 @@ describe("projectThreadAwareness", () => {
     // durable signal. Without this the thread resolves to null persistently
     // and gets tombstoned off the lock-screen card instead of showing Done.
     expect(state?.phase).toBe("completed");
+    expect(state?.updatedAt).toBe(TERMINAL_AT);
 
     const trulyInterrupted = projectThreadAwareness({
       environmentId: "env-1" as EnvironmentId,
@@ -146,12 +159,13 @@ describe("projectThreadAwareness", () => {
           runtimeMode: "full-access",
           activeTurnId: null,
           lastError: null,
-          updatedAt: NOW,
+          updatedAt: TERMINAL_AT,
         },
       }),
     });
 
     expect(state?.phase).toBe("completed");
+    expect(state?.updatedAt).toBe(TERMINAL_AT);
   });
 
   it("projects failures with the session error detail", () => {
@@ -166,7 +180,7 @@ describe("projectThreadAwareness", () => {
           runtimeMode: "full-access",
           activeTurnId: null,
           lastError: "Provider process exited.",
-          updatedAt: NOW,
+          updatedAt: TERMINAL_AT,
         },
       }),
     });
@@ -175,6 +189,7 @@ describe("projectThreadAwareness", () => {
       phase: "failed",
       headline: "Agent failed",
       detail: "Provider process exited.",
+      updatedAt: TERMINAL_AT,
     });
   });
 });

--- a/packages/shared/src/agentAwareness.ts
+++ b/packages/shared/src/agentAwareness.ts
@@ -60,6 +60,21 @@ export function projectThreadAwareness(
   }
 
   const detail = detailForPhase(phase, thread);
+  // Thread metadata can change after work finishes. Keep notification freshness
+  // tied to the terminal turn or session transition instead.
+  const terminalSessionAt =
+    (phase === "completed" &&
+      (thread.session?.status === "ready" || thread.session?.status === "idle")) ||
+    (phase === "failed" && thread.session?.status === "error")
+      ? thread.session?.updatedAt
+      : null;
+  const updatedAt =
+    phase === "completed" || phase === "failed"
+      ? (terminalSessionAt ??
+        thread.latestTurn?.completedAt ??
+        thread.session?.updatedAt ??
+        thread.updatedAt)
+      : thread.updatedAt;
   return {
     environmentId,
     threadId: thread.id,
@@ -69,7 +84,7 @@ export function projectThreadAwareness(
     headline: headlineForPhase(phase),
     ...(detail === undefined ? {} : { detail }),
     modelTitle: thread.modelSelection.model,
-    updatedAt: thread.updatedAt,
+    updatedAt,
     deepLink: buildAgentAwarenessDeepLink({ environmentId, threadId: thread.id }),
   };
 }


### PR DESCRIPTION
Automatic thread settlement refreshes a thread's general update time. Existing completed or failed agent-awareness state then looks fresh enough to queue another mobile notification.

Terminal awareness now keeps the actual turn or provider-session terminal time. Running and waiting states still use the thread update time, so live activity freshness is unchanged. Focused coverage includes settlement cleanup, ready sessions without a materialized turn, and failed sessions.

## Validation

- 54 focused shared, server relay, and APNs tests passed
- Shared and server typechecks passed
- Targeted lint and formatting passed
- `git diff --check` passed

Closes #9057
Closes #11938

Made with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to awareness `updatedAt` selection for terminal phases only; active-state freshness is unchanged and behavior is covered by focused tests.
> 
> **Overview**
> **Fixes duplicate or stale mobile notifications** when automatic thread settlement bumps `thread.updatedAt` after work has already finished.
> 
> For **completed** and **failed** awareness phases, `projectThreadAwareness` no longer always exposes `thread.updatedAt`. It now prefers the provider session’s terminal `updatedAt` (ready/idle for success, error for failure), then `latestTurn.completedAt`, with fallbacks to session and thread times. **Running and waiting phases** still use `thread.updatedAt` so live activity stays current.
> 
> Tests separate a later settlement time (`NOW`) from terminal work time (`TERMINAL_AT`) and assert `updatedAt` on interrupted-but-completed turns, ready sessions without a turn row, and failed sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f9b1f92212c208b5f7fe696602bde12bb0e8460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale settlement `updatedAt` in `projectThreadAwareness`
> The `updatedAt` field of the returned `AgentAwarenessState` no longer always uses `thread.updatedAt`. For `completed` and `failed` phases, it now prefers the session's terminal transition time or the latest turn's `completedAt`.
>
> - Computes `terminalSessionAt` from `session.updatedAt` when a completed/failed phase has the matching terminal session status.
> - For terminal phases, `updatedAt` falls back through `terminalSessionAt`, `latestTurn.completedAt`, `session.updatedAt`, then `thread.updatedAt`.
> - Tests in [agentAwareness.test.ts](https://github.com/pingdotgg/t3code/pull/9081/files#diff-ea477106d904ad24f6a6fcf96f590b8e7efacf2302f0632c7430fe972dcc8f10) now use a `TERMINAL_AT` constant and assert the new `updatedAt` behavior.
> - Risk: callers that relied on `state.updatedAt` always matching `thread.updatedAt` for terminal phases will see a different value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f9b1f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
