### PR TITLE
fix(grok): emit task lifecycle for monitors and background shells

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -30,6 +30,8 @@ const emitXAiAskUserQuestionThenHang =
 const emitContentThenHang = process.env.T3_ACP_EMIT_CONTENT_THEN_HANG === "1";
 const emitPlanThenHang = process.env.T3_ACP_EMIT_PLAN_THEN_HANG === "1";
 const emitActiveToolThenHang = process.env.T3_ACP_EMIT_ACTIVE_TOOL_THEN_HANG === "1";
+const emitGrokMonitorPostTurnPoll = process.env.T3_ACP_EMIT_GROK_MONITOR_POST_TURN_POLL === "1";
+const emitGrokBackgroundTaskStarted = process.env.T3_ACP_EMIT_GROK_BACKGROUND_TASK_STARTED === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
 const waitForResumeRelease = process.env.T3_ACP_WAIT_FOR_RESUME_RELEASE === "1";
 const completeFirstPromptOnCancel = process.env.T3_ACP_COMPLETE_FIRST_PROMPT_ON_CANCEL === "1";
@@ -832,6 +834,108 @@ const program = Effect.gen(function* () {
           },
         });
 
+        return yield* Effect.never;
+      }
+
+      if (emitGrokMonitorPostTurnPoll) {
+        const monitorCallId = "call-monitor-1";
+        const pollCallId = "call-monitor-poll-1";
+        const taskId = "01a05f41-5107-7550-821e-79e8d1cd7687";
+        const description = "Watch count-sheet Typst unit until done";
+        writeJsonRpcNotification("session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: monitorCallId,
+            title: "monitor",
+            kind: "other",
+            status: "pending",
+            rawInput: { description },
+            _meta: {
+              "x.ai/tool": { version: 1, name: "monitor", kind: "task", namespace: "grok_build" },
+            },
+          },
+        });
+        writeJsonRpcNotification("session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: monitorCallId,
+            status: "completed",
+            rawInput: { description },
+            rawOutput: {
+              type: "Monitor",
+              taskId,
+              timeoutMs: 36_000_000,
+            },
+          },
+        });
+        writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+          sessionId: requestedSessionId,
+          promptId: promptIdFromRequestMeta(request) ?? "mock-xai-prompt-1",
+          stopReason: "end_turn",
+          agentResult: null,
+        });
+        yield* Effect.sleep("120 millis");
+        writeJsonRpcNotification("session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: pollCallId,
+            title: "get_command_or_subagent_output",
+            kind: "other",
+            status: "completed",
+            rawInput: { variant: "TaskOutput", task_ids: [taskId], timeout_ms: 0 },
+            rawOutput: {
+              type: "TaskOutput",
+              Result: {
+                task_id: taskId,
+                command: `[monitor] ${description}`,
+                status: "completed",
+                exit_code: 0,
+                output: "Monitor finished.",
+              },
+            },
+          },
+        });
+        return yield* Effect.never;
+      }
+
+      if (emitGrokBackgroundTaskStarted) {
+        const toolCallId = "call-fb9d0000-0000-0000-0000-000000000026";
+        const command = "sleep 40; echo done-a";
+        writeJsonRpcNotification("session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId,
+            title: "run_terminal_command",
+            kind: "execute",
+            status: "in_progress",
+            rawInput: { command },
+          },
+        });
+        writeJsonRpcNotification("session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId,
+            status: "completed",
+            rawOutput: {
+              type: "BackgroundTaskStarted",
+              task_id: toolCallId,
+              task_type: "bash",
+              status: "running",
+              command,
+            },
+          },
+        });
+        writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+          sessionId: requestedSessionId,
+          promptId: promptIdFromRequestMeta(request) ?? "mock-xai-prompt-1",
+          stopReason: "end_turn",
+          agentResult: null,
+        });
         return yield* Effect.never;
       }
 

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -24,8 +24,10 @@ import {
   TurnId,
   type ProviderRuntimeEvent,
 } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import { ServerConfig } from "../../config.ts";
+import { execScriptSource, writeFakeCli } from "../../testUtils/fakeCli.ts";
 import {
   grokPromptSettlementBelongsToContext,
   isGrokEnterPlanModeToolCall,
@@ -33,8 +35,7 @@ import {
   nextGrokPlanModeActive,
   selectGrokPermissionOptionId,
 } from "./GrokAdapter.ts";
-import { execScriptSource, writeFakeCli } from "../../testUtils/fakeCli.ts";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
@@ -212,6 +213,132 @@ it("requires a settlement to match the live Grok turn", () => {
 });
 
 it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
+  it.effect("emits monitor task.started then post-turn task.completed", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-monitor-post-turn");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_GROK_MONITOR_POST_TURN_POLL: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const taskCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "task.completed"
+              ? Deferred.succeed(taskCompleted, undefined)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "watch the unit",
+        attachments: [],
+      });
+      yield* Deferred.await(taskCompleted).pipe(Effect.timeout("3 seconds"));
+
+      const started = runtimeEvents.find(
+        (event): event is Extract<ProviderRuntimeEvent, { type: "task.started" }> =>
+          event.type === "task.started",
+      );
+      const completed = runtimeEvents.find(
+        (event): event is Extract<ProviderRuntimeEvent, { type: "task.completed" }> =>
+          event.type === "task.completed",
+      );
+      const turnCompletedIndex = runtimeEvents.findIndex(
+        (event) => event.type === "turn.completed",
+      );
+      const taskCompletedIndex = runtimeEvents.findIndex(
+        (event) => event.type === "task.completed",
+      );
+      const toolEventsAfterTurn = runtimeEvents
+        .slice(turnCompletedIndex + 1)
+        .filter((event) => event.type === "item.updated" || event.type === "item.completed");
+
+      assert.isDefined(started);
+      if (started?.type === "task.started") {
+        assert.equal(started.payload.taskType, "monitor");
+        assert.equal(String(started.payload.taskId), "01a05f41-5107-7550-821e-79e8d1cd7687");
+      }
+      assert.isDefined(completed);
+      if (completed?.type === "task.completed") {
+        assert.equal(completed.payload.status, "completed");
+        assert.equal(String(completed.payload.taskId), "01a05f41-5107-7550-821e-79e8d1cd7687");
+      }
+      assert.isAtLeast(turnCompletedIndex, 0);
+      assert.isAbove(taskCompletedIndex, turnCompletedIndex);
+      assert.equal(completed?.turnId, undefined);
+      assert.deepEqual(toolEventsAfterTurn, []);
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }).pipe(TestClock.withLive),
+  );
+
+  it.effect("emits task.started shell from BackgroundTaskStarted", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-background-task-started");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_GROK_BACKGROUND_TASK_STARTED: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const taskStarted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "task.started" ? Deferred.succeed(taskStarted, undefined) : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "sleep then echo",
+        attachments: [],
+      });
+      yield* Deferred.await(taskStarted).pipe(Effect.timeout("3 seconds"));
+
+      const started = runtimeEvents.find(
+        (event): event is Extract<ProviderRuntimeEvent, { type: "task.started" }> =>
+          event.type === "task.started",
+      );
+      assert.isDefined(started);
+      if (started?.type === "task.started") {
+        assert.equal(started.payload.taskType, "shell");
+        assert.equal(started.payload.description, "sleep 40; echo done-a");
+        assert.equal(String(started.payload.taskId), "call-fb9d0000-0000-0000-0000-000000000026");
+      }
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }).pipe(TestClock.withLive),
+  );
+
   it.effect("sends runtime context with the current model without changing saved prompts", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-runtime-context");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -184,6 +184,8 @@ interface GrokSessionContext {
   readonly backgroundTasks: Map<string, GrokBackgroundTaskRecord>;
   /** `x.ai/tool` stamps keyed by ACP toolCallId. Completed updates drop `_meta`. */
   readonly xaiToolMetaByToolCallId: Map<string, XAiToolMeta>;
+  /** Turn that started each background task; later events attach to it only while it is still active. */
+  readonly backgroundTaskTurnIds: Map<string, TurnId>;
 }
 
 function settlePendingApprovalsAsCancelled(
@@ -1317,6 +1319,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             stopped: false,
             backgroundTasks: new Map(),
             xaiToolMetaByToolCallId: new Map(),
+            backgroundTaskTurnIds: new Map(),
           };
 
           const nf = yield* Stream.runDrain(
@@ -1366,16 +1369,35 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       toolCallId: event.toolCall.toolCallId,
                       rawInput: event.toolCall.data.rawInput,
                       rawOutput: event.toolCall.data.rawOutput,
+                      toolCallStatus: event.toolCall.status,
                     });
                     for (const backgroundEvent of backgroundEvents) {
                       const taskStamp = yield* makeEventStamp();
+                      const rawTaskId = backgroundEvent.payload.taskId;
+                      if (
+                        backgroundEvent.type === "task.started" &&
+                        notificationTurnId !== undefined
+                      ) {
+                        ctx.backgroundTaskTurnIds.set(rawTaskId, notificationTurnId);
+                      }
+                      // Attribute to the originating turn only while that turn
+                      // is still the active one; a task that outlives its turn
+                      // must not be billed to whatever turn runs next.
+                      const originTurnId = ctx.backgroundTaskTurnIds.get(rawTaskId);
+                      const taskTurnId =
+                        originTurnId !== undefined && originTurnId === notificationTurnId
+                          ? originTurnId
+                          : undefined;
+                      if (backgroundEvent.type === "task.completed") {
+                        ctx.backgroundTaskTurnIds.delete(rawTaskId);
+                      }
                       const taskBase = {
                         ...taskStamp,
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        ...(notificationTurnId !== undefined ? { turnId: notificationTurnId } : {}),
+                        ...(taskTurnId !== undefined ? { turnId: taskTurnId } : {}),
                       };
-                      const taskId = RuntimeTaskId.make(backgroundEvent.payload.taskId);
+                      const taskId = RuntimeTaskId.make(rawTaskId);
                       switch (backgroundEvent.type) {
                         case "task.started":
                           yield* offerRuntimeEvent({

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -9,6 +9,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   RuntimeRequestId,
+  RuntimeTaskId,
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -68,6 +69,14 @@ import {
   normalizeGrokReasoningEffort,
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
+import {
+  buildGrokBackgroundTaskEvents,
+  parseBackgroundTaskStarted,
+  rememberXAiToolMeta,
+  resolveCompletedXAiToolMeta,
+  type GrokBackgroundTaskRecord,
+  type XAiToolMeta,
+} from "../acp/XAiBackgroundTasks.ts";
 import {
   extractGrokPlanMarkdownFromToolCallData,
   extractXAiAskUserQuestions,
@@ -171,6 +180,10 @@ interface GrokSessionContext {
   currentModelId: string | undefined;
   currentReasoningEffort: string | undefined;
   stopped: boolean;
+  /** Remembered Grok background subagent/monitor identities for task linkage. */
+  readonly backgroundTasks: Map<string, GrokBackgroundTaskRecord>;
+  /** `x.ai/tool` stamps keyed by ACP toolCallId. Completed updates drop `_meta`. */
+  readonly xaiToolMetaByToolCallId: Map<string, XAiToolMeta>;
 }
 
 function settlePendingApprovalsAsCancelled(
@@ -1302,6 +1315,8 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 ? normalizeGrokReasoningEffort(requestedStartReasoningEffort)
                 : currentStartReasoningEffort,
             stopped: false,
+            backgroundTasks: new Map(),
+            xaiToolMetaByToolCallId: new Map(),
           };
 
           const nf = yield* Stream.runDrain(
@@ -1324,6 +1339,73 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 }
 
                 const notificationTurnId = resolveNotificationTurnId(ctx);
+                if (event._tag === "ToolCallUpdated" && !ctx.stopped) {
+                  rememberXAiToolMeta(
+                    ctx.xaiToolMetaByToolCallId,
+                    event.toolCall.toolCallId,
+                    event.rawPayload,
+                  );
+                  const terminal =
+                    event.toolCall.status === "completed" || event.toolCall.status === "failed";
+                  const backgroundStarted = parseBackgroundTaskStarted(
+                    event.toolCall.data.rawOutput,
+                  );
+                  if (terminal || backgroundStarted) {
+                    const toolMeta = resolveCompletedXAiToolMeta({
+                      cache: ctx.xaiToolMetaByToolCallId,
+                      toolCallId: event.toolCall.toolCallId,
+                      rawPayload: event.rawPayload,
+                      rawInput: event.toolCall.data.rawInput,
+                      rawOutput: event.toolCall.data.rawOutput,
+                      title: event.toolCall.title,
+                      command: event.toolCall.command,
+                    });
+                    const backgroundEvents = buildGrokBackgroundTaskEvents({
+                      tasks: ctx.backgroundTasks,
+                      toolMeta,
+                      toolCallId: event.toolCall.toolCallId,
+                      rawInput: event.toolCall.data.rawInput,
+                      rawOutput: event.toolCall.data.rawOutput,
+                    });
+                    for (const backgroundEvent of backgroundEvents) {
+                      const taskStamp = yield* makeEventStamp();
+                      const taskBase = {
+                        ...taskStamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        ...(notificationTurnId !== undefined ? { turnId: notificationTurnId } : {}),
+                      };
+                      const taskId = RuntimeTaskId.make(backgroundEvent.payload.taskId);
+                      switch (backgroundEvent.type) {
+                        case "task.started":
+                          yield* offerRuntimeEvent({
+                            ...taskBase,
+                            type: "task.started",
+                            payload: { ...backgroundEvent.payload, taskId },
+                          });
+                          break;
+                        case "task.progress":
+                          yield* offerRuntimeEvent({
+                            ...taskBase,
+                            type: "task.progress",
+                            payload: { ...backgroundEvent.payload, taskId },
+                          });
+                          break;
+                        case "task.completed":
+                          yield* offerRuntimeEvent({
+                            ...taskBase,
+                            type: "task.completed",
+                            payload: { ...backgroundEvent.payload, taskId },
+                          });
+                          break;
+                      }
+                    }
+                  }
+                  if (terminal) {
+                    ctx.xaiToolMetaByToolCallId.delete(event.toolCall.toolCallId);
+                  }
+                }
+
                 if (
                   notificationTurnId === undefined ||
                   ctx.interruptedTurnIds.has(notificationTurnId)

--- a/apps/server/src/provider/acp/XAiBackgroundTasks.test.ts
+++ b/apps/server/src/provider/acp/XAiBackgroundTasks.test.ts
@@ -254,6 +254,22 @@ describe("XAiBackgroundTasks", () => {
     }
   });
 
+  it("ignores a failed kill call and keeps the task live", () => {
+    const tasks = new Map([
+      ["shell-1", { taskType: "shell", description: "sleep 40", toolUseId: "call-1" }],
+    ]);
+    const events = buildGrokBackgroundTaskEvents({
+      tasks,
+      toolMeta: { name: "kill_command_or_subagent", kind: "kill_task_action" },
+      toolCallId: "call-kill-failed",
+      rawInput: { task_ids: ["shell-1"] },
+      rawOutput: { error: "no such task" },
+      toolCallStatus: "failed",
+    });
+    expect(events).toEqual([]);
+    expect(tasks.has("shell-1")).toBe(true);
+  });
+
   it("evicts the task map on kill completions", () => {
     const tasks = new Map();
     tasks.set("shell-1", { taskType: "shell", description: "sleep 40" });
@@ -263,6 +279,7 @@ describe("XAiBackgroundTasks", () => {
       toolCallId: "call-kill",
       rawInput: { task_ids: ["shell-1"] },
       rawOutput: {},
+      toolCallStatus: "completed",
     });
     expect(events).toEqual([
       {

--- a/apps/server/src/provider/acp/XAiBackgroundTasks.test.ts
+++ b/apps/server/src/provider/acp/XAiBackgroundTasks.test.ts
@@ -254,6 +254,27 @@ describe("XAiBackgroundTasks", () => {
     }
   });
 
+  it("skips orphan subagent poll rows instead of inventing a roster entry", () => {
+    const tasks = new Map();
+    const events = buildGrokBackgroundTaskEvents({
+      tasks,
+      toolMeta: { name: "get_command_or_subagent_output", kind: "background_task_action" },
+      toolCallId: "call-poll-orphan",
+      rawInput: { task_ids: ["01a06da3-71a7-7e50-a759-614f65dd1eb4"] },
+      rawOutput: {
+        type: "TaskOutput",
+        Result: {
+          task_id: "01a06da3-71a7-7e50-a759-614f65dd1eb4",
+          command: "[subagent:executor-cursor] Fix empty Sample Ops UI",
+          status: "running",
+        },
+      },
+      toolCallStatus: "completed",
+    });
+    expect(events).toEqual([]);
+    expect(tasks.size).toBe(0);
+  });
+
   it("ignores a failed kill call and keeps the task live", () => {
     const tasks = new Map([
       ["shell-1", { taskType: "shell", description: "sleep 40", toolUseId: "call-1" }],

--- a/apps/server/src/provider/acp/XAiBackgroundTasks.test.ts
+++ b/apps/server/src/provider/acp/XAiBackgroundTasks.test.ts
@@ -1,0 +1,381 @@
+import { it } from "@effect/vitest";
+import { describe, expect } from "vite-plus/test";
+
+import {
+  buildGrokBackgroundTaskEvents,
+  inferXAiToolMetaFromCompleted,
+  parseBackgroundTaskStarted,
+  parseKillTaskIds,
+  parseMonitorStart,
+  parseSpawnSubagentStart,
+  parseTaskOutputResults,
+  rememberXAiToolMeta,
+  resolveCompletedXAiToolMeta,
+  xaiToolMeta,
+} from "./XAiBackgroundTasks.ts";
+
+const spawnOutputText = [
+  "Subagent started in background.",
+  "subagent_id: 01a05f6b-5076-7303-b3a5-03d743b8de9b",
+  "type: executor-cursor",
+  "description: T3 Grok background task mapper",
+].join("\n");
+
+describe("XAiBackgroundTasks", () => {
+  it("parses x.ai background task tool metadata and lifecycle payloads", () => {
+    const spawnRawPayload = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        _meta: {
+          "x.ai/tool": {
+            version: 1,
+            name: "spawn_subagent",
+            kind: "task",
+            namespace: "grok_build",
+            label: "Subagent",
+            read_only: false,
+          },
+        },
+        rawOutput: { type: "Text", text: spawnOutputText },
+        status: "completed",
+        toolCallId: "call-spawn-1",
+      },
+    };
+
+    expect(xaiToolMeta(spawnRawPayload)).toEqual({
+      name: "spawn_subagent",
+      kind: "task",
+    });
+    expect(parseSpawnSubagentStart(spawnRawPayload.update.rawOutput)).toEqual({
+      subagentId: "01a05f6b-5076-7303-b3a5-03d743b8de9b",
+      subagentType: "executor-cursor",
+      description: "T3 Grok background task mapper",
+    });
+
+    const monitorRawInput = {
+      description: "Watch count-sheet Typst unit until done/fail/stall",
+    };
+    const monitorRawOutput = {
+      type: "Monitor",
+      taskId: "01a05f41-5107-7550-821e-79e8d1cd7687",
+      timeoutMs: 36_000_000,
+      persistent: false,
+    };
+    expect(parseMonitorStart(monitorRawInput, monitorRawOutput)).toEqual({
+      taskId: "01a05f41-5107-7550-821e-79e8d1cd7687",
+      description: "Watch count-sheet Typst unit until done/fail/stall",
+      timeoutMs: 36_000_000,
+    });
+
+    expect(
+      parseTaskOutputResults({
+        type: "TaskOutput",
+        Result: {
+          task_id: "01a05f6b-5076-7303-b3a5-03d743b8de9b",
+          command: "sleep 40; echo done-a",
+          status: "running",
+          exit_code: null,
+          output: "still running",
+        },
+      }),
+    ).toEqual([
+      {
+        taskId: "01a05f6b-5076-7303-b3a5-03d743b8de9b",
+        command: "sleep 40; echo done-a",
+        lifecycle: "running",
+        output: "still running",
+        summary: "still running",
+      },
+    ]);
+
+    expect(parseKillTaskIds({ task_id: "call-87feed80-6aa1-47b5-87d5-199396c432ba-124" })).toEqual([
+      "call-87feed80-6aa1-47b5-87d5-199396c432ba-124",
+    ]);
+    expect(
+      parseKillTaskIds({
+        variant: "KillTask",
+        task_ids: ["task-a", "task-b"],
+      }),
+    ).toEqual(["task-a", "task-b"]);
+  });
+
+  it("does not infer spawn_subagent from output shape alone", () => {
+    expect(
+      inferXAiToolMetaFromCompleted({
+        cache: new Map(),
+        toolCallId: "call-spawn",
+        rawInput: {},
+        rawOutput: { type: "Text", text: spawnOutputText },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("infers spawn_subagent only from rawInput or title", () => {
+    expect(
+      inferXAiToolMetaFromCompleted({
+        cache: new Map(),
+        toolCallId: "call-spawn",
+        rawInput: { subagent_type: "executor-cursor" },
+        rawOutput: { type: "Text", text: spawnOutputText },
+      }),
+    ).toEqual({ name: "spawn_subagent", kind: "task" });
+    expect(
+      inferXAiToolMetaFromCompleted({
+        cache: new Map(),
+        toolCallId: "call-spawn",
+        rawInput: { variant: "Task" },
+        rawOutput: { type: "Text", text: spawnOutputText },
+      }),
+    ).toEqual({ name: "spawn_subagent", kind: "task" });
+    expect(
+      inferXAiToolMetaFromCompleted({
+        cache: new Map(),
+        toolCallId: "call-spawn",
+        rawInput: {},
+        rawOutput: { type: "Text", text: spawnOutputText },
+        title: "spawn_subagent",
+      }),
+    ).toEqual({ name: "spawn_subagent", kind: "task" });
+  });
+
+  it("does not map spawn_subagent completions to task events", () => {
+    const started = buildGrokBackgroundTaskEvents({
+      tasks: new Map(),
+      toolMeta: { name: "spawn_subagent", kind: "task" },
+      toolCallId: "call-spawn-1",
+      rawInput: { variant: "Task", subagent_type: "executor-cursor" },
+      rawOutput: { type: "Text", text: spawnOutputText },
+    });
+    expect(started).toEqual([]);
+  });
+
+  it("maps monitor completion to task.started", () => {
+    const tasks = new Map();
+    const started = buildGrokBackgroundTaskEvents({
+      tasks,
+      toolMeta: { name: "monitor", kind: "task" },
+      toolCallId: "call-monitor-1",
+      rawInput: { description: "Watch the unit" },
+      rawOutput: {
+        type: "Monitor",
+        taskId: "monitor-1",
+        timeoutMs: 1_000,
+      },
+    });
+    expect(started).toEqual([
+      {
+        type: "task.started",
+        payload: {
+          taskId: "monitor-1",
+          description: "Watch the unit",
+          title: "Watch the unit",
+          taskType: "monitor",
+          toolUseId: "call-monitor-1",
+        },
+      },
+    ]);
+    expect(tasks.get("monitor-1")?.taskType).toBe("monitor");
+  });
+
+  it("emits task.started then task.progress for an orphan running poll", () => {
+    const tasks = new Map();
+    const events = buildGrokBackgroundTaskEvents({
+      tasks,
+      toolMeta: { name: "get_command_or_subagent_output", kind: "background_task_action" },
+      toolCallId: "call-poll-running",
+      rawInput: { variant: "TaskOutput", task_ids: ["shell-1"] },
+      rawOutput: {
+        type: "TaskOutput",
+        Result: {
+          task_id: "shell-1",
+          command: "sleep 40; echo done-a",
+          status: "running",
+          exit_code: null,
+          output: "still going",
+        },
+      },
+    });
+    expect(events.map((event) => event.type)).toEqual(["task.started", "task.progress"]);
+    expect(events[0]?.payload.taskType).toBe("shell");
+    expect(events[0]?.payload.description).toBe("sleep 40; echo done-a");
+    expect(tasks.has("shell-1")).toBe(true);
+  });
+
+  it("emits task.started then task.completed for an orphan terminal poll", () => {
+    const tasks = new Map();
+    const events = buildGrokBackgroundTaskEvents({
+      tasks,
+      toolMeta: { name: "get_command_or_subagent_output", kind: "background_task_action" },
+      toolCallId: "call-poll-done",
+      rawInput: { variant: "TaskOutput", task_ids: ["shell-1"] },
+      rawOutput: {
+        type: "TaskOutput",
+        Result: {
+          task_id: "shell-1",
+          command: "sleep 40; echo done-a",
+          status: "completed",
+          exit_code: 0,
+          output: "done-a",
+        },
+      },
+    });
+    expect(events.map((event) => event.type)).toEqual(["task.started", "task.completed"]);
+    expect(events[1]?.type === "task.completed" && events[1].payload.status).toBe("completed");
+    expect(tasks.has("shell-1")).toBe(false);
+  });
+
+  it("preserves stopped/killed/cancelled as task.completed status stopped", () => {
+    for (const status of ["stopped", "killed", "cancelled"] as const) {
+      const tasks = new Map();
+      tasks.set("shell-1", { taskType: "shell", description: "sleep 40" });
+      const events = buildGrokBackgroundTaskEvents({
+        tasks,
+        toolMeta: { name: "get_command_or_subagent_output", kind: "background_task_action" },
+        toolCallId: "call-poll-stopped",
+        rawInput: { variant: "TaskOutput", task_ids: ["shell-1"] },
+        rawOutput: {
+          type: "TaskOutput",
+          Result: {
+            task_id: "shell-1",
+            command: "sleep 40",
+            status,
+            exit_code: 137,
+            output: "killed",
+          },
+        },
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]?.type).toBe("task.completed");
+      if (events[0]?.type === "task.completed") {
+        expect(events[0].payload.status).toBe("stopped");
+      }
+      expect(tasks.has("shell-1")).toBe(false);
+    }
+  });
+
+  it("evicts the task map on kill completions", () => {
+    const tasks = new Map();
+    tasks.set("shell-1", { taskType: "shell", description: "sleep 40" });
+    const events = buildGrokBackgroundTaskEvents({
+      tasks,
+      toolMeta: { name: "kill_command_or_subagent", kind: "kill_task_action" },
+      toolCallId: "call-kill",
+      rawInput: { task_ids: ["shell-1"] },
+      rawOutput: {},
+    });
+    expect(events).toEqual([
+      {
+        type: "task.completed",
+        payload: {
+          taskId: "shell-1",
+          description: "sleep 40",
+          title: "sleep 40",
+          taskType: "shell",
+          status: "stopped",
+        },
+      },
+    ]);
+    expect(tasks.size).toBe(0);
+  });
+
+  it("maps BackgroundTaskStarted to task.started shell without tool meta", () => {
+    const tasks = new Map();
+    const toolCallId = "call-fb9d-26";
+    const events = buildGrokBackgroundTaskEvents({
+      tasks,
+      toolCallId,
+      rawInput: { command: "sleep 40; echo done-a" },
+      rawOutput: {
+        type: "BackgroundTaskStarted",
+        task_id: toolCallId,
+        task_type: "bash",
+        status: "running",
+        command: "sleep 40; echo done-a",
+      },
+    });
+    expect(events).toEqual([
+      {
+        type: "task.started",
+        payload: {
+          taskId: toolCallId,
+          description: "sleep 40; echo done-a",
+          title: "sleep 40; echo done-a",
+          taskType: "shell",
+          toolUseId: toolCallId,
+        },
+      },
+    ]);
+    expect(
+      parseBackgroundTaskStarted({ type: "BackgroundTaskStarted", task_id: toolCallId }),
+    ).toBeUndefined();
+  });
+
+  it("infers monitor and poll tools from distinctive completed shapes", () => {
+    const empty = new Map();
+    expect(
+      inferXAiToolMetaFromCompleted({
+        cache: empty,
+        toolCallId: "call-monitor",
+        rawInput: { description: "Watch count-sheet Typst unit until done/fail/stall" },
+        rawOutput: {
+          type: "Monitor",
+          taskId: "01a05f41-5107-7550-821e-79e8d1cd7687",
+          timeoutMs: 36_000_000,
+        },
+      }),
+    ).toEqual({ name: "monitor", kind: "task" });
+
+    expect(
+      inferXAiToolMetaFromCompleted({
+        cache: empty,
+        toolCallId: "call-poll",
+        rawInput: { variant: "TaskOutput", task_ids: ["shell-1"] },
+        rawOutput: {
+          type: "TaskOutput",
+          Result: {
+            task_id: "shell-1",
+            command: "sleep 40",
+            status: "running",
+            exit_code: null,
+            output: "still",
+          },
+        },
+      }),
+    ).toEqual({ name: "get_command_or_subagent_output", kind: "background_task_action" });
+
+    expect(
+      inferXAiToolMetaFromCompleted({
+        cache: empty,
+        toolCallId: "call-kill",
+        rawInput: { task_id: "task-a" },
+        rawOutput: undefined,
+        title: "kill_command_or_subagent",
+      }),
+    ).toEqual({ name: "kill_command_or_subagent", kind: "kill_task_action" });
+  });
+
+  it("resolves monitor meta from cache when completed drops _meta", () => {
+    const cache = new Map();
+    const toolCallId = "call-monitor-1";
+    rememberXAiToolMeta(cache, toolCallId, {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        _meta: { "x.ai/tool": { name: "monitor", kind: "task" } },
+        toolCallId,
+      },
+    });
+    const toolMeta = resolveCompletedXAiToolMeta({
+      cache,
+      toolCallId,
+      rawPayload: {
+        sessionId: "session-1",
+        update: { sessionUpdate: "tool_call_update", status: "completed", toolCallId },
+      },
+      rawInput: { description: "Watch" },
+      rawOutput: { type: "Monitor", taskId: "monitor-1", timeoutMs: 1 },
+    });
+    expect(toolMeta).toEqual({ name: "monitor", kind: "task" });
+  });
+});

--- a/apps/server/src/provider/acp/XAiBackgroundTasks.ts
+++ b/apps/server/src/provider/acp/XAiBackgroundTasks.ts
@@ -1,0 +1,528 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const text = value?.trim();
+  return text && text.length > 0 ? text : undefined;
+}
+
+function sessionUpdateFromRawPayload(rawPayload: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(rawPayload)) {
+    return undefined;
+  }
+  const update = rawPayload.update;
+  return isRecord(update) ? update : undefined;
+}
+
+export interface XAiToolMeta {
+  readonly name: string;
+  readonly kind: string;
+}
+
+/** Read Grok's `x.ai/tool` stamp from a session/update notification payload. */
+export function xaiToolMeta(rawPayload: unknown): XAiToolMeta | undefined {
+  const update = sessionUpdateFromRawPayload(rawPayload);
+  if (!update) {
+    return undefined;
+  }
+  const meta = update._meta;
+  if (!isRecord(meta)) {
+    return undefined;
+  }
+  const tool = meta["x.ai/tool"];
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  const name = trimmed(typeof tool.name === "string" ? tool.name : undefined);
+  const kind = trimmed(typeof tool.kind === "string" ? tool.kind : undefined);
+  if (!name || !kind) {
+    return undefined;
+  }
+  return { name, kind };
+}
+
+/** Store `x.ai/tool` from a tool_call / tool_call_update so later completed updates can reuse it. */
+export function rememberXAiToolMeta(
+  cache: Map<string, XAiToolMeta>,
+  toolCallId: string,
+  rawPayload: unknown,
+): void {
+  const meta = xaiToolMeta(rawPayload);
+  if (meta) {
+    cache.set(toolCallId, meta);
+  }
+}
+
+function looksLikeKill(title: string | undefined, command: string | undefined): boolean {
+  const haystack = `${title ?? ""} ${command ?? ""}`.toLowerCase();
+  return haystack.includes("kill");
+}
+
+/**
+ * Infer a background-tool stamp from completed rawInput/rawOutput when `_meta` was dropped.
+ * Kill is gated: `task_ids`/`task_id` alone are not distinctive (polls use the same fields).
+ */
+function looksLikeSpawnSubagentInput(rawInput: unknown, title: string | undefined): boolean {
+  if (trimmed(title) === "spawn_subagent") {
+    return true;
+  }
+  if (!isRecord(rawInput)) {
+    return false;
+  }
+  return typeof rawInput.subagent_type === "string" || rawInput.variant === "Task";
+}
+
+export function inferXAiToolMetaFromCompleted(input: {
+  readonly cache: ReadonlyMap<string, XAiToolMeta>;
+  readonly toolCallId: string;
+  readonly rawInput: unknown;
+  readonly rawOutput: unknown;
+  readonly title?: string | undefined;
+  readonly command?: string | undefined;
+}): XAiToolMeta | undefined {
+  if (looksLikeSpawnSubagentInput(input.rawInput, input.title)) {
+    return { name: "spawn_subagent", kind: "task" };
+  }
+  if (parseMonitorStart(input.rawInput, input.rawOutput)) {
+    return { name: "monitor", kind: "task" };
+  }
+  if (parseTaskOutputResults(input.rawOutput).length > 0) {
+    return { name: "get_command_or_subagent_output", kind: "background_task_action" };
+  }
+  if (parseKillTaskIds(input.rawInput).length === 0) {
+    return undefined;
+  }
+  const cachedName = input.cache.get(input.toolCallId)?.name;
+  if (cachedName === "kill_command_or_subagent" || looksLikeKill(input.title, input.command)) {
+    return { name: "kill_command_or_subagent", kind: "kill_task_action" };
+  }
+  return undefined;
+}
+
+/** Resolve the completed-tool stamp: live `_meta`, then cache, then distinctive rawOutput/rawInput. */
+export function resolveCompletedXAiToolMeta(input: {
+  readonly cache: ReadonlyMap<string, XAiToolMeta>;
+  readonly toolCallId: string;
+  readonly rawPayload: unknown;
+  readonly rawInput: unknown;
+  readonly rawOutput: unknown;
+  readonly title?: string | undefined;
+  readonly command?: string | undefined;
+}): XAiToolMeta | undefined {
+  return (
+    xaiToolMeta(input.rawPayload) ??
+    input.cache.get(input.toolCallId) ??
+    inferXAiToolMetaFromCompleted(input)
+  );
+}
+
+export interface SpawnSubagentStart {
+  readonly subagentId: string;
+  readonly subagentType: string;
+  readonly description: string;
+}
+
+function spawnSubagentTextFromOutput(rawOutput: unknown): string | undefined {
+  if (typeof rawOutput === "string") {
+    return rawOutput;
+  }
+  if (!isRecord(rawOutput)) {
+    return undefined;
+  }
+  if (typeof rawOutput.text === "string") {
+    return rawOutput.text;
+  }
+  return undefined;
+}
+
+/** Parse spawn_subagent completion text into subagent identity fields. */
+export function parseSpawnSubagentStart(rawOutput: unknown): SpawnSubagentStart | undefined {
+  const text = spawnSubagentTextFromOutput(rawOutput);
+  if (!text) {
+    return undefined;
+  }
+  const lines = text.split("\n");
+  let subagentId: string | undefined;
+  let subagentType: string | undefined;
+  let description: string | undefined;
+  for (const line of lines) {
+    const match = /^(\w+):\s*(.+)$/.exec(line.trim());
+    if (!match) {
+      continue;
+    }
+    const [, key, value] = match;
+    switch (key) {
+      case "subagent_id":
+        subagentId = trimmed(value);
+        break;
+      case "type":
+        subagentType = trimmed(value);
+        break;
+      case "description":
+        description = trimmed(value);
+        break;
+      default:
+        break;
+    }
+  }
+  if (!subagentId || !subagentType || !description) {
+    return undefined;
+  }
+  return { subagentId, subagentType, description };
+}
+
+export interface MonitorStart {
+  readonly taskId: string;
+  readonly description: string;
+  readonly timeoutMs: number;
+}
+
+/** Parse monitor tool completion into a background monitor task identity. */
+export function parseMonitorStart(rawInput: unknown, rawOutput: unknown): MonitorStart | undefined {
+  if (!isRecord(rawOutput) || rawOutput.type !== "Monitor") {
+    return undefined;
+  }
+  const taskId = trimmed(typeof rawOutput.taskId === "string" ? rawOutput.taskId : undefined);
+  if (!taskId) {
+    return undefined;
+  }
+  const timeoutMs =
+    typeof rawOutput.timeoutMs === "number" && Number.isFinite(rawOutput.timeoutMs)
+      ? rawOutput.timeoutMs
+      : 0;
+  const description =
+    trimmed(
+      isRecord(rawInput) && typeof rawInput.description === "string"
+        ? rawInput.description
+        : undefined,
+    ) ?? "Monitor";
+  return { taskId, description, timeoutMs };
+}
+
+export type TaskOutputLifecycle = "running" | "completed" | "failed" | "stopped";
+
+export interface TaskOutputResult {
+  readonly taskId: string;
+  readonly command: string;
+  readonly lifecycle: TaskOutputLifecycle;
+  readonly output: string;
+  readonly summary: string | undefined;
+}
+
+function normalizeTaskOutputLifecycle(
+  status: unknown,
+  exitCode: unknown,
+): TaskOutputLifecycle | undefined {
+  const normalizedStatus = typeof status === "string" ? status.trim().toLowerCase() : "";
+  if (normalizedStatus === "running" || normalizedStatus === "pending") {
+    return "running";
+  }
+  if (
+    normalizedStatus === "completed" ||
+    normalizedStatus === "success" ||
+    normalizedStatus === "succeeded"
+  ) {
+    return "completed";
+  }
+  if (normalizedStatus === "failed" || normalizedStatus === "error") {
+    return "failed";
+  }
+  if (
+    normalizedStatus === "stopped" ||
+    normalizedStatus === "killed" ||
+    normalizedStatus === "cancelled"
+  ) {
+    return "stopped";
+  }
+  if (typeof exitCode === "number" && Number.isFinite(exitCode)) {
+    return exitCode === 0 ? "completed" : "failed";
+  }
+  return undefined;
+}
+
+function firstLine(text: string): string | undefined {
+  const line = text
+    .split("\n")
+    .find((entry) => entry.trim().length > 0)
+    ?.trim();
+  return line && line.length > 0 ? line : undefined;
+}
+
+function parseTaskOutputEntry(entry: unknown): TaskOutputResult | undefined {
+  if (!isRecord(entry)) {
+    return undefined;
+  }
+  const taskId = trimmed(typeof entry.task_id === "string" ? entry.task_id : undefined);
+  const command = trimmed(typeof entry.command === "string" ? entry.command : undefined);
+  const lifecycle = normalizeTaskOutputLifecycle(entry.status, entry.exit_code);
+  if (!taskId || !command || !lifecycle) {
+    return undefined;
+  }
+  const output = typeof entry.output === "string" ? entry.output : "";
+  return {
+    taskId,
+    command,
+    lifecycle,
+    output,
+    summary: firstLine(output),
+  };
+}
+
+/** Parse get_command_or_subagent_output completion into per-task poll rows. */
+export function parseTaskOutputResults(rawOutput: unknown): ReadonlyArray<TaskOutputResult> {
+  if (!isRecord(rawOutput) || rawOutput.type !== "TaskOutput") {
+    return [];
+  }
+  const multi = rawOutput.MultiResult;
+  if (isRecord(multi) && Array.isArray(multi.results)) {
+    return multi.results.flatMap((entry) => {
+      const parsed = parseTaskOutputEntry(entry);
+      return parsed ? [parsed] : [];
+    });
+  }
+  const single = rawOutput.Result;
+  const parsed = parseTaskOutputEntry(single);
+  return parsed ? [parsed] : [];
+}
+
+const MAX_TASK_DESCRIPTION_CHARS = 200;
+
+function truncatedFirstLine(text: string): string {
+  const line = firstLine(text) ?? text.trim();
+  if (line.length <= MAX_TASK_DESCRIPTION_CHARS) {
+    return line;
+  }
+  return line.slice(0, MAX_TASK_DESCRIPTION_CHARS);
+}
+
+export interface BackgroundTaskStarted {
+  readonly taskId: string;
+  readonly command: string;
+  readonly summary: string | undefined;
+}
+
+/** Parse Grok auto-backgrounded shell `rawOutput.type === "BackgroundTaskStarted"`. */
+export function parseBackgroundTaskStarted(rawOutput: unknown): BackgroundTaskStarted | undefined {
+  if (!isRecord(rawOutput) || rawOutput.type !== "BackgroundTaskStarted") {
+    return undefined;
+  }
+  const taskId =
+    trimmed(typeof rawOutput.task_id === "string" ? rawOutput.task_id : undefined) ??
+    trimmed(typeof rawOutput.taskId === "string" ? rawOutput.taskId : undefined);
+  const command = trimmed(typeof rawOutput.command === "string" ? rawOutput.command : undefined);
+  if (!taskId || !command) {
+    return undefined;
+  }
+  const summary = trimmed(typeof rawOutput.summary === "string" ? rawOutput.summary : undefined);
+  return { taskId, command, summary };
+}
+
+/** Parse kill_command_or_subagent rawInput into task ids to stop. */
+export function parseKillTaskIds(rawInput: unknown): ReadonlyArray<string> {
+  if (!isRecord(rawInput)) {
+    return [];
+  }
+  const fromList = rawInput.task_ids;
+  if (Array.isArray(fromList)) {
+    return fromList.flatMap((entry) => {
+      const id = trimmed(typeof entry === "string" ? entry : undefined);
+      return id ? [id] : [];
+    });
+  }
+  const single = trimmed(typeof rawInput.task_id === "string" ? rawInput.task_id : undefined);
+  return single ? [single] : [];
+}
+
+export interface GrokBackgroundTaskRecord {
+  readonly taskType: string;
+  readonly description: string;
+  readonly role?: string;
+  readonly toolUseId?: string;
+}
+
+export interface GrokBackgroundTaskEventBase {
+  readonly taskId: string;
+  readonly description: string;
+  readonly title: string;
+  readonly taskType: string;
+  readonly role?: string;
+  readonly toolUseId?: string;
+}
+
+export type GrokBackgroundTaskRuntimeEvent =
+  | { readonly type: "task.started"; readonly payload: GrokBackgroundTaskEventBase }
+  | {
+      readonly type: "task.progress";
+      readonly payload: GrokBackgroundTaskEventBase & {
+        readonly summary?: string;
+      };
+    }
+  | {
+      readonly type: "task.completed";
+      readonly payload: GrokBackgroundTaskEventBase & {
+        readonly status: "completed" | "failed" | "stopped";
+        readonly summary?: string;
+      };
+    };
+
+function linkageFor(
+  tasks: Map<string, GrokBackgroundTaskRecord>,
+  taskId: string,
+  fallbackDescription?: string,
+): GrokBackgroundTaskEventBase {
+  const known = tasks.get(taskId);
+  const description = known?.description ?? fallbackDescription ?? taskId;
+  return {
+    taskId,
+    description,
+    title: description,
+    taskType: known?.taskType ?? "shell",
+    ...(known?.role ? { role: known.role } : {}),
+    ...(known?.toolUseId ? { toolUseId: known.toolUseId } : {}),
+  };
+}
+
+function inferTaskTypeFromCommand(command: string): string {
+  if (command.startsWith("[subagent:")) {
+    return "subagent";
+  }
+  if (command.startsWith("[monitor:")) {
+    return "monitor";
+  }
+  return "shell";
+}
+
+function evictCompletedTask(
+  tasks: Map<string, GrokBackgroundTaskRecord>,
+  taskId: string,
+  fallbackDescription: string | undefined,
+  status: "completed" | "failed" | "stopped",
+  summary: string | undefined,
+): GrokBackgroundTaskRuntimeEvent {
+  const linkage = linkageFor(tasks, taskId, fallbackDescription);
+  tasks.delete(taskId);
+  return {
+    type: "task.completed",
+    payload: {
+      ...linkage,
+      status,
+      ...(summary ? { summary } : {}),
+    },
+  };
+}
+
+function inferRoleFromCommand(command: string): string | undefined {
+  const match = /^\[subagent:([^\]]+)\]/.exec(command);
+  return match?.[1] ? trimmed(match[1]) : undefined;
+}
+
+/**
+ * Synthesize task.* runtime events from a Grok background-tool call.
+ * Mutates `tasks` so later poll/kill rows carry linkage fields.
+ * Subagent spawn is owned by #8412; this mapper covers monitors and shells.
+ */
+export function buildGrokBackgroundTaskEvents(input: {
+  readonly tasks: Map<string, GrokBackgroundTaskRecord>;
+  readonly toolMeta?: XAiToolMeta | undefined;
+  readonly toolCallId: string;
+  readonly rawInput: unknown;
+  readonly rawOutput: unknown;
+}): ReadonlyArray<GrokBackgroundTaskRuntimeEvent> {
+  const { tasks, toolMeta, toolCallId, rawInput, rawOutput } = input;
+
+  const backgroundStarted = parseBackgroundTaskStarted(rawOutput);
+  if (backgroundStarted) {
+    if (tasks.has(backgroundStarted.taskId)) {
+      return [];
+    }
+    const description = truncatedFirstLine(backgroundStarted.command);
+    tasks.set(backgroundStarted.taskId, {
+      taskType: "shell",
+      description,
+      toolUseId: toolCallId,
+    });
+    return [
+      {
+        type: "task.started",
+        payload: {
+          taskId: backgroundStarted.taskId,
+          description,
+          title: description,
+          taskType: "shell",
+          toolUseId: toolCallId,
+        },
+      },
+    ];
+  }
+
+  switch (toolMeta?.name) {
+    case "monitor": {
+      const start = parseMonitorStart(rawInput, rawOutput);
+      if (!start) {
+        return [];
+      }
+      tasks.set(start.taskId, {
+        taskType: "monitor",
+        description: start.description,
+        toolUseId: toolCallId,
+      });
+      return [
+        {
+          type: "task.started",
+          payload: {
+            taskId: start.taskId,
+            description: start.description,
+            title: start.description,
+            taskType: "monitor",
+            toolUseId: toolCallId,
+          },
+        },
+      ];
+    }
+    case "get_command_or_subagent_output":
+      return parseTaskOutputResults(rawOutput).flatMap((result) => {
+        const inferredType = inferTaskTypeFromCommand(result.command);
+        const inferredRole = inferRoleFromCommand(result.command);
+        const existing = tasks.get(result.taskId);
+        const events: GrokBackgroundTaskRuntimeEvent[] = [];
+        if (!existing) {
+          tasks.set(result.taskId, {
+            taskType: inferredType,
+            description: result.command,
+            ...(inferredRole ? { role: inferredRole } : {}),
+          });
+          events.push({
+            type: "task.started",
+            payload: linkageFor(tasks, result.taskId, result.command),
+          });
+        }
+        if (result.lifecycle === "running") {
+          events.push({
+            type: "task.progress",
+            payload: {
+              ...linkageFor(tasks, result.taskId, result.command),
+              ...(result.summary ? { summary: result.summary } : {}),
+            },
+          });
+          return events;
+        }
+        events.push(
+          evictCompletedTask(
+            tasks,
+            result.taskId,
+            result.command,
+            result.lifecycle,
+            result.summary,
+          ),
+        );
+        return events;
+      });
+    case "kill_command_or_subagent":
+      return parseKillTaskIds(rawInput).map((taskId) =>
+        evictCompletedTask(tasks, taskId, undefined, "stopped", undefined),
+      );
+    default:
+      return [];
+  }
+}

--- a/apps/server/src/provider/acp/XAiBackgroundTasks.ts
+++ b/apps/server/src/provider/acp/XAiBackgroundTasks.ts
@@ -488,6 +488,11 @@ export function buildGrokBackgroundTaskEvents(input: {
         const inferredRole = inferRoleFromCommand(result.command);
         const existing = tasks.get(result.taskId);
         const events: GrokBackgroundTaskRuntimeEvent[] = [];
+        if (!existing && inferredType === "subagent") {
+          // Subagent identity is established by #8412, not here. An orphan
+          // poll row must not invent a subagent roster entry.
+          return events;
+        }
         if (!existing) {
           tasks.set(result.taskId, {
             taskType: inferredType,

--- a/apps/server/src/provider/acp/XAiBackgroundTasks.ts
+++ b/apps/server/src/provider/acp/XAiBackgroundTasks.ts
@@ -428,8 +428,10 @@ export function buildGrokBackgroundTaskEvents(input: {
   readonly toolCallId: string;
   readonly rawInput: unknown;
   readonly rawOutput: unknown;
+  /** ACP tool-call status. A failed kill call must not retire the task. */
+  readonly toolCallStatus?: "pending" | "inProgress" | "completed" | "failed" | undefined;
 }): ReadonlyArray<GrokBackgroundTaskRuntimeEvent> {
-  const { tasks, toolMeta, toolCallId, rawInput, rawOutput } = input;
+  const { tasks, toolMeta, toolCallId, rawInput, rawOutput, toolCallStatus } = input;
 
   const backgroundStarted = parseBackgroundTaskStarted(rawOutput);
   if (backgroundStarted) {
@@ -519,6 +521,9 @@ export function buildGrokBackgroundTaskEvents(input: {
         return events;
       });
     case "kill_command_or_subagent":
+      if (toolCallStatus !== "completed") {
+        return [];
+      }
       return parseKillTaskIds(rawInput).map((taskId) =>
         evictCompletedTask(tasks, taskId, undefined, "stopped", undefined),
       );


### PR DESCRIPTION
grok monitors and background shells outlive their turns, but without task lifecycle events t3 shows them as idle and can reap the live session. map grok's discriminated tool results directly to the existing task events, with one map for live task identity and originating turn. completion and successful kills clear monitoring; failed or already-exited kills do not falsely mark tasks stopped.

verified with 96 focused tests, server typecheck, scoped lint and formatting on blacksmith. authenticated grok 1.0.30 in the real t3 web client exercised monitor/shell starts, automatic completion, mixed polling across turns, and explicit cancellation.

known limitation: the existing t3 stop button sends turn cancellation rather than killing a background monitor. grok's explicit kill tool works; changing that control is outside this lifecycle-mapping change.

![authenticated grok monitor being killed and returning to idle](https://uploads-production-47e4.up.railway.app/files/d95a41e1-5f33-4b9d-a9be-dbb490bb15f9/pr9139-monitor-kill-final.gif)

model: `gpt-6-astra`; harness: codex.
