### PR TITLE
fix(web): hide pull request rows after account changes

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -53,6 +53,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.cloudGetRelayClientStatus]: AuthRelayReadScope,
   [WS_METHODS.cloudInstallRelayClient]: AuthRelayWriteScope,
   [WS_METHODS.pullRequestsList]: AuthOrchestrationReadScope,
+  [WS_METHODS.pullRequestsViewers]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsListStats]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDetail]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsActivity]: AuthOrchestrationReadScope,

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -166,6 +166,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.attachmentUploads).toBe(true);
       expect(second.capabilities.fileAttachments).toEqual({ maxUploadBytes: 50 * 1024 * 1024 });
       expect(second.capabilities.pullRequests).toBe(true);
+      expect(second.capabilities.pullRequestViewers).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -208,6 +208,7 @@ export const make = Effect.gen(function* () {
       attachmentUploads: true,
       fileAttachments: { maxUploadBytes: PROVIDER_SEND_TURN_MAX_FILE_BYTES },
       pullRequests: true,
+      pullRequestViewers: true,
       threadSettlement: true,
       threadAutoSettlement: true,
       threadSnooze: true,

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1,5 +1,7 @@
 import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as TestClock from "effect/testing/TestClock";
 import type {
@@ -209,6 +211,44 @@ it.effect("refines unknown self-hosted GitLab projects before listing merge requ
     assert.strictEqual(refinementCalls, 1);
     assert.strictEqual(result.providers[0]?.host, "code.example.test");
     assert.strictEqual(result.providers[0]?.kind, "gitlab");
+  }),
+);
+
+it.effect("does not refine legacy projects outside the requested project ids", () =>
+  Effect.gen(function* () {
+    const asked: string[] = [];
+    const service = yield* makeService({
+      projects: [
+        project({
+          id: "p1",
+          title: "selected",
+          workspaceRoot: "/selected",
+          repository: "group/selected",
+          provider: "unknown",
+          host: "selected.example.test",
+        }),
+        project({
+          id: "p2",
+          title: "unrelated",
+          workspaceRoot: "/unrelated",
+          repository: "group/unrelated",
+          provider: "unknown",
+          host: "unrelated.example.test",
+        }),
+      ],
+      providers: [fakeProvider("gitlab")],
+      resolveHandle: ({ cwd, context }) => {
+        asked.push(cwd);
+        return Effect.succeed({
+          context: { ...context!, provider: { ...context!.provider, kind: "gitlab" } },
+          provider: undefined as never,
+        });
+      },
+    });
+
+    yield* service.viewers({ projectIds: ["p1" as ProjectId] });
+
+    assert.deepStrictEqual(asked, ["/selected"]);
   }),
 );
 
@@ -610,6 +650,113 @@ it.effect("calls a transient viewer failure a failed operation, not a signed-out
 
     // `cli-unauthenticated` would send the reader to `gh auth login` over a transient error.
     assert.strictEqual(error._tag, "PullRequestOperationError");
+  }),
+);
+
+it.effect("reads snapshot viewer identity freshly after the host account changes", () =>
+  Effect.gen(function* () {
+    let viewer = "Bilal";
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [fakeProvider("github", { getViewer: () => Effect.succeed(viewer) })],
+    });
+
+    const listing = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(listing.viewers, { "github.com": "Bilal" });
+
+    viewer = "Octocat";
+    const identity = yield* service.viewers({});
+    assert.deepStrictEqual(identity.viewers, { "github.com": "Octocat" });
+
+    const refreshedListing = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(refreshedListing.viewers, { "github.com": "Octocat" });
+  }),
+);
+
+it.effect("keeps a healthy host when another host's viewer verification fails", () =>
+  Effect.gen(function* () {
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "github", workspaceRoot: "/a", repository: "acme/web" }),
+        project({
+          id: "p2",
+          title: "gitlab",
+          workspaceRoot: "/b",
+          repository: "acme/api",
+          provider: "gitlab",
+        }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () => Effect.fail(requestFailed),
+        }),
+        fakeProvider("gitlab", {
+          getViewer: () => Effect.succeed("healthy-viewer"),
+        }),
+      ],
+    });
+
+    const result = yield* service.viewers({});
+
+    assert.deepStrictEqual(result.viewers, { "gitlab.com": "healthy-viewer" });
+  }),
+);
+
+it.effect("strands a list that was in flight when the host account changed", () =>
+  Effect.gen(function* () {
+    const firstListStarted = yield* Deferred.make<void>();
+    const releaseFirstList = yield* Deferred.make<void>();
+    let viewer = "Bilal";
+    let listCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () => Effect.succeed(viewer),
+          listChangeRequests: () =>
+            Effect.gen(function* () {
+              listCalls += 1;
+              const call = listCalls;
+              if (call === 1) {
+                yield* Deferred.succeed(firstListStarted, undefined);
+                yield* Deferred.await(releaseFirstList);
+              }
+              return {
+                items: [changeRequest(call, `2026-07-0${call}T00:00:00Z`)],
+                truncated: false,
+                continues: true,
+              };
+            }),
+        }),
+      ],
+    });
+
+    const oldListing = yield* service.list({ state: "open" }).pipe(Effect.forkChild);
+    yield* Deferred.await(firstListStarted);
+
+    viewer = "Octocat";
+    assert.deepStrictEqual((yield* service.viewers({})).viewers, { "github.com": "Octocat" });
+
+    const current = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(current.viewers, { "github.com": "Octocat" });
+    assert.deepStrictEqual(
+      current.entries.map((entry) => entry.number),
+      [2],
+    );
+
+    yield* Deferred.succeed(releaseFirstList, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(oldListing)).viewers, { "github.com": "Bilal" });
+
+    const cached = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(
+      cached.entries.map((entry) => entry.number),
+      [2],
+    );
+    assert.strictEqual(listCalls, 2);
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -724,6 +724,46 @@ it.effect("does not let an older viewer request replace a newer identity", () =>
   }),
 );
 
+it.effect("does not let an in-flight viewer request survive invalidation", () =>
+  Effect.gen(function* () {
+    const staleRequestStarted = yield* Deferred.make<void>();
+    const releaseStaleRequest = yield* Deferred.make<void>();
+    let viewerCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () =>
+            Effect.gen(function* () {
+              viewerCalls += 1;
+              if (viewerCalls === 2) {
+                yield* Deferred.succeed(staleRequestStarted, undefined);
+                yield* Deferred.await(releaseStaleRequest);
+              }
+              return viewerCalls < 3 ? "Bilal" : "Octocat";
+            }),
+        }),
+      ],
+    });
+
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Bilal",
+    });
+    const stale = yield* service.viewers({}).pipe(Effect.forkChild);
+    yield* Deferred.await(staleRequestStarted);
+    yield* service.invalidate({});
+    yield* Deferred.succeed(releaseStaleRequest, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(stale)).viewers, { "github.com": "Bilal" });
+
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Octocat",
+    });
+    assert.strictEqual(viewerCalls, 3);
+  }),
+);
+
 it.effect("keeps a healthy host when another host's viewer verification fails", () =>
   Effect.gen(function* () {
     const service = yield* makeService({

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -675,6 +675,55 @@ it.effect("reads snapshot viewer identity freshly after the host account changes
   }),
 );
 
+it.effect("does not let an older viewer request replace a newer identity", () =>
+  Effect.gen(function* () {
+    const firstFreshStarted = yield* Deferred.make<void>();
+    const releaseFirstFresh = yield* Deferred.make<void>();
+    let viewerCalls = 0;
+    let listCalls = 0;
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getViewer: () =>
+            Effect.gen(function* () {
+              viewerCalls += 1;
+              if (viewerCalls === 2) {
+                yield* Deferred.succeed(firstFreshStarted, undefined);
+                yield* Deferred.await(releaseFirstFresh);
+                return "Bilal";
+              }
+              return viewerCalls === 1 ? "Bilal" : "Octocat";
+            }),
+          listChangeRequests: () => {
+            listCalls += 1;
+            return Effect.succeed({
+              items: [changeRequest(listCalls, `2026-07-0${listCalls}T00:00:00Z`)],
+              truncated: false,
+              continues: true,
+            });
+          },
+        }),
+      ],
+    });
+
+    assert.deepStrictEqual((yield* service.list({ state: "open" })).viewers, {
+      "github.com": "Bilal",
+    });
+    const older = yield* service.viewers({}).pipe(Effect.forkChild);
+    yield* Deferred.await(firstFreshStarted);
+    assert.deepStrictEqual((yield* service.viewers({})).viewers, { "github.com": "Octocat" });
+    yield* Deferred.succeed(releaseFirstFresh, undefined);
+    assert.deepStrictEqual((yield* Fiber.join(older)).viewers, { "github.com": "Bilal" });
+
+    const current = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(current.viewers, { "github.com": "Octocat" });
+    assert.strictEqual(listCalls, 2);
+  }),
+);
+
 it.effect("keeps a healthy host when another host's viewer verification fails", () =>
   Effect.gen(function* () {
     const service = yield* makeService({

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -706,7 +706,9 @@ export const make = Effect.gen(function* () {
   // signed-out after the reader has signed in.
   let epochCounter = 0;
   let listingsEpoch = 0;
+  let viewerRequestCounter = 0;
   const viewersByHost = new Map<string, { readonly at: number; readonly result: ResolvedViewer }>();
+  const latestViewerRequestByHost = new Map<string, number>();
 
   const resolveViewers = (
     projects: ReadonlyArray<SupportedProject>,
@@ -727,6 +729,8 @@ export const make = Effect.gen(function* () {
           }
           const forHost = projects.filter((project) => project.host === host);
           const api = forHost[0]!.api;
+          const request = ++viewerRequestCounter;
+          latestViewerRequestByHost.set(host, request);
           // Every checkout on the host, not just the ones that survived de-duplication: one
           // unreadable worktree would otherwise report the whole host as signed out.
           const roots =
@@ -740,6 +744,7 @@ export const make = Effect.gen(function* () {
             })),
             Effect.tap((result) =>
               Effect.map(Clock.currentTimeMillis, (at) => {
+                if (latestViewerRequestByHost.get(host) !== request) return;
                 if (
                   options.fresh === true &&
                   held !== undefined &&
@@ -752,6 +757,9 @@ export const make = Effect.gen(function* () {
             ),
             Effect.catch((error) =>
               Effect.sync(() => {
+                if (latestViewerRequestByHost.get(host) !== request) {
+                  return { host, kind: api.kind, viewer: null, error };
+                }
                 if (options.fresh === true && held !== undefined && held.result.viewer !== null) {
                   listingsEpoch = ++epochCounter;
                 }

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -43,6 +43,8 @@ import {
   type PullRequestThreadCommentsInput,
   type PullRequestThreadCommentsResult,
   type PullRequestUpdateInput,
+  type PullRequestViewerInput,
+  type PullRequestViewerResult,
   type SourceControlProviderInfo,
   type SourceControlProviderKind,
 } from "@t3tools/contracts";
@@ -116,6 +118,9 @@ export type PullRequestError = PullRequestUnavailableError | PullRequestOperatio
 export class PullRequestService extends Context.Service<
   PullRequestService,
   {
+    readonly viewers: (
+      input: PullRequestViewerInput,
+    ) => Effect.Effect<PullRequestViewerResult, PullRequestError>;
     readonly list: (
       input: PullRequestListInput,
     ) => Effect.Effect<PullRequestListResult, PullRequestError>;
@@ -492,7 +497,7 @@ export const make = Effect.gen(function* () {
 
   const refineUnknownProjectKinds = (
     projects: ReadonlyArray<OrchestrationProjectShell>,
-    filter: Pick<PullRequestListInput, "projectId" | "host">,
+    filter: Pick<PullRequestListInput, "projectId" | "projectIds" | "host">,
   ) => {
     type RefinementCandidate = {
       readonly project: OrchestrationProjectShell;
@@ -503,6 +508,7 @@ export const make = Effect.gen(function* () {
     const refinements = new Map<string, RefinementCandidate[]>();
     for (const project of projects) {
       if (filter.projectId !== undefined && project.id !== filter.projectId) continue;
+      if (filter.projectIds !== undefined && !filter.projectIds.includes(project.id)) continue;
       const identity = project.repositoryIdentity;
       if (identity?.provider !== "unknown" || repositoryIdentityOf(project) === null) continue;
       const host = pullRequestHostOf(identity, "unknown");
@@ -698,18 +704,25 @@ export const make = Effect.gen(function* () {
   // per read, three reads per page. Only a success is believed for a while: a failure is the
   // "is this host set up" answer the provider switcher shows, and holding it would keep saying
   // signed-out after the reader has signed in.
+  let epochCounter = 0;
+  let listingsEpoch = 0;
   const viewersByHost = new Map<string, { readonly at: number; readonly result: ResolvedViewer }>();
 
   const resolveViewers = (
     projects: ReadonlyArray<SupportedProject>,
     viewerRoots: WorkspaceProjects["viewerRoots"],
+    options: { readonly fresh?: boolean } = {},
   ) =>
     Effect.forEach(
       [...new Set(projects.map(({ host }) => host))],
       (host) =>
         Effect.flatMap(Clock.currentTimeMillis, (now): Effect.Effect<ResolvedViewer> => {
           const held = viewersByHost.get(host);
-          if (held !== undefined && now - held.at <= Duration.toMillis(VIEWER_CACHE_TTL)) {
+          if (
+            options.fresh !== true &&
+            held !== undefined &&
+            now - held.at <= Duration.toMillis(VIEWER_CACHE_TTL)
+          ) {
             return Effect.succeed(held.result);
           }
           const forHost = projects.filter((project) => project.host === host);
@@ -726,12 +739,46 @@ export const make = Effect.gen(function* () {
               error: null as PullRequestProviderError | null,
             })),
             Effect.tap((result) =>
-              Effect.map(Clock.currentTimeMillis, (at) => viewersByHost.set(host, { at, result })),
+              Effect.map(Clock.currentTimeMillis, (at) => {
+                if (
+                  options.fresh === true &&
+                  held !== undefined &&
+                  held.result.viewer !== result.viewer
+                ) {
+                  listingsEpoch = ++epochCounter;
+                }
+                viewersByHost.set(host, { at, result });
+              }),
             ),
-            Effect.catch((error) => Effect.succeed({ host, kind: api.kind, viewer: null, error })),
+            Effect.catch((error) =>
+              Effect.sync(() => {
+                if (options.fresh === true && held !== undefined && held.result.viewer !== null) {
+                  listingsEpoch = ++epochCounter;
+                }
+                viewersByHost.delete(host);
+                return { host, kind: api.kind, viewer: null, error };
+              }),
+            ),
           );
         }),
       { concurrency: REPOSITORY_CONCURRENCY },
+    );
+
+  // Snapshot hydration needs identity before the slower repository listing has answered. This
+  // read deliberately bypasses the viewer cache: an account can be switched outside T3, and a
+  // cached identity must never authorize rows persisted for the previous account.
+  const viewers: PullRequestService["Service"]["viewers"] = (input) =>
+    listWorkspaceProjects(input).pipe(
+      Effect.flatMap(({ supported, viewerRoots }) =>
+        resolveViewers(supported, viewerRoots, { fresh: true }),
+      ),
+      Effect.map((results) => ({
+        viewers: Object.fromEntries(
+          results.flatMap((result) =>
+            result.viewer === null ? [] : [[result.host, result.viewer] as const],
+          ),
+        ),
+      })),
     );
 
   /**
@@ -1849,8 +1896,6 @@ export const make = Effect.gen(function* () {
   // epoch strands every entry made under the old one — no enumerating a cache whose keys
   // (cursors, commits) nothing holds a list of. The counter is shared and monotonic so a
   // scope re-entering `refEpochs` after eviction can never mint a key an old entry still has.
-  let epochCounter = 0;
-  let listingsEpoch = 0;
   const refEpochs = new Map<string, number>();
   const REF_EPOCH_CAPACITY = 2_048;
   const refScope = (ref: PullRequestRef) => `${ref.projectId} ${ref.repository} ${ref.number}`;
@@ -2086,6 +2131,7 @@ export const make = Effect.gen(function* () {
       );
 
   return PullRequestService.of({
+    viewers,
     list,
     listStats,
     detail,

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2116,6 +2116,7 @@ export const make = Effect.gen(function* () {
         // A whole-workspace refresh is the reader asking to be re-answered from the hosts,
         // and that includes who the hosts say they are.
         viewersByHost.clear();
+        latestViewerRequestByHost.clear();
         return;
       }
       bumpRefEpoch(input.reference);

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1827,6 +1827,10 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.pullRequestsList, pullRequests.list(input), {
             "rpc.aggregate": "pull-requests",
           }),
+        [WS_METHODS.pullRequestsViewers]: (input) =>
+          observeRpcEffect(WS_METHODS.pullRequestsViewers, pullRequests.viewers(input), {
+            "rpc.aggregate": "pull-requests",
+          }),
         [WS_METHODS.pullRequestsListStats]: (input) =>
           observeRpcEffect(WS_METHODS.pullRequestsListStats, pullRequests.listStats(input), {
             "rpc.aggregate": "pull-requests",

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -7,6 +7,10 @@ import {
   mergePullRequestLists,
   pullRequestEntryKey,
   pullRequestEnvironmentSetKey,
+  pullRequestListViewersMatchVerification,
+  retainPullRequestEntriesForVerifiedViewers,
+  pullRequestViewersMatch,
+  pullRequestViewersMatchForEnvironments,
   groupPullRequestsByInvolvement,
   matchesPullRequestFilters,
   matchesPullRequestQuery,
@@ -19,12 +23,14 @@ import {
   narrowPullRequestsToFilters,
   partitionPullRequestsWithPriority,
   readPullRequestListSnapshot,
+  resolvePullRequestRetainedVerification,
   writePullRequestListSnapshot,
   rankPullRequestMatches,
   scorePullRequestMatch,
   retainVisiblePullRequestStatsBatches,
   withDiffStat,
   resolveProjectScope,
+  resolvePullRequestViewerGate,
   resolveQueryEnvironmentIds,
   resolveSelectedEnvironmentId,
   type EnvironmentPullRequestEntry,
@@ -758,6 +764,7 @@ describe("partitioning with the hosts' own priority reads", () => {
 });
 
 describe("the list snapshot across a reload", () => {
+  const NOW = Date.parse("2026-08-13T12:00:00Z");
   const makeStorage = () => {
     const held = new Map<string, string>();
     return {
@@ -773,27 +780,295 @@ describe("the list snapshot across a reload", () => {
     truncated: true,
     nextCursors: { "pingdotgg/t3code": "cursor-1" },
   } as never;
+  const readSnapshot = (
+    storage: ReturnType<typeof makeStorage> | undefined,
+    environmentKey: string,
+    viewers: Record<string, string> = { "github.com": "Bilal" },
+    now = NOW,
+  ) => readPullRequestListSnapshot(storage, environmentKey, { viewers, now });
+
+  it("compares viewer identities independently of host insertion order", () => {
+    expect(
+      pullRequestViewersMatch(
+        { "env-1 github.com": "Bilal", "env-2 gitlab.com": "Theo" },
+        { "env-2 gitlab.com": "Theo", "env-1 github.com": "Bilal" },
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatch({ "env-1 github.com": "Bilal" }, { "env-1 github.com": "Octocat" }),
+    ).toBe(false);
+  });
+
+  it("compares only the viewer-capable environments in a mixed-server list", () => {
+    const capable = new Set(["env-1"]);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Octocat" },
+        capable,
+      ),
+    ).toBe(false);
+    expect(
+      pullRequestViewersMatchForEnvironments({ "env-1 github.com": "Bilal" }, {}, capable),
+    ).toBe(false);
+  });
+
+  it("compares only retained hosts relevant to a narrower scope", () => {
+    const capable = new Set(["env-1"]);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+        new Set(["env-1 github.com"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Octocat" },
+        capable,
+        new Set(["env-1 github.com"]),
+      ),
+    ).toBe(false);
+    expect(
+      pullRequestViewersMatchForEnvironments(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        capable,
+        new Set(["env-1 gitlab.com"]),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts live rows when the current scope queries only legacy servers", () => {
+    expect(
+      pullRequestListViewersMatchVerification({ "env-2 github.com": "Legacy" }, null, new Set()),
+    ).toBe(true);
+  });
+
+  it("accepts legacy rows when a separate capable server fails viewer verification", () => {
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-2 github.com": "Legacy" },
+        null,
+        new Set(["env-1"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Bilal" },
+        null,
+        new Set(["env-1"]),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a verified continuation page from only the hosts with cursors", () => {
+    const capable = new Set(["env-1", "env-2"]);
+    const verified = {
+      "env-1 github.com": "Bilal",
+      "env-2 github.com": "Octocat",
+    };
+
+    expect(
+      pullRequestListViewersMatchVerification({ "env-1 github.com": "Bilal" }, verified, capable),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification({ "env-1 github.com": "Octocat" }, verified, capable),
+    ).toBe(false);
+  });
+
+  it("accepts live rows when fresh verification could not read one host", () => {
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(true);
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Octocat", "env-1 gitlab.com": "Theo" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(false);
+  });
+
+  it("retains only rows whose capable hosts still have the same verified viewer", () => {
+    const github = entry({ environmentId: ENV_1, host: "github.com", number: 1 });
+    const gitlab = entry({ environmentId: ENV_1, host: "gitlab.com", number: 2 });
+    const legacy = entry({ environmentId: ENV_2, host: "github.com", number: 3 });
+
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, gitlab, legacy],
+        {
+          "env-1 github.com": "Bilal",
+          "env-1 gitlab.com": "Theo",
+          "env-2 github.com": "Legacy",
+        },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ).map((item) => item.number),
+    ).toEqual([1, 3]);
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, entry({ environmentId: ENV_2, host: "github.com", number: 4 })],
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Octocat" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1", "env-2"]),
+      ).map((item) => item.number),
+    ).toEqual([1]);
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        [github, legacy],
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        {},
+        new Set(["env-1"]),
+      ).map((item) => item.number),
+    ).toEqual([3]);
+
+    const alreadyVerified = [github, legacy];
+    expect(
+      retainPullRequestEntriesForVerifiedViewers(
+        alreadyVerified,
+        { "env-1 github.com": "Bilal", "env-2 github.com": "Legacy" },
+        { "env-1 github.com": "Bilal" },
+        new Set(["env-1"]),
+      ),
+    ).toBe(alreadyVerified);
+  });
+
+  it("removes the old account before accepting the replacement account's rows", () => {
+    const previous = entry({ number: 1 });
+    const queriedEnvironments = new Set(["env-1"]);
+
+    const verifying = resolvePullRequestRetainedVerification({
+      verificationPending: true,
+      verificationFailed: false,
+      viewerMismatch: false,
+      entries: [previous],
+      ordered: [previous],
+      listedViewers: { "env-1 github.com": "Bilal" },
+      verifiedViewers: null,
+      queriedEnvironmentIds: queriedEnvironments,
+    });
+    expect(verifying.status).toBe("verifying");
+
+    const changed = resolvePullRequestRetainedVerification({
+      verificationPending: false,
+      verificationFailed: false,
+      viewerMismatch: true,
+      entries: [previous],
+      ordered: [previous],
+      listedViewers: { "env-1 github.com": "Bilal" },
+      verifiedViewers: { "env-1 github.com": "Octocat" },
+      queriedEnvironmentIds: queriedEnvironments,
+    });
+    expect(changed).toMatchObject({
+      status: "accountChanged",
+      entries: [],
+      ordered: [],
+      changed: true,
+      empty: true,
+    });
+
+    const replacement = entry({ number: 2 });
+    expect(
+      pullRequestListViewersMatchVerification(
+        { "env-1 github.com": "Octocat" },
+        { "env-1 github.com": "Octocat" },
+        queriedEnvironments,
+      ),
+    ).toBe(true);
+    expect(replacement.number).toBe(2);
+  });
 
   it("hydrates the retained rows so ghosts never replace them", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "env-1:open:all::", data }, NOW);
+    const snapshot = readSnapshot(storage, "env-1");
     expect(snapshot?.scope).toBe("env-1:open:all::");
     expect(snapshot?.data.entries.map((item) => item.number)).toEqual([1]);
   });
 
+  it("hydrates across scopes only when every relevant row keeps its viewer", () => {
+    const storage = makeStorage();
+    const github = entry({ environmentId: ENV_1, host: "github.com", number: 1 });
+    const gitlab = entry({ environmentId: ENV_1, host: "gitlab.com", number: 2 });
+    writePullRequestListSnapshot(
+      storage,
+      "env-1",
+      {
+        scope: "broad",
+        data: {
+          entries: [github, gitlab],
+          viewers: { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
+          providers: [],
+          errors: [],
+          truncated: false,
+          nextCursors: {},
+          truncatedEnvironments: [],
+        },
+      },
+      NOW,
+    );
+    const readGithub = (viewer: string | undefined) =>
+      readPullRequestListSnapshot(storage, "env-1", {
+        viewers: viewer === undefined ? {} : { "env-1 github.com": viewer },
+        now: NOW,
+        includeEntry: (item) => item.host === "github.com",
+      });
+
+    expect(readGithub("Bilal")?.data.entries.map((item) => item.host)).toEqual(["github.com"]);
+    expect(readGithub("Octocat")).toBeNull();
+    expect(readGithub(undefined)).toBeNull();
+  });
+
   it("carries neither stale failures nor stale cursors", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+    const snapshot = readSnapshot(storage, "env-1");
     expect(snapshot?.data.errors).toEqual([]);
     expect(snapshot?.data.nextCursors).toEqual({});
   });
 
   it("answers nothing for another environment", () => {
     const storage = makeStorage();
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data });
-    expect(readPullRequestListSnapshot(storage, "env-2")).toBeNull();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+    expect(readSnapshot(storage, "env-2")).toBeNull();
+  });
+
+  it("rejects snapshots from another host account", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(readSnapshot(storage, "env-1", { "github.com": "Octocat" })).toBeNull();
+  });
+
+  it("rejects an existing snapshot when viewer verification failed", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(readPullRequestListSnapshot(storage, "env-1", { viewers: null, now: NOW })).toBeNull();
+  });
+
+  it("rejects snapshots after their short reload window", () => {
+    const storage = makeStorage();
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data }, NOW);
+
+    expect(
+      readSnapshot(storage, "env-1", { "github.com": "Bilal" }, NOW + 5 * 60 * 1_000 + 1),
+    ).toBeNull();
   });
 
   it("rejects a snapshot whose rows do not decode as entries", () => {
@@ -802,19 +1077,19 @@ describe("the list snapshot across a reload", () => {
       "t3.pullRequests.list:env-1",
       JSON.stringify({ scope: "s", data: { entries: [null] } }),
     );
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
     storage.setItem(
       "t3.pullRequests.list:env-1",
       JSON.stringify({ scope: "s", data: { entries: [{ host: "github.com" }] } }),
     );
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
   });
 
   it("shrugs off corrupt storage and no storage at all", () => {
     const storage = makeStorage();
     storage.setItem("t3.pullRequests.list:env-1", "{not json");
-    expect(readPullRequestListSnapshot(storage, "env-1")).toBeNull();
-    expect(readPullRequestListSnapshot(undefined, "env-1")).toBeNull();
+    expect(readSnapshot(storage, "env-1")).toBeNull();
+    expect(readSnapshot(undefined, "env-1")).toBeNull();
   });
 
   it("caps the accumulated rows but keeps the whole host set", () => {
@@ -850,8 +1125,8 @@ describe("the list snapshot across a reload", () => {
       truncated: true,
       nextCursors: {},
     } as never;
-    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data: accumulated });
-    const snapshot = readPullRequestListSnapshot(storage, "env-1");
+    writePullRequestListSnapshot(storage, "env-1", { scope: "s", data: accumulated }, NOW);
+    const snapshot = readSnapshot(storage, "env-1", viewers);
     expect(snapshot?.data.entries).toHaveLength(99);
     expect(snapshot?.data.viewers).toEqual(viewers);
     expect(snapshot?.data.providers).toEqual(providers);
@@ -860,6 +1135,32 @@ describe("the list snapshot across a reload", () => {
 
 const ENV_1 = "env-1" as EnvironmentId;
 const ENV_2 = "env-2" as EnvironmentId;
+
+describe("viewer verification gating", () => {
+  it("withholds a capable server while account verification races an in-flight list", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set([ENV_1]), [ENV_1], true);
+
+    expect(gate.listEnvironmentIds).toEqual([]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(false);
+  });
+
+  it("keeps live lists working on old servers without trusting their snapshots", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set(), [], false);
+
+    expect(gate.listEnvironmentIds).toEqual([ENV_1]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(false);
+  });
+
+  it("clears retained rows once viewer verification has actually failed", () => {
+    const gate = resolvePullRequestViewerGate([ENV_1], new Set([ENV_1]), [], false);
+
+    expect(gate.listEnvironmentIds).toEqual([]);
+    expect(gate.canHydrateSnapshot).toBe(false);
+    expect(gate.shouldClearRetainedRows).toBe(true);
+  });
+});
 
 describe("merging the environments' own listings", () => {
   const answer = (

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -886,14 +886,14 @@ describe("the list snapshot across a reload", () => {
     ).toBe(false);
   });
 
-  it("accepts live rows when fresh verification could not read one host", () => {
+  it("rejects live rows when fresh verification could not read one listed host", () => {
     expect(
       pullRequestListViewersMatchVerification(
         { "env-1 github.com": "Bilal", "env-1 gitlab.com": "Theo" },
         { "env-1 github.com": "Bilal" },
         new Set(["env-1"]),
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       pullRequestListViewersMatchVerification(
         { "env-1 github.com": "Octocat", "env-1 gitlab.com": "Theo" },

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -852,12 +852,7 @@ export const pullRequestListViewersMatchVerification = (
   );
   if (scopedViewers.length === 0) return true;
   if (verifiedViewers === null) return false;
-  // The gated live list runs after the fresh viewer read. A host omitted by that read has had its
-  // server cache cleared, so the list's own viewer is a fresh retry; only a known disagreement is
-  // an account switch. Snapshot and retained-row checks remain strict about missing identities.
-  return scopedViewers.every(
-    ([key, viewer]) => verifiedViewers[key] === undefined || verifiedViewers[key] === viewer,
-  );
+  return scopedViewers.every(([key, viewer]) => verifiedViewers[key] === viewer);
 };
 
 export const retainPullRequestEntriesForVerifiedViewers = (

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -741,6 +741,8 @@ export function mergePullRequestLists(
 
 /** One page is what the list itself starts with, and all a cold start needs to look warm. */
 const SNAPSHOT_MAX_ENTRIES = 99;
+/** A persisted list is only a short bridge across a reload, never a durable source of truth. */
+const SNAPSHOT_MAX_AGE_MS = 5 * 60 * 1_000;
 
 type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
 
@@ -751,6 +753,40 @@ type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
  */
 export const pullRequestEnvironmentSetKey = (environmentIds: ReadonlyArray<string>): string =>
   [...environmentIds].sort((left, right) => left.localeCompare(right)).join(",");
+
+export function resolvePullRequestViewerGate<Id extends string>(
+  environmentIds: ReadonlyArray<Id>,
+  viewerCapableEnvironmentIds: ReadonlySet<Id>,
+  verifiedEnvironmentIds: ReadonlyArray<Id>,
+  verificationPending: boolean,
+): {
+  readonly listEnvironmentIds: ReadonlyArray<Id>;
+  readonly canHydrateSnapshot: boolean;
+  readonly shouldClearRetainedRows: boolean;
+} {
+  const verified = new Set(verifiedEnvironmentIds);
+  const hasUnverifiedCapableEnvironment = environmentIds.some(
+    (environmentId) =>
+      viewerCapableEnvironmentIds.has(environmentId) && !verified.has(environmentId),
+  );
+  return {
+    listEnvironmentIds: environmentIds.filter(
+      (environmentId) =>
+        !viewerCapableEnvironmentIds.has(environmentId) ||
+        (!verificationPending && verified.has(environmentId)),
+    ),
+    canHydrateSnapshot:
+      environmentIds.length > 0 &&
+      !verificationPending &&
+      environmentIds.every(
+        (environmentId) =>
+          viewerCapableEnvironmentIds.has(environmentId) && verified.has(environmentId),
+      ),
+    // A refresh in flight still carries the identity this session already verified. Keep those
+    // rows visible until the read settles; only a settled failure proves they cannot be retained.
+    shouldClearRetainedRows: !verificationPending && hasUnverifiedCapableEnvironment,
+  };
+}
 
 const snapshotStorageKey = (environmentSetKey: string) =>
   `t3.pullRequests.list:${environmentSetKey}`;
@@ -766,9 +802,148 @@ export interface PullRequestPartitionsSnapshot {
 }
 
 export interface PullRequestListSnapshot {
+  readonly writtenAt: number;
   readonly scope: string;
   readonly data: MergedPullRequestList;
   readonly partitions?: PullRequestPartitionsSnapshot | undefined;
+}
+
+const viewerIdentity = (viewers: PullRequestViewers): string =>
+  JSON.stringify(Object.entries(viewers).toSorted(([left], [right]) => left.localeCompare(right)));
+
+export const pullRequestViewersMatch = (
+  left: PullRequestViewers,
+  right: PullRequestViewers,
+): boolean => viewerIdentity(left) === viewerIdentity(right);
+
+export const pullRequestViewersMatchForEnvironments = (
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers,
+  environmentIds: ReadonlySet<string>,
+  requiredViewerKeys?: ReadonlySet<string>,
+): boolean => {
+  const prefixes = [...environmentIds].map((environmentId) => `${environmentId} `);
+  const scopedListedViewers = Object.fromEntries(
+    Object.entries(listedViewers).filter(([key]) =>
+      prefixes.some((prefix) => key.startsWith(prefix)),
+    ),
+  );
+  if (requiredViewerKeys === undefined) {
+    return pullRequestViewersMatch(scopedListedViewers, verifiedViewers);
+  }
+  return [...requiredViewerKeys]
+    .filter((key) => prefixes.some((prefix) => key.startsWith(prefix)))
+    .every(
+      (key) =>
+        scopedListedViewers[key] !== undefined && scopedListedViewers[key] === verifiedViewers[key],
+    );
+};
+
+export const pullRequestListViewersMatchVerification = (
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers | null,
+  verifiedEnvironmentIds: ReadonlySet<string>,
+): boolean => {
+  if (verifiedEnvironmentIds.size === 0) return true;
+
+  const prefixes = [...verifiedEnvironmentIds].map((environmentId) => `${environmentId} `);
+  const scopedViewers = Object.entries(listedViewers).filter(([key]) =>
+    prefixes.some((prefix) => key.startsWith(prefix)),
+  );
+  if (scopedViewers.length === 0) return true;
+  if (verifiedViewers === null) return false;
+  // The gated live list runs after the fresh viewer read. A host omitted by that read has had its
+  // server cache cleared, so the list's own viewer is a fresh retry; only a known disagreement is
+  // an account switch. Snapshot and retained-row checks remain strict about missing identities.
+  return scopedViewers.every(
+    ([key, viewer]) => verifiedViewers[key] === undefined || verifiedViewers[key] === viewer,
+  );
+};
+
+export const retainPullRequestEntriesForVerifiedViewers = (
+  entries: ReadonlyArray<EnvironmentPullRequestEntry>,
+  listedViewers: PullRequestViewers,
+  verifiedViewers: PullRequestViewers,
+  verifiedEnvironmentIds: ReadonlySet<string>,
+): ReadonlyArray<EnvironmentPullRequestEntry> => {
+  const retained = entries.filter((entry) => {
+    if (!verifiedEnvironmentIds.has(entry.environmentId)) return true;
+    const key = pullRequestViewerKey(entry);
+    return listedViewers[key] !== undefined && listedViewers[key] === verifiedViewers[key];
+  });
+  return retained.length === entries.length ? entries : retained;
+};
+
+export type PullRequestRetainedVerification =
+  | { readonly status: "verifying" }
+  | { readonly status: "verified" }
+  | {
+      readonly status: "failed" | "accountChanged";
+      readonly entries: ReadonlyArray<EnvironmentPullRequestEntry>;
+      readonly ordered: ReadonlyArray<EnvironmentPullRequestEntry>;
+      readonly partitions?: PullRequestPartitionsSnapshot | undefined;
+      readonly changed: boolean;
+      readonly empty: boolean;
+    };
+
+/**
+ * Reduces a settled viewer check to the only retained rows the route may keep. The route owns
+ * pagination and React state; this controller owns the security transition so partial failures,
+ * account changes, and partitioned rows cannot drift into separate code paths.
+ */
+export function resolvePullRequestRetainedVerification({
+  verificationPending,
+  verificationFailed,
+  viewerMismatch,
+  entries,
+  ordered,
+  partitions,
+  listedViewers,
+  verifiedViewers,
+  queriedEnvironmentIds,
+}: {
+  readonly verificationPending: boolean;
+  readonly verificationFailed: boolean;
+  readonly viewerMismatch: boolean;
+  readonly entries: ReadonlyArray<EnvironmentPullRequestEntry>;
+  readonly ordered: ReadonlyArray<EnvironmentPullRequestEntry>;
+  readonly partitions?: PullRequestPartitionsSnapshot | undefined;
+  readonly listedViewers: PullRequestViewers;
+  readonly verifiedViewers: PullRequestViewers | null;
+  readonly queriedEnvironmentIds: ReadonlySet<string>;
+}): PullRequestRetainedVerification {
+  if (verificationPending) return { status: "verifying" };
+  if (!verificationFailed && !viewerMismatch) return { status: "verified" };
+
+  const viewers = verifiedViewers ?? {};
+  const retain = (rows: ReadonlyArray<EnvironmentPullRequestEntry>) =>
+    retainPullRequestEntriesForVerifiedViewers(rows, listedViewers, viewers, queriedEnvironmentIds);
+  const retainedEntries = retain(entries);
+  const retainedOrdered = retain(ordered);
+  const retainedAuthored = partitions === undefined ? undefined : retain(partitions.authored);
+  const retainedReviewing = partitions === undefined ? undefined : retain(partitions.reviewing);
+  const retainedPartitions =
+    partitions === undefined
+      ? undefined
+      : { authored: retainedAuthored ?? [], reviewing: retainedReviewing ?? [] };
+  const changed =
+    retainedEntries !== entries ||
+    retainedOrdered !== ordered ||
+    (partitions !== undefined &&
+      (retainedAuthored !== partitions.authored || retainedReviewing !== partitions.reviewing));
+
+  return {
+    status: viewerMismatch ? "accountChanged" : "failed",
+    entries: retainedEntries,
+    ordered: retainedOrdered,
+    ...(retainedPartitions === undefined ? {} : { partitions: retainedPartitions }),
+    changed,
+    empty:
+      retainedEntries.length === 0 &&
+      retainedOrdered.length === 0 &&
+      (retainedPartitions === undefined ||
+        (retainedPartitions.authored.length === 0 && retainedPartitions.reviewing.length === 0)),
+  };
 }
 
 /**
@@ -789,6 +964,7 @@ const EnvironmentPullRequestErrorSchema = Schema.Struct({
 
 const decodeSnapshot = Schema.decodeUnknownOption(
   Schema.Struct({
+    writtenAt: Schema.Number,
     scope: Schema.String,
     data: Schema.Struct({
       ...PullRequestListResult.fields,
@@ -818,12 +994,58 @@ const decodeSnapshot = Schema.decodeUnknownOption(
 export function readPullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
+  context:
+    | {
+        readonly viewers: PullRequestViewers | null;
+        readonly now?: number;
+        readonly includeEntry?: (entry: EnvironmentPullRequestEntry) => boolean;
+      }
+    | undefined = undefined,
 ): PullRequestListSnapshot | null {
   try {
+    // Older route code cannot prove snapshot ownership. It gets a cold start until the stacked
+    // route integration supplies the fresh viewer result.
+    if (context === undefined || context.viewers === null) return null;
+    const viewers = context.viewers;
     const raw = storage?.getItem(snapshotStorageKey(environmentSetKey));
     if (!raw) return null;
     const decoded = decodeSnapshot(JSON.parse(raw));
-    return decoded._tag === "Some" ? decoded.value : null;
+    if (decoded._tag === "None") return null;
+    const now = context.now ?? Date.now();
+    if (decoded.value.writtenAt > now || now - decoded.value.writtenAt > SNAPSHOT_MAX_AGE_MS) {
+      return null;
+    }
+    if (context.includeEntry === undefined) {
+      if (!pullRequestViewersMatch(decoded.value.data.viewers, viewers)) return null;
+    } else {
+      const includedEntries = decoded.value.data.entries.filter(context.includeEntry);
+      const includedAuthored = decoded.value.partitions?.authored.filter(context.includeEntry);
+      const includedReviewing = decoded.value.partitions?.reviewing.filter(context.includeEntry);
+      const requiredViewerKeys = new Set(
+        [...includedEntries, ...(includedAuthored ?? []), ...(includedReviewing ?? [])].map(
+          pullRequestViewerKey,
+        ),
+      );
+      if (
+        [...requiredViewerKeys].some(
+          (key) =>
+            decoded.value.data.viewers[key] === undefined ||
+            decoded.value.data.viewers[key] !== viewers[key],
+        )
+      ) {
+        return null;
+      }
+      return {
+        ...decoded.value,
+        data: { ...decoded.value.data, entries: includedEntries },
+        ...(decoded.value.partitions === undefined
+          ? {}
+          : {
+              partitions: { authored: includedAuthored ?? [], reviewing: includedReviewing ?? [] },
+            }),
+      };
+    }
+    return decoded.value;
   } catch {
     return null;
   }
@@ -832,12 +1054,14 @@ export function readPullRequestListSnapshot(
 export function writePullRequestListSnapshot(
   storage: SnapshotStorage | undefined,
   environmentSetKey: string,
-  snapshot: PullRequestListSnapshot,
+  snapshot: Omit<PullRequestListSnapshot, "writtenAt">,
+  now = Date.now(),
 ): void {
   try {
     storage?.setItem(
       snapshotStorageKey(environmentSetKey),
       JSON.stringify({
+        writtenAt: now,
         scope: snapshot.scope,
         data: {
           ...snapshot.data,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -901,6 +901,7 @@ function PullRequestsRouteView() {
   // another account.
   const verifiedListData = acceptVerifiedData(listQuery.data);
   const verifiedBaselineData = acceptVerifiedData(baselineQuery.data);
+  const verifiedFacetData = acceptVerifiedData(facetQuery.data);
   const verifiedAuthoredData = acceptVerifiedData(authoredQuery.data);
   const verifiedReviewingData = acceptVerifiedData(reviewingQuery.data);
   const rejectedRefreshes = useRef(new Map<string, () => void>());
@@ -911,6 +912,7 @@ function PullRequestsRouteView() {
     const queries = [
       ["list", listQuery, verifiedListData],
       ["baseline", baselineQuery, verifiedBaselineData],
+      ["facet", facetQuery, verifiedFacetData],
       ["authored", authoredQuery, verifiedAuthoredData],
       ["reviewing", reviewingQuery, verifiedReviewingData],
     ] as const;
@@ -938,6 +940,10 @@ function PullRequestsRouteView() {
     baselineQuery.error,
     baselineQuery.isPending,
     baselineQuery.refresh,
+    facetQuery.data,
+    facetQuery.error,
+    facetQuery.isPending,
+    facetQuery.refresh,
     listQuery.data,
     listQuery.error,
     listQuery.isPending,
@@ -948,6 +954,7 @@ function PullRequestsRouteView() {
     reviewingQuery.refresh,
     verifiedAuthoredData,
     verifiedBaselineData,
+    verifiedFacetData,
     verifiedListData,
     verifiedReviewingData,
     viewerQuery.error,
@@ -1236,17 +1243,31 @@ function PullRequestsRouteView() {
   // row it excludes. Narrowed to nothing there is nothing to carry, and the skeletons below are
   // right after all. Rows read from a different set of environments are dropped rather than
   // narrowed: one of those environments may no longer be connected.
+  const verifiedLoadedData = loaded === null ? null : acceptVerifiedData(loaded.data);
   const narrowed = useMemo(() => {
-    if (loaded === null || loaded.environmentKey !== environmentKey || loaded.scope === scopeKey) {
+    if (
+      loaded === null ||
+      verifiedLoadedData === null ||
+      loaded.environmentKey !== environmentKey ||
+      loaded.scope === scopeKey
+    ) {
       return null;
     }
-    const entries = narrowPullRequestsToFilters(loaded.data.entries, {
+    const entries = narrowPullRequestsToFilters(verifiedLoadedData.entries, {
       state: search.state,
       projectId: scopedProjectId,
       host: search.host,
     });
-    return entries.length === 0 ? null : { ...loaded.data, entries };
-  }, [environmentKey, loaded, scopeKey, scopedProjectId, search.host, search.state]);
+    return entries.length === 0 ? null : { ...verifiedLoadedData, entries };
+  }, [
+    environmentKey,
+    loaded,
+    scopeKey,
+    scopedProjectId,
+    search.host,
+    search.state,
+    verifiedLoadedData,
+  ]);
   // With nothing typed and nothing to carry on from, the answer is taken from the read that is
   // keyed to exactly that question. Otherwise a search's answer lingers for a render after the
   // text has gone — the data cannot say which question it belongs to, but the read it came from
@@ -1258,12 +1279,12 @@ function PullRequestsRouteView() {
     (sentQuery.length === 0 && sentCursors === null && pageSize === PAGE_SIZE
       ? verifiedBaselineData
       : verifiedListData) ??
-    (loaded?.scope === scopeKey && loaded.query === sentQuery ? loaded.data : null);
+    (loaded?.scope === scopeKey && loaded.query === sentQuery ? verifiedLoadedData : null);
   // Clearing a search returns to a list that has already been read, so it comes back at once
   // rather than after another round trip: the search was the temporary state, not the list.
   const carried =
     (sentQuery.length === 0 ? verifiedBaselineData : undefined) ??
-    (loaded?.scope === scopeKey ? loaded.data : null) ??
+    (loaded?.scope === scopeKey ? verifiedLoadedData : null) ??
     narrowed;
   const listData = answered ?? carried;
   const baselineAnswers = sentQuery.length === 0 && sentCursors === null && pageSize === PAGE_SIZE;
@@ -1395,12 +1416,12 @@ function PullRequestsRouteView() {
     () =>
       collectPullRequestListFacets(
         [
-          ...(facetQuery.data?.entries ?? []),
+          ...(verifiedFacetData?.entries ?? []),
           ...(verifiedBaselineData?.entries ?? listData?.entries ?? []),
         ],
         search.state,
       ),
-    [facetQuery.data?.entries, listData?.entries, search.state, verifiedBaselineData?.entries],
+    [listData?.entries, search.state, verifiedBaselineData?.entries, verifiedFacetData?.entries],
   );
 
   /** The hosts that narrowed the listing themselves, so their answer is not narrowed again. */
@@ -1415,7 +1436,10 @@ function PullRequestsRouteView() {
   );
 
   const entries = useMemo(() => {
-    const known = ordered?.key === filterKey ? ordered.entries : (listData?.entries ?? []);
+    const known =
+      verifiedLoadedData !== null && ordered?.key === filterKey
+        ? ordered.entries
+        : (listData?.entries ?? []);
     const involvementEntries = filterPullRequestsByInvolvement(known, viewers, search.involvement);
     // The hosts search more than the row shows — a body, a review, a commit message — so once
     // their answer is in, narrowing it again here would throw away matches the reader asked for.
@@ -1455,6 +1479,7 @@ function PullRequestsRouteView() {
     searchingHosts,
     showingCarried,
     typedParsed.text,
+    verifiedLoadedData,
     viewers,
   ]);
 

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -56,9 +56,14 @@ import {
   pullRequestDiffStatKey,
   pullRequestEntryKey,
   pullRequestEntryViewer,
+  pullRequestViewerKey,
   rankPullRequestMatches,
   pullRequestEnvironmentSetKey,
+  pullRequestListViewersMatchVerification,
+  pullRequestViewersMatchForEnvironments,
   readPullRequestListSnapshot,
+  resolvePullRequestRetainedVerification,
+  resolvePullRequestViewerGate,
   resolveProjectScope,
   resolveQueryEnvironmentIds,
   resolveSelectedEnvironmentId,
@@ -122,6 +127,7 @@ import {
   pullRequestEnvironment,
   usePullRequestList,
   usePullRequestListStats,
+  usePullRequestViewers,
   type EnvironmentQueryTarget,
 } from "../state/pullRequests";
 import { useAtomCommand } from "../state/use-atom-command";
@@ -302,6 +308,17 @@ function PullRequestsRouteView() {
         )
         .toSorted((left, right) => left.environmentId.localeCompare(right.environmentId)),
     [environments],
+  );
+  const viewerCapableEnvironmentIds = useMemo(
+    () =>
+      new Set(
+        capableEnvironments.flatMap((environment) =>
+          environment.serverConfig?.environment.capabilities.pullRequestViewers === true
+            ? [environment.environmentId]
+            : [],
+        ),
+      ),
+    [capableEnvironments],
   );
   // The server the URL asks for, kept only while it is one the page could read: a link naming a
   // server this workspace no longer has falls back to all of them rather than to nothing.
@@ -698,7 +715,59 @@ function PullRequestsRouteView() {
       sentParsed.text,
     ],
   );
-  const listQuery = usePullRequestList(listTargets);
+  // Verify the account independently of the slower repository listing. This is deliberately a
+  // fresh server read: the host CLI account can change outside T3 between two page loads.
+  const viewerTargets = useMemo(
+    () =>
+      environmentQueries.flatMap(({ environmentId, projectIds }) =>
+        viewerCapableEnvironmentIds.has(environmentId)
+          ? [
+              {
+                environmentId,
+                input: {
+                  ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
+                  ...(projectIds ? { projectIds } : {}),
+                  ...(search.host ? { host: search.host } : {}),
+                },
+              },
+            ]
+          : [],
+      ),
+    [environmentQueries, scopedProjectId, search.host, viewerCapableEnvironmentIds],
+  );
+  const viewerQuery = usePullRequestViewers(viewerTargets);
+  const queriedViewerEnvironmentIds = useMemo(
+    () => new Set(viewerTargets.map(({ environmentId }) => environmentId)),
+    [viewerTargets],
+  );
+  // The fresh viewer read also invalidates server-side listing caches when the CLI account has
+  // changed. Do not race a warm list hit against that read, and never ask an environment whose
+  // identity check failed. Older servers without this method keep their live-list behavior, but
+  // cannot hydrate a persisted snapshot because their identity cannot be verified independently.
+  const viewerGate = useMemo(
+    () =>
+      resolvePullRequestViewerGate(
+        environmentQueries.map(({ environmentId }) => environmentId),
+        viewerCapableEnvironmentIds,
+        viewerQuery.environmentIds,
+        viewerQuery.isPending,
+      ),
+    [
+      environmentQueries,
+      viewerCapableEnvironmentIds,
+      viewerQuery.environmentIds,
+      viewerQuery.isPending,
+    ],
+  );
+  const verifiedEnvironmentIds = useMemo(
+    () => new Set(viewerGate.listEnvironmentIds),
+    [viewerGate.listEnvironmentIds],
+  );
+  const verifiedListTargets = useMemo(
+    () => listTargets.filter(({ environmentId }) => verifiedEnvironmentIds.has(environmentId)),
+    [listTargets, verifiedEnvironmentIds],
+  );
+  const listQuery = usePullRequestList(verifiedListTargets);
 
   /**
    * The same filters with nothing typed, read whether or not anything is. It is the same atom the
@@ -734,21 +803,38 @@ function PullRequestsRouteView() {
       search.state,
     ],
   );
-  const baselineQuery = usePullRequestList(baselineTargets);
+  const verifiedBaselineTargets = useMemo(
+    () => baselineTargets.filter(({ environmentId }) => verifiedEnvironmentIds.has(environmentId)),
+    [baselineTargets, verifiedEnvironmentIds],
+  );
+  const baselineQuery = usePullRequestList(verifiedBaselineTargets);
   const facetTargets = useMemo(() => {
     if (!filtersOpen) return NO_LIST_TARGETS;
-    return environmentQueries.map(({ environmentId, projectIds }) => ({
-      environmentId,
-      input: {
-        state: "all",
-        involvement: search.involvement,
-        limit: PAGE_SIZE,
-        ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
-        ...(projectIds ? { projectIds } : {}),
-        ...(search.host ? { host: search.host } : {}),
-      } satisfies PullRequestListInput,
-    }));
-  }, [environmentQueries, filtersOpen, scopedProjectId, search.host, search.involvement]);
+    return environmentQueries.flatMap(({ environmentId, projectIds }) =>
+      verifiedEnvironmentIds.has(environmentId)
+        ? [
+            {
+              environmentId,
+              input: {
+                state: "all",
+                involvement: search.involvement,
+                limit: PAGE_SIZE,
+                ...(scopedProjectId ? { projectId: scopedProjectId } : {}),
+                ...(projectIds ? { projectIds } : {}),
+                ...(search.host ? { host: search.host } : {}),
+              } satisfies PullRequestListInput,
+            },
+          ]
+        : [],
+    );
+  }, [
+    environmentQueries,
+    filtersOpen,
+    scopedProjectId,
+    search.host,
+    search.involvement,
+    verifiedEnvironmentIds,
+  ]);
   const facetQuery = usePullRequestList(facetTargets);
   // The priority groups' own reads. The feed below is paginated by recency, so an older authored
   // or review-requested row can be missing from its first page; partitioned from these
@@ -784,8 +870,90 @@ function PullRequestsRouteView() {
     search.host,
     search.state,
   ]);
-  const authoredQuery = usePullRequestList(partitionTargets.authored);
-  const reviewingQuery = usePullRequestList(partitionTargets.reviewing);
+  const verifiedAuthoredTargets = useMemo(
+    () =>
+      partitionTargets.authored.filter(({ environmentId }) =>
+        verifiedEnvironmentIds.has(environmentId),
+      ),
+    [partitionTargets.authored, verifiedEnvironmentIds],
+  );
+  const verifiedReviewingTargets = useMemo(
+    () =>
+      partitionTargets.reviewing.filter(({ environmentId }) =>
+        verifiedEnvironmentIds.has(environmentId),
+      ),
+    [partitionTargets.reviewing, verifiedEnvironmentIds],
+  );
+  const authoredQuery = usePullRequestList(verifiedAuthoredTargets);
+  const reviewingQuery = usePullRequestList(verifiedReviewingTargets);
+  const acceptVerifiedData = (data: MergedPullRequestList | null) => {
+    if (data === null) return null;
+    return pullRequestListViewersMatchVerification(
+      data.viewers,
+      viewerQuery.viewers,
+      queriedViewerEnvironmentIds,
+    )
+      ? data
+      : null;
+  };
+  // Query atoms retain their previous success while refreshing. Keep that useful behavior for
+  // the same account, but never render the retained answer after fresh verification identifies
+  // another account.
+  const verifiedListData = acceptVerifiedData(listQuery.data);
+  const verifiedBaselineData = acceptVerifiedData(baselineQuery.data);
+  const verifiedAuthoredData = acceptVerifiedData(authoredQuery.data);
+  const verifiedReviewingData = acceptVerifiedData(reviewingQuery.data);
+  const rejectedRefreshes = useRef(new Map<string, () => void>());
+  useEffect(() => {
+    const viewers = viewerQuery.viewers;
+    if (viewerQuery.isPending || viewerQuery.error !== null || viewers === null) return;
+
+    const queries = [
+      ["list", listQuery, verifiedListData],
+      ["baseline", baselineQuery, verifiedBaselineData],
+      ["authored", authoredQuery, verifiedAuthoredData],
+      ["reviewing", reviewingQuery, verifiedReviewingData],
+    ] as const;
+    for (const [name, query, accepted] of queries) {
+      if (query.data === null || accepted !== null) {
+        rejectedRefreshes.current.delete(name);
+        continue;
+      }
+      if (
+        query.isPending ||
+        query.error !== null ||
+        rejectedRefreshes.current.get(name) === query.refresh
+      ) {
+        continue;
+      }
+      rejectedRefreshes.current.set(name, query.refresh);
+      query.refresh();
+    }
+  }, [
+    authoredQuery.data,
+    authoredQuery.error,
+    authoredQuery.isPending,
+    authoredQuery.refresh,
+    baselineQuery.data,
+    baselineQuery.error,
+    baselineQuery.isPending,
+    baselineQuery.refresh,
+    listQuery.data,
+    listQuery.error,
+    listQuery.isPending,
+    listQuery.refresh,
+    reviewingQuery.data,
+    reviewingQuery.error,
+    reviewingQuery.isPending,
+    reviewingQuery.refresh,
+    verifiedAuthoredData,
+    verifiedBaselineData,
+    verifiedListData,
+    verifiedReviewingData,
+    viewerQuery.error,
+    viewerQuery.isPending,
+    viewerQuery.viewers,
+  ]);
   // The header's refresh punches through the server's cache before re-reading; the error and
   // empty states retry plainly, because a failure is never cached.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
@@ -810,6 +978,7 @@ function PullRequestsRouteView() {
       setInvalidating(false);
     }
     refreshList();
+    viewerQuery.refresh();
     baselineQuery.refresh();
     facetQuery.refresh();
     authoredQuery.refresh();
@@ -828,7 +997,7 @@ function PullRequestsRouteView() {
     }
     setDetailRefreshToken((token) => token + 1);
   };
-  const refreshing = invalidating || listQuery.isPending;
+  const refreshing = invalidating || viewerQuery.isPending || listQuery.isPending;
 
   // Every page size and every search is its own query, and a new one starts empty. The last
   // answer for these filters is held so the page grows and narrows in place rather than blanking
@@ -854,17 +1023,121 @@ function PullRequestsRouteView() {
   // A reload recreates the registry the queries live in, so with nothing held the page would
   // cold-start into skeletons even though almost every row is unchanged. The last answer for
   // this set of environments is kept across reloads and hydrated here as the carried rows: they
-  // render at once — narrowed to the current filters like any carried answer — and the live read
-  // reconciles them in place by key rather than replacing them with ghosts.
+  // render once the current host identities are known — narrowed to the current filters like any
+  // carried answer — and the live read reconciles them in place by key rather than replacing them
+  // with ghosts. Waiting for identity prevents one CLI account from seeing another's stored rows.
   useEffect(() => {
+    const viewers = viewerQuery.viewers;
     if (environmentKey.length === 0) return;
+    const projectScopes = new Map(
+      environmentQueries.map(({ environmentId, projectIds }) => [environmentId, projectIds]),
+    );
+    if (loaded !== null) {
+      const heldOrdered = ordered?.entries ?? loaded.data.entries;
+      const retainedViewerKeys = new Set(
+        [
+          ...heldOrdered,
+          ...(loaded.partitions?.authored ?? []),
+          ...(loaded.partitions?.reviewing ?? []),
+        ]
+          .filter((entry) => {
+            const projectIds = projectScopes.get(entry.environmentId);
+            return projectIds === undefined || projectIds.includes(entry.projectId);
+          })
+          .map(pullRequestViewerKey),
+      );
+      const retainedViewerMismatch =
+        !viewerQuery.isPending &&
+        loaded.environmentKey === environmentKey &&
+        viewers !== null &&
+        !pullRequestViewersMatchForEnvironments(
+          loaded.data.viewers,
+          viewers,
+          queriedViewerEnvironmentIds,
+          retainedViewerKeys,
+        );
+      const verification = resolvePullRequestRetainedVerification({
+        verificationPending: viewerQuery.isPending,
+        verificationFailed: viewerGate.shouldClearRetainedRows,
+        viewerMismatch: retainedViewerMismatch,
+        entries: loaded.data.entries,
+        ordered: heldOrdered,
+        partitions: loaded.partitions,
+        listedViewers: loaded.data.viewers,
+        verifiedViewers: viewers,
+        queriedEnvironmentIds: queriedViewerEnvironmentIds,
+      });
+      if (verification.status === "verifying") return;
+      if (verification.status === "failed" || verification.status === "accountChanged") {
+        if (!verification.changed) return;
+        if (verification.empty) {
+          setLoaded(null);
+          setOrdered(null);
+          setPage({ key: filterKey, size: PAGE_SIZE, cursors: null, regrown: [] });
+          return;
+        }
+        if (
+          verification.entries !== loaded.data.entries ||
+          verification.partitions !== loaded.partitions
+        ) {
+          setLoaded((current) =>
+            current === null
+              ? null
+              : {
+                  ...current,
+                  data: { ...current.data, entries: verification.entries },
+                  ...(verification.partitions === undefined
+                    ? {}
+                    : { partitions: verification.partitions }),
+                },
+          );
+        }
+        if (verification.ordered !== heldOrdered) {
+          setOrdered({ key: ordered?.key ?? filterKey, entries: verification.ordered });
+        }
+        const heldVisible = ordered?.key === filterKey ? heldOrdered : loaded.data.entries;
+        const retainedVisible =
+          ordered?.key === filterKey ? verification.ordered : verification.entries;
+        if (retainedVisible !== heldVisible) {
+          setPage({
+            key: filterKey,
+            size: Math.min(
+              Math.max(pageSize, Math.ceil(retainedVisible.length / PAGE_SIZE) * PAGE_SIZE),
+              MAX_PAGE_SIZE,
+            ),
+            cursors: null,
+            regrown: [],
+          });
+        }
+        return;
+      }
+    }
+    // A pending read is not a mismatch: keep what this session already verified until the fresh
+    // identity arrives. A legacy-only environment has no independent identity to compare and
+    // continues to use live rows, but never hydrates persisted ones.
+    if (viewerQuery.isPending || viewers === null) return;
     setLoaded((current) => {
+      if (!viewerGate.canHydrateSnapshot) return current;
       // Rows read from a different set of environments cannot even be narrowed — one of them may
       // no longer be connected at all — so that set's own snapshot beats holding them.
       if (current !== null && current.environmentKey === environmentKey) return current;
       const snapshot = readPullRequestListSnapshot(
         typeof window === "undefined" ? undefined : window.localStorage,
         environmentKey,
+        {
+          viewers,
+          includeEntry: (entry) => {
+            const projectIds = projectScopes.get(entry.environmentId);
+            return (
+              (projectIds === undefined || projectIds.includes(entry.projectId)) &&
+              narrowPullRequestsToFilters([entry], {
+                state: search.state,
+                projectId: scopedProjectId,
+                host: search.host,
+              }).length > 0
+            );
+          },
+        },
       );
       if (snapshot === null) return null;
       return {
@@ -875,22 +1148,36 @@ function PullRequestsRouteView() {
         ...(snapshot.partitions === undefined ? {} : { partitions: snapshot.partitions }),
       };
     });
-  }, [environmentKey]);
+  }, [
+    environmentKey,
+    environmentQueries,
+    filterKey,
+    loaded,
+    ordered,
+    pageSize,
+    queriedViewerEnvironmentIds,
+    scopedProjectId,
+    search.host,
+    search.state,
+    viewerGate,
+    viewerQuery.isPending,
+    viewerQuery.viewers,
+  ]);
   useEffect(() => {
     // Only once this query has settled. While a search is being swapped in or out the text has
     // already changed and the data has not, so recording them together would file the previous
     // answer under the new question — which is how a search's answer came to speak for the
     // workspace after the search was cleared.
-    if (!listQuery.data || listQuery.isPending) return;
-    const data = listQuery.data;
+    if (!verifiedListData || listQuery.isPending) return;
+    const data = verifiedListData;
     setLoaded((current) => {
       // The partitions arrive on their own clock, so this records whichever have landed by
       // now and runs again when the rest do. Until then the ones already held for this scope
       // stay — hydrated or previously answered — rather than being dropped for a feed that
       // merely settled first.
       const partitions =
-        partitionsWanted && authoredQuery.data !== null && reviewingQuery.data !== null
-          ? { authored: authoredQuery.data.entries, reviewing: reviewingQuery.data.entries }
+        partitionsWanted && verifiedAuthoredData !== null && verifiedReviewingData !== null
+          ? { authored: verifiedAuthoredData.entries, reviewing: verifiedReviewingData.entries }
           : current !== null &&
               current.environmentKey === environmentKey &&
               current.scope === scopeKey
@@ -915,8 +1202,8 @@ function PullRequestsRouteView() {
             data: {
               ...data,
               entries: accumulatedEntries,
-              viewers: baselineQuery.data?.viewers ?? data.viewers,
-              providers: baselineQuery.data?.providers ?? data.providers,
+              viewers: verifiedBaselineData?.viewers ?? data.viewers,
+              providers: verifiedBaselineData?.providers ?? data.providers,
             },
             ...(partitions === undefined ? {} : { partitions }),
           },
@@ -934,14 +1221,14 @@ function PullRequestsRouteView() {
     environmentKey,
     scopeKey,
     sentQuery,
-    listQuery.data,
+    verifiedListData,
     listQuery.isPending,
     partitionsWanted,
-    authoredQuery.data,
-    reviewingQuery.data,
+    verifiedAuthoredData,
+    verifiedReviewingData,
     ordered,
     filterKey,
-    baselineQuery.data,
+    verifiedBaselineData,
   ]);
   // Changing a filter asks a question nothing has answered yet, and the page is already holding
   // perfectly good rows for the last one. Rather than blank out for the round trip, those rows
@@ -969,21 +1256,39 @@ function PullRequestsRouteView() {
   // have its extra rows thrown away for the ninety-nine the baseline keeps answering with.
   const answered =
     (sentQuery.length === 0 && sentCursors === null && pageSize === PAGE_SIZE
-      ? baselineQuery.data
-      : listQuery.data) ??
+      ? verifiedBaselineData
+      : verifiedListData) ??
     (loaded?.scope === scopeKey && loaded.query === sentQuery ? loaded.data : null);
   // Clearing a search returns to a list that has already been read, so it comes back at once
   // rather than after another round trip: the search was the temporary state, not the list.
   const carried =
-    (sentQuery.length === 0 ? baselineQuery.data : undefined) ??
+    (sentQuery.length === 0 ? verifiedBaselineData : undefined) ??
     (loaded?.scope === scopeKey ? loaded.data : null) ??
     narrowed;
   const listData = answered ?? carried;
+  const baselineAnswers = sentQuery.length === 0 && sentCursors === null && pageSize === PAGE_SIZE;
+  const answerRejected = baselineAnswers
+    ? baselineQuery.data !== null && verifiedBaselineData === null
+    : listQuery.data !== null && verifiedListData === null;
+  const answerQueryName = baselineAnswers ? "baseline" : "list";
+  const answerQuery = baselineAnswers ? baselineQuery : listQuery;
+  const verificationFailed =
+    answerRejected &&
+    !answerQuery.isPending &&
+    rejectedRefreshes.current.get(answerQueryName) === answerQuery.refresh;
   /** The rows on screen answer the previous question, held while this one is on its way. */
   const showingCarried = answered === null && carried !== null;
   const loadingMore = listQuery.isPending && listData !== null;
+  const listError =
+    viewerQuery.error ??
+    listQuery.error ??
+    (verificationFailed
+      ? "Could not verify the pull request account. Retry to load safely."
+      : null);
   /** Nothing read and nothing to carry, which is the one thing skeletons are for. */
-  const firstLoad = listQuery.isPending && listData === null;
+  const firstLoad =
+    (viewerQuery.isPending || listQuery.isPending || (answerRejected && listError === null)) &&
+    listData === null;
 
   // `ordered` is declared above, ahead of the snapshot write, but grown here from this round's
   // own answer.
@@ -1076,6 +1381,7 @@ function PullRequestsRouteView() {
   // host's rate limit.
   useLiveRefresh(
     () => {
+      viewerQuery.refresh();
       refreshList();
       authoredQuery.refresh();
       reviewingQuery.refresh();
@@ -1083,29 +1389,29 @@ function PullRequestsRouteView() {
     { enabled: pullRequestsSupported },
   );
 
-  const viewers = baselineQuery.data?.viewers ?? listData?.viewers ?? EMPTY_VIEWERS;
-  const listErrors = baselineQuery.data?.errors ?? listData?.errors ?? [];
+  const viewers = verifiedBaselineData?.viewers ?? listData?.viewers ?? EMPTY_VIEWERS;
+  const listErrors = verifiedBaselineData?.errors ?? listData?.errors ?? [];
   const facets = useMemo(
     () =>
       collectPullRequestListFacets(
         [
           ...(facetQuery.data?.entries ?? []),
-          ...(baselineQuery.data?.entries ?? listData?.entries ?? []),
+          ...(verifiedBaselineData?.entries ?? listData?.entries ?? []),
         ],
         search.state,
       ),
-    [baselineQuery.data?.entries, facetQuery.data?.entries, listData?.entries, search.state],
+    [facetQuery.data?.entries, listData?.entries, search.state, verifiedBaselineData?.entries],
   );
 
   /** The hosts that narrowed the listing themselves, so their answer is not narrowed again. */
   const searchingHosts = useMemo(
     () =>
       new Set(
-        (baselineQuery.data?.providers ?? listData?.providers ?? []).flatMap((provider) =>
+        (verifiedBaselineData?.providers ?? listData?.providers ?? []).flatMap((provider) =>
           provider.searchesOnHost ? [provider.host] : [],
         ),
       ),
-    [baselineQuery.data?.providers, listData?.providers],
+    [verifiedBaselineData?.providers, listData?.providers],
   );
 
   const entries = useMemo(() => {
@@ -1168,6 +1474,7 @@ function PullRequestsRouteView() {
       !sentinel ||
       entries.length === 0 ||
       listData?.truncated !== true ||
+      viewerQuery.isPending ||
       listQuery.isPending ||
       listQuery.error !== null ||
       // The rows on screen belong to the previous question, so nothing about them says where
@@ -1200,6 +1507,7 @@ function PullRequestsRouteView() {
     listQuery.isPending,
     pageSize,
     showingCarried,
+    viewerQuery.isPending,
   ]);
 
   /**
@@ -1228,10 +1536,10 @@ function PullRequestsRouteView() {
             matchesPullRequestFilters(entry, localFilters, pullRequestEntryViewer(entry, viewers)),
           );
     const authored = narrow(
-      partitionsWanted ? (authoredQuery.data?.entries ?? held?.authored) : undefined,
+      partitionsWanted ? (verifiedAuthoredData?.entries ?? held?.authored) : undefined,
     );
     const reviewing = narrow(
-      partitionsWanted ? (reviewingQuery.data?.entries ?? held?.reviewing) : undefined,
+      partitionsWanted ? (verifiedReviewingData?.entries ?? held?.reviewing) : undefined,
     );
     if (authored === undefined || reviewing === undefined) {
       return groupPullRequestsByInvolvement(entries, viewers);
@@ -1240,12 +1548,12 @@ function PullRequestsRouteView() {
   }, [
     hasLocalFilters,
     localFilters,
-    authoredQuery.data?.entries,
+    verifiedAuthoredData?.entries,
     entries,
     environmentKey,
     loaded,
     partitionsWanted,
-    reviewingQuery.data?.entries,
+    verifiedReviewingData?.entries,
     scopeKey,
     search.involvement,
     viewers,
@@ -1574,7 +1882,10 @@ function PullRequestsRouteView() {
   // so that case waits with the skeletons rather than answering for the hosts. A search says so
   // in its own words and is left to.
   const carriedToNothing =
-    showingCarried && listQuery.isPending && entries.length === 0 && typedQuery.length === 0;
+    showingCarried &&
+    (viewerQuery.isPending || listQuery.isPending) &&
+    entries.length === 0 &&
+    typedQuery.length === 0;
   const listBody = (
     <>
       {!capabilityKnown ? (
@@ -1586,8 +1897,14 @@ function PullRequestsRouteView() {
         />
       ) : firstLoad ? (
         <PullRequestListGhost rows={7} />
-      ) : listQuery.error && listData === null ? (
-        <PullRequestsUnavailableState error={listQuery.error} onRetry={() => listQuery.refresh()} />
+      ) : listError && listData === null ? (
+        <PullRequestsUnavailableState
+          error={listError}
+          onRetry={() => {
+            viewerQuery.refresh();
+            listQuery.refresh();
+          }}
+        />
       ) : carriedToNothing ? (
         <PullRequestListGhost rows={7} />
       ) : entries.length === 0 ? (
@@ -1652,10 +1969,17 @@ function PullRequestsRouteView() {
         </div>
       )}
 
-      {listQuery.error && listData !== null ? (
+      {listError && listData !== null ? (
         <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs">
           <span>The latest request failed. Showing the last pull requests loaded.</span>
-          <Button size="xs" variant="outline" onClick={() => listQuery.refresh()}>
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={() => {
+              viewerQuery.refresh();
+              listQuery.refresh();
+            }}
+          >
             Retry
           </Button>
         </div>

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -7,6 +7,7 @@ import type {
   EnvironmentId,
   PullRequestListInput,
   PullRequestListStatsInput,
+  PullRequestViewerInput,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
@@ -33,6 +34,8 @@ export interface EnvironmentQueryTarget<Input> {
 interface MergedEnvironmentQueryView<A> {
   /** One entry per query target that has answered, in the order the targets were given. */
   readonly values: ReadonlyArray<readonly [EnvironmentId, A]>;
+  /** Current successes only. A failed refresh may still leave its prior answer in `values`. */
+  readonly successfulValues: ReadonlyArray<readonly [EnvironmentId, A]>;
   /** The first environment that failed. Others may still have answered — this is not fatal. */
   readonly error: string | null;
   readonly isPending: boolean;
@@ -56,6 +59,7 @@ function createMergedEnvironmentQuery<Input, A>(
     Atom.make((get): MergedEnvironmentQueryView<A> => {
       const targets = JSON.parse(key) as ReadonlyArray<EnvironmentQueryTarget<Input>>;
       const values: Array<readonly [EnvironmentId, A]> = [];
+      const successfulValues: Array<readonly [EnvironmentId, A]> = [];
       let error: string | null = null;
       let isPending = false;
       for (const target of targets) {
@@ -66,12 +70,16 @@ function createMergedEnvironmentQuery<Input, A>(
         }
         const value = Option.getOrNull(AsyncResult.value(result));
         if (value !== null) values.push([target.environmentId, value]);
+        if (result._tag === "Success") {
+          successfulValues.push([target.environmentId, result.value]);
+        }
       }
-      return { values, error, isPending };
+      return { values, successfulValues, error, isPending };
     }).pipe(Atom.withLabel(`${label}:${key}`)),
   );
   const empty = Atom.make<MergedEnvironmentQueryView<A>>({
     values: [],
+    successfulValues: [],
     error: null,
     isPending: false,
   }).pipe(Atom.withLabel(`${label}:empty`));
@@ -97,6 +105,11 @@ const usePullRequestListsQuery = createMergedEnvironmentQuery(
   pullRequestEnvironment.list,
 );
 
+const usePullRequestViewersQuery = createMergedEnvironmentQuery(
+  "web-pull-requests:viewers",
+  pullRequestEnvironment.viewers,
+);
+
 const usePullRequestStatsQuery = createMergedEnvironmentQuery(
   "web-pull-requests:list-stats",
   pullRequestEnvironment.listStats,
@@ -107,6 +120,43 @@ export interface MergedPullRequestListView {
   readonly error: string | null;
   readonly isPending: boolean;
   readonly refresh: () => void;
+}
+
+/** Fresh host identities, scoped by environment so equal hostnames on two servers stay distinct. */
+export function usePullRequestViewers(
+  targets: ReadonlyArray<EnvironmentQueryTarget<PullRequestViewerInput>>,
+): {
+  readonly viewers: Readonly<Record<string, string>> | null;
+  readonly environmentIds: ReadonlyArray<EnvironmentId>;
+  readonly error: string | null;
+  readonly isPending: boolean;
+  readonly refresh: () => void;
+} {
+  const query = usePullRequestViewersQuery(targets);
+  const viewers = useMemo(
+    () =>
+      query.successfulValues.length === 0
+        ? null
+        : Object.fromEntries(
+            query.successfulValues.flatMap(([environmentId, result]) =>
+              Object.entries(result.viewers).map(
+                ([host, viewer]) => [`${environmentId} ${host}`, viewer] as const,
+              ),
+            ),
+          ),
+    [query.successfulValues],
+  );
+  const environmentIds = useMemo(
+    () => query.successfulValues.map(([environmentId]) => environmentId),
+    [query.successfulValues],
+  );
+  return {
+    viewers,
+    environmentIds,
+    error: query.error,
+    isPending: query.isPending,
+    refresh: query.refresh,
+  };
 }
 
 /** One listing per environment, merged into the single list the page renders. */

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -71,6 +71,11 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     staleTimeMs: 15_000,
   });
   return {
+    viewers: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:viewers",
+      tag: WS_METHODS.pullRequestsViewers,
+      staleTimeMs: 0,
+    }),
     list: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:list",
       tag: WS_METHODS.pullRequestsList,

--- a/packages/contracts/src/environment.test.ts
+++ b/packages/contracts/src/environment.test.ts
@@ -16,6 +16,7 @@ const descriptor = {
 describe("ExecutionEnvironmentDescriptor", () => {
   it("treats a missing pull-request capability as unsupported under version skew", () => {
     expect(decodeDescriptor(descriptor).capabilities.pullRequests).toBeUndefined();
+    expect(decodeDescriptor(descriptor).capabilities.pullRequestViewers).toBeUndefined();
   });
 
   it("preserves an advertised pull-request capability", () => {
@@ -24,6 +25,12 @@ describe("ExecutionEnvironmentDescriptor", () => {
         ...descriptor,
         capabilities: { ...descriptor.capabilities, pullRequests: true },
       }).capabilities.pullRequests,
+    ).toBe(true);
+    expect(
+      decodeDescriptor({
+        ...descriptor,
+        capabilities: { ...descriptor.capabilities, pullRequestViewers: true },
+      }).capabilities.pullRequestViewers,
     ).toBe(true);
   });
 

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -59,6 +59,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   /** Server exposes the pull-request list, detail, activity, diff, and mutation APIs. Absent on
       servers from before the pull-request workspace shipped, so clients must not probe them. */
   pullRequests: Schema.optionalKey(Schema.Boolean),
+  /** Server exposes the fresh pull-request viewer identity API. Absent on servers from before
+      snapshot identity verification shipped, so clients keep live listing but skip hydration. */
+  pullRequestViewers: Schema.optionalKey(Schema.Boolean),
   /** Server understands thread.settle / thread.unsettle commands. Absent on
       pre-settlement servers, so clients treat missing as unsupported and
       never send the commands under version skew. */

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -528,6 +528,24 @@ export const PullRequestListInput = Schema.Struct({
 export type PullRequestListInput = typeof PullRequestListInput.Type;
 
 /**
+ * The project and host scope whose signed-in identities a client needs before it can safely
+ * hydrate a persisted listing. Kept separate from the listing so account verification does not
+ * wait for every repository to be read.
+ */
+export const PullRequestViewerInput = Schema.Struct({
+  projectId: Schema.optional(ProjectId),
+  projectIds: Schema.optional(Schema.Array(ProjectId).check(Schema.isMaxLength(100))),
+  host: Schema.optional(TrimmedNonEmptyString),
+});
+export type PullRequestViewerInput = typeof PullRequestViewerInput.Type;
+
+export const PullRequestViewerResult = Schema.Struct({
+  /** The currently signed-in account per host. Unreadable hosts are absent. */
+  viewers: Schema.Record(TrimmedNonEmptyString, TrimmedNonEmptyString),
+});
+export type PullRequestViewerResult = typeof PullRequestViewerResult.Type;
+
+/**
  * A host the workspace has projects on, and whether it can be read right now. Drives the host
  * switcher and explains projects the list leaves out.
  *

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -93,6 +93,8 @@ import {
   PullRequestListResult,
   PullRequestListStatsInput,
   PullRequestListStatsResult,
+  PullRequestViewerInput,
+  PullRequestViewerResult,
   PullRequestOperationError,
   PullRequestReactionInput,
   PullRequestRef,
@@ -298,6 +300,7 @@ export const WS_METHODS = {
 
   // Pull request methods
   pullRequestsList: "pullRequests.list",
+  pullRequestsViewers: "pullRequests.viewers",
   pullRequestsListStats: "pullRequests.listStats",
   pullRequestsDetail: "pullRequests.detail",
   pullRequestsActivity: "pullRequests.activity",
@@ -497,6 +500,12 @@ const PullRequestRpcError = Schema.Union([
 export const WsPullRequestsListRpc = Rpc.make(WS_METHODS.pullRequestsList, {
   payload: PullRequestListInput,
   success: PullRequestListResult,
+  error: PullRequestRpcError,
+});
+
+export const WsPullRequestsViewersRpc = Rpc.make(WS_METHODS.pullRequestsViewers, {
+  payload: PullRequestViewerInput,
+  success: PullRequestViewerResult,
   error: PullRequestRpcError,
 });
 
@@ -1051,6 +1060,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsCloudGetRelayClientStatusRpc,
   WsCloudInstallRelayClientRpc,
   WsPullRequestsListRpc,
+  WsPullRequestsViewersRpc,
   WsPullRequestsListStatsRpc,
   WsPullRequestsDetailRpc,
   WsPullRequestsActivityRpc,


### PR DESCRIPTION
## What Changed

Wires fresh viewer verification into the pull request route before list queries, snapshot hydration, refresh, pagination, and retained-row rendering. Account changes now produce one explicit transition that removes the previous viewer's feed, accumulated pages, and priority partitions before replacement rows render.

This is the second replacement for #6470 and is stacked on #9109. Once #9109 merges, this diff is one route with 404 effective changed lines, below the repository's XL threshold.

## Why

The original route spread authorization-sensitive behavior across query filters, effects, retained values, and pagination state. Review bots found repeated interactions between those paths. The route now consumes the tested verification controller from the foundation PR and keeps only React state coordination locally.

The integration preserves the fixes already made during #6470 review: legacy servers keep live listing, partial failures retain healthy environments, failed or mismatched rows cannot return through ordered pages, and rejected live results trigger one corrective refresh.

## UI Changes

No visual design change. A stale or differently owned list falls back to the existing loading or unavailable state until a safe replacement arrives.

## Validation

- `vp test run apps/web/src/components/pullRequest/pullRequestList.logic.test.ts` (118 passed)
- `vp run --filter @t3tools/web typecheck`
- `git diff --check fix/pr-viewer-server...HEAD`

## Checklist

- [x] This PR is small and focused after the foundation PR merges
- [x] I explained what changed and why
- [x] No visual UI change requires before/after screenshots
- [x] No animation or interaction change requires a video

Generated with GPT-5.6 in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-environment viewer verification to hide stale pull request rows after account changes
> - Adds a new `viewers` RPC (`pullRequests.viewers`) and `PullRequestService.viewers` method that fetches fresh host viewer identities, bypassing the cache and bumping `listingsEpoch` when an account change is detected.
> - Introduces an optional `pullRequestViewers` capability in `ExecutionEnvironmentCapabilities`, advertised as `true` by the server.
> - Rewrites `PullRequestsRouteView` to pre-verify the signed-in account per environment before issuing list queries; environments that fail or mismatch verification are excluded, and returned data whose embedded viewers disagree is rejected and auto-refreshed.
> - Adds snapshot freshness and ownership checks in `readPullRequestListSnapshot` / `writePullRequestListSnapshot`: snapshots now require a `writtenAt` timestamp, are rejected after 5 minutes (`SNAPSHOT_MAX_AGE_MS`), and only hydrate when viewer identity matches the current context.
> - Risk: `readPullRequestListSnapshot` signature and `PullRequestListSnapshot` type now require viewer context and `writtenAt`; any out-of-tree callers or persisted snapshots lacking these fields will be rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized be26677. 11 files reviewed, 5 issues evaluated, 2 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/pullRequest/pullRequestList.logic.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 773](https://github.com/pingdotgg/t3code/blob/be26677dfd26f89893ab66f68cdf52d7c0a6cebd/apps/web/src/components/pullRequest/pullRequestList.logic.ts#L773): `listEnvironmentIds` treats any successful `pullRequests.viewers` response as verification of the entire environment. That RPC catches `getViewer` failures per host and returns a successful result with the failed host omitted; after switching accounts, a transient failure for a host therefore leaves the environment enabled. The route then accepts its retained list response when that host is absent from the verification map, so rows belonging to the previous account can remain visible instead of being cleared. <b>[ Cross-file consolidated ]</b>
> - [line 859](https://github.com/pingdotgg/t3code/blob/be26677dfd26f89893ab66f68cdf52d7c0a6cebd/apps/web/src/components/pullRequest/pullRequestList.logic.ts#L859): `pullRequestListViewersMatchVerification` accepts a listed host when the fresh verification omitted that host (`verifiedViewers[key] === undefined`). The list query atom retains prior successful values (the merged query includes `AsyncResult.value(result)` even while refreshing), so after an account switch a cached list containing the previous account's rows and viewer can be accepted without a new list response. If the viewer endpoint succeeds but omits one host, those old-account pull-request rows remain visible to the new account instead of being rejected. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->