### PR TITLE
fix(web): keep theme placeholder text dimmer than entered text

### DIFF
--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -157,6 +157,9 @@ describe("theme files", () => {
       expect(contrastRatio(colors.textMuted, colors.canvas)).toBeLessThan(5.5);
       expect(contrastRatio(colors.mutedForeground, colors.muted)).toBeGreaterThanOrEqual(4.5);
       expect(contrastRatio(colors.placeholder, colors.surfaceRaised)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(colors.placeholder, colors.surfaceRaised)).toBeLessThan(
+        contrastRatio(colors.text, colors.surfaceRaised),
+      );
       expect(colors.secondaryLabel).toBe(colors.textMuted);
       expect(contrastRatio(colors.accentForeground, colors.accent)).toBeGreaterThanOrEqual(4.5);
       expect(

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -917,7 +917,7 @@ export function createVividThemeColors(
       solveOklchLightness(textBase, surfaceRgb, 4.6, dark ? "lighter" : "darker"),
     );
   const mutedForeground = foregroundOn(mutedRgb);
-  const placeholder = foregroundOn(surfaceRaisedRgb);
+  const placeholder = themeRgbToThemeColor(readableThemeText(surfaceRaisedRgb, textRgb, 1, 4.6));
 
   const actionHover: ThemeOklch = { ...action, L: action.L + (dark ? 0.06 : -0.06) };
 

--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -90,6 +90,28 @@ describe("VS Code theme import", () => {
     expect(theme.colors.sidebarRowSelected).not.toBe(theme.colors.sidebar);
   });
 
+  it("keeps a fallback placeholder dimmer than entered text", () => {
+    const theme = parseVsCodeThemeFile({
+      name: "Dark placeholder fallback",
+      type: "dark",
+      colors: {
+        "editor.background": "#1e1e2e",
+        "editor.foreground": "#cdd6f4",
+        "input.placeholderForeground": "#cdd6f473",
+      },
+    });
+
+    expect(
+      contrastRatio(theme.colors.placeholder, theme.colors.surfaceRaised),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(theme.colors.placeholder, theme.colors.canvas)).toBeGreaterThanOrEqual(
+      4.5,
+    );
+    expect(contrastRatio(theme.colors.placeholder, theme.colors.canvas)).toBeLessThan(
+      contrastRatio(theme.colors.text, theme.colors.canvas),
+    );
+  });
+
   it("fills every role the file omits with a readable derived value", () => {
     const theme = parseVsCodeThemeFile(VSCODE_DARK);
     const colors = getThemeColorsForMode(theme, "dark")!;


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Fable 5.1 on behalf of Oliver**

## Problem

Generated themes render placeholder text at the same brightness as entered text. `createVividThemeColors` solves the placeholder with `solveOklchLightness`, which only pushes lightness toward readability and never dims. Primary text already clears the 4.6:1 floor, so the placeholder came out identical to `text`.

Every consumer of that generator is affected: imported VS Code themes, themes built in the theme editor, and environment themes. The hand-tuned built-in palettes keep placeholder near muted-text strength and were never affected.

## Fix

Derive placeholder the way `createManagedThemeColors` already does: soften the text color toward the raised surface with `readableThemeText` and stop at the quietest mix that still clears 4.6:1. One line in the generator, no importer changes.

For a dark canvas of `#1e1e2e`, contrast against the raised surface:

| Role | Before | After |
|---|---|---|
| text | 12.07 | 12.07 |
| placeholder | 12.07 | 4.61 |

Tests: the vivid-seeds palette test now asserts placeholder is quieter than text on the raised surface. The importer test adds a dark fixture without a widget background, so the derived raised surface is lighter than the canvas, and checks the fallback placeholder clears 4.5:1 on both surfaces while staying dimmer than text.

## UI changes

### Before

Placeholder renders at full text brightness:

<img width="1926" height="938" alt="Placeholder as bright as entered text" src="https://github.com/user-attachments/assets/e2e9b0ff-2b81-44e9-8623-6c5dc73eaaff" />

### After

Placeholder reads as secondary text:

<img width="1852" height="826" alt="Placeholder dimmer than entered text" src="https://github.com/user-attachments/assets/bee80b54-3107-4c67-a33d-6e2f4fbdcae1" />

## Verification

- `npx vitest run src/themePalette.test.ts src/vscodeThemeImport.test.ts` in `apps/web`, 49 tests passed
- `tsc --noEmit` for `apps/web`
- Targeted lint and format checks on the changed files

Changes prepared by GPT-5.6 Sol through Codex, directed and reviewed by Claude Fable 5.1 in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `createVividThemeColors` to keep placeholder text dimmer than entered text
> The placeholder color now uses `readableThemeText(surfaceRaisedRgb, textRgb, 1, 4.6)` instead of `foregroundOn(surfaceRaisedRgb)`, producing a readable but dimmer variant of the primary text while maintaining at least ~4.6 contrast against the raised surface. Tests in [themePalette.test.ts](https://github.com/pingdotgg/t3code/pull/9104/files#diff-88ae5e69aa5213efaa17629674a2c2cc74063504ea0063e011c5ec249bb217d7) and [vscodeThemeImport.test.ts](https://github.com/pingdotgg/t3code/pull/9104/files#diff-d690b716e49037069fdbd1c1dbd75556f04ec3c7ed6b8e46ab0f9a7e9cda82ad) verify the placeholder stays dimmer than primary text and meets minimum contrast thresholds.
> - Risk: imported VS Code themes with an explicit `input.placeholderForeground` may now produce a different placeholder color than the source theme specified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a00a002.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->