### PR TITLE
fix(web): render assistant images inline in chat

### DIFF
--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -145,6 +145,25 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).not.toContain("Image unavailable");
   });
 
+  it("loads a POSIX absolute path and file URI through a signed asset URL", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/workspace/project"
+        threadRef={threadRef}
+        text={[
+          "![absolute](/tmp/embed-test/2.png)",
+          "![file URL](file:///tmp/embed-test/5.png)",
+        ].join("\n\n")}
+      />,
+    );
+
+    expect(testState.resources).toEqual([
+      { _tag: "media-file", threadId: threadRef.threadId, path: "/tmp/embed-test/2.png" },
+      { _tag: "media-file", threadId: threadRef.threadId, path: "/tmp/embed-test/5.png" },
+    ]);
+    expect(html).not.toContain("Image unavailable");
+  });
+
   it("normalizes a drive-absolute src in raw image HTML", () => {
     const html = render(String.raw`<img src="D:\screens\workspace-image.svg" alt="raw">`);
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -894,6 +894,63 @@ describe("deriveMessagesTimelineRows", () => {
     expect(rows.find((row) => row.id === "work-image-entry")?.kind).toBe("work");
   });
 
+  it("keeps a trailing image preview row visible while the turn is still working", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "user-entry",
+          kind: "message" as const,
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "user-1" as never,
+            role: "user" as const,
+            text: "show me the result",
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "work-command-entry",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:02Z",
+          entry: {
+            id: "work-command",
+            createdAt: "2026-01-01T00:00:02Z",
+            turnId: "turn-1" as never,
+            label: "Ran command",
+            tone: "tool" as const,
+          },
+        },
+        {
+          id: "work-image-entry",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:04Z",
+          entry: {
+            id: "work-image",
+            createdAt: "2026-01-01T00:00:04Z",
+            turnId: "turn-1" as never,
+            label: "Image view",
+            detail: "screenshots/result.png",
+            itemType: "image_view" as const,
+            tone: "tool" as const,
+          },
+        },
+      ],
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:01Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    // The live activity row must not swallow the image: it renders only a
+    // label, which would hide the image until the turn settles.
+    const imageRow = rows.find((row) => row.id === "work-image-entry");
+    expect(imageRow?.kind).toBe("work");
+    expect(rows.some((row) => row.kind === "work-live")).toBe(false);
+  });
+
   it("folds all assistant messages before the terminal message", () => {
     const timelineEntries = [
       {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -832,6 +832,66 @@ describe("deriveMessagesTimelineRows", () => {
       showAssistantMeta: false,
       showAssistantCopyButton: false,
     });
+  it("keeps an image preview row visible after the turn settles", () => {
+    const timelineEntries = [
+      {
+        id: "work-command-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:02Z",
+        entry: {
+          id: "work-command",
+          createdAt: "2026-01-01T00:00:02Z",
+          turnId: "turn-1" as never,
+          label: "Ran command",
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "work-image-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:04Z",
+        entry: {
+          id: "work-image",
+          createdAt: "2026-01-01T00:00:04Z",
+          turnId: "turn-1" as never,
+          label: "Image view",
+          detail: "screenshots/result.png",
+          itemType: "image_view" as const,
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "assistant-final-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:06Z",
+        message: {
+          id: "assistant-final" as never,
+          role: "assistant" as const,
+          text: "Here is the screenshot.",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:06Z",
+          updatedAt: "2026-01-01T00:00:07Z",
+          streaming: false,
+        },
+      },
+    ];
+
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries,
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    // The command row folds, the image row stays as its own visible row rather
+    // than collapsing into a tool group summary.
+    expect(rows.map((row) => row.id)).toEqual([
+      "turn-fold:turn-1",
+      "work-image-entry",
+      "assistant-final-entry",
+    ]);
+    expect(rows.find((row) => row.id === "work-image-entry")?.kind).toBe("work");
   });
 
   it("folds all assistant messages before the terminal message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -12,6 +12,7 @@ import {
   shouldPreserveAssistantLineBreaks,
   type MessagesTimelineRow,
   workEntryDisplayLabel,
+  workEntryIsVisibleInGroup,
 } from "./MessagesTimeline.logic";
 
 describe("expanded tool group scrolling", () => {
@@ -471,6 +472,22 @@ describe("resolveAssistantMessageCopyState", () => {
   });
 });
 
+describe("workEntryIsVisibleInGroup", () => {
+  it("keeps an in-progress image preview row visible outside a group", () => {
+    const entry = {
+      id: "work-image",
+      createdAt: "2026-01-01T00:00:04Z",
+      turnId: "turn-1" as never,
+      label: "Image view",
+      detail: "screenshots/result.png",
+      itemType: "image_view" as const,
+      tone: "tool" as const,
+      toolLifecycleStatus: "inProgress" as const,
+    };
+    expect(workEntryIsVisibleInGroup(entry, false)).toBe(true);
+  });
+});
+
 describe("deriveMessagesTimelineRows", () => {
   it("only enables assistant copy for the terminal assistant message in a turn", () => {
     const rows = deriveMessagesTimelineRows({
@@ -832,6 +849,8 @@ describe("deriveMessagesTimelineRows", () => {
       showAssistantMeta: false,
       showAssistantCopyButton: false,
     });
+  });
+
   it("keeps an image preview row visible after the turn settles", () => {
     const timelineEntries = [
       {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -90,6 +90,15 @@ export function liveWorkEntryLabel(
   return workEntryDisplayLabel(entry, workspaceRoot);
 }
 
+/**
+ * Rows that preview an image the agent viewed or produced. They stay out of
+ * tool groups and out of the settled-turn fold: the image is the answer the
+ * user asked for, not tool noise to hide behind "Worked for ...".
+ */
+function workEntryRendersImagePreview(entry: WorkLogEntry): boolean {
+  return workEntryViewedImagePath(entry) !== null;
+}
+
 export function workEntryIsVisibleInGroup(
   entry: WorkLogEntry,
   expandedToolGroupEntry = false,
@@ -98,6 +107,9 @@ export function workEntryIsVisibleInGroup(
     (expandedToolGroupEntry &&
       (entry.toolLifecycleStatus === "inProgress" ||
         entry.sourceActivityKind === "task.progress")) ||
+    // An image row stands alone outside any group, so the neutral filter
+    // would leave an empty gap while its tool is still in progress.
+    workEntryRendersImagePreview(entry) ||
     !workEntryIndicatesToolNeutralStatus(entry)
   );
 }
@@ -129,15 +141,6 @@ export function shouldFollowWorkGroupAppend(
     distanceFromEnd <= 1 &&
     previous.every((entry, index) => entry.id === entries[index]?.id)
   );
-}
-
-/**
- * Rows that preview an image the agent viewed or produced. They stay out of
- * tool groups and out of the settled-turn fold: the image is the answer the
- * user asked for, not tool noise to hide behind "Worked for ...".
- */
-function workEntryRendersImagePreview(entry: WorkLogEntry): boolean {
-  return workEntryViewedImagePath(entry) !== null;
 }
 
 export interface TimelineEndState {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -800,7 +800,8 @@ export function deriveMessagesTimelineRows(input: {
       !entryBelongsToActiveTurn(entry, index) ||
       entry.kind !== "work" ||
       entry.entry.agentSpawn !== undefined ||
-      entry.entry.tone === "error"
+      entry.entry.tone === "error" ||
+      workEntryRendersImagePreview(entry.entry)
     ) {
       break;
     }

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -9,6 +9,7 @@ import {
   summarizeToolGroup,
   toolGroupAction,
   toolGroupSummaryKind,
+  workEntryViewedImagePath,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
 export {
@@ -128,6 +129,15 @@ export function shouldFollowWorkGroupAppend(
     distanceFromEnd <= 1 &&
     previous.every((entry, index) => entry.id === entries[index]?.id)
   );
+}
+
+/**
+ * Rows that preview an image the agent viewed or produced. They stay out of
+ * tool groups and out of the settled-turn fold: the image is the answer the
+ * user asked for, not tool noise to hide behind "Worked for ...".
+ */
+function workEntryRendersImagePreview(entry: WorkLogEntry): boolean {
+  return workEntryViewedImagePath(entry) !== null;
 }
 
 export interface TimelineEndState {
@@ -591,6 +601,9 @@ function deriveTurnFolds(input: {
       if (entry.kind === "work" && entry.entry.agentSpawn !== undefined) {
         continue;
       }
+      if (entry.kind === "work" && workEntryRendersImagePreview(entry.entry)) {
+        continue;
+      }
       hiddenEntryIds.add(entry.id);
     }
     if (hiddenEntryIds.size === 0) {
@@ -890,7 +903,11 @@ export function deriveMessagesTimelineRows(input: {
     }
 
     if (timelineEntry.kind === "work") {
-      if (timelineEntry.entry.agentSpawn !== undefined || timelineEntry.entry.tone === "error") {
+      if (
+        timelineEntry.entry.agentSpawn !== undefined ||
+        timelineEntry.entry.tone === "error" ||
+        workEntryRendersImagePreview(timelineEntry.entry)
+      ) {
         nextRows.push({
           kind: "work",
           id: timelineEntry.id,
@@ -909,6 +926,7 @@ export function deriveMessagesTimelineRows(input: {
           nextEntry.kind !== "work" ||
           nextEntry.entry.agentSpawn !== undefined ||
           nextEntry.entry.tone === "error" ||
+          workEntryRendersImagePreview(nextEntry.entry) ||
           activeWorkEntryIds.has(nextEntry.id) ||
           collapsedEntryIds.has(nextEntry.id) ||
           foldsByAnchorEntryId.has(nextEntry.id)

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3159,25 +3159,29 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           </span>
         </div>
       </div>
+      {viewedImage && threadRef ? (
+        <div
+          className="mt-1 ms-7 cursor-default"
+          onClick={stopRowToggle}
+          onPointerDown={stopRowToggle}
+        >
+          <ChatMarkdownAssetImage
+            environmentId={threadRef.environmentId}
+            resource={viewedImage.resource}
+            alt={viewedImage.alt}
+            srcFragment={viewedImage.srcFragment}
+            workspaceRoot={workspaceRoot}
+            style={{ maxHeight: "16rem" }}
+            onImageExpand={onImageExpand}
+          />
+        </div>
+      ) : null}
       {expanded && canExpand && expandedBody ? (
         <div
           className="mt-1 ms-7 cursor-default border-s border-border/45 ps-3 pt-0.5"
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          {viewedImage && threadRef ? (
-            <div className="mb-1.5">
-              <ChatMarkdownAssetImage
-                environmentId={threadRef.environmentId}
-                resource={viewedImage.resource}
-                alt={viewedImage.alt}
-                srcFragment={viewedImage.srcFragment}
-                workspaceRoot={workspaceRoot}
-                style={{ maxHeight: "16rem" }}
-                onImageExpand={onImageExpand}
-              />
-            </div>
-          ) : null}
           <pre className={toolCallExpandedBodyClassName}>{expandedBody}</pre>
         </div>
       ) : null}


### PR DESCRIPTION
## Problem

When an agent viewed or produced an image, the chat timeline hid it twice. The tool row folded under the "Worked for ..." summary once the turn settled, and even unfolded, the image only appeared after the user clicked the row open. The agent thought it had shown a screenshot; the user saw nothing.

## What changed

Rows that preview an image now render on their own. They stay out of tool groups, stay out of the settled-turn fold, and show the image without an expand click. This reuses the existing signed asset route, so no image bytes travel over the websocket.

The change is in `apps/web`, which desktop wraps. Mobile has a parallel work-log row and still gates its image behind expand; that is a separate fix.

## Markdown images with local paths

Absolute paths and `file://` URIs already resolve through the signed asset route after #9023, which introduced the `media-file` resource. The reporter tested a build from before that merge. I added a POSIX regression test for `![x](/tmp/embed-test/2.png)` and `![x](file:///tmp/embed-test/5.png)` because the existing coverage only exercised Windows path forms.

## Still unsupported: data URIs

`data:` images in Markdown and in HTML `<img>` stay unsupported on purpose. Large base64 in a message is a performance problem twice over: it inflates every websocket frame that carries the message, and it inflates the DOM node that renders it. Agents should write the file and reference its path instead.

## Provider coverage

Claude and the ACP providers (Cursor, Grok) are the only ones that put real image data on the wire. T3 Code does not carry those bytes through. It carries the file path and re-reads the file through the signed asset route, which is why this fix is a rendering change and not a contract change. Codex `view_image` and OpenCode only emit a label, no pixels, so path-based rendering is all they could ever support.

## Tests

- `apps/web/src/components/chat/MessagesTimeline.logic.test.ts` covers the row placement: the command row folds, the image row stays visible and does not collapse into a tool group.
- `apps/web/src/components/ChatMarkdown.workspace-images.test.tsx` covers POSIX absolute and `file://` sources resolving to a signed `media-file` asset.

`vp test run` on the touched files plus the neighboring work-log and markdown-image suites: 147 passed. Web typecheck and lint clean.

No before/after images. This was not run in a browser.

Refs #9094

Built by Claude Opus 5 in the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timeline and markdown rendering changes with broad test coverage; no auth, API, or data contract changes.
> 
> **Overview**
> **Image-preview work rows** (agent viewed/produced screenshots) now stay visible in the chat timeline instead of folding into “Worked for …” or hiding behind tool groups and expand clicks.
> 
> Timeline derivation adds `workEntryRendersImagePreview` (via `workEntryViewedImagePath`) and threads it through **group visibility**, **settled-turn folds**, **live activity grouping**, and **standalone row emission** so image rows behave like first-class answers. `MessagesTimeline.tsx` renders `ChatMarkdownAssetImage` **below the row header** without requiring expand; tool output text remains behind expand.
> 
> Adds regression tests for POSIX/`file://` markdown images resolving to signed `media-file` assets, plus timeline tests that image rows survive folding and in-progress turns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b2d496cda14c9b624e00b554e47ddf874f5bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render assistant images inline in chat timeline work rows
> - Adds `workEntryRendersImagePreview` predicate in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/9126/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) to classify work entries with a viewed image path as image-preview rows.
> - Updates `workEntryIsVisibleInGroup`, `deriveTurnFolds`, and `deriveMessagesTimelineRows` so image-preview entries pass the group-visibility filter, are excluded from settled-turn folds, and are emitted as standalone rows rather than absorbed into active or adjacent tool groups.
> - Moves the viewed-image rendering in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9126/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) out of the expanded-detail container so it displays without expanding the row; expanding still controls the separate tool body.
> - Adds tests covering POSIX/file-URI asset loading in [ChatMarkdown.workspace-images.test.tsx](https://github.com/pingdotgg/t3code/pull/9126/files#diff-717805f526075aa50c8cbb0acf2429b7c718a9a0f29a91ef07f8e7ebded695e5) and image-preview visibility in [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9126/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72).
> - Behavioral Change: work entries previously folded or grouped when neutral will now appear as visible image rows when they have a viewed image path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54b2d49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->