### PR TITLE
fix(server): add fresh pull request viewer verification

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -54,6 +54,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.cloudGetRelayClientStatus]: AuthRelayReadScope,
   [WS_METHODS.cloudInstallRelayClient]: AuthRelayWriteScope,
   [WS_METHODS.pullRequestsList]: AuthOrchestrationReadScope,
+  [WS_METHODS.pullRequestsViewers]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsListStats]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsSummary]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDetail]: AuthOrchestrationReadScope,

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -166,6 +166,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.attachmentUploads).toBe(true);
       expect(second.capabilities.fileAttachments).toEqual({ maxUploadBytes: 50 * 1024 * 1024 });
       expect(second.capabilities.pullRequests).toBe(true);
+      expect(second.capabilities.pullRequestViewers).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -217,6 +217,7 @@ export const make = Effect.gen(function* () {
       attachmentUploads: true,
       fileAttachments: { maxUploadBytes: PROVIDER_SEND_TURN_MAX_FILE_BYTES },
       pullRequests: true,
+      pullRequestViewers: true,
       threadSettlement: true,
       threadAutoSettlement: true,
       threadSnooze: true,

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -727,6 +727,58 @@ it.effect("does not reuse a cached viewer after fresh verification fails", () =>
   }),
 );
 
+it.effect("strands a cold list when fresh verification wins its viewer race", () =>
+  Effect.gen(function* () {
+    const firstViewerStarted = yield* Deferred.make<void>();
+    const releaseFirstViewer = yield* Deferred.make<void>();
+    let viewerCalls = 0;
+    let listCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () =>
+            Effect.gen(function* () {
+              viewerCalls += 1;
+              if (viewerCalls === 1) {
+                yield* Deferred.succeed(firstViewerStarted, undefined);
+                yield* Deferred.await(releaseFirstViewer);
+                return "Bilal";
+              }
+              return "Octocat";
+            }),
+          listChangeRequests: () => {
+            listCalls += 1;
+            return Effect.succeed({
+              items: [changeRequest(listCalls, `2026-07-0${listCalls}T00:00:00Z`)],
+              truncated: false,
+              continues: true,
+            });
+          },
+        }),
+      ],
+    });
+
+    const oldListing = yield* service.list({ state: "open" }).pipe(Effect.forkChild);
+    yield* Deferred.await(firstViewerStarted);
+    assert.deepStrictEqual((yield* service.viewers({})).viewers, { "github.com": "Octocat" });
+
+    yield* Deferred.succeed(releaseFirstViewer, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(oldListing)).viewers, { "github.com": "Bilal" });
+
+    const current = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(current.viewers, { "github.com": "Octocat" });
+    assert.deepStrictEqual(
+      current.entries.map((entry) => entry.number),
+      [2],
+    );
+    assert.strictEqual(viewerCalls, 2);
+    assert.strictEqual(listCalls, 2);
+  }),
+);
+
 it.effect("does not let an older viewer request replace a newer identity", () =>
   Effect.gen(function* () {
     const firstFreshStarted = yield* Deferred.make<void>();

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -698,6 +698,55 @@ it.effect("reads snapshot viewer identity freshly after the host account changes
   }),
 );
 
+it.effect("does not let an older viewer request replace a newer identity", () =>
+  Effect.gen(function* () {
+    const firstFreshStarted = yield* Deferred.make<void>();
+    const releaseFirstFresh = yield* Deferred.make<void>();
+    let viewerCalls = 0;
+    let listCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () =>
+            Effect.gen(function* () {
+              viewerCalls += 1;
+              if (viewerCalls === 2) {
+                yield* Deferred.succeed(firstFreshStarted, undefined);
+                yield* Deferred.await(releaseFirstFresh);
+                return "Bilal";
+              }
+              return viewerCalls === 1 ? "Bilal" : "Octocat";
+            }),
+          listChangeRequests: () => {
+            listCalls += 1;
+            return Effect.succeed({
+              items: [changeRequest(listCalls, `2026-07-0${listCalls}T00:00:00Z`)],
+              truncated: false,
+              continues: true,
+            });
+          },
+        }),
+      ],
+    });
+
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Bilal",
+    });
+    const older = yield* service.viewers({}).pipe(Effect.forkChild);
+    yield* Deferred.await(firstFreshStarted);
+    assert.deepStrictEqual((yield* service.viewers({})).viewers, { "github.com": "Octocat" });
+    yield* Deferred.succeed(releaseFirstFresh, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(older)).viewers, { "github.com": "Bilal" });
+
+    const current = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(current.viewers, { "github.com": "Octocat" });
+    assert.strictEqual(listCalls, 2);
+  }),
+);
+
 it.effect("keeps a healthy host when another host's viewer verification fails", () =>
   Effect.gen(function* () {
     const service = yield* makeService({

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -747,6 +747,46 @@ it.effect("does not let an older viewer request replace a newer identity", () =>
   }),
 );
 
+it.effect("does not let an in-flight viewer request survive invalidation", () =>
+  Effect.gen(function* () {
+    const staleRequestStarted = yield* Deferred.make<void>();
+    const releaseStaleRequest = yield* Deferred.make<void>();
+    let viewerCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () =>
+            Effect.gen(function* () {
+              viewerCalls += 1;
+              if (viewerCalls === 2) {
+                yield* Deferred.succeed(staleRequestStarted, undefined);
+                yield* Deferred.await(releaseStaleRequest);
+              }
+              return viewerCalls < 3 ? "Bilal" : "Octocat";
+            }),
+        }),
+      ],
+    });
+
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Bilal",
+    });
+    const stale = yield* service.viewers({}).pipe(Effect.forkChild);
+    yield* Deferred.await(staleRequestStarted);
+    yield* service.invalidate({});
+    yield* Deferred.succeed(releaseStaleRequest, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(stale)).viewers, { "github.com": "Bilal" });
+
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Octocat",
+    });
+    assert.strictEqual(viewerCalls, 3);
+  }),
+);
+
 it.effect("keeps a healthy host when another host's viewer verification fails", () =>
   Effect.gen(function* () {
     const service = yield* makeService({

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -237,6 +237,44 @@ it.effect("refines unknown self-hosted GitLab projects before listing merge requ
   }),
 );
 
+it.effect("does not refine legacy projects outside the requested project ids", () =>
+  Effect.gen(function* () {
+    const asked: string[] = [];
+    const service = yield* makeService({
+      projects: [
+        project({
+          id: "p1",
+          title: "selected",
+          workspaceRoot: "/selected",
+          repository: "group/selected",
+          provider: "unknown",
+          host: "selected.example.test",
+        }),
+        project({
+          id: "p2",
+          title: "unrelated",
+          workspaceRoot: "/unrelated",
+          repository: "group/unrelated",
+          provider: "unknown",
+          host: "unrelated.example.test",
+        }),
+      ],
+      providers: [fakeProvider("gitlab")],
+      resolveHandle: ({ cwd, context }) => {
+        asked.push(cwd);
+        return Effect.succeed({
+          context: { ...context!, provider: { ...context!.provider, kind: "gitlab" } },
+          provider: undefined as never,
+        });
+      },
+    });
+
+    yield* service.viewers({ projectIds: ["p1" as ProjectId] });
+
+    assert.deepStrictEqual(asked, ["/selected"]);
+  }),
+);
+
 it.effect("derives a legacy repository host after refining its provider", () =>
   Effect.gen(function* () {
     const current = project({
@@ -635,6 +673,113 @@ it.effect("calls a transient viewer failure a failed operation, not a signed-out
 
     // `cli-unauthenticated` would send the reader to `gh auth login` over a transient error.
     assert.strictEqual(error._tag, "PullRequestOperationError");
+  }),
+);
+
+it.effect("reads snapshot viewer identity freshly after the host account changes", () =>
+  Effect.gen(function* () {
+    let viewer = "Bilal";
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [fakeProvider("github", { getViewer: () => Effect.succeed(viewer) })],
+    });
+
+    const listing = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(listing.viewers, { "github.com": "Bilal" });
+
+    viewer = "Octocat";
+    const identity = yield* service.viewers({});
+    assert.deepStrictEqual(identity.viewers, { "github.com": "Octocat" });
+
+    const refreshedListing = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(refreshedListing.viewers, { "github.com": "Octocat" });
+  }),
+);
+
+it.effect("keeps a healthy host when another host's viewer verification fails", () =>
+  Effect.gen(function* () {
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "github", workspaceRoot: "/a", repository: "acme/web" }),
+        project({
+          id: "p2",
+          title: "gitlab",
+          workspaceRoot: "/b",
+          repository: "acme/api",
+          provider: "gitlab",
+        }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () => Effect.fail(requestFailed),
+        }),
+        fakeProvider("gitlab", {
+          getViewer: () => Effect.succeed("healthy-viewer"),
+        }),
+      ],
+    });
+
+    const result = yield* service.viewers({});
+
+    assert.deepStrictEqual(result.viewers, { "gitlab.com": "healthy-viewer" });
+  }),
+);
+
+it.effect("strands a list that was in flight when the host account changed", () =>
+  Effect.gen(function* () {
+    const firstListStarted = yield* Deferred.make<void>();
+    const releaseFirstList = yield* Deferred.make<void>();
+    let viewer = "Bilal";
+    let listCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () => Effect.succeed(viewer),
+          listChangeRequests: () =>
+            Effect.gen(function* () {
+              listCalls += 1;
+              const call = listCalls;
+              if (call === 1) {
+                yield* Deferred.succeed(firstListStarted, undefined);
+                yield* Deferred.await(releaseFirstList);
+              }
+              return {
+                items: [changeRequest(call, `2026-07-0${call}T00:00:00Z`)],
+                truncated: false,
+                continues: true,
+              };
+            }),
+        }),
+      ],
+    });
+
+    const oldListing = yield* service.list({ state: "open" }).pipe(Effect.forkChild);
+    yield* Deferred.await(firstListStarted);
+
+    viewer = "Octocat";
+    assert.deepStrictEqual((yield* service.viewers({})).viewers, { "github.com": "Octocat" });
+
+    const current = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(current.viewers, { "github.com": "Octocat" });
+    assert.deepStrictEqual(
+      current.entries.map((entry) => entry.number),
+      [2],
+    );
+
+    yield* Deferred.succeed(releaseFirstList, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(oldListing)).viewers, { "github.com": "Bilal" });
+
+    const cached = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(
+      cached.entries.map((entry) => entry.number),
+      [2],
+    );
+    assert.strictEqual(listCalls, 2);
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -698,6 +698,35 @@ it.effect("reads snapshot viewer identity freshly after the host account changes
   }),
 );
 
+it.effect("does not reuse a cached viewer after fresh verification fails", () =>
+  Effect.gen(function* () {
+    let viewerCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () => {
+            viewerCalls += 1;
+            if (viewerCalls === 2) return Effect.fail(requestFailed);
+            return Effect.succeed(viewerCalls === 1 ? "Bilal" : "Octocat");
+          },
+        }),
+      ],
+    });
+
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Bilal",
+    });
+    assert.deepStrictEqual((yield* service.viewers({})).viewers, {});
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Octocat",
+    });
+    assert.strictEqual(viewerCalls, 3);
+  }),
+);
+
 it.effect("does not let an older viewer request replace a newer identity", () =>
   Effect.gen(function* () {
     const firstFreshStarted = yield* Deferred.make<void>();

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -846,10 +846,12 @@ export const make = Effect.gen(function* () {
           const roots =
             viewerRoots.get(host) ?? forHost.map(({ project }) => project.workspaceRoot);
           const uniqueRoots = [...new Set(roots)].sort();
-          if (options.fresh === true) {
-            return readViewer(host, api.kind, uniqueRoots, options);
-          }
           const key = JSON.stringify([host, api.kind, uniqueRoots]);
+          if (options.fresh === true) {
+            return readViewer(host, api.kind, uniqueRoots, options).pipe(
+              Effect.tap(() => Cache.invalidate(viewerFlights, key)),
+            );
+          }
           return Cache.get(viewerFlights, key);
         }),
       { concurrency: REPOSITORY_CONCURRENCY },

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -51,6 +51,8 @@ import {
   type PullRequestThreadCommentsInput,
   type PullRequestThreadCommentsResult,
   type PullRequestUpdateInput,
+  type PullRequestViewerInput,
+  type PullRequestViewerResult,
   type SourceControlProviderInfo,
   type SourceControlProviderKind,
 } from "@t3tools/contracts";
@@ -133,6 +135,9 @@ export type PullRequestError = PullRequestUnavailableError | PullRequestOperatio
 export class PullRequestService extends Context.Service<
   PullRequestService,
   {
+    readonly viewers: (
+      input: PullRequestViewerInput,
+    ) => Effect.Effect<PullRequestViewerResult, PullRequestError>;
     readonly list: (
       input: PullRequestListInput,
     ) => Effect.Effect<PullRequestListResult, PullRequestError>;
@@ -538,7 +543,7 @@ export const make = Effect.gen(function* () {
 
   const refineUnknownProjectKinds = (
     projects: ReadonlyArray<OrchestrationProjectShell>,
-    filter: Pick<PullRequestListInput, "projectId" | "host">,
+    filter: Pick<PullRequestListInput, "projectId" | "projectIds" | "host">,
   ) => {
     type RefinementCandidate = {
       readonly project: OrchestrationProjectShell;
@@ -549,6 +554,7 @@ export const make = Effect.gen(function* () {
     const refinements = new Map<string, RefinementCandidate[]>();
     for (const project of projects) {
       if (filter.projectId !== undefined && project.id !== filter.projectId) continue;
+      if (filter.projectIds !== undefined && !filter.projectIds.includes(project.id)) continue;
       const identity = project.repositoryIdentity;
       if (identity?.provider !== "unknown" || repositoryIdentityOf(project) === null) continue;
       const host = pullRequestHostOf(identity, "unknown");
@@ -744,6 +750,8 @@ export const make = Effect.gen(function* () {
   // per read, three reads per page. Only a success is believed for a while: a failure is the
   // "is this host set up" answer the provider switcher shows, and holding it would keep saying
   // signed-out after the reader has signed in.
+  let epochCounter = 0;
+  let listingsEpoch = 0;
   const viewersByHost = new Map<string, { readonly at: number; readonly result: ResolvedViewer }>();
   const viewerFlights = yield* Cache.makeWith(
     (key: string): Effect.Effect<ResolvedViewer> => {
@@ -789,13 +797,18 @@ export const make = Effect.gen(function* () {
   const resolveViewers = (
     projects: ReadonlyArray<SupportedProject>,
     viewerRoots: WorkspaceProjects["viewerRoots"],
+    options: { readonly fresh?: boolean } = {},
   ) =>
     Effect.forEach(
       [...new Set(projects.map(({ host }) => host))],
       (host) =>
         Effect.flatMap(Clock.currentTimeMillis, (now): Effect.Effect<ResolvedViewer> => {
           const held = viewersByHost.get(host);
-          if (held !== undefined && now - held.at <= Duration.toMillis(VIEWER_CACHE_TTL)) {
+          if (
+            options.fresh !== true &&
+            held !== undefined &&
+            now - held.at <= Duration.toMillis(VIEWER_CACHE_TTL)
+          ) {
             return Effect.succeed(held.result);
           }
           const forHost = projects.filter((project) => project.host === host);
@@ -804,10 +817,58 @@ export const make = Effect.gen(function* () {
           // unreadable worktree would otherwise report the whole host as signed out.
           const roots =
             viewerRoots.get(host) ?? forHost.map(({ project }) => project.workspaceRoot);
-          const key = JSON.stringify([host, api.kind, [...new Set(roots)].sort()]);
+          const uniqueRoots = [...new Set(roots)].sort();
+          const fresh = Effect.firstSuccessOf(uniqueRoots.map((cwd) => api.getViewer({ cwd }))).pipe(
+            Effect.map((viewer) => ({
+              host,
+              kind: api.kind,
+              viewer: viewer as string | null,
+              error: null as PullRequestProviderError | null,
+            })),
+            Effect.tap((result) =>
+              Effect.map(Clock.currentTimeMillis, (at) => {
+                if (
+                  options.fresh === true &&
+                  held !== undefined &&
+                  held.result.viewer !== result.viewer
+                ) {
+                  listingsEpoch = ++epochCounter;
+                }
+                viewersByHost.set(host, { at, result });
+              }),
+            ),
+            Effect.catch((error) =>
+              Effect.sync(() => {
+                if (options.fresh === true && held !== undefined && held.result.viewer !== null) {
+                  listingsEpoch = ++epochCounter;
+                }
+                viewersByHost.delete(host);
+                return { host, kind: api.kind, viewer: null, error };
+              }),
+            ),
+          );
+          if (options.fresh === true) return fresh;
+          const key = JSON.stringify([host, api.kind, uniqueRoots]);
           return Cache.get(viewerFlights, key);
         }),
       { concurrency: REPOSITORY_CONCURRENCY },
+    );
+
+  // Snapshot hydration needs identity before the slower repository listing has answered. This
+  // read deliberately bypasses the viewer cache: an account can be switched outside T3, and a
+  // cached identity must never authorize rows persisted for the previous account.
+  const viewers: PullRequestService["Service"]["viewers"] = (input) =>
+    listWorkspaceProjects(input).pipe(
+      Effect.flatMap(({ supported, viewerRoots }) =>
+        resolveViewers(supported, viewerRoots, { fresh: true }),
+      ),
+      Effect.map((results) => ({
+        viewers: Object.fromEntries(
+          results.flatMap((result) =>
+            result.viewer === null ? [] : [[result.host, result.viewer] as const],
+          ),
+        ),
+      })),
     );
 
   /**
@@ -2121,8 +2182,6 @@ export const make = Effect.gen(function* () {
   // epoch strands every entry made under the old one — no enumerating a cache whose keys
   // (cursors, commits) nothing holds a list of. The counter is shared and monotonic so a
   // scope re-entering `refEpochs` after eviction can never mint a key an old entry still has.
-  let epochCounter = 0;
-  let listingsEpoch = 0;
   const refEpochs = new Map<string, number>();
   const REF_EPOCH_CAPACITY = 2_048;
   const refScope = (ref: PullRequestRef) => `${ref.projectId} ${ref.repository} ${ref.number}`;
@@ -2429,6 +2488,7 @@ export const make = Effect.gen(function* () {
   });
 
   return PullRequestService.of({
+    viewers,
     list,
     listStats,
     summary,

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -752,7 +752,58 @@ export const make = Effect.gen(function* () {
   // signed-out after the reader has signed in.
   let epochCounter = 0;
   let listingsEpoch = 0;
+  let viewerRequestCounter = 0;
   const viewersByHost = new Map<string, { readonly at: number; readonly result: ResolvedViewer }>();
+  const latestViewerRequestByHost = new Map<string, number>();
+  const readViewer = Effect.fn("PullRequestService.readViewer")(function* (
+    host: string,
+    kind: SourceControlProviderKind,
+    roots: ReadonlyArray<string>,
+    options: { readonly fresh?: boolean } = {},
+  ) {
+    const registered = registry.get(kind);
+    if (registered === null) {
+      return yield* Effect.die(new Error(`Missing pull request provider: ${kind}`));
+    }
+    const api = withRateLimitBackoff(registered, host, rateLimits);
+    const held = viewersByHost.get(host);
+    const request = ++viewerRequestCounter;
+    latestViewerRequestByHost.set(host, request);
+    return yield* Effect.firstSuccessOf(roots.map((cwd) => api.getViewer({ cwd }))).pipe(
+      Effect.map((viewer) => ({
+        host,
+        kind,
+        viewer: viewer as string | null,
+        error: null as PullRequestProviderError | null,
+      })),
+      Effect.tap((result) =>
+        Effect.map(Clock.currentTimeMillis, (at) => {
+          if (latestViewerRequestByHost.get(host) !== request) return;
+          if (
+            options.fresh === true &&
+            held !== undefined &&
+            held.result.viewer !== result.viewer
+          ) {
+            listingsEpoch = ++epochCounter;
+          }
+          viewersByHost.set(host, { at, result });
+        }),
+      ),
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          if (latestViewerRequestByHost.get(host) !== request) {
+            return { host, kind, viewer: null, error };
+          }
+          if (options.fresh === true && held !== undefined && held.result.viewer !== null) {
+            listingsEpoch = ++epochCounter;
+          }
+          viewersByHost.delete(host);
+          return { host, kind, viewer: null, error };
+        }),
+      ),
+    );
+  });
+
   const viewerFlights = yield* Cache.makeWith(
     (key: string): Effect.Effect<ResolvedViewer> => {
       const [host, kind, roots] = JSON.parse(key) as [
@@ -760,30 +811,7 @@ export const make = Effect.gen(function* () {
         SourceControlProviderKind,
         ReadonlyArray<string>,
       ];
-      const registered = registry.get(kind);
-      if (registered === null) {
-        return Effect.die(new Error(`Missing pull request provider: ${kind}`));
-      }
-      const api = withRateLimitBackoff(registered, host, rateLimits);
-      return Effect.firstSuccessOf(roots.map((cwd) => api.getViewer({ cwd }))).pipe(
-        Effect.map((viewer) => ({
-          host,
-          kind,
-          viewer: viewer as string | null,
-          error: null as PullRequestProviderError | null,
-        })),
-        Effect.tap((result) =>
-          Effect.map(Clock.currentTimeMillis, (at) => viewersByHost.set(host, { at, result })),
-        ),
-        Effect.catch((error) =>
-          Effect.succeed({
-            host,
-            kind,
-            viewer: null,
-            error,
-          }),
-        ),
-      );
+      return readViewer(host, kind, roots);
     },
     {
       capacity: VIEWER_CACHE_CAPACITY,
@@ -818,36 +846,9 @@ export const make = Effect.gen(function* () {
           const roots =
             viewerRoots.get(host) ?? forHost.map(({ project }) => project.workspaceRoot);
           const uniqueRoots = [...new Set(roots)].sort();
-          const fresh = Effect.firstSuccessOf(uniqueRoots.map((cwd) => api.getViewer({ cwd }))).pipe(
-            Effect.map((viewer) => ({
-              host,
-              kind: api.kind,
-              viewer: viewer as string | null,
-              error: null as PullRequestProviderError | null,
-            })),
-            Effect.tap((result) =>
-              Effect.map(Clock.currentTimeMillis, (at) => {
-                if (
-                  options.fresh === true &&
-                  held !== undefined &&
-                  held.result.viewer !== result.viewer
-                ) {
-                  listingsEpoch = ++epochCounter;
-                }
-                viewersByHost.set(host, { at, result });
-              }),
-            ),
-            Effect.catch((error) =>
-              Effect.sync(() => {
-                if (options.fresh === true && held !== undefined && held.result.viewer !== null) {
-                  listingsEpoch = ++epochCounter;
-                }
-                viewersByHost.delete(host);
-                return { host, kind: api.kind, viewer: null, error };
-              }),
-            ),
-          );
-          if (options.fresh === true) return fresh;
+          if (options.fresh === true) {
+            return readViewer(host, api.kind, uniqueRoots, options);
+          }
           const key = JSON.stringify([host, api.kind, uniqueRoots]);
           return Cache.get(viewerFlights, key);
         }),

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2452,7 +2452,10 @@ export const make = Effect.gen(function* () {
     }
     return Effect.sync(() => {
       listingsEpoch = ++epochCounter;
+      // A whole-workspace refresh is the reader asking to be re-answered from the hosts,
+      // and that includes who the hosts say they are.
       viewersByHost.clear();
+      latestViewerRequestByHost.clear();
     }).pipe(Effect.andThen(Cache.invalidateAll(viewerFlights)));
   };
 

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -779,11 +779,7 @@ export const make = Effect.gen(function* () {
       Effect.tap((result) =>
         Effect.map(Clock.currentTimeMillis, (at) => {
           if (latestViewerRequestByHost.get(host) !== request) return;
-          if (
-            options.fresh === true &&
-            held !== undefined &&
-            held.result.viewer !== result.viewer
-          ) {
+          if (options.fresh === true && held?.result.viewer !== result.viewer) {
             listingsEpoch = ++epochCounter;
           }
           viewersByHost.set(host, { at, result });
@@ -794,7 +790,7 @@ export const make = Effect.gen(function* () {
           if (latestViewerRequestByHost.get(host) !== request) {
             return { host, kind, viewer: null, error };
           }
-          if (options.fresh === true && held !== undefined && held.result.viewer !== null) {
+          if (options.fresh === true && held?.result.viewer !== null) {
             listingsEpoch = ++epochCounter;
           }
           viewersByHost.delete(host);

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1890,6 +1890,10 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.pullRequestsList, pullRequests.list(input), {
             "rpc.aggregate": "pull-requests",
           }),
+        [WS_METHODS.pullRequestsViewers]: (input) =>
+          observeRpcEffect(WS_METHODS.pullRequestsViewers, pullRequests.viewers(input), {
+            "rpc.aggregate": "pull-requests",
+          }),
         [WS_METHODS.pullRequestsListStats]: (input) =>
           observeRpcEffect(WS_METHODS.pullRequestsListStats, pullRequests.listStats(input), {
             "rpc.aggregate": "pull-requests",

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -7,6 +7,10 @@ import {
   mergePullRequestLists,
   pullRequestEntryKey,
   pullRequestEnvironmentSetKey,
+  pullRequestListViewersMatchVerification,
+  retainPullRequestEntriesForVerifiedViewers,
+  pullRequestViewersMatch,
+  pullRequestViewersMatchForEnvironments,
   groupPullRequestsByInvolvement,
   matchesPullRequestFilters,
   matchesPullRequestQuery,
@@ -19,6 +23,7 @@ import {
   narrowPullRequestsToFilters,
   partitionPullRequestsWithPriority,
   readPullRequestListSnapshot,
+  resolvePullRequestRetainedVerification,
   writePullRequestListSnapshot,
   rankPullRequestMatches,
   rankPullRequestsByMergeReadiness,
@@ -26,6 +31,7 @@ import {
   retainVisiblePullRequestStatsBatches,
   withDiffStat,
   resolveProjectScope,
+  resolvePullRequestViewerGate,
   resolveQueryEnvironmentIds,
   resolveSelectedEnvironmentId,
   type EnvironmentPullRequestEntry,
@@ -857,6 +863,7 @@ describe("partitioning with the hosts' own priority reads", () => {
 });
 
 describe("the list snapshot across a reload", () => {
+  const NOW = Date.parse("2026-08-13T12:00:00Z");
   const makeStorage = () => {
     const held = new Map<string, string>();
     return {
@@ -872,27 +879,295 @@ describe("the list snapshot across a reload", () => {
     truncated: true,
     nextCursors: { "pingdotgg/t3code": "cursor-1" },
   } as never;
+  const readSnapshot = (
+    storage: ReturnType<typeof makeStorage> | undefined,
+    environmentKey: string,
+    viewers: Record<string, string> = { "github.com": "Bilal" },
+    now = NOW,
+  ) => readPullRequestListSnapshot(storage, environmentKey, { viewers, now });
+
+  it("compares viewer identities independently of host insertion order", () => {
+    expect(
+      pullRequestViewersMatch(
+        { "env-1 github.com": "Bilal", "env-2 gitlab.com": "Theo" },
+        { "env-2 gitlab.com": "Theo", "env-1 github.com": "Bilal" },
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatch({ "env-1 github.com": "Bilal" }, { "env-1 github.com": "Octocat" }),
+    ).toBe(false);
+  });
+
+  it("compares only the viewer-capable environments in a mixed-server list", () => {
+    const capable = new Set(["env-1"]);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Octocat" },
+        capable,
+      ),
+    ).toBe(false);
+    expect(
+      pullRequestViewersMatchForEnvironments({ "env-1 github.com": "Bilal" }, {}, capable),
+    ).toBe(false);
+  });
+
+  it("compares only retained hosts relevant to a narrower scope", () => {
+    const capable = new Set(["env-1"]);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+        new Set(["env-1 github.com"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Octocat" },
+        capable,
+        new Set(["env-1 github.com"]),
+      ),
+    ).toBe(false);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+        new Set(["env-1 gitlab.com"]),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts live rows when the current scope queries only legacy servers", () => {
+    expect(
+      pullRequestListViewersMatchVerification({ "env-2 github.com": "Legacy" }, null, new Set()),
+    ).toBe(true);
+  });
+
+  it("accepts legacy rows when a separate capable server fails viewer verification", () => {
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-2 github.com": "Legacy" },
+        null,
+        new Set(["env-1"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Bilal" },
+        null,
+        new Set(["env-1"]),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a verified continuation page from only the hosts with cursors", () => {
+    const capable = new Set(["env-1", "env-2"]);
+    const verified = {
+      "env-1 github.com": "Bilal",
+      "env-2 github.com": "Octocat",
+    };
+
+    expect(
+      pullRequestListViewersMatchVerification({ "env-1 github.com": "Bilal" }, verified, capable),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification({ "env-1 github.com": "Octocat" }, verified, capable),
+    ).toBe(false);
+  });
+
+  it("accepts live rows when fresh verification could not read one host", () => {
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Octocat", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(false);
+  });
+
+  it("retains only rows whose capable hosts still have the same verified viewer", () => {
+    const github = entry({ environmentId: ENV_1, host: "github.com", number: 1 });
+    const gitlab = entry({ environmentId: ENV_1, host: "gitlab.com", number: 2 });
+    const legacy = entry({ environmentId: ENV_2, host: "github.com", number: 3 });
+
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, gitlab, legacy],
+        {
+          "env-1 github.com": "Bilal",
+          "env-1 gitlab.com": "Theo",
+          "env-2 github.com": "Legacy",
+        },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ).map((item) => item.number),
+    ).toEqual([1, 3]);
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, entry({ environmentId: ENV_2, host: "github.com", number: 4 })],
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Octocat" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1", "env-2"]),
+      ).map((item) => item.number),
+    ).toEqual([1]);
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, legacy],
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        {},
+        new Set(["env-1"]),
+      ).map((item) => item.number),
+    ).toEqual([3]);
+
+    const alreadyVerified = [github, legacy];
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        alreadyVerified,
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(alreadyVerified);
+  });
+
+  it("removes the old account before accepting the replacement account's rows", () => {
+    const previous = entry({ number: 1 });
+    const queriedEnvironments = new Set(["env-1"]);
+
+    const verifying = resolvePullRequestRetainedVerification({
+      verificationPending: true,
+      verificationFailed: false,
+      viewerMismatch: false,
+      entries: [previous],
+      ordered: [previous],
+      listedViewers: { "env-1 github.com": "Bilal" },
+      verifiedViewers: null,
+      queriedEnvironmentIds: queriedEnvironments,
+    });
+    expect(verifying.status).toBe("verifying");
+
+    const changed = resolvePullRequestRetainedVerification({
+      verificationPending: false,
+      verificationFailed: false,
+      viewerMismatch: true,
+      entries: [previous],
+      ordered: [previous],
+      listedViewers: { "env-1 github.com": "Bilal" },
+      verifiedViewers: { "env-1 github.com": "Octocat" },
+      queriedEnvironmentIds: queriedEnvironments,
+    });
+    expect(changed).toMatchObject({
+      status: "accountChanged",
+      entries: [],
+      ordered: [],
+      changed: true,
+      empty: true,
+    });
+
+    const replacement = entry({ number: 2 });
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Octocat" },
+        { "env-1 github.com": "Octocat" },
+        queriedEnvironments,
+      ),
+    ).toBe(true);
+    expect(replacement.number).toBe(2);
+  });
 
   it("hydrates the retained rows so ghosts never replace them", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data }, NOW);
+    const snapshot = readSnapshot(storage, "env-1");
     expect(snapshot?.scope).toBe("env-1:open:all::");
     expect(snapshot?.data.entries.map((item) => item.number)).toEqual([1]);
   });
 
+  it("hydrates across scopes only when every relevant row keeps its viewer", () => {
+    const storage = makeStorage();
+    const github = entry({ environmentId: ENV_1, host: "github.com", number: 1 });
+    const gitlab = entry({ environmentId: ENV_1, host: "gitlab.com", number: 2 });
+    writePullRequestListSnapshot(
+      storage,
+      "env-1",
+      {
+        scope: "broad",
+        data: {
+          entries: [github, gitlab],
+          viewers: { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+          providers: [],
+          errors: [],
+          truncated: false,
+          nextCursors: {},
+          truncatedEnvironments: [],
+        },
+      },
+      NOW,
+    );
+    const readGithub = (viewer: string | undefined) =>
+      readPullRequestListSnapshot(storage, "env-1", {
+        viewers: viewer === undefined ? {} : { "env-1 github.com": viewer },
+        now: NOW,
+        includeEntry: (item) => item.host === "github.com",
+      });
+
+    expect(readGithub("Bilal")?.data.entries.map((item) => item.host)).toEqual(["github.com"]);
+    expect(readGithub("Octocat")).toBeNull();
+    expect(readGithub(undefined)).toBeNull();
+  });
+
   it("carries neither stale failures nor stale cursors", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+    const snapshot = readSnapshot(storage, "env-1");
     expect(snapshot?.data.errors).toEqual([]);
     expect(snapshot?.data.nextCursors).toEqual({});
   });
 
   it("answers nothing for another environment", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data });
-    expect(readPullRequestListSnapshot(storage, "env-2")).toBeNull();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+    expect(readSnapshot(storage, "env-2")).toBeNull();
+  });
+
+  it("rejects snapshots from another host account", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(readSnapshot(storage, "env-1", { "github.com": "Octocat" })).toBeNull();
+  });
+
+  it("rejects an existing snapshot when viewer verification failed", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(readPullRequestListSnapshot(storage, "env-1", { viewers: null, now: NOW })).toBeNull();
+  });
+
+  it("rejects snapshots after their short reload window", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(
+      readSnapshot(storage, "env-1", { "github.com": "Bilal" }, NOW + 5 * 60 * 1_000 + 1),
+    ).toBeNull();
   });
 
   it("rejects a snapshot whose rows do not decode as entries", () => {
@@ -901,19 +1176,19 @@ describe("the list snapshot across a reload", () => {
       "t3.pullRequests.list:env-1",
       JSON.stringify({ scope: "s", data: { entries: [null] } }),
     );
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
     storage.setItem(
       "t3.pullRequests.list:env-1",
       JSON.stringify({ scope: "s", data: { entries: [{ host: "github.com" }] } }),
     );
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
   });
 
   it("shrugs off corrupt storage and no storage at all", () => {
     const storage = makeStorage();
     storage.setItem("t3.pullRequests.list:env-1", "{not json");
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
-    expect(readPullRequestListSnapshot(undefined, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(undefined, "env-1")).toBeNull();
   });
 
   it("caps the accumulated rows but keeps the whole host set", () => {
@@ -949,8 +1224,8 @@ describe("the list snapshot across a reload", () => {
       truncated: true,
       nextCursors: {},
     } as never;
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data: accumulated });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data: accumulated }, NOW);
+    const snapshot = readSnapshot(storage, "env-1", viewers);
     expect(snapshot?.data.entries).toHaveLength(99);
     expect(snapshot?.data.viewers).toEqual(viewers);
     expect(snapshot?.data.providers).toEqual(providers);
@@ -1027,6 +1302,32 @@ describe("remembered pull request list controls", () => {
 
 const ENV_1 = "env-1" as EnvironmentId;
 const ENV_2 = "env-2" as EnvironmentId;
+
+describe("viewer verification gating", () => {
+  it("withholds a capable server while account verification races an in-flight list", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set([ENV_1]), [ENV_1], true);
+
+    expect(gate.listEnvironmentIds).toEqual([]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(false);
+  });
+
+  it("keeps live lists working on old servers without trusting their snapshots", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set(), [], false);
+
+    expect(gate.listEnvironmentIds).toEqual([ENV_1]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(false);
+  });
+
+  it("clears retained rows once viewer verification has actually failed", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set([ENV_1]), [], false);
+
+    expect(gate.listEnvironmentIds).toEqual([]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(true);
+  });
+});
 
 describe("merging the environments' own listings", () => {
   const answer = (

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -909,6 +909,13 @@ describe("the list snapshot across a reload", () => {
     ).toBe(true);
     expect(
       pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal" },
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Octocat" },
+        capable,
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatchForEnvironments(
         { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
         { "env-1 github.com": "Octocat" },
         capable,

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -823,16 +823,18 @@ export const pullRequestViewersMatchForEnvironments = (
   requiredViewerKeys?: ReadonlySet<string>,
 ): boolean => {
   const prefixes = [...environmentIds].map((environmentId) => `${environmentId} `);
+  const belongsToEnvironment = (key: string) => prefixes.some((prefix) => key.startsWith(prefix));
   const scopedListedViewers = Object.fromEntries(
-    Object.entries(listedViewers).filter(([key]) =>
-      prefixes.some((prefix) => key.startsWith(prefix)),
-    ),
+    Object.entries(listedViewers).filter(([key]) => belongsToEnvironment(key)),
   );
   if (requiredViewerKeys === undefined) {
-    return pullRequestViewersMatch(scopedListedViewers, verifiedViewers);
+    const scopedVerifiedViewers = Object.fromEntries(
+      Object.entries(verifiedViewers).filter(([key]) => belongsToEnvironment(key)),
+    );
+    return pullRequestViewersMatch(scopedListedViewers, scopedVerifiedViewers);
   }
   return [...requiredViewerKeys]
-    .filter((key) => prefixes.some((prefix) => key.startsWith(prefix)))
+    .filter(belongsToEnvironment)
     .every(
       (key) =>
         scopedListedViewers[key] !== undefined && scopedListedViewers[key] === verifiedViewers[key],

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -741,6 +741,8 @@ export function mergePullRequestLists(
 
 /** One page is what the list itself starts with, and all a cold start needs to look warm. */
 const SNAPSHOT_MAX_ENTRIES = 99;
+/** A persisted list is only a short bridge across a reload, never a durable source of truth. */
+const SNAPSHOT_MAX_AGE_MS = 5 * 60 * 1_000;
 
 type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
 
@@ -751,6 +753,40 @@ type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
  */
 export const pullRequestEnvironmentSetKey = (environmentIds: ReadonlyArray<string>): string =>
   [...environmentIds].sort((left, right) => left.localeCompare(right)).join(",");
+
+export function resolvePullRequestViewerGate<Id extends string>(
+  environmentIds: ReadonlyArray<Id>,
+  viewerCapableEnvironmentIds: ReadonlySet<Id>,
+  verifiedEnvironmentIds: ReadonlyArray<Id>,
+  verificationPending: boolean,
+): {
+  readonly listEnvironmentIds: ReadonlyArray<Id>;
+  readonly canHydrateSnapshot: boolean;
+  readonly shouldClearRetainedRows: boolean;
+} {
+  const verified = new Set(verifiedEnvironmentIds);
+  const hasUnverifiedCapableEnvironment = environmentIds.some(
+    (environmentId) =>
+      viewerCapableEnvironmentIds.has(environmentId) && !verified.has(environmentId),
+  );
+  return {
+    listEnvironmentIds: environmentIds.filter(
+      (environmentId) =>
+        !viewerCapableEnvironmentIds.has(environmentId) ||
+        (!verificationPending && verified.has(environmentId)),
+    ),
+    canHydrateSnapshot:
+      environmentIds.length > 0 &&
+      !verificationPending &&
+      environmentIds.every(
+        (environmentId) =>
+          viewerCapableEnvironmentIds.has(environmentId) && verified.has(environmentId),
+      ),
+    // A refresh in flight still carries the identity this session already verified. Keep those
+    // rows visible until the read settles; only a settled failure proves they cannot be retained.
+    shouldClearRetainedRows: !verificationPending && hasUnverifiedCapableEnvironment,
+  };
+}
 
 const snapshotStorageKey = (environmentSetKey: string) =>
   `t3.pullRequests.list:${environmentSetKey}`;
@@ -766,9 +802,148 @@ export interface PullRequestPartitionsSnapshot {
 }
 
 export interface PullRequestListSnapshot {
+  readonly writtenAt: number;
   readonly scope: string;
   readonly data: MergedPullRequestList;
   readonly partitions?: PullRequestPartitionsSnapshot | undefined;
+}
+
+const viewerIdentity = (viewers: PullRequestViewers): string =>
+  JSON.stringify(Object.entries(viewers).toSorted(([left], [right]) => left.localeCompare(right)));
+
+export const pullRequestViewersMatch = (
+  left: PullRequestViewers,
+  right: PullRequestViewers,
+): boolean => viewerIdentity(left) === viewerIdentity(right);
+
+export const pullRequestViewersMatchForEnvironments = (
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers,
+  environmentIds: ReadonlySet<string>,
+  requiredViewerKeys?: ReadonlySet<string>,
+): boolean => {
+  const prefixes = [...environmentIds].map((environmentId) => `${environmentId} `);
+  const scopedListedViewers = Object.fromEntries(
+    Object.entries(listedViewers).filter(([key]) =>
+      prefixes.some((prefix) => key.startsWith(prefix)),
+    ),
+  );
+  if (requiredViewerKeys === undefined) {
+    return pullRequestViewersMatch(scopedListedViewers, verifiedViewers);
+  }
+  return [...requiredViewerKeys]
+    .filter((key) => prefixes.some((prefix) => key.startsWith(prefix)))
+    .every(
+      (key) =>
+        scopedListedViewers[key] !== undefined && scopedListedViewers[key] === verifiedViewers[key],
+    );
+};
+
+export const pullRequestListViewersMatchVerification = (
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers | null,
+  verifiedEnvironmentIds: ReadonlySet<string>,
+): boolean => {
+  if (verifiedEnvironmentIds.size === 0) return true;
+
+  const prefixes = [...verifiedEnvironmentIds].map((environmentId) => `${environmentId} `);
+  const scopedViewers = Object.entries(listedViewers).filter(([key]) =>
+    prefixes.some((prefix) => key.startsWith(prefix)),
+  );
+  if (scopedViewers.length === 0) return true;
+  if (verifiedViewers === null) return false;
+  // The gated live list runs after the fresh viewer read. A host omitted by that read has had its
+  // server cache cleared, so the list's own viewer is a fresh retry; only a known disagreement is
+  // an account switch. Snapshot and retained-row checks remain strict about missing identities.
+  return scopedViewers.every(
+    ([key, viewer]) => verifiedViewers[key] === undefined || verifiedViewers[key] === viewer,
+  );
+};
+
+export const retainPullRequestEntriesForVerifiedViewers = (
+  entries: ReadonlyArray<EnvironmentPullRequestEntry>,
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers,
+  verifiedEnvironmentIds: ReadonlySet<string>,
+): ReadonlyArray<EnvironmentPullRequestEntry> => {
+  const retained = entries.filter((entry) => {
+    if (!verifiedEnvironmentIds.has(entry.environmentId)) return true;
+    const key = pullRequestViewerKey(entry);
+    return listedViewers[key] !== undefined && listedViewers[key] === verifiedViewers[key];
+  });
+  return retained.length === entries.length ? entries : retained;
+};
+
+export type PullRequestRetainedVerification =
+  | { readonly status: "verifying" }
+  | { readonly status: "verified" }
+  | {
+      readonly status: "failed" | "accountChanged";
+      readonly entries: ReadonlyArray<EnvironmentPullRequestEntry>;
+      readonly ordered: ReadonlyArray<EnvironmentPullRequestEntry>;
+      readonly partitions?: PullRequestPartitionsSnapshot | undefined;
+      readonly changed: boolean;
+      readonly empty: boolean;
+    };
+
+/**
+ * Reduces a settled viewer check to the only retained rows the route may keep. The route owns
+ * pagination and React state; this controller owns the security transition so partial failures,
+ * account changes, and partitioned rows cannot drift into separate code paths.
+ */
+export function resolvePullRequestRetainedVerification({
+  verificationPending,
+  verificationFailed,
+  viewerMismatch,
+  entries,
+  ordered,
+  partitions,
+  listedViewers,
+  verifiedViewers,
+  queriedEnvironmentIds,
+}: {
+  readonly verificationPending: boolean;
+  readonly verificationFailed: boolean;
+  readonly viewerMismatch: boolean;
+  readonly entries: ReadonlyArray<EnvironmentPullRequestEntry>;
+  readonly ordered: ReadonlyArray<EnvironmentPullRequestEntry>;
+  readonly partitions?: PullRequestPartitionsSnapshot | undefined;
+  readonly listedViewers: PullRequestViewers;
+  readonly verifiedViewers: PullRequestViewers | null;
+  readonly queriedEnvironmentIds: ReadonlySet<string>;
+}): PullRequestRetainedVerification {
+  if (verificationPending) return { status: "verifying" };
+  if (!verificationFailed && !viewerMismatch) return { status: "verified" };
+
+  const viewers = verifiedViewers ?? {};
+  const retain = (rows: ReadonlyArray<EnvironmentPullRequestEntry>) =>
+    retainPullRequestEntriesForVerifiedViewers(rows, listedViewers, viewers, queriedEnvironmentIds);
+  const retainedEntries = retain(entries);
+  const retainedOrdered = retain(ordered);
+  const retainedAuthored = partitions === undefined ? undefined : retain(partitions.authored);
+  const retainedReviewing = partitions === undefined ? undefined : retain(partitions.reviewing);
+  const retainedPartitions =
+    partitions === undefined
+      ? undefined
+      : { authored: retainedAuthored ?? [], reviewing: retainedReviewing ?? [] };
+  const changed =
+    retainedEntries !== entries ||
+    retainedOrdered !== ordered ||
+    (partitions !== undefined &&
+      (retainedAuthored !== partitions.authored || retainedReviewing !== partitions.reviewing));
+
+  return {
+    status: viewerMismatch ? "accountChanged" : "failed",
+    entries: retainedEntries,
+    ordered: retainedOrdered,
+    ...(retainedPartitions === undefined ? {} : { partitions: retainedPartitions }),
+    changed,
+    empty:
+      retainedEntries.length === 0 &&
+      retainedOrdered.length === 0 &&
+      (retainedPartitions === undefined ||
+        (retainedPartitions.authored.length === 0 && retainedPartitions.reviewing.length === 0)),
+  };
 }
 
 /**
@@ -789,6 +964,7 @@ const EnvironmentPullRequestErrorSchema = Schema.Struct({
 
 const decodeSnapshot = Schema.decodeUnknownOption(
   Schema.Struct({
+    writtenAt: Schema.Number,
     scope: Schema.String,
     data: Schema.Struct({
       ...PullRequestListResult.fields,
@@ -818,12 +994,58 @@ const decodeSnapshot = Schema.decodeUnknownOption(
 export function readPullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
+  context:
+    | {
+        readonly viewers: PullRequestViewers | null;
+        readonly now?: number;
+        readonly includeEntry?: (entry: EnvironmentPullRequestEntry) => boolean;
+      }
+    | undefined = undefined,
 ): PullRequestListSnapshot | null {
   try {
+    // Older route code cannot prove snapshot ownership. It gets a cold start until the stacked
+    // route integration supplies the fresh viewer result.
+    if (context === undefined || context.viewers === null) return null;
+    const viewers = context.viewers;
     const raw = storage?.getItem(snapshotStorageKey(environmentSetKey));
     if (!raw) return null;
     const decoded = decodeSnapshot(JSON.parse(raw));
-    return decoded._tag === "Some" ? decoded.value : null;
+    if (decoded._tag === "None") return null;
+    const now = context.now ?? Date.now();
+    if (decoded.value.writtenAt > now || now - decoded.value.writtenAt > SNAPSHOT_MAX_AGE_MS) {
+      return null;
+    }
+    if (context.includeEntry === undefined) {
+      if (!pullRequestViewersMatch(decoded.value.data.viewers, viewers)) return null;
+    } else {
+      const includedEntries = decoded.value.data.entries.filter(context.includeEntry);
+      const includedAuthored = decoded.value.partitions?.authored.filter(context.includeEntry);
+      const includedReviewing = decoded.value.partitions?.reviewing.filter(context.includeEntry);
+      const requiredViewerKeys = new Set(
+        [...includedEntries, ...(includedAuthored ?? []), ...(includedReviewing ?? [])].map(
+          pullRequestViewerKey,
+        ),
+      );
+      if (
+        [...requiredViewerKeys].some(
+          (key) =>
+            decoded.value.data.viewers[key] === undefined ||
+            decoded.value.data.viewers[key] !== viewers[key],
+        )
+      ) {
+        return null;
+      }
+      return {
+        ...decoded.value,
+        data: { ...decoded.value.data, entries: includedEntries },
+        ...(decoded.value.partitions === undefined
+          ? {}
+          : {
+              partitions: { authored: includedAuthored ?? [], reviewing: includedReviewing ?? [] },
+            }),
+      };
+    }
+    return decoded.value;
   } catch {
     return null;
   }
@@ -832,12 +1054,14 @@ export function readPullRequestListSnapshot(
 export function writePullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
-  snapshot: PullRequestListSnapshot,
+  snapshot: Omit<PullRequestListSnapshot, "writtenAt">,
+  now = Date.now(),
 ): void {
   try {
     storage?.setItem(
       snapshotStorageKey(environmentSetKey),
       JSON.stringify({
+        writtenAt: now,
         scope: snapshot.scope,
         data: {
           ...snapshot.data,

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -9,6 +9,7 @@ import type {
   PullRequestListStatsInput,
   PullRequestRef,
   PullRequestSummary,
+  PullRequestViewerInput,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
@@ -79,6 +80,8 @@ export interface EnvironmentQueryTarget<Input> {
 interface MergedEnvironmentQueryView<A> {
   /** One entry per query target that has answered, in the order the targets were given. */
   readonly values: ReadonlyArray<readonly [EnvironmentId, A]>;
+  /** Current successes only. A failed refresh may still leave its prior answer in `values`. */
+  readonly successfulValues: ReadonlyArray<readonly [EnvironmentId, A]>;
   /** The first environment that failed. Others may still have answered — this is not fatal. */
   readonly error: string | null;
   readonly isPending: boolean;
@@ -102,6 +105,7 @@ function createMergedEnvironmentQuery<Input, A>(
     Atom.make((get): MergedEnvironmentQueryView<A> => {
       const targets = JSON.parse(key) as ReadonlyArray<EnvironmentQueryTarget<Input>>;
       const values: Array<readonly [EnvironmentId, A]> = [];
+      const successfulValues: Array<readonly [EnvironmentId, A]> = [];
       let error: string | null = null;
       let isPending = false;
       for (const target of targets) {
@@ -112,12 +116,16 @@ function createMergedEnvironmentQuery<Input, A>(
         }
         const value = Option.getOrNull(AsyncResult.value(result));
         if (value !== null) values.push([target.environmentId, value]);
+        if (result._tag === "Success") {
+          successfulValues.push([target.environmentId, result.value]);
+        }
       }
-      return { values, error, isPending };
+      return { values, successfulValues, error, isPending };
     }).pipe(Atom.withLabel(`${label}:${key}`)),
   );
   const empty = Atom.make<MergedEnvironmentQueryView<A>>({
     values: [],
+    successfulValues: [],
     error: null,
     isPending: false,
   }).pipe(Atom.withLabel(`${label}:empty`));
@@ -143,6 +151,11 @@ const usePullRequestListsQuery = createMergedEnvironmentQuery(
   pullRequestEnvironment.list,
 );
 
+const usePullRequestViewersQuery = createMergedEnvironmentQuery(
+  "web-pull-requests:viewers",
+  pullRequestEnvironment.viewers,
+);
+
 const usePullRequestStatsQuery = createMergedEnvironmentQuery(
   "web-pull-requests:list-stats",
   pullRequestEnvironment.listStats,
@@ -153,6 +166,43 @@ export interface MergedPullRequestListView {
   readonly error: string | null;
   readonly isPending: boolean;
   readonly refresh: () => void;
+}
+
+/** Fresh host identities, scoped by environment so equal hostnames on two servers stay distinct. */
+export function usePullRequestViewers(
+  targets: ReadonlyArray<EnvironmentQueryTarget<PullRequestViewerInput>>,
+): {
+  readonly viewers: Readonly<Record<string, string>> | null;
+  readonly environmentIds: ReadonlyArray<EnvironmentId>;
+  readonly error: string | null;
+  readonly isPending: boolean;
+  readonly refresh: () => void;
+} {
+  const query = usePullRequestViewersQuery(targets);
+  const viewers = useMemo(
+    () =>
+      query.successfulValues.length === 0
+        ? null
+        : Object.fromEntries(
+            query.successfulValues.flatMap(([environmentId, result]) =>
+              Object.entries(result.viewers).map(
+                ([host, viewer]) => [`${environmentId} ${host}`, viewer] as const,
+              ),
+            ),
+          ),
+    [query.successfulValues],
+  );
+  const environmentIds = useMemo(
+    () => query.successfulValues.map(([environmentId]) => environmentId),
+    [query.successfulValues],
+  );
+  return {
+    viewers,
+    environmentIds,
+    error: query.error,
+    isPending: query.isPending,
+    refresh: query.refresh,
+  };
 }
 
 /** One listing per environment, merged into the single list the page renders. */

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -80,6 +80,11 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     staleTimeMs: 15_000,
   });
   return {
+    viewers: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:viewers",
+      tag: WS_METHODS.pullRequestsViewers,
+      staleTimeMs: 0,
+    }),
     list: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:list",
       tag: WS_METHODS.pullRequestsList,

--- a/packages/contracts/src/environment.test.ts
+++ b/packages/contracts/src/environment.test.ts
@@ -16,6 +16,7 @@ const descriptor = {
 describe("ExecutionEnvironmentDescriptor", () => {
   it("treats a missing pull-request capability as unsupported under version skew", () => {
     expect(decodeDescriptor(descriptor).capabilities.pullRequests).toBeUndefined();
+    expect(decodeDescriptor(descriptor).capabilities.pullRequestViewers).toBeUndefined();
   });
 
   it("preserves an advertised pull-request capability", () => {
@@ -24,6 +25,12 @@ describe("ExecutionEnvironmentDescriptor", () => {
         ...descriptor,
         capabilities: { ...descriptor.capabilities, pullRequests: true },
       }).capabilities.pullRequests,
+    ).toBe(true);
+    expect(
+      decodeDescriptor({
+        ...descriptor,
+        capabilities: { ...descriptor.capabilities, pullRequestViewers: true },
+      }).capabilities.pullRequestViewers,
     ).toBe(true);
   });
 

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -88,6 +88,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   /** Server exposes the pull-request list, detail, activity, diff, and mutation APIs. Absent on
       servers from before the pull-request workspace shipped, so clients must not probe them. */
   pullRequests: Schema.optionalKey(Schema.Boolean),
+  /** Server exposes the fresh pull-request viewer identity API. Absent on servers from before
+      snapshot identity verification shipped, so clients keep live listing but skip hydration. */
+  pullRequestViewers: Schema.optionalKey(Schema.Boolean),
   /** Server understands thread.settle / thread.unsettle commands. Absent on
       pre-settlement servers, so clients treat missing as unsupported and
       never send the commands under version skew. */

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -560,6 +560,24 @@ export const PullRequestListInput = Schema.Struct({
 export type PullRequestListInput = typeof PullRequestListInput.Type;
 
 /**
+ * The project and host scope whose signed-in identities a client needs before it can safely
+ * hydrate a persisted listing. Kept separate from the listing so account verification does not
+ * wait for every repository to be read.
+ */
+export const PullRequestViewerInput = Schema.Struct({
+  projectId: Schema.optional(ProjectId),
+  projectIds: Schema.optional(Schema.Array(ProjectId).check(Schema.isMaxLength(100))),
+  host: Schema.optional(TrimmedNonEmptyString),
+});
+export type PullRequestViewerInput = typeof PullRequestViewerInput.Type;
+
+export const PullRequestViewerResult = Schema.Struct({
+  /** The currently signed-in account per host. Unreadable hosts are absent. */
+  viewers: Schema.Record(TrimmedNonEmptyString, TrimmedNonEmptyString),
+});
+export type PullRequestViewerResult = typeof PullRequestViewerResult.Type;
+
+/**
  * A host the workspace has projects on, and whether it can be read right now. Drives the host
  * switcher and explains projects the list leaves out.
  *

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -94,6 +94,8 @@ import {
   PullRequestListResult,
   PullRequestListStatsInput,
   PullRequestListStatsResult,
+  PullRequestViewerInput,
+  PullRequestViewerResult,
   PullRequestOperationError,
   PullRequestReactionInput,
   PullRequestRef,
@@ -304,6 +306,7 @@ export const WS_METHODS = {
 
   // Pull request methods
   pullRequestsList: "pullRequests.list",
+  pullRequestsViewers: "pullRequests.viewers",
   pullRequestsListStats: "pullRequests.listStats",
   pullRequestsSummary: "pullRequests.summary",
   pullRequestsDetail: "pullRequests.detail",
@@ -513,6 +516,12 @@ const PullRequestRpcError = Schema.Union([
 export const WsPullRequestsListRpc = Rpc.make(WS_METHODS.pullRequestsList, {
   payload: PullRequestListInput,
   success: PullRequestListResult,
+  error: PullRequestRpcError,
+});
+
+export const WsPullRequestsViewersRpc = Rpc.make(WS_METHODS.pullRequestsViewers, {
+  payload: PullRequestViewerInput,
+  success: PullRequestViewerResult,
   error: PullRequestRpcError,
 });
 
@@ -1087,6 +1096,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsCloudGetRelayClientStatusRpc,
   WsCloudInstallRelayClientRpc,
   WsPullRequestsListRpc,
+  WsPullRequestsViewersRpc,
   WsPullRequestsListStatsRpc,
   WsPullRequestsSummaryRpc,
   WsPullRequestsDetailRpc,


### PR DESCRIPTION
## What Changed

Adds a fresh `pullRequests.viewers` read and invalidates cached listings when a host account changes. The same foundation defines short-lived, viewer-owned snapshots and one tested controller for retained feed, pagination, and priority rows.

This is the first of two replacements for #6470. It contains the server contract and pure client safety rules. Draft PR #9110 wires those rules into rendering after this lands.

## Why

Pull request snapshots were scoped only to environments. A host CLI could switch accounts while the web client still held rows from the previous viewer. Separating identity verification from repository listing lets the client reject those rows without waiting for the slower list call.

The final state preserves the edge cases found during review of #6470, including mixed legacy servers, partial viewer failures, pagination, narrowed project scopes, and in-flight lists stranded by an account change.

## UI Changes

No visual design changes. This foundation disables unverified snapshot hydration; the follow-up route PR restores safe early hydration after fresh identity verification.

## Validation

- `vp test run apps/server/src/pullRequest/PullRequestService.test.ts apps/server/src/auth/RpcAuthorization.test.ts apps/server/src/environment/ServerEnvironment.test.ts packages/contracts/src/environment.test.ts packages/contracts/src/pullRequest.test.ts` (131 passed)
- `vp test run apps/web/src/components/pullRequest/pullRequestList.logic.test.ts` (118 passed)
- `vp run --filter t3 typecheck`
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter @t3tools/client-runtime typecheck`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual UI change requires before/after screenshots
- [x] No animation or interaction change requires a video

Generated with GPT-5.6 in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `pullRequests.viewers` RPC for fresh pull-request viewer verification
> - Server adds `PullRequestService.viewers` to query fresh viewer identities per host. It uses request ordering and invalidation so older concurrent reads cannot overwrite newer identities.
> - Web client verifies viewer identities before hydrating pull-request list snapshots. It rejects snapshots older than 5 minutes or with mismatched identities, and filters retained rows against the verified identities.
> - Environment capability schema adds optional `pullRequestViewers` to advertise support; older servers omitting it are treated as unsupported.
> - Risk: `readPullRequestListSnapshot` in [pullRequestList.logic.ts](https://github.com/pingdotgg/t3code/pull/9109/files#diff-f8ca5dc8d0f0bac3b412ba2abaf7fca00497f36286660cfeb38242768c60e478) now requires a non-null viewer context and rejects snapshots older than 5 minutes or with mismatched host identities; existing callers lacking viewer context will fail to hydrate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffd6060. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how PR list data is cached and hydrated across host account switches; incorrect gating could hide lists or briefly show wrong-account rows, though logic is heavily tested.
> 
> **Overview**
> Adds **`pullRequests.viewers`** end-to-end (contract RPC, WS handler, read auth, `PullRequestService.viewers`, client-runtime query with `staleTimeMs: 0`) so clients can read **current signed-in host identities without waiting on a full PR list**. Servers advertise **`pullRequestViewers`** in environment capabilities; legacy servers omit it and keep live listing without verified snapshot hydration.
> 
> **Server viewer cache behavior** is tightened: fresh reads bypass the TTL cache, stale in-flight lookups cannot overwrite newer results, a changed or failed fresh identity **bumps listing epoch** / clears per-host cache, and workspace **`invalidate`** clears viewer state. Legacy project refinement now respects **`projectIds`** when resolving unknown providers.
> 
> **Web foundation** adds viewer-comparison helpers, a **verification gate** (delay list fetches for capable envs until verified), and stricter **local list snapshots**: require matching verified viewers, **`writtenAt`**, and a **5-minute** max age; retained rows drop when identity no longer matches. **`usePullRequestViewers`** merges per-environment fresh reads; merged environment queries expose **`successfulValues`** so a failed refresh can keep the last good answer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd6060b716e23a0a4b1ce32abba497f49e2561e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->