### PR TITLE
feat(files): open markdown, HTML, and PDF files outside the workspace

### DIFF
--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -60,6 +60,7 @@ import { WorkspaceFileVideoPreview } from "./WorkspaceFileVideoPreview";
 import { WorkspaceFileWebPreview } from "./WorkspaceFileWebPreview";
 import {
   basename,
+  isAbsolutePath,
   isMarkdownPreviewFile,
   isSvgImagePreviewFile,
   isVideoPreviewFile,
@@ -783,7 +784,10 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
   }
 
   const parentDir = relativePath.split("/").slice(0, -1).join("/");
-  const headerSubtitle = [projectName, parentDir].filter(Boolean).join(" · ");
+  // A host file outside the workspace is not under the project name.
+  const headerSubtitle = isAbsolutePath(relativePath)
+    ? parentDir
+    : [projectName, parentDir].filter(Boolean).join(" · ");
 
   return (
     <ReviewHighlighterProvider>

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -783,7 +783,10 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
     );
   }
 
-  const parentDir = relativePath.split("/").slice(0, -1).join("/");
+  const parentDir = relativePath.slice(
+    0,
+    Math.max(relativePath.lastIndexOf("/"), relativePath.lastIndexOf("\\"), 0),
+  );
   // A host file outside the workspace is not under the project name.
   const headerSubtitle = isAbsolutePath(relativePath)
     ? parentDir

--- a/apps/mobile/src/features/files/filePath.test.ts
+++ b/apps/mobile/src/features/files/filePath.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { isSvgImagePreviewFile, resolveWorkspaceRelativeFilePath } from "./filePath";
+import {
+  fileRoutePathSegments,
+  isSvgImagePreviewFile,
+  resolveWorkspaceRelativeFilePath,
+} from "./filePath";
+
+describe("fileRoutePathSegments", () => {
+  it("round-trips workspace-relative and host paths through the route", () => {
+    expect(fileRoutePathSegments("src/main.ts")).toEqual(["src", "main.ts"]);
+    expect(fileRoutePathSegments("/tmp/t3-cleanup/report.md").join("/")).toBe(
+      "/tmp/t3-cleanup/report.md",
+    );
+  });
+});
 
 describe("resolveWorkspaceRelativeFilePath", () => {
   it("keeps normalized workspace-relative paths", () => {

--- a/apps/mobile/src/features/files/filePath.ts
+++ b/apps/mobile/src/features/files/filePath.ts
@@ -10,8 +10,15 @@ function isWindowsAbsolutePath(value: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
 }
 
-function isAbsolutePath(value: string): boolean {
+/** A file route holding an absolute path shows a host file outside the workspace. */
+export function isAbsolutePath(value: string): boolean {
   return value.startsWith("/") || isWindowsAbsolutePath(value);
+}
+
+/** Route segments that `normalizeRoutePath` joins back into the same path, root included. */
+export function fileRoutePathSegments(path: string): string[] {
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  return path.startsWith("/") ? ["", ...segments] : segments;
 }
 
 function isWindowsPathStyle(value: string): boolean {

--- a/apps/mobile/src/features/files/workspaceFileAssetUrl.ts
+++ b/apps/mobile/src/features/files/workspaceFileAssetUrl.ts
@@ -2,7 +2,7 @@ import type { AssetResource, EnvironmentId, ThreadId } from "@t3tools/contracts"
 import { useMemo } from "react";
 
 import { useAssetUrlState, useRefreshAssetUrl } from "../../state/assets";
-import { isVideoPreviewFile, resolveWorkspaceFilePath } from "./filePath";
+import { isAbsolutePath, isVideoPreviewFile, resolveWorkspaceFilePath } from "./filePath";
 
 export function useWorkspaceFileAssetUrlState(props: {
   readonly cwd: string | null;
@@ -18,16 +18,22 @@ export function useWorkspaceFileAssetUrlState(props: {
     [props.cwd, props.relativePath],
   );
 
+  // Videos stream from an exact-file URL, and so does anything outside the
+  // workspace, where no workspace-scoped URL can exist.
+  const relativePath = props.relativePath;
   const resource = useMemo<AssetResource | null>(
     () =>
-      absolutePath !== null && props.threadId !== null
+      absolutePath !== null && relativePath !== null && props.threadId !== null
         ? {
-            _tag: isVideoPreviewFile(absolutePath) ? "media-file" : "workspace-file",
+            _tag:
+              isVideoPreviewFile(absolutePath) || isAbsolutePath(relativePath)
+                ? "media-file"
+                : "workspace-file",
             threadId: props.threadId,
             path: absolutePath,
           }
         : null,
-    [absolutePath, props.threadId],
+    [absolutePath, relativePath, props.threadId],
   );
   const state = useAssetUrlState(props.environmentId, resource);
   const refresh = useRefreshAssetUrl(props.environmentId, resource);

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -166,7 +166,12 @@ import {
 import { useAtomQueryRunner } from "../../state/use-atom-query-runner";
 import { usePreparedConnection } from "../../state/session";
 import * as Option from "effect/Option";
-import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import {
+  basename,
+  fileRoutePathSegments,
+  isAbsolutePath,
+  resolveWorkspaceRelativeFilePath,
+} from "../files/filePath";
 import { MARKDOWN_IMAGE_MAX_WIDTH, resolveMarkdownImageDisplaySize } from "./markdownImageSize";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
@@ -2068,7 +2073,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
           navigation.navigate("ThreadFile", {
             environmentId: String(props.environmentId),
             threadId: String(props.threadId),
-            path: relativePath.split("/").filter((segment) => segment.length > 0),
+            path: fileRoutePathSegments(relativePath),
             ...(presentation.line ? { line: String(presentation.line) } : {}),
           });
           return;
@@ -2087,6 +2092,35 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         } else {
           setExpandedFile((current) => current ?? media.source);
         }
+        return;
+      }
+
+      // A host file outside the workspace, such as a report an agent wrote to
+      // a temp directory, opens read-only in the file screen.
+      if (presentation.kind === "file" && isAbsolutePath(presentation.path)) {
+        void Haptics.selectionAsync();
+        if (isPdfFile({ name: presentation.path })) {
+          setExpandedFile(
+            (current) =>
+              current ?? {
+                kind: "pdf",
+                name: basename(presentation.path),
+                environmentId: props.environmentId,
+                resource: {
+                  _tag: "media-file",
+                  threadId: props.threadId,
+                  path: presentation.path,
+                },
+              },
+          );
+          return;
+        }
+        navigation.navigate("ThreadFile", {
+          environmentId: String(props.environmentId),
+          threadId: String(props.threadId),
+          path: fileRoutePathSegments(presentation.path),
+          ...(presentation.line ? { line: String(presentation.line) } : {}),
+        });
         return;
       }
 

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -44,7 +44,7 @@ const testLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(NodeServices.layer));
 
 describe("AssetAccess", () => {
-  it.effect("issues exact URLs for images and videos outside the workspace", () =>
+  it.effect("issues exact URLs for media and browser documents outside the workspace", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -54,6 +54,8 @@ describe("AssetAccess", () => {
         ["screenshot.png", "image/png"],
         ["recording.mp4", "video/mp4"],
         ["recording.webm", "video/webm"],
+        ["report.html", "text/html"],
+        ["report.pdf", "application/pdf"],
       ] as const) {
         const filePath = path.join(outside, name);
         yield* fs.writeFileString(filePath, "media");
@@ -104,12 +106,12 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  it.effect("rejects non-media files, disguised targets, and directories", () =>
+  it.effect("rejects non-previewable files, disguised targets, and directories", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const root = yield* fs.makeTempDirectoryScoped({ prefix: "t3-media-validation-" });
-      for (const name of ["report.html", "secret.txt", "secret.%70ng", "secret.png#private.txt"]) {
+      for (const name of ["report.md", "secret.txt", "secret.%70ng", "secret.png#private.txt"]) {
         const filePath = path.join(root, name);
         yield* fs.writeFileString(filePath, "not media");
         const error = yield* issueAssetUrl({
@@ -118,7 +120,7 @@ describe("AssetAccess", () => {
         expect(error).toBeInstanceOf(AssetPreviewTypeValidationError);
       }
       const disguisedPath = path.join(root, "disguised.png");
-      yield* fs.symlink(path.join(root, "report.html"), disguisedPath);
+      yield* fs.symlink(path.join(root, "secret.txt"), disguisedPath);
       const disguisedError = yield* issueAssetUrl({
         resource: { _tag: "media-file", threadId: ThreadId.make("thread-1"), path: disguisedPath },
       }).pipe(Effect.flip);

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -14,9 +14,9 @@ import {
   AssetWorkspaceRootNormalizationError,
 } from "@t3tools/contracts";
 import {
+  hostPreviewMimeTypeFromExtension,
   isWorkspaceImagePreviewPath,
   isWorkspacePreviewEntryPath,
-  mediaMimeTypeFromExtension,
   WORKSPACE_BROWSER_PREVIEW_EXTENSIONS,
   WORKSPACE_IMAGE_PREVIEW_EXTENSIONS,
 } from "@t3tools/shared/filePreview";
@@ -246,7 +246,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       if (!canonicalFile) {
         return yield* new AssetWorkspaceAssetNotFoundError({ resource: input.resource });
       }
-      if (mediaMimeTypeFromExtension(path.extname(canonicalFile)) === null) {
+      if (hostPreviewMimeTypeFromExtension(path.extname(canonicalFile)) === null) {
         return yield* new AssetPreviewTypeValidationError({ resource: input.resource });
       }
       const identity = yield* openMediaFile(canonicalFile).pipe(
@@ -598,7 +598,7 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       Effect.orElseSucceed(() => null),
     );
     if (canonicalFile !== claims.filePath) return null;
-    const mimeType = mediaMimeTypeFromExtension(path.extname(canonicalFile));
+    const mimeType = hostPreviewMimeTypeFromExtension(path.extname(canonicalFile));
     if (!mimeType) return null;
     const file = yield* openMediaFile(canonicalFile, claims).pipe(
       Effect.tapError((cause) =>

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -324,15 +324,13 @@ describe("assetResponseHeaders", () => {
       "X-Content-Type-Options": "nosniff",
     });
   });
-  it("declares utf-8 for HTML assets so non-ASCII content renders correctly", () => {
-    expect(assetResponseHeaders("/workspace/page.html")).toHaveProperty(
-      "Content-Type",
-      "text/html; charset=utf-8",
-    );
-    expect(assetResponseHeaders("/workspace/PAGE.HTM")).toHaveProperty(
-      "Content-Type",
-      "text/html; charset=utf-8",
-    );
+  it("serves HTML assets as utf-8 inside a sandboxed origin", () => {
+    for (const path of ["/workspace/page.html", "/workspace/PAGE.HTM", "/tmp/report.html"]) {
+      expect(assetResponseHeaders(path)).toMatchObject({
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Security-Policy": "sandbox allow-scripts allow-forms allow-popups allow-modals",
+      });
+    }
   });
 
   it("downloads uploaded documents without executing their content", () => {

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -51,6 +51,10 @@ const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
 const SVG_CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+// HTML previews are agent output, not the app. The sandbox gives the document an
+// opaque origin: scripts run, but same-origin cookies, storage, and API calls are
+// out of reach. Relative sibling assets still load through their signed URLs.
+const HTML_CONTENT_SECURITY_POLICY = "sandbox allow-scripts allow-forms allow-popups allow-modals";
 
 // Types a browser may render as a document if a proxy strips the disposition
 // header. Downloads of these fall back to octet-stream.
@@ -105,7 +109,10 @@ export function assetResponseHeaders(
       : inlineVideoMimeType !== undefined && isSafeInlineVideoMimeType(inlineVideoMimeType)
         ? { "Content-Type": inlineVideoMimeType }
         : lowerPath.endsWith(".html") || lowerPath.endsWith(".htm")
-          ? { "Content-Type": "text/html; charset=utf-8" }
+          ? {
+              "Content-Type": "text/html; charset=utf-8",
+              "Content-Security-Policy": HTML_CONTENT_SECURITY_POLICY,
+            }
           : {}),
     ...(!options?.download && lowerPath.endsWith(".svg")
       ? { "Content-Security-Policy": SVG_CONTENT_SECURITY_POLICY }

--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -73,6 +73,29 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
       }),
     );
 
+    it.effect("reads host files outside the workspace root by absolute path", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const outsideDir = yield* makeTempDir;
+        yield* writeTextFile(outsideDir, "cleanup-report.md", "# Report\n");
+        const absolutePath = path.join(outsideDir, "cleanup-report.md");
+
+        const result = yield* workspaceFileSystem.readFile({
+          cwd,
+          relativePath: absolutePath,
+        });
+
+        expect(result).toEqual({
+          relativePath: absolutePath,
+          contents: "# Report\n",
+          byteLength: 9,
+          truncated: false,
+        });
+      }),
+    );
+
     it.effect("rejects reads outside the workspace root", () =>
       Effect.gen(function* () {
         const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
@@ -209,6 +232,22 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
 
         expect(result).toEqual({ relativePath: "plans/effect-rpc.md" });
         expect(saved).toBe("# Plan\n");
+      }),
+    );
+
+    it.effect("rejects writes by absolute path", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const outsideDir = yield* makeTempDir;
+        const absolutePath = path.join(outsideDir, "cleanup-report.md");
+
+        const error = yield* workspaceFileSystem
+          .writeFile({ cwd, relativePath: absolutePath, contents: "# Edited\n" })
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(WorkspacePaths.WorkspacePathOutsideRootError);
       }),
     );
 

--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -1,3 +1,6 @@
+// @effect-diagnostics nodeBuiltinImport:off - FileSystem cannot create a FIFO.
+import * as NodeChildProcess from "node:child_process";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -93,6 +96,30 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
           byteLength: 9,
           truncated: false,
         });
+      }),
+    );
+
+    it.effect("rejects a FIFO without blocking on open", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const outsideDir = yield* makeTempDir;
+        const fifoPath = path.join(outsideDir, "pipe");
+        yield* Effect.promise(
+          () =>
+            new Promise<void>((resolve, reject) =>
+              NodeChildProcess.execFile("mkfifo", [fifoPath], (error) =>
+                error ? reject(error) : resolve(),
+              ),
+            ),
+        );
+
+        const error = yield* workspaceFileSystem
+          .readFile({ cwd, relativePath: fifoPath })
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(WorkspaceFileSystem.WorkspacePathNotFileError);
       }),
     );
 

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -3,7 +3,9 @@
  * WorkspaceFileSystem - Effect service contract for workspace file mutations.
  *
  * Owns workspace-root-relative file read/write operations and their associated
- * safety checks and cache invalidation hooks.
+ * safety checks and cache invalidation hooks. Reads also accept absolute host
+ * paths so clients can show files an agent left outside the workspace; writes
+ * never leave the root.
  *
  * @module WorkspaceFileSystem
  */
@@ -104,7 +106,10 @@ export type WorkspaceFileSystemError = typeof WorkspaceFileSystemError.Type;
 export class WorkspaceFileSystem extends Context.Service<
   WorkspaceFileSystem,
   {
-    /** Read a UTF-8 text file relative to the workspace root. */
+    /**
+     * Read a UTF-8 text file relative to the workspace root, or any host file by
+     * absolute path.
+     */
     readonly readFile: (
       input: ProjectReadFileInput,
     ) => Effect.Effect<
@@ -132,9 +137,31 @@ export const make = Effect.gen(function* () {
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
 
-  const readFile: WorkspaceFileSystem["Service"]["readFile"] = Effect.fn(
-    "WorkspaceFileSystem.readFile",
-  )(function* (input) {
+  /**
+   * Resolves the file a read targets. Workspace-relative paths must stay inside the
+   * root, symlinks included. An absolute path reads a host file in place, such as a
+   * report an agent wrote to a temp directory; it gets no root check.
+   */
+  const resolveReadTarget = Effect.fn("WorkspaceFileSystem.resolveReadTarget")(function* (
+    input: ProjectReadFileInput,
+  ) {
+    const requestedPath = input.relativePath.trim();
+    if (path.isAbsolute(requestedPath)) {
+      const realTargetPath = yield* Effect.tryPromise({
+        try: () => NodeFSP.realpath(requestedPath),
+        catch: (cause) =>
+          new WorkspaceFileSystemOperationError({
+            workspaceRoot: input.cwd,
+            relativePath: input.relativePath,
+            resolvedPath: requestedPath,
+            operationPath: requestedPath,
+            operation: "realpath-target",
+            cause,
+          }),
+      });
+      return { relativePath: requestedPath, realTargetPath };
+    }
+
     const target = yield* workspacePaths.resolveRelativePathWithinRoot({
       workspaceRoot: input.cwd,
       relativePath: input.relativePath,
@@ -177,6 +204,14 @@ export const make = Effect.gen(function* () {
         resolvedPath: realTargetPath,
       });
     }
+    return { relativePath: target.relativePath, realTargetPath };
+  });
+
+  const readFile: WorkspaceFileSystem["Service"]["readFile"] = Effect.fn(
+    "WorkspaceFileSystem.readFile",
+  )(function* (input) {
+    const target = yield* resolveReadTarget(input);
+    const realTargetPath = target.realTargetPath;
 
     return yield* Effect.acquireUseRelease(
       Effect.tryPromise({

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -9,6 +9,7 @@
  *
  * @module WorkspaceFileSystem
  */
+import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 
 import type {
@@ -215,7 +216,13 @@ export const make = Effect.gen(function* () {
 
     return yield* Effect.acquireUseRelease(
       Effect.tryPromise({
-        try: () => NodeFSP.open(realTargetPath, "r"),
+        // Non-blocking so a FIFO cannot hang the open; the stat below rejects
+        // it. Regular files ignore the flag. Windows lacks it.
+        try: () =>
+          NodeFSP.open(
+            realTargetPath,
+            NodeFS.constants.O_RDONLY | (NodeFS.constants.O_NONBLOCK ?? 0),
+          ),
         catch: (cause) =>
           new WorkspaceFileSystemOperationError({
             workspaceRoot: input.cwd,

--- a/apps/web/src/browser/openFileInPreview.ts
+++ b/apps/web/src/browser/openFileInPreview.ts
@@ -6,6 +6,7 @@ import type {
   PreviewSessionSnapshot,
   ScopedThreadRef,
 } from "@t3tools/contracts";
+import { mediaFileReference } from "@t3tools/client-runtime/media-reference";
 import {
   type AtomCommandResult,
   mapAtomCommandResult,
@@ -52,9 +53,14 @@ export async function openUrlInPreview<E>(input: {
   });
 }
 
+/**
+ * Opens a browser document in the integrated browser. Inside the workspace the
+ * page may load sibling assets; a file outside it is served on its own.
+ */
 export async function openFileInPreview<AssetError, PreviewError>(input: {
   readonly threadRef: ScopedThreadRef;
   readonly filePath: string;
+  readonly workspaceRoot: string | undefined;
   readonly httpBaseUrl: string;
   readonly createAssetUrl: (input: {
     readonly environmentId: EnvironmentId;
@@ -71,11 +77,13 @@ export async function openFileInPreview<AssetError, PreviewError>(input: {
       ),
     );
   }
+  const insideWorkspace =
+    mediaFileReference(input.filePath, input.workspaceRoot).relativePath !== undefined;
   const assetResult = await input.createAssetUrl({
     environmentId: input.threadRef.environmentId,
     input: {
       resource: {
-        _tag: "workspace-file",
+        _tag: insideWorkspace ? "workspace-file" : "media-file",
         threadId: input.threadRef.threadId,
         path: input.filePath,
       },

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -164,7 +164,7 @@ import {
 } from "~/lib/openPullRequestLink";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
-import { resolvePathLinkTarget } from "../terminal-links";
+import { isAbsolutePath, resolvePathLinkTarget } from "../terminal-links";
 import {
   isBrowserPreviewFile,
   openFileInPreview,
@@ -1017,14 +1017,16 @@ interface MarkdownFileLinkProps {
   targetPath: string;
   iconPath: string;
   displayPath: string;
-  workspaceRelativePath: string | null;
+  /** What the files panel opens: workspace-relative inside the workspace, the
+      absolute host path outside it, null when the panel cannot show the file. */
+  panelPath: string | null;
   line?: number | undefined;
   label: string;
   copyMarkdown: string;
   theme: "light" | "dark";
   threadRef?: ScopedThreadRef | undefined;
   onOpen?: ((targetPath: string) => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
-  onOpenInPanel: (workspaceRelativePath: string, line: number | undefined) => void;
+  onOpenInPanel: (panelPath: string, line: number | undefined) => void;
   openInEditorMenuLabel: string;
   onOpenInBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
   onOpenMedia?: (() => void) | undefined;
@@ -1603,7 +1605,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   targetPath,
   iconPath,
   displayPath,
-  workspaceRelativePath,
+  panelPath,
   line,
   label,
   copyMarkdown,
@@ -1657,8 +1659,8 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   }, [onOpen, targetPath]);
 
   const handleOpenInFilePreview = useCallback(() => {
-    if (threadRef && workspaceRelativePath) {
-      onOpenInPanel(workspaceRelativePath, line);
+    if (threadRef && panelPath) {
+      onOpenInPanel(panelPath, line);
       return;
     }
     if (onOpenMedia) {
@@ -1666,7 +1668,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       return;
     }
     handleOpenInEditor();
-  }, [handleOpenInEditor, line, onOpenInPanel, onOpenMedia, threadRef, workspaceRelativePath]);
+  }, [handleOpenInEditor, line, onOpenInPanel, onOpenMedia, panelPath, threadRef]);
 
   const handleOpenInBrowser = useCallback(() => {
     if (!onOpenInBrowser) {
@@ -1867,7 +1869,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
 
   const canOpenInEditor = onOpen !== undefined;
   const canOpenInBrowser = onOpenInBrowser !== undefined;
-  const canOpenInPanel = threadRef !== undefined && Boolean(workspaceRelativePath);
+  const canOpenInPanel = threadRef !== undefined && Boolean(panelPath);
   const hasPrimaryAction = hasMarkdownFilePrimaryAction({
     canOpenInEditor,
     canOpenInBrowser,
@@ -1954,7 +1956,7 @@ function areMarkdownFileLinkPropsEqual(
     previous.targetPath === next.targetPath &&
     previous.iconPath === next.iconPath &&
     previous.displayPath === next.displayPath &&
-    previous.workspaceRelativePath === next.workspaceRelativePath &&
+    previous.panelPath === next.panelPath &&
     previous.line === next.line &&
     previous.label === next.label &&
     previous.copyMarkdown === next.copyMarkdown &&
@@ -2223,12 +2225,13 @@ function ChatMarkdown({
       return openFileInPreview({
         threadRef,
         filePath: path,
+        workspaceRoot: cwd,
         httpBaseUrl: preparedConnection.value.httpBaseUrl,
         createAssetUrl,
         openPreview,
       });
     },
-    [createAssetUrl, openPreview, preparedConnection, threadRef],
+    [createAssetUrl, cwd, openPreview, preparedConnection, threadRef],
   );
   const findWorkspaceBasenameMatch = useCallback(
     async (workspaceRelativePath: string) => {
@@ -2251,23 +2254,23 @@ function ChatMarkdown({
     [cwd, environmentId, searchProjectEntries],
   );
   // A bare filename resolves to the workspace root, which is rarely where the
-  // file is, so ask the index before opening.
+  // file is, so ask the index before opening. Absolute host paths open as-is.
   const openFileInPanel = useCallback(
-    (workspaceRelativePath: string, line: number | undefined) => {
+    (panelPath: string, line: number | undefined) => {
       if (!threadRef) return;
       // Claimed on every open so a synchronous one supersedes a lookup already
       // in flight.
       const isLatestLookup = claimWorkspaceBasenameLookup();
       const openAt = (path: string) =>
         useRightPanelStore.getState().openFile(threadRef, path, line);
-      if (!cwd || !needsWorkspaceBasenameLookup(workspaceRelativePath)) {
-        openAt(workspaceRelativePath);
+      if (!cwd || !needsWorkspaceBasenameLookup(panelPath)) {
+        openAt(panelPath);
         return;
       }
       void (async () => {
-        const match = await findWorkspaceBasenameMatch(workspaceRelativePath);
+        const match = await findWorkspaceBasenameMatch(panelPath);
         if (!isLatestLookup()) return;
-        openAt(match ?? workspaceRelativePath);
+        openAt(match ?? panelPath);
       })();
     },
     [cwd, findWorkspaceBasenameMatch, threadRef],
@@ -2310,6 +2313,11 @@ function ChatMarkdown({
         mediaMimeTypeFromExtension(
           fileLinkMeta.basename.slice(fileLinkMeta.basename.lastIndexOf(".")),
         ) !== null;
+      // Media outside the workspace keeps the expanded preview; other host
+      // files (a report in a temp dir) open read-only in the files panel.
+      const panelPath =
+        fileLinkMeta.workspaceRelativePath ??
+        (!canPreviewMedia && isAbsolutePath(fileLinkMeta.filePath) ? fileLinkMeta.filePath : null);
 
       return (
         <MarkdownFileLink
@@ -2317,7 +2325,7 @@ function ChatMarkdown({
           targetPath={fileLinkMeta.targetPath}
           iconPath={fileLinkMeta.filePath}
           displayPath={fileLinkMeta.displayPath}
-          workspaceRelativePath={fileLinkMeta.workspaceRelativePath}
+          panelPath={panelPath}
           line={fileLinkMeta.line}
           label={labelParts.join(" · ")}
           copyMarkdown={copyMarkdown}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -188,6 +188,8 @@ interface ChatMarkdownProps {
   parseRawHtml?: boolean;
   /** Append a prompt that invokes a newly created artifact-template skill. */
   onUseArtifactTemplate?: ((template: CodexArtifactTemplate) => void) | undefined;
+  /** Directory that anchors relative links and images; defaults to `cwd`. Set
+      to the file's own directory when rendering a markdown file. */
   imageBaseDir?: string | undefined;
   onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
   extraRemarkPlugins?: NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
@@ -2100,24 +2102,24 @@ function ChatMarkdown({
     for (const href of extractMarkdownLinkHrefs(renderCodexFileCitationsAsMarkdown(text))) {
       const normalizedHref = normalizeMarkdownLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
-      const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
+      const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd, imageBaseDir ?? cwd);
       if (meta) {
         metaByHref.set(normalizedHref, meta);
       }
     }
     return metaByHref;
-  }, [cwd, text]);
+  }, [cwd, imageBaseDir, text]);
   const inlineCodeFileLinkMetaByText = useMemo(() => {
     const metaByText = new Map<string, MarkdownFileLinkMeta>();
     for (const span of extractInlineCodeSpans(text)) {
       if (metaByText.has(span)) continue;
-      const meta = resolveInlineCodeFileLinkMeta(span, cwd);
+      const meta = resolveInlineCodeFileLinkMeta(span, cwd, imageBaseDir ?? cwd);
       if (meta) {
         metaByText.set(span, meta);
       }
     }
     return metaByText;
-  }, [cwd, text]);
+  }, [cwd, imageBaseDir, text]);
   const fileLinkParentSuffixByPath = useMemo(() => {
     const filePaths = [
       ...[...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath),
@@ -2442,7 +2444,7 @@ function ChatMarkdown({
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
         const fileLinkMeta = normalizedHref
           ? (markdownFileLinkMetaByHref.get(normalizedHref) ??
-            resolveMarkdownFileLinkMeta(normalizedHref, cwd))
+            resolveMarkdownFileLinkMeta(normalizedHref, cwd, imageBaseDir ?? cwd))
           : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
@@ -2588,7 +2590,7 @@ function ChatMarkdown({
           const codeText = nodeToPlainText(children);
           const fileLinkMeta =
             inlineCodeFileLinkMetaByText.get(codeText.trim()) ??
-            resolveInlineCodeFileLinkMeta(codeText, cwd);
+            resolveInlineCodeFileLinkMeta(codeText, cwd, imageBaseDir ?? cwd);
           if (fileLinkMeta) {
             return fileLinkChip(
               fileLinkMeta,

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -498,7 +498,9 @@ function surfaceTitle(
     case "files":
       return "Files";
     case "file":
-      return surface.relativePath.slice(surface.relativePath.lastIndexOf("/") + 1);
+      return surface.relativePath.slice(
+        Math.max(surface.relativePath.lastIndexOf("/"), surface.relativePath.lastIndexOf("\\")) + 1,
+      );
     case "terminal":
       return (
         terminalLabelsById.get(surface.activeTerminalId) ??

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -33,7 +33,7 @@ import { useWorkspaceMutationRefresh } from "~/hooks/useWorkspaceMutationRefresh
 import { DIFF_SURFACE_THEME_UNSAFE_CSS, resolveDiffThemeName } from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
-import { resolvePathLinkTarget } from "~/terminal-links";
+import { isAbsolutePath, resolvePathLinkTarget } from "~/terminal-links";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Toggle } from "~/components/ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
@@ -791,6 +791,7 @@ function RenderedMarkdownSurface({
   relativePath,
   contents,
   threadRef,
+  readOnly,
   onPendingChange,
 }: Omit<
   EditableFileSurfaceProps,
@@ -802,6 +803,7 @@ function RenderedMarkdownSurface({
   | "onPostRender"
 > & {
   threadRef: ScopedThreadRef;
+  readOnly: boolean;
 }) {
   const saveCoordinator = useFileSaveCoordinator({
     environmentId,
@@ -817,15 +819,19 @@ function RenderedMarkdownSurface({
         cwd={cwd}
         relativePath={relativePath}
         threadRef={threadRef}
-        onTaskListChange={({ markerOffset, checked }) => {
-          const currentContents =
-            getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
-            contents;
-          const nextContents = setMarkdownTaskChecked(currentContents, markerOffset, checked);
-          if (nextContents === currentContents) return;
-          setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
-          saveCoordinator.change(nextContents);
-        }}
+        onTaskListChange={
+          readOnly
+            ? undefined
+            : ({ markerOffset, checked }) => {
+                const currentContents =
+                  getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
+                  contents;
+                const nextContents = setMarkdownTaskChecked(currentContents, markerOffset, checked);
+                if (nextContents === currentContents) return;
+                setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
+                saveCoordinator.change(nextContents);
+              }
+        }
       />
     </ScrollArea>
   );
@@ -870,6 +876,8 @@ export default function FilePreviewPanel({
   const isVideo = relativePath !== null && isWorkspaceVideoPreviewPath(relativePath);
   const isImage = relativePath !== null && !isVideo && isWorkspaceImagePreviewPath(relativePath);
   const isMedia = isImage || isVideo;
+  // A file outside the workspace (an absolute path) is shown, never edited.
+  const isHostFile = relativePath !== null && isAbsolutePath(relativePath);
   const file = useProjectFileQuery(environmentId, cwd, relativePath, !isMedia);
   const [explorerOpen, setExplorerOpen] = useState(initialExplorerOpen);
   // Reading markdown rendered is a preference, not a property of one file. Keeping
@@ -936,6 +944,7 @@ export default function FilePreviewPanel({
       const result = await openFileInPreview({
         threadRef,
         filePath: absolutePath,
+        workspaceRoot: cwd,
         httpBaseUrl: environmentHttpBaseUrl,
         createAssetUrl,
         openPreview,
@@ -952,7 +961,7 @@ export default function FilePreviewPanel({
         }),
       );
     })();
-  }, [absolutePath, createAssetUrl, environmentHttpBaseUrl, openPreview, threadRef]);
+  }, [absolutePath, createAssetUrl, cwd, environmentHttpBaseUrl, openPreview, threadRef]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
@@ -1128,9 +1137,10 @@ export default function FilePreviewPanel({
                 relativePath={relativePath}
                 threadRef={threadRef}
                 contents={file.data.contents}
+                readOnly={isHostFile}
                 onPendingChange={onPendingChange}
               />
-            ) : file.data.truncated ? (
+            ) : file.data.truncated || isHostFile ? (
               <Virtualizer
                 key={`${relativePath}:${resolvedTheme}:${file.data.byteLength}`}
                 className="file-preview-virtualizer min-h-0 flex-1 overflow-auto"

--- a/apps/web/src/components/files/filePath.test.ts
+++ b/apps/web/src/components/files/filePath.test.ts
@@ -14,10 +14,23 @@ describe("fileBreadcrumbs", () => {
   });
 
   it("normalizes repeated separators", () => {
-    expect(fileBreadcrumbs("workspace", "/src//index.ts").map((crumb) => crumb.label)).toEqual([
+    expect(fileBreadcrumbs("workspace", "src//index.ts").map((crumb) => crumb.label)).toEqual([
       "workspace",
       "src",
       "index.ts",
+    ]);
+  });
+
+  it("starts host paths outside the workspace at the filesystem root", () => {
+    expect(fileBreadcrumbs("t3code", "/tmp/t3-cleanup/report.md")).toEqual([
+      { label: "tmp", path: "/tmp", kind: "directory" },
+      { label: "t3-cleanup", path: "/tmp/t3-cleanup", kind: "directory" },
+      { label: "report.md", path: "/tmp/t3-cleanup/report.md", kind: "file" },
+    ]);
+    expect(fileBreadcrumbs("t3code", "C:\\Temp\\report.md")).toEqual([
+      { label: "C:", path: "C:", kind: "directory" },
+      { label: "Temp", path: "C:\\Temp", kind: "directory" },
+      { label: "report.md", path: "C:\\Temp\\report.md", kind: "file" },
     ]);
   });
 });

--- a/apps/web/src/components/files/filePath.test.ts
+++ b/apps/web/src/components/files/filePath.test.ts
@@ -32,5 +32,10 @@ describe("fileBreadcrumbs", () => {
       { label: "Temp", path: "C:\\Temp", kind: "directory" },
       { label: "report.md", path: "C:\\Temp\\report.md", kind: "file" },
     ]);
+    expect(fileBreadcrumbs("t3code", "\\\\server\\share\\report.md").map((c) => c.path)).toEqual([
+      "\\\\server",
+      "\\\\server\\share",
+      "\\\\server\\share\\report.md",
+    ]);
   });
 });

--- a/apps/web/src/components/files/filePath.ts
+++ b/apps/web/src/components/files/filePath.ts
@@ -16,7 +16,7 @@ export function fileBreadcrumbs(projectName: string, relativePath: string): File
   const hostPath = isAbsolutePath(relativePath);
   const separator = isWindowsAbsolutePath(relativePath) ? "\\" : "/";
   const parts = relativePath.split(/[\\/]/).filter(Boolean);
-  const root = hostPath && separator === "/" ? "/" : "";
+  const root = relativePath.startsWith("\\\\") ? "\\\\" : hostPath && separator === "/" ? "/" : "";
   return [
     ...(hostPath ? [] : [{ label: projectName, path: "", kind: "project" as const }]),
     ...parts.map((part, index) => ({

--- a/apps/web/src/components/files/filePath.ts
+++ b/apps/web/src/components/files/filePath.ts
@@ -1,16 +1,27 @@
+import { isWindowsAbsolutePath } from "@t3tools/shared/path";
+
+import { isAbsolutePath } from "~/terminal-links";
+
 export interface FileBreadcrumb {
   label: string;
   path: string;
   kind: "project" | "directory" | "file";
 }
 
+/**
+ * Crumbs for a workspace-relative path start at the project. An absolute host
+ * path is outside the workspace, so its crumbs start at the filesystem root.
+ */
 export function fileBreadcrumbs(projectName: string, relativePath: string): FileBreadcrumb[] {
-  const parts = relativePath.split("/").filter(Boolean);
+  const hostPath = isAbsolutePath(relativePath);
+  const separator = isWindowsAbsolutePath(relativePath) ? "\\" : "/";
+  const parts = relativePath.split(/[\\/]/).filter(Boolean);
+  const root = hostPath && separator === "/" ? "/" : "";
   return [
-    { label: projectName, path: "", kind: "project" },
+    ...(hostPath ? [] : [{ label: projectName, path: "", kind: "project" as const }]),
     ...parts.map((part, index) => ({
       label: part,
-      path: parts.slice(0, index + 1).join("/"),
+      path: root + parts.slice(0, index + 1).join(separator),
       kind: index === parts.length - 1 ? ("file" as const) : ("directory" as const),
     })),
   ];

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -275,6 +275,22 @@ describe("resolveMarkdownFileLinkTarget", () => {
   });
 });
 
+describe("relative links inside a rendered host file", () => {
+  it("anchor to the file's directory while workspace membership follows cwd", () => {
+    const meta = resolveMarkdownFileLinkMeta("appendix.md", "/repo", "/tmp/report");
+    expect(meta).toMatchObject({
+      filePath: "/tmp/report/appendix.md",
+      workspaceRelativePath: null,
+    });
+    const inline = resolveInlineCodeFileLinkMeta("Makefile:12", "/repo", "/tmp/report");
+    expect(inline).toMatchObject({ filePath: "/tmp/report/Makefile", line: 12 });
+    expect(resolveMarkdownFileLinkMeta("src/main.ts", "/repo", "/repo/docs")).toMatchObject({
+      filePath: "/repo/docs/src/main.ts",
+      workspaceRelativePath: "docs/src/main.ts",
+    });
+  });
+});
+
 describe("resolveInlineCodeFileLinkMeta", () => {
   it("links relative paths with file extensions", () => {
     expect(

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -189,9 +189,15 @@ function hasExternalScheme(path: string): boolean {
   return !POSITION_ONLY_PATTERN.test(rest);
 }
 
+/**
+ * `baseDir` anchors relative links; it defaults to the workspace root and is the
+ * file's own directory when rendering a markdown file. `cwd` stays the workspace
+ * root so the result still knows whether the target is inside it.
+ */
 export function resolveMarkdownFileLinkTarget(
   href: string | undefined,
   cwd?: string,
+  baseDir: string | undefined = cwd,
 ): string | null {
   if (!href) return null;
   const rawHref = normalizeMarkdownLinkDestination(href);
@@ -222,8 +228,8 @@ export function resolveMarkdownFileLinkTarget(
     return pathWithPosition;
   }
 
-  if (!cwd) return null;
-  return resolvePathLinkTarget(pathWithPosition, cwd);
+  if (!baseDir) return null;
+  return resolvePathLinkTarget(pathWithPosition, baseDir);
 }
 
 /**
@@ -235,18 +241,19 @@ export function resolveMarkdownFileLinkTarget(
 export function resolveInlineCodeFileLinkMeta(
   codeText: string,
   cwd?: string,
+  baseDir: string | undefined = cwd,
 ): MarkdownFileLinkMeta | null {
   const candidate = inlineCodeFilePathCandidate(codeText);
   if (candidate === null) return null;
 
-  const resolved = resolveMarkdownFileLinkMeta(candidate, cwd);
+  const resolved = resolveMarkdownFileLinkMeta(candidate, cwd, baseDir);
   if (resolved) return resolved;
 
   // `Makefile:12` — conventional extensionless names fail the generic
   // markdown-link candidate patterns, but here the :line suffix already
   // marked the span as a file reference.
-  if (cwd && isConventionalFilePosition(candidate)) {
-    return buildFileLinkMetaFromTarget(resolvePathLinkTarget(candidate, cwd), cwd);
+  if (baseDir && isConventionalFilePosition(candidate)) {
+    return buildFileLinkMetaFromTarget(resolvePathLinkTarget(candidate, baseDir), cwd);
   }
   return null;
 }
@@ -276,8 +283,9 @@ function workspaceRelativePath(path: string, workspaceRoot: string | undefined):
 export function resolveMarkdownFileLinkMeta(
   href: string | undefined,
   cwd?: string,
+  baseDir: string | undefined = cwd,
 ): MarkdownFileLinkMeta | null {
-  const targetPath = resolveMarkdownFileLinkTarget(href, cwd);
+  const targetPath = resolveMarkdownFileLinkTarget(href, cwd, baseDir);
   if (!targetPath) return null;
   return buildFileLinkMetaFromTarget(targetPath, cwd);
 }

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -41,6 +41,7 @@ export type RightPanelSurface =
   | {
       id: `file:${string}`;
       kind: "file";
+      /** Workspace-relative, or absolute for a host file outside the workspace. */
       relativePath: string;
       revealLine: number | null;
       revealRequestId: number;

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -102,7 +102,7 @@ function isWindowsAbsolutePath(value: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
 }
 
-function isAbsolutePath(value: string): boolean {
+export function isAbsolutePath(value: string): boolean {
   return value.startsWith("/") || isWindowsAbsolutePath(value);
 }
 

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -28,22 +28,31 @@ managed relay connectivity:
 The desktop bootstrap credential and command-line administrative bootstrap
 credentials additionally grant `access:read access:write relay:write`.
 
+## Host file access
+
+Clients with `orchestration:read` can read files anywhere the environment's server account can
+read, following the environment-wide authorization model rather than introducing per-project
+filesystem permissions. `projects.readFile` accepts an absolute path and returns the text of that
+host file; only workspace-relative paths pass its root check, and `projects.writeFile` never
+accepts an absolute path. Clients use this to show files an agent wrote outside the workspace, such
+as a report in a temp directory, read-only.
+
 ## Media preview access
 
 Clients with `orchestration:read` can request a `media-file` URL through `assets.createUrl` for
-supported images and videos anywhere the environment's server account can read. A thread ID
-supplies the workspace for relative paths; absolute paths refer to the environment host, not the
-client. This follows the environment-wide authorization model rather than introducing per-project
-filesystem permissions.
+supported images, videos, HTML, and PDF files anywhere the environment's server account can read.
+A thread ID supplies the workspace for relative paths; absolute paths refer to the environment
+host, not the client.
 
 [`AssetAccess.ts`](../../apps/server/src/assets/AssetAccess.ts) resolves symlinks, requires a regular
 file, and validates the resolved file's literal extension. It opens the file and signs its canonical
 path and device/inode identity for one hour. The token grants access to that exact file, not adjacent
 files or its containing directory. Serving rechecks the canonical path, media type, and opened
 descriptor's identity, then streams full or partial responses from that descriptor. Replacing a
-file atomically requires a freshly signed URL; editing it in place does not. The existing workspace
-boundary still applies to HTML, PDF, and other workspace previews. Uploaded attachments keep their
-separate asset resource.
+file atomically requires a freshly signed URL; editing it in place does not. Because the token names
+one file, an HTML document served this way cannot load sibling assets; the directory-scoped
+`workspace-file` resource remains the route for HTML inside the workspace. Uploaded attachments keep
+their separate asset resource.
 
 Signed asset URLs are bearer credentials. Anyone who obtains a URL and can reach the environment
 can fetch that file until it expires. Clients should copy the authored reference, not the temporary

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -94,6 +94,15 @@ have a cached copy. Supported video formats and codecs depend on the browser or 
 Bare paths in ordinary prose and paths inside code blocks stay text. Raw HTML `<video>` tags
 are not supported; use the Markdown embed syntax above.
 
+## Files outside the workspace
+
+When an agent links to a file it wrote outside the workspace, such as a Markdown report in
+`/tmp`, select the link to open it in the file viewer. The viewer shows the file read-only, with
+rendered Markdown available as usual; it cannot edit files outside the workspace. HTML and PDF
+files outside the workspace open the same way as ones inside it, including the integrated browser
+where it is available. Because such a file is served on its own, an HTML page outside the workspace
+cannot load scripts, styles, or images from files beside it.
+
 ## Changing projects
 
 On web and desktop, changing the project from a new thread keeps the current environment when that

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -15,6 +15,9 @@ export const AssetResource = Schema.Union([
     threadId: ThreadId,
     path: TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
   }),
+  // One file served in place from anywhere the environment host can read:
+  // images, videos, HTML, and PDF. An absolute path may lie outside the
+  // workspace; a relative one resolves against the thread's workspace.
   Schema.TaggedStruct("media-file", {
     threadId: ThreadId,
     path: TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
@@ -157,7 +160,7 @@ export class AssetPreviewTypeValidationError extends Schema.TaggedErrorClass<Ass
 ) {
   override get message(): string {
     return this.resource._tag === "media-file"
-      ? "Only images and videos can be previewed."
+      ? "Only images, videos, HTML, and PDF files can be previewed."
       : "Only browser documents and images can be previewed.";
   }
 }

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -193,6 +193,8 @@ export class ProjectListEntriesError extends Schema.TaggedErrorClass<ProjectList
 
 export const ProjectReadFileInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
+  // Workspace-relative, or an absolute host path for a file outside the
+  // workspace. Only workspace-relative paths can be written back.
   relativePath: TrimmedNonEmptyString.check(Schema.isMaxLength(PROJECT_READ_FILE_PATH_MAX_LENGTH)),
 });
 export type ProjectReadFileInput = typeof ProjectReadFileInput.Type;

--- a/packages/shared/src/filePreview.ts
+++ b/packages/shared/src/filePreview.ts
@@ -24,12 +24,28 @@ const IMAGE_MIME_TYPE_BY_EXTENSION = new Map([
   [".webp", "image/webp"],
 ]);
 
+const BROWSER_MIME_TYPE_BY_EXTENSION = new Map([
+  [".htm", "text/html"],
+  [".html", "text/html"],
+  [".pdf", "application/pdf"],
+]);
+
 /** Classifies a literal filesystem extension, without URL decoding or suffix removal. */
 export function mediaMimeTypeFromExtension(extension: string): string | null {
   if (!/^\.[a-z0-9]+$/i.test(extension)) return null;
   return (
     IMAGE_MIME_TYPE_BY_EXTENSION.get(extension.toLowerCase()) ??
     videoMimeType({ name: `media${extension}`, mimeType: "" })
+  );
+}
+
+/** Files the server serves in place from anywhere on its host: media plus browser documents. */
+export function hostPreviewMimeTypeFromExtension(extension: string): string | null {
+  if (!/^\.[a-z0-9]+$/i.test(extension)) return null;
+  return (
+    mediaMimeTypeFromExtension(extension) ??
+    BROWSER_MIME_TYPE_BY_EXTENSION.get(extension.toLowerCase()) ??
+    null
   );
 }
 


### PR DESCRIPTION
Agents regularly write a report to a temp directory and link it in their reply. That chip was a dead end: the files panel only accepted workspace-relative paths, and `projects.readFile` rejected anything outside the root. HTML and PDF links outside the workspace failed one layer down, because the browser preview always minted a workspace-scoped asset URL.

## How

- **Server**: `WorkspaceFileSystem.readFile` accepts an absolute path and reads that host file in place. Workspace-relative paths keep the root and symlink containment checks, and `writeFile` still rejects absolute paths, so host files are read-only. The `media-file` asset resource now also accepts `.html`, `.htm`, and `.pdf`, using the same exact-file, inode-pinned token; workspace HTML keeps using the directory-scoped `workspace-file` resource so sibling assets load.
- **Web**: file chips carry a `panelPath` that falls back to the absolute host path for non-media files outside the workspace, so they open in the files panel. The panel renders host files read-only (rendered Markdown works, checkboxes do not write back) with breadcrumbs starting at the filesystem root. `openFileInPreview` picks `workspace-file` or `media-file` by workspace membership, so the panel's browser button and PDF chips work for host files.
- **Mobile**: outside-workspace chips route to the file screen (PDFs to the existing PDF preview with a `media-file` resource), and the asset URL hook picks `media-file` for host paths.
- **Docs**: user note in `composer.md`; `environment-auth.md` updated, since it explicitly stated the workspace boundary still applied to HTML and PDF.

No wire changes: `media-file` and `readFile` keep their shapes, so older clients keep working.

One deliberate widening to flag: an authenticated `orchestration:read` client can now read any text file the server account can read, not only workspace files. That matches what `filesystem.browse` and `media-file` already allow and is documented as such.

## Demo

Clicking a `/tmp/...cleanup-report.md` chip opens it in the files panel, toggling to rendered Markdown, then opening the `.html` chip beside it:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7191626f13944a44/outside-workspace-files.webm

## Verification

- `apps/server`: `WorkspaceFileSystem.test.ts` (absolute read, absolute write rejected), `AssetAccess.test.ts` (HTML/PDF minting), `http.test.ts`
- `apps/web`: `filePath.test.ts` (host breadcrumbs), `markdown-links.test.ts`, `ChatMarkdown.*.test.tsx`, `FilePreviewPanel.test.ts`
- `apps/mobile`: `filePath.test.ts` (route segments round-trip)
- Per-package typecheck and lint on the changed files; web flow exercised end to end in the recording above.

Written by Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands what authenticated `orchestration:read` clients can read and preview on the host (any text file via absolute `readFile`, HTML/PDF via `media-file`), though writes stay workspace-bound and HTML gets a sandbox CSP.
> 
> **Overview**
> Agents can link files outside the project (e.g. `/tmp/.../report.md`); this PR wires those links through end-to-end instead of stopping at workspace-only paths.
> 
> **Server:** `projects.readFile` / `WorkspaceFileSystem.readFile` now accept an **absolute host path** and read that file in place (still **read-only**—`writeFile` rejects absolutes). Workspace-relative reads keep root/symlink containment; opens use **non-blocking** mode so FIFOs fail instead of hanging. The **`media-file`** asset resource now allows **HTML and PDF** (via `hostPreviewMimeTypeFromExtension`), and inline HTML responses add a **sandbox CSP**.
> 
> **Web & mobile:** File chips carry a **`panelPath`** that can be the absolute host path; the files panel shows host files **read-only** (markdown render on, task-list edits off) with breadcrumbs from the filesystem root. **`openFileInPreview`** and asset URL minting choose **`workspace-file` vs `media-file`** based on whether the path is inside the workspace. Mobile thread links navigate to the file screen (or PDF preview) for absolute paths. Markdown relative links can anchor on **`imageBaseDir`** when rendering a file outside the repo.
> 
> **Docs/contracts:** User and environment-auth docs describe host file read and expanded media preview; contract comments/error text updated—no wire shape changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0fa311c308958fa1d6249e57d233e77254d6724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support opening markdown, HTML, and PDF files outside the workspace
> - Server `WorkspaceFileSystem.readFile` now accepts absolute host paths via `resolveReadTarget`, resolving them through `realpath` without applying the workspace-root boundary check; writes remain workspace-relative only.
> - Asset URL issuance and resolution in `AssetAccess` accept HTML and PDF (in addition to images and videos) using the new shared `hostPreviewMimeTypeFromExtension` classifier; unsupported extensions still return no asset.
> - Web and mobile clients classify absolute paths as host files, render them read-only in the file panel, and use exact media-file asset URLs for out-of-workspace previews. Markdown link resolution gains an optional `baseDir` so relative links anchor to the rendered file's directory rather than only the workspace cwd.
> - HTML asset responses now include a sandbox content-security policy (permitting scripts, forms, popups, modals) alongside the UTF-8 content type.
> - File breadcrumbs and path utilities handle POSIX, Windows drive, and UNC absolute paths, starting at the filesystem root instead of the project name.
> - Risk: `WorkspaceFileSystem.resolveReadTarget` bypasses the workspace-root boundary check for absolute reads — any reachable host file path is readable. HTML sandbox CSP permits scripts and forms within the sandboxed context; separately served HTML cannot load adjacent scripts, styles, or images.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0fa311.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->