### PR TITLE
fix(web): keep the selected environment when changing projects

### DIFF
--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -323,6 +323,74 @@ describe("environment grouping", () => {
     expect(entries[1]?.group.displayName).toBe("separate");
   });
 
+  it("keeps the current environment when available and falls back otherwise", () => {
+    const currentPrimary = makeProject({ repositoryIdentity });
+    const currentRemote = makeProject({
+      id: ProjectId.make("current-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const destinationRepositoryIdentity = {
+      canonicalKey: "github.com/example/destination",
+      locator: {
+        source: "git-remote" as const,
+        remoteName: "origin",
+        remoteUrl: "https://github.com/example/destination.git",
+      },
+    };
+    const destinationPrimary = makeProject({
+      id: ProjectId.make("destination-primary"),
+      title: "destination",
+      workspaceRoot: "/tmp/destination",
+      repositoryIdentity: destinationRepositoryIdentity,
+    });
+    const destinationRemote = makeProject({
+      id: ProjectId.make("destination-remote"),
+      environmentId: remoteEnvironmentId,
+      title: "destination",
+      workspaceRoot: "/remote/destination",
+      repositoryIdentity: destinationRepositoryIdentity,
+    });
+    const fallbackPrimary = makeProject({
+      id: ProjectId.make("fallback-primary"),
+      title: "fallback",
+      workspaceRoot: "/tmp/fallback",
+    });
+    const groups = buildSidebarProjectSnapshots({
+      projects: [
+        currentPrimary,
+        currentRemote,
+        destinationPrimary,
+        destinationRemote,
+        fallbackPrimary,
+      ],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    const entries = buildSidebarProjectPickerEntries({
+      groups,
+      preferredProjectRef: {
+        environmentId: remoteEnvironmentId,
+        projectId: currentRemote.id,
+      },
+    });
+    const destination = entries.find(
+      (entry) => entry.group.projectKey === destinationRepositoryIdentity.canonicalKey,
+    );
+    const fallback = entries.find((entry) => entry.group.displayName === "fallback");
+
+    expect(destination?.targetProject).toMatchObject({
+      environmentId: remoteEnvironmentId,
+      id: destinationRemote.id,
+    });
+    expect(fallback?.targetProject).toMatchObject({
+      environmentId: primaryEnvironmentId,
+      id: fallbackPrimary.id,
+    });
+  });
+
   it("keeps manual project order when building grouped sidebar entries", () => {
     const primary = makeProject({ repositoryIdentity });
     const remote = makeProject({

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -118,22 +118,23 @@ export function buildSidebarProjectPickerEntries(input: {
   groups: ReadonlyArray<SidebarProjectSnapshot>;
   preferredProjectRef: ScopedProjectRef | null;
 }) {
+  const preferredProjectRef = input.preferredProjectRef;
   const entries = input.groups.flatMap((group): SidebarProjectPickerEntry[] => {
-    const isPreferred = input.preferredProjectRef
+    const isPreferred = preferredProjectRef
       ? group.memberProjectRefs.some(
           (projectRef) =>
-            projectRef.environmentId === input.preferredProjectRef?.environmentId &&
-            projectRef.projectId === input.preferredProjectRef.projectId,
+            projectRef.environmentId === preferredProjectRef.environmentId &&
+            projectRef.projectId === preferredProjectRef.projectId,
         )
       : false;
-    const preferredProject = isPreferred
+    const preferredProject = preferredProjectRef
       ? (group.memberProjects.find(
           (project) =>
-            project.environmentId === input.preferredProjectRef?.environmentId &&
-            project.id === input.preferredProjectRef?.projectId,
+            project.environmentId === preferredProjectRef.environmentId &&
+            project.id === preferredProjectRef.projectId,
         ) ??
         group.memberProjects.find(
-          (project) => project.environmentId === input.preferredProjectRef?.environmentId,
+          (project) => project.environmentId === preferredProjectRef.environmentId,
         ))
       : null;
     const targetProject =

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -52,6 +52,11 @@ On mobile, the model picker shows each OpenCode model's upstream provider, such 
 GitHub Copilot, or OpenCode Zen, beneath its name. Search by that provider name to narrow the list
 when starting a thread or changing an existing thread's model.
 
+## Changing projects
+
+On web and desktop, changing the project from a new thread keeps the current environment when that
+project exists there. If it does not, T3 Code selects another environment that has the project.
+
 ## Notices above the composer
 
 On web and desktop, loading and syncing statuses fill the available banner width beside the


### PR DESCRIPTION
Changing projects from a new thread could reset the selected environment, even when the destination project existed there.

T3 Code now keeps the current environment when possible. If that environment does not have the destination project, it selects another environment that does. This applies to the composer and command palette.

Verification: 144 focused tests, web typecheck, targeted lint, and targeted formatting checks passed. Browser verification has not run because it needs user permission.

Made with GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to sidebar picker target resolution with a new unit test; no auth, data, or API surface changes.
> 
> **Overview**
> **Project switching** on web/desktop (new-thread composer and command palette) no longer drops the active environment when you pick a different logical project.
> 
> `buildSidebarProjectPickerEntries` now uses the current `preferredProjectRef` for **every** sidebar group, not only the group that contains the active project. For each group it picks the member on that environment (exact project ref first, then any member in that environment), then falls back to the group representative / first member as before.
> 
> A regression test covers switching to a repo that exists on the remote env vs. a project that only exists on primary. User docs add a **Changing projects** note under the composer guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cf46da5ca1a342fec51578d0e4acf03a695e093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep selected environment when changing projects in `buildSidebarProjectPickerEntries`
> - Updates [sidebarProjectGrouping.ts](https://github.com/pingdotgg/t3code/pull/9102/files#diff-56beffcb94c48f4ebb0f187f3a8be66f26b116bb7a3e13fd196af3753e10d9a9) so that when a `preferredProjectRef` is provided, each group first tries to find the exact project match, then falls back to any project in the group matching the preferred `environmentId`, before using the group's default.
> - Adds a test in [environmentGrouping.test.ts](https://github.com/pingdotgg/t3code/pull/9102/files#diff-9acd9b2d2555beeaa5d09e6270032cd8cb9990f34ffb3bdab69f8b5d3dde2036) covering both the exact-match case and the environment-fallback case.
> - Documents the new behavior in [composer.md](https://github.com/pingdotgg/t3code/pull/9102/files#diff-6c496fed927e1ba2296273bdfca78fd482921ebd76a32bb9d0c534f7bda35b63) under a 'Changing projects' section.
> - Behavioral Change: groups that do not contain the exact preferred project now target a member in the preferred environment instead of ignoring the preferred environment and using the group's first member.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cf46da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->