### PR TITLE
feat(web): add mobile sidebar swipe actions

### DIFF
--- a/apps/web/src/components/Sidebar.swipe.test.ts
+++ b/apps/web/src/components/Sidebar.swipe.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  clampSidebarSwipeOffset,
+  resolveSidebarSwipeIntent,
+  shouldOpenSidebarSwipe,
+} from "./Sidebar.swipe";
+
+describe("resolveSidebarSwipeIntent", () => {
+  it("waits for enough movement before claiming a gesture", () => {
+    expect(resolveSidebarSwipeIntent(-7, 0)).toBe("pending");
+    expect(resolveSidebarSwipeIntent(3, 7)).toBe("pending");
+  });
+
+  it("claims only clearly horizontal movement", () => {
+    expect(resolveSidebarSwipeIntent(-30, 8)).toBe("horizontal");
+    expect(resolveSidebarSwipeIntent(-20, 18)).toBe("vertical");
+  });
+
+  it("keeps vertical scroll gestures vertical", () => {
+    expect(resolveSidebarSwipeIntent(2, 20)).toBe("vertical");
+    expect(resolveSidebarSwipeIntent(-8, 30)).toBe("vertical");
+  });
+});
+
+describe("clampSidebarSwipeOffset", () => {
+  it("reveals left-side movement without changing row geometry", () => {
+    expect(clampSidebarSwipeOffset({ originOffset: 0, deltaX: -60, revealWidth: 216 })).toBe(-60);
+  });
+
+  it("does not drag beyond the tray or past the closed position", () => {
+    expect(clampSidebarSwipeOffset({ originOffset: 0, deltaX: -300, revealWidth: 216 })).toBe(-216);
+    expect(clampSidebarSwipeOffset({ originOffset: -216, deltaX: 300, revealWidth: 216 })).toBe(0);
+  });
+});
+
+describe("shouldOpenSidebarSwipe", () => {
+  it("opens after a deliberate reveal and otherwise settles closed", () => {
+    expect(shouldOpenSidebarSwipe({ offset: -76, revealWidth: 216 })).toBe(true);
+    expect(shouldOpenSidebarSwipe({ offset: -75, revealWidth: 216 })).toBe(false);
+  });
+});

--- a/apps/web/src/components/Sidebar.swipe.ts
+++ b/apps/web/src/components/Sidebar.swipe.ts
@@ -1,0 +1,33 @@
+export const SIDEBAR_SWIPE_ACTION_WIDTH = 72;
+
+const SWIPE_INTENT_DISTANCE = 8;
+const HORIZONTAL_INTENT_RATIO = 1.25;
+
+export type SidebarSwipeIntent = "pending" | "horizontal" | "vertical";
+
+/**
+ * Bias ambiguous gestures toward vertical scrolling. A row only takes over
+ * once the finger has moved clearly farther sideways than up or down.
+ */
+export function resolveSidebarSwipeIntent(deltaX: number, deltaY: number): SidebarSwipeIntent {
+  const horizontalDistance = Math.abs(deltaX);
+  const verticalDistance = Math.abs(deltaY);
+  if (Math.max(horizontalDistance, verticalDistance) < SWIPE_INTENT_DISTANCE) return "pending";
+  return horizontalDistance > verticalDistance * HORIZONTAL_INTENT_RATIO
+    ? "horizontal"
+    : "vertical";
+}
+
+export function clampSidebarSwipeOffset(input: {
+  originOffset: number;
+  deltaX: number;
+  revealWidth: number;
+}): number {
+  const { originOffset, deltaX, revealWidth } = input;
+  return Math.min(0, Math.max(-revealWidth, originOffset + deltaX));
+}
+
+/** A short deliberate pull opens the tray; a mostly closed row stays closed. */
+export function shouldOpenSidebarSwipe(input: { offset: number; revealWidth: number }): boolean {
+  return input.offset <= -input.revealWidth * 0.35;
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -166,6 +166,8 @@ import {
   snoozeWakeLabel,
   type SnoozePreset,
 } from "./Sidebar.snooze";
+import { SIDEBAR_SWIPE_ACTION_WIDTH } from "./Sidebar.swipe";
+import { MobileSidebarSwipeActions, useMobileSidebarRowSwipe } from "./SidebarSwipeActions";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
@@ -728,6 +730,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // When a snooze ended (timer or early wake); drives the Woke pill until
   // the user visits the thread.
   wokeAt: string | null;
+  mobileSwipeOpen: boolean;
+  mobileSwipeEnabled: boolean;
   isActive: boolean;
   openPullRequestsInRightPanel: boolean;
   jumpLabel: string | null;
@@ -751,7 +755,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   onUnsettle: (threadRef: ScopedThreadRef) => void;
   onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
   onUnsnooze: (threadRef: ScopedThreadRef) => void;
+  onPin: (threadRef: ScopedThreadRef) => void;
   onUnpin: (threadRef: ScopedThreadRef) => void;
+  onMobileSwipeOpenChange: (threadKey: string, open: boolean) => void;
   onAcknowledgeWoke: (threadRef: ScopedThreadRef, visitedAt: string) => void;
   changeRequestSnapshot: ThreadChangeRequestSnapshot | null;
   onChangeRequestSnapshot: (
@@ -770,6 +776,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     onRenameTitleChange,
     onSettle,
     onSnooze,
+    onPin,
     onStartRename,
     onThreadActivate,
     onThreadClick,
@@ -787,6 +794,35 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     [thread.environmentId, thread.id],
   );
   const threadKey = scopedThreadKey(threadRef);
+  // Snooze is offered only where it can succeed: capability-gated and never
+  // on blocked-on-you work or queued turns (the server rejects both).
+  const showSnoozeButton =
+    props.snoozeSupported && canSnooze(thread, { now: new Date().toISOString() });
+  const swipeActionCount =
+    (props.settlementSupported ? 1 : 0) +
+    (showSnoozeButton ? 1 : 0) +
+    (props.pinningSupported ? 1 : 0);
+  const swipeRevealWidth = swipeActionCount * SIDEBAR_SWIPE_ACTION_WIDTH;
+  const swipeEnabled =
+    props.mobileSwipeEnabled && variant === "card" && !isRenaming && swipeActionCount > 0;
+  const setMobileSwipeOpen = useCallback(
+    (open: boolean) => props.onMobileSwipeOpenChange(threadKey, open),
+    [props.onMobileSwipeOpenChange, threadKey],
+  );
+  const {
+    consumeSuppressedClick,
+    dragging: swipeDragging,
+    offset: swipeOffset,
+    onPointerCancel: handleSwipePointerCancel,
+    onPointerDown: handleSwipePointerDown,
+    onPointerMove: handleSwipePointerMove,
+    onPointerUp: handleSwipePointerUp,
+  } = useMobileSidebarRowSwipe({
+    enabled: swipeEnabled,
+    open: props.mobileSwipeOpen && swipeEnabled,
+    revealWidth: swipeRevealWidth,
+    onOpenChange: setMobileSwipeOpen,
+  });
   const isRegeneratingTitle = thread.titleRegeneration != null;
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
@@ -978,9 +1014,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
 
   const handleClick = useCallback(
     (event: ReactMouseEvent) => {
+      if (consumeSuppressedClick()) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (props.mobileSwipeOpen) {
+        event.preventDefault();
+        event.stopPropagation();
+        setMobileSwipeOpen(false);
+        return;
+      }
       onThreadClick(event, threadRef);
     },
-    [onThreadClick, threadRef],
+    [consumeSuppressedClick, onThreadClick, props.mobileSwipeOpen, setMobileSwipeOpen, threadRef],
   );
   const handleAcknowledgeWokeClick = useCallback(
     (event: ReactMouseEvent) => {
@@ -1075,6 +1122,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     },
     [onUnpin, threadRef],
   );
+  const handlePinClick = useCallback(() => onPin(threadRef), [onPin, threadRef]);
   const handleSnoozePreset = useCallback(
     (preset: SnoozePreset) => {
       onSnooze(threadRef, preset);
@@ -1084,10 +1132,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // While the snooze popover is open the pointer leaves the row, which
   // would fade the hover actions out from under the open menu; pin them.
   const [snoozeMenuOpenRaw, setSnoozeMenuOpen] = useState(false);
-  // Snooze is offered only where it can succeed: capability-gated and never
-  // on blocked-on-you work or queued turns (the server rejects both).
-  const showSnoozeButton =
-    props.snoozeSupported && canSnooze(thread, { now: new Date().toISOString() });
   // If the thread becomes blocked while the popover is open, the button
   // unmounts without firing onOpenChange(false). Deriving the flag keeps a
   // stale true from permanently hiding the status label / pinning the
@@ -1400,9 +1444,24 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       {...(sortable?.listeners ?? {})}
       className={cn(
         "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_96px]",
+        swipeEnabled && "relative overflow-hidden rounded-md",
         sortable?.isDragging && "z-20 opacity-80",
       )}
     >
+      {swipeEnabled ? (
+        <MobileSidebarSwipeActions
+          open={props.mobileSwipeOpen}
+          showSettle={props.settlementSupported}
+          showSnooze={showSnoozeButton}
+          showPin={props.pinningSupported}
+          isPinned={props.isPinned}
+          timestampFormat={props.timestampFormat}
+          onSettle={() => onSettle(threadRef)}
+          onSnooze={handleSnoozePreset}
+          onPinToggle={props.isPinned ? () => onUnpin(threadRef) : handlePinClick}
+          onClose={() => setMobileSwipeOpen(false)}
+        />
+      ) : null}
       <Tooltip>
         <TooltipTrigger
           render={
@@ -1411,11 +1470,24 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               tabIndex={0}
               data-testid="sidebar-row-card"
               aria-busy={isRegeneratingTitle || undefined}
-              className={rowSurfaceClassName}
+              className={cn(
+                rowSurfaceClassName,
+                swipeEnabled && "touch-pan-y",
+                swipeEnabled && !props.isActive && !isSelected && "bg-sidebar",
+                swipeEnabled && !swipeDragging && "transition-transform duration-200 ease-out",
+                swipeEnabled && (swipeDragging || props.mobileSwipeOpen) && "will-change-transform",
+              )}
+              style={
+                swipeEnabled ? { transform: `translate3d(${swipeOffset}px, 0, 0)` } : undefined
+              }
               onClick={handleClick}
               onDoubleClick={handleDoubleClick}
               onKeyDown={handleKeyDown}
               onContextMenu={handleContextMenu}
+              onPointerDown={handleSwipePointerDown}
+              onPointerMove={handleSwipePointerMove}
+              onPointerUp={handleSwipePointerUp}
+              onPointerCancel={handleSwipePointerCancel}
             />
           }
         >
@@ -1732,7 +1804,14 @@ export default function Sidebar() {
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
   const router = useRouter();
-  const { isMobile, setOpenMobile } = useSidebar();
+  const { isMobile, openMobile, setOpenMobile } = useSidebar();
+  const [mobileSwipeOpenThreadKey, setMobileSwipeOpenThreadKey] = useState<string | null>(null);
+  const handleMobileSwipeOpenChange = useCallback((threadKey: string, open: boolean) => {
+    setMobileSwipeOpenThreadKey(open ? threadKey : null);
+  }, []);
+  useEffect(() => {
+    if (!openMobile) setMobileSwipeOpenThreadKey(null);
+  }, [openMobile]);
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
@@ -3791,6 +3870,8 @@ export default function Sidebar() {
                         // the wake signal must survive the trip. Still-snoozed
                         // rows resolve to null on their own.
                         wokeAt={threadWokeAt(thread, { now: snoozeNow })}
+                        mobileSwipeEnabled={isMobile}
+                        mobileSwipeOpen={mobileSwipeOpenThreadKey === threadKey}
                         isActive={routeThreadKey === threadKey}
                         openPullRequestsInRightPanel={routeThreadRef !== null}
                         jumpLabel={
@@ -3829,7 +3910,9 @@ export default function Sidebar() {
                         onUnsettle={attemptUnsettle}
                         onSnooze={attemptSnooze}
                         onUnsnooze={attemptUnsnooze}
+                        onPin={attemptPin}
                         onUnpin={attemptUnpin}
+                        onMobileSwipeOpenChange={handleMobileSwipeOpenChange}
                         onAcknowledgeWoke={acknowledgeWoke}
                         changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
                         onChangeRequestSnapshot={setThreadChangeRequestSnapshot}

--- a/apps/web/src/components/SidebarSwipeActions.tsx
+++ b/apps/web/src/components/SidebarSwipeActions.tsx
@@ -1,0 +1,233 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import type { TimestampFormat } from "@t3tools/contracts/settings";
+import { CheckIcon, ClockIcon, PinIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
+import { resolveSnoozePresets, type SnoozePreset } from "./Sidebar.snooze";
+import {
+  clampSidebarSwipeOffset,
+  resolveSidebarSwipeIntent,
+  shouldOpenSidebarSwipe,
+  type SidebarSwipeIntent,
+} from "./Sidebar.swipe";
+
+export function useMobileSidebarRowSwipe(props: {
+  enabled: boolean;
+  open: boolean;
+  revealWidth: number;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { enabled, open, revealWidth, onOpenChange } = props;
+  const restingOffset = open ? -revealWidth : 0;
+  const [offset, setOffset] = useState(restingOffset);
+  const offsetRef = useRef(restingOffset);
+  const [dragging, setDragging] = useState(false);
+  const gestureRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    originOffset: number;
+    intent: SidebarSwipeIntent;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
+
+  useEffect(() => {
+    if (!dragging) {
+      offsetRef.current = restingOffset;
+      setOffset(restingOffset);
+    }
+  }, [dragging, restingOffset]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled || !event.isPrimary || event.button !== 0) return;
+      if ((event.target as HTMLElement).closest("button, a, input")) return;
+      // Whole-row dnd listeners live on the parent <li>. Mobile horizontal
+      // swipes own this pointer; vertical scrolling remains native via pan-y.
+      event.stopPropagation();
+      gestureRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        originOffset: restingOffset,
+        intent: "pending",
+      };
+      suppressClickRef.current = false;
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [enabled, restingOffset],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (gesture === null || gesture.pointerId !== event.pointerId) return;
+      const deltaX = event.clientX - gesture.startX;
+      const deltaY = event.clientY - gesture.startY;
+      if (gesture.intent === "pending") {
+        gesture.intent = resolveSidebarSwipeIntent(deltaX, deltaY);
+        if (gesture.intent === "vertical") {
+          gestureRef.current = null;
+          if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
+          return;
+        }
+      }
+      if (gesture.intent !== "horizontal") return;
+      event.preventDefault();
+      setDragging(true);
+      suppressClickRef.current = true;
+      const nextOffset = clampSidebarSwipeOffset({
+        originOffset: gesture.originOffset,
+        deltaX,
+        revealWidth,
+      });
+      offsetRef.current = nextOffset;
+      setOffset(nextOffset);
+    },
+    [revealWidth],
+  );
+
+  const finishGesture = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (gesture === null || gesture.pointerId !== event.pointerId) return;
+      gestureRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (gesture.intent !== "horizontal") return;
+      const nextOpen = shouldOpenSidebarSwipe({ offset: offsetRef.current, revealWidth });
+      setDragging(false);
+      offsetRef.current = nextOpen ? -revealWidth : 0;
+      setOffset(offsetRef.current);
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, revealWidth],
+  );
+
+  const consumeSuppressedClick = useCallback(() => {
+    if (!suppressClickRef.current) return false;
+    suppressClickRef.current = false;
+    return true;
+  }, []);
+
+  return {
+    consumeSuppressedClick,
+    dragging,
+    offset,
+    onPointerCancel: finishGesture,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: finishGesture,
+  };
+}
+
+export function MobileSidebarSwipeActions(props: {
+  open: boolean;
+  showSettle: boolean;
+  showSnooze: boolean;
+  showPin: boolean;
+  isPinned: boolean;
+  timestampFormat: TimestampFormat;
+  onSettle: () => void;
+  onSnooze: (preset: SnoozePreset) => void;
+  onPinToggle: () => void;
+  onClose: () => void;
+}) {
+  const [snoozeOpen, setSnoozeOpen] = useState(false);
+  const presets = useMemo(
+    () => (snoozeOpen ? resolveSnoozePresets(new Date(), props.timestampFormat) : []),
+    [props.timestampFormat, snoozeOpen],
+  );
+  useEffect(() => {
+    if (!props.open) setSnoozeOpen(false);
+  }, [props.open]);
+  const actionClassName =
+    "flex h-full w-[72px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 text-[11px] font-medium text-white outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/80";
+  return (
+    <div
+      role="group"
+      aria-label="Thread swipe actions"
+      className="absolute inset-y-0.5 right-0 flex overflow-hidden rounded-r-md"
+      inert={!props.open}
+    >
+      {props.showSettle ? (
+        <button
+          type="button"
+          aria-label="Settle thread"
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onClose();
+            props.onSettle();
+          }}
+          className={cn(actionClassName, "bg-emerald-600 active:bg-emerald-700")}
+        >
+          <CheckIcon aria-hidden className="size-5" />
+          <span>Settle</span>
+        </button>
+      ) : null}
+      {props.showSnooze ? (
+        <Popover open={snoozeOpen} onOpenChange={setSnoozeOpen}>
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                aria-label="Snooze thread"
+                onClick={(event) => event.stopPropagation()}
+                className={cn(actionClassName, "bg-amber-500 active:bg-amber-600")}
+              />
+            }
+          >
+            <ClockIcon aria-hidden className="size-5" />
+            <span>Snooze</span>
+          </PopoverTrigger>
+          <PopoverPopup side="bottom" align="end" className="w-56" viewportClassName="p-1">
+            {presets.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setSnoozeOpen(false);
+                  props.onClose();
+                  props.onSnooze(preset);
+                }}
+                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left text-xs text-foreground/90 hover:bg-accent hover:text-foreground"
+              >
+                <span className="flex-1">{preset.label}</span>
+                <span className="font-mono text-[10px] text-muted-foreground/60 tabular-nums">
+                  {preset.whenLabel}
+                </span>
+              </button>
+            ))}
+          </PopoverPopup>
+        </Popover>
+      ) : null}
+      {props.showPin ? (
+        <button
+          type="button"
+          aria-label={props.isPinned ? "Unpin thread" : "Pin thread"}
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onClose();
+            props.onPinToggle();
+          }}
+          className={cn(actionClassName, "bg-blue-600 active:bg-blue-700")}
+        >
+          <PinIcon aria-hidden className="size-5" />
+          <span>{props.isPinned ? "Unpin" : "Pin"}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -28,6 +28,10 @@ Right-click a pull request link in a thread and choose **Link to thread** to sho
 in the sidebar. The thread settles when the linked pull request merges if **Auto-settle merged
 threads** is enabled. Right-click the same link and choose **Unlink from thread** to remove it.
 
+In the mobile-width web app, swipe an active thread to the left to reveal **Settle**, **Snooze**,
+and **Pin** actions. A pinned thread shows **Unpin** instead. Vertical movement continues to scroll
+the sidebar, and tapping the revealed thread closes its actions.
+
 On web and desktop, drag a pinned thread to change its position. On mobile, open the thread's menu
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.


### PR DESCRIPTION
<!--
GitHub CLI posting step (run from the repository root after pushing the branch):

gh pr create \
  -R pingdotgg/t3code \
  --title "feat(web): add mobile sidebar swipe actions" \
  --body-file artifacts/mobile-sidebar-swipe/pr-draft.md

The screenshots below are hosted as GitHub user attachments. Do not commit the screenshots or the
disposable Playwright artifact test.

Related issue: #9148
-->

Closes #9148

## What Changed

- Added a mobile-width left-swipe gesture to active and pinned web sidebar thread cards.
- Reveals capability-aware **Settle**, **Snooze**, and **Pin/Unpin** touch actions.
- Reuses the existing settle, snooze preset, pin, and unpin command paths.
- Keeps one tray open at a time and clears it when the mobile sidebar closes.
- Added direction locking that favors vertical scrolling for ambiguous gestures.
- Translates only the inner row surface, preserving list height and `auto-animate` geometry.
- Documented the mobile web interaction in the thread sidebar user guide.

No server contracts or native mobile code changed.

## Why

The desktop sidebar exposes quick actions through hover, but phone browsers have no hover. Common
thread-triage actions therefore require extra menu navigation on mobile web.

This adds a familiar Mail-style touch interaction while keeping lifecycle behavior in the existing
action implementations. The gesture code is isolated from sorting and list layout to reduce
conflicts with current pinned reordering and the active-thread reorder work in #8666.

## UI Changes

| Before | After |
| --- | --- |
| ![Mobile sidebar before swipe](https://github.com/user-attachments/assets/81dae1bb-23b0-42fc-b394-cb4cd9ecb136) | ![Settle, Snooze, and Pin actions revealed](https://github.com/user-attachments/assets/27b9887b-b680-46ef-a6c2-52121e05a0e7) |

### Gesture progress

![Thread following the pointer during a partial swipe](https://github.com/user-attachments/assets/4405c4fd-12db-4d9b-af8b-c06fbf65cd3d)

The screenshots were captured at a 430 × 932 CSS-pixel viewport with a disposable, synthetic T3
environment. The temporary Playwright artifact test also asserts that the row remains translated
`-216px` after pointer-up and that exactly one Settle, Snooze, and Pin action exists for the target
row.

During visual verification, the test caught a post-pointer-up synthetic click that initially closed
the freshly opened tray. Click suppression now consumes that event without changing the tray's open
state.

## Verification

- `vp test run apps/web/src/components/Sidebar.swipe.test.ts --passWithNoTests`
  - 6 tests passed.
- `tsgo -p apps/web/tsconfig.json --noEmit`
- Targeted lint passed for:
  - `apps/web/src/components/Sidebar.tsx`
  - `apps/web/src/components/SidebarSwipeActions.tsx`
  - `apps/web/src/components/Sidebar.swipe.ts`
  - `apps/web/src/components/Sidebar.swipe.test.ts`
- Formatting and `git diff --check` passed.
- Disposable Playwright artifact test passed at mobile viewport and produced the screenshots above.

## Surface coverage

- **Entry points:** The gesture is an additional mobile sidebar entry point; context menus and chat
  header actions remain unchanged.
- **Clients:** Mobile-width web is changed. Desktop retains existing hover behavior. Native iOS and
  Android are unchanged.
- **Providers:** Provider-independent; actions use environment capability flags and shared thread
  commands.
- **Contracts:** No changes.
- **Reverse states:** Pinned cards show Unpin; existing snooze and settle reversal flows remain
  available.
- **Connection modes:** Uses the existing per-environment command routing for local, remote, relay,
  and tunnel connections.
- **Docs:** Updated `docs/user/thread-sidebar.md`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [ ] I included a video for animation/interaction changes

Built by GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only sidebar UX with isolated pointer handling; main risk is gesture/click edge cases conflicting with pinned drag-and-drop or navigation, mitigated by intent locking and click suppression.
> 
> **Overview**
> Adds **left-swipe on mobile-width web** for sidebar **thread card** rows (active and pinned), exposing the same triage actions as desktop hover: **Settle**, **Snooze** (with presets), and **Pin/Unpin**, gated by existing environment capabilities and snooze eligibility.
> 
> Gesture behavior lives in new **`Sidebar.swipe`** helpers (intent vs scroll, clamped offset, ~35% open threshold) and **`SidebarSwipeActions`** (`useMobileSidebarRowSwipe` + action tray). The row **translates horizontally** with `touch-pan-y` so vertical scroll wins ambiguous moves; **one open tray** at a time and it **resets when the mobile sidebar closes**. Row clicks **close an open tray** or **suppress the post-gesture synthetic click** so the tray stays open. Actions call the same **`attemptSettle` / snooze / pin** paths as the rest of the sidebar.
> 
> User docs in **`thread-sidebar.md`** describe the interaction. Unit tests cover the swipe math; no API or server contract changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7b77b200af7b7d047898004f01b0f111968ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mobile sidebar swipe actions for `SidebarThreadRow`
> - Adds `resolveSidebarSwipeIntent`, `clampSidebarSwipeOffset`, and `shouldOpenSidebarSwipe` utils in [Sidebar.swipe.ts](https://github.com/pingdotgg/t3code/pull/9149/files#diff-f4bbd8bfd7b233f8c7b289739a4f3e1d57b16f68f4c858d4add536a9438dceae) to classify gestures, bound row offsets, and settle open at >=35% of the reveal width.
> - Adds the `useMobileSidebarRowSwipe` hook and `MobileSidebarSwipeActions` component in [SidebarSwipeActions.tsx](https://github.com/pingdotgg/t3code/pull/9149/files#diff-78ad6d6130ce8bb762d67464d9e1496d2dfd8297a81be8a0c6da358ccf002763) to drive pointer-based horizontal swipes and render capability-gated Settle, Snooze, and Pin/Unpin buttons.
> - Wires swipe state into [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9149/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1): only one mobile row is open at a time, closing the mobile sidebar clears the open row, and swipe is disabled during rename or when no actions are available.
> - Vertical gestures are released for native scrolling; a completed swipe suppresses the row click; tapping an open row closes its actions instead of opening the thread.
> - Documents the new behavior in [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/9149/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a).
> - Behavioral Change: mobile sidebar rows that previously only responded to tap now also respond to horizontal left-swipe; existing hover actions on desktop are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5e7b77b. 4 files reviewed, 4 issues evaluated, 1 issue filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/SidebarSwipeActions.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 128](https://github.com/pingdotgg/t3code/blob/5e7b77b200af7b7d047898004f01b0f111968ed6/apps/web/src/components/SidebarSwipeActions.tsx#L128): `onPointerCancel` is wired to `finishGesture`, which commits the current `offsetRef` just like a successful pointer-up. `pointercancel` is also emitted when a pointer is interrupted (for example app switching, orientation changes, or additional pointers), so an interrupted partial horizontal drag past the 35% threshold opens the tray even though the user never completed the gesture. Handle cancellation by clearing the gesture and restoring `restingOffset` instead of calling `onOpenChange` with the drag result. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->