### PR TITLE
perf(client-runtime): keep turn and checkpoint refs stable while streaming

### DIFF
--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -497,6 +497,139 @@ describe("applyThreadDetailEvent", () => {
         expect(result.thread.latestTurn?.completedAt).toBeNull();
       }
     });
+
+    it("keeps latestTurn and checkpoints references across a streaming delta", () => {
+      const streamingThread: OrchestrationThread = {
+        ...baseThread,
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "claude",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-1"),
+          lastError: null,
+          updatedAt: "2026-04-01T06:59:00.000Z",
+        },
+        latestTurn: {
+          turnId: TurnId.make("turn-1"),
+          state: "running",
+          requestedAt: "2026-04-01T06:59:00.000Z",
+          startedAt: "2026-04-01T06:59:00.000Z",
+          completedAt: null,
+          assistantMessageId: MessageId.make("msg-2"),
+        },
+        messages: [
+          {
+            id: MessageId.make("msg-2"),
+            role: "assistant",
+            text: "Hello",
+            turnId: TurnId.make("turn-1"),
+            streaming: true,
+            createdAt: "2026-04-01T06:00:00.000Z",
+            updatedAt: "2026-04-01T06:00:00.000Z",
+          },
+        ],
+        checkpoints: [
+          {
+            turnId: TurnId.make("turn-1"),
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("ref-1"),
+            status: "ready",
+            files: [],
+            assistantMessageId: MessageId.make("msg-2"),
+            completedAt: "2026-04-01T06:00:30.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(streamingThread, {
+        ...baseEventFields,
+        sequence: 9,
+        occurredAt: "2026-04-01T07:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.message-sent",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("msg-2"),
+          role: "assistant",
+          text: ", world",
+          turnId: TurnId.make("turn-1"),
+          streaming: true,
+          createdAt: "2026-04-01T06:00:00.000Z",
+          updatedAt: "2026-04-01T07:00:00.000Z",
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages).not.toBe(streamingThread.messages);
+        expect(result.thread.messages[0]?.text).toBe("Hello, world");
+        expect(result.thread.latestTurn).toBe(streamingThread.latestTurn);
+        expect(result.thread.checkpoints).toBe(streamingThread.checkpoints);
+      }
+    });
+
+    it("replaces latestTurn and checkpoints when the first assistant message binds the turn", () => {
+      const unboundThread: OrchestrationThread = {
+        ...baseThread,
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "claude",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-1"),
+          lastError: null,
+          updatedAt: "2026-04-01T06:59:00.000Z",
+        },
+        latestTurn: {
+          turnId: TurnId.make("turn-1"),
+          state: "running",
+          requestedAt: "2026-04-01T06:59:00.000Z",
+          startedAt: "2026-04-01T06:59:00.000Z",
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        checkpoints: [
+          {
+            turnId: TurnId.make("turn-1"),
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("ref-1"),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: "2026-04-01T06:59:30.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(unboundThread, {
+        ...baseEventFields,
+        sequence: 9,
+        occurredAt: "2026-04-01T07:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.message-sent",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("msg-2"),
+          role: "assistant",
+          text: "Hello",
+          turnId: TurnId.make("turn-1"),
+          streaming: true,
+          createdAt: "2026-04-01T07:00:00.000Z",
+          updatedAt: "2026-04-01T07:00:00.000Z",
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.latestTurn).not.toBe(unboundThread.latestTurn);
+        expect(result.thread.latestTurn?.assistantMessageId).toBe("msg-2");
+        expect(result.thread.checkpoints).not.toBe(unboundThread.checkpoints);
+        expect(result.thread.checkpoints[0]?.assistantMessageId).toBe("msg-2");
+      }
+    });
   });
 
   describe("thread.session-set", () => {

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -331,16 +331,18 @@ export function applyThreadDetailEvent(
       // assistant message only settles the turn once the session is no longer
       // running it — providers may emit several assistant messages per turn
       // (commentary between tool calls), and the turn must stay unsettled
-      // until the provider reports turn end.
+      // until the provider reports turn end. Streaming deltas recompute the
+      // same record, so the previous reference is kept when nothing changed.
       const turnStillRunning =
         event.payload.turnId !== null &&
         thread.session?.status === "running" &&
         thread.session.activeTurnId === event.payload.turnId;
       const settlesTurn = !event.payload.streaming && !turnStillRunning;
-      const latestTurn: OrchestrationThread["latestTurn"] =
+      const latestTurn = reuseLatestTurn(
+        thread.latestTurn,
         event.payload.role === "assistant" &&
-        event.payload.turnId !== null &&
-        (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
+          event.payload.turnId !== null &&
+          (thread.latestTurn === null || thread.latestTurn.turnId === event.payload.turnId)
           ? {
               turnId: event.payload.turnId,
               state: settlesTurn
@@ -365,9 +367,11 @@ export function applyThreadDetailEvent(
                   : null,
               assistantMessageId: event.payload.messageId,
             }
-          : thread.latestTurn;
+          : thread.latestTurn,
+      );
 
-      // Rebind checkpoint assistant message IDs for assistant messages.
+      // Rebind checkpoint assistant message IDs for assistant messages. The
+      // helper hands back the same array when the entry is already bound.
       const checkpoints =
         event.payload.role === "assistant" && event.payload.turnId !== null
           ? rebindCheckpointAssistantMessage(
@@ -394,7 +398,8 @@ export function applyThreadDetailEvent(
       // Leaving the "running" session status is the turn-end signal: settle a
       // still-running latest turn so its duration reflects the whole turn.
       const settledTurnState = settledTurnStateForSessionStatus(event.payload.session.status);
-      const latestTurn: OrchestrationLatestTurn | null =
+      const latestTurn = reuseLatestTurn(
+        thread.latestTurn,
         event.payload.session.status === "running" && event.payload.session.activeTurnId !== null
           ? {
               turnId: event.payload.session.activeTurnId,
@@ -424,7 +429,8 @@ export function applyThreadDetailEvent(
                 // "running" is the authoritative turn end.
                 completedAt: event.payload.session.updatedAt,
               }
-            : thread.latestTurn;
+            : thread.latestTurn,
+      );
 
       return {
         kind: "updated",
@@ -652,11 +658,46 @@ function checkpointStatusToTurnState(
   }
 }
 
+/**
+ * Returns `previous` when `next` matches it field for field, otherwise `next`.
+ * Streaming cases recompute the latest turn on every delta, and keeping the
+ * old reference lets selectors and memos keyed on `latestTurn` skip work.
+ */
+function reuseLatestTurn(
+  previous: OrchestrationLatestTurn | null,
+  next: OrchestrationLatestTurn | null,
+): OrchestrationLatestTurn | null {
+  if (previous === null || next === null) {
+    return next;
+  }
+  return previous.turnId === next.turnId &&
+    previous.state === next.state &&
+    previous.requestedAt === next.requestedAt &&
+    previous.startedAt === next.startedAt &&
+    previous.completedAt === next.completedAt &&
+    previous.assistantMessageId === next.assistantMessageId &&
+    previous.sourceProposedPlan?.threadId === next.sourceProposedPlan?.threadId &&
+    previous.sourceProposedPlan?.planId === next.sourceProposedPlan?.planId
+    ? previous
+    : next;
+}
+
+/**
+ * Points the checkpoint for `turnId` at `messageId`. Returns the input array
+ * untouched when no checkpoint needs rebinding, so streaming deltas for an
+ * already-bound message do not allocate a new `checkpoints` reference.
+ */
 function rebindCheckpointAssistantMessage(
   checkpoints: ReadonlyArray<OrchestrationCheckpointSummary>,
   turnId: TurnId,
   messageId: MessageId,
-): OrchestrationCheckpointSummary[] {
+): ReadonlyArray<OrchestrationCheckpointSummary> {
+  const needsRebind = checkpoints.some(
+    (entry) => entry.turnId === turnId && entry.assistantMessageId !== messageId,
+  );
+  if (!needsRebind) {
+    return checkpoints;
+  }
   return Arr.map(checkpoints, (entry) =>
     entry.turnId === turnId ? { ...entry, assistantMessageId: messageId } : entry,
   );


### PR DESCRIPTION
## Problem

During assistant streaming every text delta arrives as a `thread.message-sent` event. The reducer rebuilt `latestTurn` as a new object and mapped `checkpoints` into a new array even when nothing in them changed. Any selector or memo keyed on `thread.latestTurn` or `thread.checkpoints` recomputed on every delta for no reason.

## Fix

- `thread.message-sent` and `thread.session-set` pass the recomputed latest turn through `reuseLatestTurn`, which returns the previous object when every field matches.
- `rebindCheckpointAssistantMessage` returns the input array when no checkpoint for that turn needs a new `assistantMessageId`.
- The `messages` array still changes on every delta, as it must.

I checked every `latestTurn` and `checkpoints` consumer in `apps/web`, `apps/mobile`, and `packages/client-runtime`. All of them compare values, none rely on a fresh reference.

## Tests

- `vp test run packages/client-runtime/src/state/threadReducer.test.ts` (30 passed, 2 new: refs stay stable across a streaming delta, refs change when the first assistant message binds the turn)
- `vp run --filter @t3tools/client-runtime typecheck`
- `vp lint` and `vp fmt --check` on the two changed files

Change authored by Claude Fable 5.1 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure reducer structural-sharing change with behavioral tests; no API or security surface change, only reference identity when values are equal.
> 
> **Overview**
> Reduces unnecessary re-renders during assistant streaming by preserving object identity on `thread` state when turn and checkpoint data are unchanged.
> 
> `applyThreadDetailEvent` now routes recomputed `latestTurn` through **`reuseLatestTurn`**, which returns the previous object when every field (including optional `sourceProposedPlan`) matches. **`rebindCheckpointAssistantMessage`** skips mapping and returns the existing **`checkpoints`** array when the turn’s checkpoint already has the right **`assistantMessageId`**. **`thread.message-sent`** and **`thread.session-set`** use both behaviors; **`messages`** still get a new array on each streaming delta as before.
> 
> Tests assert reference stability across a streaming text delta and new references when the first assistant message binds **`assistantMessageId`** on **`latestTurn`** and checkpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8173ee6ca25652fecf522ad452fdf1a73127b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `latestTurn` and `checkpoints` object references during streaming in `threadReducer`
> - Adds `reuseLatestTurn` helper to `applyThreadDetailEvent` that returns the prior `latestTurn` object when all compared fields (turn identity, state, timestamps, assistant message ID, and `sourceProposedPlan` thread/plan IDs) are equal, and returns the computed value otherwise
> - Updates `rebindCheckpointAssistantMessage` to return the input `checkpoints` array unchanged when no checkpoint needs rebinding, and only allocates a new array when a binding actually changes
> - Routes `thread.message-sent` and `thread.session-set` through `reuseLatestTurn`, preserving existing turn-state and settlement rules while avoiding new object references for equivalent records
> - Adds regression tests verifying that streaming deltas mutate message text and collection without replacing `latestTurn` or `checkpoints` references, and that the first assistant message correctly binds its ID into both
> - Behavioral Change: `latestTurn` and `checkpoints` references now remain stable across streaming deltas when content is unchanged; consumers relying on reference inequality to detect any reducer pass will no longer see updates on no-op deltas
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c8173e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->