### PR TITLE
feat(web): arrow through a message's images as one gallery

### DIFF
--- a/apps/web/src/components/ChatMarkdown.gallery.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.gallery.test.tsx
@@ -1,0 +1,133 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
+vi.mock("../assets/assetUrls", () => ({
+  useAssetUrlRefresh: () => vi.fn(),
+  useAssetUrlState: () => ({ _tag: "Success", url: "https://signed.test/image.png" }),
+}));
+vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+vi.mock("../state/use-atom-query-runner", () => ({ useAtomQueryRunner: () => vi.fn() }));
+vi.mock("../state/use-atom-command", () => ({ useAtomCommand: () => vi.fn() }));
+vi.mock("../state/session", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../state/session")>()),
+  usePreparedConnection: () => ({ _tag: "Loading" }),
+}));
+vi.mock("../state/entities", () => ({
+  readThreadShell: () => null,
+  useProjects: () => [],
+}));
+vi.mock("../remoteOpen", () => ({
+  useRemoteOpenResolution: () => ({ state: { mode: "local-exec" }, isResolved: true }),
+}));
+vi.mock("../editorPreferences", () => ({
+  useOpenInPreferredEditor: () => vi.fn(),
+  usePreferredEditor: () => [null, vi.fn()],
+}));
+vi.mock("~/lib/openPullRequestLink", () => ({
+  findProjectForChangeRequest: () => undefined,
+  matchesLinkedPullRequestUrl: () => false,
+  parseChangeRequestUrl: () => null,
+  useOpenChangeRequestLink: () => vi.fn(),
+}));
+
+import ChatMarkdown, {
+  markdownImageGalleryPreview,
+  registerMarkdownGalleryImage,
+} from "./ChatMarkdown";
+
+const threadRef = {
+  environmentId: EnvironmentId.make("env-1"),
+  threadId: ThreadId.make("thread-1"),
+};
+
+/** Elements sharing one message scope, in document order. */
+function fakeGalleryElements(count: number): Element[] {
+  const elements: Array<Record<string, unknown>> = [];
+  const scope = { querySelectorAll: () => elements };
+  for (let position = 0; position < count; position += 1) {
+    elements.push({ closest: () => scope });
+  }
+  return elements as unknown as Element[];
+}
+
+describe("markdownImageGalleryPreview", () => {
+  it("collects registered sibling images in document order around the clicked one", () => {
+    const [first, second, third] = fakeGalleryElements(3);
+    registerMarkdownGalleryImage(first!, { src: "blob:1", name: "one" });
+    registerMarkdownGalleryImage(second!, {
+      src: "https://signed.test/2.png",
+      name: "two",
+      actionsSource: { kind: "image", name: "2.png", src: "https://signed.test/2.png" },
+    });
+    registerMarkdownGalleryImage(third!, { src: "data:image/png;base64,AA", name: "three" });
+
+    const preview = markdownImageGalleryPreview(third!, {
+      src: "data:image/png;base64,AA",
+      name: "three",
+    });
+
+    expect(preview.index).toBe(2);
+    expect(preview.images.map((image) => image.name)).toEqual(["one", "two", "three"]);
+    expect(preview.images[1]).toMatchObject({
+      src: "https://signed.test/2.png",
+      actionsSource: { kind: "image" },
+    });
+    expect(markdownImageGalleryPreview(first!, { src: "blob:1", name: "one" }).index).toBe(0);
+  });
+
+  it("skips unregistered siblings while keeping the clicked index correct", () => {
+    const [first, , third] = fakeGalleryElements(3);
+    registerMarkdownGalleryImage(first!, { src: "blob:1", name: "one" });
+
+    const preview = markdownImageGalleryPreview(third!, { src: "blob:3", name: "three" });
+
+    expect(preview).toEqual({
+      images: [
+        { src: "blob:1", name: "one" },
+        { src: "blob:3", name: "three" },
+      ],
+      index: 1,
+    });
+  });
+
+  it("falls back to a single image outside a message body", () => {
+    const orphan = { closest: () => null } as unknown as Element;
+
+    expect(markdownImageGalleryPreview(orphan, { src: "blob:solo", name: "solo" })).toEqual({
+      images: [{ src: "blob:solo", name: "solo" }],
+      index: 0,
+    });
+  });
+});
+
+describe("ChatMarkdown gallery membership", () => {
+  it("marks each preview-enabled image as a gallery member", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/workspace/project"
+        threadRef={threadRef}
+        text={"![one](https://example.com/1.png)\n\n![two](https://example.com/2.png)"}
+        onImageExpand={() => {}}
+      />,
+    );
+
+    expect(html.match(/data-preview-image/g)).toHaveLength(2);
+  });
+
+  it("keeps link favicons and linked images out of the gallery", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/workspace/project"
+        threadRef={threadRef}
+        text={
+          "[![linked](https://example.com/1.png)](https://example.com) [site](https://example.com)"
+        }
+        onImageExpand={() => {}}
+      />,
+    );
+
+    expect(html).not.toContain("data-preview-image");
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -81,6 +81,7 @@ import {
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
 import {
   resolveMarkdownMediaPreview,
+  type ExpandedImageItem,
   type ExpandedImagePreview,
 } from "./chat/ExpandedImagePreview";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
@@ -1197,6 +1198,38 @@ const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
 );
 const MarkdownLinkContext = React.createContext(false);
 
+const MARKDOWN_GALLERY_IMAGE_ATTRIBUTE = "data-preview-image";
+
+/** Current preview item for each mounted preview-enabled image element. */
+const markdownGalleryItemsByElement = new WeakMap<Element, ExpandedImageItem>();
+
+export function registerMarkdownGalleryImage(element: Element, item: ExpandedImageItem): void {
+  markdownGalleryItemsByElement.set(element, item);
+}
+
+/**
+ * Every preview-enabled image in the same rendered message forms one gallery,
+ * so the expanded dialog can arrow through them in document order. Falls back
+ * to a single-image preview when the clicked image is outside a message body.
+ */
+export function markdownImageGalleryPreview(
+  target: Element,
+  clicked: ExpandedImageItem,
+): ExpandedImagePreview {
+  const galleryElements = [
+    ...(target
+      .closest(".chat-markdown")
+      ?.querySelectorAll(`img[${MARKDOWN_GALLERY_IMAGE_ATTRIBUTE}]`) ?? []),
+  ];
+  const images = galleryElements.flatMap((element) => {
+    const item = element === target ? clicked : markdownGalleryItemsByElement.get(element);
+    return item ? [{ element, item }] : [];
+  });
+  const index = images.findIndex(({ element }) => element === target);
+  if (index < 0) return { images: [clicked], index: 0 };
+  return { images: images.map(({ item }) => item), index };
+}
+
 function expandableMarkdownImageProps(
   onImageExpand: ((preview: ExpandedImagePreview) => void) | undefined,
   src: string,
@@ -1206,23 +1239,23 @@ function expandableMarkdownImageProps(
 ) {
   if (!onImageExpand) return {};
   const previewName = alt.trim() || "image";
+  const item: ExpandedImageItem = {
+    src,
+    name: previewName,
+    ...(originalUrl ? { originalUrl } : {}),
+    ...(actionsSource ? { actionsSource } : {}),
+  };
   const expand = (event: ReactMouseEvent | ReactKeyboardEvent) => {
     if (event.currentTarget.closest("a")) return;
     event.preventDefault();
     event.stopPropagation();
-    onImageExpand({
-      images: [
-        {
-          src,
-          name: previewName,
-          ...(originalUrl ? { originalUrl } : {}),
-          ...(actionsSource ? { actionsSource } : {}),
-        },
-      ],
-      index: 0,
-    });
+    onImageExpand(markdownImageGalleryPreview(event.currentTarget, item));
   };
   return {
+    ref: (element: HTMLImageElement | null) => {
+      if (element) markdownGalleryItemsByElement.set(element, item);
+    },
+    [MARKDOWN_GALLERY_IMAGE_ATTRIBUTE]: true,
     role: "button" as const,
     tabIndex: 0,
     "aria-label": `Preview ${previewName}`,


### PR DESCRIPTION
## Problem

When an assistant response embeds several images, clicking one opens the expanded preview with only that image. The dialog already supports multi-image navigation (arrow keys, chevrons, an n/m counter) — user attachment rows use it — but markdown images always pass a single-item list, so sequential images can't be flipped through.

## Change

Preview-enabled markdown images in the same message body now form one gallery in document order. Each image registers its full preview item (including `originalUrl` and media actions) keyed by its element, and a click assembles the gallery from the message scope, so the existing dialog navigation works across all of them. Linked images and link favicons stay out of the gallery, and images outside a message body (e.g. the work-log viewed image) keep their single-image preview.

No new UI: this only feeds the existing `ExpandedImageDialog` navigation, so there's no added rendering cost while the timeline is idle.

## Verification

- New unit tests: document-order collection with the clicked index, preservation of per-image media actions, unregistered siblings skipped, single-image fallback outside a message, and gallery membership markers (linked images excluded).
- `vp test run apps/web/src/components/ChatMarkdown.gallery.test.tsx` — 5 passed.
- Verified by hand in a locally installed build: clicking any of four images in one response and arrowing through them (clip incoming below).

---
Written by Claude Fable 5 on Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat markdown preview behavior with unit tests; reuses existing `ExpandedImageDialog` navigation and no auth or data-path changes.
> 
> **Overview**
> **Markdown image previews in a single message now open as one gallery**, so the existing expanded-image dialog can move between them in document order (arrows/chevrons) instead of always showing only the clicked image.
> 
> Preview-enabled standalone images register their full `ExpandedImageItem` (including `originalUrl` and media actions) on mount via a `data-preview-image` marker and a `WeakMap`; on expand, `markdownImageGalleryPreview` gathers all marked siblings under the same `.chat-markdown` scope. **Linked images and link favicons stay excluded** (still gated by `MarkdownLinkContext`), and images outside a message body fall back to a single-item preview.
> 
> Adds **`ChatMarkdown.gallery.test.tsx`** covering gallery ordering/index, skipped unregistered siblings, orphan fallback, and membership vs linked-image exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208b0dd23328cd136db7c21e64c451abcedccde5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add arrow-through image gallery preview to `ChatMarkdown` messages
> - Adds a `WeakMap` registry and `registerMarkdownGalleryImage` utility that associate each mounted preview-enabled markdown image element with its expanded-image item.
> - Adds `markdownImageGalleryPreview`, which finds marked images under the clicked image's nearest `.chat-markdown` ancestor, returns their registered items in document order with the correct clicked index, and falls back to a single-image preview outside a message scope.
> - Updates `expandableMarkdownImageProps` to register each image via ref, emit the gallery marker attribute, and pass the computed gallery preview to the expansion callback instead of a one-image preview.
> - Linked images and link favicons are excluded from gallery membership; each image still retains its individual source and action metadata.
> - Risk: `markdownImageGalleryPreview` relies on the `.chat-markdown` ancestor and the marker attribute on `img` elements in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/9134/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05); images rendered outside that scope or without registration fall back to single-image preview.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 208b0dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Screenshots

Four inline images in one assistant response:

![Four inline images rendered in an assistant response](https://raw.githubusercontent.com/brahimhamichan/t3code/evidence/docs/evidence/t3code-9134/inline-images.png)

After clicking the first image and pressing the right arrow key — the dialog shows the second image with the (2/4) counter and both navigation chevrons:

![Expanded preview showing Screenshot 2 with a 2/4 counter and chevrons](https://raw.githubusercontent.com/brahimhamichan/t3code/evidence/docs/evidence/t3code-9134/gallery-dialog.png)
