### PR TITLE
feat(usage): add month-to-date range

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -9,6 +9,7 @@ import {
   formatPercent,
   formatTokens,
   formatUsd,
+  makeMonthToDateWindow,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
 import { useMemo, useState } from "react";
@@ -25,11 +26,19 @@ import type { UsageChartMetric } from "./usageChartData";
 import { PROVIDER_LABEL, useProviderColors } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
-  { days: 1, label: "Past 24h" },
-  { days: 7, label: "7 days" },
-  { days: 30, label: "30 days" },
-  { days: 90, label: "90 days" },
+  { value: 1, label: "Past 24h" },
+  { value: 7, label: "7 days" },
+  { value: "mtd", label: "MTD" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
 ] as const;
+
+type WindowPeriod = (typeof WINDOW_OPTIONS)[number]["value"];
+
+function makeWindowForPeriod(period: WindowPeriod) {
+  if (period === "mtd") return makeMonthToDateWindow();
+  return makeWindow(period, undefined, period === 1 ? "hour" : "day");
+}
 
 const CHART_HEIGHT = 180;
 
@@ -37,12 +46,12 @@ export function UsageRouteScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const [windowSelection, setWindowSelection] = useState(() => ({
-    days: 30,
+    period: 30 as WindowPeriod,
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
-  const { days: windowDays, window } = windowSelection;
-  const isPast24Hours = windowDays === 1;
+  const { period: windowPeriod, window } = windowSelection;
+  const isPast24Hours = windowPeriod === 1;
   const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
 
   const days = useMemo(
@@ -73,14 +82,14 @@ export function UsageRouteScreen() {
   // before. The initial scan renders its own placeholder, and an unreachable
   // environment stays pending forever — neither may pin the spinner on.
   const refreshing = environments.some((entry) => entry.isPending && entry.summary !== null);
-  const selectWindow = (days: number) => {
+  const selectWindow = (period: WindowPeriod) => {
     setWindowSelection({
-      days,
-      window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
+      period,
+      window: makeWindowForPeriod(period),
     });
   };
   const refreshWindow = () => {
-    const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
+    const nextWindow = makeWindowForPeriod(windowPeriod);
     if (
       nextWindow.sinceDay === window.sinceDay &&
       nextWindow.untilDay === window.untilDay &&
@@ -89,7 +98,7 @@ export function UsageRouteScreen() {
     ) {
       refresh();
     } else {
-      setWindowSelection({ days: windowDays, window: nextWindow });
+      setWindowSelection({ period: windowPeriod, window: nextWindow });
     }
   };
 
@@ -110,8 +119,8 @@ export function UsageRouteScreen() {
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refreshWindow} />}
       >
         <SegmentedControl
-          options={WINDOW_OPTIONS.map((option) => ({ value: option.days, label: option.label }))}
-          selected={windowDays}
+          options={WINDOW_OPTIONS}
+          selected={windowPeriod}
           onSelect={selectWindow}
         />
 

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -16,7 +16,7 @@ vi.mock("react", async (importOriginal) => {
     useState: vi.fn((initial: unknown) => [
       typeof initial === "function"
         ? {
-            days: 1,
+            period: 1,
             window: {
               sinceDay: "2026-08-10",
               untilDay: "2026-08-11",

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -17,6 +17,7 @@ import {
   formatPercent,
   formatTokens,
   formatUsd,
+  makeMonthToDateWindow,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
 import { Button } from "../ui/button";
@@ -35,21 +36,29 @@ import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart"
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
-  { days: 1, label: "Past 24h" },
-  { days: 7, label: "7 days" },
-  { days: 30, label: "30 days" },
-  { days: 90, label: "90 days" },
+  { value: 1, label: "Past 24h" },
+  { value: 7, label: "7 days" },
+  { value: "mtd", label: "MTD" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
 ] as const;
+
+type WindowPeriod = (typeof WINDOW_OPTIONS)[number]["value"];
+
+function makeWindowForPeriod(period: WindowPeriod) {
+  if (period === "mtd") return makeMonthToDateWindow();
+  return makeWindow(period, undefined, period === 1 ? "hour" : "day");
+}
 
 export function UsagePage() {
   const [windowSelection, setWindowSelection] = useState(() => ({
-    days: 30,
+    period: 30 as WindowPeriod,
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
-  const { days: windowDays, window } = windowSelection;
-  const isPast24Hours = windowDays === 1;
+  const { period: windowPeriod, window } = windowSelection;
+  const isPast24Hours = windowPeriod === 1;
   const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
 
   // Hold the content until every environment is terminal. Rendering merged
@@ -86,14 +95,14 @@ export function UsagePage() {
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
 
-  const selectWindow = (days: number) => {
+  const selectWindow = (period: WindowPeriod) => {
     setWindowSelection({
-      days,
-      window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
+      period,
+      window: makeWindowForPeriod(period),
     });
   };
   const refreshWindow = () => {
-    const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
+    const nextWindow = makeWindowForPeriod(windowPeriod);
     if (
       nextWindow.sinceDay === window.sinceDay &&
       nextWindow.untilDay === window.untilDay &&
@@ -102,7 +111,7 @@ export function UsagePage() {
     ) {
       refresh();
     } else {
-      setWindowSelection({ days: windowDays, window: nextWindow });
+      setWindowSelection({ period: windowPeriod, window: nextWindow });
     }
   };
   const windowLabel =
@@ -139,14 +148,15 @@ export function UsagePage() {
         <ToggleGroup
           aria-label="Usage period"
           variant="segmented"
-          value={[String(windowDays)]}
+          value={[String(windowPeriod)]}
           onValueChange={(next) => {
             const value = next[0];
-            if (value) selectWindow(Number(value));
+            const option = WINDOW_OPTIONS.find((candidate) => String(candidate.value) === value);
+            if (option) selectWindow(option.value);
           }}
         >
           {WINDOW_OPTIONS.map((option) => (
-            <Toggle key={option.days} value={String(option.days)}>
+            <Toggle key={option.value} value={String(option.value)}>
               {option.label}
             </Toggle>
           ))}
@@ -175,7 +185,13 @@ export function UsagePage() {
             <SelectItem value="tokens">Tokens</SelectItem>
           </SelectPopup>
         </Select>
-        <Select value={String(windowDays)} onValueChange={(value) => selectWindow(Number(value))}>
+        <Select
+          value={String(windowPeriod)}
+          onValueChange={(value) => {
+            const option = WINDOW_OPTIONS.find((candidate) => String(candidate.value) === value);
+            if (option) selectWindow(option.value);
+          }}
+        >
           <SelectTrigger
             aria-label="Usage period"
             size="compact"
@@ -183,12 +199,12 @@ export function UsagePage() {
             className="w-auto min-w-0"
           >
             <SelectValue>
-              {WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
+              {WINDOW_OPTIONS.find((option) => option.value === windowPeriod)?.label}
             </SelectValue>
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
             {WINDOW_OPTIONS.map((option) => (
-              <SelectItem key={option.days} value={String(option.days)}>
+              <SelectItem key={option.value} value={String(option.value)}>
                 {option.label}
               </SelectItem>
             ))}

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -9,5 +9,6 @@ Grok Build totals come from persisted session updates. Interactive turns that ne
 completed-turn record will not appear.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
-**30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
-headline and chart, and refreshing rescans every connected environment.
+**30 days**, and **90 days** ranges use daily resolution. **MTD** covers the first day of the current
+month through today in your local time zone. Cost and token toggles update both the headline and
+chart, and refreshing rescans every connected environment.

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -6,6 +6,7 @@ import {
   formatDateTimeShort,
   formatHourShort,
   formatRelativeHourShort,
+  makeMonthToDateWindow,
   makeWindow,
 } from "./usageFormat.ts";
 
@@ -53,6 +54,26 @@ describe("hourly usage formatting", () => {
     expect(window.resolution).toBe("hour");
     expect(window.sinceTime).toBe("2026-08-10T12:37:00.000Z");
     expect(window.untilTime).toBe("2026-08-11T12:37:00.000Z");
+  });
+
+  it("builds a month-to-date request in the viewer's time zone", () => {
+    const resolved = new Intl.DateTimeFormat().resolvedOptions();
+    const resolvedOptions = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ ...resolved, timeZone: "America/Los_Angeles" });
+
+    try {
+      const window = makeMonthToDateWindow(new Date("2026-09-01T06:30:00.000Z"));
+
+      expect(window).toMatchObject({
+        sinceDay: "2026-08-01",
+        untilDay: "2026-08-31",
+        timeZone: "America/Los_Angeles",
+        resolution: "day",
+      });
+    } finally {
+      resolvedOptions.mockRestore();
+    }
   });
 
   it("degrades an unknown resolved zone to UTC instead of crashing", () => {

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -230,3 +230,12 @@ export function makeWindow(
     resolution,
   };
 }
+
+/** The current calendar month through today in the viewer's own time zone. */
+export function makeMonthToDateWindow(now = new Date()): UsageSummaryInput {
+  const window = makeWindow(1, now);
+  return {
+    ...window,
+    sinceDay: UsageDay.make(`${window.untilDay.slice(0, 7)}-01`),
+  };
+}


### PR DESCRIPTION
## What Changed

Added an **MTD (month to date)** option to the Usage page on web, desktop, and mobile.

The new range covers the first day of the current month through today using the user’s local time zone. Refreshing the page also recalculates the range when the day or month changes.

## Why

The existing 30-day range is a rolling window, so it can include usage from the previous month. This makes it harder for API-billed users to estimate their current monthly spend.

MTD provides a calendar-aligned view of usage and estimated API costs for the current month.

## UI Changes

### Before

<img width="2804" height="1753" alt="browser-screenshot-localhost-mtj73986" src="https://github.com/user-attachments/assets/20201745-95f0-4b8e-b313-763be4a80ea6" />

### After

<img width="2804" height="1753" alt="Usage page with MTD selected" src="https://github.com/user-attachments/assets/352305c4-5dff-4b88-83d4-7ed7cc5d3481" />

## Verification

- Added coverage for month-to-date boundaries in the user’s local time zone
- Existing Usage page tests pass
- Shared, web, and mobile typechecks pass
- Targeted lint and formatting checks pass

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI and date-window helpers for usage display; no auth, billing, or data-pipeline changes beyond existing usage queries.
> 
> **Overview**
> Adds an **MTD** period to Usage on web and mobile so totals and charts use the **first day of the current calendar month through today** in the viewer’s local time zone, instead of only rolling day windows.
> 
> Shared **`makeMonthToDateWindow`** builds that daily-resolution window (reusing `makeWindow` for “today” and timezone, then setting `sinceDay` to `YYYY-MM-01`). Period selectors now use a **`value`** of `number | "mtd"` with **`makeWindowForPeriod`**, including on refresh when the calendar day rolls over. Web period toggles/selects resolve options by string value so **MTD** is not coerced with `Number()`. User docs and a timezone-focused unit test cover the new range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f15c835c4f5e8bdce9c70f6c20f21754e0ea788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add month-to-date range option to usage screens
> - Adds `makeMonthToDateWindow(now?)` in [usageFormat.ts](https://github.com/pingdotgg/t3code/pull/9108/files#diff-fe92f08893f2c1ba1424fe730fd95fbb0ef2269ab3266b4e47c98aa5ea918552) which builds a daily-resolution window from the first day of the current month to today in the viewer's time zone
> - Updates the mobile and web usage screens to include an MTD option in the period selector, refactoring state from `{ days, window }` to `{ period, window }` where `period` is a union of numbers and `'mtd'`
> - Introduces `makeWindowForPeriod` helper on both platforms that delegates to `makeMonthToDateWindow()` for MTD and preserves hourly resolution for 24h and daily resolution for other numeric ranges
> - Updates tests and [usage.md](https://github.com/pingdotgg/t3code/pull/9108/files#diff-d73591feaa8c26e8f16b7467464af0044ee0a9c288ef17901538a61715440e62) to cover the new option
> - Behavioral Change: `WINDOW_OPTIONS` entries now use `value` instead of `days`; any code referencing the old `days` field on these options will need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f15c83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->