### PR TITLE
fix(desktop): stop preview element capture from hanging

### DIFF
--- a/apps/desktop/src/preview/PickPreload.test.ts
+++ b/apps/desktop/src/preview/PickPreload.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, it, vi } from "vite-plus/test";
+
+const { getElementContext, ipcRenderer } = vi.hoisted(() => ({
+  getElementContext: vi.fn(),
+  ipcRenderer: { on: vi.fn(), send: vi.fn() },
+}));
+
+vi.mock("electron", () => ({ ipcRenderer }));
+vi.mock("react-grab/primitives", () => ({ getElementContext }));
+
+vi.stubGlobal("window", { addEventListener: vi.fn() });
+vi.stubGlobal("location", { href: "https://example.com/dashboard" });
+vi.stubGlobal("document", { title: "Dashboard" });
+
+const { captureElement } = await import("./PickPreload.ts");
+
+afterEach(() => {
+  vi.useRealTimers();
+  getElementContext.mockReset();
+});
+
+it("falls back when react-grab element context never settles", async () => {
+  vi.useFakeTimers();
+  getElementContext.mockReturnValue(new Promise(() => undefined));
+
+  const element = {
+    tagName: "DIV",
+    outerHTML: '<div class="css-view-g5y9jx flex-row">Logos</div>',
+  } as Element;
+  const capture = captureElement(element);
+
+  await vi.advanceTimersByTimeAsync(5_000);
+  const result = await Promise.race([capture, Promise.resolve("still pending")]);
+
+  expect(result).toEqual(
+    expect.objectContaining({
+      pageUrl: "https://example.com/dashboard",
+      tagName: "div",
+      selector: null,
+      htmlPreview: element.outerHTML,
+      componentName: null,
+      source: null,
+      stack: [],
+      styles: "",
+    }),
+  );
+});

--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -1,4 +1,4 @@
-// @effect-diagnostics globalDate:off - This isolated Electron preload does not run inside an Effect runtime.
+// @effect-diagnostics globalDate:off globalTimers:off - This isolated Electron preload does not run inside an Effect runtime.
 import { ipcRenderer } from "electron";
 import { getElementContext } from "react-grab/primitives";
 import type {
@@ -279,24 +279,32 @@ function toStackFrame(frame: {
   };
 }
 
-async function captureElement(element: Element): Promise<PickedElementPayload | null> {
+export async function captureElement(element: Element): Promise<PickedElementPayload | null> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
   try {
-    const context = await getElementContext(element);
-    const stack = (context.stack ?? []).map(toStackFrame);
+    const context = await Promise.race([
+      getElementContext(element).catch(() => null),
+      new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), 5_000);
+      }),
+    ]);
+    const stack = (context?.stack ?? []).map(toStackFrame);
     return {
       pageUrl: location.href,
       pageTitle: document.title?.trim() || null,
       tagName: element.tagName.toLowerCase(),
-      selector: context.selector,
-      htmlPreview: context.htmlPreview ?? "",
-      componentName: context.componentName,
+      selector: context?.selector ?? null,
+      htmlPreview: context?.htmlPreview ?? element.outerHTML.slice(0, 4_000),
+      componentName: context?.componentName ?? null,
       source: stack[0] ?? null,
       stack,
-      styles: context.styles ?? "",
+      styles: context?.styles ?? "",
       pickedAt: new Date().toISOString(),
     };
   } catch {
     return null;
+  } finally {
+    if (timeoutId !== null) clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
A selected preview element could leave capture waiting forever when react-grab context enrichment never settled. Because annotation IPC only runs after every selected element finishes, the editor stayed locked on Capturing….

This bounds enrichment to five seconds. On timeout, capture retains safe DOM context (URL, tag, and truncated HTML) and continues the existing screenshot and send path. The picker itself remains unbounded while the user is annotating.

Verified with:

- 92 focused desktop preview tests
- Desktop typecheck
- Targeted lint and format checks
- Desktop production bundle

Fixes #9026

Made with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop preview preload behavior with a safe DOM fallback; no auth, data, or API surface changes beyond fixing a hang.
> 
> **Overview**
> **Preview element capture no longer blocks indefinitely** when `react-grab`’s `getElementContext` never resolves—a case that left the annotation editor stuck on “Capturing…” because screenshot/IPC only ran after every selected element finished enriching.
> 
> `captureElement` now **races** context enrichment against a **5s timeout** (with rejections treated as missing context), **clears the timer** in `finally`, and on timeout/failure still returns a `PickedElementPayload` using page URL/title, tag name, and **truncated `outerHTML`** instead of react-grab selector/component/stack/styles. **`captureElement` is exported** for unit testing, and diagnostics allow `setTimeout` in this preload.
> 
> A new **`PickPreload.test.ts`** asserts the timeout path returns the expected fallback fields when `getElementContext` never settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd40ed800763d9568a9be8c049cbc948545f9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 5s timeout to `captureElement` in desktop preview to prevent hanging
> - Wraps `await getElementContext(element)` in `Promise.race` against a 5,000 ms timeout in [PickPreload.ts](https://github.com/pingdotgg/t3code/pull/9082/files#diff-a19a7f6aa07147ba64b95dfc017ebf3427a82f067b93b614488e7485689df0b1), resolving to `null` on timeout or rejection
> - Adds fallback values for optional context fields: `htmlPreview` defaults to `element.outerHTML` (truncated to 4,000 chars), `selector` and `componentName` default to `null`, `styles` defaults to empty string
> - Exports `captureElement` from the module
> - Adds test in [PickPreload.test.ts](https://github.com/pingdotgg/t3code/pull/9082/files#diff-02814888fbfd2bbefc3cc32f1a10e6c04f3d85346c11b72acaaa577532002a8f) verifying the promise resolves after 5s when `getElementContext` never settles
> - Risk: `captureElement` now returns a minimal fallback payload instead of hanging; consumers expecting the full context object may receive `null` for `selector`, `componentName`, or `stack`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbd40ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->