### PR TITLE
perf(ci): cut duplicate release and dependency work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
           run-install: |
             args:
               - --filter=t3...
+              # ActivityPayloadProjection.test.ts imports mobile code and needs Expo's tsconfig.
+              - --filter=@t3tools/mobile...
 
       # No Electron setup here: `t3` (apps/server) has no Electron dependency
       # and none of its tests touch the runtime. Only the non-server `test`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,24 @@ jobs:
         uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: package.json
-          cache: true
-          run-install: true
+          cache: false
+          run-install: false
+
+      # Filtered installs use other keys so they cannot populate this full-workspace cache.
+      - name: Resolve pnpm store path
+        id: pnpm_store
+        run: echo "path=$(vp pm cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache full pnpm store
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.pnpm_store.outputs.path }}
+          key: pnpm-full-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-full-v1-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install dependencies
+        run: vp install
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
@@ -79,8 +95,24 @@ jobs:
         uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: package.json
-          cache: true
-          run-install: true
+          cache: false
+          run-install: false
+
+      # Filtered installs use other keys so they cannot populate this full-workspace cache.
+      - name: Resolve pnpm store path
+        id: pnpm_store
+        run: echo "path=$(vp pm cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache full pnpm store
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.pnpm_store.outputs.path }}
+          key: pnpm-full-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-full-v1-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install dependencies
+        run: vp install
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
@@ -114,7 +146,9 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: true
+          run-install: |
+            args:
+              - --filter=t3...
 
       # No Electron setup here: `t3` (apps/server) has no Electron dependency
       # and none of its tests touch the runtime. Only the non-server `test`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,9 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: true
+          run-install: |
+            args:
+              - --filter=@t3tools/scripts...
 
       - id: release_meta
         name: Resolve release version
@@ -194,8 +196,25 @@ jobs:
         uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: package.json
-          cache: true
-          run-install: true
+          cache: false
+          run-install: false
+
+      - name: Resolve pnpm store path
+        id: pnpm_store
+        run: echo "path=$(vp pm cache dir)" >> "$GITHUB_OUTPUT"
+
+      # setup-vp's cache key does not include install filters. Keep full installs
+      # separate so a filtered exact hit cannot leave this job downloading the rest.
+      - name: Cache full pnpm store
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.pnpm_store.outputs.path }}
+          key: pnpm-full-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-full-v1-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install dependencies
+        run: vp install
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
@@ -663,6 +682,13 @@ jobs:
 
           vp run dist:desktop:artifact "${args[@]}"
 
+      # The Linux build already produces the same server/web bundle that npm
+      # publishes. Preserve file modes inside a tarball and reuse it after the
+      # full build matrix and release checks pass.
+      - name: Archive CLI build
+        if: matrix.platform == 'linux'
+        run: tar -czf "$RUNNER_TEMP/t3-cli-dist.tar.gz" -C apps/server dist
+
       - name: Collect release assets
         shell: bash
         run: |
@@ -720,6 +746,17 @@ jobs:
           name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
           path: release-publish/*
           if-no-files-found: error
+          compression-level: 0
+
+      - name: Upload CLI build
+        if: matrix.platform == 'linux'
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-dist-linux-x64
+          path: ${{ runner.temp }}/t3-cli-dist.tar.gz
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
 
       - name: Upload resource monitor
         uses: actions/upload-artifact@v7
@@ -780,10 +817,14 @@ jobs:
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
 
-      # The t3 build task depends on @t3tools/web#build, so the web client is
-      # built (once) as part of this step.
-      - name: Build CLI package
-        run: vp run --filter t3 build
+      - name: Download CLI build
+        uses: actions/download-artifact@v8
+        with:
+          name: cli-dist-linux-x64
+          path: ${{ runner.temp }}/cli-dist
+
+      - name: Restore CLI build
+        run: tar -xzf "$RUNNER_TEMP/cli-dist/t3-cli-dist.tar.gz" -C apps/server
 
       - name: Download resource monitors
         uses: actions/download-artifact@v8

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       define: publicConfigDefine,
@@ -52,6 +53,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       define: publicConfigDefine,
@@ -66,6 +68,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       entry: ["src/preview-pick-preload.ts"],
@@ -76,6 +79,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       entry: ["src/preview-pip-preload.ts"],

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -25,6 +25,7 @@ This document covers the unified release workflow for stable and nightly desktop
   - Automatically generated release notes are pinned to the previous tag in the same channel, so stable compares to the previous stable tag and nightly compares to the previous nightly tag.
 - Includes Electron auto-update metadata (for example `latest*.yml`, `nightly*.yml`, and `*.blockmap`) in release assets.
 - Publishes the CLI package (`apps/server`, npm package `t3`) with OIDC trusted publishing from the same workflow file:
+  - reuses the server and web bundle from the Linux desktop build instead of building it again after the artifact matrix
   - stable releases publish npm dist-tag `latest`
   - nightly releases publish npm dist-tag `nightly`
 - Deploys the hosted web app to Vercel only after a release is published:


### PR DESCRIPTION
CI repeated expensive work across jobs. Releases rebuilt the CLI after the desktop matrix, and full installs could restore pnpm caches populated by filtered jobs but still download 749 packages.

This reuses the Linux desktop server and web bundle for npm publishing, avoids recompressing release artifacts, filters installs that need only part of the workspace, and gives full installs a separate cache namespace. Desktop bundling skips declaration output that no runtime consumer uses. Release checks still gate publishing. Publication still runs in order: npm, then GitHub Release, then hosted web.

Measured results:

- the removed CLI rebuild took 31 to 41 seconds in recent releases
- the server test install dropped from 1,747 packages to 1,180 while keeping the mobile code used by server projection tests
- desktop pack time dropped from 3.69 seconds to 0.42 seconds with identical runtime output

The new artifact transfer adds some overhead, so the total release timing still needs a real CI run. The new full-install cache starts cold on its first run.

Verified with 86 release tests, 15 ACP tests in an isolated filtered install, 18 activity projection tests in an isolated 1,180-package server install, desktop build, pack, typecheck, and preload checks, targeted lint and format checks, and stable and nightly publish dry runs after archive restoration with native monitors. No new workflow lint issues.

Made with GPT-5.6 Sol in Codex through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release CLI publish now depends on a Linux desktop artifact instead of a fresh build; a missing or wrong tarball fails publish rather than rebuilding locally.
> 
> **Overview**
> **CI and release workflows** stop relying on `setup-vp` for install/cache on full-workspace jobs: they disable built-in cache/install, restore a dedicated `pnpm-full-v1` pnpm store via `actions/cache@v6`, then run `vp install`. Filtered jobs (server tests, release preflight/smoke, etc.) keep `setup-vp` caching but pass install `args` so partial installs do not poison the full-workspace cache.
> 
> **Release publishing** no longer runs `vp run --filter t3 build` in `publish_cli`. The Linux desktop matrix job tarballs `apps/server/dist` and uploads it; npm publish downloads and extracts that artifact instead. Desktop release uploads use `compression-level: 0` to avoid recompressing large binaries.
> 
> **Desktop Electron pack** sets `dts: false` on all `pack` targets in `vite.config.ts`, skipping declaration emit for main/preload bundles. **Release docs** note that the CLI npm bundle is reused from the Linux desktop build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 828e522fb8b8a4c50574074e049d0fe9a357c6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut duplicate dependency and release work in CI workflows
> - Reworks dependency setup in [ci.yml](https://github.com/pingdotgg/t3code/pull/9121/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) and [release.yml](https://github.com/pingdotgg/t3code/pull/9121/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) to use explicit pnpm store caching and filtered installs instead of `setup-vp`'s automatic full-workspace install
> - Server test shards now install only the `t3` and `mobile` dependency graphs; release preflight installs only `scripts`
> - The Linux release build now archives the server `dist` directory as a CLI artifact, and `publish_cli` downloads it instead of rebuilding `t3`
> - Sets `declaration` to `false` for the main and preload bundles in [vite.config.ts](https://github.com/pingdotgg/t3code/pull/9121/files#diff-5fc8c830ebf6102f62b066b8a0120f2bb98d8ab83abe63719f30a03c5dc16b2c) so generated `.d.ts` files are omitted from desktop output
> - Risk: `publish_cli` now depends on the Linux build artifact being present and correctly archived; a missing or stale `dist` tarball will fail the publish job
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 828e522.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
