### PR TITLE
fix(desktop): hold-to-quit no longer gets stuck

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -105,6 +105,8 @@ function makeFakeBrowserWindow() {
     restore: vi.fn(),
     setBackgroundColor: vi.fn(),
     setAutoHideCursor: vi.fn(),
+    setFullScreen: vi.fn(),
+    setOpacity: vi.fn(),
     setTitle: vi.fn(),
     setTitleBarOverlay: vi.fn(),
     show: vi.fn(),
@@ -127,6 +129,8 @@ function makeFakeBrowserWindow() {
     setZoomLevel: webContents.setZoomLevel,
     setBackgroundThrottling: webContents.setBackgroundThrottling,
     setAutoHideCursor: window.setAutoHideCursor,
+    setFullScreen: window.setFullScreen,
+    setOpacity: window.setOpacity,
     webContentsListeners,
     windowListeners,
   };
@@ -394,6 +398,25 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
   });
 
 describe("DesktopWindow", () => {
+  it("leaves fullscreen before concealing a pending quit", () => {
+    const fakeWindow = makeFakeBrowserWindow();
+
+    DesktopWindow.concealPendingQuitWindow(fakeWindow.window);
+    assert.deepEqual(fakeWindow.setOpacity.mock.calls, [[0]]);
+
+    fakeWindow.setOpacity.mockClear();
+    fakeWindow.isFullScreen.mockReturnValue(true);
+    DesktopWindow.concealPendingQuitWindow(fakeWindow.window);
+    assert.deepEqual(fakeWindow.setFullScreen.mock.calls, [[false]]);
+    assert.deepEqual(fakeWindow.setOpacity.mock.calls, [[0]]);
+
+    fakeWindow.setOpacity.mockClear();
+    fakeWindow.isFullScreen.mockReturnValue(false);
+    fakeWindow.isDestroyed.mockReturnValue(true);
+    DesktopWindow.concealPendingQuitWindow(fakeWindow.window);
+    assert.equal(fakeWindow.setOpacity.mock.calls.length, 0);
+  });
+
   it("restores bounds only when the window fits within a connected display", () => {
     const persistedBounds = { x: 2040, y: 80, width: 1320, height: 880 };
     const displays = [

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -207,6 +207,21 @@ export function isRetryableDevelopmentRendererLoadFailure(input: {
   );
 }
 
+export function concealPendingQuitWindow(
+  window: Pick<
+    Electron.BrowserWindow,
+    "isDestroyed" | "isFullScreen" | "setFullScreen" | "setOpacity"
+  >,
+): void {
+  if (window.isDestroyed()) return;
+  if (window.isFullScreen()) {
+    window.setFullScreen(false);
+  }
+  // Electron implements window opacity on macOS and Windows. Linux keeps the
+  // release-gated quit behavior but cannot make the pending window disappear.
+  window.setOpacity(0);
+}
+
 function getWindowTitleBarOptions(
   shouldUseDarkColors: boolean,
   platform: NodeJS.Platform,
@@ -570,6 +585,9 @@ export const make = Effect.gen(function* () {
           window.webContents.send(QUIT_SHORTCUT_CHANNEL, hint);
         }
       },
+      // Keep the transparent window focused until the physical shortcut is
+      // released so its remaining repeats cannot reach the next app.
+      concealWindow: () => concealPendingQuitWindow(window),
       quit: () => {
         void runPromise(electronApp.quit);
       },

--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -94,6 +94,55 @@ describe("makeQuitShortcutHandler", () => {
     expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
   });
 
+  it("quits when a completed hold goes quiet without release events", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    await harness.holdFor(QUIT_HOLD_DURATION_MS + QUIT_HOLD_RELEASE_GRACE_MS * 2);
+
+    // If neither keyUp reaches the handler, continued repeats must keep the
+    // app alive. Once they stop, the quiet period is the release signal.
+    expect(harness.quit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
+
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
+  });
+
+  it("waits for slow repeats to stop before quitting", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+
+    vi.advanceTimersByTime(300);
+    await harness.send(makeInput({ isAutoRepeat: true }));
+    vi.advanceTimersByTime(900);
+    await harness.send(makeInput({ isAutoRepeat: true }));
+
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
+    expect(harness.quit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+    await harness.send(makeInput({ isAutoRepeat: true }));
+    vi.advanceTimersByTime(1_799);
+    expect(harness.quit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the initial repeat delay when the first repeat completes the hold", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+
+    vi.advanceTimersByTime(QUIT_HOLD_DURATION_MS + 100);
+    await harness.send(makeInput({ isAutoRepeat: true }));
+
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
+    expect(harness.quit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1_999);
+    expect(harness.quit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+  });
+
   it("waits for Q release when Cmd is released first", async () => {
     const harness = makeHarness();
     await harness.send(makeInput({}));

--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -32,11 +32,13 @@ function makeHarness(options?: {
   getMode?: () => Promise<QuitConfirmationMode>;
 }) {
   const notifications: Array<QuitShortcutHintEvent> = [];
+  const concealWindow = vi.fn();
   const quit = vi.fn();
   const handler = makeQuitShortcutHandler({
     platform: options?.platform ?? "darwin",
     getMode: options?.getMode ?? (() => Promise.resolve(options?.mode ?? "hold")),
     notify: (event) => notifications.push(event),
+    concealWindow,
     quit,
   });
   const preventDefault = vi.fn();
@@ -57,7 +59,7 @@ function makeHarness(options?: {
       await send(makeInput({ isAutoRepeat: true, ...repeatOverrides }));
     }
   };
-  return { notifications, quit, preventDefault, send, holdFor };
+  return { notifications, concealWindow, quit, preventDefault, send, holdFor };
 }
 
 describe("makeQuitShortcutHandler", () => {
@@ -82,16 +84,43 @@ describe("makeQuitShortcutHandler", () => {
     expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
   });
 
-  it("quits after a completed hold is released", async () => {
+  it("conceals a completed hold, then quits after release", async () => {
     const harness = makeHarness();
     await harness.send(makeInput({}));
     await harness.holdFor(QUIT_HOLD_DURATION_MS + 200);
+    expect(harness.concealWindow).toHaveBeenCalledTimes(1);
     expect(harness.quit).not.toHaveBeenCalled();
     await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
     expect(harness.quit).not.toHaveBeenCalled();
     vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
     expect(harness.quit).toHaveBeenCalledTimes(1);
     expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
+  });
+
+  it("keeps a concealed hold committed when another key is pressed", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    await harness.holdFor(QUIT_HOLD_DURATION_MS);
+
+    await harness.send(makeInput({ key: "Shift", shift: true }));
+    expect(harness.concealWindow).toHaveBeenCalledTimes(1);
+    expect(harness.quit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a concealed hold committed through a fresh Cmd+Q press", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    await harness.holdFor(QUIT_HOLD_DURATION_MS);
+
+    await harness.send(makeInput({}));
+    expect(harness.concealWindow).toHaveBeenCalledTimes(1);
+    expect(harness.quit).not.toHaveBeenCalled();
+
+    await harness.send(makeInput({ type: "keyUp" }));
+    expect(harness.quit).toHaveBeenCalledTimes(1);
   });
 
   it("quits when a completed hold goes quiet without release events", async () => {
@@ -164,6 +193,7 @@ describe("makeQuitShortcutHandler", () => {
     await harness.send(makeInput({ type: "keyUp" }));
     expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
     vi.advanceTimersByTime((QUIT_HOLD_DURATION_MS + QUIT_HOLD_RELEASE_GRACE_MS) * 2);
+    expect(harness.concealWindow).not.toHaveBeenCalled();
     expect(harness.quit).not.toHaveBeenCalled();
   });
 
@@ -179,6 +209,7 @@ describe("makeQuitShortcutHandler", () => {
   it("quits without showing a hint in direct mode", async () => {
     const harness = makeHarness({ mode: "direct" });
     await harness.send(makeInput({}));
+    expect(harness.concealWindow).not.toHaveBeenCalled();
     expect(harness.quit).toHaveBeenCalledTimes(1);
     expect(harness.notifications).toEqual([]);
   });
@@ -272,6 +303,7 @@ describe("makeQuitShortcutHandler", () => {
     await harness.send(makeInput({}));
     vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
     await harness.send(makeInput({}));
+    expect(harness.concealWindow).not.toHaveBeenCalled();
     expect(harness.quit).toHaveBeenCalledTimes(1);
     expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP]);
   });

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -32,6 +32,7 @@ export interface QuitShortcutOptions {
   readonly platform: NodeJS.Platform;
   readonly getMode: () => Promise<QuitConfirmationMode>;
   readonly notify: (event: QuitShortcutHintEvent) => void;
+  readonly concealWindow: () => void;
   readonly quit: () => void;
 }
 
@@ -120,12 +121,14 @@ export function makeQuitShortcutHandler(
       repeatCadenceMs = now - (lastRepeatAt === 0 ? heldSince : lastRepeatAt);
       lastRepeatAt = now;
     }
-    if (quitOnRelease && input.isAutoRepeat && key === "q") {
+    if (quitOnRelease) {
       event.preventDefault();
-      if (modifierDown) {
-        quitAfterQuietPeriod();
-      } else {
-        clearWatchdog();
+      if (key === "q") {
+        if (modifierDown) {
+          quitAfterQuietPeriod();
+        } else {
+          clearWatchdog();
+        }
       }
       return;
     }
@@ -154,6 +157,7 @@ export function makeQuitShortcutHandler(
       if (mode === "hold" && armed && Date.now() - heldSince >= QUIT_HOLD_DURATION_MS) {
         armed = false;
         quitOnRelease = true;
+        options.concealWindow();
         quitAfterQuietPeriod();
       }
       return;

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -11,9 +11,12 @@ export const QUIT_DOUBLE_PRESS_MS = 500;
 // release: macOS suppresses a letter keyUp while the command key is down, so a
 // tap release can go completely unseen and a release-based timer would quit
 // anyway. Once held, quitting waits for Q keyUp or a quiet grace period after
-// modifier keyUp so repeats cannot reach the next app. Keyboards with
+// repeats stop so they cannot reach the next app. Keyboards with
 // auto-repeat disabled fall back to the application menu Quit action.
 export const QUIT_HOLD_RELEASE_GRACE_MS = 600;
+// A slow repeat rate can exceed the fixed grace. Waiting for two observed
+// cadences keeps the timer behind the next repeat without slowing normal rates.
+const QUIT_HOLD_REPEAT_CADENCE_MULTIPLIER = 2;
 
 export interface QuitHoldKeyInput {
   readonly type: string;
@@ -45,6 +48,8 @@ export function makeQuitShortcutHandler(
   let quitOnRelease = false;
   let heldSince = 0;
   let lastPressAt = 0;
+  let lastRepeatAt = 0;
+  let repeatCadenceMs = 0;
   // Incremented when a press is superseded or explicitly cancelled. A plain
   // key release does not invalidate its pending mode read: direct mode and a
   // completed second press must still be honored after that read settles.
@@ -64,6 +69,8 @@ export function makeQuitShortcutHandler(
     holding = false;
     armed = false;
     quitOnRelease = false;
+    lastRepeatAt = 0;
+    repeatCadenceMs = 0;
     if (keepHint) return;
 
     mode = undefined;
@@ -80,6 +87,15 @@ export function makeQuitShortcutHandler(
     options.quit();
   };
 
+  const quitAfterQuietPeriod = () => {
+    clearWatchdog();
+    const quietPeriodMs = Math.max(
+      QUIT_HOLD_RELEASE_GRACE_MS,
+      repeatCadenceMs * QUIT_HOLD_REPEAT_CADENCE_MULTIPLIER,
+    );
+    watchdog = setTimeout(quitNow, quietPeriodMs);
+  };
+
   return (event, input) => {
     const key = input.key.toLowerCase();
     if (input.type === "keyUp") {
@@ -91,20 +107,29 @@ export function makeQuitShortcutHandler(
         if (!quitOnRelease) {
           release(false, true);
         } else {
-          watchdog = setTimeout(quitNow, QUIT_HOLD_RELEASE_GRACE_MS);
+          quitAfterQuietPeriod();
         }
       }
       return;
     }
     if (input.type !== "keyDown") return;
 
+    const modifierDown = options.platform === "darwin" ? input.meta : input.control;
+    if (input.isAutoRepeat && modifierDown && key === "q") {
+      const now = Date.now();
+      repeatCadenceMs = now - (lastRepeatAt === 0 ? heldSince : lastRepeatAt);
+      lastRepeatAt = now;
+    }
     if (quitOnRelease && input.isAutoRepeat && key === "q") {
       event.preventDefault();
-      clearWatchdog();
+      if (modifierDown) {
+        quitAfterQuietPeriod();
+      } else {
+        clearWatchdog();
+      }
       return;
     }
 
-    const modifierDown = options.platform === "darwin" ? input.meta : input.control;
     if (!modifierDown || input.alt || input.shift || key !== "q") {
       // Re-pressing the platform modifier is the first half of a second full
       // quit shortcut, so it must not cancel an active double-press window.
@@ -129,7 +154,7 @@ export function makeQuitShortcutHandler(
       if (mode === "hold" && armed && Date.now() - heldSince >= QUIT_HOLD_DURATION_MS) {
         armed = false;
         quitOnRelease = true;
-        clearWatchdog();
+        quitAfterQuietPeriod();
       }
       return;
     }


### PR DESCRIPTION
## What Changed

Completed hold-to-quit gestures now finish after Cmd+Q repeats stop, even when macOS omits the useful key-up event. At the 1.2-second threshold, T3 makes its focused window transparent so the interaction feels complete while the process continues consuming repeats. Native fullscreen exits before concealment. The process quits after release is safely detected.

The quiet timer follows the observed repeat cadence so slow keyboard settings do not send Cmd+Q into the next app. Once the window is concealed, other keys cannot cancel the committed quit and strand an invisible process.

This changes only the desktop window and shortcut handler. It does not change web, mobile, providers, or wire contracts.

## Why

The original handler could wait forever after a completed hold when macOS suppressed the release event. Waiting for repeat silence fixed that hang, but left the window visible after the 1.2-second hold threshold and gave no clear indication that the gesture had completed.

Quitting the process at the threshold would reintroduce the shortcut spillover fixed in #7369. Concealing the still-focused window gives immediate visual completion while keeping T3 alive long enough to consume the remaining repeats.

## Verification

- `vp test run src/window/QuitHold.test.ts src/window/DesktopWindow.test.ts` in `apps/desktop`: 51 passed, 0 failed.
- `pnpm --filter @t3tools/desktop typecheck`: passed.
- Targeted lint and format checks for the four changed desktop files: passed.
- Added regressions for missing release events, slow repeat cadences, concealment at the hold threshold, committed gestures surviving extra input, and fullscreen exit before concealment.
- Manually verified in an isolated `T3 Code (Dev)` instance on macOS in both normal-window and native-fullscreen modes. In each mode the window disappeared at the threshold, the process quit after release, and the next app stayed open.
- Two Fable 5 review rounds checked the handler state machine and Electron focus behavior. The final implementation includes the resulting committed-gesture and fullscreen safeguards.

## UI Changes

The existing hold hint is unchanged. The T3 window now disappears when the hold reaches its threshold instead of remaining visible until the release grace period ends.

No recording was captured because the verification used native keyboard input in the maintainer's isolated desktop session.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Static screenshots are not applicable because no layout or visual design changed
- [ ] I included a video for the interaction timing change

Implementation used GPT-5.6 Sol in T3 Code. Independent review used Fable 5 through Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hold-to-quit getting stuck in `makeQuitShortcutHandler`
> - A completed hold now conceals the window via `concealPendingQuitWindow` in [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/9141/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429), which exits fullscreen and sets opacity to 0 before waiting for key release.
> - The handler in [QuitHold.ts](https://github.com/pingdotgg/t3code/pull/9141/files#diff-c9e580dbc762f19a498b272467ed869973f2fb60fb1765ebbdf7b0d3c2883760) tracks observed auto-repeat cadence and waits for the larger of the fixed grace period or twice the repeat interval before timing out, so continued repeats postpone quitting instead of stalling.
> - Committed holds stay committed through unrelated keydowns and fresh qualifying presses; only `keyup` or the quiet-period timeout completes the quit.
> - Risk: `QuitShortcutOptions` now requires a `conceal` callback — all callers of `makeQuitShortcutHandler` must supply it or compilation fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f72b306.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->