### PR TITLE
fix(settings): sync auto-settle and other shared preferences across environments

### DIFF
--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -597,8 +597,11 @@ function AutoSettleSettingsRows() {
 
   const afterDays = referenceSettings.sidebarAutoSettleAfterDays;
   const commitDays = () => {
-    const parsed = Number.parseInt(daysDraft ?? "", 10);
+    const draft = (daysDraft ?? "").trim();
     setDaysDraft(null);
+    // Whole-string check so "3.5" and "3days" are rejected instead of
+    // silently becoming 3 on every connected environment.
+    const parsed = /^\d+$/.test(draft) ? Number(draft) : Number.NaN;
     if (
       Number.isInteger(parsed) &&
       parsed >= MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS &&

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -19,7 +19,7 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
-import { AppText as Text } from "../../components/AppText";
+import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { supportsAgentAwarenessPush } from "../agent-awareness/capabilities";
 import { setLiveActivityUpdatesEnabled } from "../agent-awareness/liveActivityPreferences";
 import { requestAgentNotificationPermission } from "../agent-awareness/notificationPermissions";
@@ -36,7 +36,17 @@ import { runtime } from "../../lib/runtime";
 import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
-import type { EnvironmentId } from "@t3tools/contracts";
+import { useEnvironments } from "../../state/environments";
+import {
+  DEFAULT_SERVER_SETTINGS,
+  MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+  MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
+  type ServerSettingsPatch,
+} from "@t3tools/contracts";
+import {
+  findSharedSettingsMismatches,
+  pickSharedServerSettings,
+} from "@t3tools/client-runtime/state/shared-settings";
 import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
 import {
   type AppUpdateCheckState,
@@ -530,51 +540,133 @@ function ConfiguredSettingsRouteScreen() {
 }
 
 function GeneralSettingsSection() {
-  const { savedConnectionsById } = useSavedRemoteConnections();
-  const connections = Object.values(savedConnectionsById).sort((left, right) =>
-    left.environmentLabel.localeCompare(right.environmentLabel),
-  );
-
   return (
     <SettingsSection title="General">
       <SettingsRow icon="folder" label="Project Grouping" target="SettingsProjectGrouping" />
-      {connections.map((connection) => (
-        <EnvironmentAutoSettleSwitch
-          key={connection.environmentId}
-          environmentId={connection.environmentId}
-          environmentLabel={connection.environmentLabel}
-        />
-      ))}
+      <AutoSettleSettingsRows />
       <SettingsRow icon="chart.bar.xaxis" label="Usage" target="SettingsUsage" />
     </SettingsSection>
   );
 }
 
-function EnvironmentAutoSettleSwitch(props: {
-  readonly environmentId: EnvironmentId;
-  readonly environmentLabel: string;
-}) {
-  const settings = useAtomValue(serverEnvironment.settingsValueAtom(props.environmentId));
-  const config = useAtomValue(serverEnvironment.configValueAtom(props.environmentId));
+const AUTO_SETTLE_DEFAULT_DAYS = DEFAULT_SERVER_SETTINGS.sidebarAutoSettleAfterDays ?? 3;
+
+/**
+ * Auto-settlement is a user preference that every server has to hold. Mobile
+ * has no primary environment, so the first connected environment that
+ * supports it is the reference value. Edits fan out to every connected
+ * environment, and a mismatch row lets the user push the reference out.
+ */
+function AutoSettleSettingsRows() {
+  const { environments } = useEnvironments();
   const updateSettings = useAtomCommand(serverEnvironment.updateSettings, {
-    label: "auto-settle settings update",
+    label: "server settings update",
     reportFailure: true,
   });
-  if (config?.environment.capabilities.threadAutoSettlement !== true || settings === null) {
+
+  const connected = environments.filter(
+    (environment) =>
+      environment.connection.phase === "connected" &&
+      environment.serverConfig?.environment.capabilities.threadAutoSettlement === true,
+  );
+  const reference = connected[0] ?? null;
+  const referenceSettings = reference?.serverConfig?.settings ?? null;
+
+  const [daysDraft, setDaysDraft] = useState<string | null>(null);
+
+  if (reference === null || referenceSettings === null) {
     return null;
   }
+
+  const writeToAll = (patch: ServerSettingsPatch) => {
+    for (const environment of connected) {
+      void updateSettings({ environmentId: environment.environmentId, input: { patch } });
+    }
+  };
+
+  const mismatches = findSharedSettingsMismatches({
+    primaryEnvironmentId: reference.environmentId,
+    primarySettings: referenceSettings,
+    environments: environments.map((environment) => ({
+      environmentId: environment.environmentId,
+      label: environment.label,
+      connected: environment.connection.phase === "connected",
+      settings: environment.serverConfig?.settings ?? null,
+    })),
+  });
+
+  const afterDays = referenceSettings.sidebarAutoSettleAfterDays;
+  const commitDays = () => {
+    const parsed = Number.parseInt(daysDraft ?? "", 10);
+    setDaysDraft(null);
+    if (
+      Number.isInteger(parsed) &&
+      parsed >= MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS &&
+      parsed <= MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS &&
+      parsed !== afterDays
+    ) {
+      writeToAll({ sidebarAutoSettleAfterDays: parsed });
+    }
+  };
+
   return (
-    <SettingsSwitchRow
-      icon="arrow.triangle.branch"
-      label={`Auto-settle merged threads · ${props.environmentLabel}`}
-      value={settings?.sidebarAutoSettleOnMerge ?? true}
-      onValueChange={(value) => {
-        void updateSettings({
-          environmentId: props.environmentId,
-          input: { patch: { sidebarAutoSettleOnMerge: value } },
-        });
-      }}
-    />
+    <>
+      <SettingsSwitchRow
+        icon="arrow.triangle.branch"
+        label="Auto-settle merged threads"
+        value={referenceSettings.sidebarAutoSettleOnMerge}
+        onValueChange={(value) => writeToAll({ sidebarAutoSettleOnMerge: value })}
+      />
+      <SettingsSwitchRow
+        icon="clock"
+        label="Auto-settle inactive threads"
+        subtitle={afterDays === null ? undefined : `After ${afterDays} days without activity`}
+        value={afterDays !== null}
+        onValueChange={(value) =>
+          writeToAll({ sidebarAutoSettleAfterDays: value ? AUTO_SETTLE_DEFAULT_DAYS : null })
+        }
+      />
+      {afterDays !== null ? (
+        <View className="flex-row items-center gap-4 border-t border-border-subtle p-4">
+          <Text className="flex-1 text-lg text-foreground">Days before auto-settle</Text>
+          <TextInput
+            className="min-h-10 w-20 rounded-xl px-3 py-2 text-center text-base"
+            keyboardType="number-pad"
+            returnKeyType="done"
+            value={daysDraft ?? String(afterDays)}
+            onChangeText={setDaysDraft}
+            onBlur={commitDays}
+            onSubmitEditing={commitDays}
+            accessibilityLabel="Days before auto-settle"
+          />
+        </View>
+      ) : null}
+      {mismatches.length > 0 ? (
+        <View className="flex-row items-center gap-4 border-t border-border-subtle p-4">
+          <View className="min-w-0 flex-1">
+            <Text className="text-lg text-foreground">Settings differ</Text>
+            <Text className="text-sm text-foreground-muted">
+              {mismatches.map((mismatch) => mismatch.label).join(", ")}
+            </Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => {
+              const patch = pickSharedServerSettings(referenceSettings);
+              for (const mismatch of mismatches) {
+                void updateSettings({
+                  environmentId: mismatch.environmentId,
+                  input: { patch },
+                });
+              }
+            }}
+            className="rounded-full bg-subtle px-4 py-2 active:opacity-70"
+          >
+            <Text className="text-base font-t3-medium text-foreground">Apply to all</Text>
+          </Pressable>
+        </View>
+      ) : null}
+    </>
   );
 }
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -112,6 +112,7 @@ import {
   TYPOGRAPHY_ADVANCED_STORAGE_KEY,
 } from "../../appearanceFonts";
 import { CodeFontPreview, PromptFontPreview, TerminalFontPreview } from "./SettingsFontPreviews";
+import { SharedSettingsMismatchAlert } from "./SharedSettingsMismatchAlert";
 import { discoverInstalledFonts, FontFamilyPicker, useFontEnumeration } from "./FontFamilyPicker";
 import {
   NumberField,
@@ -1928,6 +1929,7 @@ export function GeneralSettingsPanel() {
 
   return (
     <SettingsPageContainer>
+      <SharedSettingsMismatchAlert />
       <SettingsSection title="General">
         <SettingsRow
           {...searchableSetting("project-grouping")}

--- a/apps/web/src/components/settings/SharedSettingsMismatchAlert.tsx
+++ b/apps/web/src/components/settings/SharedSettingsMismatchAlert.tsx
@@ -1,0 +1,32 @@
+import { TriangleAlertIcon } from "lucide-react";
+
+import { useSharedSettingsSync } from "../../hooks/useSettings";
+import { Alert, AlertAction, AlertDescription } from "../ui/alert";
+import { Button } from "../ui/button";
+
+/**
+ * Warns when a connected environment holds different shared settings than
+ * the primary one, and offers to write the primary's values everywhere.
+ * Renders nothing when every connected environment agrees.
+ */
+export function SharedSettingsMismatchAlert() {
+  const { mismatches, applyToAll } = useSharedSettingsSync();
+  if (mismatches.length === 0) {
+    return null;
+  }
+  const labels = mismatches.map((mismatch) => mismatch.label).join(", ");
+  return (
+    <Alert variant="warning" className="mx-3 sm:mx-4">
+      <TriangleAlertIcon />
+      <AlertDescription>
+        Settings differ on {labels}. Thread and source control preferences are meant to match on
+        every environment.
+      </AlertDescription>
+      <AlertAction>
+        <Button variant="outline" size="compact" onClick={applyToAll}>
+          Apply to all
+        </Button>
+      </AlertAction>
+    </Alert>
+  );
+}

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -18,6 +18,7 @@ import {
 } from "@t3tools/shared/backgroundActivitySettings";
 
 import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { SharedSettingsMismatchAlert } from "./SharedSettingsMismatchAlert";
 import { cn } from "../../lib/utils";
 import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
@@ -548,6 +549,7 @@ export function SourceControlSettingsPanel() {
 
   return (
     <SettingsPageContainer>
+      <SharedSettingsMismatchAlert />
       {isInitialScanPending ? (
         <>
           <SourceControlSectionSkeleton title="Version Control" headerAction={scanButton} />

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -40,7 +40,11 @@ import {
 } from "~/themePalette";
 import * as Struct from "effect/Struct";
 import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
-import { useEnvironments, usePrimaryEnvironment } from "~/state/environments";
+import {
+  type EnvironmentPresentation,
+  useEnvironments,
+  usePrimaryEnvironment,
+} from "~/state/environments";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { useTheme } from "./useTheme";
 
@@ -312,14 +316,26 @@ export function usePrimarySettings<T = UnifiedSettings>(
   return useMergedSettings(useAtomValue(primaryServerSettingsAtom), selector);
 }
 
+/**
+ * Whether an environment can hold every shared key right now. Gated on the
+ * auto-settlement capability because it is the newest of the shared keys: a
+ * server that has it has all of them. Older servers drop unknown keys on
+ * write, so a mismatch against them could never clear, and their decoded
+ * defaults must not be treated as real values.
+ */
+function supportsSharedSettings(environment: EnvironmentPresentation): boolean {
+  return (
+    environment.connection.phase === "connected" &&
+    environment.serverConfig?.environment.capabilities.threadAutoSettlement === true
+  );
+}
+
 /** Environments that can receive a shared settings write right now. */
 function useConnectedEnvironmentIds(): ReadonlyArray<EnvironmentId> {
   const { environments } = useEnvironments();
   return useMemo(
     () =>
-      environments
-        .filter((environment) => environment.connection.phase === "connected")
-        .map((environment) => environment.environmentId),
+      environments.filter(supportsSharedSettings).map((environment) => environment.environmentId),
     [environments],
   );
 }
@@ -388,8 +404,12 @@ export function useSharedSettingsSync() {
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
   // Read the loaded config, not `primaryServerSettingsAtom`: that atom falls
   // back to defaults while the primary is disconnected, and "apply to all"
-  // must never push defaults over real values.
-  const primarySettings = primaryEnvironment?.serverConfig?.settings ?? null;
+  // must never push defaults over real values. Same for a primary too old to
+  // hold the shared keys: its decoded defaults are not a source of truth.
+  const primarySettings =
+    primaryEnvironment !== null && supportsSharedSettings(primaryEnvironment)
+      ? (primaryEnvironment.serverConfig?.settings ?? null)
+      : null;
   const { environments } = useEnvironments();
   const persistServerSettings = useAtomCommand(
     serverEnvironment.updateSettings,
@@ -404,7 +424,7 @@ export function useSharedSettingsSync() {
         environments: environments.map((environment) => ({
           environmentId: environment.environmentId,
           label: environment.label,
-          connected: environment.connection.phase === "connected",
+          connected: supportsSharedSettings(environment),
           settings: environment.serverConfig?.settings ?? null,
         })),
       }),

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -384,8 +384,12 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
  * an older client.
  */
 export function useSharedSettingsSync() {
-  const primaryEnvironmentId = usePrimaryEnvironment()?.environmentId ?? null;
-  const primarySettings = useAtomValue(primaryServerSettingsAtom);
+  const primaryEnvironment = usePrimaryEnvironment();
+  const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
+  // Read the loaded config, not `primaryServerSettingsAtom`: that atom falls
+  // back to defaults while the primary is disconnected, and "apply to all"
+  // must never push defaults over real values.
+  const primarySettings = primaryEnvironment?.serverConfig?.settings ?? null;
   const { environments } = useEnvironments();
   const persistServerSettings = useAtomCommand(
     serverEnvironment.updateSettings,
@@ -408,6 +412,9 @@ export function useSharedSettingsSync() {
   );
 
   const applyToAll = useCallback(() => {
+    if (primarySettings === null) {
+      return;
+    }
     const patch = pickSharedServerSettings(primarySettings);
     for (const mismatch of mismatches) {
       void persistServerSettings({

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -25,6 +25,11 @@ import {
   type UnifiedSettings,
 } from "@t3tools/contracts/settings";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
+import {
+  findSharedSettingsMismatches,
+  pickSharedServerSettings,
+  splitSharedServerPatch,
+} from "@t3tools/client-runtime/state/shared-settings";
 import { ensureLocalApi } from "~/localApi";
 import {
   getThemeDefinition,
@@ -35,7 +40,7 @@ import {
 } from "~/themePalette";
 import * as Struct from "effect/Struct";
 import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
-import { usePrimaryEnvironment } from "~/state/environments";
+import { useEnvironments, usePrimaryEnvironment } from "~/state/environments";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { useTheme } from "./useTheme";
 
@@ -307,27 +312,56 @@ export function usePrimarySettings<T = UnifiedSettings>(
   return useMergedSettings(useAtomValue(primaryServerSettingsAtom), selector);
 }
 
+/** Environments that can receive a shared settings write right now. */
+function useConnectedEnvironmentIds(): ReadonlyArray<EnvironmentId> {
+  const { environments } = useEnvironments();
+  return useMemo(
+    () =>
+      environments
+        .filter((environment) => environment.connection.phase === "connected")
+        .map((environment) => environment.environmentId),
+    [environments],
+  );
+}
+
 /**
  * Returns an updater that routes each key to the correct backing store.
  *
  * Server keys are optimistically patched in atom-backed server state, then
- * persisted via RPC. Client keys go through client persistence.
+ * persisted via RPC. Shared server keys (see `SHARED_SERVER_SETTING_KEYS`)
+ * are written to every connected environment, not only the target, so a user
+ * preference does not silently drift between machines. Client keys go through
+ * client persistence.
  */
 function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
   const persistServerSettings = useAtomCommand(
     serverEnvironment.updateSettings,
     "server settings update",
   );
+  const connectedEnvironmentIds = useConnectedEnvironmentIds();
   const updateSettings = useCallback(
     (patch: UnifiedSettingsPatch) => {
       const { serverPatch, clientPatch } = splitPatch(patch);
 
       if (Object.keys(serverPatch).length > 0) {
-        if (environmentId) {
+        const { sharedPatch, localPatch } = splitSharedServerPatch(serverPatch);
+        if (environmentId && Object.keys(localPatch).length > 0) {
           void persistServerSettings({
             environmentId,
-            input: { patch: serverPatch },
+            input: { patch: localPatch },
           });
+        }
+        if (Object.keys(sharedPatch).length > 0) {
+          const targets = new Set(connectedEnvironmentIds);
+          if (environmentId) {
+            targets.add(environmentId);
+          }
+          for (const targetId of targets) {
+            void persistServerSettings({
+              environmentId: targetId,
+              input: { patch: sharedPatch },
+            });
+          }
         }
       }
       if (Object.keys(clientPatch).length > 0) {
@@ -337,10 +371,53 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
         });
       }
     },
-    [environmentId, persistServerSettings],
+    [connectedEnvironmentIds, environmentId, persistServerSettings],
   );
 
   return updateSettings;
+}
+
+/**
+ * Connected environments whose shared settings differ from the primary's,
+ * plus an action that writes the primary's values to all of them. Drift
+ * happens when an environment was offline during an edit or was changed by
+ * an older client.
+ */
+export function useSharedSettingsSync() {
+  const primaryEnvironmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  const primarySettings = useAtomValue(primaryServerSettingsAtom);
+  const { environments } = useEnvironments();
+  const persistServerSettings = useAtomCommand(
+    serverEnvironment.updateSettings,
+    "server settings update",
+  );
+
+  const mismatches = useMemo(
+    () =>
+      findSharedSettingsMismatches({
+        primaryEnvironmentId,
+        primarySettings,
+        environments: environments.map((environment) => ({
+          environmentId: environment.environmentId,
+          label: environment.label,
+          connected: environment.connection.phase === "connected",
+          settings: environment.serverConfig?.settings ?? null,
+        })),
+      }),
+    [environments, primaryEnvironmentId, primarySettings],
+  );
+
+  const applyToAll = useCallback(() => {
+    const patch = pickSharedServerSettings(primarySettings);
+    for (const mismatch of mismatches) {
+      void persistServerSettings({
+        environmentId: mismatch.environmentId,
+        input: { patch },
+      });
+    }
+  }, [mismatches, persistServerSettings, primarySettings]);
+
+  return { mismatches, applyToAll };
 }
 
 export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -88,7 +88,10 @@ A turn is complete when its session leaves `running` status, projected by
 `settledTurnStateForSessionStatus` in [`projector.ts`][projector]. Checkpoint work settling later
 does not define turn end.
 
-Thread settlement is server-owned. Per-environment settings control PR and inactivity settlement.
+Thread settlement is server-owned. Each server's own settings control PR and inactivity
+settlement. Those keys are user preferences, so clients write them to every connected environment
+(`SHARED_SERVER_SETTING_KEYS` in `packages/client-runtime/src/state/sharedSettings.ts`) and warn
+when a connected environment drifts.
 [`ThreadSettlementReactor`][settlement] checks threads at startup, when those settings change, and
 once per minute, including when no client is connected. It dispatches the guarded internal
 `thread.auto-settle` command, which uses the existing settlement event lifecycle. Automatic

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -10,16 +10,22 @@ confirmation applies to the sidebar controls, thread menus, and the `mod+shift+p
 Pinned threads still move to **Settled** when they become inactive. They also move when their pull
 request merges if **Auto-settle merged threads** is enabled.
 
-Each environment owns its automatic settlement settings. The server checks them even when no web,
-desktop, or mobile client is connected. By default, it settles threads after three days without
+Each server stores its own copy of the automatic settlement settings and checks them even when no
+web, desktop, or mobile client is connected. By default, it settles threads after three days without
 activity and when their pull request merges. An eligible idle thread also settles when its pull
 request closes. An open pull request blocks inactivity settlement. Active work, pending input, and
 live background work keep the thread active. T3 Code settles from a closed or merged pull request
 only when its timestamp is not older than the user's latest activity. If that timestamp is not
 available, the inactivity rule still applies. A manual un-settle also keeps the thread active.
-Change these rules in **Settings > General** for the environment. A settings change affects future
-settlement and does not reopen a settled thread. Settings saved by older clients on one device no
-longer control this behavior.
+
+Change these rules in **Settings > General**. The change is written to every environment you are
+connected to at that moment. An environment that is offline keeps its old value. When a connected
+environment holds a different value, **Settings > General** shows a warning that names it. Choose
+**Apply to all** to write your current values to every connected environment. The same applies to
+the new-thread workspace mode and the source control writing style.
+
+A settings change affects future settlement and does not reopen a settled thread. Settings saved
+by older clients on one device no longer control this behavior.
 
 When you un-settle a thread, it returns to the top of the active list so you can find it right
 away. Its timestamps do not change. Other threads keep their positions.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -147,6 +147,10 @@
       "types": "./src/state/session.ts",
       "default": "./src/state/session.ts"
     },
+    "./state/shared-settings": {
+      "types": "./src/state/sharedSettings.ts",
+      "default": "./src/state/sharedSettings.ts"
+    },
     "./state/shell": {
       "types": "./src/state/shell.ts",
       "default": "./src/state/shell.ts"

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -1,0 +1,91 @@
+import { DEFAULT_SERVER_SETTINGS, EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  findSharedSettingsMismatches,
+  pickSharedServerSettings,
+  splitSharedServerPatch,
+} from "./sharedSettings.ts";
+
+const primaryId = EnvironmentId.make("env-primary");
+const laptopId = EnvironmentId.make("env-laptop");
+const boxId = EnvironmentId.make("env-box");
+
+describe("splitSharedServerPatch", () => {
+  it("routes preference keys to the shared patch and machine keys to the local patch", () => {
+    const { sharedPatch, localPatch } = splitSharedServerPatch({
+      sidebarAutoSettleAfterDays: 7,
+      sidebarAutoSettleOnMerge: false,
+      enableAgentBrowserAccess: false,
+    });
+    expect(sharedPatch).toEqual({ sidebarAutoSettleAfterDays: 7, sidebarAutoSettleOnMerge: false });
+    expect(localPatch).toEqual({ enableAgentBrowserAccess: false });
+  });
+});
+
+describe("pickSharedServerSettings", () => {
+  it("returns only the shared keys", () => {
+    expect(Object.keys(pickSharedServerSettings(DEFAULT_SERVER_SETTINGS)).sort()).toEqual([
+      "defaultThreadEnvMode",
+      "newWorktreesStartFromOrigin",
+      "sidebarAutoSettleAfterDays",
+      "sidebarAutoSettleOnMerge",
+      "sourceControlWritingStyle",
+    ]);
+  });
+});
+
+describe("findSharedSettingsMismatches", () => {
+  const primarySettings = { ...DEFAULT_SERVER_SETTINGS, sidebarAutoSettleAfterDays: 7 };
+
+  it("lists connected environments whose shared settings differ", () => {
+    const mismatches = findSharedSettingsMismatches({
+      primaryEnvironmentId: primaryId,
+      primarySettings,
+      environments: [
+        { environmentId: primaryId, label: "Desktop", connected: true, settings: primarySettings },
+        { environmentId: laptopId, label: "Laptop", connected: true, settings: primarySettings },
+        {
+          environmentId: boxId,
+          label: "Remote Box",
+          connected: true,
+          settings: DEFAULT_SERVER_SETTINGS,
+        },
+      ],
+    });
+    expect(mismatches).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
+  });
+
+  it("ignores machine-only differences", () => {
+    const mismatches = findSharedSettingsMismatches({
+      primaryEnvironmentId: primaryId,
+      primarySettings,
+      environments: [
+        {
+          environmentId: boxId,
+          label: "Remote Box",
+          connected: true,
+          settings: { ...primarySettings, enableAgentBrowserAccess: false },
+        },
+      ],
+    });
+    expect(mismatches).toEqual([]);
+  });
+
+  it("skips offline environments and environments without a loaded config", () => {
+    const mismatches = findSharedSettingsMismatches({
+      primaryEnvironmentId: primaryId,
+      primarySettings,
+      environments: [
+        {
+          environmentId: laptopId,
+          label: "Laptop",
+          connected: false,
+          settings: DEFAULT_SERVER_SETTINGS,
+        },
+        { environmentId: boxId, label: "Remote Box", connected: true, settings: null },
+      ],
+    });
+    expect(mismatches).toEqual([]);
+  });
+});

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -72,6 +72,22 @@ describe("findSharedSettingsMismatches", () => {
     expect(mismatches).toEqual([]);
   });
 
+  it("reports nothing until the primary environment's settings are loaded", () => {
+    const environments = [
+      { environmentId: boxId, label: "Remote Box", connected: true, settings: primarySettings },
+    ];
+    expect(
+      findSharedSettingsMismatches({ primaryEnvironmentId: null, primarySettings, environments }),
+    ).toEqual([]);
+    expect(
+      findSharedSettingsMismatches({
+        primaryEnvironmentId: primaryId,
+        primarySettings: null,
+        environments,
+      }),
+    ).toEqual([]);
+  });
+
   it("skips offline environments and environments without a loaded config", () => {
     const mismatches = findSharedSettingsMismatches({
       primaryEnvironmentId: primaryId,

--- a/packages/client-runtime/src/state/sharedSettings.ts
+++ b/packages/client-runtime/src/state/sharedSettings.ts
@@ -60,13 +60,19 @@ export interface SharedSettingsEnvironment {
 /**
  * Connected environments whose shared settings differ from the primary
  * environment's. Offline environments are skipped: nothing can be read from
- * or written to them, and the warning would never clear.
+ * or written to them, and the warning would never clear. With no primary
+ * settings loaded there is nothing to compare against, so nothing is
+ * reported. Callers must pass the real loaded settings, never a default
+ * fallback, or "apply to all" would push defaults over real values.
  */
 export function findSharedSettingsMismatches(input: {
   readonly primaryEnvironmentId: EnvironmentId | null;
-  readonly primarySettings: ServerSettings;
+  readonly primarySettings: ServerSettings | null;
   readonly environments: ReadonlyArray<SharedSettingsEnvironment>;
 }): ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }> {
+  if (input.primaryEnvironmentId === null || input.primarySettings === null) {
+    return [];
+  }
   const expected = pickSharedServerSettings(input.primarySettings);
   return input.environments.flatMap((environment) => {
     if (

--- a/packages/client-runtime/src/state/sharedSettings.ts
+++ b/packages/client-runtime/src/state/sharedSettings.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared server settings.
+ *
+ * Every server keeps its own `settings.json`, but some keys are user
+ * preferences that only live on the server because the server has to act on
+ * them (auto-settlement runs with no client attached). A user does not want
+ * those to differ per machine. Clients write these keys to every connected
+ * environment, and warn when a connected environment still holds a different
+ * value so the user can push their current value out.
+ */
+import type { EnvironmentId, ServerSettings, ServerSettingsPatch } from "@t3tools/contracts";
+import * as Equal from "effect/Equal";
+import * as Struct from "effect/Struct";
+
+/** Server keys that hold a user preference rather than machine config. */
+export const SHARED_SERVER_SETTING_KEYS = [
+  "sidebarAutoSettleAfterDays",
+  "sidebarAutoSettleOnMerge",
+  "defaultThreadEnvMode",
+  "newWorktreesStartFromOrigin",
+  "sourceControlWritingStyle",
+] as const satisfies ReadonlyArray<keyof ServerSettings & keyof ServerSettingsPatch>;
+
+export type SharedServerSettingKey = (typeof SHARED_SERVER_SETTING_KEYS)[number];
+
+const SHARED_KEY_SET = new Set<string>(SHARED_SERVER_SETTING_KEYS);
+
+/** Split a server patch into the keys every environment should receive and the primary-only rest. */
+export function splitSharedServerPatch(patch: ServerSettingsPatch): {
+  sharedPatch: ServerSettingsPatch;
+  localPatch: ServerSettingsPatch;
+} {
+  const sharedPatch: Record<string, unknown> = {};
+  const localPatch: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (SHARED_KEY_SET.has(key)) {
+      sharedPatch[key] = value;
+    } else {
+      localPatch[key] = value;
+    }
+  }
+  return {
+    sharedPatch: sharedPatch as ServerSettingsPatch,
+    localPatch: localPatch as ServerSettingsPatch,
+  };
+}
+
+/** The shared subset of one environment's settings, as a patch that can be written elsewhere. */
+export function pickSharedServerSettings(settings: ServerSettings): ServerSettingsPatch {
+  return Struct.pick(settings, SHARED_SERVER_SETTING_KEYS);
+}
+
+export interface SharedSettingsEnvironment {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly connected: boolean;
+  readonly settings: ServerSettings | null;
+}
+
+/**
+ * Connected environments whose shared settings differ from the primary
+ * environment's. Offline environments are skipped: nothing can be read from
+ * or written to them, and the warning would never clear.
+ */
+export function findSharedSettingsMismatches(input: {
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly primarySettings: ServerSettings;
+  readonly environments: ReadonlyArray<SharedSettingsEnvironment>;
+}): ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }> {
+  const expected = pickSharedServerSettings(input.primarySettings);
+  return input.environments.flatMap((environment) => {
+    if (
+      environment.environmentId === input.primaryEnvironmentId ||
+      !environment.connected ||
+      environment.settings === null
+    ) {
+      return [];
+    }
+    const actual = pickSharedServerSettings(environment.settings);
+    return Equal.equals(actual, expected)
+      ? []
+      : [{ environmentId: environment.environmentId, label: environment.label }];
+  });
+}


### PR DESCRIPTION
## Problem

Auto-settle, new-thread workspace mode, and source control writing style live in each server's `settings.json` because the server acts on them (auto-settlement runs with no client attached). The settings UI wrote them to the primary environment only. Every other connected machine kept its own value, and nothing showed the drift.

## Fix

- `packages/client-runtime/src/state/sharedSettings.ts` names the shared keys and has helpers to split a patch, pick the shared subset, and find connected environments that differ.
- Web: `useUpdateSettingsTarget` writes shared keys to every connected environment. Machine keys (providers, browser access, observability, and so on) stay primary-only.
- Web: Settings > General and Settings > Source Control show a warning naming the environments that differ, with an "Apply to all" button that writes the primary's values to them.
- Mobile: one set of auto-settle controls instead of one merge switch per environment. Adds the missing inactivity days input. Writes fan out the same way, and a "Settings differ" row offers "Apply to all".
- Docs updated in `docs/user/thread-sidebar.md` and `docs/internals/overview.md`.

Offline environments are skipped on write and in the warning. They pick up the value the next time you change the setting or press "Apply to all" while they are connected.

No contract or server changes.

## Verification

- `vp test run packages/client-runtime/src/state/sharedSettings.test.ts` (5 tests)
- `vp test run apps/web/src/hooks/useSettings.test.ts`
- Typecheck for web, mobile, and client-runtime
- Lint and format on changed files

Written by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Settings updates now fan out shared keys to every connected environment on each change; incorrect key classification or targeting could overwrite the wrong servers, though local-only keys remain scoped and guards avoid pushing defaults when the primary is unloaded.
> 
> **Overview**
> **Shared server settings** (auto-settle rules, default new-thread workspace mode, worktree origin behavior, and source-control writing style) are now treated as user-wide preferences: clients fan writes to every connected environment that supports them, instead of updating only the primary (or one row per environment on mobile).
> 
> Adds `packages/client-runtime` **`shared-settings`** helpers (`SHARED_SERVER_SETTING_KEYS`, patch splitting, mismatch detection, and “pick shared subset” for apply). **Web** `useUpdateSettingsTarget` routes shared keys to all capable connected environments and keeps machine-local keys on the requested environment; **`useSharedSettingsSync`** plus **`SharedSettingsMismatchAlert`** on General and Source Control warn when drift remains and offer **Apply to all** using loaded primary config (not default fallbacks). **Mobile** replaces per-connection merge toggles with a single **`AutoSettleSettingsRows`** block (inactive auto-settle, days input, same fan-out and mismatch row). User and internals docs describe multi-environment sync and offline behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a365c14457944547d202b2a411ef24b971efa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync shared auto-settle and server preferences across environments
> - Introduces shared server settings (`SHARED_SERVER_SETTING_KEYS`) covering auto-settlement, thread mode, worktree origin, and source control writing style
> - Adds mismatch detection via `findSharedSettingsMismatches` in [sharedSettings.ts](https://github.com/pingdotgg/t3code/pull/9147/files#diff-38f5f180a1e6b08473997fcfd4ea833484eedc94dcfbe574949cee47cb522f70) and displays a warning with an "Apply to all" action on web and mobile settings pages
> - Modifies `useUpdateSettingsTarget` in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/9147/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) to write shared keys to all eligible connected environments, while local server keys remain scoped to the requested environment
> - Risk: `useUpdateSettingsTarget` in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/9147/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) writes shared keys to every environment with the thread auto-settlement capability; environments holding intentionally divergent values for keys in `SHARED_SERVER_SETTING_KEYS` will be overwritten
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15a365c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->