### PR TITLE
feat(web): copy terminal selections automatically

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -827,6 +827,7 @@ export function TerminalViewport({
         if (!shouldHandle) {
           return;
         }
+        terminalRef.current?.copySelectionToClipboard();
         selectionPointerRef.current = { x: event.clientX, y: event.clientY };
         const delay = terminalSelectionActionDelayForClickCount(event.detail);
         selectionActionTimerRef.current = window.setTimeout(() => {

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -7,6 +7,7 @@ import {
   advanceTerminalSelectionClickSequence,
   applyTerminalCopyEvent,
   clearPrimedTerminalCopyInput,
+  copyTerminalSelection,
   ghosttyMouseButton,
   isTerminalAltGraphText,
   isTerminalCompositionCommitInput,
@@ -280,6 +281,33 @@ describe("applyTerminalCopyEvent", () => {
     expect(input.value).toBe("git status");
     expect(input.selectionStart).toBe(0);
     expect(input.selectionEnd).toBe(10);
+  });
+});
+
+describe("copyTerminalSelection", () => {
+  it("primes and copies a non-empty terminal selection", () => {
+    const input = {
+      value: "",
+      select: vi.fn(),
+    };
+    const copy = vi.fn(() => true);
+
+    expect(copyTerminalSelection(input, "git status", copy)).toBe(true);
+    expect(input.value).toBe("git status");
+    expect(input.select).toHaveBeenCalledOnce();
+    expect(copy).toHaveBeenCalledOnce();
+  });
+
+  it("does not copy an empty terminal selection", () => {
+    const input = {
+      value: "",
+      select: vi.fn(),
+    };
+    const copy = vi.fn(() => true);
+
+    expect(copyTerminalSelection(input, "", copy)).toBe(false);
+    expect(input.select).not.toHaveBeenCalled();
+    expect(copy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -350,6 +350,16 @@ export function primeTerminalCopyInput(
   input.select();
 }
 
+export function copyTerminalSelection(
+  input: Pick<HTMLTextAreaElement, "value" | "select">,
+  selection: string,
+  copy = () => document.execCommand("copy"),
+): boolean {
+  if (selection.length === 0) return false;
+  primeTerminalCopyInput(input, selection);
+  return copy();
+}
+
 export function clearPrimedTerminalCopyInput(
   input: Pick<HTMLTextAreaElement, "value">,
   primedSelection: string,
@@ -913,6 +923,10 @@ export class GhosttyTerminalSurface {
 
   getSelection(): string {
     return this.core.selectionText();
+  }
+
+  copySelectionToClipboard(): boolean {
+    return copyTerminalSelection(this.input, this.getSelection());
   }
 
   getSelectionPosition(): GhosttySelectionPosition | null {


### PR DESCRIPTION
## What Changed

Added support to automatically copy selected terminal text into clipboard.

## Why

iterm has this feature. I am completely loving t3 code and it has taken over my whole workflow, but having to select then click to copy text has been a small nit I have missed about my old tmux+iterm workflow.

## UI Changes

<TBD>

## Checklist

- [x] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Copy terminal selections to clipboard automatically on mouseup in `TerminalViewport`
> - Adds `copyTerminalSelection` utility in [surface.ts](https://github.com/pingdotgg/t3code/pull/9091/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) that primes the hidden input and runs `document.execCommand("copy")` for non-empty selections; returns false when selection is empty.
> - Exposes `copySelectionToClipboard()` on `GhosttyTerminalSurface` delegating to the new utility.
> - Calls `terminalRef.current?.copySelectionToClipboard()` inside the mouseup handler in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/9091/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) so qualifying selection events copy to clipboard.
> - Adds tests in [surface.test.ts](https://github.com/pingdotgg/t3code/pull/9091/files#diff-4739505f766bda541a0cf14a163fb5321204b64183ba45ffcc1a0026ad6e8029) covering non-empty and empty selection cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized eb0e487. 2 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/terminal/ghostty/surface.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 929](https://github.com/pingdotgg/t3code/blob/eb0e4873c6b2fbccf4cf28e6442e25245f4fe29c/apps/web/src/terminal/ghostty/surface.ts#L929): `copySelectionToClipboard` unconditionally copies whatever selection already exists. The drawer invokes it for every left-button gesture begun in the mount, including a click that `onPointerDown` routes to an application after DEC mouse tracking is enabled. Since that path does not change/clear a pre-existing Ghostty selection, such application clicks silently overwrite the user's clipboard with stale terminal text rather than only copying a completed selection gesture. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->