### PR TITLE
fix(mobile): show an error instead of an endless preview spinner

### DIFF
--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -37,6 +37,7 @@ import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useEnvironmentQuery } from "../../state/query";
 import { projectEnvironment } from "../../state/projects";
+import type { AssetUrlFailureReason } from "../../state/asset-url-state";
 import {
   useAdaptiveWorkspaceLayout,
   useAdaptiveWorkspacePaneRole,
@@ -56,6 +57,7 @@ import { preloadWorkspaceFileContents } from "./preload-workspace-file";
 import { SourceFileSurface } from "./SourceFileSurface";
 import { ThreadFileNavigatorPane } from "./thread-file-navigator-pane";
 import { WorkspaceFileImagePreview } from "./WorkspaceFileImagePreview";
+import { WorkspaceFilePreviewError } from "./WorkspaceFilePreviewError";
 import { WorkspaceFileVideoPreview } from "./WorkspaceFileVideoPreview";
 import { WorkspaceFileWebPreview } from "./WorkspaceFileWebPreview";
 import {
@@ -104,8 +106,10 @@ function defaultViewMode(path: string | null): FileViewMode {
 
 function FileContent(props: {
   readonly activeMode: FileViewMode;
+  readonly environmentId: EnvironmentId | null;
   readonly previewUri: string | null;
-  readonly previewUnavailable: boolean;
+  readonly previewFailure: AssetUrlFailureReason | null;
+  readonly onRetryPreview: () => void;
   readonly videoSource: MediaVideoPreviewSource | null;
   readonly mediaSource?: MediaActionsSource;
   readonly resolveVideoUri: () => Promise<string | null>;
@@ -121,8 +125,22 @@ function FileContent(props: {
   const isMarkdown = isMarkdownPreviewFile(props.relativePath);
   const isBrowserFile = isWorkspaceBrowserPreviewPath(props.relativePath);
   const isImageFile = isWorkspaceImagePreviewPath(props.relativePath);
+  const isVideoFile = isVideoPreviewFile(props.relativePath);
+  // Only the surfaces that wait on a signed asset URL can be blocked by one.
+  const needsAssetUrl =
+    isVideoFile || (props.activeMode === "preview" && (isImageFile || isBrowserFile));
 
-  if (isVideoPreviewFile(props.relativePath)) {
+  if (needsAssetUrl && props.previewFailure !== null) {
+    return (
+      <WorkspaceFilePreviewError
+        environmentId={props.environmentId}
+        reason={props.previewFailure}
+        onRetry={props.onRetryPreview}
+      />
+    );
+  }
+
+  if (isVideoFile) {
     return (
       <WorkspaceFileVideoPreview
         name={basename(props.relativePath)}
@@ -130,7 +148,6 @@ function FileContent(props: {
         uri={props.previewUri}
         source={props.videoSource}
         resolvePlaybackUri={props.resolveVideoUri}
-        unavailable={props.previewUnavailable}
       />
     );
   }
@@ -588,6 +605,10 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
     assetPreviewUri === null || previewRevision === 0
       ? assetPreviewUri
       : `${assetPreviewUri}${assetPreviewUri.includes("?") ? "&" : "?"}revision=${previewRevision}`;
+  // Remounting the preview after a re-mint is what makes a failed asset URL retryable.
+  const handleRetryPreview = () => {
+    void assetPreview.refresh().finally(() => setPreviewRevision((current) => current + 1));
+  };
   const needsFileContents =
     relativePath !== null &&
     !isVideoFile &&
@@ -889,8 +910,10 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
         <FileContent
           key={previewKey}
           activeMode={resolvedActiveMode}
+          environmentId={environmentId}
           previewUri={previewUri}
-          previewUnavailable={assetPreview._tag === "Failure"}
+          previewFailure={assetPreview._tag === "Failure" ? assetPreview.reason : null}
+          onRetryPreview={handleRetryPreview}
           videoSource={videoSource}
           mediaSource={mediaSource}
           resolveVideoUri={assetPreview.refresh}

--- a/apps/mobile/src/features/files/WorkspaceFilePreviewError.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFilePreviewError.tsx
@@ -1,0 +1,59 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useCallback } from "react";
+import { View } from "react-native";
+
+import { EmptyState } from "../../components/EmptyState";
+import { environmentCatalog } from "../../connection/catalog";
+import type { AssetUrlFailureReason } from "../../state/asset-url-state";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { useEnvironmentPresentation } from "../../state/presentation";
+import { EnvironmentConnectionNotice } from "../connection/EnvironmentConnectionNotice";
+
+/**
+ * Terminal state for a preview whose signed asset URL will not arrive. A dead
+ * environment reuses the same notice the terminal and review sheets show, so the
+ * user gets one recognizable way back online.
+ */
+export function WorkspaceFilePreviewError(props: {
+  readonly environmentId: EnvironmentId | null;
+  readonly reason: AssetUrlFailureReason;
+  readonly onRetry: () => void;
+}) {
+  const { environmentId, onRetry } = props;
+  const environment = useEnvironmentPresentation(environmentId);
+  const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, "environment retry");
+  const retryConnection = useCallback(() => {
+    if (environmentId !== null) void retryEnvironment(environmentId);
+    onRetry();
+  }, [environmentId, onRetry, retryEnvironment]);
+
+  if (props.reason === "disconnected") {
+    return (
+      <View className="flex-1 bg-sheet">
+        <EnvironmentConnectionNotice
+          environmentLabel={environment.presentation?.entry.target.label ?? "Environment"}
+          connection={
+            environment.presentation?.connection ?? {
+              phase: "available",
+              error: null,
+              traceId: null,
+            }
+          }
+          resourceName="preview"
+          onRetry={retryConnection}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 items-center justify-center bg-sheet px-6">
+      <EmptyState
+        title="Preview unavailable"
+        detail="This file may be missing, unsupported, or unavailable on this environment."
+        actionLabel="Try again"
+        onAction={props.onRetry}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/features/files/WorkspaceFileVideoPreview.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileVideoPreview.tsx
@@ -1,6 +1,5 @@
 import { View } from "react-native";
 
-import { EmptyState } from "../../components/EmptyState";
 import { MediaVideoPlayer } from "../../components/MediaVideoPlayer";
 import type { MediaVideoPreviewSource } from "../../lib/videoPreviewSource";
 
@@ -11,20 +10,8 @@ export function WorkspaceFileVideoPreview(props: {
   readonly uri: string | null;
   readonly source: MediaVideoPreviewSource | null;
   readonly resolvePlaybackUri: () => Promise<string | null>;
-  readonly unavailable: boolean;
 }) {
   const uri = props.uri;
-
-  if (props.unavailable) {
-    return (
-      <View className="flex-1 items-center justify-center bg-sheet px-6">
-        <EmptyState
-          title="Video unavailable"
-          detail="This file may be missing, unsupported, or unavailable on this environment."
-        />
-      </View>
-    );
-  }
 
   return (
     <View className="flex-1 items-center justify-center bg-sheet p-4">

--- a/apps/mobile/src/state/asset-url-state.test.ts
+++ b/apps/mobile/src/state/asset-url-state.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { deriveAssetUrlState } from "./asset-url-state";
+
+const SUCCESS = { _tag: "Success" as const, url: "https://environment.example/api/assets/abc" };
+
+describe("deriveAssetUrlState", () => {
+  it("passes a resolved URL through on a live environment", () => {
+    expect(deriveAssetUrlState({ connectionPhase: "connected", shared: SUCCESS })).toEqual(SUCCESS);
+  });
+
+  it("waits while the query is pending and the environment is still reachable", () => {
+    for (const connectionPhase of ["available", "connecting", "connected"] as const) {
+      expect(deriveAssetUrlState({ connectionPhase, shared: { _tag: "Loading" } })).toEqual({
+        _tag: "Loading",
+      });
+    }
+  });
+
+  it("stops waiting once the environment is offline, retrying, or in error", () => {
+    for (const connectionPhase of ["offline", "reconnecting", "error"] as const) {
+      expect(deriveAssetUrlState({ connectionPhase, shared: { _tag: "Loading" } })).toEqual({
+        _tag: "Failure",
+        reason: "disconnected",
+      });
+    }
+  });
+
+  // A dead environment fails the URL query itself, so the query outcome alone
+  // cannot tell a missing file from a missing connection.
+  it("reports disconnected when the query failed while the environment is down", () => {
+    for (const connectionPhase of ["available", "offline", "reconnecting", "error"] as const) {
+      expect(deriveAssetUrlState({ connectionPhase, shared: { _tag: "Failure" } })).toEqual({
+        _tag: "Failure",
+        reason: "disconnected",
+      });
+    }
+  });
+
+  it("does not hand out a resolved URL for a disconnected environment", () => {
+    for (const connectionPhase of ["offline", "reconnecting", "error"] as const) {
+      expect(deriveAssetUrlState({ connectionPhase, shared: SUCCESS })).toEqual({
+        _tag: "Failure",
+        reason: "disconnected",
+      });
+    }
+  });
+
+  it("reports a failed query on a connected environment", () => {
+    expect(
+      deriveAssetUrlState({ connectionPhase: "connected", shared: { _tag: "Failure" } }),
+    ).toEqual({ _tag: "Failure", reason: "failed" });
+  });
+});

--- a/apps/mobile/src/state/asset-url-state.ts
+++ b/apps/mobile/src/state/asset-url-state.ts
@@ -1,0 +1,47 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+import type { AssetUrlState as SharedAssetUrlState } from "@t3tools/client-runtime/state/assets";
+
+export type AssetUrlFailureReason = "disconnected" | "failed";
+
+/** The shared state plus a reason on failure, so previews can offer the right retry. */
+export type AssetUrlState =
+  | { readonly _tag: "Loading" }
+  | { readonly _tag: "Failure"; readonly reason: AssetUrlFailureReason }
+  | Extract<SharedAssetUrlState, { readonly _tag: "Success" }>;
+
+/**
+ * Folds the shared asset URL state with the environment connection phase. A
+ * dead environment wins over everything else: even a resolved URL is
+ * unreachable there, and a failed query is caused by the outage, not the file.
+ */
+export function deriveAssetUrlState(input: {
+  readonly connectionPhase: EnvironmentConnectionPhase;
+  readonly shared: SharedAssetUrlState;
+}): AssetUrlState {
+  if (
+    input.connectionPhase === "offline" ||
+    input.connectionPhase === "reconnecting" ||
+    input.connectionPhase === "error"
+  ) {
+    return { _tag: "Failure", reason: "disconnected" };
+  }
+  if (input.shared._tag === "Success") {
+    return input.shared;
+  }
+  switch (input.connectionPhase) {
+    // "available" is the idle, not yet dialled state. A pending query there is
+    // still on its way, but the query atom fails at once while idle, so a
+    // failure means the environment is not connected rather than the file is
+    // missing.
+    case "available":
+      return input.shared._tag === "Failure"
+        ? { _tag: "Failure", reason: "disconnected" }
+        : { _tag: "Loading" };
+    case "connecting":
+      return { _tag: "Loading" };
+    case "connected":
+      return input.shared._tag === "Failure"
+        ? { _tag: "Failure", reason: "failed" }
+        : { _tag: "Loading" };
+  }
+}

--- a/apps/mobile/src/state/assets.ts
+++ b/apps/mobile/src/state/assets.ts
@@ -48,12 +48,16 @@ export function useAssetUrlState(
       ? EMPTY_ASSET_URL_ATOM
       : assetEnvironment.createUrl({ environmentId, input: { resource } }),
   );
+  const shared = assetUrlStateFromResult(
+    result,
+    preparedConnection._tag === "Some" ? preparedConnection.value.httpBaseUrl : null,
+  );
   return deriveAssetUrlState({
     connectionPhase,
-    shared: assetUrlStateFromResult(
-      result,
-      preparedConnection._tag === "Some" ? preparedConnection.value.httpBaseUrl : null,
-    ),
+    // A failure left over from an outage is re-queried as soon as the
+    // connection returns. While that re-query is in flight it is not a verdict
+    // on the file, so it reads as loading rather than a false "unavailable".
+    shared: shared._tag === "Failure" && result.waiting ? { _tag: "Loading" } : shared,
   });
 }
 

--- a/apps/mobile/src/state/assets.ts
+++ b/apps/mobile/src/state/assets.ts
@@ -1,35 +1,60 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
-  type AssetUrlState,
+  type EnvironmentConnectionPhase,
+  presentConnectionState,
+} from "@t3tools/client-runtime/connection";
+import {
   assetUrlStateFromResult,
   createAssetEnvironmentAtoms,
   EMPTY_ASSET_URL_ATOM,
 } from "@t3tools/client-runtime/state/assets";
 import type { AssetResource, EnvironmentId } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback } from "react";
 
+import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
+import { type AssetUrlState, deriveAssetUrlState } from "./asset-url-state";
 import { usePreparedConnection } from "./session";
 import { useAtomQueryRunner } from "./use-atom-query-runner";
 
-export type { AssetUrlState } from "@t3tools/client-runtime/state/assets";
+export type { AssetUrlFailureReason, AssetUrlState } from "./asset-url-state";
 
 export const assetEnvironment = createAssetEnvironmentAtoms(connectionAtomRuntime);
+
+const EMPTY_CONNECTION_STATE_ATOM = Atom.make(AsyncResult.initial<never, never>(false)).pipe(
+  Atom.withLabel("mobile-asset-connection-state:empty"),
+);
+
+function useConnectionPhase(environmentId: EnvironmentId | null): EnvironmentConnectionPhase {
+  const state = useAtomValue(
+    environmentId === null
+      ? EMPTY_CONNECTION_STATE_ATOM
+      : environmentCatalog.stateAtom(environmentId),
+  );
+  const value = Option.getOrNull(AsyncResult.value(state));
+  return value === null ? "available" : presentConnectionState(value).phase;
+}
 
 export function useAssetUrlState(
   environmentId: EnvironmentId | null,
   resource: AssetResource | null,
 ): AssetUrlState {
   const preparedConnection = usePreparedConnection(environmentId);
+  const connectionPhase = useConnectionPhase(environmentId);
   const result = useAtomValue(
     environmentId === null || resource === null
       ? EMPTY_ASSET_URL_ATOM
       : assetEnvironment.createUrl({ environmentId, input: { resource } }),
   );
-  return assetUrlStateFromResult(
-    result,
-    preparedConnection._tag === "Some" ? preparedConnection.value.httpBaseUrl : null,
-  );
+  return deriveAssetUrlState({
+    connectionPhase,
+    shared: assetUrlStateFromResult(
+      result,
+      preparedConnection._tag === "Some" ? preparedConnection.value.httpBaseUrl : null,
+    ),
+  });
 }
 
 export function useAssetUrl(


### PR DESCRIPTION
On mobile, an image, PDF, or other asset preview kept spinning on "Preparing ... preview" when the environment was disconnected or the asset URL request failed. `useAssetUrlState` reported a pending query and a dead connection as the same `Loading` value, so previews had no terminal state and no way to retry.

The hook now folds the environment connection phase into its result. A query that is still pending while the environment is offline, retrying, or in error resolves to `Failure` with a `disconnected` reason. A failed query resolves to `Failure` with a `failed` reason. The derivation moved into `apps/mobile/src/state/asset-url-state.ts` so it can be tested on its own.

On the file screen, image, SVG, browser, and video previews now render an error instead of a spinner when the asset URL will not arrive. A disconnected environment gets the existing `EnvironmentConnectionNotice`, the same offline surface the terminal and review sheets use, with its "Retry now" button wired to a connection retry plus a fresh URL mint. A failed URL gets a short "Preview unavailable" line with "Try again". The video preview lost its own `unavailable` branch because the screen now owns that state for every preview type.

The other consumers, the full screen file preview modal, both video preview modals, and the chat feed image and video, already branched on `Failure`, so they pick up the disconnected case without changes. The web app has its own copy of the hook in `apps/web/src/assets/assetUrls.ts` and is left alone to keep this to one concern.

Verified with `vp test run apps/mobile/src/state/asset-url-state.test.ts`, `tsc --noEmit` in `apps/mobile`, and lint on the touched files. Not verified on a device or simulator.

Closes #7630

Built by Claude Opus 5 in the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to mobile asset URL presentation and thread file previews; logic is covered by unit tests and does not change auth or shared web hooks.
> 
> **Overview**
> Mobile workspace file previews (image, browser/PDF, video) no longer spin forever when a signed asset URL cannot be obtained. **`useAssetUrlState`** now combines the shared URL query result with the environment **connection phase** via **`deriveAssetUrlState`**, yielding **`Failure`** with **`disconnected`** vs **`failed`** so UI can distinguish outage from a bad/missing asset.
> 
> On **`ThreadFileScreen`**, **`FileContent`** shows the new **`WorkspaceFilePreviewError`** for previews that depend on an asset URL: **`EnvironmentConnectionNotice`** (with connection retry + URL refresh) when disconnected, or a **“Preview unavailable”** empty state with **Try again** otherwise. Retry refreshes the asset URL and bumps **`previewRevision`** to remount the preview. **`WorkspaceFileVideoPreview`** drops its local unavailable UI because the parent owns that terminal state.
> 
> Unit tests cover **`deriveAssetUrlState`**; other mobile **`useAssetUrlState`** consumers that already treat **`Failure`** as an error surface should pick up disconnected cases without further changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd48873f5571444a43300cf230768d9acbd467b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix endless mobile preview spinner by showing reason-specific asset URL errors
> - Adds `WorkspaceFilePreviewError` in [WorkspaceFilePreviewError.tsx](https://github.com/pingdotgg/t3code/pull/9123/files#diff-3fde1e0aa40a7664186ac8d64ebb6f4adeb06ed2f1e0684c9ac687e556d93d90) to render an environment connection notice for disconnected failures and a generic "Preview unavailable" retry state for other asset URL failures.
> - Adds `deriveAssetUrlState` in [asset-url-state.ts](https://github.com/pingdotgg/t3code/pull/9123/files#diff-4f2c88eb741c0499d3524e610e9bd11f9056a2b0018e1cb88e395e9b47dad651) to distinguish disconnected environment failures from connected query failures, and suppresses resolved URLs while the environment is offline, reconnecting, or in error.
> - Updates `useAssetUrlState` and `useConnectionPhase` in [assets.ts](https://github.com/pingdotgg/t3code/pull/9123/files#diff-7280b54c4da185cc2f02480b46955ab7dc3837e845bad7a70cb77abfa3884c00) to fold the shared asset result with the current connection phase, and treats a waiting post-outage query as Loading so stale failures are not shown.
> - Wires the typed failure reason and a retry handler (which remints the asset URL and remounts the preview) through `FileContent` and `ThreadFileScreen` in [ThreadFilesRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/9123/files#diff-9d701f672b12c7184cdf9b51e0e5b5417c35e688fe894ee38e91017bf15aea6a), removing the old boolean `previewUnavailable` prop.
> - Risk: `WorkspaceFileVideoPreview` no longer renders its own "Video unavailable" state; video asset failures must now be handled by the parent before the media player renders. Existing consumers relying on the `unavailable` prop or the boolean `previewUnavailable` prop need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cd4887.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->