### PR TITLE
fix(server): allow disabling the span exporter

### DIFF
--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -91,6 +91,7 @@ const makeCliTestServerConfig = (baseDir: string) =>
     const derivedPaths = yield* ServerConfig.deriveServerPaths(baseDir, undefined);
     return {
       logLevel: "Info",
+      traceEnabled: true,
       traceMinLevel: "Info",
       traceTimingEnabled: true,
       traceBatchWindowMs: 200,

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -41,6 +41,7 @@ const makeDesktopBootstrap = (
 
 it.layer(NodeServices.layer)("cli config resolution", (it) => {
   const defaultObservabilityConfig = {
+    traceEnabled: true,
     traceMinLevel: "Info",
     traceTimingEnabled: true,
     traceBatchWindowMs: 1_000,
@@ -134,6 +135,96 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         tailscaleServePort: 443,
       });
       assert.equal(resolved.stateDir, join(baseDir, "userdata"));
+    }),
+  );
+
+  it.effect("skips creating the trace file directory when T3CODE_TRACE_ENABLED is false", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { join } = yield* Path.Path;
+      const baseDir = join(NodeOS.tmpdir(), "t3-cli-config-trace-disabled-base");
+      const traceFile = join(baseDir, "custom-trace-dir", "server.trace.ndjson");
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.none(),
+          port: Option.none(),
+          host: Option.none(),
+          baseDir: Option.some(baseDir),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: {
+                  T3CODE_TRACE_ENABLED: "false",
+                  T3CODE_TRACE_FILE: traceFile,
+                },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      assert.equal(resolved.traceEnabled, false);
+      assert.equal(resolved.serverTracePath, traceFile);
+      const traceDirExists = yield* fs.exists(join(baseDir, "custom-trace-dir"));
+      assert.equal(traceDirExists, false);
+    }),
+  );
+
+  it.effect("creates the trace file directory by default", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { join } = yield* Path.Path;
+      const baseDir = join(NodeOS.tmpdir(), "t3-cli-config-trace-enabled-base");
+      const traceFile = join(baseDir, "custom-trace-dir", "server.trace.ndjson");
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.none(),
+          port: Option.none(),
+          host: Option.none(),
+          baseDir: Option.some(baseDir),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: {
+                  T3CODE_TRACE_FILE: traceFile,
+                },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      assert.equal(resolved.traceEnabled, true);
+      const traceDirExists = yield* fs.exists(join(baseDir, "custom-trace-dir"));
+      assert.equal(traceDirExists, true);
     }),
   );
 

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -77,6 +77,7 @@ export const tailscaleServePortFlag = Flag.integer("tailscale-serve-port").pipe(
 
 const EnvServerConfig = Config.all({
   logLevel: Config.logLevel("T3CODE_LOG_LEVEL").pipe(Config.withDefault("Info")),
+  traceEnabled: Config.boolean("T3CODE_TRACE_ENABLED").pipe(Config.withDefault(true)),
   traceMinLevel: Config.logLevel("T3CODE_TRACE_MIN_LEVEL").pipe(Config.withDefault("Info")),
   traceTimingEnabled: Config.boolean("T3CODE_TRACE_TIMING_ENABLED").pipe(Config.withDefault(true)),
   traceFile: Config.string("T3CODE_TRACE_FILE").pipe(
@@ -290,7 +291,9 @@ export const resolveServerConfig = (
       derivedPaths.settingsPath,
     );
     const serverTracePath = env.traceFile ?? derivedPaths.serverTracePath;
-    yield* fs.makeDirectory(path.dirname(serverTracePath), { recursive: true });
+    if (env.traceEnabled) {
+      yield* fs.makeDirectory(path.dirname(serverTracePath), { recursive: true });
+    }
     const startupPresentation = options?.startupPresentation ?? "browser";
     const isHeadlessStartup = startupPresentation === "headless";
     const noBrowser = Option.getOrElse(
@@ -351,6 +354,7 @@ export const resolveServerConfig = (
 
     const config: ServerConfig.ServerConfig["Service"] = {
       logLevel,
+      traceEnabled: env.traceEnabled,
       traceMinLevel: env.traceMinLevel,
       traceTimingEnabled: env.traceTimingEnabled,
       traceBatchWindowMs: env.traceBatchWindowMs,

--- a/apps/server/src/cli/pair.ts
+++ b/apps/server/src/cli/pair.ts
@@ -323,6 +323,7 @@ const makePairServerConfig = Effect.fn(function* (input: {
   );
   return ServerConfig.make({
     logLevel: input.logLevel,
+    traceEnabled: false,
     traceMinLevel: "Info",
     traceTimingEnabled: false,
     traceBatchWindowMs: 1_000,

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -61,6 +61,7 @@ export class ServerConfig extends Context.Service<
   ServerConfig,
   ServerDerivedPaths & {
     readonly logLevel: LogLevel.LogLevel;
+    readonly traceEnabled: boolean;
     readonly traceMinLevel: LogLevel.LogLevel;
     readonly traceTimingEnabled: boolean;
     readonly traceBatchWindowMs: number;
@@ -183,6 +184,7 @@ const makeTest = Effect.fn("ServerConfig.makeTest")(function* (
 
   return ServerConfig.of({
     logLevel: "Error",
+    traceEnabled: true,
     traceMinLevel: "Info",
     traceTimingEnabled: true,
     traceBatchWindowMs: 200,

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -45,6 +45,7 @@ const makeServerConfig = Effect.fn(function* (baseDir: string) {
   return {
     ...derivedPaths,
     logLevel: "Error",
+    traceEnabled: true,
     traceMinLevel: "Info",
     traceTimingEnabled: true,
     traceBatchWindowMs: 200,

--- a/apps/server/src/observability/Layers/Observability.test.ts
+++ b/apps/server/src/observability/Layers/Observability.test.ts
@@ -1,4 +1,4 @@
-// @effect-diagnostics nodeBuiltinImport:off
+// @effect-diagnostics nodeBuiltinImport:off - the trace-directory assertions need a real OS temp directory.
 import * as NodeOS from "node:os";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";

--- a/apps/server/src/observability/Layers/Observability.test.ts
+++ b/apps/server/src/observability/Layers/Observability.test.ts
@@ -1,0 +1,86 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeOS from "node:os";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import { FetchHttpClient } from "effect/unstable/http";
+
+import * as ServerConfig from "../../config.ts";
+import * as ResourceAttribution from "../../resourceTelemetry/ResourceAttribution.ts";
+import * as BrowserTraceCollector from "../BrowserTraceCollector.ts";
+import { ObservabilityLive } from "./Observability.ts";
+
+const makeServerConfigLayer = (overrides: Partial<ServerConfig.ServerConfig["Service"]>) =>
+  Layer.effect(
+    ServerConfig.ServerConfig,
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      return { ...config, ...overrides } satisfies ServerConfig.ServerConfig["Service"];
+    }),
+  ).pipe(
+    Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-observability-test-" })),
+  );
+
+it.layer(NodeServices.layer)("ObservabilityLive trace export", (it) => {
+  it.effect("does not create the trace file directory when tracing is disabled", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { join } = yield* Path.Path;
+      const now = yield* Clock.currentTimeMillis;
+      const traceDir = join(NodeOS.tmpdir(), `t3-observability-disabled-${now}`);
+      const serverTracePath = join(traceDir, "server.trace.ndjson");
+
+      const configLayer = makeServerConfigLayer({ traceEnabled: false, serverTracePath });
+
+      // Requesting BrowserTraceCollector forces the layer's Layer.unwrap to run, the same
+      // point at which the real tracer would create its trace file directory.
+      const collector = yield* BrowserTraceCollector.BrowserTraceCollector.pipe(
+        Effect.provide(
+          ObservabilityLive.pipe(
+            Layer.provide(
+              Layer.mergeAll(configLayer, ResourceAttribution.layer, FetchHttpClient.layer),
+            ),
+          ),
+        ),
+        Effect.scoped,
+      );
+      yield* collector.record([]);
+
+      const traceDirExists = yield* fs.exists(traceDir);
+      assert.equal(traceDirExists, false);
+    }),
+  );
+
+  it.effect("creates the trace file directory when tracing is enabled (default)", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { join } = yield* Path.Path;
+      const now = yield* Clock.currentTimeMillis;
+      const traceDir = join(NodeOS.tmpdir(), `t3-observability-enabled-${now}`);
+      const serverTracePath = join(traceDir, "server.trace.ndjson");
+
+      const configLayer = makeServerConfigLayer({ traceEnabled: true, serverTracePath });
+
+      yield* BrowserTraceCollector.BrowserTraceCollector.pipe(
+        Effect.provide(
+          ObservabilityLive.pipe(
+            Layer.provide(
+              Layer.mergeAll(configLayer, ResourceAttribution.layer, FetchHttpClient.layer),
+            ),
+          ),
+        ),
+        Effect.scoped,
+      );
+
+      const traceDirExists = yield* fs.exists(traceDir);
+      assert.equal(traceDirExists, true);
+
+      yield* fs.remove(traceDir, { recursive: true }).pipe(Effect.ignore);
+    }),
+  );
+});

--- a/apps/server/src/observability/Layers/Observability.ts
+++ b/apps/server/src/observability/Layers/Observability.ts
@@ -27,52 +27,65 @@ export const ObservabilityLive = Layer.unwrap(
       httpHeaderRedactionLayer,
     );
 
-    const tracerLayer = Layer.unwrap(
-      Effect.gen(function* () {
-        const sink = yield* makeTraceSink({
-          filePath: config.serverTracePath,
-          maxBytes: config.traceMaxBytes,
-          maxFiles: config.traceMaxFiles,
-          batchWindowMs: config.traceBatchWindowMs,
-          onFlush: (stats) =>
-            attribution.record({
-              component: "server-trace",
-              operation: "append",
-              logicalWriteBytes: stats.logicalWriteBytes,
-              count: stats.count,
-              durationMs: stats.durationMs,
-            }),
-        });
-        const delegate =
-          config.otlpTracesUrl === undefined
-            ? undefined
-            : yield* OtlpTracer.make({
-                url: config.otlpTracesUrl,
-                exportInterval: `${config.otlpExportIntervalMs} millis`,
-                resource: {
-                  serviceName: config.otlpServiceName,
-                  attributes: {
-                    "service.runtime": "t3-server",
-                    "service.mode": config.mode,
-                  },
-                },
-              });
+    const tracerLayer = config.traceEnabled
+      ? Layer.unwrap(
+          Effect.gen(function* () {
+            const sink = yield* makeTraceSink({
+              filePath: config.serverTracePath,
+              maxBytes: config.traceMaxBytes,
+              maxFiles: config.traceMaxFiles,
+              batchWindowMs: config.traceBatchWindowMs,
+              onFlush: (stats) =>
+                attribution.record({
+                  component: "server-trace",
+                  operation: "append",
+                  logicalWriteBytes: stats.logicalWriteBytes,
+                  count: stats.count,
+                  durationMs: stats.durationMs,
+                }),
+            });
+            const delegate =
+              config.otlpTracesUrl === undefined
+                ? undefined
+                : yield* OtlpTracer.make({
+                    url: config.otlpTracesUrl,
+                    exportInterval: `${config.otlpExportIntervalMs} millis`,
+                    resource: {
+                      serviceName: config.otlpServiceName,
+                      attributes: {
+                        "service.runtime": "t3-server",
+                        "service.mode": config.mode,
+                      },
+                    },
+                  });
 
-        const tracer = yield* makeLocalFileTracer({
-          filePath: config.serverTracePath,
-          maxBytes: config.traceMaxBytes,
-          maxFiles: config.traceMaxFiles,
-          batchWindowMs: config.traceBatchWindowMs,
-          sink,
-          ...(delegate ? { delegate } : {}),
-        });
+            const tracer = yield* makeLocalFileTracer({
+              filePath: config.serverTracePath,
+              maxBytes: config.traceMaxBytes,
+              maxFiles: config.traceMaxFiles,
+              batchWindowMs: config.traceBatchWindowMs,
+              sink,
+              ...(delegate ? { delegate } : {}),
+            });
 
-        return Layer.mergeAll(
-          Layer.succeed(Tracer.Tracer, tracer),
-          BrowserTraceCollector.layer(sink),
+            return Layer.mergeAll(
+              Layer.succeed(Tracer.Tracer, tracer),
+              BrowserTraceCollector.layer(sink),
+            );
+          }),
+        ).pipe(Layer.provide(OtlpExporter.layerFlusher), Layer.provideMerge(otlpSerializationLayer))
+      : // Tracing is disabled: no sink is created, no trace directory or file is touched, and the
+        // default (no-op) Tracer.Tracer reference is left in place. BrowserTraceCollector still
+        // needs a service so the browser-trace HTTP route keeps working; it just discards records.
+        Layer.succeed(
+          BrowserTraceCollector.BrowserTraceCollector,
+          BrowserTraceCollector.make({
+            push: () => {},
+            flush: Effect.void,
+            close: () => Effect.void,
+            filePath: config.serverTracePath,
+          }),
         );
-      }),
-    ).pipe(Layer.provide(OtlpExporter.layerFlusher), Layer.provideMerge(otlpSerializationLayer));
 
     const metricsLayer =
       config.otlpMetricsUrl === undefined

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -493,6 +493,7 @@ const buildAppUnderTest = (options?: {
     const derivedPaths = yield* ServerConfig.deriveServerPaths(baseDir, devUrl);
     const config: ServerConfig.ServerConfig["Service"] = {
       logLevel: "Info",
+      traceEnabled: true,
       traceMinLevel: "Info",
       traceTimingEnabled: true,
       traceBatchWindowMs: 200,

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -519,7 +519,8 @@ It provides:
 Local trace file:
 
 - `T3CODE_TRACE_ENABLED`: set to `false` to disable the local NDJSON trace exporter entirely. When
-  disabled, no trace file or directory is created and no spans are written to disk. Default `true`.
+  disabled, no trace file is created and no spans are written to disk; the default logs directory
+  still exists for the other logs. Default `true`.
 - `T3CODE_TRACE_FILE`: override trace file path
 - `T3CODE_TRACE_MAX_BYTES`: per-file rotation size, default `10485760`
 - `T3CODE_TRACE_MAX_FILES`: rotated file count, default `10`

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -32,7 +32,8 @@ server starts: production and explicitly configured homes use
 `<home>/userdata/logs/server.trace.ndjson` (so `~/.t3/userdata/...` by default, or
 `/custom/path/userdata/...` with `--home-dir /custom/path`), a linked worktree dev run uses
 `<worktree>/.t3/userdata/logs/server.trace.ndjson`, and an implicit dev run outside a linked
-worktree uses `~/.t3/dev/logs/server.trace.ndjson`.
+worktree uses `~/.t3/dev/logs/server.trace.ndjson`. Set `T3CODE_TRACE_ENABLED=false` to disable
+local trace export; no file or directory is created in that case.
 
 Important fields common to both record types:
 
@@ -76,7 +77,8 @@ There are two useful modes:
 - local-only: stdout + local `server.trace.ndjson`
 - full local observability: stdout + local trace file + OTLP export to Grafana/Tempo/Prometheus
 
-The local trace file is always on. OTLP export is opt-in.
+The local trace file is on by default. Set `T3CODE_TRACE_ENABLED=false` to turn it off. OTLP export
+is opt-in.
 
 ### Option 1: Local Traces Only
 
@@ -515,6 +517,8 @@ It provides:
 
 Local trace file:
 
+- `T3CODE_TRACE_ENABLED`: set to `false` to disable the local NDJSON trace exporter entirely. When
+  disabled, no trace file or directory is created and no spans are written to disk. Default `true`.
 - `T3CODE_TRACE_FILE`: override trace file path
 - `T3CODE_TRACE_MAX_BYTES`: per-file rotation size, default `10485760`
 - `T3CODE_TRACE_MAX_FILES`: rotated file count, default `10`

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -33,7 +33,8 @@ server starts: production and explicitly configured homes use
 `/custom/path/userdata/...` with `--home-dir /custom/path`), a linked worktree dev run uses
 `<worktree>/.t3/userdata/logs/server.trace.ndjson`, and an implicit dev run outside a linked
 worktree uses `~/.t3/dev/logs/server.trace.ndjson`. Set `T3CODE_TRACE_ENABLED=false` to disable
-local trace export; no file or directory is created in that case.
+local trace export; no trace file is written in that case. The standard logs directory still
+exists because the server log and provider logs live there too.
 
 Important fields common to both record types:
 


### PR DESCRIPTION
The server writes Effect tracing spans to `<home>/userdata/logs/server.trace.ndjson` for the whole life of the process, rotating through 11 files of 10 MB, and `T3CODE_TRACE_FILE` can only relocate it. There was no supported way to turn the exporter off.

This adds `T3CODE_TRACE_ENABLED` (default `true`). When set to `false`, no trace sink or tracer is constructed and no trace file is written; the trace directory is no longer created for a custom trace path. The browser-trace collector stays available as a no-op so the relay route keeps working. Documented in `docs/operations/observability.md`.

Tests cover both the config layer (no trace directory creation when disabled) and the observability layer (no trace file when disabled, file present by default).

Closes #8764

Claude Fable 5.1 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with a safe default; pairing already disables tracing explicitly, and the browser trace endpoint remains wired via a no-op collector.
> 
> **Overview**
> Adds **`T3CODE_TRACE_ENABLED`** (default **`true`**) and a **`traceEnabled`** field on **`ServerConfig`** so local NDJSON span export can be turned off without only relocating the file via **`T3CODE_TRACE_FILE`**.
> 
> When tracing is disabled, **`resolveServerConfig`** no longer creates the trace file’s parent directory, and **`ObservabilityLive`** skips the file sink, local tracer, and OTLP trace delegate while keeping **`BrowserTraceCollector`** as a no-op so the browser-trace route still works. Pairing flows explicitly set **`traceEnabled: false`**.
> 
> Tests cover config resolution and the observability layer for directory creation behavior; **`docs/operations/observability.md`** documents the new env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5261360871fbba7d743658959d2ec5eb3086e727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `traceEnabled` config flag to disable span exporter via `T3CODE_TRACE_ENABLED`
> - Introduces a new boolean `traceEnabled` field on `ServerConfig`, sourced from the `T3CODE_TRACE_ENABLED` env var (default `true`), so operators can disable local trace file creation.
> - When `traceEnabled` is false, [Observability.ts](https://github.com/pingdotgg/t3code/pull/9115/files#diff-7a5c18b26b28e7a6496742e45b9391ca8004b50688bea5b5d877edc282a25f32) skips tracer/sink initialization and leaves the default no-op `Tracer` in place; `BrowserTraceCollector` stays available but discards records.
> - [config.ts](https://github.com/pingdotgg/t3code/pull/9115/files#diff-16c068d320ce481e506eae4c06ff006a27585a4833a2d7d3dd1b584e5b8d8fdb) makes trace directory creation conditional on `traceEnabled`, and [pair.ts](https://github.com/pingdotgg/t3code/pull/9115/files#diff-7326618ccfd09900176b612acc8fd16fbeb01bddd2ba054af9dff737684e075a) hard-disables tracing for pair-mode server configs.
> - Risk: callers that previously relied on `BrowserTraceCollector` always writing to disk will silently lose spans when `T3CODE_TRACE_ENABLED=false`; verify no downstream consumers depend on the trace file existing in disabled mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5261360.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->