### PR TITLE
fix(web): project default model works on the hosted app

### DIFF
--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -408,6 +408,7 @@ function AgentBrowserAccessSetting() {
 
   return (
     <SettingsRow
+      serverScoped
       {...searchableSetting("agent-browser-access")}
       description="Let agents open and drive the preview browser. When off, the browser tools and the instructions describing them are withheld from agent sessions. Your own browser panel is unaffected."
       status={

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -517,8 +517,9 @@ export function IntegrationsSettingsPanel() {
   return (
     <SettingsPageContainer>
       <SettingsSection id="browser" title="Browser">
-        {/* Server-authoritative, so it stays editable on every client and sits
-            outside the block covering the desktop-only defaults. */}
+        {/* Server-authoritative, so it stays editable on any client anchored to
+            a server; `serverScoped` covers the hosted app, which has none. It
+            sits outside the block covering the desktop-only defaults. */}
         <AgentBrowserAccessSetting />
         {previewDefaultsDisabled ? (
           <DesktopOnlyBrowserDefaults>{previewDefaults}</DesktopOnlyBrowserDefaults>

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -39,6 +39,7 @@ import { useComposerDraftStore } from "../../composerDraftStore";
 import { isElectron } from "../../env";
 import {
   useClientSettings,
+  useEnvironmentSettings,
   useUpdateClientSettings,
   usePrimarySettings,
 } from "../../hooks/useSettings";
@@ -69,7 +70,7 @@ import {
 import { useEnvironments, usePrimaryEnvironmentId } from "../../state/environments";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { projectEnvironment } from "../../state/projects";
-import { primaryServerProvidersAtom, serverEnvironment } from "../../state/server";
+import { EMPTY_SERVER_PROVIDERS, serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { TraitsPicker } from "../chat/TraitsPicker";
@@ -292,10 +293,20 @@ export function ProjectSettingsPanel({ projectKey }: { projectKey: string }) {
 function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   const navigate = useNavigate();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const representative =
+    group.memberProjects.find(
+      (member) => member.environmentId === group.environmentId && member.id === group.id,
+    ) ?? group.memberProjects[0]!;
   const settings = usePrimarySettings();
+  // Provider instances and model options belong to the environment that runs
+  // the project's threads. The hosted app has no primary environment, so
+  // reading them from there would show "No providers available" everywhere.
+  const projectSettings = useEnvironmentSettings(representative.environmentId);
+  const serverProviders =
+    useAtomValue(serverEnvironment.providersValueAtom(representative.environmentId)) ??
+    EMPTY_SERVER_PROVIDERS;
   const updateClientSettings = useUpdateClientSettings();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const threads = useThreadShells();
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
   const deleteProject = useAtomCommand(projectEnvironment.delete, { reportFailure: false });
@@ -321,10 +332,6 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
     },
   });
 
-  const representative =
-    group.memberProjects.find(
-      (member) => member.environmentId === group.environmentId && member.id === group.id,
-    ) ?? group.memberProjects[0]!;
   const faviconPath = representative.faviconPath ?? null;
   const pickProjectFavicon =
     typeof window !== "undefined" &&
@@ -422,14 +429,22 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   const instanceEntries = useMemo(
     () =>
       sortProviderInstanceEntries(
-        applyProviderInstanceSettings(deriveProviderInstanceEntries(serverProviders), settings),
+        applyProviderInstanceSettings(
+          deriveProviderInstanceEntries(serverProviders),
+          projectSettings,
+        ),
       ),
-    [serverProviders, settings],
+    [serverProviders, projectSettings],
   );
   const modelOptionsByInstance = useMemo(
     () =>
-      getCustomModelOptionsByInstance(settings, serverProviders, resolvedInstanceId, resolvedModel),
-    [resolvedInstanceId, resolvedModel, serverProviders, settings],
+      getCustomModelOptionsByInstance(
+        projectSettings,
+        serverProviders,
+        resolvedInstanceId,
+        resolvedModel,
+      ),
+    [resolvedInstanceId, resolvedModel, serverProviders, projectSettings],
   );
   const activeEntry = instanceEntries.find((entry) => entry.instanceId === resolvedInstanceId);
   const setDefaultModel = useCallback(
@@ -864,7 +879,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                     onPromptChange={() => {}}
                     modelOptions={resolvedSelection.options ?? []}
                     allowPromptInjectedEffort={false}
-                    planModeEnabled={settings.planModeEnabled}
+                    planModeEnabled={projectSettings.planModeEnabled}
                     triggerVariant="outline"
                     triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
                     onModelOptionsChange={(nextOptions) => {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1826,6 +1826,7 @@ function LegacyFeaturesSection() {
               }
             />
             <SettingsRow
+              serverScoped
               {...searchableSetting("legacy-token-streaming")}
               description="Paints assistant output token by token instead of in complete chunks. Not recommended: it is significantly slower, and long responses become harder to follow. Kept only for compatibility with the old behavior."
               control={
@@ -1968,6 +1969,7 @@ export function GeneralSettingsPanel() {
         {supportsAutoSettlement ? (
           <>
             <SettingsRow
+              serverScoped
               {...searchableSetting("auto-settle-merged-threads")}
               description="Settle a thread when its pull request merges. Closed pull requests still settle automatically."
               resetAction={
@@ -1995,6 +1997,7 @@ export function GeneralSettingsPanel() {
             />
 
             <SettingsRow
+              serverScoped
               {...searchableSetting("auto-settle-inactive-threads")}
               description="Sidebar threads with no activity for this long settle automatically."
               resetAction={
@@ -2025,6 +2028,7 @@ export function GeneralSettingsPanel() {
             />
             {settings.sidebarAutoSettleAfterDays !== null ? (
               <SettingsRow
+                serverScoped
                 title={searchableSetting("days-before-auto-settle").title}
                 description="Any new activity un-settles a thread automatically."
                 control={
@@ -2133,6 +2137,7 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          serverScoped
           {...searchableSetting("provider-update-checks")}
           description="Check installed provider CLIs for newer available versions."
           resetAction={
@@ -2160,6 +2165,7 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          serverScoped
           id={searchableSetting("background-activity").id}
           title={
             <span className="inline-flex items-center gap-1.5">
@@ -2243,6 +2249,7 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          serverScoped
           {...searchableSetting("new-threads")}
           description="Pick the default workspace mode for newly created draft threads."
           resetAction={
@@ -2289,6 +2296,7 @@ export function GeneralSettingsPanel() {
 
         {settings.defaultThreadEnvMode === "worktree" ? (
           <SettingsRow
+            serverScoped
             className="bg-muted/20 sm:pl-9"
             title={searchableSetting("start-from-origin").title}
             description="Creates the worktree from the latest matching branch on origin instead of your local branch."
@@ -2319,6 +2327,7 @@ export function GeneralSettingsPanel() {
         ) : null}
 
         <SettingsRow
+          serverScoped
           {...searchableSetting("add-project-starts-in")}
           description='Leave empty to use "~/" when the Add Project browser opens.'
           resetAction={
@@ -2463,6 +2472,7 @@ export function GeneralSettingsPanel() {
         ) : null}
 
         <SettingsRow
+          serverScoped
           {...searchableSetting("text-generation-model")}
           description="Default model for generated text like thread titles and source control content. Source control settings can override it with a dedicated source control writer model."
           resetAction={

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -591,7 +591,9 @@ export function SourceControlSettingsPanel() {
         />
       )}
 
-      {isPrimaryEnvironment ? <SourceControlWritingSettingsSection /> : null}
+      {/* Its rows are serverScoped: without a primary they render inert with
+          an explanation, which beats disappearing. */}
+      <SourceControlWritingSettingsSection />
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -74,6 +74,7 @@ export function SourceControlWritingSettingsSection() {
   return (
     <SettingsSection title="Text generation">
       <SettingsRow
+        serverScoped
         {...searchableSetting("source-control-writing-style")}
         description={MODE_OPTIONS[style.mode].description}
         resetAction={
@@ -138,6 +139,7 @@ export function SourceControlWritingSettingsSection() {
       </SettingsRow>
 
       <SettingsRow
+        serverScoped
         {...searchableSetting("follow-change-request-templates")}
         description="Structures change request descriptions using the current repository's template when one is available."
         resetAction={
@@ -170,6 +172,7 @@ export function SourceControlWritingSettingsSection() {
       />
 
       <SettingsRow
+        serverScoped
         {...searchableSetting("source-control-writer-model")}
         description="Optional model override for change descriptions, change request titles and descriptions, and branch or bookmark names. Off uses the global text generation model."
         control={

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -244,7 +244,13 @@ export function SettingsRow({
           </div>
         ) : null}
       </div>
-      {children}
+      {unavailable && children ? (
+        <div inert className="opacity-50">
+          {children}
+        </div>
+      ) : (
+        children
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -11,6 +11,10 @@ import {
   useState,
 } from "react";
 
+import {
+  PRIMARY_SETTINGS_UNAVAILABLE_MESSAGE,
+  usePrimarySettingsAvailable,
+} from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { WorkspacePageContainer, type WorkspacePageWidth } from "../WorkspacePageContainer";
 import { Button } from "../ui/button";
@@ -159,12 +163,19 @@ export function SettingsSection({
   );
 }
 
+/**
+ * One setting. `serverScoped` marks rows whose value lives in the primary
+ * environment's settings.json; where there is no primary (the hosted app)
+ * the control goes inert with a tooltip instead of showing an editable
+ * default that would never save.
+ */
 export function SettingsRow({
   title,
   description,
   status,
   resetAction,
   control,
+  serverScoped = false,
   children,
   className,
   ...rowProps
@@ -174,9 +185,28 @@ export function SettingsRow({
   status?: ReactNode;
   resetAction?: ReactNode;
   control?: ReactNode;
+  serverScoped?: boolean;
   children?: ReactNode;
 }) {
   const targetRef = useSettingsSearchTarget<HTMLDivElement>(rowProps.id);
+  const primarySettingsAvailable = usePrimarySettingsAvailable();
+  const unavailable = serverScoped && !primarySettingsAvailable;
+  const renderedReset = unavailable ? null : resetAction;
+  const renderedControl =
+    unavailable && control ? (
+      <Tooltip>
+        <TooltipTrigger render={<span className="flex w-full items-center sm:w-auto" />}>
+          <div inert className="flex w-full items-center gap-2 opacity-50 sm:w-auto">
+            {control}
+          </div>
+        </TooltipTrigger>
+        <TooltipPopup side="top" className="max-w-72">
+          {PRIMARY_SETTINGS_UNAVAILABLE_MESSAGE}
+        </TooltipPopup>
+      </Tooltip>
+    ) : (
+      control
+    );
 
   return (
     <div
@@ -190,7 +220,7 @@ export function SettingsRow({
           <div className="flex min-h-5 items-center gap-1.5">
             <h3 className="text-sm font-medium tracking-[-0.005em] text-foreground">{title}</h3>
             <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-              {resetAction}
+              {renderedReset}
             </span>
           </div>
           {description ? (
@@ -200,9 +230,9 @@ export function SettingsRow({
           ) : null}
           {status ? <div className="pt-0.5 text-xs text-muted-foreground">{status}</div> : null}
         </div>
-        {control ? (
+        {renderedControl ? (
           <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
-            {control}
+            {renderedControl}
           </div>
         ) : null}
       </div>

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -195,7 +195,15 @@ export function SettingsRow({
   const renderedControl =
     unavailable && control ? (
       <Tooltip>
-        <TooltipTrigger render={<span className="flex w-full items-center sm:w-auto" />}>
+        <TooltipTrigger
+          render={
+            // Focusable so keyboard users can still reach the explanation.
+            <span
+              tabIndex={0}
+              className="flex w-full items-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-auto"
+            />
+          }
+        >
           <div inert className="flex w-full items-center gap-2 opacity-50 sm:w-auto">
             {control}
           </div>

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -34,6 +34,8 @@ import {
   themeAllowsSidebarArtwork,
 } from "~/themePalette";
 import * as Struct from "effect/Struct";
+import { toastManager } from "~/components/ui/toast";
+import { isHostedStaticApp } from "~/hostedPairing";
 import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
 import { usePrimaryEnvironment } from "~/state/environments";
 import { useAtomCommand } from "~/state/use-atom-command";
@@ -307,6 +309,20 @@ export function usePrimarySettings<T = UnifiedSettings>(
   return useMergedSettings(useAtomValue(primaryServerSettingsAtom), selector);
 }
 
+export const PRIMARY_SETTINGS_UNAVAILABLE_MESSAGE =
+  "This setting is saved on a server, and the hosted app is not anchored to one. Change it from the desktop app or from the server's own address.";
+
+/**
+ * Whether primary-scoped server settings have a server to live on. The
+ * hosted app connects to every environment as a remote, so it has no primary:
+ * `usePrimarySettings` reads schema defaults there and writes have nowhere
+ * to go. Desktop and server-served web always have one.
+ */
+export function usePrimarySettingsAvailable(): boolean {
+  const primaryEnvironment = usePrimaryEnvironment();
+  return primaryEnvironment !== null || !isHostedStaticApp();
+}
+
 /**
  * Returns an updater that routes each key to the correct backing store.
  *
@@ -327,6 +343,13 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
           void persistServerSettings({
             environmentId,
             input: { patch: serverPatch },
+          });
+        } else {
+          // Dropping the write silently leaves the control looking saved.
+          toastManager.add({
+            type: "warning",
+            title: "Setting not saved",
+            description: PRIMARY_SETTINGS_UNAVAILABLE_MESSAGE,
           });
         }
       }

--- a/apps/web/src/hostedPairing.ts
+++ b/apps/web/src/hostedPairing.ts
@@ -31,7 +31,7 @@ function originFromUrl(value: string): string | null {
   }
 }
 
-export function isHostedStaticApp(url: URL = new URL(window.location.href)): boolean {
+export function isHostedStaticApp(url?: URL): boolean {
   if (configuredBackendUrl()) {
     return false;
   }
@@ -40,8 +40,13 @@ export function isHostedStaticApp(url: URL = new URL(window.location.href)): boo
     return true;
   }
 
+  // No window (tests, static render) means no origin to be hosted at.
+  if (url === undefined && typeof window === "undefined") {
+    return false;
+  }
+
   const hostedOrigin = originFromUrl(configuredHostedAppUrl());
-  return hostedOrigin !== null && url.origin === hostedOrigin;
+  return hostedOrigin !== null && (url ?? new URL(window.location.href)).origin === hostedOrigin;
 }
 
 export function readHostedPairingRequest(url: URL = new URL(window.location.href)) {


### PR DESCRIPTION
On app.t3.codes, project settings showed **"No providers available"** for the default model, and the global server-scoped settings (new-thread workspace, background activity, …) displayed schema defaults and silently dropped every write. Not local state: the hosted app registers no `PrimaryConnectionTarget` (`platform.ts` returns `Stream.empty` when `isHostedStaticApp()`), so everything wired to the primary-environment atoms resolved to nothing there.

**Fix**

- Project settings reads providers and provider-instance settings from the environment that owns the project (`serverEnvironment.providersValueAtom` / `useEnvironmentSettings`), the same way the composer already does. The model picker now works on hosted; desktop and server-served web are unchanged since primary and project environment coincide there.
- Stopgap for global settings, which need a proper anchor-environment story separately: `SettingsRow` gets a `serverScoped` flag. Rows whose value lives in the primary environment's `settings.json` (14 across General, Integrations, Source Control) render inert with a tooltip when there is no primary, instead of an editable control that never saves. Client-keyed rows are untouched.
- `useUpdateSettingsTarget` toasts "Setting not saved" when a server patch has no environment to go to, instead of discarding it.

`usePrimarySettingsAvailable()` is `primaryEnvironment !== null || !isHostedStaticApp()`, so desktop/local never flash the disabled state during boot, and if hosted later gains an anchor environment the disabling switches itself off.

**Before / after** (hosted mode: `VITE_HOSTED_APP_CHANNEL=nightly`, server paired as a remote)

| Before | After |
| --- | --- |
| ![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/010d166acf506513/hosted-project-settings-before.png) | ![after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/fca2a38fa63256fa/hosted-project-settings-after.png) |

Server-scoped global rows on hosted:

![tooltip](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6d557dc1a83033b9/hosted-general-settings-tooltip.png)

**Demo** — picking and resetting a project default model on the hosted client, then the inert global rows with their tooltip:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b5fa546346309015/hosted-settings-demo-trimmed.mp4

Verified with `apps/web` typecheck, lint on the changed files, and the `useSettings` / `settingsLayout` / `ProjectSettingsPanel.logic` tests.

Claude Fable 5 via Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches settings persistence and provider resolution paths; hosted users lose editability for primary-only globals (by design), while desktop/server-served behavior should be unchanged via `usePrimarySettingsAvailable`.
> 
> **Overview**
> Fixes **hosted app** (`app.t3.codes`) behavior where project default model showed **"No providers available"** and global server settings looked editable but never persisted.
> 
> **Project settings** now load providers and provider-instance settings from the **project's environment** (`useEnvironmentSettings` / per-environment provider atoms) instead of the primary server, so the default model picker works when every connection is a remote.
> 
> **Global server-scoped settings** get a `serverScoped` flag on `SettingsRow`: when there is no primary environment, controls render **inert** (dimmed, non-interactive) with a tooltip explaining the setting must be changed from desktop or the server's URL. Many General, Integrations, and Source Control rows are marked accordingly; source-control writing sections stay visible instead of being hidden on non-primary environments.
> 
> **Persistence**: `useUpdateSettingsTarget` shows a **"Setting not saved"** warning toast instead of silently dropping server patches when no `environmentId` is available. `isHostedStaticApp()` is safe to call without `window` for tests/static render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a79208c2e45e66bb907ba80aa18d515e276fde58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make hosted-app settings server-scoped and resolve project default model from its own environment
> - Adds a `serverScoped` flag to `SettingsRow` in [settingsLayout.tsx](https://github.com/pingdotgg/t3code/pull/9142/files#diff-b320015b8831dfe0790cf2606a38785fca21e9a39f13b7d8afefbead69523dc9) so rows become inert and show a shared explanation when the hosted static app has no primary server
> - Adds `usePrimarySettingsAvailable` in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/9142/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) to detect the hosted-without-server state, and emits a warning toast when server-backed settings are updated without a target environment
> - Reworks [ProjectSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/9142/files#diff-0240d4863349583155edae77c3bfab65683d7e019508379850a5b96167960cdc) to load provider instances, model options, and plan-mode flags from the representative project's environment rather than primary settings
> - Marks many general, legacy, source-control, and integration rows as server-scoped across multiple settings panels
> - Fixes `isHostedStaticApp` in [hostedPairing.ts](https://github.com/pingdotgg/t3code/pull/9142/files#diff-f791c48c17f96ca81a039bf7675078f1327912cc3498bbc304fcc289408524ea) to avoid accessing `window` in windowless runtimes
> - Risk: `useUpdateSettingsTarget` now shows a warning toast and drops server-setting patches that arrive without an environment ID; reviewers should verify the no-env path in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/9142/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) does not regress existing client-side setting saves
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a79208c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->