### PR TITLE
test(server): measure shell, second client, and reconnect transfer

### DIFF
--- a/apps/server/integration/NetworkTransferMeasurement.integration.ts
+++ b/apps/server/integration/NetworkTransferMeasurement.integration.ts
@@ -5,8 +5,10 @@ import * as NodeZlib from "node:zlib";
 import * as NodeSocket from "@effect/platform-node/NodeSocket";
 import { WsRpcGroup } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import * as Socket from "effect/unstable/socket/Socket";
 
@@ -101,6 +103,8 @@ export interface WebSocketTransferRecorder {
   ) => globalThis.WebSocket;
   readonly totals: () => WebSocketTransferTotals;
   readonly negotiatedExtensions: () => string;
+  /** Resolves once the upgrade completes, so totals taken after it exclude the upgrade response. */
+  readonly awaitOpen: Effect.Effect<void>;
 }
 
 interface NodeWebSocketWithTransport extends NodeSocket.NodeWS.WebSocket {
@@ -118,8 +122,15 @@ function rawDataBytes(data: NodeSocket.NodeWS.RawData): number {
 
 export function makeWebSocketTransferRecorder(): WebSocketTransferRecorder {
   let socket: NodeWebSocketWithTransport | null = null;
+  // Held separately from the WebSocket so wire totals survive a close, which
+  // is when a reconnect measurement reads them.
+  let transport: NodeWebSocketWithTransport["_socket"] | null = null;
   let decodedBytes = 0;
   let messages = 0;
+  let resolveOpen: () => void = () => {};
+  const opened = new Promise<void>((resolve) => {
+    resolveOpen = resolve;
+  });
 
   return {
     connect: (url, protocols, cookie) => {
@@ -128,6 +139,10 @@ export function makeWebSocketTransferRecorder(): WebSocketTransferRecorder {
         perMessageDeflate: true,
       }) as NodeWebSocketWithTransport;
       socket = nextSocket;
+      nextSocket.once("open", () => {
+        transport = nextSocket._socket ?? null;
+        resolveOpen();
+      });
       nextSocket.on("message", (data) => {
         const bytes = rawDataBytes(data);
         decodedBytes += bytes;
@@ -136,11 +151,17 @@ export function makeWebSocketTransferRecorder(): WebSocketTransferRecorder {
       return nextSocket as unknown as globalThis.WebSocket;
     },
     totals: () => ({
-      wireBytes: socket?._socket?.bytesRead ?? 0,
+      wireBytes: transport?.bytesRead ?? socket?._socket?.bytesRead ?? 0,
       decodedBytes,
       messages,
     }),
     negotiatedExtensions: () => socket?.extensions ?? "",
+    awaitOpen: Effect.promise(() => opened).pipe(
+      Effect.timeoutOrElse({
+        duration: "10 seconds",
+        orElse: () => Effect.die(new Error("Timed out waiting for the WebSocket to open")),
+      }),
+    ),
   };
 }
 
@@ -175,3 +196,40 @@ export function countingWsRpcProtocolLayer(input: {
 
 export const makeCountingWsRpcClient = RpcClient.make(WsRpcGroup);
 export type CountingWsRpcClient = Effect.Success<typeof makeCountingWsRpcClient>;
+
+export interface MeasuredWsClient {
+  readonly client: CountingWsRpcClient;
+  readonly recorder: WebSocketTransferRecorder;
+  /** Fork subscription consumers here so they stop before the socket closes. */
+  readonly scope: Scope.Scope;
+  /** Closes the socket now. The enclosing scope closes it otherwise. */
+  readonly close: Effect.Effect<void>;
+}
+
+/**
+ * Opens one WebSocket RPC client on a child of the current scope. Several
+ * clients can share one test scope and still disconnect independently, which
+ * a reconnect measurement needs.
+ */
+export const openMeasuredWsClient = Effect.fn("TransferBudget.openMeasuredWsClient")(
+  function* (input: { readonly url: string; readonly cookie: string }) {
+    const recorder = makeWebSocketTransferRecorder();
+    const parent = yield* Effect.scope;
+    const scope = yield* Scope.fork(parent);
+    const protocol = yield* Layer.buildWithScope(
+      countingWsRpcProtocolLayer({ url: input.url, cookie: input.cookie, recorder }),
+      scope,
+    );
+    const client = yield* makeCountingWsRpcClient.pipe(
+      Effect.provide(protocol),
+      Scope.provide(scope),
+    );
+    yield* recorder.awaitOpen;
+    return {
+      client,
+      recorder,
+      scope,
+      close: Scope.close(scope, Exit.void),
+    } satisfies MeasuredWsClient;
+  },
+);

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -22,6 +22,7 @@ import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
+import * as Tracer from "effect/Tracer";
 
 import * as CheckpointStore from "../src/checkpointing/CheckpointStore.ts";
 import { TextGeneration, type TextGenerationShape } from "../src/textGeneration/TextGeneration.ts";
@@ -231,6 +232,8 @@ export interface OrchestrationIntegrationHarness {
 interface MakeOrchestrationIntegrationHarnessOptions {
   readonly provider?: ProviderDriverKind;
   readonly realCodex?: boolean;
+  /** Tracer for every fiber the harness runtime runs, including reactors. */
+  readonly tracer?: Tracer.Tracer;
 }
 
 export const makeOrchestrationIntegrationHarness = (
@@ -399,6 +402,9 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(ServerConfig.layerTest(workspaceDir, rootDir)),
       Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(
+        options?.tracer ? Layer.succeed(Tracer.Tracer, options.tracer) : Layer.empty,
+      ),
     );
 
     const runtime = ManagedRuntime.make(layer);

--- a/apps/server/integration/SqlStatementCounter.integration.ts
+++ b/apps/server/integration/SqlStatementCounter.integration.ts
@@ -1,0 +1,24 @@
+import * as Tracer from "effect/Tracer";
+
+export interface SqlStatementCounter {
+  readonly tracer: Tracer.Tracer;
+  /** Statements executed so far. Read before and after a phase and subtract. */
+  readonly count: () => number;
+}
+
+/**
+ * Counts `sql.execute` spans, which the Effect SQL client opens once per
+ * statement. Spans behave exactly as with the native tracer. Install the same
+ * counter on every runtime under test, otherwise statements run by background
+ * reactors and statements run by request handlers land in different counters.
+ */
+export function makeSqlStatementCounter(): SqlStatementCounter {
+  let statements = 0;
+  const tracer = Tracer.make({
+    span: (options) => {
+      if (options.name === "sql.execute") statements += 1;
+      return new Tracer.NativeSpan(options);
+    },
+  });
+  return { tracer, count: () => statements };
+}

--- a/apps/server/integration/TransferBudgetReport.integration.ts
+++ b/apps/server/integration/TransferBudgetReport.integration.ts
@@ -12,10 +12,28 @@ import {
   TRANSFER_MEASURED_TOOLS,
 } from "./fixtures/transferBudget.ts";
 
+/** Catch-up delivered to a resubscribing client, and which path the server chose. */
+export interface WebSocketCatchUpMeasurement extends WebSocketTransferTotals {
+  readonly mode: "replay" | "snapshot";
+}
+
 export interface TransferBudgetRun {
   readonly provider: ProviderDriverKind;
   readonly threadSnapshot: HttpTransferMeasurement;
+  /** One socket holding only the thread subscription. This is the capped measurement. */
   readonly measuredTurnWebSocket: WebSocketTransferTotals;
+  readonly shellSnapshot: HttpTransferMeasurement;
+  /** One socket holding only the shell (sidebar) subscription during the same turn. */
+  readonly measuredTurnShellWebSocket: WebSocketTransferTotals;
+  /** A second client: one socket holding both the thread and shell subscriptions. */
+  readonly measuredTurnSecondClientWebSocket: WebSocketTransferTotals;
+  /** The second client resubscribes after the turn from the cursor it held before it. */
+  readonly reconnectThread: WebSocketCatchUpMeasurement;
+  readonly reconnectShell: WebSocketCatchUpMeasurement;
+  /** `sql.execute` spans opened server-wide during the measured turn. */
+  readonly measuredTurnSqlStatements: number;
+  /** `sql.execute` spans opened while serving both reconnect catch-ups. */
+  readonly reconnectSqlStatements: number;
 }
 
 interface ProviderTransferBudget {
@@ -45,6 +63,15 @@ export const TRANSFER_BUDGETS: Readonly<Record<string, ProviderTransferBudget>> 
 
 function totalWireBytes(run: TransferBudgetRun): number {
   return run.threadSnapshot.wireBytes + run.measuredTurnWebSocket.wireBytes;
+}
+
+/** Bytes the server wrote to every measured socket during the turn. */
+function serverEgressWireBytes(run: TransferBudgetRun): number {
+  return (
+    run.measuredTurnWebSocket.wireBytes +
+    run.measuredTurnShellWebSocket.wireBytes +
+    run.measuredTurnSecondClientWebSocket.wireBytes
+  );
 }
 
 function observedTransfer(run: TransferBudgetRun) {
@@ -105,6 +132,33 @@ function row(
   return `| ${provider} | ${phase} | ${metric} | ${format(observed)} | ${format(maximum)} | ${status} |`;
 }
 
+// Shell, second-client, reconnect, and SQL rows are reported without a cap.
+// Shell delivery coalesces on a 50 ms window, so message counts and bytes move
+// with scheduler timing between runs, and the reconnect and SQL figures follow
+// the same batches. The rows exist so CI shows the numbers next to the capped
+// thread measurement.
+function infoRow(
+  provider: ProviderDriverKind,
+  phase: string,
+  metric: string,
+  observed: number,
+  format: (value: number) => string = formatBytes,
+): string {
+  return `| ${provider} | ${phase} | ${metric} | ${format(observed)} | none | INFO |`;
+}
+
+function webSocketRows(
+  provider: ProviderDriverKind,
+  phase: string,
+  totals: WebSocketTransferTotals,
+): string[] {
+  return [
+    infoRow(provider, phase, "WebSocket wire", totals.wireBytes),
+    infoRow(provider, phase, "WebSocket decoded", totals.decodedBytes),
+    infoRow(provider, phase, "WebSocket messages", totals.messages, String),
+  ];
+}
+
 export function transferBudgetViolations(runs: ReadonlyArray<TransferBudgetRun>): string[] {
   const violations: string[] = [];
   for (const run of runs) {
@@ -146,6 +200,7 @@ export function formatTransferBudgetReport(runs: ReadonlyArray<TransferBudgetRun
     "# T3 Code thread transfer budget",
     "",
     "Wire values are thread data bytes read from local HTTP and WebSocket sockets. HTTP includes response headers; WebSocket measurement starts after the resumed thread subscription synchronizes. TCP/IP, TLS framing, and the WebSocket upgrade are excluded. WebSocket permessage-deflate is negotiated.",
+    "The measured turn is observed on three sockets at once: one with only the thread subscription (the capped rows), one with only the shell subscription, and a second client holding both. Server egress is the sum of the three. After the turn the second client disconnects and resubscribes from the cursor it held before the turn, which is the cursor a backgrounded phone would hold. SQL statements are `sql.execute` spans counted across the orchestration runtime and the WebSocket handlers.",
     `Scenario: ${TRANSFER_HISTORY_TURN_COUNT} historical turns with ${TRANSFER_HISTORY_TOOLS_PER_TURN} command tools and one retained ${formatBytes(TRANSFER_HISTORY_MCP_RESULT_BYTES)} MCP result each, followed by one measured turn with ${TRANSFER_MEASURED_TOOLS} command tools and a retained ${formatBytes(TRANSFER_MEASURED_MCP_RESULT_BYTES)} MCP result. Payload sizes are calibrated from heavy local Codex and Claude histories and contain no user data.`,
     "",
     "| Provider | Total thread wire | Budget | Result |",
@@ -198,6 +253,32 @@ export function formatTransferBudgetReport(runs: ReadonlyArray<TransferBudgetRun
         budget.measuredTurnWebSocketMessages,
         String,
       ),
+      infoRow(run.provider, "shell snapshot", "HTTP wire", run.shellSnapshot.wireBytes),
+      ...webSocketRows(run.provider, "measured turn, shell", run.measuredTurnShellWebSocket),
+      ...webSocketRows(
+        run.provider,
+        "measured turn, second client",
+        run.measuredTurnSecondClientWebSocket,
+      ),
+      infoRow(run.provider, "measured turn", "server egress wire", serverEgressWireBytes(run)),
+      infoRow(
+        run.provider,
+        "measured turn",
+        "SQL statements",
+        run.measuredTurnSqlStatements,
+        String,
+      ),
+      ...webSocketRows(
+        run.provider,
+        `reconnect, thread (${run.reconnectThread.mode})`,
+        run.reconnectThread,
+      ),
+      ...webSocketRows(
+        run.provider,
+        `reconnect, shell (${run.reconnectShell.mode})`,
+        run.reconnectShell,
+      ),
+      infoRow(run.provider, "reconnect", "SQL statements", run.reconnectSqlStatements, String),
     );
   }
 
@@ -205,6 +286,7 @@ export function formatTransferBudgetReport(runs: ReadonlyArray<TransferBudgetRun
   for (const run of runs) {
     lines.push(
       `- ${run.provider}: thread snapshot ${formatBytes(run.threadSnapshot.decodedBodyBytes)} decoded to ${formatBytes(run.threadSnapshot.encodedBodyBytes)} gzip.`,
+      `- ${run.provider}: shell snapshot ${formatBytes(run.shellSnapshot.decodedBodyBytes)} decoded to ${formatBytes(run.shellSnapshot.encodedBodyBytes)} gzip.`,
     );
   }
 

--- a/apps/server/integration/TransferBudgetScenario.integration.ts
+++ b/apps/server/integration/TransferBudgetScenario.integration.ts
@@ -5,13 +5,20 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   MessageId,
+  ORCHESTRATION_WS_METHODS,
+  type OrchestrationShellStreamItem,
+  type OrchestrationThreadStreamItem,
   ProjectId,
   ProviderDriverKind,
   ThreadId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Queue from "effect/Queue";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
 
 import type { TurnProcessingQuiescedReceipt } from "../src/orchestration/Services/RuntimeReceiptBus.ts";
+import type { MeasuredWsClient } from "./NetworkTransferMeasurement.integration.ts";
 import type { OrchestrationIntegrationHarness } from "./OrchestrationEngineHarness.integration.ts";
 import {
   expectedRecordedAssistantText,
@@ -124,5 +131,82 @@ export const queueMeasuredTransferTurn = Effect.fn("TransferBudget.queueMeasured
 export function expectedMeasuredAssistantText(provider: ProviderDriverKind): string {
   return expectedRecordedAssistantText(provider, TRANSFER_MEASURED_TURN_INDEX);
 }
+
+/** Takes from the queue until one value matches, and returns everything taken. */
+export const collectQueueUntil = Effect.fn("TransferBudget.collectQueueUntil")(function* <A>(
+  queue: Queue.Queue<A>,
+  predicate: (value: A) => boolean,
+  waitDescription: string,
+) {
+  return yield* Effect.gen(function* () {
+    const values: A[] = [];
+    while (true) {
+      const value = yield* Queue.take(queue);
+      values.push(value);
+      if (predicate(value)) return values;
+    }
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: "10 seconds",
+      orElse: () => Effect.die(new Error(`Timed out waiting for ${waitDescription}`)),
+    }),
+  );
+});
+
+/**
+ * Resumes the thread subscription from a cursor on a measured client. The
+ * consumer runs in the client's scope, so closing the client stops it. Callers
+ * read items from the returned queue.
+ */
+export const subscribeThreadItems = Effect.fn("TransferBudget.subscribeThreadItems")(function* (
+  measured: MeasuredWsClient,
+  afterSequence: number,
+) {
+  const items = yield* Queue.unbounded<OrchestrationThreadStreamItem>();
+  yield* measured.client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+    threadId: TRANSFER_THREAD_ID,
+    afterSequence,
+    requestCompletionMarker: true,
+  }).pipe(
+    Stream.runForEach((item) => Queue.offer(items, item).pipe(Effect.asVoid)),
+    Scope.provide(measured.scope),
+    Effect.forkIn(measured.scope),
+  );
+  return items;
+});
+
+/** Shell counterpart of subscribeThreadItems. */
+export const subscribeShellItems = Effect.fn("TransferBudget.subscribeShellItems")(function* (
+  measured: MeasuredWsClient,
+  afterSequence: number,
+) {
+  const items = yield* Queue.unbounded<OrchestrationShellStreamItem>();
+  yield* measured.client[ORCHESTRATION_WS_METHODS.subscribeShell]({
+    afterSequence,
+    requestCompletionMarker: true,
+  }).pipe(
+    Stream.runForEach((item) => Queue.offer(items, item).pipe(Effect.asVoid)),
+    Scope.provide(measured.scope),
+    Effect.forkIn(measured.scope),
+  );
+  return items;
+});
+
+/** Waits for the initial catch-up and reports whether it was a replay or a snapshot reset. */
+export const awaitSubscriptionSynchronized = Effect.fn(
+  "TransferBudget.awaitSubscriptionSynchronized",
+)(function* <Item extends OrchestrationThreadStreamItem | OrchestrationShellStreamItem>(
+  items: Queue.Queue<Item>,
+  waitDescription: string,
+) {
+  const initial = yield* collectQueueUntil(
+    items,
+    (item) => item.kind === "synchronized",
+    waitDescription,
+  );
+  return initial.some((item) => item.kind === "snapshot")
+    ? ("snapshot" as const)
+    : ("replay" as const);
+});
 
 export { TRANSFER_HISTORY_TURN_COUNT, waitForTurnQuiesced };

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -17,6 +17,8 @@ import {
   KeybindingRule,
   MessageId,
   ExternalLauncherCommandNotFoundError,
+  OrchestrationShellSnapshot,
+  type OrchestrationShellStreamItem,
   OrchestrationThreadDetailSnapshot,
   type OrchestrationThreadStreamItem,
   type OrchestrationThreadActivity,
@@ -58,11 +60,11 @@ import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
-import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
+import * as Tracer from "effect/Tracer";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import {
   FetchHttpClient,
@@ -82,26 +84,9 @@ const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
 const decodeTransferThreadSnapshot = Schema.decodeUnknownEffect(
   Schema.fromJsonString(OrchestrationThreadDetailSnapshot),
 );
-
-const collectQueueUntil = Effect.fn("TransferBudget.collectQueueUntil")(function* <A>(
-  queue: Queue.Queue<A>,
-  predicate: (value: A) => boolean,
-  waitDescription: string,
-) {
-  return yield* Effect.gen(function* () {
-    const values: A[] = [];
-    while (true) {
-      const value = yield* Queue.take(queue);
-      values.push(value);
-      if (predicate(value)) return values;
-    }
-  }).pipe(
-    Effect.timeoutOrElse({
-      duration: "10 seconds",
-      orElse: () => Effect.die(new Error(`Timed out waiting for ${waitDescription}`)),
-    }),
-  );
-});
+const decodeTransferShellSnapshot = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(OrchestrationShellSnapshot),
+);
 
 import * as BackgroundPolicy from "./background/BackgroundPolicy.ts";
 import * as ServerConfig from "./config.ts";
@@ -171,16 +156,19 @@ import * as Data from "effect/Data";
 
 import { makeOrchestrationIntegrationHarness } from "../integration/OrchestrationEngineHarness.integration.ts";
 import {
-  countingWsRpcProtocolLayer,
-  makeCountingWsRpcClient,
-  makeWebSocketTransferRecorder,
   measureHttpGet,
+  openMeasuredWsClient,
   transferDelta,
 } from "../integration/NetworkTransferMeasurement.integration.ts";
+import { makeSqlStatementCounter } from "../integration/SqlStatementCounter.integration.ts";
 import {
+  awaitSubscriptionSynchronized,
+  collectQueueUntil,
   expectedMeasuredAssistantText,
   queueMeasuredTransferTurn,
   seedTransferBudgetHistory,
+  subscribeShellItems,
+  subscribeThreadItems,
   TRANSFER_HISTORY_TURN_COUNT,
   TRANSFER_MEASURED_TURN_CREATED_AT,
   TRANSFER_MEASURED_TURN_INDEX,
@@ -9313,9 +9301,12 @@ it.live(
 
       const runs = yield* Effect.forEach(
         providers,
-        (provider) =>
-          Effect.acquireUseRelease(
-            makeOrchestrationIntegrationHarness({ provider }),
+        (provider) => {
+          // One counter for the orchestration runtime and the HTTP/WS handlers,
+          // so reactor writes and subscription reads land in the same total.
+          const sqlCounter = makeSqlStatementCounter();
+          return Effect.acquireUseRelease(
+            makeOrchestrationIntegrationHarness({ provider, tracer: sqlCounter.tracer }),
             (harness) =>
               Effect.gen(function* () {
                 yield* seedTransferBudgetHistory(harness, provider);
@@ -9328,19 +9319,10 @@ it.live(
 
                 const baseUrl = yield* getHttpServerUrl();
                 const cookie = yield* getAuthenticatedSessionCookieHeader();
-
-                const recorder = makeWebSocketTransferRecorder();
                 const wsUrl = baseUrl.replace(/^http:/, "ws:") + "/ws";
-                const protocolLayer = countingWsRpcProtocolLayer({
-                  url: wsUrl,
-                  cookie,
-                  recorder,
-                });
 
                 return yield* Effect.scoped(
                   Effect.gen(function* () {
-                    const client = yield* makeCountingWsRpcClient;
-
                     const threadSnapshot = yield* measureHttpGet({
                       url: `${baseUrl}/api/orchestration/threads/${TRANSFER_THREAD_ID}`,
                       headers: { cookie },
@@ -9354,29 +9336,78 @@ it.live(
                       decodedThread.thread.messages.length,
                       TRANSFER_HISTORY_TURN_COUNT * 2,
                     );
+                    const shellSnapshot = yield* measureHttpGet({
+                      url: `${baseUrl}/api/orchestration/shell`,
+                      headers: { cookie },
+                    });
+                    assert.equal(shellSnapshot.status, 200);
+                    const decodedShell = yield* decodeTransferShellSnapshot(
+                      Buffer.from(shellSnapshot.decodedBody).toString("utf8"),
+                    );
+                    assert.equal(decodedShell.threads.length, 1);
 
-                    const threadItems = yield* Queue.unbounded<OrchestrationThreadStreamItem>();
-                    yield* client[ORCHESTRATION_WS_METHODS.subscribeThread]({
-                      threadId: TRANSFER_THREAD_ID,
-                      afterSequence: decodedThread.snapshotSequence,
-                      requestCompletionMarker: true,
-                    }).pipe(
-                      Stream.runForEach((item) =>
-                        Queue.offer(threadItems, item).pipe(Effect.asVoid),
+                    // Three sockets, the way real installs look: the capped
+                    // thread-only client, a shell-only socket that isolates the
+                    // sidebar cost, and a second device holding both.
+                    const threadClient = yield* openMeasuredWsClient({ url: wsUrl, cookie });
+                    const shellClient = yield* openMeasuredWsClient({ url: wsUrl, cookie });
+                    const secondClient = yield* openMeasuredWsClient({ url: wsUrl, cookie });
+                    assert.include(
+                      threadClient.recorder.negotiatedExtensions(),
+                      "permessage-deflate",
+                    );
+
+                    const threadItems = yield* subscribeThreadItems(
+                      threadClient,
+                      decodedThread.snapshotSequence,
+                    );
+                    const shellItems = yield* subscribeShellItems(
+                      shellClient,
+                      decodedShell.snapshotSequence,
+                    );
+                    const secondThreadItems = yield* subscribeThreadItems(
+                      secondClient,
+                      decodedThread.snapshotSequence,
+                    );
+                    const secondShellItems = yield* subscribeShellItems(
+                      secondClient,
+                      decodedShell.snapshotSequence,
+                    );
+                    assert.equal(
+                      yield* awaitSubscriptionSynchronized(
+                        threadItems,
+                        `${provider} thread subscription to synchronize`,
                       ),
-                      Effect.forkScoped,
+                      "replay",
                     );
-                    const initialThreadItems = yield* collectQueueUntil(
-                      threadItems,
-                      (item) => item.kind === "synchronized",
-                      `${provider} thread subscription to synchronize`,
+                    assert.equal(
+                      yield* awaitSubscriptionSynchronized(
+                        shellItems,
+                        `${provider} shell subscription to synchronize`,
+                      ),
+                      "replay",
                     );
-                    assert.isFalse(initialThreadItems.some((item) => item.kind === "snapshot"));
-                    assert.include(recorder.negotiatedExtensions(), "permessage-deflate");
+                    assert.equal(
+                      yield* awaitSubscriptionSynchronized(
+                        secondThreadItems,
+                        `${provider} second client thread subscription to synchronize`,
+                      ),
+                      "replay",
+                    );
+                    assert.equal(
+                      yield* awaitSubscriptionSynchronized(
+                        secondShellItems,
+                        `${provider} second client shell subscription to synchronize`,
+                      ),
+                      "replay",
+                    );
 
                     yield* queueMeasuredTransferTurn(harness, provider);
-                    const turnStartTotals = recorder.totals();
-                    yield* client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+                    const turnStartTotals = threadClient.recorder.totals();
+                    const shellTurnStartTotals = shellClient.recorder.totals();
+                    const secondTurnStartTotals = secondClient.recorder.totals();
+                    const turnStartSqlStatements = sqlCounter.count();
+                    yield* threadClient.client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
                       type: "thread.turn.start",
                       commandId: CommandId.make(`transfer:${provider}:measured-turn`),
                       threadId: TRANSFER_THREAD_ID,
@@ -9392,26 +9423,95 @@ it.live(
                       createdAt: TRANSFER_MEASURED_TURN_CREATED_AT,
                     });
                     yield* waitForTurnQuiesced(harness, TRANSFER_MEASURED_TURN_INDEX + 1);
-                    const finalThreadSequence = yield* harness.engine
+                    const finalSequences = yield* harness.engine
                       .readEvents(decodedThread.snapshotSequence, 10_000)
                       .pipe(
                         Stream.runFold(
-                          () => decodedThread.snapshotSequence,
-                          (sequence, event) =>
-                            event.aggregateId === TRANSFER_THREAD_ID && isThreadDetailEvent(event)
-                              ? Math.max(sequence, event.sequence)
-                              : sequence,
+                          () => ({
+                            detail: decodedThread.snapshotSequence,
+                            aggregate: decodedShell.snapshotSequence,
+                          }),
+                          (sequences, event) =>
+                            event.aggregateId !== TRANSFER_THREAD_ID
+                              ? sequences
+                              : {
+                                  detail: isThreadDetailEvent(event)
+                                    ? Math.max(sequences.detail, event.sequence)
+                                    : sequences.detail,
+                                  aggregate: Math.max(sequences.aggregate, event.sequence),
+                                },
                         ),
                       );
+                    const finalThreadSequence = finalSequences.detail;
                     assert.isAbove(finalThreadSequence, decodedThread.snapshotSequence);
 
+                    const reachedFinalThreadEvent = (item: OrchestrationThreadStreamItem) =>
+                      item.kind === "event" && item.event.sequence === finalThreadSequence;
+                    // Shell items carry the sequence of the latest coalesced
+                    // event for the thread, so the last one lands at or past
+                    // the final thread event.
+                    const reachedFinalShellEvent = (item: OrchestrationShellStreamItem) =>
+                      item.kind === "thread-upserted" && item.sequence >= finalSequences.aggregate;
                     yield* collectQueueUntil(
                       threadItems,
-                      (item) =>
-                        item.kind === "event" && item.event.sequence === finalThreadSequence,
+                      reachedFinalThreadEvent,
                       `${provider} thread stream to reach sequence ${finalThreadSequence}`,
                     );
-                    const measuredTurnWebSocket = transferDelta(turnStartTotals, recorder.totals());
+                    yield* collectQueueUntil(
+                      secondThreadItems,
+                      reachedFinalThreadEvent,
+                      `${provider} second client thread stream to reach sequence ${finalThreadSequence}`,
+                    );
+                    yield* collectQueueUntil(
+                      shellItems,
+                      reachedFinalShellEvent,
+                      `${provider} shell stream to reach sequence ${finalSequences.aggregate}`,
+                    );
+                    yield* collectQueueUntil(
+                      secondShellItems,
+                      reachedFinalShellEvent,
+                      `${provider} second client shell stream to reach sequence ${finalSequences.aggregate}`,
+                    );
+                    const measuredTurnWebSocket = transferDelta(
+                      turnStartTotals,
+                      threadClient.recorder.totals(),
+                    );
+                    const measuredTurnShellWebSocket = transferDelta(
+                      shellTurnStartTotals,
+                      shellClient.recorder.totals(),
+                    );
+                    const measuredTurnSecondClientWebSocket = transferDelta(
+                      secondTurnStartTotals,
+                      secondClient.recorder.totals(),
+                    );
+                    const measuredTurnSqlStatements = sqlCounter.count() - turnStartSqlStatements;
+
+                    // The second device drops and comes back with the cursors it
+                    // held before the turn, one subscription at a time so the
+                    // catch-up bytes stay separable.
+                    yield* secondClient.close;
+                    const reconnectSqlStart = sqlCounter.count();
+                    const reconnected = yield* openMeasuredWsClient({ url: wsUrl, cookie });
+                    const reconnectStartTotals = reconnected.recorder.totals();
+                    const reconnectThreadItems = yield* subscribeThreadItems(
+                      reconnected,
+                      decodedThread.snapshotSequence,
+                    );
+                    const reconnectThreadMode = yield* awaitSubscriptionSynchronized(
+                      reconnectThreadItems,
+                      `${provider} reconnected thread subscription to synchronize`,
+                    );
+                    const reconnectThreadTotals = reconnected.recorder.totals();
+                    const reconnectShellItems = yield* subscribeShellItems(
+                      reconnected,
+                      decodedShell.snapshotSequence,
+                    );
+                    const reconnectShellMode = yield* awaitSubscriptionSynchronized(
+                      reconnectShellItems,
+                      `${provider} reconnected shell subscription to synchronize`,
+                    );
+                    const reconnectShellTotals = reconnected.recorder.totals();
+                    const reconnectSqlStatements = sqlCounter.count() - reconnectSqlStart;
 
                     const finalThreadSnapshot = yield* harness.snapshotQuery
                       .getThreadDetailSnapshot(TRANSFER_THREAD_ID)
@@ -9436,12 +9536,29 @@ it.live(
                       provider,
                       threadSnapshot,
                       measuredTurnWebSocket,
+                      shellSnapshot,
+                      measuredTurnShellWebSocket,
+                      measuredTurnSecondClientWebSocket,
+                      reconnectThread: {
+                        mode: reconnectThreadMode,
+                        ...transferDelta(reconnectStartTotals, reconnectThreadTotals),
+                      },
+                      reconnectShell: {
+                        mode: reconnectShellMode,
+                        ...transferDelta(reconnectThreadTotals, reconnectShellTotals),
+                      },
+                      measuredTurnSqlStatements,
+                      reconnectSqlStatements,
                     } satisfies TransferBudgetRun;
-                  }).pipe(Effect.provide(protocolLayer)),
+                  }),
                 );
               }),
             (harness) => harness.dispose,
-          ).pipe(Effect.provide(NodeHttpServerTestWithWsDeflate)),
+          ).pipe(
+            Effect.provideService(Tracer.Tracer, sqlCounter.tracer),
+            Effect.provide(NodeHttpServerTestWithWsDeflate),
+          );
+        },
         { concurrency: 1 },
       );
 


### PR DESCRIPTION
The transfer budget measured one thread subscription during one turn. Real clients also hold the sidebar (shell) subscription, users often have a desktop and a phone connected at once, and clients reconnect. Nobody had measured those, and the larger perf proposals (sharing the sidebar projector across clients, sharing git services across connections, incremental history) are gated on knowing whether they matter.

This PR measures them in the same test and prints them next to the existing capped rows. The single-thread measurement and its caps are unchanged.

What it adds:

- A shell-only socket and a second client socket holding both the thread and shell subscriptions during the measured turn. The report shows per-socket wire bytes, decoded bytes, message counts, and total server egress.
- A reconnect after the turn. The second client disconnects and resubscribes each subscription from the cursor it held before the turn. The report shows catch-up bytes and whether the server chose replay or a snapshot reset.
- A SQL statement count from `sql.execute` spans. A counting tracer is installed on the harness runtime and the HTTP/WS app so reactor writes and subscription reads land in one total. No new instrumentation in `src/`.
- `openMeasuredWsClient` opens each RPC socket on its own child scope so clients disconnect independently.

The new rows have no caps. The shell stream coalesces on a 50 ms window, so the second client's message count moved between 9 and 10 across runs and its wire bytes between 6.7 and 7.1 KiB. SQL statement counts moved between 1096 and 1167 for the same reason. The capped thread rows stayed within a few bytes.

Measured (local, one run):

| Provider | Phase | Metric | Observed | Budget | Result |
| --- | --- | --- | ---: | ---: | --- |
| codex | thread snapshot | HTTP wire | 6.9 KiB (7,049 B) | 7.3 KiB (7,500 B) | PASS |
| codex | measured turn | WebSocket wire | 6.3 KiB (6,401 B) | 7.8 KiB (8,000 B) | PASS |
| codex | measured turn | WebSocket decoded | 54.7 KiB (55,974 B) | 66.4 KiB (68,000 B) | PASS |
| codex | measured turn | WebSocket messages | 8 | 21 | PASS |
| codex | shell snapshot | HTTP wire | 829 B | none | INFO |
| codex | measured turn, shell | WebSocket wire | 628 B | none | INFO |
| codex | measured turn, shell | WebSocket decoded | 3.7 KiB (3,793 B) | none | INFO |
| codex | measured turn, shell | WebSocket messages | 3 | none | INFO |
| codex | measured turn, second client | WebSocket wire | 7.0 KiB (7,144 B) | none | INFO |
| codex | measured turn, second client | WebSocket decoded | 58.3 KiB (59,723 B) | none | INFO |
| codex | measured turn, second client | WebSocket messages | 10 | none | INFO |
| codex | measured turn | server egress wire | 13.8 KiB (14,173 B) | none | INFO |
| codex | measured turn | SQL statements | 1096 | none | INFO |
| codex | reconnect, thread (replay) | WebSocket wire | 6.2 KiB (6,325 B) | none | INFO |
| codex | reconnect, thread (replay) | WebSocket decoded | 54.4 KiB (55,707 B) | none | INFO |
| codex | reconnect, thread (replay) | WebSocket messages | 2 | none | INFO |
| codex | reconnect, shell (replay) | WebSocket wire | 386 B | none | INFO |
| codex | reconnect, shell (replay) | WebSocket decoded | 1.3 KiB (1,355 B) | none | INFO |
| codex | reconnect, shell (replay) | WebSocket messages | 2 | none | INFO |
| codex | reconnect | SQL statements | 10 | none | INFO |
| claudeAgent | thread snapshot | HTTP wire | 6.9 KiB (7,059 B) | 7.3 KiB (7,500 B) | PASS |
| claudeAgent | measured turn | WebSocket wire | 6.3 KiB (6,409 B) | 7.8 KiB (8,000 B) | PASS |
| claudeAgent | measured turn | WebSocket decoded | 55.5 KiB (56,806 B) | 66.4 KiB (68,000 B) | PASS |
| claudeAgent | measured turn | WebSocket messages | 8 | 21 | PASS |
| claudeAgent | shell snapshot | HTTP wire | 829 B | none | INFO |
| claudeAgent | measured turn, shell | WebSocket wire | 626 B | none | INFO |
| claudeAgent | measured turn, shell | WebSocket decoded | 3.8 KiB (3,877 B) | none | INFO |
| claudeAgent | measured turn, shell | WebSocket messages | 3 | none | INFO |
| claudeAgent | measured turn, second client | WebSocket wire | 7.0 KiB (7,161 B) | none | INFO |
| claudeAgent | measured turn, second client | WebSocket decoded | 59.2 KiB (60,602 B) | none | INFO |
| claudeAgent | measured turn, second client | WebSocket messages | 10 | none | INFO |
| claudeAgent | measured turn | server egress wire | 13.9 KiB (14,196 B) | none | INFO |
| claudeAgent | measured turn | SQL statements | 1096 | none | INFO |
| claudeAgent | reconnect, thread (replay) | WebSocket wire | 6.2 KiB (6,342 B) | none | INFO |
| claudeAgent | reconnect, thread (replay) | WebSocket decoded | 55.2 KiB (56,539 B) | none | INFO |
| claudeAgent | reconnect, thread (replay) | WebSocket messages | 2 | none | INFO |
| claudeAgent | reconnect, shell (replay) | WebSocket wire | 379 B | none | INFO |
| claudeAgent | reconnect, shell (replay) | WebSocket decoded | 1.4 KiB (1,383 B) | none | INFO |
| claudeAgent | reconnect, shell (replay) | WebSocket messages | 2 | none | INFO |
| claudeAgent | reconnect | SQL statements | 10 | none | INFO |

Reading the numbers:

- The sidebar costs about 630 B wire and 3 messages per turn, about 10% of the thread stream. A second device costs one more thread stream plus one more shell stream, about 7 KiB. Egress scales linearly with connected clients and there is no hidden multiplier.
- Reconnecting from the pre-turn cursor replays about the same bytes as live delivery (6.3 KiB thread, 380 B shell) in 2 messages each and 10 SQL statements total. Replay was chosen every time at this gap size. Snapshot fallback did not trigger.
- This fixture mocks git, so it says nothing about sharing git services across connections.

Change authored by Claude Fable 5.1 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to integration tests and reporting helpers; production server code is not modified.
> 
> **Overview**
> Extends the **thread transfer budget** integration test so CI reports more than a single thread WebSocket during one turn. **Existing capped thread snapshot and measured-turn rows are unchanged.**
> 
> The scenario now opens **three measured WebSocket clients** (thread-only, shell-only, and a second device with both subscriptions), records **shell HTTP snapshot** size, and sums **server egress** across the three sockets. After the turn, the second client **closes and resubscribes** from its pre-turn cursors; the report records catch-up wire/decoded/message totals and whether catch-up used **replay** or **snapshot**.
> 
> **Test harness plumbing** adds `openMeasuredWsClient` (per-client forked scope + `close`), WebSocket recorder improvements (`awaitOpen`, wire totals after close), shared **SQL statement counting** via a counting `Tracer` on the orchestration harness and HTTP/WS app (`sql.execute` spans), and helpers moved into `TransferBudgetScenario` for thread/shell subscribe and sync detection. New report fields are **INFO-only** (no new budgets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aff2b183c9d5c6858aea93750367a49e0f7e0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand transfer-budget test to measure shell, second client, and reconnect transfer
> - Reworks the live transfer-budget integration test in [server.test.ts](https://github.com/pingdotgg/t3code/pull/9157/files#diff-311d34bc81e1c9cdae991c24771a5c0b8f02084dc94251982be7466403965b9f) to open three concurrent measured clients (thread-only, shell-only, second-client), capture per-socket WebSocket transfer and server-wide `sql.execute` deltas, then close and reconnect the second client to measure replay-or-snapshot catch-up
> - Adds `openMeasuredWsClient`, a factory that forks a per-client child scope, builds a counting WebSocket protocol, waits for open (10s timeout defect), and returns an explicit close effect
> - Updates `makeWebSocketTransferRecorder` to retain the underlying transport at open time so wire-byte totals remain readable after socket closure
> - Adds `makeSqlStatementCounter`, a tracer that increments a counter for spans named exactly `sql.execute` while returning native spans for all operations
> - Extends `formatTransferBudgetReport` with informational (uncapped) rows for shell snapshot, shell-only and second-client WebSocket diagnostics, aggregate server egress, SQL counts, and reconnect catch-up modes alongside existing capped thread rows
> - Adds subscription helpers `subscribeThreadItems`, `subscribeShellItems`, and `awaitSubscriptionSynchronized` in [TransferBudgetScenario.integration.ts](https://github.com/pingdotgg/t3code/pull/9157/files#diff-360e157299a158e31e629d089334fe56c9c66cda6a0f4b709faf9a856f248052) that run scoped subscriptions and classify initial catch-up as replay or snapshot
> - Risk: `makeWebSocketTransferRecorder` open wait fails with a timeout defect after 10 seconds; `awaitSubscriptionSynchronized` similarly defects after 10 seconds if the synchronization marker never arrives
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7aff2b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->