### PR TITLE
fix(web): keep generated muted foreground dimmer than entered text

### DIFF
--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -156,6 +156,9 @@ describe("theme files", () => {
       expect(contrastRatio(colors.textMuted, colors.canvas)).toBeGreaterThanOrEqual(4.5);
       expect(contrastRatio(colors.textMuted, colors.canvas)).toBeLessThan(5.5);
       expect(contrastRatio(colors.mutedForeground, colors.muted)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(colors.mutedForeground, colors.muted)).toBeLessThan(
+        contrastRatio(colors.text, colors.muted),
+      );
       expect(contrastRatio(colors.placeholder, colors.surfaceRaised)).toBeGreaterThanOrEqual(4.5);
       expect(contrastRatio(colors.placeholder, colors.surfaceRaised)).toBeLessThan(
         contrastRatio(colors.text, colors.surfaceRaised),

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -916,7 +916,7 @@ export function createVividThemeColors(
     themeOklchToThemeColor(
       solveOklchLightness(textBase, surfaceRgb, 4.6, dark ? "lighter" : "darker"),
     );
-  const mutedForeground = foregroundOn(mutedRgb);
+  const mutedForeground = themeRgbToThemeColor(readableThemeText(mutedRgb, textRgb, 1, 4.6));
   const placeholder = themeRgbToThemeColor(readableThemeText(surfaceRaisedRgb, textRgb, 1, 4.6));
 
   const actionHover: ThemeOklch = { ...action, L: action.L + (dark ? 0.06 : -0.06) };


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-5.6 Sol on behalf of Oliver**

## Problem

Vivid generated themes used the primary-text solver for `mutedForeground`, so an already readable text color stayed unchanged. In dark themes, this made the attach icon, context-window meter icon, and "Context Window" popover heading as bright as primary text.

This is a follow-up to #9104, which corrected the same behavior for placeholders.

## Fix

One line now generates `mutedForeground` with `readableThemeText`, matching managed themes and choosing the quietest mix that still clears the contrast minimum.

|         | Hex       | Contrast vs canvas | Contrast vs muted |
| ------- | --------- | -----------------: | ----------------: |
| Before  | `#edecff` |            14.09:1 |           11.78:1 |
| After   | `#9593aa` |             5.49:1 |            4.59:1 |

## UI changes

### Before
(note that the before shows old placeholder text because latest nightly hasn't rolled out with the changes from #9104)

<img width="850" height="235" alt="image" src="https://github.com/user-attachments/assets/b0959c35-8d10-49b6-9031-f01869b590d1" />

### After

<img width="814" height="240" alt="image" src="https://github.com/user-attachments/assets/3ee8206f-8c8e-492f-89af-d3f1ad191e06" />


## Verification

- `cd apps/web && npx vitest run src/themePalette.test.ts src/vscodeThemeImport.test.ts` — passed, 2 files and 49 tests.
- `vp lint apps/web/src/themePalette.ts apps/web/src/themePalette.test.ts` — passed.
- `vp fmt --check apps/web/src/themePalette.ts apps/web/src/themePalette.test.ts` — passed, 2 files.
- `cd apps/web && vp run typecheck` — passed with `tsgo --noEmit`.

Changes prepared by GPT-5.6 Sol through Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `mutedForeground` in `createVividThemeColors` to stay dimmer than primary text
> Replaces the `foregroundOn(mutedRgb)` derivation of `mutedForeground` with `readableThemeText(mutedRgb, textRgb, 1, 4.6)`, then converts the result via `themeRgbToThemeColor`. This keeps `mutedForeground` accessible on the `muted` surface while ensuring it has lower contrast than the primary `text` color on that surface. Adds a test in [themePalette.test.ts](https://github.com/pingdotgg/t3code/pull/9113/files#diff-88ae5e69aa5213efaa17629674a2c2cc74063504ea0063e011c5ec249bb217d7) asserting the contrast ordering.
> - Risk: any consumers relying on the old surface-dependent `mutedForeground` lightness value will see a different color; verify in-tree usages in `apps/web/src`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68211cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->