### PR TITLE
perf: make streaming projection and activity appends incremental

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2474,6 +2474,217 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
+  it.effect("maintains shell summary fields across message and activity streams", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "project.created",
+        eventId: EventId.make("evt-shell-summary-1"),
+        aggregateKind: "project",
+        aggregateId: ProjectId.make("project-shell-summary"),
+        occurredAt: "2026-03-01T08:00:00.000Z",
+        commandId: CommandId.make("cmd-shell-summary-1"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-shell-summary-1"),
+        metadata: {},
+        payload: {
+          projectId: ProjectId.make("project-shell-summary"),
+          title: "Project Shell Summary",
+          workspaceRoot: "/tmp/project-shell-summary",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: "2026-03-01T08:00:00.000Z",
+          updatedAt: "2026-03-01T08:00:00.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.created",
+        eventId: EventId.make("evt-shell-summary-2"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-shell-summary"),
+        occurredAt: "2026-03-01T08:00:01.000Z",
+        commandId: CommandId.make("cmd-shell-summary-2"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-shell-summary-2"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-shell-summary"),
+          projectId: ProjectId.make("project-shell-summary"),
+          title: "Thread Shell Summary",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: "2026-03-01T08:00:01.000Z",
+          updatedAt: "2026-03-01T08:00:01.000Z",
+        },
+      });
+
+      const readSummary = sql<{
+        readonly latestUserMessageAt: string | null;
+        readonly pendingUserInputCount: number;
+        readonly updatedAt: string;
+      }>`
+        SELECT
+          latest_user_message_at AS "latestUserMessageAt",
+          pending_user_input_count AS "pendingUserInputCount",
+          updated_at AS "updatedAt"
+        FROM projection_threads
+        WHERE thread_id = 'thread-shell-summary'
+      `;
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-shell-summary-3"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-shell-summary"),
+        occurredAt: "2026-03-01T08:00:02.000Z",
+        commandId: CommandId.make("cmd-shell-summary-3"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-shell-summary-3"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-shell-summary"),
+          messageId: MessageId.make("message-shell-summary-user"),
+          role: "user",
+          text: "please do the thing",
+          turnId: TurnId.make("turn-shell-summary-1"),
+          streaming: false,
+          createdAt: "2026-03-01T08:00:02.000Z",
+          updatedAt: "2026-03-01T08:00:02.000Z",
+        },
+      });
+
+      assert.deepEqual(yield* readSummary, [
+        {
+          latestUserMessageAt: "2026-03-01T08:00:02.000Z",
+          pendingUserInputCount: 0,
+          updatedAt: "2026-03-01T08:00:02.000Z",
+        },
+      ]);
+
+      // Streaming assistant deltas bump updatedAt but must not disturb
+      // latestUserMessageAt or the pending counters.
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-shell-summary-4"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-shell-summary"),
+        occurredAt: "2026-03-01T08:00:03.000Z",
+        commandId: CommandId.make("cmd-shell-summary-4"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-shell-summary-4"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-shell-summary"),
+          messageId: MessageId.make("message-shell-summary-assistant"),
+          role: "assistant",
+          text: "working on it",
+          turnId: TurnId.make("turn-shell-summary-1"),
+          streaming: true,
+          createdAt: "2026-03-01T08:00:03.000Z",
+          updatedAt: "2026-03-01T08:00:03.000Z",
+        },
+      });
+
+      assert.deepEqual(yield* readSummary, [
+        {
+          latestUserMessageAt: "2026-03-01T08:00:02.000Z",
+          pendingUserInputCount: 0,
+          updatedAt: "2026-03-01T08:00:03.000Z",
+        },
+      ]);
+
+      // Ordinary tool activities bump updatedAt without touching the
+      // user-input counter; user-input lifecycle activities update it.
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-shell-summary-5"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-shell-summary"),
+        occurredAt: "2026-03-01T08:00:04.000Z",
+        commandId: CommandId.make("cmd-shell-summary-5"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-shell-summary-5"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-shell-summary"),
+          activity: {
+            id: EventId.make("activity-shell-summary-command"),
+            tone: "tool",
+            kind: "command",
+            summary: "Ran a command",
+            payload: {},
+            turnId: TurnId.make("turn-shell-summary-1"),
+            createdAt: "2026-03-01T08:00:04.000Z",
+          },
+        },
+      });
+
+      assert.deepEqual(yield* readSummary, [
+        {
+          latestUserMessageAt: "2026-03-01T08:00:02.000Z",
+          pendingUserInputCount: 0,
+          updatedAt: "2026-03-01T08:00:04.000Z",
+        },
+      ]);
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-shell-summary-6"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-shell-summary"),
+        occurredAt: "2026-03-01T08:00:05.000Z",
+        commandId: CommandId.make("cmd-shell-summary-6"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-shell-summary-6"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-shell-summary"),
+          activity: {
+            id: EventId.make("activity-shell-summary-user-input"),
+            tone: "info",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            payload: {
+              requestId: "user-input-request-shell-summary-1",
+              questions: [
+                {
+                  id: "confirm",
+                  header: "Confirm",
+                  question: "Proceed?",
+                  options: [{ label: "yes", description: "Proceed" }],
+                },
+              ],
+            },
+            turnId: TurnId.make("turn-shell-summary-1"),
+            createdAt: "2026-03-01T08:00:05.000Z",
+          },
+        },
+      });
+
+      assert.deepEqual(yield* readSummary, [
+        {
+          latestUserMessageAt: "2026-03-01T08:00:02.000Z",
+          pendingUserInputCount: 1,
+          updatedAt: "2026-03-01T08:00:05.000Z",
+        },
+      ]);
+    }),
+  );
+
   it.effect("ignores non-stale provider approval response failures", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2422,44 +2422,35 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
             json_object('requestId', 'user-input-active'),
             NULL,
             '2026-02-26T12:35:07.000Z'
-          ),
-          (
-            'activity-user-input-active-failed',
-            'thread-stale-user-input',
-            NULL,
-            'error',
-            'provider.user-input.respond.failed',
-            'Provider user input response failed',
-            json_object(
-              'requestId',
-              'user-input-active',
-              'detail',
-              'Provider is temporarily unavailable'
-            ),
-            NULL,
-            '2026-02-26T12:35:08.000Z'
           )
       `;
 
+      // A user-input lifecycle activity is one of the events that still
+      // refreshes the shell summary, so it forces the read under test.
       yield* appendAndProject({
-        type: "thread.message-sent",
+        type: "thread.activity-appended",
         eventId: EventId.make("evt-stale-user-input-3"),
         aggregateKind: "thread",
         aggregateId: ThreadId.make("thread-stale-user-input"),
-        occurredAt: "2026-02-26T12:35:09.000Z",
+        occurredAt: "2026-02-26T12:35:08.000Z",
         commandId: CommandId.make("cmd-stale-user-input-3"),
         causationEventId: null,
         correlationId: CorrelationId.make("cmd-stale-user-input-3"),
         metadata: {},
         payload: {
           threadId: ThreadId.make("thread-stale-user-input"),
-          messageId: MessageId.make("message-stale-user-input"),
-          role: "user",
-          text: "Continue",
-          turnId: null,
-          streaming: false,
-          createdAt: "2026-02-26T12:35:09.000Z",
-          updatedAt: "2026-02-26T12:35:09.000Z",
+          activity: {
+            id: EventId.make("activity-user-input-active-failed"),
+            tone: "error",
+            kind: "provider.user-input.respond.failed",
+            summary: "Provider user input response failed",
+            payload: {
+              requestId: "user-input-active",
+              detail: "Provider is temporarily unavailable",
+            },
+            turnId: null,
+            createdAt: "2026-02-26T12:35:08.000Z",
+          },
         },
       });
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -130,12 +130,8 @@ function isStalePendingApprovalFailureDetail(detail: string | null): boolean {
   );
 }
 
-// A refresh reads each persisted summary source, so skip events that cannot change the result.
+// A refresh reads each persisted summary source, so skip activities that cannot change the result.
 function shouldRefreshThreadShellSummary(event: OrchestrationEvent): boolean {
-  if (event.type === "thread.message-sent") {
-    return event.payload.role === "user";
-  }
-
   if (event.type !== "thread.activity-appended") {
     return true;
   }
@@ -897,7 +893,33 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
-        case "thread.message-sent":
+        // Message events cannot change any derived summary field except
+        // latestUserMessageAt, which is a monotonic maximum that folds in
+        // directly — the full refresh would re-read every message, plan,
+        // activity, and approval on each streaming assistant delta.
+        // A message cannot change any summary field except latestUserMessageAt,
+        // which is a monotonic maximum that folds in directly. The full refresh
+        // would re-read every message body in the thread per user message.
+        case "thread.message-sent": {
+          const existingRow = yield* projectionThreadRepository.getById({
+            threadId: event.payload.threadId,
+          });
+          if (Option.isNone(existingRow)) {
+            return;
+          }
+          const previousLatest = existingRow.value.latestUserMessageAt;
+          yield* projectionThreadRepository.upsert({
+            ...existingRow.value,
+            updatedAt: event.occurredAt,
+            latestUserMessageAt:
+              event.payload.role === "user" &&
+              (previousLatest === null || event.payload.createdAt > previousLatest)
+                ? event.payload.createdAt
+                : previousLatest,
+          });
+          return;
+        }
+
         case "thread.proposed-plan-upserted":
         case "thread.activity-appended":
         case "thread.approval-response-requested":

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -893,10 +893,6 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
-        // Message events cannot change any derived summary field except
-        // latestUserMessageAt, which is a monotonic maximum that folds in
-        // directly — the full refresh would re-read every message, plan,
-        // activity, and approval on each streaming assistant delta.
         // A message cannot change any summary field except latestUserMessageAt,
         // which is a monotonic maximum that folds in directly. The full refresh
         // would re-read every message body in the thread per user message.

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -768,6 +768,49 @@ describe("applyThreadDetailEvent", () => {
       }
     });
 
+    it("dedupes a re-delivery arriving right after an in-order append", () => {
+      const makeActivity = (id: string, sequence: number, summary: string) => ({
+        id: EventId.make(id),
+        tone: "tool" as const,
+        kind: "command",
+        summary,
+        payload: {},
+        turnId: TurnId.make("turn-1"),
+        sequence,
+        createdAt: "2026-04-01T11:00:00.000Z",
+      });
+      const makeEvent = (sequence: number, activity: ReturnType<typeof makeActivity>) =>
+        ({
+          ...baseEventFields,
+          sequence,
+          occurredAt: "2026-04-01T11:01:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-1"),
+          type: "thread.activity-appended",
+          payload: { threadId: ThreadId.make("thread-1"), activity },
+        }) as const;
+      const first = applyThreadDetailEvent(
+        { ...baseThread, activities: [makeActivity("activity-a", 1, "first")] },
+        makeEvent(133, makeActivity("activity-b", 2, "second")),
+      );
+      expect(first.kind).toBe("updated");
+      if (first.kind !== "updated") {
+        return;
+      }
+      const second = applyThreadDetailEvent(
+        first.thread,
+        makeEvent(134, makeActivity("activity-b", 3, "second (redelivered)")),
+      );
+      expect(second.kind).toBe("updated");
+      if (second.kind === "updated") {
+        expect(second.thread.activities.map((activity) => activity.id)).toEqual([
+          "activity-a",
+          "activity-b",
+        ]);
+        expect(second.thread.activities[1]?.summary).toBe("second (redelivered)");
+      }
+    });
+
     it("replaces a re-delivered activity instead of duplicating it", () => {
       const makeActivity = (id: string, sequence: number, summary: string) => ({
         id: EventId.make(id),

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -728,6 +728,89 @@ describe("applyThreadDetailEvent", () => {
       }
     });
 
+    it("re-sorts when an activity arrives out of order", () => {
+      const makeActivity = (id: string, sequence: number) => ({
+        id: EventId.make(id),
+        tone: "tool" as const,
+        kind: "command",
+        summary: `Ran command ${sequence}`,
+        payload: {},
+        turnId: TurnId.make("turn-1"),
+        sequence,
+        createdAt: "2026-04-01T11:00:00.000Z",
+      });
+      const result = applyThreadDetailEvent(
+        {
+          ...baseThread,
+          activities: [makeActivity("activity-a", 1), makeActivity("activity-c", 3)],
+        },
+        {
+          ...baseEventFields,
+          sequence: 131,
+          occurredAt: "2026-04-01T11:01:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-1"),
+          type: "thread.activity-appended",
+          payload: {
+            threadId: ThreadId.make("thread-1"),
+            activity: makeActivity("activity-b", 2),
+          },
+        },
+      );
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.activities.map((activity) => activity.id)).toEqual([
+          "activity-a",
+          "activity-b",
+          "activity-c",
+        ]);
+      }
+    });
+
+    it("replaces a re-delivered activity instead of duplicating it", () => {
+      const makeActivity = (id: string, sequence: number, summary: string) => ({
+        id: EventId.make(id),
+        tone: "tool" as const,
+        kind: "command",
+        summary,
+        payload: {},
+        turnId: TurnId.make("turn-1"),
+        sequence,
+        createdAt: "2026-04-01T11:00:00.000Z",
+      });
+      const result = applyThreadDetailEvent(
+        {
+          ...baseThread,
+          activities: [
+            makeActivity("activity-a", 1, "first"),
+            makeActivity("activity-b", 2, "second"),
+          ],
+        },
+        {
+          ...baseEventFields,
+          sequence: 132,
+          occurredAt: "2026-04-01T11:01:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-1"),
+          type: "thread.activity-appended",
+          payload: {
+            threadId: ThreadId.make("thread-1"),
+            activity: makeActivity("activity-b", 2, "second (redelivered)"),
+          },
+        },
+      );
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.activities.map((activity) => activity.id)).toEqual([
+          "activity-a",
+          "activity-b",
+        ]);
+        expect(result.thread.activities[1]?.summary).toBe("second (redelivered)");
+      }
+    });
+
     it("replaces earlier resolvable context-window updates for the same turn", () => {
       const contextWindowActivity = (id: string, sequence: number, usedTokens: unknown) => ({
         id: EventId.make(id),

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -768,6 +768,49 @@ describe("applyThreadDetailEvent", () => {
       }
     });
 
+    it("repairs snapshot ordering before fast-path appends engage", () => {
+      const makeActivity = (id: string, sequence: number | null) => ({
+        id: EventId.make(id),
+        tone: "tool" as const,
+        kind: "command",
+        summary: `Ran ${id}`,
+        payload: {},
+        turnId: TurnId.make("turn-1"),
+        ...(sequence === null ? {} : { sequence }),
+        createdAt: "2026-04-01T11:00:00.000Z",
+      });
+      // Snapshot loads deliver null-sequence rows first (DB order), which
+      // activityOrder sorts last; an in-order live append must not freeze
+      // that prefix.
+      const result = applyThreadDetailEvent(
+        {
+          ...baseThread,
+          activities: [makeActivity("activity-null", null), makeActivity("activity-a", 1)],
+        },
+        {
+          ...baseEventFields,
+          sequence: 135,
+          occurredAt: "2026-04-01T11:01:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-1"),
+          type: "thread.activity-appended",
+          payload: {
+            threadId: ThreadId.make("thread-1"),
+            activity: makeActivity("activity-b", 2),
+          },
+        },
+      );
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.activities.map((activity) => activity.id)).toEqual([
+          "activity-a",
+          "activity-b",
+          "activity-null",
+        ]);
+      }
+    });
+
     it("dedupes a re-delivery arriving right after an in-order append", () => {
       const makeActivity = (id: string, sequence: number, summary: string) => ({
         id: EventId.make(id),
@@ -799,15 +842,24 @@ describe("applyThreadDetailEvent", () => {
       }
       const second = applyThreadDetailEvent(
         first.thread,
-        makeEvent(134, makeActivity("activity-b", 3, "second (redelivered)")),
+        makeEvent(134, makeActivity("activity-c", 3, "third")),
       );
       expect(second.kind).toBe("updated");
-      if (second.kind === "updated") {
-        expect(second.thread.activities.map((activity) => activity.id)).toEqual([
+      if (second.kind !== "updated") {
+        return;
+      }
+      const third = applyThreadDetailEvent(
+        second.thread,
+        makeEvent(135, makeActivity("activity-c", 4, "third (redelivered)")),
+      );
+      expect(third.kind).toBe("updated");
+      if (third.kind === "updated") {
+        expect(third.thread.activities.map((activity) => activity.id)).toEqual([
           "activity-a",
           "activity-b",
+          "activity-c",
         ]);
-        expect(second.thread.activities[1]?.summary).toBe("second (redelivered)");
+        expect(third.thread.activities[2]?.summary).toBe("third (redelivered)");
       }
     });
 

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -36,6 +36,29 @@ const activityOrder = O.combineAll<OrchestrationThreadActivity>([
 ]);
 
 /**
+ * Id index for each activities array, so the streaming append path can check
+ * for a re-delivered id without scanning the whole history per event. Keyed
+ * by array identity: the append path moves the set forward to the array it
+ * produces, and any array reduced without a cached set (an older state, a
+ * snapshot) rebuilds it once.
+ */
+const activityIdIndex = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  Set<OrchestrationThreadActivity["id"]>
+>();
+
+function activityIds(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): Set<OrchestrationThreadActivity["id"]> {
+  let ids = activityIdIndex.get(activities);
+  if (ids === undefined) {
+    ids = new Set(activities.map((activity) => activity.id));
+    activityIdIndex.set(activities, ids);
+  }
+  return ids;
+}
+
+/**
  * Matches the validity rule in `deriveLatestContextWindowSnapshot` (and the
  * server's snapshot-side `dropStaleContextWindowActivities`): rows without a
  * finite, non-negative `usedTokens` are skipped during the consumer's backward
@@ -589,13 +612,20 @@ export function applyThreadDetailEvent(
       if (
         !supersedesContextWindow &&
         (lastActivity === undefined || activityOrder(lastActivity, activity) <= 0) &&
-        !thread.activities.some((entry) => entry.id === activity.id)
+        !activityIds(thread.activities).has(activity.id)
       ) {
+        const activities = Arr.append(thread.activities, activity);
+        // Move the id set forward instead of copying it: the superseded array
+        // rebuilds its set on the off chance it is reduced against again.
+        const ids = activityIds(thread.activities);
+        activityIdIndex.delete(thread.activities);
+        ids.add(activity.id);
+        activityIdIndex.set(activities, ids);
         return {
           kind: "updated",
           thread: {
             ...thread,
-            activities: Arr.append(thread.activities, activity),
+            activities,
             updatedAt: event.occurredAt,
           },
         };

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -582,6 +582,24 @@ export function applyThreadDetailEvent(
       // thread.reverted that discards turns can still resolve a value from
       // the turns that survive.
       const supersedesContextWindow = isResolvableContextWindowActivity(activity);
+      // Live streams append in order: when the new activity sorts at or after
+      // the tail and its id is unseen, a plain append preserves ordering
+      // without re-filtering and re-sorting the whole history on every event.
+      const lastActivity = thread.activities.at(-1);
+      if (
+        !supersedesContextWindow &&
+        (lastActivity === undefined || activityOrder(lastActivity, activity) <= 0) &&
+        !thread.activities.some((entry) => entry.id === activity.id)
+      ) {
+        return {
+          kind: "updated",
+          thread: {
+            ...thread,
+            activities: Arr.append(thread.activities, activity),
+            updatedAt: event.occurredAt,
+          },
+        };
+      }
       const activities = pipe(
         thread.activities,
         Arr.filter(

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -35,28 +35,14 @@ const activityOrder = O.combineAll<OrchestrationThreadActivity>([
   O.mapInput(O.String, (a) => a.id),
 ]);
 
-/**
- * Id index for each activities array, so the streaming append path can check
- * for a re-delivered id without scanning the whole history per event. Keyed
- * by array identity: the append path moves the set forward to the array it
- * produces, and any array reduced without a cached set (an older state, a
- * snapshot) rebuilds it once.
- */
+// Per-array id index so the streaming append path can reject a re-delivered
+// id without rescanning the history. Only arrays this reducer produced are
+// indexed: presence also proves the array is activityOrder-sorted, which
+// snapshot-loaded arrays (DB order, null sequences first) are not.
 const activityIdIndex = new WeakMap<
   ReadonlyArray<OrchestrationThreadActivity>,
   Set<OrchestrationThreadActivity["id"]>
 >();
-
-function activityIds(
-  activities: ReadonlyArray<OrchestrationThreadActivity>,
-): Set<OrchestrationThreadActivity["id"]> {
-  let ids = activityIdIndex.get(activities);
-  if (ids === undefined) {
-    ids = new Set(activities.map((activity) => activity.id));
-    activityIdIndex.set(activities, ids);
-  }
-  return ids;
-}
 
 /**
  * Matches the validity rule in `deriveLatestContextWindowSnapshot` (and the
@@ -605,19 +591,19 @@ export function applyThreadDetailEvent(
       // thread.reverted that discards turns can still resolve a value from
       // the turns that survive.
       const supersedesContextWindow = isResolvableContextWindowActivity(activity);
-      // Live streams append in order: when the new activity sorts at or after
-      // the tail and its id is unseen, a plain append preserves ordering
-      // without re-filtering and re-sorting the whole history on every event.
+      // Live streams append in order: an unseen id sorting at/after the tail
+      // of a known-sorted array appends without re-filtering and re-sorting
+      // the whole history on every event. The id set moves forward to the new
+      // array; a superseded array falls back to the sorting path.
+      const ids = activityIdIndex.get(thread.activities);
       const lastActivity = thread.activities.at(-1);
       if (
         !supersedesContextWindow &&
+        ids !== undefined &&
         (lastActivity === undefined || activityOrder(lastActivity, activity) <= 0) &&
-        !activityIds(thread.activities).has(activity.id)
+        !ids.has(activity.id)
       ) {
         const activities = Arr.append(thread.activities, activity);
-        // Move the id set forward instead of copying it: the superseded array
-        // rebuilds its set on the off chance it is reduced against again.
-        const ids = activityIds(thread.activities);
         activityIdIndex.delete(thread.activities);
         ids.add(activity.id);
         activityIdIndex.set(activities, ids);
@@ -644,6 +630,7 @@ export function applyThreadDetailEvent(
         Arr.append(activity),
         Arr.sort(activityOrder),
       );
+      activityIdIndex.set(activities, new Set(activities.map((entry) => entry.id)));
 
       return {
         kind: "updated",


### PR DESCRIPTION
Takes over #6608 by @x1xhlol.

## Problem

A streaming turn emits one `thread.activity-appended` event per tool step and one `thread.message-sent` per delta. On the server, each user message still ran the full `refreshThreadShellSummary`, which reads every message body in the thread. On the client, every appended activity re-filtered and re-sorted the whole activity array, so a long turn cost O(n² log n) across the stream.

## Fix

Server (`ProjectionPipeline.ts`): `thread.message-sent` now updates the thread row directly. It bumps `updatedAt` and advances `latestUserMessageAt` only when a newer user message arrives. That is the only summary field a message can change, and the message projector never rewrites `createdAt` of an existing message, so the running maximum matches the full recompute. Activities keep the existing lifecycle-kind gate from #8150.

Client (`threadReducer.ts`): `thread.activity-appended` takes an O(1) append path when the current array was produced by this reducer (so it is known to be `activityOrder` sorted), the new activity sorts at or after the tail, and its id is unseen. A `WeakMap` keyed by array identity holds the id set and moves forward with each append. Out-of-order arrivals, re-deliveries, resolvable context-window updates (which supersede earlier ones for the same turn), and snapshot-loaded arrays all fall through to the existing filter and sort path, which rebuilds the index.

## Rebase notes

Main moved under the original branch:

- #8150 added `shouldRefreshThreadShellSummary`, which already gates activity kinds and skips non-user messages. I dropped the PR's duplicate `activityAffectsShellSummary` helper and its separate `thread.activity-appended` case, and kept the PR's direct `thread.message-sent` row update on top of the #8150 gate. The gate no longer needs its `thread.message-sent` branch.
- #9032 changed the message projector to `appendStreaming` for streaming deltas. That is a different projector and is untouched.
- #8600 (server-side settlement) reads `latestUserMessageAt` but did not change how the summary is computed, so nothing to reconcile.
- The existing test "reads only user-input activities when refreshing shell summaries" used a user message to trigger the refresh. It now appends the last lifecycle activity through the pipeline instead.

Audit of every field `refreshThreadShellSummary` computes and which events can change it:

| Field | Source rows | Events that write them | Still refreshes |
| --- | --- | --- | --- |
| `latestUserMessageAt` | messages (role user) | `thread.message-sent` (user), `thread.reverted` | folded directly / yes |
| `pendingApprovalCount` | pending approvals | `approval.requested`, `approval.resolved`, `provider.approval.respond.failed`, `thread.approval-response-requested` | yes |
| `pendingUserInputCount` | user-input lifecycle activities | `user-input.requested`, `user-input.resolved`, `provider.user-input.respond.failed` | yes |
| `hasActionableProposedPlan` | `latestTurnId` plus plan rows | `thread.proposed-plan-upserted`, `thread.session-set`, `thread.turn-diff-completed`, `thread.reverted` | yes |

## Measurement

Reducer benchmark, N in-order `thread.activity-appended` events on one thread, vitest on this machine, best of 2:

| N | main | this branch |
| --- | --- | --- |
| 2,000 | 61 ms (31 us per append) | 12 ms (6 us per append) |
| 10,000 | 1,180 ms (118 us per append) | 70 ms (7 us per append) |

The per-append cost on this branch stays flat as the thread grows. Server side, each user message no longer runs the four summary queries, including the full message-body read.

## Tests

- `vp test run apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts packages/client-runtime/src/state/threadReducer.test.ts`: 58 passed
- `pnpm typecheck` in `apps/server` and `packages/client-runtime`: clean
- `vp lint` on the four changed files: clean

The original commits are cherry-picked with @x1xhlol as author.

Change authored by Claude Fable 5.1 running in Claude Code, based on work by @x1xhlol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes projection correctness for `latestUserMessageAt` and client activity ordering; behavior is heavily tested but touches hot paths during streaming.
> 
> **Overview**
> **Streaming turns were doing redundant work on every event:** user messages triggered a full thread shell summary recompute (including scanning all message bodies), and each `thread.activity-appended` on the client re-sorted the entire activity list.
> 
> On the **server** (`ProjectionPipeline.ts`), `thread.message-sent` now updates `projection_threads` in place—`updatedAt` always advances; `latestUserMessageAt` only moves forward for newer user messages. The `shouldRefreshThreadShellSummary` gate no longer treats user messages as refresh triggers; lifecycle activities and other events still use the full refresh path.
> 
> On the **client** (`threadReducer.ts`), in-order live `thread.activity-appended` events can take an **O(1) append** when the activities array was produced by this reducer (tracked via a `WeakMap` id set), the new row sorts at or after the tail, and the id is new. Out-of-order delivery, re-deliveries, context-window supersession, and snapshot-loaded arrays still use filter, dedupe, and sort.
> 
> **Tests** add end-to-end shell summary assertions (user vs streaming assistant vs tool vs user-input activities) and reducer cases for reordering, snapshot repair, and redelivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ce4259888cc91813355176d746fb77a39d665c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make thread projection and client activity appends incremental
> - Server projection now treats every `thread.message-sent` event as eligible to refresh the thread shell summary, and the `applyProjectsProjection` handler for `thread.message-sent` updates `updatedAt` on every event while advancing `latestUserMessageAt` only for newer user messages.
> - Client `threadReducer` adds a `WeakMap`-backed activity-id index and an in-order fast path for `activity-appended` events: unseen activities that sort at or after the tail are appended without a full re-sort. The fallback deduplicates re-delivered activity ids, removes superseded context-window activities, and sorts the result.
> - Adds regression and integration tests covering shell-summary field persistence, out-of-order activity sorting, snapshot ordering repair, and activity redelivery deduplication.
> - Behavioral Change: `shouldRefreshThreadShellSummary` in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/9152/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4) no longer returns `false` for any `thread.message-sent` event; activity refresh is now restricted to approval and user-input lifecycle kinds only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5ce425.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->