### PR TITLE
feat(web): opt-in project sections in the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -86,10 +86,44 @@ describe("groupThreadsIntoProjectSections", () => {
       { id: "a-old", environmentId: "remote", projectId: "a-copy" },
     ] as const;
 
-    expect(groupThreadsIntoProjectSections(projects, threads)).toEqual([
-      { project: projects[0], threads: [threads[1]] },
-      { project: projects[1], threads: [threads[0], threads[2]] },
-    ]);
+    expect(groupThreadsIntoProjectSections(projects, threads)).toEqual({
+      sections: [
+        { project: projects[0], threads: [threads[1]] },
+        { project: projects[1], threads: [threads[0], threads[2]] },
+      ],
+      ungroupedThreads: [],
+    });
+  });
+
+  it("keeps threads without a matching project in an ungrouped bucket", () => {
+    const threads = [
+      { id: "orphan", environmentId: "local", projectId: "removed-project" },
+      { id: "b-new", environmentId: "local", projectId: "b" },
+    ] as const;
+
+    expect(groupThreadsIntoProjectSections(projects, threads)).toEqual({
+      sections: [{ project: projects[0], threads: [threads[1]] }],
+      ungroupedThreads: [threads[0]],
+    });
+  });
+
+  it("never conflates identifiers across the composite key boundary", () => {
+    const colonProjects = [
+      {
+        projectKey: "left",
+        memberProjectRefs: [{ environmentId: "env:a", projectId: "b" }],
+      },
+      {
+        projectKey: "right",
+        memberProjectRefs: [{ environmentId: "env", projectId: "a:b" }],
+      },
+    ] as const;
+    const threads = [{ id: "t", environmentId: "env", projectId: "a:b" }] as const;
+
+    expect(groupThreadsIntoProjectSections(colonProjects, threads)).toEqual({
+      sections: [{ project: colonProjects[1], threads: [threads[0]] }],
+      ungroupedThreads: [],
+    });
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -13,6 +13,7 @@ import {
   reduceSidebarProjectScopeMenuState,
   getFallbackThreadIdAfterDelete,
   getVisibleThreadsForProject,
+  groupThreadsIntoProjectSections,
   getProjectSortTimestamp,
   hasUnseenCompletion,
   isContextMenuPointerDown,
@@ -55,6 +56,42 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("groupThreadsIntoProjectSections", () => {
+  const projects = [
+    {
+      projectKey: "project-b",
+      displayName: "Beta",
+      memberProjectRefs: [{ environmentId: "local", projectId: "b" }],
+    },
+    {
+      projectKey: "project-a",
+      displayName: "Alpha",
+      memberProjectRefs: [
+        { environmentId: "local", projectId: "a" },
+        { environmentId: "remote", projectId: "a-copy" },
+      ],
+    },
+    {
+      projectKey: "empty",
+      displayName: "Empty",
+      memberProjectRefs: [{ environmentId: "local", projectId: "empty" }],
+    },
+  ] as const;
+
+  it("preserves project order, thread order, and omits empty projects", () => {
+    const threads = [
+      { id: "a-new", environmentId: "local", projectId: "a" },
+      { id: "b-new", environmentId: "local", projectId: "b" },
+      { id: "a-old", environmentId: "remote", projectId: "a-copy" },
+    ] as const;
+
+    expect(groupThreadsIntoProjectSections(projects, threads)).toEqual([
+      { project: projects[0], threads: [threads[1]] },
+      { project: projects[1], threads: [threads[0], threads[2]] },
+    ]);
+  });
+});
 
 describe("animatePinnedLayoutChanges", () => {
   const baseArgs: Parameters<AnimateLayoutChanges>[0] = {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -108,6 +108,38 @@ type LogicalSidebarProject = SidebarProject & {
   }[];
 };
 
+export function groupThreadsIntoProjectSections<
+  const TProject extends {
+    readonly projectKey: string;
+    readonly memberProjectRefs: readonly {
+      readonly environmentId: string;
+      readonly projectId: string;
+    }[];
+  },
+  const TThread extends { readonly environmentId: string; readonly projectId: string },
+>(projects: readonly TProject[], threads: readonly TThread[]) {
+  const projectKeyByMember = new Map(
+    projects.flatMap((project) =>
+      project.memberProjectRefs.map(
+        (ref) => [`${ref.environmentId}:${ref.projectId}`, project.projectKey] as const,
+      ),
+    ),
+  );
+  const threadsByProjectKey = new Map<string, TThread[]>();
+  for (const thread of threads) {
+    const projectKey = projectKeyByMember.get(`${thread.environmentId}:${thread.projectId}`);
+    if (!projectKey) continue;
+    const projectThreads = threadsByProjectKey.get(projectKey);
+    if (projectThreads) projectThreads.push(thread);
+    else threadsByProjectKey.set(projectKey, [thread]);
+  }
+
+  return projects.flatMap((project) => {
+    const projectThreads = threadsByProjectKey.get(project.projectKey);
+    return projectThreads ? [{ project, threads: projectThreads }] : [];
+  });
+}
+
 export type ThreadTraversalDirection = "previous" | "next";
 
 export async function archiveSelectedThreadEntries<

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -108,6 +108,15 @@ type LogicalSidebarProject = SidebarProject & {
   }[];
 };
 
+// NUL cannot appear in either identifier, so the composite key never collides.
+const projectMemberKey = (environmentId: string, projectId: string) =>
+  `${environmentId}\u0000${projectId}`;
+
+/**
+ * Threads whose project is in no group (e.g. the project was removed while its
+ * threads live on) land in `ungroupedThreads` so the sectioned sidebar can
+ * still render them; hiding them would make live work unreachable.
+ */
 export function groupThreadsIntoProjectSections<
   const TProject extends {
     readonly projectKey: string;
@@ -121,23 +130,32 @@ export function groupThreadsIntoProjectSections<
   const projectKeyByMember = new Map(
     projects.flatMap((project) =>
       project.memberProjectRefs.map(
-        (ref) => [`${ref.environmentId}:${ref.projectId}`, project.projectKey] as const,
+        (ref) => [projectMemberKey(ref.environmentId, ref.projectId), project.projectKey] as const,
       ),
     ),
   );
   const threadsByProjectKey = new Map<string, TThread[]>();
+  const ungroupedThreads: TThread[] = [];
   for (const thread of threads) {
-    const projectKey = projectKeyByMember.get(`${thread.environmentId}:${thread.projectId}`);
-    if (!projectKey) continue;
+    const projectKey = projectKeyByMember.get(
+      projectMemberKey(thread.environmentId, thread.projectId),
+    );
+    if (!projectKey) {
+      ungroupedThreads.push(thread);
+      continue;
+    }
     const projectThreads = threadsByProjectKey.get(projectKey);
     if (projectThreads) projectThreads.push(thread);
     else threadsByProjectKey.set(projectKey, [thread]);
   }
 
-  return projects.flatMap((project) => {
-    const projectThreads = threadsByProjectKey.get(project.projectKey);
-    return projectThreads ? [{ project, threads: projectThreads }] : [];
-  });
+  return {
+    sections: projects.flatMap((project) => {
+      const projectThreads = threadsByProjectKey.get(project.projectKey);
+      return projectThreads ? [{ project, threads: projectThreads }] : [];
+    }),
+    ungroupedThreads,
+  };
 }
 
 export type ThreadTraversalDirection = "previous" | "next";

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -995,7 +995,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const detailsTooltip = (
     <SidebarThreadTooltip
       thread={thread}
-      projectTitle={props.showProjectIdentity ? props.projectTitle : null}
+      projectTitle={props.projectTitle}
       projectCwd={props.projectCwd}
       projectFaviconPath={props.projectFaviconPath}
       projectIcon={props.projectIcon}
@@ -4134,6 +4134,18 @@ export default function Sidebar() {
                     // Threads whose project is in no group (e.g. removed
                     // projects) render after the sections; hiding them would
                     // make live work unreachable.
+                    if (
+                      activeProjectSections.sections.length > 0 &&
+                      activeProjectSections.ungroupedThreads.length > 0
+                    ) {
+                      items.push(
+                        <li
+                          key="ungrouped-divider"
+                          aria-hidden
+                          className="mx-2.5 my-1.5 h-px list-none bg-sidebar-border/60"
+                        />,
+                      );
+                    }
                     for (const thread of activeProjectSections.ungroupedThreads) {
                       items.push(renderThreadRow(thread, "active"));
                     }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4089,7 +4089,9 @@ export default function Sidebar() {
                             <ProjectFavicon
                               environmentId={project.environmentId}
                               cwd={project.workspaceRoot}
+                              projectName={project.displayName}
                               faviconPath={project.faviconPath}
+                              projectIcon={project.projectIcon}
                               className="size-3.5 shrink-0"
                             />
                             <span className="min-w-0 flex-1 truncate text-xs font-medium text-sidebar-muted-foreground/70">

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2242,7 +2242,9 @@ export default function Sidebar() {
   >(() => new Set());
   useEffect(() => {
     if (activeProjectSections === null) return;
-    const activeKeys = new Set(activeProjectSections.map(({ project }) => project.projectKey));
+    const activeKeys = new Set(
+      activeProjectSections.sections.map(({ project }) => project.projectKey),
+    );
     setCollapsedProjectSectionKeys((collapsedKeys) => {
       const nextCollapsedKeys = new Set(
         [...collapsedKeys].filter((projectKey) => activeKeys.has(projectKey)),
@@ -2261,15 +2263,23 @@ export default function Sidebar() {
       return nextCollapsedKeys;
     });
   }, []);
-  const visibleActiveThreads = useMemo(
-    () =>
-      activeProjectSections === null
-        ? activeThreads
-        : activeProjectSections.flatMap(({ project, threads: projectThreads }) =>
-            collapsedProjectSectionKeys.has(project.projectKey) ? [] : projectThreads,
-          ),
-    [activeProjectSections, activeThreads, collapsedProjectSectionKeys],
-  );
+  const visibleActiveThreads = useMemo(() => {
+    if (activeProjectSections === null) return activeThreads;
+    const sectionThreads = activeProjectSections.sections.flatMap(
+      ({ project, threads: projectThreads }) => {
+        if (!collapsedProjectSectionKeys.has(project.projectKey)) return projectThreads;
+        // The open thread must never vanish behind a collapsed section — same
+        // exception the snoozed and settled shelves make for the routed row.
+        if (routeThreadKey === null) return [];
+        const routeThread = projectThreads.find(
+          (thread) =>
+            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === routeThreadKey,
+        );
+        return routeThread === undefined ? [] : [routeThread];
+      },
+    );
+    return [...sectionThreads, ...activeProjectSections.ungroupedThreads];
+  }, [activeProjectSections, activeThreads, collapsedProjectSectionKeys, routeThreadKey]);
 
   const threadSearchInputRef = useRef<HTMLInputElement>(null);
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
@@ -4060,7 +4070,10 @@ export default function Sidebar() {
                     );
                   }
                   if (activeProjectSections) {
-                    for (const { project, threads: projectThreads } of activeProjectSections) {
+                    for (const {
+                      project,
+                      threads: projectThreads,
+                    } of activeProjectSections.sections) {
                       const isExpanded = !collapsedProjectSectionKeys.has(project.projectKey);
                       items.push(
                         <li
@@ -4104,7 +4117,25 @@ export default function Sidebar() {
                         for (const thread of projectThreads) {
                           items.push(renderThreadRow(thread, "active", undefined, false));
                         }
+                      } else if (routeThreadKey !== null) {
+                        // The open thread must never vanish behind a collapsed
+                        // section — same exception the snoozed/settled shelves
+                        // make for the routed row.
+                        const routeThread = projectThreads.find(
+                          (thread) =>
+                            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) ===
+                            routeThreadKey,
+                        );
+                        if (routeThread !== undefined) {
+                          items.push(renderThreadRow(routeThread, "active", undefined, false));
+                        }
                       }
+                    }
+                    // Threads whose project is in no group (e.g. removed
+                    // projects) render after the sections; hiding them would
+                    // make live work unreachable.
+                    for (const thread of activeProjectSections.ungroupedThreads) {
+                      items.push(renderThreadRow(thread, "active"));
                     }
                   } else {
                     for (const thread of activeThreads) {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -216,7 +216,8 @@ const SETTLED_TAIL_PAGE_COUNT = 25;
 const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar:settled-expanded";
 const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar:snoozed-expanded";
 const PROJECT_SECTIONS_COLLAPSED_KEY = "t3code:sidebar:project-sections-collapsed";
-
+const PROJECT_SECTIONS_COLLAPSED_DEFAULT: readonly string[] = [];
+const PROJECT_SECTIONS_COLLAPSED_SCHEMA = Schema.Array(Schema.String);
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
   return label.endsWith(" ago") ? label.slice(0, -4) : label;
@@ -2243,8 +2244,8 @@ export default function Sidebar() {
   // disappears and returns) keeps the way the user left it.
   const [collapsedProjectSectionKeyList, setCollapsedProjectSectionKeyList] = useLocalStorage(
     PROJECT_SECTIONS_COLLAPSED_KEY,
-    [] as readonly string[],
-    Schema.Array(Schema.String),
+    PROJECT_SECTIONS_COLLAPSED_DEFAULT,
+    PROJECT_SECTIONS_COLLAPSED_SCHEMA,
   );
   const collapsedProjectSectionKeys = useMemo(
     () => new Set(collapsedProjectSectionKeyList),

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -215,6 +215,7 @@ const SETTLED_TAIL_PAGE_COUNT = 25;
 // Fresh keys deliberately reset both shelves to collapsed for existing users.
 const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar:settled-expanded";
 const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar:snoozed-expanded";
+const PROJECT_SECTIONS_COLLAPSED_KEY = "t3code:sidebar:project-sections-collapsed";
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -2237,32 +2238,28 @@ export default function Sidebar() {
         : null,
     [activeThreads, projectGroups, projectScopeKey, projectSectionsEnabled],
   );
-  const [collapsedProjectSectionKeys, setCollapsedProjectSectionKeys] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
-  useEffect(() => {
-    if (activeProjectSections === null) return;
-    const activeKeys = new Set(
-      activeProjectSections.sections.map(({ project }) => project.projectKey),
-    );
-    setCollapsedProjectSectionKeys((collapsedKeys) => {
-      const nextCollapsedKeys = new Set(
-        [...collapsedKeys].filter((projectKey) => activeKeys.has(projectKey)),
+  // Collapsed sections persist like the snoozed/settled shelves. Keys are
+  // never pruned: a section that momentarily empties (or a project that
+  // disappears and returns) keeps the way the user left it.
+  const [collapsedProjectSectionKeyList, setCollapsedProjectSectionKeyList] = useLocalStorage(
+    PROJECT_SECTIONS_COLLAPSED_KEY,
+    [] as readonly string[],
+    Schema.Array(Schema.String),
+  );
+  const collapsedProjectSectionKeys = useMemo(
+    () => new Set(collapsedProjectSectionKeyList),
+    [collapsedProjectSectionKeyList],
+  );
+  const toggleProjectSection = useCallback(
+    (projectKey: string) => {
+      setCollapsedProjectSectionKeyList((collapsedKeys) =>
+        collapsedKeys.includes(projectKey)
+          ? collapsedKeys.filter((key) => key !== projectKey)
+          : [...collapsedKeys, projectKey],
       );
-      return nextCollapsedKeys.size === collapsedKeys.size ? collapsedKeys : nextCollapsedKeys;
-    });
-  }, [activeProjectSections]);
-  const toggleProjectSection = useCallback((projectKey: string) => {
-    setCollapsedProjectSectionKeys((collapsedKeys) => {
-      const nextCollapsedKeys = new Set(collapsedKeys);
-      if (nextCollapsedKeys.has(projectKey)) {
-        nextCollapsedKeys.delete(projectKey);
-      } else {
-        nextCollapsedKeys.add(projectKey);
-      }
-      return nextCollapsedKeys;
-    });
-  }, []);
+    },
+    [setCollapsedProjectSectionKeyList],
+  );
   const visibleActiveThreads = useMemo(() => {
     if (activeProjectSections === null) return activeThreads;
     const sectionThreads = activeProjectSections.sections.flatMap(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1556,7 +1556,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
           <div
             className={cn(
               "relative z-10 px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]",
-              props.showProjectIdentity ? "h-[4.875rem]" : "h-[3.5rem]",
+              props.showProjectIdentity ? "h-[4.875rem]" : "h-[3.375rem]",
             )}
           >
             {props.showProjectIdentity ? (

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -133,6 +133,7 @@ import {
   filterSidebarProjectScopeItems,
   formatWorkingDurationLabel,
   firstValidTimestampMs,
+  groupThreadsIntoProjectSections,
   hasUnseenCompletion,
   isSidebarNestedLinkClick,
   isTrailingDoubleClick,
@@ -759,6 +760,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   projectFaviconPath: string | null;
   projectIcon: ProjectIconOverride | null;
   projectTitle: string | null;
+  showProjectIdentity: boolean;
   providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
   timestampFormat: TimestampFormat;
   onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
@@ -993,7 +995,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   const detailsTooltip = (
     <SidebarThreadTooltip
       thread={thread}
-      projectTitle={props.projectTitle}
+      projectTitle={props.showProjectIdentity ? props.projectTitle : null}
       projectCwd={props.projectCwd}
       projectFaviconPath={props.projectFaviconPath}
       projectIcon={props.projectIcon}
@@ -1418,6 +1420,99 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   }
 
   const diff = latestTurnDiff(thread);
+  const cardStatusSlot = (
+    <span className="group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
+      {/* Read-only status labels yield to the hover actions. Woke is itself
+          an action, so it stays pointer-enabled while the controls appear. */}
+      <span
+        className={cn(
+          isWokeStatus
+            ? "pointer-events-auto"
+            : "pointer-events-none group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
+          "flex items-center self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
+          snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
+        )}
+      >
+        {topStatus ? (
+          isWokeStatus ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    aria-label="Dismiss Woke notification"
+                    onClick={handleAcknowledgeWokeClick}
+                    className={cn(
+                      "inline-flex cursor-pointer items-center gap-1 rounded-sm font-medium outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring",
+                      topStatus.className,
+                    )}
+                  >
+                    <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
+                    <span role="status">{topStatus.label}</span>
+                  </button>
+                }
+              />
+              <TooltipPopup side="top">Dismiss Woke notification</TooltipPopup>
+            </Tooltip>
+          ) : (
+            <span className={cn("inline-flex items-center gap-1 font-medium", topStatus.className)}>
+              {topStatus.icon === "working" ? (
+                <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
+              ) : topStatus.icon === "done" ? (
+                <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
+              ) : null}
+              {/* Keep the ticking duration outside the live region. */}
+              <span role="status">{topStatus.label}</span>
+              {status === "working" ? (
+                <span aria-hidden>
+                  <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
+                </span>
+              ) : null}
+            </span>
+          )
+        ) : (
+          threadTimeLabel(thread)
+        )}
+      </span>
+      {props.settlementSupported || showSnoozeButton ? (
+        <span
+          className={cn(
+            // focus-visible, not focus-within: mouse focus should not pin the
+            // controls over the status once the pointer leaves the row.
+            "pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity has-[:focus-visible]:pointer-events-auto has-[:focus-visible]:static has-[:focus-visible]:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:static group-hover/sidebar-row:opacity-100",
+            snoozeMenuOpen && "pointer-events-auto static opacity-100",
+          )}
+        >
+          {showSnoozeButton ? (
+            <SnoozePopoverButton
+              open={snoozeMenuOpen}
+              onOpenChange={setSnoozeMenuOpen}
+              onSnooze={handleSnoozePreset}
+              timestampFormat={props.timestampFormat}
+            />
+          ) : null}
+          {props.settlementSupported ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    aria-label="Settle thread"
+                    onClick={handleSettleClick}
+                    className="-mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
+                  />
+                }
+              >
+                <CheckIcon className="size-3.5" />
+                {props.showProjectIdentity ? "Settle" : null}
+              </TooltipTrigger>
+              <TooltipPopup>Settle thread</TooltipPopup>
+            </Tooltip>
+          ) : null}
+        </span>
+      ) : null}
+    </span>
+  );
 
   const sortable = props.sortable;
   return (
@@ -1434,7 +1529,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       }
       {...(sortable?.listeners ?? {})}
       className={cn(
-        "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_96px]",
+        "list-none py-0.5 [content-visibility:auto]",
+        props.showProjectIdentity
+          ? "[contain-intrinsic-size:auto_96px]"
+          : "[contain-intrinsic-size:auto_64px]",
         sortable?.isDragging && "z-20 opacity-80",
       )}
     >
@@ -1455,143 +1553,56 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             />
           }
         >
-          <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
-            <div className="flex h-5 min-w-0 items-center gap-1.5">
-              <ProjectFavicon
-                environmentId={thread.environmentId}
-                cwd={props.projectCwd ?? ""}
-                projectName={props.projectTitle ?? ""}
-                faviconPath={props.projectFaviconPath}
-                projectIcon={props.projectIcon}
-                className="size-4 shrink-0"
-              />
-              {props.projectTitle ? (
-                <span
-                  className={cn(
-                    "min-w-0 flex-1 truncate text-secondary-label text-xs",
-                    shouldRecede ? "font-normal" : "font-medium",
-                  )}
-                >
-                  {props.projectTitle}
-                </span>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {pinIndicator}
-              {/* The visible state owns this slot's width: status at rest,
+          <div
+            className={cn(
+              "relative z-10 px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]",
+              props.showProjectIdentity ? "h-[4.875rem]" : "h-[3.5rem]",
+            )}
+          >
+            {props.showProjectIdentity ? (
+              <div className="flex h-5 min-w-0 items-center gap-1.5">
+                <ProjectFavicon
+                  environmentId={thread.environmentId}
+                  cwd={props.projectCwd ?? ""}
+                  projectName={props.projectTitle ?? ""}
+                  faviconPath={props.projectFaviconPath}
+                  projectIcon={props.projectIcon}
+                  className="size-4 shrink-0"
+                />
+                {props.projectTitle ? (
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate text-secondary-label text-xs",
+                      shouldRecede ? "font-normal" : "font-medium",
+                    )}
+                  >
+                    {props.projectTitle}
+                  </span>
+                ) : (
+                  <span className="flex-1" />
+                )}
+                {pinIndicator}
+                {/* The visible state owns this slot's width: status at rest,
                   actions on hover/keyboard focus or while the popover is open. Keeping
                   the hidden state out of flow lets the project label reclaim
                   space without either state overlapping it. */}
-              <span className="group/sidebar-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
-                {/* Read-only status labels yield to the hover actions. Woke is
-                    itself an action, so it stays pointer-enabled and visible
-                    while the other controls appear beside it. */}
-                <span
-                  className={cn(
-                    isWokeStatus
-                      ? "pointer-events-auto"
-                      : "pointer-events-none group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
-                    "flex items-center self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
-                    snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
-                  )}
-                >
-                  {topStatus ? (
-                    isWokeStatus ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <button
-                              type="button"
-                              aria-label="Dismiss Woke notification"
-                              onClick={handleAcknowledgeWokeClick}
-                              className={cn(
-                                "inline-flex cursor-pointer items-center gap-1 rounded-sm font-medium outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring",
-                                topStatus.className,
-                              )}
-                            >
-                              <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
-                              <span role="status">{topStatus.label}</span>
-                            </button>
-                          }
-                        />
-                        <TooltipPopup side="top">Dismiss Woke notification</TooltipPopup>
-                      </Tooltip>
-                    ) : (
-                      <span
-                        className={cn(
-                          "inline-flex items-center gap-1 font-medium",
-                          topStatus.className,
-                        )}
-                      >
-                        {topStatus.icon === "working" ? (
-                          <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
-                        ) : topStatus.icon === "done" ? (
-                          <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
-                        ) : null}
-                        {/* The label alone is the live region: a role="status"
-                            wrapper around the ticking duration would make
-                            screen readers announce every second. */}
-                        <span role="status">{topStatus.label}</span>
-                        {status === "working" ? (
-                          <span aria-hidden>
-                            <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
-                          </span>
-                        ) : null}
-                      </span>
-                    )
-                  ) : (
-                    threadTimeLabel(thread)
-                  )}
-                </span>
-                {props.settlementSupported || showSnoozeButton ? (
-                  <span
-                    className={cn(
-                      // focus-visible, not focus-within: a mouse click leaves
-                      // the Settle button focused, and a plain focus-within
-                      // would keep the controls pinned over the status label
-                      // once the pointer moves away (e.g. after a failed
-                      // settle) instead of cross-fading back.
-                      "pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity has-[:focus-visible]:pointer-events-auto has-[:focus-visible]:static has-[:focus-visible]:opacity-100 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:static group-hover/sidebar-row:opacity-100",
-                      snoozeMenuOpen && "pointer-events-auto static opacity-100",
-                    )}
-                  >
-                    {showSnoozeButton ? (
-                      <SnoozePopoverButton
-                        open={snoozeMenuOpen}
-                        onOpenChange={setSnoozeMenuOpen}
-                        onSnooze={handleSnoozePreset}
-                        timestampFormat={props.timestampFormat}
-                      />
-                    ) : null}
-                    {props.settlementSupported ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <button
-                              type="button"
-                              aria-label="Settle thread"
-                              onClick={handleSettleClick}
-                              className="-mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
-                            />
-                          }
-                        >
-                          <CheckIcon className="size-3.5" />
-                          Settle
-                        </TooltipTrigger>
-                        <TooltipPopup>Settle thread</TooltipPopup>
-                      </Tooltip>
-                    ) : null}
-                  </span>
-                ) : null}
-              </span>
-            </div>
-            <div className="mt-1 flex min-w-0">
+                {cardStatusSlot}
+              </div>
+            ) : null}
+            <div
+              className={cn(
+                "flex h-5 min-w-0 items-center gap-1.5",
+                props.showProjectIdentity && "mt-1",
+              )}
+            >
               {title}
               {isRegeneratingTitle ? (
                 <span role="status" className="sr-only">
                   Regenerating title
                 </span>
               ) : null}
+              {!props.showProjectIdentity ? pinIndicator : null}
+              {!props.showProjectIdentity ? cardStatusSlot : null}
             </div>
             <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-secondary-label text-xs">
               {/* Always the branch. The plan step used to take this slot while
@@ -1792,6 +1803,7 @@ export default function Sidebar() {
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
+  const projectSectionsEnabled = useClientSettings((s) => s.projectSectionsEnabled);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const {
@@ -2218,6 +2230,47 @@ export default function Sidebar() {
     };
   }, [nowMinute, scopedProjectKeys, serverConfigs, snoozeWakeTick, threads]);
 
+  const activeProjectSections = useMemo(
+    () =>
+      projectSectionsEnabled && projectScopeKey === null
+        ? groupThreadsIntoProjectSections(projectGroups, activeThreads)
+        : null,
+    [activeThreads, projectGroups, projectScopeKey, projectSectionsEnabled],
+  );
+  const [collapsedProjectSectionKeys, setCollapsedProjectSectionKeys] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  useEffect(() => {
+    if (activeProjectSections === null) return;
+    const activeKeys = new Set(activeProjectSections.map(({ project }) => project.projectKey));
+    setCollapsedProjectSectionKeys((collapsedKeys) => {
+      const nextCollapsedKeys = new Set(
+        [...collapsedKeys].filter((projectKey) => activeKeys.has(projectKey)),
+      );
+      return nextCollapsedKeys.size === collapsedKeys.size ? collapsedKeys : nextCollapsedKeys;
+    });
+  }, [activeProjectSections]);
+  const toggleProjectSection = useCallback((projectKey: string) => {
+    setCollapsedProjectSectionKeys((collapsedKeys) => {
+      const nextCollapsedKeys = new Set(collapsedKeys);
+      if (nextCollapsedKeys.has(projectKey)) {
+        nextCollapsedKeys.delete(projectKey);
+      } else {
+        nextCollapsedKeys.add(projectKey);
+      }
+      return nextCollapsedKeys;
+    });
+  }, []);
+  const visibleActiveThreads = useMemo(
+    () =>
+      activeProjectSections === null
+        ? activeThreads
+        : activeProjectSections.flatMap(({ project, threads: projectThreads }) =>
+            collapsedProjectSectionKeys.has(project.projectKey) ? [] : projectThreads,
+          ),
+    [activeProjectSections, activeThreads, collapsedProjectSectionKeys],
+  );
+
   const threadSearchInputRef = useRef<HTMLInputElement>(null);
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
   const [activeSearchResultIndex, setActiveSearchResultIndex] = useState(0);
@@ -2342,8 +2395,13 @@ export default function Sidebar() {
   }, [routeThreadKey, snoozedShelfExpanded, snoozedThreads]);
 
   const orderedThreads = useMemo(
-    () => [...pinnedThreads, ...activeThreads, ...visibleSnoozedThreads, ...renderedSettledThreads],
-    [pinnedThreads, activeThreads, visibleSnoozedThreads, renderedSettledThreads],
+    () => [
+      ...pinnedThreads,
+      ...visibleActiveThreads,
+      ...visibleSnoozedThreads,
+      ...renderedSettledThreads,
+    ],
+    [pinnedThreads, renderedSettledThreads, visibleActiveThreads, visibleSnoozedThreads],
   );
   const orderedThreadKeys = useMemo(
     () =>
@@ -3824,6 +3882,7 @@ export default function Sidebar() {
                     thread: EnvironmentThreadShell,
                     section: "pinned" | "active" | "snoozed" | "settled",
                     sortable?: SortablePinnedRowBag,
+                    showProjectIdentity = true,
                   ) => {
                     const threadKey = scopedThreadKey(
                       scopeThreadRef(thread.environmentId, thread.id),
@@ -3906,6 +3965,7 @@ export default function Sidebar() {
                             `${thread.environmentId}:${thread.projectId}`,
                           ) ?? null
                         }
+                        showProjectIdentity={showProjectIdentity}
                         providerEntryByInstanceId={
                           providerEntriesByEnvironment.get(thread.environmentId) ??
                           EMPTY_PROVIDER_ENTRIES
@@ -3999,8 +4059,57 @@ export default function Sidebar() {
                       />,
                     );
                   }
-                  for (const thread of activeThreads) {
-                    items.push(renderThreadRow(thread, "active"));
+                  if (activeProjectSections) {
+                    for (const { project, threads: projectThreads } of activeProjectSections) {
+                      const isExpanded = !collapsedProjectSectionKeys.has(project.projectKey);
+                      items.push(
+                        <li
+                          key={`project-section:${project.projectKey}`}
+                          data-thread-selection-safe
+                          className="mt-3 list-none first:mt-0"
+                        >
+                          <button
+                            type="button"
+                            aria-expanded={isExpanded}
+                            aria-label={`${isExpanded ? "Collapse" : "Expand"} ${project.displayName} project section, ${projectThreads.length} ${projectThreads.length === 1 ? "thread" : "threads"}`}
+                            onClick={() => toggleProjectSection(project.projectKey)}
+                            className="flex w-full cursor-pointer items-center gap-2 px-[var(--sidebar-row-content-inset)] text-left outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                          >
+                            <ProjectFavicon
+                              environmentId={project.environmentId}
+                              cwd={project.workspaceRoot}
+                              faviconPath={project.faviconPath}
+                              className="size-3.5 shrink-0"
+                            />
+                            <span className="min-w-0 flex-1 truncate text-xs font-medium text-sidebar-muted-foreground/70">
+                              {project.displayName}
+                            </span>
+                            <span
+                              aria-hidden
+                              className="shrink-0 text-xs tabular-nums text-sidebar-muted-foreground/45"
+                            >
+                              {projectThreads.length}
+                            </span>
+                            <ChevronDownIcon
+                              aria-hidden
+                              className={cn(
+                                "size-3 shrink-0 text-sidebar-muted-foreground/50 transition-transform",
+                                isExpanded && "rotate-180",
+                              )}
+                            />
+                          </button>
+                        </li>,
+                      );
+                      if (isExpanded) {
+                        for (const thread of projectThreads) {
+                          items.push(renderThreadRow(thread, "active", undefined, false));
+                        }
+                      }
+                    }
+                  } else {
+                    for (const thread of activeThreads) {
+                      items.push(renderThreadRow(thread, "active"));
+                    }
                   }
                   // Snoozed shelf: between the inbox and Settled — out of the
                   // way, never gone. The header always renders while anything

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4073,7 +4073,7 @@ export default function Sidebar() {
                             aria-expanded={isExpanded}
                             aria-label={`${isExpanded ? "Collapse" : "Expand"} ${project.displayName} project section, ${projectThreads.length} ${projectThreads.length === 1 ? "thread" : "threads"}`}
                             onClick={() => toggleProjectSection(project.projectKey)}
-                            className="flex w-full cursor-pointer items-center gap-2 px-[var(--sidebar-row-content-inset)] text-left outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                            className="mb-1 flex w-full cursor-pointer items-center gap-2 rounded-md px-[var(--sidebar-row-content-inset)] text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
                           >
                             <ProjectFavicon
                               environmentId={project.environmentId}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -523,6 +523,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
         : []),
+      ...(settings.projectSectionsEnabled !== DEFAULT_UNIFIED_SETTINGS.projectSectionsEnabled
+        ? ["Project sections"]
+        : []),
       ...(settings.sidebarAutoSettleAfterDays !==
       DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
         ? ["Auto-settle inactive threads"]
@@ -623,6 +626,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.sidebarAutoSettleAfterDays,
       settings.sidebarAutoSettleOnMerge,
       settings.sidebarProjectGroupingMode,
+      settings.projectSectionsEnabled,
       settings.sidebarThreadPreviewCount,
       settings.showSkillsInSlashMenu,
       settings.timestampFormat,
@@ -709,6 +713,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       panelAnimationDurationMs: DEFAULT_UNIFIED_SETTINGS.panelAnimationDurationMs,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+      projectSectionsEnabled: DEFAULT_UNIFIED_SETTINGS.projectSectionsEnabled,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
       sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
@@ -2099,6 +2104,32 @@ export function GeneralSettingsPanel() {
                 });
               }}
               aria-label="Project grouping"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("project-sections")}
+          description="Group active threads by project when viewing All projects in the new sidebar."
+          resetAction={
+            settings.projectSectionsEnabled !== DEFAULT_UNIFIED_SETTINGS.projectSectionsEnabled ? (
+              <SettingResetButton
+                label="project sections"
+                onClick={() =>
+                  updateSettings({
+                    projectSectionsEnabled: DEFAULT_UNIFIED_SETTINGS.projectSectionsEnabled,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.projectSectionsEnabled}
+              onCheckedChange={(checked) =>
+                updateSettings({ projectSectionsEnabled: Boolean(checked) })
+              }
+              aria-label="Project sections"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -183,6 +183,10 @@ describe("searchSettings", () => {
   it("serves anchor props to panels from the catalog", () => {
     expect(searchableSetting("word-wrap")).toEqual({ id: "word-wrap", title: "Word wrap" });
     expect(searchableSetting("archive")).toEqual({ id: "archive", title: "Archived threads" });
+    expect(searchSettings("project sections")[0]).toMatchObject({
+      id: "project-sections",
+      to: "/settings/general",
+    });
   });
 
   it("routes appearance settings to their current section", () => {

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -151,6 +151,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["combine matching repositories environments sidebar"],
   },
   {
+    id: "project-sections",
+    title: "Project sections",
+    to: "/settings/general",
+    searchTerms: ["sidebar headings group threads all projects count"],
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -209,6 +209,17 @@ describe("ClientSettings sidebar", () => {
     );
   });
 
+  it("defaults project sections off and keeps them patchable", () => {
+    expect(decodeClientSettings({}).projectSectionsEnabled).toBe(false);
+    expect(decodeClientSettings({ projectSectionsEnabled: true }).projectSectionsEnabled).toBe(
+      true,
+    );
+    expect(decodeClientSettingsPatch({ projectSectionsEnabled: true }).projectSectionsEnabled).toBe(
+      true,
+    );
+    expect(() => decodeClientSettingsPatch({ projectSectionsEnabled: "yes" })).toThrow();
+  });
+
   it("keeps unpin confirmation opt-in and patchable", () => {
     expect(decodeClientSettings({}).confirmThreadUnpin).toBe(false);
     expect(decodeClientSettingsPatch({ confirmThreadUnpin: true }).confirmThreadUnpin).toBe(true);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -326,6 +326,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  projectSectionsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -1168,6 +1169,7 @@ export const ClientSettingsPatch = Schema.Struct({
   proactivePanelsEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  projectSectionsEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
## What

Add a **Project sections** setting (General settings, default off) that groups active threads by project when viewing All projects in the sidebar. Each project gets a collapsible section header with its thread count, so people juggling several projects can scan the active list by project instead of one interleaved stream.

Scope decisions:
- Opt-in and default-off — the flat list stays the default experience.
- Applies only to the All-projects view in the current sidebar; filtered single-project views are unchanged.
- Wired through settings search, settings restore, and the contracts `ClientSettingsSchema`/patch so all clients agree on the key.

## Screenshots

The setting in General settings:

![Project sections setting row in General settings](https://raw.githubusercontent.com/brahimhamichan/t3code/evidence/docs/evidence/t3code-sections/settings-project-sections.png)

Enabled, with active threads grouped under collapsible per-project headers:

![Sidebar with threads grouped under project section headers](https://raw.githubusercontent.com/brahimhamichan/t3code/evidence/docs/evidence/t3code-sections/sidebar-project-sections.png)

## Verification

- `vp test run` on the touched suites (Sidebar.logic, settingsSearch, onboarding, contracts settings) — 200 tests pass.
- Typecheck clean across `apps/web`, `packages/contracts`, `packages/client-runtime`.
- Verified in a locally built install against a seeded demo environment (screenshots above).

---
Written by Claude Fable 5 on Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When enabled, active thread ordering and visibility change (section collapse, project grouping), which affects keyboard navigation and selection; default-off limits blast radius.
> 
> **Overview**
> Adds an opt-in **Project sections** client setting (default off) that, on the **All projects** sidebar view, groups active threads under collapsible per-project headers with counts instead of one flat list.
> 
> **`groupThreadsIntoProjectSections`** maps threads to logical projects via a NUL-separated composite key, preserves project and thread order, skips empty projects, and puts orphaned threads in an **ungrouped** tail so they stay reachable.
> 
> The sidebar persists expand/collapse per section in local storage (same spirit as snoozed/settled shelves). Collapsed sections hide threads except the **currently routed** thread. Section rows use a **compact** card layout (`showProjectIdentity: false`) without repeating project favicon/title; ungrouped threads keep the full card.
> 
> The setting is wired through contracts (`ClientSettingsSchema`/patch), General settings UI, settings search, and restore-defaults. **`orderedThreads`** and related traversal use visibility-filtered active threads when sections are on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1c40de2ad4f42f8ff3ead6171746a04f5761ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in collapsible project sections to sidebar `Sidebar`
> - Adds a boolean `projectSectionsEnabled` client setting (default `false`) to [settings.ts](https://github.com/pingdotgg/t3code/pull/9156/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), with a toggle and search entry in General settings
> - In the unscoped "All projects" view, [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9156/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) groups active threads under collapsible project headers using `groupThreadsIntoProjectSections`, preserving project and thread order; unmatched threads render in an ungrouped tail
> - Collapsed-section state persists in local storage; the currently routed thread stays visible even when its section is collapsed
> - Threads inside sections use a compact `SidebarThreadRow` that omits project identity but keeps title, pin, status, and action controls
> - Behavioral Change: the setting defaults to `false`; when enabled, active-thread list calculations in the "All projects" scope are filtered by section visibility, which can hide collapsed-section threads except the routed one
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1c40de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->