### PR TITLE
fix(mobile): invalidate stale scheduler delegates

### DIFF
--- a/patches/expo@57.0.18.patch
+++ b/patches/expo@57.0.18.patch
@@ -1,0 +1,66 @@
+diff --git a/ios/AppDelegates/ExpoReactNativeFactory.mm b/ios/AppDelegates/ExpoReactNativeFactory.mm
+index ed884041d8..3e51144cec 100644
+--- a/ios/AppDelegates/ExpoReactNativeFactory.mm
++++ b/ios/AppDelegates/ExpoReactNativeFactory.mm
+@@ -21,11 +21,58 @@
+ #import <ReactCommon/RCTHost.h>
+ #import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+ #import <ExpoModulesCore/EXReactSchedulerDispatch.h>
++#import <react/featureflags/ReactNativeFeatureFlags.h>
++#import <react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h>
+-
++
++namespace {
++class T3ReactNativeFeatureFlagsOverridesOSSStable final
++    : public facebook::react::ReactNativeFeatureFlagsOverridesOSSStable {
++ public:
++  bool enableSchedulerDelegateInvalidation() override
++  {
++    return true;
++  }
++};
++} // namespace
++
++@interface RCTReactNativeFactory (T3FeatureFlags)
++- (void)_setUpFeatureFlags:(RCTReleaseLevel)releaseLevel;
++@end
++
+ @implementation EXReactNativeFactory {
+   EXAppContext *_appContext;
+ }
+-
++
++// RN 0.86.3's prebuilt Scheduler contains this delegate lifetime guard, but its
++// OSS Stable provider leaves it off. Remove this override once Stable enables it.
++- (void)_setUpFeatureFlags:(RCTReleaseLevel)releaseLevel
++{
++  static BOOL initialized = NO;
++  static RCTReleaseLevel chosenReleaseLevel;
++  NSLog(@"_setUpFeatureFlags called with release level %li", releaseLevel);
++  if (!initialized) {
++    chosenReleaseLevel = releaseLevel;
++    initialized = YES;
++  } else if (chosenReleaseLevel != releaseLevel) {
++    [NSException
++         raise:@"RCTReactNativeFactory::_setUpFeatureFlags releaseLevel mismatch between React Native instances"
++        format:@"The releaseLevel (%li) of the new instance does not match the previous instance's releaseLevel (%li)",
++               releaseLevel,
++               chosenReleaseLevel];
++  }
++
++  if (releaseLevel != Stable) {
++    [super _setUpFeatureFlags:releaseLevel];
++    return;
++  }
++
++  static dispatch_once_t setupFeatureFlagsToken;
++  dispatch_once(&setupFeatureFlagsToken, ^{
++    facebook::react::ReactNativeFeatureFlags::override(
++        std::make_unique<T3ReactNativeFeatureFlagsOverridesOSSStable>());
++  });
++}
++
+ #pragma mark - RCTHostDelegate
+-
++
+ #if TARGET_OS_OSX

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,7 @@ patchedDependencies:
   effect@4.0.0-beta.103: af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6
   expo-audio@57.0.4: fa9a3e0442ed395d4071bb406e08c3a471c9a84700bdfa0b9ad7ff144c96041a
   expo-sharing@57.0.16: 8d2e3b10eb3f52036a9a086800180ec6cebf3b75bccc5b1775117a7244d4ac45
+  expo@57.0.18: d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a
   react-native-gesture-handler@2.32.0: 808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3
   react-native-keyboard-controller@1.21.13: 6e4339347bc5bb3c9ea67d85ff5c814058b211c5750f247aba59d07869a2e787
   react-native-nitro-modules@0.35.9: 825622aae63a8fb5b904f3c77908a0e216261d727ea171709f2c0b6088422675
@@ -297,7 +298,7 @@ importers:
         version: 4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6)
       expo:
         specifier: ~57.0.18
-        version: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+        version: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-asset:
         specifier: ~57.0.15
         version: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
@@ -11504,7 +11505,7 @@ snapshots:
       '@clerk/shared': 4.30.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@expo/config-plugins': 57.0.9(typescript@6.0.3)
       base-64: 1.0.0
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-url-polyfill: 4.0.0(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
@@ -12151,7 +12152,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-server: 57.0.3
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -12228,7 +12229,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       expo-server: 57.0.3
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -12335,13 +12336,13 @@ snapshots:
 
   '@expo/dom-webview@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   '@expo/dom-webview@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       react: 19.2.6
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optional: true
@@ -12422,7 +12423,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       anser: 1.4.10
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
@@ -12431,7 +12432,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       react: 19.2.6
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
@@ -12463,7 +12464,7 @@ snapshots:
       postcss: 8.5.15
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12485,7 +12486,7 @@ snapshots:
     dependencies:
       '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       anser: 1.4.10
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
@@ -12498,7 +12499,7 @@ snapshots:
     dependencies:
       '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       pretty-format: 29.7.0
       react: 19.2.6
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
@@ -12587,7 +12588,7 @@ snapshots:
   '@expo/router-server@57.0.8(@expo/metro-runtime@57.0.14)(expo-constants@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)))(expo-font@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(expo-server@57.0.3)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       debug: 4.4.3
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-constants: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-font: 57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-server: 57.0.3
@@ -12601,7 +12602,7 @@ snapshots:
   '@expo/router-server@57.0.8(@expo/metro-runtime@57.0.14)(expo-constants@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(expo-font@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo-server@57.0.3)(expo@57.0.18)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       debug: 4.4.3
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       expo-constants: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       expo-font: 57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-server: 57.0.3
@@ -12625,7 +12626,7 @@ snapshots:
 
   '@expo/ui@57.0.14(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
@@ -15434,7 +15435,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-widgets: 57.0.15(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
@@ -16323,12 +16324,12 @@ snapshots:
 
   expo-application@57.0.2(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-asset@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.11.5(typescript@6.0.3)
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-constants: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
@@ -16339,7 +16340,7 @@ snapshots:
   expo-asset@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.11.5(typescript@6.0.3)
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       expo-constants: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       react: 19.2.6
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
@@ -16350,7 +16351,7 @@ snapshots:
 
   expo-audio@57.0.4(patch_hash=fa9a3e0442ed395d4071bb406e08c3a471c9a84700bdfa0b9ad7ff144c96041a)(expo-asset@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-asset: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
@@ -16371,21 +16372,21 @@ snapshots:
 
   expo-blur@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-build-properties@57.0.15(expo@57.0.18):
     dependencies:
       '@expo/schema-utils': 57.0.2
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       resolve-from: 5.0.0
       semver: 7.8.5
 
   expo-camera@57.0.4(@types/emscripten@1.41.5)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       barcode-detector: 3.2.0(@types/emscripten@1.41.5)
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
@@ -16393,14 +16394,14 @@ snapshots:
 
   expo-clipboard@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-constants@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/env': 2.4.3
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
@@ -16408,7 +16409,7 @@ snapshots:
   expo-constants@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/env': 2.4.3
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
@@ -16416,11 +16417,11 @@ snapshots:
 
   expo-crypto@57.0.2(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-dev-client@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-dev-launcher: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-dev-menu: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-dev-menu-interface: 57.0.0(expo@57.0.18)
@@ -16432,53 +16433,53 @@ snapshots:
   expo-dev-launcher@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/schema-utils': 57.0.2
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-dev-menu: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-manifests: 57.0.1(expo@57.0.18)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-dev-menu-interface@57.0.0(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-dev-menu@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-dev-menu-interface: 57.0.0(expo@57.0.18)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-device@57.0.1(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       ua-parser-js: 0.7.41
 
   expo-document-picker@57.0.1(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-eas-client@57.0.2: {}
 
   expo-file-system@57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-file-system@57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optional: true
 
   expo-font@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       fontfaceobserver: 2.3.0
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-font@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       fontfaceobserver: 2.3.0
       react: 19.2.6
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
@@ -16486,26 +16487,26 @@ snapshots:
 
   expo-glass-effect@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-haptics@57.0.2(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-image-loader@57.0.1(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-image-picker@57.0.14(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-image-loader: 57.0.1(expo@57.0.18)
 
   expo-image@57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
@@ -16514,12 +16515,12 @@ snapshots:
 
   expo-keep-awake@57.0.1(expo@57.0.18)(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
 
   expo-keep-awake@57.0.1(expo@57.0.18)(react@19.2.6):
     dependencies:
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       react: 19.2.6
     optional: true
 
@@ -16535,7 +16536,7 @@ snapshots:
 
   expo-manifests@57.0.1(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-json-utils: 57.0.1
 
   expo-modules-autolinking@57.0.12(typescript@6.0.3):
@@ -16580,7 +16581,7 @@ snapshots:
 
   expo-network@57.0.1(expo@57.0.18)(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
 
   expo-notifications@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
@@ -16588,7 +16589,7 @@ snapshots:
       '@expo/image-utils': 0.11.5(typescript@6.0.3)
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-application: 57.0.2(expo@57.0.18)
       expo-constants: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       react: 19.2.3
@@ -16599,14 +16600,14 @@ snapshots:
 
   expo-paste-input@0.1.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-quick-actions@6.0.2(expo@57.0.18)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@6.0.3)
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       schema-utils: 4.3.3
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
@@ -16615,7 +16616,7 @@ snapshots:
 
   expo-secure-store@57.0.2(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-server@57.0.3: {}
 
@@ -16624,7 +16625,7 @@ snapshots:
       '@expo/config-plugins': 57.0.9(typescript@6.0.3)
       '@expo/config-types': 57.0.2
       '@expo/plist': 0.8.1
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
@@ -16635,7 +16636,7 @@ snapshots:
     dependencies:
       '@expo/config-plugins': 57.0.9(typescript@6.0.3)
       '@expo/image-utils': 0.11.5(typescript@6.0.3)
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -16644,14 +16645,14 @@ snapshots:
   expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       await-lock: 2.2.2
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       await-lock: 2.2.2
-      expo: 57.0.18(ecb3896f1dbe5154a21ddc585503f306)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306)
       react: 19.2.6
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optional: true
@@ -16661,7 +16662,7 @@ snapshots:
   expo-symbols@57.0.2(expo-font@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.38
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-font: 57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
@@ -16669,7 +16670,7 @@ snapshots:
 
   expo-updates-interface@57.0.1(expo@57.0.18):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
 
   expo-updates@57.0.19(expo-dev-client@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -16679,7 +16680,7 @@ snapshots:
       arg: 4.1.3
       chalk: 4.1.2
       debug: 4.4.3
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       expo-eas-client: 57.0.2
       expo-manifests: 57.0.1(expo@57.0.18)
       expo-structured-headers: 57.0.0
@@ -16698,20 +16699,20 @@ snapshots:
 
   expo-video@57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-web-browser@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
   expo-widgets@57.0.15(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       '@expo/plist': 0.8.1
       '@expo/ui': 57.0.14(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo: 57.0.18(f9c992a5d7c53d81398568d3950992dc)
+      expo: 57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
@@ -16721,7 +16722,7 @@ snapshots:
       - react-dom
       - react-native-worklets
 
-  expo@57.0.18(ecb3896f1dbe5154a21ddc585503f306):
+  expo@57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(ecb3896f1dbe5154a21ddc585503f306):
     dependencies:
       '@babel/runtime': 7.29.7
       '@expo/cli': 57.0.20(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-constants@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(expo-font@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo@57.0.18)(react-dom@19.2.6(react@19.2.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -16764,7 +16765,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  expo@57.0.18(f9c992a5d7c53d81398568d3950992dc):
+  expo@57.0.18(patch_hash=d5e6da6b932e5b37d6201927ec002d63ac4fc76d8234d63a2ae6468ad776f11a)(f9c992a5d7c53d81398568d3950992dc):
     dependencies:
       '@babel/runtime': 7.29.7
       '@expo/cli': 57.0.20(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-constants@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)))(expo-font@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -155,6 +155,7 @@ patchedDependencies:
   "@react-navigation/native-stack@7.17.6": patches/@react-navigation%2Fnative-stack@7.17.6.patch
   effect@4.0.0-beta.103: patches/effect@4.0.0-beta.103.patch
   expo-audio@57.0.4: patches/expo-audio@57.0.4.patch
+  expo@57.0.18: patches/expo@57.0.18.patch
   expo-sharing@57.0.16: patches/expo-sharing@57.0.16.patch
   react-native-gesture-handler@2.32.0: patches/react-native-gesture-handler@2.32.0.patch
   react-native-keyboard-controller@1.21.13: patches/react-native-keyboard-controller@1.21.13.patch


### PR DESCRIPTION
React Native 0.86.3 contains a guard that invalidates queued Scheduler callbacks before their delegate can be destroyed, but the OSS Stable feature-flag provider leaves it disabled.

Patch Expo's `EXReactNativeFactory` Stable setup to inherit every existing Stable default and enable only `enableSchedulerDelegateInvalidation`. Canary and Experimental setup still use React Native's providers unchanged. This is native code, so the fix requires a new native build or TestFlight release; an OTA update cannot apply it.

Verification:

- Compiled the patched Expo factory as Objective-C++ for arm64 iOS Simulator and linked it with the React Native 0.86.3 prebuilt frameworks.
- The primary agent ran one focused native harness on an iPhone 17 Pro iOS 26.5 Simulator. Three real `EXReactNativeFactory` Stable initializations dispatched through the prebuilt `RCTReactNativeFactory`, and all three observed the guard as enabled.
- Checked the exact prebuilt Scheduler binary and source paths that read the flag during delegate replacement, teardown, and queued rendering callbacks.
- Verified the pnpm patch applies to the installed Expo package and that the lockfile changes contain only the patch registration and expected hash propagation.

This did not run the full T3 Code app, reproduce the teardown race, exercise reload, or test a physical device. The native harness proves flag activation and repeated factory initialization against the shipped React Native version.

Implemented with GPT-5.6 Sol xhigh in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS React Native startup and global feature flags for Stable builds, which can affect scheduler teardown and reload behavior; scope is narrow and intended as a temporary workaround until upstream enables the flag.
> 
> **Overview**
> Adds a **pnpm patch for `expo@57.0.18`** and wires it through `pnpm-workspace.yaml` and the lockfile so every Expo dependency resolves to the patched package.
> 
> The patch overrides **`EXReactNativeFactory`'s `_setUpFeatureFlags`** on iOS when the release level is **Stable**: it installs a small OSS Stable feature-flag override that turns on **`enableSchedulerDelegateInvalidation`**, matching behavior already present in RN 0.86.3's prebuilt Scheduler but left off by the default Stable provider. **Canary/Experimental** paths still delegate to React Native's normal setup, and mismatched release levels across instances raise an exception.
> 
> This is **native Objective-C++** in the Expo factory, so it only ships with a **new native build** (not OTA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10942be0361a5b85d4ca9e1724e926fd0d3ac1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force-enable `enableSchedulerDelegateInvalidation` for Stable release in `RCTReactNativeFactory`
> - Patches `expo@57.0.18` to install a React Native feature flag override (`T3ReactNativeFeatureFlagsOverridesOSSStable`) that forces `enableSchedulerDelegateInvalidation()` to return true at the Stable release level.
> - The override is installed once via `dispatch_once` in `RCTReactNativeFactory._setUpFeatureFlags:`; non-Stable levels defer to `super`.
> - Adds a guard that throws an `NSException` if a subsequent call to `_setUpFeatureFlags:` uses a different `RCTReleaseLevel` than the first.
> - Registers the patch in [pnpm-workspace.yaml](https://github.com/pingdotgg/t3code/pull/9089/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c) under `patchedDependencies`.
> - Risk: the release-level mismatch guard in `RCTReactNativeFactory._setUpFeatureFlags:` will crash the app if multiple React instances are initialized with different `RCTReleaseLevel` values.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 10942be. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->