### PR TITLE
fix: let Claude run skills selected from the menu

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -11,6 +11,7 @@ import {
 } from "@t3tools/shared/searchRanking";
 import {
   dedupeProviderSkillsByName,
+  formatProviderSkillInvocation,
   getProviderSkillsForSlashMenu,
 } from "@t3tools/client-runtime/providerSkills";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -268,7 +269,7 @@ export function useComposerCommandMenu({
       if (item.type === "path") {
         replacement = `${serializeComposerFileLink(item.path)} `;
       } else if (item.type === "skill") {
-        replacement = `$${item.skill.name} `;
+        replacement = `${formatProviderSkillInvocation(selectedProviderStatus?.driver, item.skill.name)} `;
       } else if (item.type === "slash-command") {
         replacement = `/${item.command} `;
       } else if (item.type === "provider-slash-command") {
@@ -284,7 +285,13 @@ export function useComposerCommandMenu({
       setSelection({ start: result.cursor, end: result.cursor });
       onChangeDraftMessage(result.text);
     },
-    [draftMessage, onChangeDraftMessage, onUpdateInteractionMode, trigger],
+    [
+      draftMessage,
+      onChangeDraftMessage,
+      onUpdateInteractionMode,
+      selectedProviderStatus?.driver,
+      trigger,
+    ],
   );
 
   return {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -330,6 +330,7 @@ import type { PendingApproval, PendingUserInput } from "../../session-logic";
 import type { ContextWindowSnapshot } from "../../lib/contextWindow";
 import {
   formatProviderSkillDisplayName,
+  formatProviderSkillInvocation,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
 } from "@t3tools/client-runtime/providerSkills";
@@ -2053,7 +2054,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         return;
       }
       if (item.type === "skill") {
-        const replacement = `$${item.skill.name} `;
+        const replacement = `${formatProviderSkillInvocation(item.provider, item.skill.name)} `;
         const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
           snapshot.value,
           trigger.rangeEnd,

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -99,9 +99,10 @@ use the skills and commands from the selected environment and provider.
 
 By default, the `/` menu includes skills. To keep this menu command-only, turn off **Show skills in
 slash menu** in **Settings → General**. Skill results use the `/skill:Skill Name` label and add the
-same `$name` skill token to your message. The original skill name remains searchable. If the provider
-also reports that skill as a native slash command, T3 Code hides the duplicate native entry and keeps
-the `/skill:Skill Name` label.
+provider's invocation text to your message. For Claude, both menus insert `/name`, so skills that
+require explicit user invocation can run. Other providers keep `$name`. The original skill name
+remains searchable. If the provider also reports that skill as a native slash command, T3 Code hides
+the duplicate native entry and keeps the `/skill:Skill Name` label.
 
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -1,12 +1,46 @@
 import { describe, expect, it } from "vite-plus/test";
+import { ProviderDriverKind } from "@t3tools/contracts";
+import { detectComposerTrigger, replaceTextRange } from "@t3tools/shared/composerTrigger";
 
 import {
   dedupeProviderSkillsByName,
   formatProviderSkillDisplayName,
+  formatProviderSkillInvocation,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
   resolveProviderSkillSourceKind,
 } from "./providerSkills.ts";
+
+describe("formatProviderSkillInvocation", () => {
+  it.each([
+    ["claudeAgent", "/clarify"],
+    ["codex", "$clarify"],
+    ["cursor", "$clarify"],
+    ["grok", "$clarify"],
+    ["opencode", "$clarify"],
+  ])("uses the invocation syntax for %s", (driver, expected) => {
+    expect(formatProviderSkillInvocation(ProviderDriverKind.make(driver), "clarify")).toBe(
+      expected,
+    );
+  });
+
+  it.each(["/clar", "$clar", "Please $clar"])(
+    "keeps Claude skill selections as slash invocations in %s",
+    (draft) => {
+      const trigger = detectComposerTrigger(draft, draft.length);
+      expect(trigger).not.toBeNull();
+      if (!trigger) throw new Error("Expected a skill or slash command trigger");
+
+      const replacement = `${formatProviderSkillInvocation(ProviderDriverKind.make("claudeAgent"), "plugin:clarify")} `;
+      const result = replaceTextRange(draft, trigger.rangeStart, trigger.rangeEnd, replacement);
+
+      expect(result).toEqual({
+        text: `${draft.slice(0, trigger.rangeStart)}/plugin:clarify `,
+        cursor: trigger.rangeStart + "/plugin:clarify ".length,
+      });
+    },
+  );
+});
 
 describe("formatProviderSkillDisplayName", () => {
   it("prefers the provider display name", () => {

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -1,4 +1,8 @@
-import type { ServerProviderSkill, ServerProviderSlashCommand } from "@t3tools/contracts";
+import type {
+  ProviderDriverKind,
+  ServerProviderSkill,
+  ServerProviderSlashCommand,
+} from "@t3tools/contracts";
 
 export type ProviderSkillSourceKind = "app" | "repo" | "project" | "personal" | "system" | "other";
 
@@ -23,6 +27,14 @@ export function formatProviderSkillDisplayName(
     return displayName;
   }
   return titleCaseWords(skill.name);
+}
+
+/** Claude needs a slash to authorize skills reserved for explicit user invocation. */
+export function formatProviderSkillInvocation(
+  driver: ProviderDriverKind | undefined,
+  skillName: string,
+): string {
+  return `${driver === "claudeAgent" ? "/" : "$"}${skillName}`;
 }
 
 export function dedupeProviderSkillsByName(


### PR DESCRIPTION
Picking a Claude skill inserted `$name`, so skills with `disable-model-invocation: true` could not run.

Both the `/` and `$` menus now insert `/name` for Claude on web, desktop, and mobile. Other providers keep `$name`. Skill discovery and filtering stay unchanged.

Fixes https://github.com/pingdotgg/t3code/issues/8295

Checks passed: 84 focused composer tests, 4 Claude adapter and prompt-effort tests, web/mobile/client-runtime typechecks, scoped lint, and formatting.

No browser or simulator check. The live Claude check was blocked by expired local OAuth credentials.

Made by GPT-5.6 Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized composer text insertion and shared helper with unit tests; no auth, data, or server-path changes.
> 
> **Overview**
> Fixes composer skill picks for **Claude** by centralizing invocation text in **`formatProviderSkillInvocation`** (`/` for `claudeAgent`, `$` for other drivers).
> 
> **Web** (`ChatComposer`) and **mobile** (`use-composer-command-menu`) now call that helper when a skill row is selected instead of always inserting `$name`, so skills that require explicit user invocation can run on Claude. Discovery, slash-menu labels, and non-Claude behavior stay the same.
> 
> User docs describe the provider-specific insertion rules; **client-runtime** tests cover driver mapping and Claude replacement in triggered drafts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58275d2089cbbb3f7a0eb8d5aa755c8bf149370d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix skill menu to insert provider-specific invocation text for Claude
> - Adds `formatProviderSkillInvocation(driver, skillName)` to [providerSkills.ts](https://github.com/pingdotgg/t3code/pull/9105/files#diff-476dddad7957a4fde40db8096524533f59b357b62c8d01c6d9f05f2c0b12c63c), returning `"/skillName "` for the `claudeAgent` driver and `"$skillName "` for all others
> - Updates both the mobile ([use-composer-command-menu.ts](https://github.com/pingdotgg/t3code/pull/9105/files#diff-765bb6c8049500163389336a7a5e0c83873e041f5b14c72e5f5804359e6492d9)) and web ([ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/9105/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a)) composers to use this function instead of the hardcoded `"$name"` when a skill is selected from the menu
> - Updates [composer.md](https://github.com/pingdotgg/t3code/pull/9105/files#diff-6c496fed927e1ba2296273bdfca78fd482921ebd76a32bb9d0c534f7bda35b63) to document the provider-specific behavior and that Claude uses slash invocations so skills requiring explicit user invocation can run
> - Behavioral Change: skill menu selections now insert `"/skillName "` for Claude instead of `"$skillName "`; the mobile callback also re-renders on `selectedProviderStatus?.driver` changes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58275d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->