### PR TITLE
fix(web): unlock the composer when preview capture fails

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3213,6 +3213,87 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("a stale capture from a replaced pick never touches the next pick", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let onPicked: ((event: unknown, ...args: unknown[]) => void) | undefined;
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com",
+          getTitle: () => "Example",
+          isLoading: () => false,
+          isFocused: () => true,
+          getZoomFactor: () => 1,
+          setZoomFactor: vi.fn(),
+          setAudioMuted: vi.fn(),
+          isCurrentlyAudible: () => false,
+          on: vi.fn(),
+          once: vi.fn(),
+          off: vi.fn(),
+          capturePage: vi.fn(() => new Promise(() => {})),
+          ipc: {
+            on: vi.fn((channel: string, listener: typeof onPicked) => {
+              if (channel === "preview:element-picked") onPicked = listener;
+            }),
+            off: vi.fn(),
+            removeListener: vi.fn(),
+          },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand: vi.fn(async () => undefined),
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+        } as never);
+        const annotation = {
+          id: "annotation_1",
+          pageUrl: "https://example.com",
+          pageTitle: "Example",
+          comment: "Tighten this spacing",
+          elements: [],
+          regions: [{ id: "region_1", rect: { x: 5, y: 6, width: 20, height: 30 } }],
+          strokes: [],
+          styleChanges: [],
+          screenshot: null,
+          createdAt: "2026-06-11T00:00:00.000Z",
+        };
+
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+        const firstPick = yield* manager.pickElement("tab_1").pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+        // The first pick submits and its crop hangs.
+        onPicked?.({}, annotation, null, "send");
+        yield* Effect.yieldNow;
+
+        // A second pick on the same tab replaces the first, which resumes null.
+        const secondPick = yield* manager.pickElement("tab_1").pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+        expect(yield* Fiber.join(firstPick)).toBeNull();
+        webviewSend.mockClear();
+
+        // The first pick's crop times out while the second pick is live. It
+        // must not signal the overlay, which would tear down the second pick.
+        yield* TestClock.adjust("6 seconds");
+        yield* Effect.yieldNow;
+        expect(webviewSend).not.toHaveBeenCalledWith("preview:annotation-captured");
+        expect(secondPick.pollUnsafe()).toBeUndefined();
+
+        onPicked?.({}, { ...annotation, id: "annotation_2" }, null, "attach");
+        yield* TestClock.adjust("6 seconds");
+        const result = yield* Fiber.join(secondPick);
+        expect(result?.annotation.id).toBe("annotation_2");
+        expect(result?.submission).toBe("attach");
+      }),
+    ),
+  );
+
   effectIt.effect("navigates the guest history when the thumb-button ipc fires", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3137,6 +3137,82 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("settles the pick when the annotation screenshot never arrives", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let onPicked: ((event: unknown, ...args: unknown[]) => void) | undefined;
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com",
+          getTitle: () => "Example",
+          isLoading: () => false,
+          isFocused: () => true,
+          getZoomFactor: () => 1,
+          setZoomFactor: vi.fn(),
+          setAudioMuted: vi.fn(),
+          isCurrentlyAudible: () => false,
+          on: vi.fn(),
+          once: vi.fn(),
+          off: vi.fn(),
+          // A wedged compositor leaves `capturePage` pending forever.
+          capturePage: vi.fn(() => new Promise(() => {})),
+          ipc: {
+            on: vi.fn((channel: string, listener: typeof onPicked) => {
+              if (channel === "preview:element-picked") onPicked = listener;
+            }),
+            off: vi.fn(),
+            removeListener: vi.fn(),
+          },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand: vi.fn(async () => undefined),
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+        } as never);
+
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+        const pick = yield* manager.pickElement("tab_1").pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+
+        onPicked?.(
+          {},
+          {
+            id: "annotation_1",
+            pageUrl: "https://example.com",
+            pageTitle: "Example",
+            comment: "Tighten this spacing",
+            elements: [],
+            regions: [{ id: "region_1", rect: { x: 5, y: 6, width: 20, height: 30 } }],
+            strokes: [],
+            styleChanges: [],
+            screenshot: null,
+            createdAt: "2026-06-11T00:00:00.000Z",
+          },
+          null,
+          "send",
+        );
+        yield* Effect.yieldNow;
+        expect(pick.pollUnsafe()).toBeUndefined();
+
+        yield* TestClock.adjust("6 seconds");
+        // The pick has to give up on the crop rather than strand the renderer,
+        // which would leave the composer stuck on "Capturing…".
+        const result = yield* Fiber.join(pick);
+        expect(result?.annotation.screenshot).toBeNull();
+        expect(result?.submission).toBe("send");
+        expect(webviewSend).toHaveBeenCalledWith("preview:annotation-captured");
+      }),
+    ),
+  );
+
   effectIt.effect("navigates the guest history when the thumb-button ipc fires", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3207,6 +3207,7 @@ describe("PreviewManager", () => {
         // which would leave the composer stuck on "Capturing…".
         const result = yield* Fiber.join(pick);
         expect(result?.annotation.screenshot).toBeNull();
+        expect(result?.screenshotFailed).toBe(true);
         expect(result?.submission).toBe("send");
         expect(webviewSend).toHaveBeenCalledWith("preview:annotation-captured");
       }),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -309,6 +309,11 @@ const normalizeCaptureRect = (value: unknown): PreviewAnnotationRect | null => {
 /** `capturePage` never settles when the guest's compositor is wedged. */
 const ANNOTATION_SCREENSHOT_TIMEOUT = "5 seconds";
 
+/**
+ * Crops the guest for a picked annotation. A stalled `capturePage` resolves to
+ * `null` after the timeout: the annotation is still sendable without its
+ * screenshot, and the pick session must settle either way.
+ */
 const captureAnnotationScreenshot = (
   tabId: string,
   wc: Electron.WebContents,
@@ -337,19 +342,7 @@ const captureAnnotationScreenshot = (
         cause,
       }),
   }).pipe(
-    Effect.timeoutOrElse({
-      duration: ANNOTATION_SCREENSHOT_TIMEOUT,
-      orElse: () =>
-        Effect.fail(
-          new PreviewOperationError({
-            operation: "captureAnnotationScreenshot",
-            tabId,
-            webContentsId: wc.id,
-            cause: new Error(`capturePage exceeded ${ANNOTATION_SCREENSHOT_TIMEOUT}`),
-          }),
-        ),
-    }),
-    Effect.map((image) => {
+    Effect.map((image): PreviewAnnotationPayload["screenshot"] => {
       const size = image.getSize();
       return {
         dataUrl: image.toDataURL(),
@@ -358,6 +351,15 @@ const captureAnnotationScreenshot = (
         cropRect: cropRect ?? { x: 0, y: 0, width: size.width, height: size.height },
       };
     }),
+    Effect.timeoutOption(ANNOTATION_SCREENSHOT_TIMEOUT),
+    Effect.flatMap((screenshot) =>
+      Option.isSome(screenshot)
+        ? Effect.succeed(screenshot.value)
+        : Effect.logWarning("preview annotation screenshot timed out").pipe(
+            Effect.annotateLogs({ tabId, webContentsId: wc.id }),
+            Effect.as(null),
+          ),
+    ),
   );
 
 const findZoomStep = (current: number): number => {
@@ -2388,16 +2390,23 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const annotationTheme = yield* Ref.get(annotationThemeRef);
     return yield* Effect.callback<PreviewAnnotationSubmissionResult | null, PreviewManagerError>(
       (resume) => {
+        // Declared first so cleanup can check slot ownership by identity
+        // without a type cycle through the cancel effect it builds.
+        const session: PickSession = { cancel: Effect.suspend(() => cancelPickSession()) };
         const cleanup = Effect.fn("PreviewManager.cleanupPickElement")(function* () {
           yield* attempt({ operation: "pickElement.cleanup", tabId, webContentsId: wc.id }, () => {
             wc.ipc.removeListener(ELEMENT_PICKED_CHANNEL, onMessage);
             wc.off("destroyed", onDestroyed);
             wc.off("did-start-navigation", onNavigated);
           }).pipe(Effect.ignore);
+          // Only drop the slot while it is still ours. A newer session may
+          // already have swapped itself in before cancelling this one.
           yield* Ref.update(pickSessionsRef, (sessions) =>
-            replaceMap(sessions, (copy) => {
-              copy.delete(tabId);
-            }),
+            sessions.get(tabId) === session
+              ? replaceMap(sessions, (copy) => {
+                  copy.delete(tabId);
+                })
+              : sessions,
           );
         });
         // Every exit from this session runs through `claimSettle`, so the
@@ -2410,12 +2419,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           settled = true;
           return true;
         };
+        const finishPick = Effect.fn("PreviewManager.finishPickElement")(function* (
+          payload: PreviewAnnotationSubmissionResult | null,
+        ) {
+          yield* cleanup();
+          resume(Effect.succeed(payload));
+        });
         const settlePick = Effect.fn("PreviewManager.settlePickElement")(function* (
           payload: PreviewAnnotationSubmissionResult | null,
         ) {
           if (!claimSettle()) return;
-          yield* cleanup();
-          resume(Effect.succeed(payload));
+          yield* finishPick(payload);
         });
         const settle = (payload: PreviewAnnotationSubmissionResult | null) => {
           runFork(settlePick(payload));
@@ -2440,7 +2454,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           }
           resume(Effect.succeed(null));
         });
-        const cancel = cancelPickSession();
         const onMessage = (_event: Electron.IpcMainEvent, ...args: unknown[]): void => {
           const payload = args[0];
           if (!isPreviewAnnotationPayload(payload)) {
@@ -2451,19 +2464,22 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           const submission = args[2] === "send" ? "send" : "attach";
           runFork(
             captureAnnotationScreenshot(tabId, wc, cropRect).pipe(
-              Effect.matchEffect({
-                onFailure: () => Effect.sync(() => settle({ annotation: payload, submission })),
-                onSuccess: (screenshot) =>
-                  Effect.sync(() => settle({ annotation: { ...payload, screenshot }, submission })),
+              Effect.match({
+                onFailure: () => payload,
+                onSuccess: (screenshot) => ({ ...payload, screenshot }),
               }),
-              Effect.ensuring(
-                attempt(
+              Effect.flatMap((annotation) => {
+                // A capture that outlives its session must not touch the
+                // overlay: the preload tears down on the captured signal, and
+                // by now it may be running a newer pick.
+                if (!claimSettle()) return Effect.void;
+                return attempt(
                   { operation: "pickElement.captureComplete", tabId, webContentsId: wc.id },
                   () => {
                     if (!wc.isDestroyed()) wc.send(ANNOTATION_CAPTURED_CHANNEL);
                   },
-                ).pipe(Effect.ignore),
-              ),
+                ).pipe(Effect.ignore, Effect.andThen(finishPick({ annotation, submission })));
+              }),
             ),
           );
         };
@@ -2477,21 +2493,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           if (isMainFrame) settle(null);
         };
         const registerPickElement = Effect.fn("PreviewManager.registerPickElement")(function* () {
-          // Two picks on one tab can overlap. Take the slot, settle whoever
-          // held it, and only then claim it, so the session we push out never
-          // leaves its renderer awaiting a pick that no longer exists.
+          // Two picks on one tab can overlap. Swap this session in and cancel
+          // the previous holder in one step, so no third pick can slip into an
+          // empty slot in between and the session we push out still resumes
+          // its renderer.
           const replaced = yield* Ref.modify(pickSessionsRef, (sessions) => [
             sessions.get(tabId) ?? null,
             replaceMap(sessions, (copy) => {
-              copy.delete(tabId);
+              copy.set(tabId, session);
             }),
           ]);
           if (replaced) yield* replaced.cancel;
-          yield* Ref.update(pickSessionsRef, (sessions) =>
-            replaceMap(sessions, (copy) => {
-              copy.set(tabId, { cancel });
-            }),
-          );
           yield* attempt({ operation: "pickElement.register", tabId, webContentsId: wc.id }, () => {
             wc.ipc.on(ELEMENT_PICKED_CHANNEL, onMessage);
             wc.once("destroyed", onDestroyed);
@@ -2509,7 +2521,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             }),
           ),
         );
-        return cancel;
+        return session.cancel;
       },
     );
   });

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -306,13 +306,19 @@ const normalizeCaptureRect = (value: unknown): PreviewAnnotationRect | null => {
   };
 };
 
+/** `capturePage` never settles when the guest's compositor is wedged. */
+const ANNOTATION_SCREENSHOT_TIMEOUT = "5 seconds";
+
 const captureAnnotationScreenshot = (
   tabId: string,
   wc: Electron.WebContents,
   cropRect: PreviewAnnotationRect | null,
 ): Effect.Effect<PreviewAnnotationPayload["screenshot"], PreviewManagerError> =>
   Effect.tryPromise({
-    try: () =>
+    // The unused abort signal is what makes this interruptible, and therefore
+    // what lets the timeout below fire. Drop the parameter and a stalled
+    // capture strands the pick session again.
+    try: (_signal) =>
       wc.capturePage(
         cropRect
           ? {
@@ -331,6 +337,18 @@ const captureAnnotationScreenshot = (
         cause,
       }),
   }).pipe(
+    Effect.timeoutOrElse({
+      duration: ANNOTATION_SCREENSHOT_TIMEOUT,
+      orElse: () =>
+        Effect.fail(
+          new PreviewOperationError({
+            operation: "captureAnnotationScreenshot",
+            tabId,
+            webContentsId: wc.id,
+            cause: new Error(`capturePage exceeded ${ANNOTATION_SCREENSHOT_TIMEOUT}`),
+          }),
+        ),
+    }),
     Effect.map((image) => {
       const size = image.getSize();
       return {
@@ -2382,11 +2400,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             }),
           );
         });
+        // Every exit from this session runs through `claimSettle`, so the
+        // renderer's `pickElement` promise resolves exactly once. The previous
+        // identity check let a cancelled or replaced session return without
+        // resuming, which left the composer waiting forever.
+        let settled = false;
+        const claimSettle = (): boolean => {
+          if (settled) return false;
+          settled = true;
+          return true;
+        };
         const settlePick = Effect.fn("PreviewManager.settlePickElement")(function* (
           payload: PreviewAnnotationSubmissionResult | null,
         ) {
-          const active = (yield* Ref.get(pickSessionsRef)).get(tabId);
-          if (!active || active.cancel !== cancel) return;
+          if (!claimSettle()) return;
           yield* cleanup();
           resume(Effect.succeed(payload));
         });
@@ -2394,6 +2421,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           runFork(settlePick(payload));
         };
         const cancelPickSession = Effect.fn("PreviewManager.cancelPickSession")(function* () {
+          if (!claimSettle()) return;
           yield* cleanup();
           const tabs = yield* SynchronizedRef.get(tabsRef);
           const activeTab = tabs.get(tabId);
@@ -2449,6 +2477,21 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           if (isMainFrame) settle(null);
         };
         const registerPickElement = Effect.fn("PreviewManager.registerPickElement")(function* () {
+          // Two picks on one tab can overlap. Take the slot, settle whoever
+          // held it, and only then claim it, so the session we push out never
+          // leaves its renderer awaiting a pick that no longer exists.
+          const replaced = yield* Ref.modify(pickSessionsRef, (sessions) => [
+            sessions.get(tabId) ?? null,
+            replaceMap(sessions, (copy) => {
+              copy.delete(tabId);
+            }),
+          ]);
+          if (replaced) yield* replaced.cancel;
+          yield* Ref.update(pickSessionsRef, (sessions) =>
+            replaceMap(sessions, (copy) => {
+              copy.set(tabId, { cancel });
+            }),
+          );
           yield* attempt({ operation: "pickElement.register", tabId, webContentsId: wc.id }, () => {
             wc.ipc.on(ELEMENT_PICKED_CHANNEL, onMessage);
             wc.once("destroyed", onDestroyed);
@@ -2456,15 +2499,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             if (!wc.isFocused()) wc.focus();
             wc.send(START_PICK_CHANNEL, annotationTheme);
           });
-          yield* Ref.update(pickSessionsRef, (sessions) =>
-            replaceMap(sessions, (copy) => {
-              copy.set(tabId, { cancel });
-            }),
-          );
         });
         runFork(
           registerPickElement().pipe(
             Effect.catch((error: PreviewManagerError) => {
+              if (!claimSettle()) return Effect.void;
               resume(Effect.fail(error));
               return cleanup();
             }),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -2504,6 +2504,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             }),
           ]);
           if (replaced) yield* replaced.cancel;
+          // A newer pick may have cancelled this session while the previous
+          // one was torn down. Cleanup already ran, so attaching listeners now
+          // would leak them and start an overlay nobody is waiting on.
+          if (settled) return;
           yield* attempt({ operation: "pickElement.register", tabId, webContentsId: wc.id }, () => {
             wc.ipc.on(ELEMENT_PICKED_CHANNEL, onMessage);
             wc.once("destroyed", onDestroyed);

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -2464,11 +2464,21 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           const submission = args[2] === "send" ? "send" : "attach";
           runFork(
             captureAnnotationScreenshot(tabId, wc, cropRect).pipe(
+              // The renderer cannot tell a dropped crop from a comment-only
+              // pick by the null alone, so a failed or timed-out capture is
+              // flagged on the result.
               Effect.match({
-                onFailure: () => payload,
-                onSuccess: (screenshot) => ({ ...payload, screenshot }),
+                onFailure: (): PreviewAnnotationSubmissionResult => ({
+                  annotation: payload,
+                  submission,
+                  screenshotFailed: true,
+                }),
+                onSuccess: (screenshot): PreviewAnnotationSubmissionResult =>
+                  screenshot === null
+                    ? { annotation: payload, submission, screenshotFailed: true }
+                    : { annotation: { ...payload, screenshot }, submission },
               }),
-              Effect.flatMap((annotation) => {
+              Effect.flatMap((result) => {
                 // A capture that outlives its session must not touch the
                 // overlay: the preload tears down on the captured signal, and
                 // by now it may be running a newer pick.
@@ -2478,7 +2488,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                   () => {
                     if (!wc.isDestroyed()) wc.send(ANNOTATION_CAPTURED_CHANNEL);
                   },
-                ).pipe(Effect.ignore, Effect.andThen(finishPick({ annotation, submission })));
+                ).pipe(Effect.ignore, Effect.andThen(finishPick(result)));
               }),
             ),
           );

--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -1,4 +1,4 @@
-// @effect-diagnostics globalDate:off - This isolated Electron preload does not run inside an Effect runtime.
+// @effect-diagnostics globalDate:off globalTimers:off - This isolated Electron preload does not run inside an Effect runtime.
 import { ipcRenderer } from "electron";
 import { getElementContext } from "react-grab/primitives";
 import type {
@@ -30,6 +30,8 @@ const Z_INDEX_OVERLAY = 2147483646;
 const PRIMARY = "var(--t3-primary)";
 const PRIMARY_FILL = "color-mix(in srgb, var(--t3-primary) 10%, transparent)";
 const MAX_MARQUEE_ELEMENTS = 20;
+/** Upper bound on one element's React context lookup during submit. */
+const ELEMENT_CONTEXT_TIMEOUT_MS = 5_000;
 const CONTENT_LAYER_Z_INDEX = 1;
 const CHROME_LAYER_Z_INDEX = 10;
 
@@ -279,9 +281,29 @@ function toStackFrame(frame: {
   };
 }
 
+/**
+ * Resolves to `null` instead of hanging when `promise` outlives `millis`.
+ * `getElementContext` walks the inspected page's React internals, and some
+ * pages leave it pending forever. Without a bound, the whole submit chain
+ * stalls and the overlay sits on "Capturing…".
+ */
+function withCaptureTimeout<A>(promise: Promise<A>, millis: number): Promise<A | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise,
+    new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), millis);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
 async function captureElement(element: Element): Promise<PickedElementPayload | null> {
   try {
-    const context = await getElementContext(element);
+    const context = await withCaptureTimeout(
+      Promise.resolve(getElementContext(element)),
+      ELEMENT_CONTEXT_TIMEOUT_MS,
+    );
+    if (!context) return null;
     const stack = (context.stack ?? []).map(toStackFrame);
     return {
       pageUrl: location.href,
@@ -1238,30 +1260,37 @@ function startAnnotation(): void {
           rect: rectFromDomRect(target.element.getBoundingClientRect()),
         };
       }),
-    ).then((captured) => {
-      const elements = captured.filter((target) => target !== null);
-      const annotation: PreviewAnnotationPayload = {
-        id: nextId("annotation"),
-        pageUrl: location.href,
-        pageTitle: document.title?.trim() || null,
-        comment: comment.value.trim(),
-        elements,
-        regions: [...regions],
-        strokes: [...strokes],
-        styleChanges: Array.from(styleChanges.values()),
-        screenshot: null,
-        createdAt: new Date().toISOString(),
-      };
-      editor.style.display = "none";
-      toolbar.style.display = "none";
-      hoverOutline.style.display = "none";
-      const screenshotRect = unionRects([
-        ...elements.map((target) => target.rect),
-        ...regions.map((region) => region.rect),
-        ...strokes.map((stroke) => stroke.bounds),
-      ]);
-      ipcRenderer.send(ELEMENT_PICKED_CHANNEL, annotation, screenshotRect, submission);
-    });
+    )
+      .then((captured) => {
+        const elements = captured.filter((target) => target !== null);
+        const annotation: PreviewAnnotationPayload = {
+          id: nextId("annotation"),
+          pageUrl: location.href,
+          pageTitle: document.title?.trim() || null,
+          comment: comment.value.trim(),
+          elements,
+          regions: [...regions],
+          strokes: [...strokes],
+          styleChanges: Array.from(styleChanges.values()),
+          screenshot: null,
+          createdAt: new Date().toISOString(),
+        };
+        editor.style.display = "none";
+        toolbar.style.display = "none";
+        hoverOutline.style.display = "none";
+        const screenshotRect = unionRects([
+          ...elements.map((target) => target.rect),
+          ...regions.map((region) => region.rect),
+          ...strokes.map((stroke) => stroke.bounds),
+        ]);
+        ipcRenderer.send(ELEMENT_PICKED_CHANNEL, annotation, screenshotRect, submission);
+      })
+      .catch(() => {
+        // Last resort. Main is waiting on this message, so hand it an empty
+        // pick rather than leaving the button stuck on "Capturing…" and the
+        // renderer's pick promise pending.
+        teardown(true);
+      });
   };
   submit.addEventListener("click", () => submitAnnotation("attach"));
   root.addEventListener("keydown", (event) => {

--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -1262,6 +1262,9 @@ function startAnnotation(): void {
       }),
     )
       .then((captured) => {
+        // The overlay may have been cancelled or replaced while the capture
+        // ran. A late submit must not deliver into the next pick's listener.
+        if (finished) return;
         const elements = captured.filter((target) => target !== null);
         const annotation: PreviewAnnotationPayload = {
           id: nextId("annotation"),
@@ -1288,7 +1291,7 @@ function startAnnotation(): void {
       .catch(() => {
         // Last resort. Main is waiting on this message, so hand it an empty
         // pick rather than leaving the button stuck on "Capturing…" and the
-        // renderer's pick promise pending.
+        // renderer's pick promise pending. teardown is a no-op once finished.
         teardown(true);
       });
   };

--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -1247,11 +1247,18 @@ function startAnnotation(): void {
     pendingCapture = true;
     submit.disabled = true;
     submit.textContent = "Capturing…";
+    // Snapshot everything the annotation will carry before the capture runs.
+    // The element context lookup can take up to its timeout, and the user can
+    // keep editing meanwhile; the annotation must describe what they submitted.
+    const submittedComment = comment.value.trim();
+    const submittedRegions = [...regions];
+    const submittedStrokes = [...strokes];
+    const submittedStyleChanges = Array.from(styleChanges.values(), (change) => ({ ...change }));
     void Promise.all(
       Array.from(selected.values()).map(async (target) => {
         const element = await captureElement(target.element);
         if (!element) return null;
-        for (const change of styleChanges.values()) {
+        for (const change of submittedStyleChanges) {
           if (change.targetId === target.id) change.selector = element.selector;
         }
         return {
@@ -1270,11 +1277,11 @@ function startAnnotation(): void {
           id: nextId("annotation"),
           pageUrl: location.href,
           pageTitle: document.title?.trim() || null,
-          comment: comment.value.trim(),
+          comment: submittedComment,
           elements,
-          regions: [...regions],
-          strokes: [...strokes],
-          styleChanges: Array.from(styleChanges.values()),
+          regions: submittedRegions,
+          strokes: submittedStrokes,
+          styleChanges: submittedStyleChanges,
           screenshot: null,
           createdAt: new Date().toISOString(),
         };
@@ -1283,8 +1290,8 @@ function startAnnotation(): void {
         hoverOutline.style.display = "none";
         const screenshotRect = unionRects([
           ...elements.map((target) => target.rect),
-          ...regions.map((region) => region.rect),
-          ...strokes.map((stroke) => stroke.bounds),
+          ...submittedRegions.map((region) => region.rect),
+          ...submittedStrokes.map((stroke) => stroke.bounds),
         ]);
         ipcRenderer.send(ELEMENT_PICKED_CHANNEL, annotation, screenshotRect, submission);
       })

--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -297,29 +297,51 @@ function withCaptureTimeout<A>(promise: Promise<A>, millis: number): Promise<A |
   ]).finally(() => clearTimeout(timer));
 }
 
-async function captureElement(element: Element): Promise<PickedElementPayload | null> {
+/** Truncation for the DOM-only preview used when React context is unavailable. */
+const HTML_PREVIEW_MAX_CHARS = 500;
+
+/**
+ * Describes a picked element. The React context lookup can stall or throw on
+ * some pages, so the element is never dropped: without context it still
+ * carries its tag, a short HTML preview, and its rect so the crop stays on the
+ * pick instead of falling back to the whole viewport.
+ */
+async function captureElement(element: Element): Promise<PickedElementPayload> {
+  const base = {
+    pageUrl: location.href,
+    pageTitle: document.title?.trim() || null,
+    tagName: element.tagName.toLowerCase(),
+    pickedAt: new Date().toISOString(),
+  };
   try {
     const context = await withCaptureTimeout(
       Promise.resolve(getElementContext(element)),
       ELEMENT_CONTEXT_TIMEOUT_MS,
     );
-    if (!context) return null;
-    const stack = (context.stack ?? []).map(toStackFrame);
-    return {
-      pageUrl: location.href,
-      pageTitle: document.title?.trim() || null,
-      tagName: element.tagName.toLowerCase(),
-      selector: context.selector,
-      htmlPreview: context.htmlPreview ?? "",
-      componentName: context.componentName,
-      source: stack[0] ?? null,
-      stack,
-      styles: context.styles ?? "",
-      pickedAt: new Date().toISOString(),
-    };
+    if (context) {
+      const stack = (context.stack ?? []).map(toStackFrame);
+      return {
+        ...base,
+        selector: context.selector,
+        htmlPreview: context.htmlPreview ?? "",
+        componentName: context.componentName,
+        source: stack[0] ?? null,
+        stack,
+        styles: context.styles ?? "",
+      };
+    }
   } catch {
-    return null;
+    // Fall through to the DOM-only payload.
   }
+  return {
+    ...base,
+    selector: null,
+    htmlPreview: element.outerHTML.slice(0, HTML_PREVIEW_MAX_CHARS),
+    componentName: null,
+    source: null,
+    stack: [],
+    styles: "",
+  };
 }
 
 function createButton(label: string, title: string): HTMLButtonElement {
@@ -1257,9 +1279,10 @@ function startAnnotation(): void {
     void Promise.all(
       Array.from(selected.values()).map(async (target) => {
         const element = await captureElement(target.element);
-        if (!element) return null;
         for (const change of submittedStyleChanges) {
-          if (change.targetId === target.id) change.selector = element.selector;
+          if (change.targetId === target.id && element.selector !== null) {
+            change.selector = element.selector;
+          }
         }
         return {
           id: target.id,
@@ -1268,11 +1291,10 @@ function startAnnotation(): void {
         };
       }),
     )
-      .then((captured) => {
+      .then((elements) => {
         // The overlay may have been cancelled or replaced while the capture
         // ran. A late submit must not deliver into the next pick's listener.
         if (finished) return;
-        const elements = captured.filter((target) => target !== null);
         const annotation: PreviewAnnotationPayload = {
           id: nextId("annotation"),
           pageUrl: location.href,

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   openPictureInPicture: vi.fn(async (_tabId: string): Promise<void> => undefined),
   closePictureInPicture: vi.fn(async (_tabId: string): Promise<void> => undefined),
   pickElement: vi.fn(),
-  previewAnnotationScreenshotFile: vi.fn(),
+  capturePreviewAnnotationScreenshot: vi.fn(),
   addPreviewAnnotation: vi.fn(),
   addImage: vi.fn(),
   toggleAnnotation: null as (() => void) | null,
@@ -90,7 +90,7 @@ vi.mock("~/composerDraftStore", () => ({
 }));
 
 vi.mock("~/lib/previewAnnotation", () => ({
-  previewAnnotationScreenshotFile: mocks.previewAnnotationScreenshotFile,
+  capturePreviewAnnotationScreenshot: mocks.capturePreviewAnnotationScreenshot,
 }));
 
 vi.mock("~/localApi", () => ({
@@ -339,7 +339,8 @@ describe("PreviewView navigation", () => {
     mocks.openPictureInPicture.mockClear();
     mocks.closePictureInPicture.mockClear();
     mocks.pickElement.mockReset();
-    mocks.previewAnnotationScreenshotFile.mockReset();
+    mocks.capturePreviewAnnotationScreenshot.mockReset();
+    mocks.capturePreviewAnnotationScreenshot.mockResolvedValue({ status: "none" });
     mocks.addPreviewAnnotation.mockClear();
     mocks.addImage.mockClear();
     mocks.toggleAnnotation = null;
@@ -551,7 +552,7 @@ describe("PreviewView navigation", () => {
     expect(mocks.addPreviewAnnotation).toHaveBeenCalledWith(TEST_THREAD_REF, annotation);
   });
 
-  it("still sends when screenshot attachment conversion fails", async () => {
+  it("still sends when the picked element's crop cannot be captured", async () => {
     const annotation = {
       id: "annotation-2",
       pageUrl: "https://example.com/dashboard",
@@ -571,7 +572,7 @@ describe("PreviewView navigation", () => {
     };
     const onSendAnnotation = vi.fn();
     mocks.pickElement.mockResolvedValue({ annotation, submission: "send" });
-    mocks.previewAnnotationScreenshotFile.mockRejectedValue(new Error("conversion failed"));
+    mocks.capturePreviewAnnotationScreenshot.mockResolvedValue({ status: "failed" });
 
     renderToStaticMarkup(
       <PreviewView

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -584,7 +584,11 @@ describe("PreviewView navigation", () => {
     );
     mocks.toggleAnnotation?.();
 
-    await vi.waitFor(() => expect(onSendAnnotation).toHaveBeenCalledWith(annotation, null));
+    // The forwarded and stored annotation both drop the screenshot, so the
+    // prompt does not claim a crop that was never attached.
+    const sent = { ...annotation, screenshot: null };
+    await vi.waitFor(() => expect(onSendAnnotation).toHaveBeenCalledWith(sent, null));
+    expect(mocks.addPreviewAnnotation).toHaveBeenCalledWith(TEST_THREAD_REF, sent);
     expect(mocks.addImage).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -252,6 +252,7 @@ vi.mock("~/browser/BrowserSurfaceSlot", () => ({ BrowserSurfaceSlot: () => null 
 vi.mock("./usePreviewSession", () => ({ usePreviewSession: vi.fn() }));
 
 import { PreviewView, previewProfileName } from "./PreviewView";
+import { toastManager } from "~/components/ui/toast";
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 
 const TEST_THREAD_REF = {
@@ -342,6 +343,7 @@ describe("PreviewView navigation", () => {
     mocks.capturePreviewAnnotationScreenshot.mockReset();
     mocks.capturePreviewAnnotationScreenshot.mockResolvedValue({ status: "none" });
     mocks.addPreviewAnnotation.mockClear();
+    vi.mocked(toastManager.add).mockClear();
     mocks.addImage.mockClear();
     mocks.toggleAnnotation = null;
     mocks.pictureInPicture = false;
@@ -550,6 +552,38 @@ describe("PreviewView navigation", () => {
 
     await vi.waitFor(() => expect(onSendAnnotation).toHaveBeenCalledWith(annotation, null));
     expect(mocks.addPreviewAnnotation).toHaveBeenCalledWith(TEST_THREAD_REF, annotation);
+  });
+
+  it("warns when main dropped the crop before handing over the pick", async () => {
+    const annotation = {
+      id: "annotation-3",
+      pageUrl: "https://example.com/dashboard",
+      pageTitle: "Dashboard",
+      comment: "Tighten this spacing",
+      elements: [],
+      regions: [],
+      strokes: [],
+      styleChanges: [],
+      screenshot: null,
+      createdAt: "2026-07-27T00:00:00.000Z",
+    };
+    const onSendAnnotation = vi.fn();
+    mocks.pickElement.mockResolvedValue({ annotation, submission: "send", screenshotFailed: true });
+
+    renderToStaticMarkup(
+      <PreviewView
+        threadRef={TEST_THREAD_REF}
+        tabId="tab-1"
+        visible
+        onSendAnnotation={onSendAnnotation}
+      />,
+    );
+    mocks.toggleAnnotation?.();
+
+    await vi.waitFor(() => expect(onSendAnnotation).toHaveBeenCalledWith(annotation, null));
+    // A null screenshot alone looks like a comment-only pick; the flag is what
+    // separates "no crop requested" from "crop lost to a timeout".
+    expect(toastManager.add).toHaveBeenCalledTimes(1);
   });
 
   it("still sends when the picked element's crop cannot be captured", async () => {

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -593,10 +593,9 @@ export function PreviewView({
             stackedThreadToast({
               type: "error",
               title: "Could not capture the picked element",
-              description:
-                submission === "send"
-                  ? "The message was sent without the screenshot."
-                  : "The annotation was added without the screenshot.",
+              // The send path reports its own outcome, so only say what this
+              // handler knows: the crop was dropped.
+              description: "The annotation was kept without the screenshot.",
             }),
           );
         }

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -590,7 +590,10 @@ export function PreviewView({
             stackedThreadToast({
               type: "error",
               title: "Could not capture the picked element",
-              description: "Send again without it.",
+              description:
+                submission === "send"
+                  ? "The message was sent without the screenshot."
+                  : "The annotation was added without the screenshot.",
             }),
           );
         }

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -579,12 +579,15 @@ export function PreviewView({
       try {
         const result = await previewBridge.pickElement(runtimeTabId);
         if (!result) return;
-        const { annotation, submission } = result;
-        addPreviewAnnotation(threadRef, annotation);
+        const { annotation: picked, submission } = result;
         // The structured annotation is still sendable when its optional crop
         // stalls or fails, so tell the user what they lost and keep going
         // instead of holding the composer for an attachment that never lands.
-        const capture = await capturePreviewAnnotationScreenshot(annotation);
+        // The stored copy drops the screenshot on failure, otherwise the prompt
+        // would tell the agent a crop is attached when none was sent.
+        const capture = await capturePreviewAnnotationScreenshot(picked);
+        const annotation = capture.status === "failed" ? { ...picked, screenshot: null } : picked;
+        addPreviewAnnotation(threadRef, annotation);
         if (capture.status === "failed") {
           toastManager.add(
             stackedThreadToast({

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -20,7 +20,7 @@ import {
   useThreadRecentHistory,
 } from "~/browserHistoryStore";
 import { type ComposerImageAttachment, useComposerDraftStore } from "~/composerDraftStore";
-import { previewAnnotationScreenshotFile } from "~/lib/previewAnnotation";
+import { capturePreviewAnnotationScreenshot } from "~/lib/previewAnnotation";
 import { ensureLocalApi } from "~/localApi";
 import {
   rememberPreviewUrl,
@@ -581,13 +581,20 @@ export function PreviewView({
         if (!result) return;
         const { annotation, submission } = result;
         addPreviewAnnotation(threadRef, annotation);
-        let screenshotFile: File | null = null;
-        try {
-          screenshotFile = await previewAnnotationScreenshotFile(annotation);
-        } catch {
-          // The structured annotation is still sendable when converting its
-          // optional screenshot into a composer attachment fails.
+        // The structured annotation is still sendable when its optional crop
+        // stalls or fails, so tell the user what they lost and keep going
+        // instead of holding the composer for an attachment that never lands.
+        const capture = await capturePreviewAnnotationScreenshot(annotation);
+        if (capture.status === "failed") {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not capture the picked element",
+              description: "Send again without it.",
+            }),
+          );
         }
+        const screenshotFile = capture.status === "captured" ? capture.file : null;
         const image =
           screenshotFile && annotation.screenshot
             ? ({

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -579,16 +579,19 @@ export function PreviewView({
       try {
         const result = await previewBridge.pickElement(runtimeTabId);
         if (!result) return;
-        const { annotation: picked, submission } = result;
+        const { annotation: picked, submission, screenshotFailed = false } = result;
         // The structured annotation is still sendable when its optional crop
         // stalls or fails, so tell the user what they lost and keep going
         // instead of holding the composer for an attachment that never lands.
         // The stored copy drops the screenshot on failure, otherwise the prompt
         // would tell the agent a crop is attached when none was sent.
         const capture = await capturePreviewAnnotationScreenshot(picked);
+        // Main reports a crop that failed or timed out on its side; the local
+        // conversion can fail too. Either way the user should hear about it.
+        const cropDropped = screenshotFailed || capture.status === "failed";
         const annotation = capture.status === "failed" ? { ...picked, screenshot: null } : picked;
         addPreviewAnnotation(threadRef, annotation);
-        if (capture.status === "failed") {
+        if (cropDropped) {
           toastManager.add(
             stackedThreadToast({
               type: "error",

--- a/apps/web/src/lib/previewAnnotation.test.ts
+++ b/apps/web/src/lib/previewAnnotation.test.ts
@@ -1,9 +1,10 @@
 import type { PreviewAnnotationPayload } from "@t3tools/contracts";
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   appendPreviewAnnotationPrompt,
   buildPreviewAnnotationPrompt,
+  capturePreviewAnnotationScreenshot,
   extractTrailingPreviewAnnotation,
 } from "./previewAnnotation";
 
@@ -83,5 +84,38 @@ describe("preview annotations", () => {
     expect(extractedSecond.annotation?.id).toBe("annotation_2");
     expect(extractedFirst.annotation?.id).toBe("annotation_1");
     expect(extractedFirst.promptText).toBe("Fix this");
+  });
+});
+
+describe("preview annotation capture", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the crop when the fetch resolves", async () => {
+    vi.stubGlobal("fetch", async () => new Response(new Blob(["png"], { type: "image/png" })));
+    const capture = await capturePreviewAnnotationScreenshot(annotation);
+    expect(capture.status).toBe("captured");
+  });
+
+  it("reports none when the annotation carries no crop", async () => {
+    const capture = await capturePreviewAnnotationScreenshot({ ...annotation, screenshot: null });
+    expect(capture).toEqual({ status: "none" });
+  });
+
+  it("fails instead of hanging when the crop never arrives", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", () => new Promise<Response>(() => {}));
+    const capturePromise = capturePreviewAnnotationScreenshot(annotation, 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await capturePromise).toEqual({ status: "failed" });
+  });
+
+  it("fails when the crop fetch throws", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("data url unreadable");
+    });
+    expect(await capturePreviewAnnotationScreenshot(annotation)).toEqual({ status: "failed" });
   });
 });

--- a/apps/web/src/lib/previewAnnotation.ts
+++ b/apps/web/src/lib/previewAnnotation.ts
@@ -99,7 +99,7 @@ export function extractTrailingPreviewAnnotation(prompt: string): ExtractedPrevi
   };
 }
 
-export async function previewAnnotationScreenshotFile(
+async function previewAnnotationScreenshotFile(
   annotation: PreviewAnnotationPayload,
 ): Promise<File | null> {
   if (!annotation.screenshot) return null;
@@ -108,4 +108,41 @@ export async function previewAnnotationScreenshotFile(
   return new File([blob], `preview-annotation-${annotation.id}.png`, {
     type: blob.type || "image/png",
   });
+}
+
+/** Upper bound on turning a picked element's crop into a composer attachment. */
+export const PREVIEW_ANNOTATION_CAPTURE_TIMEOUT_MS = 5_000;
+
+export type PreviewAnnotationCapture =
+  /** The crop is ready to attach. */
+  | { readonly status: "captured"; readonly file: File }
+  /** The pick carried no crop, which is normal for comment-only annotations. */
+  | { readonly status: "none" }
+  /** The crop stalled or threw. Send the annotation without it. */
+  | { readonly status: "failed" };
+
+/**
+ * Bounded wrapper around `previewAnnotationScreenshotFile`. The picker holds the
+ * composer while this runs, so it must always settle: a stalled crop resolves as
+ * `failed` instead of leaving the caller waiting.
+ */
+export async function capturePreviewAnnotationScreenshot(
+  annotation: PreviewAnnotationPayload,
+  timeoutMs: number = PREVIEW_ANNOTATION_CAPTURE_TIMEOUT_MS,
+): Promise<PreviewAnnotationCapture> {
+  if (!annotation.screenshot) return { status: "none" };
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const file = await Promise.race([
+      previewAnnotationScreenshotFile(annotation),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+    return file ? { status: "captured", file } : { status: "failed" };
+  } catch {
+    return { status: "failed" };
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -934,11 +934,14 @@ export const PreviewAnnotationSubmissionSchema: Schema.Codec<PreviewAnnotationSu
 export interface PreviewAnnotationSubmissionResult {
   annotation: PreviewAnnotationPayload;
   submission: PreviewAnnotationSubmission;
+  /** The crop was requested but failed or timed out, so `annotation.screenshot` is null. */
+  screenshotFailed?: boolean;
 }
 export const PreviewAnnotationSubmissionResultSchema: Schema.Codec<PreviewAnnotationSubmissionResult> =
   Schema.Struct({
     annotation: PreviewAnnotationPayloadSchema,
     submission: PreviewAnnotationSubmissionSchema,
+    screenshotFailed: Schema.optionalKey(Schema.Boolean),
   });
 
 export const DesktopPreviewTabInputSchema = Schema.Struct({


### PR DESCRIPTION
Picking an element in the browser preview and pressing send could leave the overlay stuck on "Capturing..." forever. No attachment landed, no message went out, and the composer stayed locked until the thread reloaded.

Two unbounded waits caused it. In the main process, `capturePage` never settles when the guest's compositor is wedged. In the picker preload, `getElementContext` can stay pending on some pages. Either one strands the pick session, so the renderer keeps awaiting a result that never arrives and focus never returns to the composer.

The fix bounds both capture steps with a timeout. Every exit from a pick session now resolves the renderer's promise exactly once, so a cancelled or replaced session can no longer return without settling. When the crop fails, the picker raises an error toast and sends the message without the attachment instead of holding the composer.

Closes #9026

Built by Claude Opus 5 in the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent pick-session lifecycle and timed capture paths across main, preload, and renderer; legitimate crops slower than 5s may now arrive without a screenshot instead of blocking indefinitely.
> 
> **Overview**
> Fixes preview element picks that could hang on **"Capturing…"** and never return focus to the composer when screenshot or context capture never completes.
> 
> **Desktop (`PreviewManager`)** adds a **5-second** bound on guest `capturePage` for annotation crops (interruptible via abort signal) and returns **`screenshotFailed: true`** when the crop times out or errors. **`pickElement`** is reworked so each session settles **exactly once** (cancel/replace always resolves the renderer), overlapping picks swap sessions atomically, and a **late crop from a replaced pick** cannot send `preview:annotation-captured` or tear down a newer overlay.
> 
> **Guest preload (`PickPreload`)** caps **`getElementContext`** at 5s and falls back to a **DOM-only** element payload instead of dropping the target; submit **snapshots** comment/regions/strokes/style changes, skips IPC if the overlay already finished, and tears down on capture rejection so main is not left waiting.
> 
> **Web** replaces direct screenshot file conversion with **`capturePreviewAnnotationScreenshot`** (timed fetch → `captured` / `none` / `failed`). **`PreviewView`** shows an error toast when the crop was dropped, stores/forwards annotations **without** a screenshot on failure, and still sends the message without an image attachment.
> 
> **Contracts** add optional **`screenshotFailed`** on `PreviewAnnotationSubmissionResult`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b925f2e4ecc171174c8563cafd387e63f8484f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unlock composer when preview screenshot capture fails or times out
> - Adds a 5-second timeout to desktop screenshot capture ([Manager.ts](https://github.com/pingdotgg/t3code/pull/9127/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53)), web screenshot conversion ([previewAnnotation.ts](https://github.com/pingdotgg/t3code/pull/9127/files#diff-4f6516f29e073bf9d9f15f429f23d915b31313516e21ce1915bfb98e71416788)), and React context lookup ([PickPreload.ts](https://github.com/pingdotgg/t3code/pull/9127/files#diff-a19a7f6aa07147ba64b95dfc017ebf3427a82f067b93b614488e7485689df0b1)) so the annotation flow always settles instead of hanging
> - Reworks `PreviewManager.pickElement` pick-session ownership so cancellation, replacement, and navigation each settle the pick at most once; stale captures from a replaced session no longer send `annotation-captured` IPC into the active session
> - Adds optional `screenshotFailed` to `PreviewAnnotationSubmissionResult` in [ipc.ts](https://github.com/pingdotgg/t3code/pull/9127/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a) and updates [PreviewView.tsx](https://github.com/pingdotgg/t3code/pull/9127/files#diff-c02d770e873143915b2b12f22b2539bd0111c82465ae9e385583be2391fbcad5) to keep the annotation with a null screenshot and show an error toast when capture or conversion fails
> - Behavioral Change: annotations with a failed screenshot are now stored with `screenshot: null` and `screenshotFailed: true` instead of being dropped or hanging the composer; out-of-tree consumers expecting rejection on capture failure will receive a settled result with a null screenshot
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b925f2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->