### PR TITLE
refactor(claude): simplify Fable model support

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -525,51 +525,29 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("preserves xhigh effort for Claude Fable 5.1", () => {
-    const harness = makeHarness();
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        modelSelection: createModelSelection(
-          ProviderInstanceId.make("claudeAgent"),
-          "claude-fable-5-1",
-          [{ id: "effort", value: "xhigh" }],
-        ),
-        runtimeMode: "full-access",
-      });
+  it.effect.each<{ model: string }>([{ model: "claude-fable-5-1" }, { model: "claude-fable-5" }])(
+    "preserves xhigh effort for $model",
+    ({ model }) => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          modelSelection: createModelSelection(ProviderInstanceId.make("claudeAgent"), model, [
+            { id: "effort", value: "xhigh" },
+          ]),
+          runtimeMode: "full-access",
+        });
 
-      const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.effort, "xhigh");
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(harness.layer),
-    );
-  });
-
-  it.effect("preserves xhigh effort for Claude Fable 5", () => {
-    const harness = makeHarness();
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        modelSelection: createModelSelection(
-          ProviderInstanceId.make("claudeAgent"),
-          "claude-fable-5",
-          [{ id: "effort", value: "xhigh" }],
-        ),
-        runtimeMode: "full-access",
-      });
-
-      const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.effort, "xhigh");
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(harness.layer),
-    );
-  });
+        const createInput = harness.getLastCreateQueryInput();
+        assert.equal(createInput?.options.effort, "xhigh");
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
 
   it.effect("preserves xhigh effort for Claude Opus 5", () => {
     const harness = makeHarness();

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -57,76 +57,49 @@ const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";
 
+const CLAUDE_FABLE_MODEL_CAPABILITIES = createModelCapabilities({
+  optionDescriptors: [
+    buildSelectOptionDescriptor({
+      id: "effort",
+      label: "Reasoning",
+      options: [
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "xhigh", label: "Extra High" },
+        { value: "max", label: "Max" },
+        {
+          value: "ultracode",
+          label: "Ultracode",
+          description: "xhigh effort plus multi-agent workflow orchestration",
+        },
+        { value: "ultrathink", label: "Ultrathink" },
+      ],
+      promptInjectedValues: ["ultrathink"],
+    }),
+    buildSelectOptionDescriptor({
+      id: "contextWindow",
+      label: "Context Window",
+      options: [
+        { value: "200k", label: "200k" },
+        { value: "1m", label: "1M", isDefault: true },
+      ],
+    }),
+  ],
+});
+
 const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
   {
     slug: "claude-fable-5-1",
     name: "Claude Fable 5.1",
     isCustom: false,
-    capabilities: createModelCapabilities({
-      optionDescriptors: [
-        buildSelectOptionDescriptor({
-          id: "effort",
-          label: "Reasoning",
-          options: [
-            { value: "low", label: "Low" },
-            { value: "medium", label: "Medium" },
-            { value: "high", label: "High", isDefault: true },
-            { value: "xhigh", label: "Extra High" },
-            { value: "max", label: "Max" },
-            {
-              value: "ultracode",
-              label: "Ultracode",
-              description: "xhigh effort plus multi-agent workflow orchestration",
-            },
-            { value: "ultrathink", label: "Ultrathink" },
-          ],
-          promptInjectedValues: ["ultrathink"],
-        }),
-        buildSelectOptionDescriptor({
-          id: "contextWindow",
-          label: "Context Window",
-          options: [
-            { value: "200k", label: "200k" },
-            { value: "1m", label: "1M", isDefault: true },
-          ],
-        }),
-      ],
-    }),
+    capabilities: CLAUDE_FABLE_MODEL_CAPABILITIES,
   },
   {
     slug: "claude-fable-5",
     name: "Claude Fable 5",
     isCustom: false,
-    capabilities: createModelCapabilities({
-      optionDescriptors: [
-        buildSelectOptionDescriptor({
-          id: "effort",
-          label: "Reasoning",
-          options: [
-            { value: "low", label: "Low" },
-            { value: "medium", label: "Medium" },
-            { value: "high", label: "High", isDefault: true },
-            { value: "xhigh", label: "Extra High" },
-            { value: "max", label: "Max" },
-            {
-              value: "ultracode",
-              label: "Ultracode",
-              description: "xhigh effort plus multi-agent workflow orchestration",
-            },
-            { value: "ultrathink", label: "Ultrathink" },
-          ],
-          promptInjectedValues: ["ultrathink"],
-        }),
-        buildSelectOptionDescriptor({
-          id: "contextWindow",
-          label: "Context Window",
-          options: [
-            { value: "200k", label: "200k" },
-            { value: "1m", label: "1M", isDefault: true },
-          ],
-        }),
-      ],
-    }),
+    capabilities: CLAUDE_FABLE_MODEL_CAPABILITIES,
   },
   {
     slug: "claude-opus-5",

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -2107,6 +2107,49 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
+      it.effect.each<{
+        version: string;
+        expectedModel: string;
+        expectedMessage: string | undefined;
+      }>([
+        {
+          version: "2.1.257",
+          expectedModel: "claude-fable-5-1",
+          expectedMessage: undefined,
+        },
+        {
+          version: "2.1.256",
+          expectedModel: "claude-fable-5",
+          expectedMessage:
+            "Claude Code v2.1.256 is too old for Claude Fable 5.1. Upgrade to v2.1.257 or newer to access it.",
+        },
+      ])(
+        "selects $expectedModel on Claude Code $version",
+        ({ version, expectedModel, expectedMessage }) =>
+          Effect.gen(function* () {
+            const status = yield* checkClaudeProviderStatus(
+              defaultClaudeSettings,
+              claudeCapabilities(),
+            );
+            assert.strictEqual(status.models[0]?.slug, expectedModel);
+            assert.strictEqual(status.message, expectedMessage);
+          }).pipe(
+            Effect.provide(
+              mockSpawnerLayer((args) => {
+                const joined = args.join(" ");
+                if (joined === "--version") return { stdout: `${version}\n`, stderr: "", code: 0 };
+                if (joined === "auth status")
+                  return {
+                    stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                    stderr: "",
+                    code: 0,
+                  };
+                throw new Error(`Unexpected args: ${joined}`);
+              }),
+            ),
+          ),
+      );
+
       it.effect("includes Claude Fable 5 on supported Claude Code versions", () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(
@@ -2120,62 +2163,6 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             mockSpawnerLayer((args) => {
               const joined = args.join(" ");
               if (joined === "--version") return { stdout: "2.1.169\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("includes Claude Fable 5.1 on supported Claude Code versions", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          const fable51 = status.models.find((model) => model.slug === "claude-fable-5-1");
-          assert.strictEqual(fable51?.name, "Claude Fable 5.1");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "2.1.257\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("hides Claude Fable 5.1 on older Claude Code versions", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          assert.strictEqual(
-            status.models.some((model) => model.slug === "claude-fable-5-1"),
-            false,
-          );
-          assert.strictEqual(
-            status.message,
-            "Claude Code v2.1.256 is too old for Claude Fable 5.1. Upgrade to v2.1.257 or newer to access it.",
-          );
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "2.1.256\n", stderr: "", code: 0 };
               if (joined === "auth status")
                 return {
                   stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -34,6 +34,11 @@ When you set this field, T3 Code points Claude Code at that directory with the
 `CLAUDE_CONFIG_DIR` environment variable. It does not change `HOME`, so your system keychain and
 the rest of your environment stay as they are.
 
+## Model Availability
+
+T3 Code only shows models supported by the installed Claude Code version. Claude Fable 5.1 requires
+Claude Code 2.1.257 or newer.
+
 ## Reduce Context Usage
 
 In Settings, open your Claude provider and set **Auto-compact after** to a token count between


### PR DESCRIPTION
#9078 added Claude Fable 5.1 support, but it duplicated the same Fable capabilities and test setup for both model generations.

This follow-up shares the identical capabilities, makes the version and effort coverage table-driven, and documents the Claude Code 2.1.257 requirement. Runtime behavior is unchanged.

## Verification

- `vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts -t "selects"`
- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts -t "claude-fable-5-1"`
- `vp run --filter t3 typecheck`
- Targeted lint and formatting

The combined provider run still reproduces the unrelated existing Codex binary-path reprobe failure at `ProviderRegistry.test.ts:1820`; all Fable-focused tests pass.

Made with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and test/docs only; no changes to provider selection logic beyond sharing constants and consolidating tests.
> 
> **Overview**
> This follow-up to Fable 5.1 support **deduplicates** identical reasoning/context-window capability definitions for **Claude Fable 5.1** and **Claude Fable 5** via a shared `CLAUDE_FABLE_MODEL_CAPABILITIES` constant in `ClaudeProvider.ts`. **Runtime model gating and effort behavior are unchanged.**
> 
> Tests are consolidated: **xhigh effort** coverage for both Fable slugs uses `it.effect.each`, and **ProviderRegistry** version checks use a table (e.g. **2.1.257** → Fable 5.1 as default, **2.1.256** → Fable 5 with the Fable 5.1 upgrade message) instead of separate inclusion/hide cases.
> 
> User docs add a **Model Availability** note that **Claude Fable 5.1** requires **Claude Code 2.1.257+**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b3bda111db23a8caddf4bafe5914f12c1bd56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `CLAUDE_FABLE_MODEL_CAPABILITIES` and consolidate Claude Fable tests
> - Introduces `CLAUDE_FABLE_MODEL_CAPABILITIES` in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/9083/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) to hold shared `effort` and `contextWindow` descriptors for `claude-fable-5-1` and `claude-fable-5`, removing duplicated capability definitions in `CLAUDE_MODEL_CATALOG`
> - Replaces separate per-model test cases in [ClaudeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/9083/files#diff-1657a55ebc1e3682293aa20a7f71a55adf8de546f36af50f289dca9da45b0b6f) and [ProviderRegistry.test.ts](https://github.com/pingdotgg/t3code/pull/9083/files#diff-28b6372c54d8310c6909678b338ea3a67f48ea13b57386544bfe5ffdfa742b6f) with parameterized `it.effect.each` tests covering both Fable models
> - Adds a 'Model Availability' section to [providers-claude.md](https://github.com/pingdotgg/t3code/pull/9083/files#diff-f3b54bb573c78b526a8c1181ccd8146c7df38119b974038b08aff6f4e5a3819d) noting that Claude Fable 5.1 requires Claude Code 2.1.257 or newer
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75b3bda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->