### PR TITLE
fix(web): render data URI images in chat markdown

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -387,9 +387,12 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "file", "t3-citation"],
-    src: [...(defaultSchema.protocols?.src ?? []), "file"],
+    src: [...(defaultSchema.protocols?.src ?? []), "file", "data"],
   },
 } satisfies Parameters<typeof rehypeSanitize>[0];
+
+/** Inline image payloads are safe on both href and src; an img never runs scripts. */
+const INLINE_DATA_IMAGE_PATTERN = /^data:image\//i;
 
 const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkGfm,
@@ -2106,7 +2109,7 @@ function ChatMarkdown({
   }, [inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
     if (parseAssistantCitationHref(href)) return href;
-    if (isWindowsDrivePathHref(href)) return href;
+    if (isWindowsDrivePathHref(href) || INLINE_DATA_IMAGE_PATTERN.test(href)) return href;
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
   // Re-emit highlighted content as markdown so copying out of the rendered

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -330,8 +330,11 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).not.toContain("Image unavailable");
   });
 
-  it("blocks non-image data URIs instead of passing them to a raw image", () => {
-    const html = render("![payload](data:text/html;base64,PHNjcmlwdC8+)");
+  it.each([
+    ["markdown", "![payload](data:text/html;base64,PHNjcmlwdC8+)"],
+    ["raw HTML", '<img src="data:text/html;base64,PHNjcmlwdC8+" alt="payload">'],
+  ])("blocks non-image %s data URIs instead of passing them to a raw image", (_variant, source) => {
+    const html = render(source);
 
     expect(testState.resources).toEqual([]);
     expect(html).toContain("Image unavailable");

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -316,4 +316,25 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("max-h-[30rem]");
     expect(html).not.toContain("Image unavailable");
   });
+
+  it.each([
+    ["markdown", (uri: string) => `![inline data](${uri})`],
+    ["raw HTML", (uri: string) => `<img src="${uri}" alt="inline data">`],
+  ])("keeps %s data URI images directly loadable", (_variant, source) => {
+    const dataUri =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+    const html = render(source(dataUri));
+
+    expect(testState.resources).toEqual([]);
+    expect(html).toContain(`src="${dataUri}"`);
+    expect(html).not.toContain("Image unavailable");
+  });
+
+  it("blocks non-image data URIs instead of passing them to a raw image", () => {
+    const html = render("![payload](data:text/html;base64,PHNjcmlwdC8+)");
+
+    expect(testState.resources).toEqual([]);
+    expect(html).toContain("Image unavailable");
+    expect(html).not.toContain("data:text/html");
+  });
 });


### PR DESCRIPTION
## Problem

Assistant messages embedding images as `data:` URIs render terminal `Image unavailable` placeholders (methods 3 and 4 in #9094). Two layers strip them independently: react-markdown's `defaultUrlTransform` empties every `data:` URL before rendering, and the chat sanitize schema does not allow the `data` protocol on `img src`.

The path-based delivery methods from #9094 were fixed by #9023's `media-file` asset flow; inline data images are the remaining gap.

## Fix

Allow `data:image/` sources through both layers — the markdown URL transform and the sanitize schema — scoped to image payloads only. An `<img>` never executes scripts, and non-image `data:` URIs keep rendering the blocked-image fallback (covered by a new test).

## Verification

- New unit tests: markdown and raw-HTML data URI images render; `data:text/html` stays blocked.
- `vp test run apps/web/src/components/ChatMarkdown.workspace-images.test.tsx` — 26 passed.
- Verified end to end in a dev build and a locally installed CLI build against real threads (screenshots incoming below).

Closes #9094.

---
Written by Claude Fable 5 on Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat markdown image URL handling and sanitization; non-image data URIs remain blocked and `<img>` does not execute scripts.
> 
> **Overview**
> **Inline `data:image/` embeds in assistant chat markdown now render as real images** instead of the `Image unavailable` placeholder.
> 
> Previously, react-markdown’s `defaultUrlTransform` stripped every `data:` URL and the chat sanitize schema did not allow `data` on `img` `src`. This change adds `data` to allowed `src` protocols, introduces `INLINE_DATA_IMAGE_PATTERN`, and updates `markdownUrlTransform` so only `data:image/…` URLs pass through unchanged (alongside existing citation and Windows-drive exceptions). Non-image `data:` URIs still hit the blocked-image fallback.
> 
> Tests cover markdown and raw HTML for both allowed PNG data URIs and blocked `data:text/html` payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c43e7a03b3606f52f902d2699e05bb2737f1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render `data:` URI images in `ChatMarkdown`
> - Extends `CHAT_MARKDOWN_SANITIZE_SCHEMA` to permit the `data:` protocol for image `src` attributes
> - Adds `INLINE_DATA_IMAGE_PATTERN` and updates `markdownUrlTransform` to pass recognized `image/` data URLs and Windows drive paths through unchanged, while non-image data URIs fall back to the unavailable image
> - Adds tests in [ChatMarkdown.workspace-images.test.tsx](https://github.com/pingdotgg/t3code/pull/9133/files#diff-717805f526075aa50c8cbb0acf2429b7c718a9a0f29a91ef07f8e7ebded695e5) covering PNG and HTML data URI rendering for both markdown and raw HTML image syntax
> - Behavioral Change: image `src` attributes with `image/` data URIs now render directly instead of undergoing workspace-file URI rewriting
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29c43e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Before / After

Before (release build): every non-HTTP embedding method renders a terminal `Image unavailable` placeholder.

![Before: all embedding methods render Image unavailable placeholders](https://raw.githubusercontent.com/brahimhamichan/t3code/evidence/docs/evidence/t3code-9133/before-image-unavailable.png)

After (patched build): the same assistant response renders the images inline. Data URI embeds render identically to the path-based methods shown.

![After: assistant images render inline in the chat timeline](https://raw.githubusercontent.com/brahimhamichan/t3code/evidence/docs/evidence/t3code-9133/after-inline-render.png)
