### PR TITLE
feat(web): add mobile sidebar swipe actions

### DIFF
--- a/apps/web/src/components/Sidebar.swipe.test.ts
+++ b/apps/web/src/components/Sidebar.swipe.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  clampSidebarSwipeOffset,
+  resolveSidebarSwipeIntent,
+  shouldOpenSidebarSwipe,
+} from "./Sidebar.swipe";
+
+describe("resolveSidebarSwipeIntent", () => {
+  it("waits for enough movement before claiming a gesture", () => {
+    expect(resolveSidebarSwipeIntent(-7, 0)).toBe("pending");
+    expect(resolveSidebarSwipeIntent(3, 7)).toBe("pending");
+  });
+
+  it("claims only clearly horizontal movement", () => {
+    expect(resolveSidebarSwipeIntent(-30, 8)).toBe("horizontal");
+    expect(resolveSidebarSwipeIntent(-20, 18)).toBe("vertical");
+  });
+
+  it("keeps vertical scroll gestures vertical", () => {
+    expect(resolveSidebarSwipeIntent(2, 20)).toBe("vertical");
+    expect(resolveSidebarSwipeIntent(-8, 30)).toBe("vertical");
+  });
+});
+
+describe("clampSidebarSwipeOffset", () => {
+  it("reveals left-side movement without changing row geometry", () => {
+    expect(clampSidebarSwipeOffset({ originOffset: 0, deltaX: -60, revealWidth: 216 })).toBe(-60);
+  });
+
+  it("does not drag beyond the tray or past the closed position", () => {
+    expect(clampSidebarSwipeOffset({ originOffset: 0, deltaX: -300, revealWidth: 216 })).toBe(-216);
+    expect(clampSidebarSwipeOffset({ originOffset: -216, deltaX: 300, revealWidth: 216 })).toBe(0);
+  });
+});
+
+describe("shouldOpenSidebarSwipe", () => {
+  it("opens after a deliberate reveal and otherwise settles closed", () => {
+    expect(shouldOpenSidebarSwipe({ offset: -76, revealWidth: 216 })).toBe(true);
+    expect(shouldOpenSidebarSwipe({ offset: -75, revealWidth: 216 })).toBe(false);
+  });
+});

--- a/apps/web/src/components/Sidebar.swipe.test.ts
+++ b/apps/web/src/components/Sidebar.swipe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   clampSidebarSwipeOffset,
+  resolveSidebarSwipeOpenThreadKey,
   resolveSidebarSwipeIntent,
   shouldOpenSidebarSwipe,
 } from "./Sidebar.swipe";
@@ -38,5 +39,34 @@ describe("shouldOpenSidebarSwipe", () => {
   it("opens after a deliberate reveal and otherwise settles closed", () => {
     expect(shouldOpenSidebarSwipe({ offset: -76, revealWidth: 216 })).toBe(true);
     expect(shouldOpenSidebarSwipe({ offset: -75, revealWidth: 216 })).toBe(false);
+  });
+});
+
+describe("resolveSidebarSwipeOpenThreadKey", () => {
+  it("opens the changed row and replaces any previously open row", () => {
+    expect(
+      resolveSidebarSwipeOpenThreadKey({
+        currentThreadKey: "thread-a",
+        changedThreadKey: "thread-b",
+        open: true,
+      }),
+    ).toBe("thread-b");
+  });
+
+  it("only lets the currently open row close itself", () => {
+    expect(
+      resolveSidebarSwipeOpenThreadKey({
+        currentThreadKey: "thread-a",
+        changedThreadKey: "thread-b",
+        open: false,
+      }),
+    ).toBe("thread-a");
+    expect(
+      resolveSidebarSwipeOpenThreadKey({
+        currentThreadKey: "thread-a",
+        changedThreadKey: "thread-a",
+        open: false,
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/components/Sidebar.swipe.ts
+++ b/apps/web/src/components/Sidebar.swipe.ts
@@ -31,3 +31,12 @@ export function clampSidebarSwipeOffset(input: {
 export function shouldOpenSidebarSwipe(input: { offset: number; revealWidth: number }): boolean {
   return input.offset <= -input.revealWidth * 0.35;
 }
+
+export function resolveSidebarSwipeOpenThreadKey(input: {
+  currentThreadKey: string | null;
+  changedThreadKey: string;
+  open: boolean;
+}): string | null {
+  if (input.open) return input.changedThreadKey;
+  return input.currentThreadKey === input.changedThreadKey ? null : input.currentThreadKey;
+}

--- a/apps/web/src/components/Sidebar.swipe.ts
+++ b/apps/web/src/components/Sidebar.swipe.ts
@@ -1,0 +1,33 @@
+export const SIDEBAR_SWIPE_ACTION_WIDTH = 72;
+
+const SWIPE_INTENT_DISTANCE = 8;
+const HORIZONTAL_INTENT_RATIO = 1.25;
+
+export type SidebarSwipeIntent = "pending" | "horizontal" | "vertical";
+
+/**
+ * Bias ambiguous gestures toward vertical scrolling. A row only takes over
+ * once the finger has moved clearly farther sideways than up or down.
+ */
+export function resolveSidebarSwipeIntent(deltaX: number, deltaY: number): SidebarSwipeIntent {
+  const horizontalDistance = Math.abs(deltaX);
+  const verticalDistance = Math.abs(deltaY);
+  if (Math.max(horizontalDistance, verticalDistance) < SWIPE_INTENT_DISTANCE) return "pending";
+  return horizontalDistance > verticalDistance * HORIZONTAL_INTENT_RATIO
+    ? "horizontal"
+    : "vertical";
+}
+
+export function clampSidebarSwipeOffset(input: {
+  originOffset: number;
+  deltaX: number;
+  revealWidth: number;
+}): number {
+  const { originOffset, deltaX, revealWidth } = input;
+  return Math.min(0, Math.max(-revealWidth, originOffset + deltaX));
+}
+
+/** A short deliberate pull opens the tray; a mostly closed row stays closed. */
+export function shouldOpenSidebarSwipe(input: { offset: number; revealWidth: number }): boolean {
+  return input.offset <= -input.revealWidth * 0.35;
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1461,8 +1461,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       ) : null}
       <div
         className={cn(
-          swipeEnabled && "bg-sidebar",
-          swipeEnabled && !swipeDragging && "transition-transform duration-200 ease-out",
+          swipeEnabled && "bg-sidebar surface-grain",
+          swipeEnabled &&
+            !swipeDragging &&
+            "transition-transform duration-200 ease-out motion-reduce:transition-none",
           swipeEnabled && (swipeDragging || props.mobileSwipeOpen) && "will-change-transform",
         )}
         style={swipeEnabled ? { transform: `translate3d(${swipeOffset}px, 0, 0)` } : undefined}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1459,233 +1459,229 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
           onClose={() => setMobileSwipeOpen(false)}
         />
       ) : null}
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <div
-              ref={rowRef}
-              role="button"
-              tabIndex={0}
-              data-testid="sidebar-row-card"
-              aria-busy={isRegeneratingTitle || undefined}
-              className={cn(
-                rowSurfaceClassName,
-                swipeEnabled && "touch-pan-y",
-                swipeEnabled && !swipeDragging && "transition-transform duration-200 ease-out",
-                swipeEnabled && (swipeDragging || props.mobileSwipeOpen) && "will-change-transform",
-              )}
-              style={
-                swipeEnabled
-                  ? {
-                      transform: `translate3d(${swipeOffset}px, 0, 0)`,
-                      background: props.isActive
-                        ? "linear-gradient(var(--sidebar-row-active), var(--sidebar-row-active)), var(--sidebar)"
-                        : isSelected
-                          ? "linear-gradient(var(--sidebar-row-selected), var(--sidebar-row-selected)), var(--sidebar)"
-                          : "var(--sidebar)",
-                    }
-                  : undefined
-              }
-              onClick={handleClick}
-              onDoubleClick={handleDoubleClick}
-              onKeyDown={handleKeyDown}
-              onContextMenu={handleContextMenu}
-              onPointerDown={handleSwipePointerDown}
-              onPointerMove={handleSwipePointerMove}
-              onPointerUp={handleSwipePointerUp}
-              onPointerCancel={handleSwipePointerCancel}
-            />
-          }
-        >
-          <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
-            <div className="flex h-5 min-w-0 items-center gap-1.5">
-              <ProjectFavicon
-                environmentId={thread.environmentId}
-                cwd={props.projectCwd ?? ""}
-                faviconPath={props.projectFaviconPath}
-                className="size-4 shrink-0"
+      <div
+        className={cn(
+          swipeEnabled && "bg-sidebar",
+          swipeEnabled && !swipeDragging && "transition-transform duration-200 ease-out",
+          swipeEnabled && (swipeDragging || props.mobileSwipeOpen) && "will-change-transform",
+        )}
+        style={swipeEnabled ? { transform: `translate3d(${swipeOffset}px, 0, 0)` } : undefined}
+      >
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <div
+                ref={rowRef}
+                role="button"
+                tabIndex={0}
+                data-testid="sidebar-row-card"
+                aria-busy={isRegeneratingTitle || undefined}
+                className={cn(rowSurfaceClassName, swipeEnabled && "touch-pan-y")}
+                onClick={handleClick}
+                onDoubleClick={handleDoubleClick}
+                onKeyDown={handleKeyDown}
+                onContextMenu={handleContextMenu}
+                onPointerDown={handleSwipePointerDown}
+                onPointerMove={handleSwipePointerMove}
+                onPointerUp={handleSwipePointerUp}
+                onPointerCancel={handleSwipePointerCancel}
               />
-              {props.projectTitle ? (
-                <span
-                  className={cn(
-                    "min-w-0 flex-1 truncate text-secondary-label text-xs",
-                    shouldRecede ? "font-normal" : "font-medium",
-                  )}
-                >
-                  {props.projectTitle}
-                </span>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {pinIndicator}
-              {/* The visible state owns this slot's width: status at rest,
+            }
+          >
+            <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
+              <div className="flex h-5 min-w-0 items-center gap-1.5">
+                <ProjectFavicon
+                  environmentId={thread.environmentId}
+                  cwd={props.projectCwd ?? ""}
+                  faviconPath={props.projectFaviconPath}
+                  className="size-4 shrink-0"
+                />
+                {props.projectTitle ? (
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate text-secondary-label text-xs",
+                      shouldRecede ? "font-normal" : "font-medium",
+                    )}
+                  >
+                    {props.projectTitle}
+                  </span>
+                ) : (
+                  <span className="flex-1" />
+                )}
+                {pinIndicator}
+                {/* The visible state owns this slot's width: status at rest,
                   actions on hover/keyboard focus or while the popover is open. Keeping
                   the hidden state out of flow lets the project label reclaim
                   space without either state overlapping it. */}
-              <span className="group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
-                {/* Read-only status labels yield to the hover actions. Woke is
+                <span className="group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
+                  {/* Read-only status labels yield to the hover actions. Woke is
                     itself an action, so it stays pointer-enabled and visible
                     while the other controls appear beside it. */}
-                <span
-                  className={cn(
-                    isWokeStatus
-                      ? "pointer-events-auto"
-                      : "pointer-events-none group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
-                    "flex items-center self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
-                    snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
-                  )}
-                >
-                  {topStatus ? (
-                    isWokeStatus ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <button
-                              type="button"
-                              aria-label="Dismiss Woke notification"
-                              onClick={handleAcknowledgeWokeClick}
-                              className={cn(
-                                "inline-flex cursor-pointer items-center gap-1 rounded-sm font-medium outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring",
-                                topStatus.className,
-                              )}
-                            >
-                              <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
-                              <span role="status">{topStatus.label}</span>
-                            </button>
-                          }
-                        />
-                        <TooltipPopup side="top">Dismiss Woke notification</TooltipPopup>
-                      </Tooltip>
-                    ) : (
-                      <span
-                        className={cn(
-                          "inline-flex items-center gap-1 font-medium",
-                          topStatus.className,
-                        )}
-                      >
-                        {topStatus.icon === "working" ? (
-                          <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
-                        ) : topStatus.icon === "done" ? (
-                          <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
-                        ) : null}
-                        {/* The label alone is the live region: a role="status"
-                            wrapper around the ticking duration would make
-                            screen readers announce every second. */}
-                        <span role="status">{topStatus.label}</span>
-                        {status === "working" ? (
-                          <span aria-hidden>
-                            <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
-                          </span>
-                        ) : null}
-                      </span>
-                    )
-                  ) : (
-                    threadTimeLabel(thread)
-                  )}
-                </span>
-                {props.settlementSupported || showSnoozeButton ? (
                   <span
                     className={cn(
-                      // focus-visible, not focus-within: a mouse click leaves
-                      // the Settle button focused, and a plain focus-within
-                      // would keep the controls pinned over the status label
-                      // once the pointer moves away (e.g. after a failed
-                      // settle) instead of cross-fading back.
-                      "pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity has-[:focus-visible]:pointer-events-auto has-[:focus-visible]:static has-[:focus-visible]:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:static group-hover/sidebar-row:opacity-100",
-                      snoozeMenuOpen && "pointer-events-auto static opacity-100",
+                      isWokeStatus
+                        ? "pointer-events-auto"
+                        : "pointer-events-none group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
+                      "flex items-center self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
+                      snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
                     )}
                   >
-                    {showSnoozeButton ? (
-                      <SnoozePopoverButton
-                        open={snoozeMenuOpen}
-                        onOpenChange={setSnoozeMenuOpen}
-                        onSnooze={handleSnoozePreset}
-                        timestampFormat={props.timestampFormat}
-                      />
-                    ) : null}
-                    {props.settlementSupported ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <button
-                              type="button"
-                              aria-label="Settle thread"
-                              onClick={handleSettleClick}
-                              className="-mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
-                            />
-                          }
+                    {topStatus ? (
+                      isWokeStatus ? (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <button
+                                type="button"
+                                aria-label="Dismiss Woke notification"
+                                onClick={handleAcknowledgeWokeClick}
+                                className={cn(
+                                  "inline-flex cursor-pointer items-center gap-1 rounded-sm font-medium outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring",
+                                  topStatus.className,
+                                )}
+                              >
+                                <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
+                                <span role="status">{topStatus.label}</span>
+                              </button>
+                            }
+                          />
+                          <TooltipPopup side="top">Dismiss Woke notification</TooltipPopup>
+                        </Tooltip>
+                      ) : (
+                        <span
+                          className={cn(
+                            "inline-flex items-center gap-1 font-medium",
+                            topStatus.className,
+                          )}
                         >
-                          <CheckIcon className="size-3.5" />
-                          Settle
-                        </TooltipTrigger>
-                        <TooltipPopup>Settle thread</TooltipPopup>
-                      </Tooltip>
-                    ) : null}
+                          {topStatus.icon === "working" ? (
+                            <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
+                          ) : topStatus.icon === "done" ? (
+                            <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
+                          ) : null}
+                          {/* The label alone is the live region: a role="status"
+                            wrapper around the ticking duration would make
+                            screen readers announce every second. */}
+                          <span role="status">{topStatus.label}</span>
+                          {status === "working" ? (
+                            <span aria-hidden>
+                              <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
+                            </span>
+                          ) : null}
+                        </span>
+                      )
+                    ) : (
+                      threadTimeLabel(thread)
+                    )}
+                  </span>
+                  {props.settlementSupported || showSnoozeButton ? (
+                    <span
+                      className={cn(
+                        // focus-visible, not focus-within: a mouse click leaves
+                        // the Settle button focused, and a plain focus-within
+                        // would keep the controls pinned over the status label
+                        // once the pointer moves away (e.g. after a failed
+                        // settle) instead of cross-fading back.
+                        "pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity has-[:focus-visible]:pointer-events-auto has-[:focus-visible]:static has-[:focus-visible]:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:static group-hover/sidebar-row:opacity-100",
+                        snoozeMenuOpen && "pointer-events-auto static opacity-100",
+                      )}
+                    >
+                      {showSnoozeButton ? (
+                        <SnoozePopoverButton
+                          open={snoozeMenuOpen}
+                          onOpenChange={setSnoozeMenuOpen}
+                          onSnooze={handleSnoozePreset}
+                          timestampFormat={props.timestampFormat}
+                        />
+                      ) : null}
+                      {props.settlementSupported ? (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <button
+                                type="button"
+                                aria-label="Settle thread"
+                                onClick={handleSettleClick}
+                                className="-mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
+                              />
+                            }
+                          >
+                            <CheckIcon className="size-3.5" />
+                            Settle
+                          </TooltipTrigger>
+                          <TooltipPopup>Settle thread</TooltipPopup>
+                        </Tooltip>
+                      ) : null}
+                    </span>
+                  ) : null}
+                </span>
+              </div>
+              <div className="mt-1 flex min-w-0">
+                {title}
+                {isRegeneratingTitle ? (
+                  <span role="status" className="sr-only">
+                    Regenerating title
                   </span>
                 ) : null}
-              </span>
-            </div>
-            <div className="mt-1 flex min-w-0">
-              {title}
-              {isRegeneratingTitle ? (
-                <span role="status" className="sr-only">
-                  Regenerating title
-                </span>
-              ) : null}
-            </div>
-            <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
-              {/* Always the branch. The plan step used to take this slot while
+              </div>
+              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
+                {/* Always the branch. The plan step used to take this slot while
                   working, but it truncated to a half-sentence and dropped the
                   branch, so the row lost its most stable identifier. */}
-              {thread.branch ? (
-                <>
-                  <ThreadWorktreeIndicator thread={thread} />
-                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
-                </>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {terminalStatusIcon}
-              {prBadge}
-              {diff ? (
-                <span className="shrink-0 font-mono">
-                  <span className="text-emerald-600 dark:text-emerald-400">+{diff.insertions}</span>{" "}
-                  <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
+                {thread.branch ? (
+                  <>
+                    <ThreadWorktreeIndicator thread={thread} />
+                    <span className="min-w-0 flex-1 truncate whitespace-nowrap">
+                      {thread.branch}
+                    </span>
+                  </>
+                ) : (
+                  <span className="flex-1" />
+                )}
+                {terminalStatusIcon}
+                {prBadge}
+                {diff ? (
+                  <span className="shrink-0 font-mono">
+                    <span className="text-emerald-600 dark:text-emerald-400">
+                      +{diff.insertions}
+                    </span>{" "}
+                    <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
+                  </span>
+                ) : null}
+                <span
+                  aria-hidden
+                  className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
+                >
+                  {isRemote ? (
+                    <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
+                      <ServerIcon aria-hidden className="size-3.5" />
+                    </span>
+                  ) : null}
+                  {driverKind ? (
+                    <span className="inline-flex shrink-0 items-center">
+                      <ProviderInstanceIcon
+                        driverKind={driverKind}
+                        displayName={
+                          providerEntry?.displayName ??
+                          thread.session?.providerName ??
+                          modelInstanceId
+                        }
+                        accentColor={providerEntry?.accentColor}
+                        showBadge={showInstanceBadge}
+                        // Glyph dims, badge stays saturated; offset matches the composer trigger.
+                        iconClassName="size-3.5 opacity-60"
+                        badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
+                      />
+                    </span>
+                  ) : null}
                 </span>
-              ) : null}
-              <span
-                aria-hidden
-                className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
-              >
-                {isRemote ? (
-                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                    <ServerIcon aria-hidden className="size-3.5" />
-                  </span>
-                ) : null}
-                {driverKind ? (
-                  <span className="inline-flex shrink-0 items-center">
-                    <ProviderInstanceIcon
-                      driverKind={driverKind}
-                      displayName={
-                        providerEntry?.displayName ??
-                        thread.session?.providerName ??
-                        modelInstanceId
-                      }
-                      accentColor={providerEntry?.accentColor}
-                      showBadge={showInstanceBadge}
-                      // Glyph dims, badge stays saturated; offset matches the composer trigger.
-                      iconClassName="size-3.5 opacity-60"
-                      badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
-                    />
-                  </span>
-                ) : null}
-              </span>
+              </div>
             </div>
-          </div>
-          {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
-        </TooltipTrigger>
-        {detailsTooltip}
-      </Tooltip>
+            {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
+          </TooltipTrigger>
+          {detailsTooltip}
+        </Tooltip>
+      </div>
     </li>
   );
 });

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -168,7 +168,7 @@ import {
   snoozeWakeLabel,
   type SnoozePreset,
 } from "./Sidebar.snooze";
-import { SIDEBAR_SWIPE_ACTION_WIDTH } from "./Sidebar.swipe";
+import { SIDEBAR_SWIPE_ACTION_WIDTH, resolveSidebarSwipeOpenThreadKey } from "./Sidebar.swipe";
 import { MobileSidebarSwipeActions, useMobileSidebarRowSwipe } from "./SidebarSwipeActions";
 import { SidebarSnoozePresetList } from "./SidebarSnoozePresetList";
 import { ProjectFavicon } from "./ProjectFavicon";
@@ -1817,7 +1817,9 @@ export default function Sidebar() {
   const { isMobile, openMobile, setOpenMobile } = useSidebar();
   const [mobileSwipeOpenThreadKey, setMobileSwipeOpenThreadKey] = useState<string | null>(null);
   const handleMobileSwipeOpenChange = useCallback((threadKey: string, open: boolean) => {
-    setMobileSwipeOpenThreadKey(open ? threadKey : null);
+    setMobileSwipeOpenThreadKey((currentThreadKey) =>
+      resolveSidebarSwipeOpenThreadKey({ currentThreadKey, changedThreadKey: threadKey, open }),
+    );
   }, []);
   useEffect(() => {
     if (!openMobile) setMobileSwipeOpenThreadKey(null);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -168,6 +168,8 @@ import {
   snoozeWakeLabel,
   type SnoozePreset,
 } from "./Sidebar.snooze";
+import { SIDEBAR_SWIPE_ACTION_WIDTH } from "./Sidebar.swipe";
+import { MobileSidebarSwipeActions, useMobileSidebarRowSwipe } from "./SidebarSwipeActions";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
@@ -730,6 +732,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // When a snooze ended (timer or early wake); drives the Woke pill until
   // the user visits the thread.
   wokeAt: string | null;
+  mobileSwipeOpen: boolean;
+  mobileSwipeEnabled: boolean;
   isActive: boolean;
   openPullRequestsInRightPanel: boolean;
   jumpLabel: string | null;
@@ -753,7 +757,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   onUnsettle: (threadRef: ScopedThreadRef) => void;
   onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
   onUnsnooze: (threadRef: ScopedThreadRef) => void;
+  onPin: (threadRef: ScopedThreadRef) => void;
   onUnpin: (threadRef: ScopedThreadRef) => void;
+  onMobileSwipeOpenChange: (threadKey: string, open: boolean) => void;
   onAcknowledgeWoke: (threadRef: ScopedThreadRef, visitedAt: string) => void;
   changeRequestSnapshot: ThreadChangeRequestSnapshot | null;
   onChangeRequestSnapshot: (
@@ -772,6 +778,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     onRenameTitleChange,
     onSettle,
     onSnooze,
+    onPin,
     onStartRename,
     onThreadActivate,
     onThreadClick,
@@ -790,6 +797,35 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   );
   const threadKey = scopedThreadKey(threadRef);
   const { leaseLiveStatus, rowRef } = useSidebarRowSubscriptionLease(props.isActive);
+  // Snooze is offered only where it can succeed: capability-gated and never
+  // on blocked-on-you work or queued turns (the server rejects both).
+  const showSnoozeButton =
+    props.snoozeSupported && canSnooze(thread, { now: new Date().toISOString() });
+  const swipeActionCount =
+    (props.settlementSupported ? 1 : 0) +
+    (showSnoozeButton ? 1 : 0) +
+    (props.pinningSupported ? 1 : 0);
+  const swipeRevealWidth = swipeActionCount * SIDEBAR_SWIPE_ACTION_WIDTH;
+  const swipeEnabled =
+    props.mobileSwipeEnabled && variant === "card" && !isRenaming && swipeActionCount > 0;
+  const setMobileSwipeOpen = useCallback(
+    (open: boolean) => props.onMobileSwipeOpenChange(threadKey, open),
+    [props.onMobileSwipeOpenChange, threadKey],
+  );
+  const {
+    consumeSuppressedClick,
+    dragging: swipeDragging,
+    offset: swipeOffset,
+    onPointerCancel: handleSwipePointerCancel,
+    onPointerDown: handleSwipePointerDown,
+    onPointerMove: handleSwipePointerMove,
+    onPointerUp: handleSwipePointerUp,
+  } = useMobileSidebarRowSwipe({
+    enabled: swipeEnabled,
+    open: props.mobileSwipeOpen && swipeEnabled,
+    revealWidth: swipeRevealWidth,
+    onOpenChange: setMobileSwipeOpen,
+  });
   const isRegeneratingTitle = thread.titleRegeneration != null;
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
@@ -985,9 +1021,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
 
   const handleClick = useCallback(
     (event: ReactMouseEvent) => {
+      if (consumeSuppressedClick()) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (props.mobileSwipeOpen) {
+        event.preventDefault();
+        event.stopPropagation();
+        setMobileSwipeOpen(false);
+        return;
+      }
       onThreadClick(event, threadRef);
     },
-    [onThreadClick, threadRef],
+    [consumeSuppressedClick, onThreadClick, props.mobileSwipeOpen, setMobileSwipeOpen, threadRef],
   );
   const handleAcknowledgeWokeClick = useCallback(
     (event: ReactMouseEvent) => {
@@ -1082,6 +1129,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     },
     [onUnpin, threadRef],
   );
+  const handlePinClick = useCallback(() => onPin(threadRef), [onPin, threadRef]);
   const handleSnoozePreset = useCallback(
     (preset: SnoozePreset) => {
       onSnooze(threadRef, preset);
@@ -1091,10 +1139,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // While the snooze popover is open the pointer leaves the row, which
   // would fade the hover actions out from under the open menu; pin them.
   const [snoozeMenuOpenRaw, setSnoozeMenuOpen] = useState(false);
-  // Snooze is offered only where it can succeed: capability-gated and never
-  // on blocked-on-you work or queued turns (the server rejects both).
-  const showSnoozeButton =
-    props.snoozeSupported && canSnooze(thread, { now: new Date().toISOString() });
   // If the thread becomes blocked while the popover is open, the button
   // unmounts without firing onOpenChange(false). Deriving the flag keeps a
   // stale true from permanently hiding the status label / pinning the
@@ -1408,9 +1452,24 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       {...(sortable?.listeners ?? {})}
       className={cn(
         "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_96px]",
+        swipeEnabled && "relative overflow-hidden rounded-md",
         sortable?.isDragging && "z-20 opacity-80",
       )}
     >
+      {swipeEnabled ? (
+        <MobileSidebarSwipeActions
+          open={props.mobileSwipeOpen}
+          showSettle={props.settlementSupported}
+          showSnooze={showSnoozeButton}
+          showPin={props.pinningSupported}
+          isPinned={props.isPinned}
+          timestampFormat={props.timestampFormat}
+          onSettle={() => onSettle(threadRef)}
+          onSnooze={handleSnoozePreset}
+          onPinToggle={props.isPinned ? () => onUnpin(threadRef) : handlePinClick}
+          onClose={() => setMobileSwipeOpen(false)}
+        />
+      ) : null}
       <Tooltip>
         <TooltipTrigger
           render={
@@ -1420,11 +1479,24 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               tabIndex={0}
               data-testid="sidebar-row-card"
               aria-busy={isRegeneratingTitle || undefined}
-              className={rowSurfaceClassName}
+              className={cn(
+                rowSurfaceClassName,
+                swipeEnabled && "touch-pan-y",
+                swipeEnabled && !props.isActive && !isSelected && "bg-sidebar",
+                swipeEnabled && !swipeDragging && "transition-transform duration-200 ease-out",
+                swipeEnabled && (swipeDragging || props.mobileSwipeOpen) && "will-change-transform",
+              )}
+              style={
+                swipeEnabled ? { transform: `translate3d(${swipeOffset}px, 0, 0)` } : undefined
+              }
               onClick={handleClick}
               onDoubleClick={handleDoubleClick}
               onKeyDown={handleKeyDown}
               onContextMenu={handleContextMenu}
+              onPointerDown={handleSwipePointerDown}
+              onPointerMove={handleSwipePointerMove}
+              onPointerUp={handleSwipePointerUp}
+              onPointerCancel={handleSwipePointerCancel}
             />
           }
         >
@@ -1749,7 +1821,14 @@ export default function Sidebar() {
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
   const router = useRouter();
-  const { isMobile, setOpenMobile } = useSidebar();
+  const { isMobile, openMobile, setOpenMobile } = useSidebar();
+  const [mobileSwipeOpenThreadKey, setMobileSwipeOpenThreadKey] = useState<string | null>(null);
+  const handleMobileSwipeOpenChange = useCallback((threadKey: string, open: boolean) => {
+    setMobileSwipeOpenThreadKey(open ? threadKey : null);
+  }, []);
+  useEffect(() => {
+    if (!openMobile) setMobileSwipeOpenThreadKey(null);
+  }, [openMobile]);
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
@@ -3808,6 +3887,8 @@ export default function Sidebar() {
                         // the wake signal must survive the trip. Still-snoozed
                         // rows resolve to null on their own.
                         wokeAt={threadWokeAt(thread, { now: snoozeNow })}
+                        mobileSwipeEnabled={isMobile}
+                        mobileSwipeOpen={mobileSwipeOpenThreadKey === threadKey}
                         isActive={routeThreadKey === threadKey}
                         openPullRequestsInRightPanel={routeThreadRef !== null}
                         jumpLabel={
@@ -3846,7 +3927,9 @@ export default function Sidebar() {
                         onUnsettle={attemptUnsettle}
                         onSnooze={attemptSnooze}
                         onUnsnooze={attemptUnsnooze}
+                        onPin={attemptPin}
                         onUnpin={attemptUnpin}
+                        onMobileSwipeOpenChange={handleMobileSwipeOpenChange}
                         onAcknowledgeWoke={acknowledgeWoke}
                         changeRequestSnapshot={changeRequestSnapshotByKey.get(threadKey) ?? null}
                         onChangeRequestSnapshot={setThreadChangeRequestSnapshot}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -170,6 +170,7 @@ import {
 } from "./Sidebar.snooze";
 import { SIDEBAR_SWIPE_ACTION_WIDTH } from "./Sidebar.swipe";
 import { MobileSidebarSwipeActions, useMobileSidebarRowSwipe } from "./SidebarSwipeActions";
+import { SidebarSnoozePresetList } from "./SidebarSnoozePresetList";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
@@ -194,7 +195,7 @@ import {
 } from "./ui/combobox";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
-import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
+import { Popover, PopoverTrigger } from "./ui/popover";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import {
   composerDraftHasUserContent,
@@ -429,25 +430,13 @@ function SnoozePopoverButton(props: {
         </TooltipTrigger>
         <TooltipPopup>Snooze thread</TooltipPopup>
       </Tooltip>
-      <PopoverPopup side="bottom" align="end" className="w-56" viewportClassName="p-1">
-        {presets.map((preset) => (
-          <button
-            key={preset.id}
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              onOpenChange(false);
-              onSnooze(preset);
-            }}
-            className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-foreground/90 hover:bg-accent hover:text-foreground"
-          >
-            <span className="flex-1">{preset.label}</span>
-            <span className="font-mono text-[10px] text-muted-foreground/60 tabular-nums">
-              {preset.whenLabel}
-            </span>
-          </button>
-        ))}
-      </PopoverPopup>
+      <SidebarSnoozePresetList
+        presets={presets}
+        onSelect={(preset) => {
+          onOpenChange(false);
+          onSnooze(preset);
+        }}
+      />
     </Popover>
   );
 }
@@ -1482,12 +1471,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               className={cn(
                 rowSurfaceClassName,
                 swipeEnabled && "touch-pan-y",
-                swipeEnabled && !props.isActive && !isSelected && "bg-sidebar",
                 swipeEnabled && !swipeDragging && "transition-transform duration-200 ease-out",
                 swipeEnabled && (swipeDragging || props.mobileSwipeOpen) && "will-change-transform",
               )}
               style={
-                swipeEnabled ? { transform: `translate3d(${swipeOffset}px, 0, 0)` } : undefined
+                swipeEnabled
+                  ? {
+                      transform: `translate3d(${swipeOffset}px, 0, 0)`,
+                      background: props.isActive
+                        ? "linear-gradient(var(--sidebar-row-active), var(--sidebar-row-active)), var(--sidebar)"
+                        : isSelected
+                          ? "linear-gradient(var(--sidebar-row-selected), var(--sidebar-row-selected)), var(--sidebar)"
+                          : "var(--sidebar)",
+                    }
+                  : undefined
               }
               onClick={handleClick}
               onDoubleClick={handleDoubleClick}

--- a/apps/web/src/components/SidebarSnoozePresetList.tsx
+++ b/apps/web/src/components/SidebarSnoozePresetList.tsx
@@ -1,0 +1,33 @@
+import { cn } from "~/lib/utils";
+import type { SnoozePreset } from "./Sidebar.snooze";
+import { PopoverPopup } from "./ui/popover";
+
+export function SidebarSnoozePresetList(props: {
+  presets: ReadonlyArray<SnoozePreset>;
+  rowSize?: "compact" | "touch";
+  onSelect: (preset: SnoozePreset) => void;
+}) {
+  return (
+    <PopoverPopup side="bottom" align="end" className="w-56" viewportClassName="p-1">
+      {props.presets.map((preset) => (
+        <button
+          key={preset.id}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onSelect(preset);
+          }}
+          className={cn(
+            "flex w-full cursor-pointer items-center gap-2 rounded-md px-2 text-left text-xs text-foreground/90 hover:bg-accent hover:text-foreground",
+            props.rowSize === "touch" ? "py-2" : "py-1.5",
+          )}
+        >
+          <span className="flex-1">{preset.label}</span>
+          <span className="font-mono text-[10px] text-muted-foreground/60 tabular-nums">
+            {preset.whenLabel}
+          </span>
+        </button>
+      ))}
+    </PopoverPopup>
+  );
+}

--- a/apps/web/src/components/SidebarSwipeActions.tsx
+++ b/apps/web/src/components/SidebarSwipeActions.tsx
@@ -1,0 +1,233 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import type { TimestampFormat } from "@t3tools/contracts/settings";
+import { CheckIcon, ClockIcon, PinIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
+import { resolveSnoozePresets, type SnoozePreset } from "./Sidebar.snooze";
+import {
+  clampSidebarSwipeOffset,
+  resolveSidebarSwipeIntent,
+  shouldOpenSidebarSwipe,
+  type SidebarSwipeIntent,
+} from "./Sidebar.swipe";
+
+export function useMobileSidebarRowSwipe(props: {
+  enabled: boolean;
+  open: boolean;
+  revealWidth: number;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { enabled, open, revealWidth, onOpenChange } = props;
+  const restingOffset = open ? -revealWidth : 0;
+  const [offset, setOffset] = useState(restingOffset);
+  const offsetRef = useRef(restingOffset);
+  const [dragging, setDragging] = useState(false);
+  const gestureRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    originOffset: number;
+    intent: SidebarSwipeIntent;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
+
+  useEffect(() => {
+    if (!dragging) {
+      offsetRef.current = restingOffset;
+      setOffset(restingOffset);
+    }
+  }, [dragging, restingOffset]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled || !event.isPrimary || event.button !== 0) return;
+      if ((event.target as HTMLElement).closest("button, a, input")) return;
+      // Whole-row dnd listeners live on the parent <li>. Mobile horizontal
+      // swipes own this pointer; vertical scrolling remains native via pan-y.
+      event.stopPropagation();
+      gestureRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        originOffset: restingOffset,
+        intent: "pending",
+      };
+      suppressClickRef.current = false;
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [enabled, restingOffset],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (gesture === null || gesture.pointerId !== event.pointerId) return;
+      const deltaX = event.clientX - gesture.startX;
+      const deltaY = event.clientY - gesture.startY;
+      if (gesture.intent === "pending") {
+        gesture.intent = resolveSidebarSwipeIntent(deltaX, deltaY);
+        if (gesture.intent === "vertical") {
+          gestureRef.current = null;
+          if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
+          return;
+        }
+      }
+      if (gesture.intent !== "horizontal") return;
+      event.preventDefault();
+      setDragging(true);
+      suppressClickRef.current = true;
+      const nextOffset = clampSidebarSwipeOffset({
+        originOffset: gesture.originOffset,
+        deltaX,
+        revealWidth,
+      });
+      offsetRef.current = nextOffset;
+      setOffset(nextOffset);
+    },
+    [revealWidth],
+  );
+
+  const finishGesture = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (gesture === null || gesture.pointerId !== event.pointerId) return;
+      gestureRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (gesture.intent !== "horizontal") return;
+      const nextOpen = shouldOpenSidebarSwipe({ offset: offsetRef.current, revealWidth });
+      setDragging(false);
+      offsetRef.current = nextOpen ? -revealWidth : 0;
+      setOffset(offsetRef.current);
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, revealWidth],
+  );
+
+  const consumeSuppressedClick = useCallback(() => {
+    if (!suppressClickRef.current) return false;
+    suppressClickRef.current = false;
+    return true;
+  }, []);
+
+  return {
+    consumeSuppressedClick,
+    dragging,
+    offset,
+    onPointerCancel: finishGesture,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: finishGesture,
+  };
+}
+
+export function MobileSidebarSwipeActions(props: {
+  open: boolean;
+  showSettle: boolean;
+  showSnooze: boolean;
+  showPin: boolean;
+  isPinned: boolean;
+  timestampFormat: TimestampFormat;
+  onSettle: () => void;
+  onSnooze: (preset: SnoozePreset) => void;
+  onPinToggle: () => void;
+  onClose: () => void;
+}) {
+  const [snoozeOpen, setSnoozeOpen] = useState(false);
+  const presets = useMemo(
+    () => (snoozeOpen ? resolveSnoozePresets(new Date(), props.timestampFormat) : []),
+    [props.timestampFormat, snoozeOpen],
+  );
+  useEffect(() => {
+    if (!props.open) setSnoozeOpen(false);
+  }, [props.open]);
+  const actionClassName =
+    "flex h-full w-[72px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 text-[11px] font-medium text-white outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/80";
+  return (
+    <div
+      role="group"
+      aria-label="Thread swipe actions"
+      className="absolute inset-y-0.5 right-0 flex overflow-hidden rounded-r-md"
+      inert={!props.open}
+    >
+      {props.showSettle ? (
+        <button
+          type="button"
+          aria-label="Settle thread"
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onClose();
+            props.onSettle();
+          }}
+          className={cn(actionClassName, "bg-emerald-600 active:bg-emerald-700")}
+        >
+          <CheckIcon aria-hidden className="size-5" />
+          <span>Settle</span>
+        </button>
+      ) : null}
+      {props.showSnooze ? (
+        <Popover open={snoozeOpen} onOpenChange={setSnoozeOpen}>
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                aria-label="Snooze thread"
+                onClick={(event) => event.stopPropagation()}
+                className={cn(actionClassName, "bg-amber-500 active:bg-amber-600")}
+              />
+            }
+          >
+            <ClockIcon aria-hidden className="size-5" />
+            <span>Snooze</span>
+          </PopoverTrigger>
+          <PopoverPopup side="bottom" align="end" className="w-56" viewportClassName="p-1">
+            {presets.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setSnoozeOpen(false);
+                  props.onClose();
+                  props.onSnooze(preset);
+                }}
+                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left text-xs text-foreground/90 hover:bg-accent hover:text-foreground"
+              >
+                <span className="flex-1">{preset.label}</span>
+                <span className="font-mono text-[10px] text-muted-foreground/60 tabular-nums">
+                  {preset.whenLabel}
+                </span>
+              </button>
+            ))}
+          </PopoverPopup>
+        </Popover>
+      ) : null}
+      {props.showPin ? (
+        <button
+          type="button"
+          aria-label={props.isPinned ? "Unpin thread" : "Pin thread"}
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onClose();
+            props.onPinToggle();
+          }}
+          className={cn(actionClassName, "bg-blue-600 active:bg-blue-700")}
+        >
+          <PinIcon aria-hidden className="size-5" />
+          <span>{props.isPinned ? "Unpin" : "Pin"}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/SidebarSwipeActions.tsx
+++ b/apps/web/src/components/SidebarSwipeActions.tsx
@@ -115,6 +115,22 @@ export function useMobileSidebarRowSwipe(props: {
     [onOpenChange, revealWidth],
   );
 
+  const cancelGesture = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (gesture === null || gesture.pointerId !== event.pointerId) return;
+      gestureRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      setDragging(false);
+      suppressClickRef.current = false;
+      offsetRef.current = restingOffset;
+      setOffset(restingOffset);
+    },
+    [restingOffset],
+  );
+
   const consumeSuppressedClick = useCallback(() => {
     if (!suppressClickRef.current) return false;
     suppressClickRef.current = false;
@@ -125,7 +141,7 @@ export function useMobileSidebarRowSwipe(props: {
     consumeSuppressedClick,
     dragging,
     offset,
-    onPointerCancel: finishGesture,
+    onPointerCancel: cancelGesture,
     onPointerDown,
     onPointerMove,
     onPointerUp: finishGesture,
@@ -160,6 +176,7 @@ export function MobileSidebarSwipeActions(props: {
       aria-label="Thread swipe actions"
       className="absolute inset-y-0.5 right-0 flex overflow-hidden rounded-r-md"
       inert={!props.open}
+      onPointerDown={(event) => event.stopPropagation()}
     >
       {props.showSettle ? (
         <button

--- a/apps/web/src/components/SidebarSwipeActions.tsx
+++ b/apps/web/src/components/SidebarSwipeActions.tsx
@@ -10,14 +10,16 @@ import type { TimestampFormat } from "@t3tools/contracts/settings";
 import { CheckIcon, ClockIcon, PinIcon } from "lucide-react";
 
 import { cn } from "~/lib/utils";
-import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
+import { Popover, PopoverTrigger } from "./ui/popover";
 import { resolveSnoozePresets, type SnoozePreset } from "./Sidebar.snooze";
 import {
+  SIDEBAR_SWIPE_ACTION_WIDTH,
   clampSidebarSwipeOffset,
   resolveSidebarSwipeIntent,
   shouldOpenSidebarSwipe,
   type SidebarSwipeIntent,
 } from "./Sidebar.swipe";
+import { SidebarSnoozePresetList } from "./SidebarSnoozePresetList";
 
 export function useMobileSidebarRowSwipe(props: {
   enabled: boolean;
@@ -169,7 +171,8 @@ export function MobileSidebarSwipeActions(props: {
     if (!props.open) setSnoozeOpen(false);
   }, [props.open]);
   const actionClassName =
-    "flex h-full w-[72px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 text-[11px] font-medium text-white outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/80";
+    "flex h-full shrink-0 cursor-pointer flex-col items-center justify-center gap-1 text-[11px] font-medium text-white outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/80";
+  const actionStyle = { width: SIDEBAR_SWIPE_ACTION_WIDTH };
   return (
     <div
       role="group"
@@ -182,6 +185,7 @@ export function MobileSidebarSwipeActions(props: {
         <button
           type="button"
           aria-label="Settle thread"
+          style={actionStyle}
           onClick={(event) => {
             event.stopPropagation();
             props.onClose();
@@ -200,40 +204,31 @@ export function MobileSidebarSwipeActions(props: {
               <button
                 type="button"
                 aria-label="Snooze thread"
+                style={actionStyle}
                 onClick={(event) => event.stopPropagation()}
-                className={cn(actionClassName, "bg-amber-500 active:bg-amber-600")}
+                className={cn(actionClassName, "bg-amber-700 active:bg-amber-800")}
               />
             }
           >
             <ClockIcon aria-hidden className="size-5" />
             <span>Snooze</span>
           </PopoverTrigger>
-          <PopoverPopup side="bottom" align="end" className="w-56" viewportClassName="p-1">
-            {presets.map((preset) => (
-              <button
-                key={preset.id}
-                type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  setSnoozeOpen(false);
-                  props.onClose();
-                  props.onSnooze(preset);
-                }}
-                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left text-xs text-foreground/90 hover:bg-accent hover:text-foreground"
-              >
-                <span className="flex-1">{preset.label}</span>
-                <span className="font-mono text-[10px] text-muted-foreground/60 tabular-nums">
-                  {preset.whenLabel}
-                </span>
-              </button>
-            ))}
-          </PopoverPopup>
+          <SidebarSnoozePresetList
+            presets={presets}
+            rowSize="touch"
+            onSelect={(preset) => {
+              setSnoozeOpen(false);
+              props.onClose();
+              props.onSnooze(preset);
+            }}
+          />
         </Popover>
       ) : null}
       {props.showPin ? (
         <button
           type="button"
           aria-label={props.isPinned ? "Unpin thread" : "Pin thread"}
+          style={actionStyle}
           onClick={(event) => {
             event.stopPropagation();
             props.onClose();

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -28,9 +28,10 @@ Right-click a pull request link in a thread and choose **Link to thread** to sho
 in the sidebar. The thread settles when the linked pull request merges if **Auto-settle merged
 threads** is enabled. Right-click the same link and choose **Unlink from thread** to remove it.
 
-In the mobile-width web app, swipe an active thread to the left to reveal **Settle**, **Snooze**,
-and **Pin** actions. A pinned thread shows **Unpin** instead. Vertical movement continues to scroll
-the sidebar, and tapping the revealed thread closes its actions.
+In the mobile-width web app, swipe an active thread to the left to reveal available actions such as
+**Settle**, **Snooze**, and **Pin**. Some actions may be omitted based on the connected environment's
+capabilities or the thread's current state. A pinned thread shows **Unpin** instead. Vertical
+movement continues to scroll the sidebar, and tapping the revealed thread closes its actions.
 
 On web and desktop, drag a pinned thread to change its position. On mobile, open the thread's menu
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -28,6 +28,10 @@ Right-click a pull request link in a thread and choose **Link to thread** to sho
 in the sidebar. The thread settles when the linked pull request merges if **Auto-settle merged
 threads** is enabled. Right-click the same link and choose **Unlink from thread** to remove it.
 
+In the mobile-width web app, swipe an active thread to the left to reveal **Settle**, **Snooze**,
+and **Pin** actions. A pinned thread shows **Unpin** instead. Vertical movement continues to scroll
+the sidebar, and tapping the revealed thread closes its actions.
+
 On web and desktop, drag a pinned thread to change its position. On mobile, open the thread's menu
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.


### PR DESCRIPTION
<!--
GitHub CLI posting step (run from the repository root after pushing the branch):

gh pr create \
  -R pingdotgg/t3code \
  --title "feat(web): add mobile sidebar swipe actions" \
  --body-file artifacts/mobile-sidebar-swipe/pr-draft.md

The screenshots below are hosted as GitHub user attachments. Do not commit the screenshots or the
disposable Playwright artifact test.

Related issue: #9148
-->

Closes #9148

## What Changed

- Added a mobile-width left-swipe gesture to active and pinned web sidebar thread cards.
- Reveals capability-aware **Settle**, **Snooze**, and **Pin/Unpin** touch actions.
- Reuses the existing settle, snooze preset, pin, and unpin command paths.
- Keeps one tray open at a time and clears it when the mobile sidebar closes.
- Added direction locking that favors vertical scrolling for ambiguous gestures.
- Translates only the inner row surface, preserving list height and `auto-animate` geometry.
- Documented the mobile web interaction in the thread sidebar user guide.

No server contracts or native mobile code changed.

## Why

The desktop sidebar exposes quick actions through hover, but phone browsers have no hover. Common
thread-triage actions therefore require extra menu navigation on mobile web.

This adds a familiar Mail-style touch interaction while keeping lifecycle behavior in the existing
action implementations. The gesture code is isolated from sorting and list layout to reduce
conflicts with current pinned reordering and the active-thread reorder work in #8666.

## UI Changes

| Before | After |
| --- | --- |
| ![Mobile sidebar before swipe](https://github.com/user-attachments/assets/81dae1bb-23b0-42fc-b394-cb4cd9ecb136) | ![Settle, Snooze, and Pin actions revealed](https://github.com/user-attachments/assets/27b9887b-b680-46ef-a6c2-52121e05a0e7) |

### Gesture progress

![Thread following the pointer during a partial swipe](https://github.com/user-attachments/assets/4405c4fd-12db-4d9b-af8b-c06fbf65cd3d)

The screenshots were captured at a 430 × 932 CSS-pixel viewport with a disposable, synthetic T3
environment. The temporary Playwright artifact test also asserts that the row remains translated
`-216px` after pointer-up and that exactly one Settle, Snooze, and Pin action exists for the target
row.

During visual verification, the test caught a post-pointer-up synthetic click that initially closed
the freshly opened tray. Click suppression now consumes that event without changing the tray's open
state.

## Verification

- `vp test run apps/web/src/components/Sidebar.swipe.test.ts --passWithNoTests`
  - 8 tests passed.
- `tsgo -p apps/web/tsconfig.json --noEmit`
- Targeted lint passed for:
  - `apps/web/src/components/Sidebar.tsx`
  - `apps/web/src/components/SidebarSwipeActions.tsx`
  - `apps/web/src/components/Sidebar.swipe.ts`
  - `apps/web/src/components/Sidebar.swipe.test.ts`
- Formatting and `git diff --check` passed.
- Disposable Playwright artifact test passed at mobile viewport and produced the screenshots above.

## Surface coverage

- **Entry points:** The gesture is an additional mobile sidebar entry point; context menus and chat
  header actions remain unchanged.
- **Clients:** Mobile-width web is changed. Desktop retains existing hover behavior. Native iOS and
  Android are unchanged.
- **Providers:** Provider-independent; actions use environment capability flags and shared thread
  commands.
- **Contracts:** No changes.
- **Reverse states:** Pinned cards show Unpin; existing snooze and settle reversal flows remain
  available.
- **Connection modes:** Uses the existing per-environment command routing for local, remote, relay,
  and tunnel connections.
- **Docs:** Updated `docs/user/thread-sidebar.md`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [ ] I included a video for animation/interaction changes

Built by GPT-5.6 Sol via the Codex harness in T3 Code.
