### PR TITLE
fix(desktop): show newest changes in nightly previews

### DIFF
--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -336,6 +336,11 @@ describe("DesktopUpdates", () => {
               version: "1.2.4-nightly.20260709.765",
               note: "- [codex] Upgrade Clerk stack by @juliusmarminge in #3821",
             },
+            { version: "1.2.4-nightly.20260709.764", note: "- Change 764" },
+            { version: "1.2.4-nightly.20260709.763", note: "- Change 763" },
+            { version: "1.2.4-nightly.20260709.762", note: "- Change 762" },
+            { version: "1.2.4-nightly.20260709.761", note: "- Change 761" },
+            { version: "1.2.4-nightly.20260709.760", note: "- Change 760" },
           ],
         });
         yield* flushCallbacks;
@@ -346,13 +351,21 @@ describe("DesktopUpdates", () => {
           {
             version: "1.2.4-nightly.20260709.766",
             items: ["feat(client): persist offline environment data by @juliusmarminge in #3795"],
+            totalItems: 1,
           },
           {
             version: "1.2.4-nightly.20260709.765",
             items: ["[codex] Upgrade Clerk stack by @juliusmarminge in #3821"],
+            totalItems: 1,
           },
+          { version: "1.2.4-nightly.20260709.764", items: ["Change 764"], totalItems: 1 },
+          { version: "1.2.4-nightly.20260709.763", items: ["Change 763"], totalItems: 1 },
+          { version: "1.2.4-nightly.20260709.762", items: ["Change 762"], totalItems: 1 },
+          { version: "1.2.4-nightly.20260709.761", items: ["Change 761"], totalItems: 1 },
         ]);
+        assert.equal(state.omittedReleaseCount, 1);
         assert.deepEqual(harness.sentStates.at(-1)?.releaseNotes, state.releaseNotes);
+        assert.equal(harness.sentStates.at(-1)?.omittedReleaseCount, 1);
       }),
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });
@@ -383,8 +396,9 @@ describe("DesktopUpdates", () => {
         assert.equal(unchangedState.status, "downloaded");
         assert.equal(unchangedState.downloadedVersion, "1.2.4");
         assert.deepEqual(unchangedState.releaseNotes, [
-          { version: "1.2.4", items: ["fix: queued update"] },
+          { version: "1.2.4", items: ["fix: queued update"], totalItems: 1 },
         ]);
+        assert.equal(unchangedState.omittedReleaseCount, 0);
 
         const nextResult = yield* updates.check("poll");
         assert.isTrue(nextResult.checked);
@@ -424,7 +438,10 @@ describe("DesktopUpdates", () => {
         assert.equal(state.status, "downloaded");
         assert.equal(state.availableVersion, "1.2.4");
         assert.equal(state.downloadedVersion, "1.2.4");
-        assert.deepEqual(state.releaseNotes, [{ version: "1.2.4", items: ["fix: queued update"] }]);
+        assert.deepEqual(state.releaseNotes, [
+          { version: "1.2.4", items: ["fix: queued update"], totalItems: 1 },
+        ]);
+        assert.equal(state.omittedReleaseCount, 0);
         assert.equal(state.downloadPercent, 100);
       }),
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
@@ -454,7 +471,10 @@ describe("DesktopUpdates", () => {
         assert.equal(state.status, "downloaded");
         assert.equal(state.availableVersion, "1.2.4");
         assert.equal(state.downloadedVersion, "1.2.4");
-        assert.deepEqual(state.releaseNotes, [{ version: "1.2.4", items: ["fix: queued update"] }]);
+        assert.deepEqual(state.releaseNotes, [
+          { version: "1.2.4", items: ["fix: queued update"], totalItems: 1 },
+        ]);
+        assert.equal(state.omittedReleaseCount, 0);
         assert.equal(state.downloadPercent, 100);
       }),
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -593,14 +593,24 @@ export const make = Effect.gen(function* () {
           }
 
           const checkedAt = yield* currentIsoTimestamp;
-          const releaseNotes = normalizeDesktopUpdateReleaseNotes(info.releaseNotes, info.version);
+          const { releaseNotes, omittedReleaseCount } = normalizeDesktopUpdateReleaseNotes(
+            info.releaseNotes,
+            info.version,
+          );
           yield* setState(
-            reduceDesktopUpdateStateOnUpdateAvailable(state, info.version, checkedAt, releaseNotes),
+            reduceDesktopUpdateStateOnUpdateAvailable(
+              state,
+              info.version,
+              checkedAt,
+              releaseNotes,
+              omittedReleaseCount,
+            ),
           );
           yield* Ref.set(lastLoggedDownloadMilestoneRef, -1);
           yield* logUpdaterInfo("update available", {
             version: info.version,
             releaseNoteGroups: releaseNotes.length,
+            omittedReleaseCount,
           });
         }),
       ),

--- a/apps/desktop/src/updates/releaseNotes.test.ts
+++ b/apps/desktop/src/updates/releaseNotes.test.ts
@@ -3,38 +3,118 @@ import { describe, expect, it } from "vite-plus/test";
 import { normalizeDesktopUpdateReleaseNotes } from "./releaseNotes.ts";
 
 describe("normalizeDesktopUpdateReleaseNotes", () => {
-  it("splits a plain string note into items under the fallback version", () => {
-    const notes = normalizeDesktopUpdateReleaseNotes(
-      "## What's changed\n- First fix\n- Second fix",
-      "1.2.3",
+  it("shows the newest changes and counts all real changes", () => {
+    const result = normalizeDesktopUpdateReleaseNotes(
+      [
+        "- feat: first change",
+        "- fix: second change",
+        "- fix: third change",
+        "- fix: fourth change",
+        "- fix: fifth change",
+        "- fix: sixth change",
+        "- fix: seventh change",
+        "- fix: eighth change",
+        "- fix(web): keep long task drawers usable on small screens by @human in #8313",
+        "- fix(opencode): handle child approvals, stops, and model catalogs by @human in #8480",
+        "## New Contributors",
+        "- @human made their first contribution in #8435",
+        "**Full Changelog**: https://github.com/pingdotgg/t3code/compare/old...new",
+      ].join("\n"),
+      "0.0.36-nightly.20260828.1213",
     );
-    expect(notes).toEqual([{ version: "1.2.3", items: ["First fix", "Second fix"] }]);
+
+    expect(result).toEqual({
+      releaseNotes: [
+        {
+          version: "0.0.36-nightly.20260828.1213",
+          items: [
+            "fix(opencode): handle child approvals, stops, and model catalogs by @human in #8480",
+            "fix(web): keep long task drawers usable on small screens by @human in #8313",
+            "fix: eighth change",
+            "fix: seventh change",
+            "fix: sixth change",
+            "fix: fifth change",
+            "fix: fourth change",
+            "fix: third change",
+          ],
+          totalItems: 10,
+        },
+      ],
+      omittedReleaseCount: 0,
+    });
   });
 
-  it("keeps per-version groups and drops empty ones", () => {
-    const notes = normalizeDesktopUpdateReleaseNotes(
+  it("excludes a GitHub HTML contributor section", () => {
+    const result = normalizeDesktopUpdateReleaseNotes(
+      "<h2>What's Changed</h2><ul><li>Older fix</li><li>Newer fix</li></ul>" +
+        "<h2>New Contributors</h2><ul><li>@human made their first contribution</li></ul>" +
+        "<h2>Full Changelog</h2>",
+      "1.2.3",
+    );
+
+    expect(result).toEqual({
+      releaseNotes: [{ version: "1.2.3", items: ["Newer fix", "Older fix"], totalItems: 2 }],
+      omittedReleaseCount: 0,
+    });
+  });
+
+  it("keeps per-version order and drops empty groups", () => {
+    const result = normalizeDesktopUpdateReleaseNotes(
       [
-        { version: "1.2.3", note: "- Newer change" },
+        { version: "1.2.3", note: "- Newer release" },
         { version: "1.2.2", note: "Full changelog: https://example.com/compare/x...y" },
-        { version: "1.2.1", note: "- Older change" },
+        { version: "1.2.1", note: "- Older release" },
       ],
       "1.2.3",
     );
-    expect(notes).toEqual([
-      { version: "1.2.3", items: ["Newer change"] },
-      { version: "1.2.1", items: ["Older change"] },
+
+    expect(result).toEqual({
+      releaseNotes: [
+        { version: "1.2.3", items: ["Newer release"], totalItems: 1 },
+        { version: "1.2.1", items: ["Older release"], totalItems: 1 },
+      ],
+      omittedReleaseCount: 0,
+    });
+  });
+
+  it("counts valid groups before applying the six-release limit", () => {
+    const releaseNotes = [
+      { version: "1.3.9", note: "- Change 9" },
+      { version: "1.3.8", note: "Full changelog: https://example.com/compare/x...y" },
+      { version: "1.3.7", note: "- Change 7" },
+      { version: "1.3.6", note: "- Change 6" },
+      { version: "1.3.5", note: "- Change 5" },
+      { version: "1.3.4", note: "- Change 4" },
+      { version: "1.3.3", note: "- Change 3" },
+      { version: "1.3.2", note: "- Change 2" },
+    ];
+
+    const result = normalizeDesktopUpdateReleaseNotes(releaseNotes, "1.3.9");
+
+    expect(result.releaseNotes.map(({ version }) => version)).toEqual([
+      "1.3.9",
+      "1.3.7",
+      "1.3.6",
+      "1.3.5",
+      "1.3.4",
+      "1.3.3",
     ]);
+    expect(result.omittedReleaseCount).toBe(1);
   });
 
   it("decodes valid HTML entities", () => {
-    const notes = normalizeDesktopUpdateReleaseNotes("- Fix &amp; polish &#128512;", "1.0.0");
-    expect(notes).toEqual([{ version: "1.0.0", items: ["Fix & polish 😀"] }]);
+    const result = normalizeDesktopUpdateReleaseNotes("- Fix &amp; polish &#128512;", "1.0.0");
+    expect(result).toEqual({
+      releaseNotes: [{ version: "1.0.0", items: ["Fix & polish 😀"], totalItems: 1 }],
+      omittedReleaseCount: 0,
+    });
   });
 
-  it("ignores malformed entries instead of throwing", () => {
-    const notes = normalizeDesktopUpdateReleaseNotes(
+  it("ignores malformed and empty entries instead of throwing", () => {
+    const result = normalizeDesktopUpdateReleaseNotes(
       [
         { version: "1.2.3", note: "- Valid change" },
+        { version: "1.2.2", note: "" },
         { version: 42, note: "- Bad version type" },
         { version: "1.2.1", note: { html: "<p>object note</p>" } },
         "not an object",
@@ -42,23 +122,25 @@ describe("normalizeDesktopUpdateReleaseNotes", () => {
       ],
       "1.2.3",
     );
-    expect(notes).toEqual([{ version: "1.2.3", items: ["Valid change"] }]);
+
+    expect(result).toEqual({
+      releaseNotes: [{ version: "1.2.3", items: ["Valid change"], totalItems: 1 }],
+      omittedReleaseCount: 0,
+    });
   });
 
-  it("returns non-empty groups even when preceded by many boilerplate-only groups", () => {
-    const boilerplate = Array.from({ length: 7 }, (_, index) => ({
-      version: `1.3.${9 - index}`,
-      note: "Full changelog: https://example.com/compare/x...y",
-    }));
-    const notes = normalizeDesktopUpdateReleaseNotes(
-      [...boilerplate, { version: "1.3.2", note: "- Older but real change" }],
-      "1.3.9",
-    );
-    expect(notes).toEqual([{ version: "1.3.2", items: ["Older but real change"] }]);
+  it("returns an empty result for an invalid payload", () => {
+    expect(normalizeDesktopUpdateReleaseNotes({ note: "- Invalid" }, "1.0.0")).toEqual({
+      releaseNotes: [],
+      omittedReleaseCount: 0,
+    });
   });
 
   it("does not throw on out-of-range numeric entities and keeps the literal", () => {
-    const notes = normalizeDesktopUpdateReleaseNotes("- Broken entity &#9999999999;", "1.0.0");
-    expect(notes).toEqual([{ version: "1.0.0", items: ["Broken entity &#9999999999;"] }]);
+    const result = normalizeDesktopUpdateReleaseNotes("- Broken entity &#9999999999;", "1.0.0");
+    expect(result).toEqual({
+      releaseNotes: [{ version: "1.0.0", items: ["Broken entity &#9999999999;"], totalItems: 1 }],
+      omittedReleaseCount: 0,
+    });
   });
 });

--- a/apps/desktop/src/updates/releaseNotes.test.ts
+++ b/apps/desktop/src/updates/releaseNotes.test.ts
@@ -58,6 +58,25 @@ describe("normalizeDesktopUpdateReleaseNotes", () => {
     });
   });
 
+  it("does not count Markdown or HTML section headings as changes", () => {
+    const changes = Array.from({ length: 8 }, (_, index) => `Change ${index + 1}`);
+    const result = normalizeDesktopUpdateReleaseNotes(
+      [
+        { version: "1.2.4", note: ["### Features", ...changes].join("\n- ") },
+        {
+          version: "1.2.3",
+          note: `<h3>Fixes</h3><ul>${changes.map((change) => `<li>${change}</li>`).join("")}</ul>`,
+        },
+      ],
+      "1.2.4",
+    );
+
+    expect(result.releaseNotes).toEqual([
+      { version: "1.2.4", items: changes.toReversed(), totalItems: 8 },
+      { version: "1.2.3", items: changes.toReversed(), totalItems: 8 },
+    ]);
+  });
+
   it("keeps per-version order and drops empty groups", () => {
     const result = normalizeDesktopUpdateReleaseNotes(
       [

--- a/apps/desktop/src/updates/releaseNotes.ts
+++ b/apps/desktop/src/updates/releaseNotes.ts
@@ -89,10 +89,16 @@ function isIgnoredReleaseNoteLine(line: string): boolean {
   );
 }
 
-function extractReleaseNoteItems(note: string | null | undefined): ReadonlyArray<string> {
-  if (!note) return [];
+interface ExtractedReleaseNoteItems {
+  readonly items: ReadonlyArray<string>;
+  readonly totalItems: number;
+}
+
+function extractReleaseNoteItems(note: string | null | undefined): ExtractedReleaseNoteItems {
+  if (!note) return { items: [], totalItems: 0 };
 
   const items: string[] = [];
+  let totalItems = 0;
   for (const rawLine of stripMarkup(note).split("\n")) {
     const item = rawLine
       .trim()
@@ -102,9 +108,11 @@ function extractReleaseNoteItems(note: string | null | undefined): ReadonlyArray
     const normalized = normalizeReleaseNoteLine(item);
     if (normalized === "new contributors" || normalized === "full changelog") break;
     if (isIgnoredReleaseNoteLine(item)) continue;
+    totalItems += 1;
     items.push(truncateReleaseNoteItem(item));
+    if (items.length > MAX_RELEASE_NOTE_ITEMS_PER_GROUP) items.shift();
   }
-  return items;
+  return { items: items.toReversed(), totalItems };
 }
 
 interface NormalizedDesktopUpdateReleaseNotes {
@@ -124,13 +132,13 @@ export function normalizeDesktopUpdateReleaseNotes(
         : [];
 
   const normalizedNotes = rawNotes.flatMap((entry) => {
-    const items = extractReleaseNoteItems(entry.note);
-    if (items.length === 0) return [];
+    const { items, totalItems } = extractReleaseNoteItems(entry.note);
+    if (totalItems === 0) return [];
     return [
       {
         version: entry.version,
-        items: items.toReversed().slice(0, MAX_RELEASE_NOTE_ITEMS_PER_GROUP),
-        totalItems: items.length,
+        items,
+        totalItems,
       },
     ];
   });

--- a/apps/desktop/src/updates/releaseNotes.ts
+++ b/apps/desktop/src/updates/releaseNotes.ts
@@ -71,17 +71,19 @@ function truncateReleaseNoteItem(item: string): string {
   return `${item.slice(0, MAX_RELEASE_NOTE_ITEM_LENGTH - 3).trimEnd()}...`;
 }
 
-function isIgnoredReleaseNoteLine(line: string): boolean {
-  const normalized = line
+function normalizeReleaseNoteLine(line: string): string {
+  return line
     .toLowerCase()
     .replace(/[*_`#]/g, "")
     .trim();
+}
+
+function isIgnoredReleaseNoteLine(line: string): boolean {
+  const normalized = normalizeReleaseNoteLine(line);
   return (
     normalized === "" ||
     normalized === "what's changed" ||
     normalized === "whats changed" ||
-    normalized === "full changelog" ||
-    normalized === "new contributors" ||
     normalized.startsWith("compare: ") ||
     normalized.includes("/compare/")
   );
@@ -97,17 +99,23 @@ function extractReleaseNoteItems(note: string | null | undefined): ReadonlyArray
       .replace(/^[-*]\s+/, "")
       .replace(/^\d+[.)]\s+/, "")
       .replace(/\s+/g, " ");
+    const normalized = normalizeReleaseNoteLine(item);
+    if (normalized === "new contributors" || normalized === "full changelog") break;
     if (isIgnoredReleaseNoteLine(item)) continue;
     items.push(truncateReleaseNoteItem(item));
-    if (items.length >= MAX_RELEASE_NOTE_ITEMS_PER_GROUP) break;
   }
   return items;
+}
+
+interface NormalizedDesktopUpdateReleaseNotes {
+  readonly releaseNotes: ReadonlyArray<DesktopUpdateReleaseNote>;
+  readonly omittedReleaseCount: number;
 }
 
 export function normalizeDesktopUpdateReleaseNotes(
   releaseNotes: unknown,
   fallbackVersion: string,
-): ReadonlyArray<DesktopUpdateReleaseNote> {
+): NormalizedDesktopUpdateReleaseNotes {
   const rawNotes =
     typeof releaseNotes === "string"
       ? [{ version: fallbackVersion, note: releaseNotes }]
@@ -115,11 +123,20 @@ export function normalizeDesktopUpdateReleaseNotes(
         ? releaseNotes.filter(isElectronReleaseNoteInfo)
         : [];
 
-  return rawNotes
-    .map((entry) => ({
-      version: entry.version,
-      items: extractReleaseNoteItems(entry.note),
-    }))
-    .filter((entry) => entry.items.length > 0)
-    .slice(0, MAX_RELEASE_NOTE_GROUPS);
+  const normalizedNotes = rawNotes.flatMap((entry) => {
+    const items = extractReleaseNoteItems(entry.note);
+    if (items.length === 0) return [];
+    return [
+      {
+        version: entry.version,
+        items: items.toReversed().slice(0, MAX_RELEASE_NOTE_ITEMS_PER_GROUP),
+        totalItems: items.length,
+      },
+    ];
+  });
+
+  return {
+    releaseNotes: normalizedNotes.slice(0, MAX_RELEASE_NOTE_GROUPS),
+    omittedReleaseCount: Math.max(0, normalizedNotes.length - MAX_RELEASE_NOTE_GROUPS),
+  };
 }

--- a/apps/desktop/src/updates/releaseNotes.ts
+++ b/apps/desktop/src/updates/releaseNotes.ts
@@ -59,6 +59,7 @@ function stripMarkup(input: string): string {
     input
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<li\b[^>]*>/gi, "\n- ")
+      .replace(/<h([1-6])\b[^>]*>/gi, (_, level: string) => `\n${"#".repeat(Number(level))} `)
       .replace(/<\/(?:p|div|li|h[1-6]|ul|ol|blockquote)>/gi, "\n")
       .replace(/<[^>]*>/g, "")
       .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
@@ -107,6 +108,7 @@ function extractReleaseNoteItems(note: string | null | undefined): ExtractedRele
       .replace(/\s+/g, " ");
     const normalized = normalizeReleaseNoteLine(item);
     if (normalized === "new contributors" || normalized === "full changelog") break;
+    if (/^#{1,6}\s+/.test(item)) continue;
     if (isIgnoredReleaseNoteLine(item)) continue;
     totalItems += 1;
     items.push(truncateReleaseNoteItem(item));

--- a/apps/desktop/src/updates/updateMachine.test.ts
+++ b/apps/desktop/src/updates/updateMachine.test.ts
@@ -62,7 +62,8 @@ describe("updateMachine", () => {
       status: "downloaded" as const,
       availableVersion: "1.1.0",
       downloadedVersion: "1.1.0",
-      releaseNotes: [{ version: "1.1.0", items: ["fix: queued update"] }],
+      releaseNotes: [{ version: "1.1.0", items: ["fix: queued update"], totalItems: 1 }],
+      omittedReleaseCount: 2,
       downloadPercent: 100,
     };
     const checking = reduceDesktopUpdateStateOnCheckStart(
@@ -78,14 +79,16 @@ describe("updateMachine", () => {
     expect(checking.status).toBe("checking");
     expect(checking.downloadedVersion).toBe("1.1.0");
     expect(checking.releaseNotes).toEqual(downloadedState.releaseNotes);
+    expect(checking.omittedReleaseCount).toBe(2);
     expect(failed.status).toBe("downloaded");
     expect(failed.downloadedVersion).toBe("1.1.0");
     expect(failed.releaseNotes).toEqual(downloadedState.releaseNotes);
+    expect(failed.omittedReleaseCount).toBe(2);
     expect(failed.message).toBeNull();
   });
 
   it("keeps the installer when the feed still offers its version", () => {
-    const releaseNotes = [{ version: "1.1.0", items: ["fix: queued update"] }];
+    const releaseNotes = [{ version: "1.1.0", items: ["fix: queued update"], totalItems: 1 }];
     const state = reduceDesktopUpdateStateOnUpdateAvailable(
       {
         ...createInitialDesktopUpdateState("1.0.0", runtimeInfo, "latest"),
@@ -94,6 +97,7 @@ describe("updateMachine", () => {
         availableVersion: "1.1.0",
         downloadedVersion: "1.1.0",
         releaseNotes,
+        omittedReleaseCount: 2,
         downloadPercent: 100,
       },
       "1.1.0",
@@ -103,6 +107,7 @@ describe("updateMachine", () => {
     expect(state.status).toBe("downloaded");
     expect(state.downloadedVersion).toBe("1.1.0");
     expect(state.releaseNotes).toEqual(releaseNotes);
+    expect(state.omittedReleaseCount).toBe(2);
     expect(state.downloadPercent).toBe(100);
   });
 
@@ -147,7 +152,7 @@ describe("updateMachine", () => {
   });
 
   it("preserves a downloaded update when no update is available", () => {
-    const releaseNotes = [{ version: "1.1.0", items: ["fix: queued update"] }];
+    const releaseNotes = [{ version: "1.1.0", items: ["fix: queued update"], totalItems: 1 }];
     const state = reduceDesktopUpdateStateOnNoUpdate(
       {
         ...createInitialDesktopUpdateState("1.0.0", runtimeInfo, "latest"),
@@ -156,6 +161,7 @@ describe("updateMachine", () => {
         availableVersion: "1.1.0",
         downloadedVersion: "1.1.0",
         releaseNotes,
+        omittedReleaseCount: 2,
         message: "old failure",
         errorContext: "download",
         canRetry: true,
@@ -167,6 +173,7 @@ describe("updateMachine", () => {
     expect(state.availableVersion).toBe("1.1.0");
     expect(state.downloadedVersion).toBe("1.1.0");
     expect(state.releaseNotes).toBe(releaseNotes);
+    expect(state.omittedReleaseCount).toBe(2);
     expect(state.downloadPercent).toBe(100);
     expect(state.message).toBeNull();
     expect(state.errorContext).toBeNull();
@@ -180,7 +187,8 @@ describe("updateMachine", () => {
         enabled: true,
         status: "error",
         availableVersion: "1.1.0",
-        releaseNotes: [{ version: "1.1.0", items: ["fix: stale update"] }],
+        releaseNotes: [{ version: "1.1.0", items: ["fix: stale update"], totalItems: 1 }],
+        omittedReleaseCount: 2,
         message: "old failure",
         errorContext: "download",
         canRetry: true,
@@ -192,6 +200,7 @@ describe("updateMachine", () => {
     expect(state.availableVersion).toBeNull();
     expect(state.downloadedVersion).toBeNull();
     expect(state.releaseNotes).toEqual([]);
+    expect(state.omittedReleaseCount).toBe(0);
     expect(state.message).toBeNull();
     expect(state.errorContext).toBeNull();
   });
@@ -201,6 +210,7 @@ describe("updateMachine", () => {
       {
         version: "1.1.0",
         items: ["feat: add update release notes"],
+        totalItems: 1,
       },
     ];
     const available = reduceDesktopUpdateStateOnUpdateAvailable(
@@ -212,6 +222,7 @@ describe("updateMachine", () => {
       "1.1.0",
       "2026-03-04T00:00:00.000Z",
       releaseNotes,
+      2,
     );
     const downloading = reduceDesktopUpdateStateOnDownloadStart(available);
     const progress = reduceDesktopUpdateStateOnDownloadProgress(downloading, 55.5);
@@ -219,6 +230,7 @@ describe("updateMachine", () => {
     expect(available.status).toBe("available");
     expect(available.channel).toBe("latest");
     expect(available.releaseNotes).toBe(releaseNotes);
+    expect(available.omittedReleaseCount).toBe(2);
     expect(downloading.releaseNotes).toBe(releaseNotes);
     expect(downloading.status).toBe("downloading");
     expect(downloading.downloadPercent).toBe(0);
@@ -233,11 +245,13 @@ describe("updateMachine", () => {
         enabled: true,
         status: "available",
         availableVersion: "1.1.0-nightly.1",
-        releaseNotes: [{ version: "1.1.0-nightly.1", items: ["feat: old note"] }],
+        releaseNotes: [{ version: "1.1.0-nightly.1", items: ["feat: old note"], totalItems: 1 }],
+        omittedReleaseCount: 2,
       },
       "2026-03-04T00:00:00.000Z",
     );
 
     expect(state.releaseNotes).toEqual([]);
+    expect(state.omittedReleaseCount).toBe(0);
   });
 });

--- a/apps/desktop/src/updates/updateMachine.ts
+++ b/apps/desktop/src/updates/updateMachine.ts
@@ -31,6 +31,7 @@ export function createInitialDesktopUpdateState(
     availableVersion: null,
     downloadedVersion: null,
     releaseNotes: [],
+    omittedReleaseCount: 0,
     downloadPercent: null,
     checkedAt: null,
     message: null,
@@ -49,6 +50,7 @@ export function reduceDesktopUpdateStateOnCheckStart(
     status: "checking",
     checkedAt,
     releaseNotes: hasDownloadedUpdate ? state.releaseNotes : [],
+    omittedReleaseCount: hasDownloadedUpdate ? state.omittedReleaseCount : 0,
     message: null,
     downloadPercent: hasDownloadedUpdate ? 100 : null,
     errorContext: null,
@@ -89,16 +91,17 @@ export function reduceDesktopUpdateStateOnUpdateAvailable(
   version: string,
   checkedAt: string,
   releaseNotes: ReadonlyArray<DesktopUpdateReleaseNote> = [],
+  omittedReleaseCount = 0,
 ): DesktopUpdateState {
   const isDownloadedVersion = state.downloadedVersion === version;
-  const nextReleaseNotes =
-    isDownloadedVersion && releaseNotes.length === 0 ? state.releaseNotes : releaseNotes;
+  const preserveReleaseNotes = isDownloadedVersion && releaseNotes.length === 0;
   return {
     ...state,
     status: isDownloadedVersion ? "downloaded" : "available",
     availableVersion: version,
     downloadedVersion: isDownloadedVersion ? version : null,
-    releaseNotes: nextReleaseNotes,
+    releaseNotes: preserveReleaseNotes ? state.releaseNotes : releaseNotes,
+    omittedReleaseCount: preserveReleaseNotes ? state.omittedReleaseCount : omittedReleaseCount,
     downloadPercent: isDownloadedVersion ? 100 : null,
     checkedAt,
     message: null,
@@ -130,6 +133,7 @@ export function reduceDesktopUpdateStateOnNoUpdate(
     availableVersion: null,
     downloadedVersion: null,
     releaseNotes: [],
+    omittedReleaseCount: 0,
     downloadPercent: null,
     checkedAt,
     message: null,

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -7,6 +7,7 @@ import {
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
+  getDesktopUpdateReleaseHistoryUrl,
   getDesktopUpdateReleaseUrl,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
@@ -26,6 +27,7 @@ const baseState: DesktopUpdateState = {
   availableVersion: null,
   downloadedVersion: null,
   releaseNotes: [],
+  omittedReleaseCount: 0,
   downloadPercent: null,
   checkedAt: null,
   message: null,
@@ -200,6 +202,12 @@ describe("desktop update UI helpers", () => {
   it("omits the release URL when the updater does not report a version", () => {
     expect(getDesktopUpdateReleaseUrl(null)).toBeNull();
     expect(getDesktopUpdateReleaseUrl("  ")).toBeNull();
+  });
+
+  it("builds the release history URL", () => {
+    expect(getDesktopUpdateReleaseHistoryUrl()).toBe(
+      "https://github.com/pingdotgg/t3code/releases",
+    );
   });
 
   it("toasts only for actionable updater errors", () => {

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -2,7 +2,8 @@ import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/con
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
-const DESKTOP_RELEASE_TAG_URL = "https://github.com/pingdotgg/t3code/releases/tag";
+const DESKTOP_RELEASE_HISTORY_URL = "https://github.com/pingdotgg/t3code/releases";
+const DESKTOP_RELEASE_TAG_URL = `${DESKTOP_RELEASE_HISTORY_URL}/tag`;
 
 /**
  * The main process fills `downloadedVersion` from the updater's `update-downloaded`
@@ -18,6 +19,10 @@ export function getDesktopUpdateReleaseUrl(version: string | null): string | nul
   const normalizedVersion = version?.trim();
   if (!normalizedVersion) return null;
   return `${DESKTOP_RELEASE_TAG_URL}/v${encodeURIComponent(normalizedVersion)}`;
+}
+
+export function getDesktopUpdateReleaseHistoryUrl(): string {
+  return DESKTOP_RELEASE_HISTORY_URL;
 }
 
 export function resolveDesktopUpdateButtonAction(

--- a/apps/web/src/components/desktopUpdate.toast.test.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.test.tsx
@@ -50,6 +50,7 @@ function downloadedState(overrides: Partial<DesktopUpdateState> = {}): DesktopUp
     availableVersion: "0.0.30",
     downloadedVersion: "0.0.30",
     releaseNotes: [],
+    omittedReleaseCount: 0,
     downloadPercent: 100,
     checkedAt: null,
     message: null,

--- a/apps/web/src/components/desktopUpdate.toast.tsx
+++ b/apps/web/src/components/desktopUpdate.toast.tsx
@@ -9,6 +9,18 @@ import { toastManager } from "./ui/toast";
 
 type DesktopUpdateShell = Pick<DesktopBridge, "openExternal">;
 
+export async function openDesktopUpdateReleaseNotes(
+  shell: DesktopUpdateShell | undefined,
+  releaseUrl: string,
+): Promise<void> {
+  try {
+    if (shell && (await shell.openExternal(releaseUrl))) return;
+  } catch {
+    // Surface rejected IPC calls through the same user-visible fallback.
+  }
+  toastManager.add({ type: "error", title: "Unable to open release notes" });
+}
+
 function ReleaseNotesLink({
   shell,
   releaseUrl,
@@ -20,14 +32,7 @@ function ReleaseNotesLink({
     <button
       className="ml-2 inline cursor-pointer text-muted-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
       onClick={() => {
-        void (async () => {
-          try {
-            if (await shell.openExternal(releaseUrl)) return;
-          } catch {
-            // Surface rejected IPC calls through the same user-visible fallback.
-          }
-          toastManager.add({ type: "error", title: "Unable to open release notes" });
-        })();
+        void openDesktopUpdateReleaseNotes(shell, releaseUrl);
       }}
       type="button"
     >

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
@@ -1,0 +1,86 @@
+import type { DesktopUpdateState } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  handleSidebarUpdateReleaseNotesPopoverOpenChange,
+  openSidebarUpdateReleaseNotesPopoverOnForwardTab,
+  shouldUseSidebarUpdateReleaseNotesPopover,
+} from "./SidebarUpdatePill";
+
+const nightlyState: DesktopUpdateState = {
+  enabled: true,
+  status: "available",
+  channel: "nightly",
+  currentVersion: "0.0.35",
+  hostArch: "arm64",
+  appArch: "arm64",
+  runningUnderArm64Translation: false,
+  availableVersion: "0.0.36-nightly.3",
+  downloadedVersion: null,
+  releaseNotes: [{ version: "0.0.36-nightly.3", items: ["Newest change"], totalItems: 1 }],
+  omittedReleaseCount: 0,
+  downloadPercent: null,
+  checkedAt: null,
+  message: null,
+  errorContext: null,
+  canRetry: false,
+};
+
+describe("sidebar update release notes popover", () => {
+  it("uses the popover only for visible nightly release notes", () => {
+    expect(shouldUseSidebarUpdateReleaseNotesPopover(true, nightlyState)).toBe(true);
+    expect(shouldUseSidebarUpdateReleaseNotesPopover(false, nightlyState)).toBe(false);
+    expect(
+      shouldUseSidebarUpdateReleaseNotesPopover(true, {
+        ...nightlyState,
+        channel: "latest",
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseSidebarUpdateReleaseNotesPopover(true, {
+        ...nightlyState,
+        releaseNotes: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("cancels trigger presses without canceling other open reasons", () => {
+    const cancelTriggerPress = vi.fn();
+    const cancelHover = vi.fn();
+
+    handleSidebarUpdateReleaseNotesPopoverOpenChange(true, {
+      reason: "trigger-press",
+      cancel: cancelTriggerPress,
+    });
+    handleSidebarUpdateReleaseNotesPopoverOpenChange(true, {
+      reason: "trigger-hover",
+      cancel: cancelHover,
+    });
+
+    expect(cancelTriggerPress).toHaveBeenCalledOnce();
+    expect(cancelHover).not.toHaveBeenCalled();
+  });
+
+  it("promotes forward Tab without preventing native navigation", () => {
+    const open = vi.fn();
+    const preventDefault = vi.fn();
+    const event = { key: "Tab", shiftKey: false, preventDefault };
+
+    openSidebarUpdateReleaseNotesPopoverOnForwardTab(event, { open }, "nightly-release-notes");
+
+    expect(open).toHaveBeenCalledWith("nightly-release-notes");
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("does not promote backward Tab", () => {
+    const open = vi.fn();
+
+    openSidebarUpdateReleaseNotesPopoverOnForwardTab(
+      { key: "Tab", shiftKey: true },
+      { open },
+      "nightly-release-notes",
+    );
+
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -1,5 +1,5 @@
 import { TriangleAlertIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { isElectron } from "../../env";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { cn } from "../../lib/utils";
@@ -19,7 +19,6 @@ import {
 } from "../desktopUpdate.logic";
 import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
-import { Separator } from "../ui/separator";
 import { SidebarMenuItem } from "../ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
@@ -27,6 +26,7 @@ import {
   shouldContinueDesktopUpdateCheckAnimation,
   shouldShowDesktopUpdateCheckIcon,
 } from "./DesktopUpdateStatusIcon";
+import { SidebarUpdateReleaseNotes } from "./SidebarUpdateReleaseNotes";
 
 function resolveSidebarUpdatePresentation({
   action,
@@ -53,67 +53,6 @@ function resolveSidebarUpdatePresentation({
     showUpdateDetails,
     showUpdateIconState: showUpdateDetails && !showCheckIcon,
   } as const;
-}
-
-function keyReleaseNoteItems(items: ReadonlyArray<string>) {
-  const occurrences = new Map<string, number>();
-  return items.map((item) => {
-    const occurrence = occurrences.get(item) ?? 0;
-    occurrences.set(item, occurrence + 1);
-    return { item, key: JSON.stringify([item, occurrence]) };
-  });
-}
-
-function SidebarUpdateReleaseNotesTooltip({
-  state,
-  tooltip,
-}: {
-  readonly state: NonNullable<ReturnType<typeof useDesktopUpdateState>>;
-  readonly tooltip: string;
-}) {
-  if (state.channel !== "nightly" || state.releaseNotes.length === 0) {
-    return <>{tooltip}</>;
-  }
-
-  return (
-    <div className="w-fit max-w-[min(24rem,calc(100vw-2rem))] text-left">
-      <div className="px-1">
-        {state.status === "available" ? (
-          <div>
-            <div className="whitespace-nowrap text-sm leading-5 font-medium">
-              Update ready to download
-            </div>
-            {state.availableVersion ? (
-              <div className="mt-0.5 text-xs leading-4 text-muted-foreground">
-                {state.availableVersion}
-              </div>
-            ) : null}
-          </div>
-        ) : (
-          <div className="text-sm leading-5 font-medium">{tooltip}</div>
-        )}
-      </div>
-      <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
-        {state.releaseNotes.map((releaseNote, index) => (
-          <div key={releaseNote.version}>
-            {index > 0 && <Separator className="my-3 bg-border/60" />}
-            <section>
-              <h3 className="text-foreground text-xs leading-4 font-semibold">
-                {index === 0 ? "What's changed" : `Changes in ${releaseNote.version}`}
-              </h3>
-              <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
-                {keyReleaseNoteItems(releaseNote.items).map(({ item, key }) => (
-                  <li className="list-disc break-words" key={key}>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </section>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
 }
 
 export function SidebarUpdateArchitectureWarning() {
@@ -145,6 +84,8 @@ function SidebarUpdateControl() {
   const [isActionPending, setIsActionPending] = useState(false);
   const [checkAnimationKey, setCheckAnimationKey] = useState(0);
   const [isCheckAnimationLatched, setIsCheckAnimationLatched] = useState(false);
+  const updateButtonRef = useRef<HTMLButtonElement>(null);
+  const firstReleaseLinkRef = useRef<HTMLAnchorElement>(null);
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   useEffect(() => {
@@ -311,6 +252,7 @@ function SidebarUpdateControl() {
         <TooltipTrigger
           render={
             <button
+              ref={updateButtonRef}
               type="button"
               aria-label={tooltip}
               aria-disabled={isInteractionDisabled || undefined}
@@ -330,6 +272,20 @@ function SidebarUpdateControl() {
                 disabled && !showUpdateIconState && "opacity-60",
               )}
               onClick={handleAction}
+              onKeyDown={(event) => {
+                if (
+                  event.key !== "Tab" ||
+                  event.shiftKey ||
+                  !showUpdateDetails ||
+                  state?.channel !== "nightly" ||
+                  state.releaseNotes.length === 0 ||
+                  !firstReleaseLinkRef.current
+                ) {
+                  return;
+                }
+                event.preventDefault();
+                firstReleaseLinkRef.current.focus();
+              }}
             >
               <DesktopUpdateStatusIcon
                 key={showCheckIcon ? checkAnimationKey : iconStatus}
@@ -354,7 +310,13 @@ function SidebarUpdateControl() {
           variant={showUpdateDetails ? "glass" : "default"}
         >
           {showUpdateDetails && state ? (
-            <SidebarUpdateReleaseNotesTooltip state={state} tooltip={tooltip} />
+            <SidebarUpdateReleaseNotes
+              firstLinkRef={firstReleaseLinkRef}
+              onBackTab={() => updateButtonRef.current?.focus()}
+              shell={window.desktopBridge}
+              state={state}
+              tooltip={tooltip}
+            />
           ) : (
             tooltip
           )}

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -334,6 +334,7 @@ function SidebarUpdateControl() {
           onOpenChange={handleSidebarUpdateReleaseNotesPopoverOpenChange}
         >
           <PopoverTrigger
+            closeDelay={150}
             handle={releaseNotesPopoverHandle}
             id={releaseNotesTriggerId}
             openOnHover

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -384,11 +384,7 @@ function SidebarUpdateControl() {
       ) : (
         <Tooltip>
           <TooltipTrigger render={updateButton} />
-          <TooltipPopup
-            align="center"
-            side="top"
-            variant={showUpdateDetails ? "glass" : "default"}
-          >
+          <TooltipPopup align="center" side="top" variant={showUpdateDetails ? "glass" : "default"}>
             {tooltip}
           </TooltipPopup>
         </Tooltip>

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -113,6 +113,10 @@ export function SidebarUpdatePill() {
 }
 
 function SidebarUpdateControl() {
+  "use no memo";
+  // Base UI loses focus restoration when React Compiler caches this Popover subtree
+  // across mixed hover and keyboard open cycles.
+
   const state = useDesktopUpdateState();
   const [isActionPending, setIsActionPending] = useState(false);
   const [checkAnimationKey, setCheckAnimationKey] = useState(0);
@@ -318,7 +322,7 @@ function SidebarUpdateControl() {
           suppressReleaseNotesFocusOpen.current = false;
           return;
         }
-        releaseNotesPopoverHandle.open(releaseNotesTriggerId);
+        flushSync(() => releaseNotesPopoverHandle.open(releaseNotesTriggerId));
       }}
       onKeyDown={(event) => {
         if (!showReleaseNotesPopover) return;
@@ -358,7 +362,7 @@ function SidebarUpdateControl() {
             aria-label="Nightly update release notes"
             className="max-w-none text-balance shadow-xl shadow-black/25"
             initialFocus={false}
-            onKeyDown={(event) => {
+            onKeyDownCapture={(event) => {
               if (
                 event.key === "Escape" &&
                 releaseNotesPopupRef.current?.contains(document.activeElement)

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -113,10 +113,6 @@ export function SidebarUpdatePill() {
 }
 
 function SidebarUpdateControl() {
-  "use no memo";
-  // Base UI loses focus restoration when React Compiler caches this Popover subtree
-  // across mixed hover and keyboard open cycles.
-
   const state = useDesktopUpdateState();
   const [isActionPending, setIsActionPending] = useState(false);
   const [checkAnimationKey, setCheckAnimationKey] = useState(0);
@@ -166,8 +162,16 @@ function SidebarUpdateControl() {
   );
 
   useEffect(() => {
-    if (!showReleaseNotesPopover) releaseNotesPopoverHandle.close();
-  }, [releaseNotesPopoverHandle, showReleaseNotesPopover]);
+    if (!showReleaseNotesPopover) {
+      releaseNotesPopoverHandle.close();
+      return;
+    }
+
+    const trigger = document.getElementById(releaseNotesTriggerId);
+    if (trigger?.matches(":focus-visible")) {
+      releaseNotesPopoverHandle.open(releaseNotesTriggerId);
+    }
+  }, [releaseNotesPopoverHandle, releaseNotesTriggerId, showReleaseNotesPopover]);
 
   const handleAction = useCallback(async () => {
     const bridge = window.desktopBridge;
@@ -345,18 +349,47 @@ function SidebarUpdateControl() {
 
   return (
     <SidebarMenuItem className="ml-auto shrink-0">
-      {showReleaseNotesPopover && state ? (
-        <Popover
-          handle={releaseNotesPopoverHandle}
-          onOpenChange={handleSidebarUpdateReleaseNotesPopoverOpenChange}
-        >
-          <PopoverTrigger
-            closeDelay={150}
-            handle={releaseNotesPopoverHandle}
+      <Popover
+        handle={releaseNotesPopoverHandle}
+        onOpenChange={(open, details) => {
+          if (open && !showReleaseNotesPopover) {
+            details.cancel();
+            return;
+          }
+          handleSidebarUpdateReleaseNotesPopoverOpenChange(open, details);
+        }}
+      >
+        <Tooltip disabled={showReleaseNotesPopover}>
+          <TooltipTrigger
             id={releaseNotesTriggerId}
-            openOnHover
-            render={updateButton}
+            render={
+              <PopoverTrigger
+                {...(!showReleaseNotesPopover
+                  ? {
+                      "aria-controls": undefined,
+                      "aria-expanded": undefined,
+                      "aria-haspopup": undefined,
+                    }
+                  : {})}
+                closeDelay={150}
+                handle={releaseNotesPopoverHandle}
+                id={releaseNotesTriggerId}
+                openOnHover={showReleaseNotesPopover}
+                render={updateButton}
+              />
+            }
           />
+          {!showReleaseNotesPopover ? (
+            <TooltipPopup
+              align="center"
+              side="top"
+              variant={showUpdateDetails ? "glass" : "default"}
+            >
+              {tooltip}
+            </TooltipPopup>
+          ) : null}
+        </Tooltip>
+        {showReleaseNotesPopover && state ? (
           <PopoverPopup
             align="center"
             aria-label="Nightly update release notes"
@@ -380,15 +413,8 @@ function SidebarUpdateControl() {
               tooltip={tooltip}
             />
           </PopoverPopup>
-        </Popover>
-      ) : (
-        <Tooltip>
-          <TooltipTrigger render={updateButton} />
-          <TooltipPopup align="center" side="top" variant={showUpdateDetails ? "glass" : "default"}>
-            {tooltip}
-          </TooltipPopup>
-        </Tooltip>
-      )}
+        ) : null}
+      </Popover>
     </SidebarMenuItem>
   );
 }

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -1,5 +1,7 @@
+import type { DesktopUpdateState } from "@t3tools/contracts";
 import { TriangleAlertIcon } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type ComponentProps, useCallback, useEffect, useId, useState } from "react";
+import { flushSync } from "react-dom";
 import { isElectron } from "../../env";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { cn } from "../../lib/utils";
@@ -19,6 +21,7 @@ import {
 } from "../desktopUpdate.logic";
 import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
+import { Popover, PopoverCreateHandle, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { SidebarMenuItem } from "../ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
@@ -27,6 +30,36 @@ import {
   shouldShowDesktopUpdateCheckIcon,
 } from "./DesktopUpdateStatusIcon";
 import { SidebarUpdateReleaseNotes } from "./SidebarUpdateReleaseNotes";
+
+type SidebarUpdatePopoverChangeDetails = Parameters<
+  NonNullable<ComponentProps<typeof Popover>["onOpenChange"]>
+>[1];
+type SidebarUpdatePopoverHandle = ReturnType<typeof PopoverCreateHandle>;
+
+export function shouldUseSidebarUpdateReleaseNotesPopover(
+  showUpdateDetails: boolean,
+  state: DesktopUpdateState | null,
+): boolean {
+  return showUpdateDetails && state?.channel === "nightly" && state.releaseNotes.length > 0;
+}
+
+export function handleSidebarUpdateReleaseNotesPopoverOpenChange(
+  _open: boolean,
+  details: Pick<SidebarUpdatePopoverChangeDetails, "reason" | "cancel">,
+): void {
+  // The trigger is the update action, so its presses must not also toggle the Popover.
+  if (details.reason === "trigger-press") details.cancel();
+}
+
+export function openSidebarUpdateReleaseNotesPopoverOnForwardTab(
+  event: { readonly key: string; readonly shiftKey: boolean },
+  handle: Pick<SidebarUpdatePopoverHandle, "open">,
+  triggerId: string,
+): void {
+  if (event.key !== "Tab" || event.shiftKey) return;
+  // Hover-open popovers do not manage focus. Promote this one before native Tab runs.
+  flushSync(() => handle.open(triggerId));
+}
 
 function resolveSidebarUpdatePresentation({
   action,
@@ -84,8 +117,8 @@ function SidebarUpdateControl() {
   const [isActionPending, setIsActionPending] = useState(false);
   const [checkAnimationKey, setCheckAnimationKey] = useState(0);
   const [isCheckAnimationLatched, setIsCheckAnimationLatched] = useState(false);
-  const updateButtonRef = useRef<HTMLButtonElement>(null);
-  const firstReleaseLinkRef = useRef<HTMLAnchorElement>(null);
+  const [releaseNotesPopoverHandle] = useState(() => PopoverCreateHandle());
+  const releaseNotesTriggerId = useId();
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   useEffect(() => {
@@ -121,6 +154,14 @@ function SidebarUpdateControl() {
       ? isDesktopUpdateButtonDisabled(state)
       : !canCheckForUpdate(state);
   const isInteractionDisabled = disabled || isActionPending;
+  const showReleaseNotesPopover = shouldUseSidebarUpdateReleaseNotesPopover(
+    showUpdateDetails,
+    state,
+  );
+
+  useEffect(() => {
+    if (!showReleaseNotesPopover) releaseNotesPopoverHandle.close();
+  }, [releaseNotesPopoverHandle, showReleaseNotesPopover]);
 
   const handleAction = useCallback(async () => {
     const bridge = window.desktopBridge;
@@ -246,82 +287,85 @@ function SidebarUpdateControl() {
     );
   }, [prefersReducedMotion, state?.status]);
 
+  const updateButton = (
+    <button
+      type="button"
+      aria-label={tooltip}
+      aria-disabled={isInteractionDisabled || undefined}
+      className={cn(
+        "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2",
+        isInteractionDisabled ? "cursor-not-allowed" : "cursor-pointer",
+        showUpdateIconState
+          ? cn(
+              "bg-sidebar-control-surface text-sidebar-foreground",
+              !isInteractionDisabled && "hover:bg-sidebar-row-hover",
+            )
+          : cn(
+              "text-[var(--sidebar-icon-color)]",
+              !isInteractionDisabled && "hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
+            ),
+        disabled && !showUpdateIconState && "opacity-60",
+      )}
+      onClick={handleAction}
+      onKeyDown={(event) => {
+        if (!showReleaseNotesPopover) return;
+        openSidebarUpdateReleaseNotesPopoverOnForwardTab(
+          event,
+          releaseNotesPopoverHandle,
+          releaseNotesTriggerId,
+        );
+      }}
+    >
+      <DesktopUpdateStatusIcon
+        key={showCheckIcon ? checkAnimationKey : iconStatus}
+        downloadPercent={state?.downloadPercent ?? null}
+        isCheckAnimating={showCheckIcon && !prefersReducedMotion}
+        onCheckAnimationIteration={handleCheckAnimationIteration}
+        status={iconStatus}
+      />
+    </button>
+  );
+
   return (
     <SidebarMenuItem className="ml-auto shrink-0">
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <button
-              ref={updateButtonRef}
-              type="button"
-              aria-label={tooltip}
-              aria-disabled={isInteractionDisabled || undefined}
-              className={cn(
-                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2",
-                isInteractionDisabled ? "cursor-not-allowed" : "cursor-pointer",
-                showUpdateIconState
-                  ? cn(
-                      "bg-sidebar-control-surface text-sidebar-foreground",
-                      !isInteractionDisabled && "hover:bg-sidebar-row-hover",
-                    )
-                  : cn(
-                      "text-[var(--sidebar-icon-color)]",
-                      !isInteractionDisabled &&
-                        "hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
-                    ),
-                disabled && !showUpdateIconState && "opacity-60",
-              )}
-              onClick={handleAction}
-              onKeyDown={(event) => {
-                if (
-                  event.key !== "Tab" ||
-                  event.shiftKey ||
-                  !showUpdateDetails ||
-                  state?.channel !== "nightly" ||
-                  state.releaseNotes.length === 0 ||
-                  !firstReleaseLinkRef.current
-                ) {
-                  return;
-                }
-                event.preventDefault();
-                firstReleaseLinkRef.current.focus();
-              }}
-            >
-              <DesktopUpdateStatusIcon
-                key={showCheckIcon ? checkAnimationKey : iconStatus}
-                downloadPercent={state?.downloadPercent ?? null}
-                isCheckAnimating={showCheckIcon && !prefersReducedMotion}
-                onCheckAnimationIteration={handleCheckAnimationIteration}
-                status={iconStatus}
-              />
-            </button>
-          }
-        />
-        <TooltipPopup
-          align="center"
-          className={
-            showUpdateDetails && state?.channel === "nightly" && state.releaseNotes.length > 0
-              ? // pointer-events-auto overrides the positioner's pointer-events-none so the
-                // release notes stay open (and scrollable) when the cursor moves into them.
-                "pointer-events-auto max-w-none text-balance"
-              : undefined
-          }
-          side="top"
-          variant={showUpdateDetails ? "glass" : "default"}
+      {showReleaseNotesPopover && state ? (
+        <Popover
+          handle={releaseNotesPopoverHandle}
+          onOpenChange={handleSidebarUpdateReleaseNotesPopoverOpenChange}
         >
-          {showUpdateDetails && state ? (
+          <PopoverTrigger
+            handle={releaseNotesPopoverHandle}
+            id={releaseNotesTriggerId}
+            openOnHover
+            render={updateButton}
+          />
+          <PopoverPopup
+            align="center"
+            aria-label="Nightly update release notes"
+            className="max-w-none text-balance shadow-xl shadow-black/25"
+            initialFocus={false}
+            side="top"
+            tooltipStyle
+          >
             <SidebarUpdateReleaseNotes
-              firstLinkRef={firstReleaseLinkRef}
-              onBackTab={() => updateButtonRef.current?.focus()}
               shell={window.desktopBridge}
               state={state}
               tooltip={tooltip}
             />
-          ) : (
-            tooltip
-          )}
-        </TooltipPopup>
-      </Tooltip>
+          </PopoverPopup>
+        </Popover>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger render={updateButton} />
+          <TooltipPopup
+            align="center"
+            side="top"
+            variant={showUpdateDetails ? "glass" : "default"}
+          >
+            {tooltip}
+          </TooltipPopup>
+        </Tooltip>
+      )}
     </SidebarMenuItem>
   );
 }

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -1,6 +1,6 @@
 import type { DesktopUpdateState } from "@t3tools/contracts";
 import { TriangleAlertIcon } from "lucide-react";
-import { type ComponentProps, useCallback, useEffect, useId, useState } from "react";
+import { type ComponentProps, useCallback, useEffect, useId, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { isElectron } from "../../env";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
@@ -118,6 +118,8 @@ function SidebarUpdateControl() {
   const [checkAnimationKey, setCheckAnimationKey] = useState(0);
   const [isCheckAnimationLatched, setIsCheckAnimationLatched] = useState(false);
   const [releaseNotesPopoverHandle] = useState(() => PopoverCreateHandle());
+  const suppressReleaseNotesFocusOpen = useRef(false);
+  const releaseNotesPopupRef = useRef<HTMLDivElement>(null);
   const releaseNotesTriggerId = useId();
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
@@ -307,6 +309,17 @@ function SidebarUpdateControl() {
         disabled && !showUpdateIconState && "opacity-60",
       )}
       onClick={handleAction}
+      onBlur={() => {
+        suppressReleaseNotesFocusOpen.current = false;
+      }}
+      onFocus={(event) => {
+        if (!showReleaseNotesPopover || !event.currentTarget.matches(":focus-visible")) return;
+        if (suppressReleaseNotesFocusOpen.current) {
+          suppressReleaseNotesFocusOpen.current = false;
+          return;
+        }
+        releaseNotesPopoverHandle.open(releaseNotesTriggerId);
+      }}
       onKeyDown={(event) => {
         if (!showReleaseNotesPopover) return;
         openSidebarUpdateReleaseNotesPopoverOnForwardTab(
@@ -345,6 +358,15 @@ function SidebarUpdateControl() {
             aria-label="Nightly update release notes"
             className="max-w-none text-balance shadow-xl shadow-black/25"
             initialFocus={false}
+            onKeyDown={(event) => {
+              if (
+                event.key === "Escape" &&
+                releaseNotesPopupRef.current?.contains(document.activeElement)
+              ) {
+                suppressReleaseNotesFocusOpen.current = true;
+              }
+            }}
+            ref={releaseNotesPopupRef}
             side="top"
             tooltipStyle
           >

--- a/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.test.tsx
@@ -1,0 +1,188 @@
+import type { DesktopUpdateState } from "@t3tools/contracts";
+import {
+  isValidElement,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({
+  addToast: vi.fn(),
+}));
+
+vi.mock("../ui/toast", () => ({
+  toastManager: { add: testState.addToast },
+}));
+
+import { SidebarUpdateReleaseNotes } from "./SidebarUpdateReleaseNotes";
+
+type AnchorElement = ReactElement<{
+  readonly children?: ReactNode;
+  readonly href?: string;
+  readonly onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  readonly onKeyDown?: (event: KeyboardEvent<HTMLAnchorElement>) => void;
+}>;
+
+const baseState: DesktopUpdateState = {
+  enabled: true,
+  status: "available",
+  channel: "nightly",
+  currentVersion: "0.0.35",
+  hostArch: "arm64",
+  appArch: "arm64",
+  runningUnderArm64Translation: false,
+  availableVersion: "0.0.36-nightly.3",
+  downloadedVersion: null,
+  releaseNotes: [],
+  omittedReleaseCount: 0,
+  downloadPercent: null,
+  checkedAt: null,
+  message: null,
+  errorContext: null,
+  canRetry: false,
+};
+
+function collectAnchors(node: ReactNode, anchors: AnchorElement[] = []): AnchorElement[] {
+  if (Array.isArray(node)) {
+    for (const child of node) collectAnchors(child, anchors);
+    return anchors;
+  }
+  if (!isValidElement(node)) return anchors;
+
+  const element = node as ReactElement<{ readonly children?: ReactNode }>;
+  if (typeof element.type === "function") {
+    const render = element.type as (props: unknown) => ReactNode;
+    return collectAnchors(render(element.props), anchors);
+  }
+  if (element.type === "a") anchors.push(element as AnchorElement);
+  return collectAnchors(element.props.children, anchors);
+}
+
+function textContent(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textContent).join("");
+  if (!isValidElement(node)) return "";
+  const element = node as ReactElement<{ readonly children?: ReactNode }>;
+  return textContent(element.props.children);
+}
+
+function renderNotes(
+  state: DesktopUpdateState,
+  openExternal = vi.fn().mockResolvedValue(true),
+  onBackTab?: () => void,
+) {
+  return SidebarUpdateReleaseNotes({
+    onBackTab,
+    shell: { openExternal },
+    state,
+    tooltip: "Update available",
+  });
+}
+
+describe("SidebarUpdateReleaseNotes", () => {
+  beforeEach(() => {
+    testState.addToast.mockReset();
+  });
+
+  it("links each preview to its exact release and labels hidden changes", () => {
+    const anchors = collectAnchors(
+      renderNotes({
+        ...baseState,
+        releaseNotes: [
+          { version: "0.0.36-nightly.3", items: ["Change 3"], totalItems: 1 },
+          { version: "0.0.36-nightly.2", items: ["Change 2"], totalItems: 2 },
+          { version: "0.0.36-nightly.1", items: ["Change 1", "Earlier"], totalItems: 4 },
+        ],
+      }),
+    );
+
+    expect(anchors.map(({ props }) => props.href)).toEqual([
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.36-nightly.3",
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.36-nightly.2",
+      "https://github.com/pingdotgg/t3code/releases/tag/v0.0.36-nightly.1",
+    ]);
+    expect(anchors.map(({ props }) => textContent(props.children))).toEqual([
+      "View release on GitHub",
+      "1 more change on GitHub",
+      "2 more changes on GitHub",
+    ]);
+  });
+
+  it("links omitted releases to release history", () => {
+    const anchors = collectAnchors(
+      renderNotes({
+        ...baseState,
+        releaseNotes: [{ version: "0.0.36-nightly.3", items: ["Change 3"], totalItems: 1 }],
+        omittedReleaseCount: 1,
+      }),
+    );
+
+    expect(anchors.at(-1)?.props.href).toBe("https://github.com/pingdotgg/t3code/releases");
+    expect(textContent(anchors.at(-1)?.props.children)).toBe("1 older release on GitHub");
+  });
+
+  it("shows plural history text for multiple omitted releases", () => {
+    const anchors = collectAnchors(
+      renderNotes({
+        ...baseState,
+        releaseNotes: [{ version: "0.0.36-nightly.3", items: ["Change 3"], totalItems: 1 }],
+        omittedReleaseCount: 3,
+      }),
+    );
+
+    expect(textContent(anchors.at(-1)?.props.children)).toBe("3 older releases on GitHub");
+  });
+
+  it("reports a release link that fails to open", async () => {
+    const openExternal = vi.fn().mockResolvedValue(false);
+    const [anchor] = collectAnchors(
+      renderNotes(
+        {
+          ...baseState,
+          releaseNotes: [{ version: "0.0.36-nightly.3", items: ["Change 3"], totalItems: 1 }],
+        },
+        openExternal,
+      ),
+    );
+    const preventDefault = vi.fn();
+
+    anchor?.props.onClick?.({ preventDefault } as unknown as MouseEvent<HTMLAnchorElement>);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(openExternal).toHaveBeenCalledWith(
+        "https://github.com/pingdotgg/t3code/releases/tag/v0.0.36-nightly.3",
+      );
+      expect(testState.addToast).toHaveBeenCalledWith({
+        type: "error",
+        title: "Unable to open release notes",
+      });
+    });
+  });
+
+  it("returns keyboard focus from the first link", () => {
+    const onBackTab = vi.fn();
+    const [anchor] = collectAnchors(
+      renderNotes(
+        {
+          ...baseState,
+          releaseNotes: [{ version: "0.0.36-nightly.3", items: ["Change 3"], totalItems: 1 }],
+        },
+        undefined,
+        onBackTab,
+      ),
+    );
+    const preventDefault = vi.fn();
+
+    anchor?.props.onKeyDown?.({
+      key: "Tab",
+      shiftKey: true,
+      preventDefault,
+    } as unknown as KeyboardEvent<HTMLAnchorElement>);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(onBackTab).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.test.tsx
@@ -1,11 +1,5 @@
 import type { DesktopUpdateState } from "@t3tools/contracts";
-import {
-  isValidElement,
-  type KeyboardEvent,
-  type MouseEvent,
-  type ReactElement,
-  type ReactNode,
-} from "react";
+import { isValidElement, type MouseEvent, type ReactElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
@@ -22,7 +16,6 @@ type AnchorElement = ReactElement<{
   readonly children?: ReactNode;
   readonly href?: string;
   readonly onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
-  readonly onKeyDown?: (event: KeyboardEvent<HTMLAnchorElement>) => void;
 }>;
 
 const baseState: DesktopUpdateState = {
@@ -68,13 +61,8 @@ function textContent(node: ReactNode): string {
   return textContent(element.props.children);
 }
 
-function renderNotes(
-  state: DesktopUpdateState,
-  openExternal = vi.fn().mockResolvedValue(true),
-  onBackTab?: () => void,
-) {
+function renderNotes(state: DesktopUpdateState, openExternal = vi.fn().mockResolvedValue(true)) {
   return SidebarUpdateReleaseNotes({
-    onBackTab,
     shell: { openExternal },
     state,
     tooltip: "Update available",
@@ -160,29 +148,5 @@ describe("SidebarUpdateReleaseNotes", () => {
         title: "Unable to open release notes",
       });
     });
-  });
-
-  it("returns keyboard focus from the first link", () => {
-    const onBackTab = vi.fn();
-    const [anchor] = collectAnchors(
-      renderNotes(
-        {
-          ...baseState,
-          releaseNotes: [{ version: "0.0.36-nightly.3", items: ["Change 3"], totalItems: 1 }],
-        },
-        undefined,
-        onBackTab,
-      ),
-    );
-    const preventDefault = vi.fn();
-
-    anchor?.props.onKeyDown?.({
-      key: "Tab",
-      shiftKey: true,
-      preventDefault,
-    } as unknown as KeyboardEvent<HTMLAnchorElement>);
-
-    expect(preventDefault).toHaveBeenCalledOnce();
-    expect(onBackTab).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
@@ -1,0 +1,142 @@
+import type { DesktopBridge, DesktopUpdateState } from "@t3tools/contracts";
+import { ExternalLinkIcon } from "lucide-react";
+import type { KeyboardEvent, Ref } from "react";
+
+import {
+  getDesktopUpdateReleaseHistoryUrl,
+  getDesktopUpdateReleaseUrl,
+} from "../desktopUpdate.logic";
+import { openDesktopUpdateReleaseNotes } from "../desktopUpdate.toast";
+import { Separator } from "../ui/separator";
+
+type DesktopUpdateShell = Pick<DesktopBridge, "openExternal">;
+
+function keyReleaseNoteItems(items: ReadonlyArray<string>) {
+  const occurrences = new Map<string, number>();
+  return items.map((item) => {
+    const occurrence = occurrences.get(item) ?? 0;
+    occurrences.set(item, occurrence + 1);
+    return { item, key: JSON.stringify([item, occurrence]) };
+  });
+}
+
+function ReleaseLink({
+  children,
+  firstLinkRef,
+  onBackTab,
+  releaseUrl,
+  shell,
+}: {
+  readonly children: string;
+  readonly firstLinkRef?: Ref<HTMLAnchorElement> | undefined;
+  readonly onBackTab?: (() => void) | undefined;
+  readonly releaseUrl: string;
+  readonly shell: DesktopUpdateShell | undefined;
+}) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLAnchorElement>) => {
+    if (event.key !== "Tab" || !event.shiftKey || !onBackTab) return;
+    event.preventDefault();
+    onBackTab();
+  };
+
+  return (
+    <a
+      className="mt-2 inline-flex items-center gap-1 text-xs leading-5 text-update-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground focus-visible:text-foreground"
+      href={releaseUrl}
+      onClick={(event) => {
+        event.preventDefault();
+        void openDesktopUpdateReleaseNotes(shell, releaseUrl);
+      }}
+      onKeyDown={handleKeyDown}
+      ref={firstLinkRef}
+    >
+      {children}
+      <ExternalLinkIcon aria-hidden className="size-3 shrink-0" strokeWidth={2.25} />
+    </a>
+  );
+}
+
+export function SidebarUpdateReleaseNotes({
+  firstLinkRef,
+  onBackTab,
+  shell,
+  state,
+  tooltip,
+}: {
+  readonly firstLinkRef?: Ref<HTMLAnchorElement> | undefined;
+  readonly onBackTab?: (() => void) | undefined;
+  readonly shell: DesktopUpdateShell | undefined;
+  readonly state: DesktopUpdateState;
+  readonly tooltip: string;
+}) {
+  if (state.channel !== "nightly" || state.releaseNotes.length === 0) {
+    return <>{tooltip}</>;
+  }
+
+  return (
+    <div className="w-fit max-w-[min(24rem,calc(100vw-2rem))] text-left">
+      <div className="px-1">
+        {state.status === "available" ? (
+          <div>
+            <div className="whitespace-nowrap text-sm leading-5 font-medium">
+              Update ready to download
+            </div>
+            {state.availableVersion ? (
+              <div className="mt-0.5 text-xs leading-4 text-update-foreground">
+                {state.availableVersion}
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div className="text-sm leading-5 font-medium">{tooltip}</div>
+        )}
+      </div>
+      <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
+        {state.releaseNotes.map((releaseNote, index) => {
+          const releaseUrl = getDesktopUpdateReleaseUrl(releaseNote.version);
+          const omittedItemCount = Math.max(0, releaseNote.totalItems - releaseNote.items.length);
+          const linkLabel =
+            omittedItemCount === 0
+              ? "View release on GitHub"
+              : `${omittedItemCount} more ${omittedItemCount === 1 ? "change" : "changes"} on GitHub`;
+
+          return (
+            <div key={releaseNote.version}>
+              {index > 0 && <Separator className="my-3 bg-border/60" />}
+              <section>
+                <h3 className="text-foreground text-xs leading-4 font-semibold">
+                  {index === 0 ? "What's changed" : `Changes in ${releaseNote.version}`}
+                </h3>
+                <ul className="mt-2 space-y-1.5 pl-4 text-xs leading-5 text-popover-foreground/90">
+                  {keyReleaseNoteItems(releaseNote.items).map(({ item, key }) => (
+                    <li className="list-disc break-words" key={key}>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+                {releaseUrl ? (
+                  <ReleaseLink
+                    firstLinkRef={index === 0 ? firstLinkRef : undefined}
+                    onBackTab={index === 0 ? onBackTab : undefined}
+                    releaseUrl={releaseUrl}
+                    shell={shell}
+                  >
+                    {linkLabel}
+                  </ReleaseLink>
+                ) : null}
+              </section>
+            </div>
+          );
+        })}
+        {state.omittedReleaseCount > 0 ? (
+          <div>
+            <Separator className="my-3 bg-border/60" />
+            <ReleaseLink releaseUrl={getDesktopUpdateReleaseHistoryUrl()} shell={shell}>
+              {`${state.omittedReleaseCount} older ${state.omittedReleaseCount === 1 ? "release" : "releases"} on GitHub`}
+            </ReleaseLink>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
@@ -1,6 +1,5 @@
 import type { DesktopBridge, DesktopUpdateState } from "@t3tools/contracts";
 import { ExternalLinkIcon } from "lucide-react";
-import type { KeyboardEvent, Ref } from "react";
 
 import {
   getDesktopUpdateReleaseHistoryUrl,
@@ -22,33 +21,21 @@ function keyReleaseNoteItems(items: ReadonlyArray<string>) {
 
 function ReleaseLink({
   children,
-  firstLinkRef,
-  onBackTab,
   releaseUrl,
   shell,
 }: {
   readonly children: string;
-  readonly firstLinkRef?: Ref<HTMLAnchorElement> | undefined;
-  readonly onBackTab?: (() => void) | undefined;
   readonly releaseUrl: string;
   readonly shell: DesktopUpdateShell | undefined;
 }) {
-  const handleKeyDown = (event: KeyboardEvent<HTMLAnchorElement>) => {
-    if (event.key !== "Tab" || !event.shiftKey || !onBackTab) return;
-    event.preventDefault();
-    onBackTab();
-  };
-
   return (
     <a
-      className="mt-2 inline-flex items-center gap-1 text-xs leading-5 text-update-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground focus-visible:text-foreground"
+      className="mt-2 inline-flex items-center gap-1 rounded-sm text-xs leading-5 text-update-foreground underline decoration-dotted underline-offset-4 outline-none transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
       href={releaseUrl}
       onClick={(event) => {
         event.preventDefault();
         void openDesktopUpdateReleaseNotes(shell, releaseUrl);
       }}
-      onKeyDown={handleKeyDown}
-      ref={firstLinkRef}
     >
       {children}
       <ExternalLinkIcon aria-hidden className="size-3 shrink-0" strokeWidth={2.25} />
@@ -57,14 +44,10 @@ function ReleaseLink({
 }
 
 export function SidebarUpdateReleaseNotes({
-  firstLinkRef,
-  onBackTab,
   shell,
   state,
   tooltip,
 }: {
-  readonly firstLinkRef?: Ref<HTMLAnchorElement> | undefined;
-  readonly onBackTab?: (() => void) | undefined;
   readonly shell: DesktopUpdateShell | undefined;
   readonly state: DesktopUpdateState;
   readonly tooltip: string;
@@ -74,8 +57,8 @@ export function SidebarUpdateReleaseNotes({
   }
 
   return (
-    <div className="w-fit max-w-[min(24rem,calc(100vw-2rem))] text-left">
-      <div className="px-1">
+    <div className="flex max-h-[calc(var(--available-height)-0.5rem)] min-h-0 w-fit max-w-[min(24rem,calc(100vw-2rem))] flex-col text-left">
+      <div className="shrink-0 px-1">
         {state.status === "available" ? (
           <div>
             <div className="whitespace-nowrap text-sm leading-5 font-medium">
@@ -91,7 +74,7 @@ export function SidebarUpdateReleaseNotes({
           <div className="text-sm leading-5 font-medium">{tooltip}</div>
         )}
       </div>
-      <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
+      <div className="min-h-0 max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
         {state.releaseNotes.map((releaseNote, index) => {
           const releaseUrl = getDesktopUpdateReleaseUrl(releaseNote.version);
           const omittedItemCount = Math.max(0, releaseNote.totalItems - releaseNote.items.length);
@@ -115,12 +98,7 @@ export function SidebarUpdateReleaseNotes({
                   ))}
                 </ul>
                 {releaseUrl ? (
-                  <ReleaseLink
-                    firstLinkRef={index === 0 ? firstLinkRef : undefined}
-                    onBackTab={index === 0 ? onBackTab : undefined}
-                    releaseUrl={releaseUrl}
-                    shell={shell}
-                  >
+                  <ReleaseLink releaseUrl={releaseUrl} shell={shell}>
                     {linkLabel}
                   </ReleaseLink>
                 ) : null}

--- a/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateReleaseNotes.tsx
@@ -30,7 +30,7 @@ function ReleaseLink({
 }) {
   return (
     <a
-      className="mt-2 inline-flex items-center gap-1 rounded-sm text-xs leading-5 text-update-foreground underline decoration-dotted underline-offset-4 outline-none transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+      className="mt-2 inline-flex items-center gap-1 rounded-sm text-xs leading-5 text-muted-foreground underline decoration-dotted underline-offset-4 outline-none transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
       href={releaseUrl}
       onClick={(event) => {
         event.preventDefault();
@@ -65,7 +65,7 @@ export function SidebarUpdateReleaseNotes({
               Update ready to download
             </div>
             {state.availableVersion ? (
-              <div className="mt-0.5 text-xs leading-4 text-update-foreground">
+              <div className="mt-0.5 text-xs leading-4 text-muted-foreground">
                 {state.availableVersion}
               </div>
             ) : null}

--- a/apps/web/src/state/desktopUpdate.test.ts
+++ b/apps/web/src/state/desktopUpdate.test.ts
@@ -16,6 +16,7 @@ const baseState: DesktopUpdateState = {
   availableVersion: null,
   downloadedVersion: null,
   releaseNotes: [],
+  omittedReleaseCount: 0,
   downloadPercent: null,
   checkedAt: null,
   message: null,

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -57,6 +57,16 @@ the warning always works.
 See [Running T3 Code in the Background](./background-service.md) for install, status, and removal
 commands.
 
+## Nightly desktop release notes
+
+The desktop app shows a compact release-notes preview when a nightly update is available. Changes
+appear newest first within each release. Each release links to its exact page on GitHub, even when
+all changes fit in the preview.
+
+The preview shows up to eight changes from each of six releases. When it leaves out changes or older
+releases, it shows the exact number and links to the rest. Contributor credits do not count as
+changes.
+
 ## After the Update
 
 Keep the web or desktop app open while the server restarts. The update completes only after the

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -209,6 +209,7 @@ export interface DesktopUpdateState {
   availableVersion: string | null;
   downloadedVersion: string | null;
   releaseNotes: ReadonlyArray<DesktopUpdateReleaseNote>;
+  omittedReleaseCount: number;
   downloadPercent: number | null;
   checkedAt: string | null;
   message: string | null;
@@ -219,11 +220,13 @@ export interface DesktopUpdateState {
 export interface DesktopUpdateReleaseNote {
   version: string;
   items: ReadonlyArray<string>;
+  totalItems: number;
 }
 
 export const DesktopUpdateReleaseNoteSchema = Schema.Struct({
   version: Schema.String,
   items: Schema.Array(Schema.String),
+  totalItems: Schema.Number,
 });
 
 export const DesktopUpdateStateSchema = Schema.Struct({
@@ -237,6 +240,7 @@ export const DesktopUpdateStateSchema = Schema.Struct({
   availableVersion: Schema.NullOr(Schema.String),
   downloadedVersion: Schema.NullOr(Schema.String),
   releaseNotes: Schema.Array(DesktopUpdateReleaseNoteSchema),
+  omittedReleaseCount: Schema.Number,
   downloadPercent: Schema.NullOr(Schema.Number),
   checkedAt: Schema.NullOr(Schema.String),
   message: Schema.NullOr(Schema.String),


### PR DESCRIPTION
Nightly update previews showed the oldest changes in each GitHub release. Contributor credits could also consume preview slots, so recent changes were often missing.

This change filters release boilerplate, keeps the newest eight changes, and reports the full change and release counts. The sidebar preview now links to each GitHub release and uses a focus-managed popover for pointer and keyboard access.

| Before | After |
| --- | --- |
| ![The old preview shows the oldest changes](https://files.tslop.org/2026/09/nightly-release-notes-before-c7e09059.png) | ![The new preview shows the newest changes and release links](https://files.tslop.org/2026/09/nightly-release-notes-after-05f436dc.png) |

[Watch the pointer and keyboard interaction](https://files.tslop.org/2026/09/nightly-release-notes-interaction-94dc874a.mp4). The 2.5-second excerpt is slowed to 2.5x duration so the focus changes are easier to see.

Verification:

- 86 focused desktop and web tests passed.
- Contracts, desktop, and web typechecks passed.
- Changed-file lint, formatting, and `git diff --check` passed.
- The affected public nightly release produced the newest eight of ten changes and excluded contributor credits.
- Markdown and HTML section headings are excluded from the reported change count.
- The real app in Chromium passed pointer travel and scrolling, release-link activation, keyboard entry and exit, Escape focus return, download, install cancellation and confirmation, and tooltip fallback checks. The test used a stubbed desktop bridge, so it did not download or install a real update.
- The same update button DOM node kept keyboard focus through idle, checking, nightly available, no-notes, and latest state changes. These flows passed with React Compiler enabled.

This continues [#8588](https://github.com/pingdotgg/t3code/pull/8588). Theo Browne authored its three original commits. This replacement preserves his authorship and adds the review fixes separately.

Made with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> IPC contract changes require `totalItems` and `omittedReleaseCount` on update state, which can break older clients or persisted snapshots. Popover focus and React Compiler opt-out add UI regression surface on the nightly update control.
> 
> **Overview**
> Nightly desktop update previews now surface the **newest** changes per release instead of the oldest, and stop treating contributor credits and full-changelog boilerplate as real changes. Normalization returns up to **eight** items and **six** release groups, with **`totalItems`** per group and **`omittedReleaseCount`** when older releases are dropped; those fields flow through IPC and the desktop update reducer.
> 
> The sidebar replaces the cramped nightly tooltip with a **hover/focus popover** (`SidebarUpdateReleaseNotes`) that links each preview to its GitHub release tag, labels hidden changes within a release, and links omitted releases to the releases history page. Popover behavior keeps the update button as the action target (no double-toggle on click), supports forward **Tab** into the panel, and restores focus sensibly on **Escape**.
> 
> User docs add a short section describing the nightly preview limits and links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90cf5f70eb63caae8fc2e2940d1a91f3e8f8d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show newest nightly release changes in sidebar popover with per-release links
> - Overhauls release-note extraction to keep the newest eight changes per release in newest-first order, excluding contributor and changelog sections, and returns up to six non-empty release groups plus an `omittedReleaseCount`
> - Replaces the sidebar tooltip with a hover- and focus-aware `Popover` that renders nightly notes via the new `SidebarUpdateReleaseNotes` component, while keeping the update button as the install action
> - `SidebarUpdateReleaseNotes` links each displayed release to its exact GitHub tag, reports omitted changes per release via `totalItems`, and links omitted release groups to the GitHub release history page
> - Adds required `omittedReleaseCount` to `DesktopUpdateState` and `totalItems` to `DesktopUpdateReleaseNote` in the IPC contracts and runtime schema
> - Risk: `omittedReleaseCount` and `totalItems` are now required fields in [ipc.ts](https://github.com/pingdotgg/t3code/pull/9138/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a); any out-of-tree desktop clients reading the update-state payload must supply or tolerate these fields
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d99162b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

