### PR TITLE
fix(web): hide build pill in narrow sidebars

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -67,7 +67,7 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
       <SidebarBrand onBackdrop={backdropVariant !== null} />
       {pillLabel ? (
         <Badge
-          className="relative z-10 ml-1 rounded-full px-1.5 text-muted-foreground"
+          className="relative z-10 ml-1 hidden rounded-full px-1.5 text-muted-foreground @[15rem]/sidebar-header:inline-flex"
           data-environment-identification="pill"
           size="sm"
           variant="secondary"


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-5.6 Sol on behalf of Oliver**

## Problem

Generated themes replace the Dev or Nightly sidebar artwork with a build pill. At small sidebar widths, that pill extends beyond the sidebar and gets clipped.

## Fix

Hide the pill below a 15rem sidebar width. Wider sidebars keep the pill, and the T3 Code brand keeps its normal sizing.

## UI changes

### Before

<!-- Attach before image here -->
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/0e1cf7a8-d147-4078-bade-533e5b0ae12b" />

### After

<!-- Attach after image here -->

https://github.com/user-attachments/assets/5ca84479-92d5-43fc-9d7c-34228d0fd13f


## Verification

- `vp lint apps/web/src/components/sidebar/SidebarChrome.tsx --report-unused-disable-directives`
- `cd apps/web && vp run typecheck`
- `cd apps/web && vp run build`
- `git diff --check`

Changes prepared by GPT-5.6 Sol through Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide build pill in `SidebarChromeHeader` when sidebar is narrower than 15rem
> The environment-identification pill badge in [SidebarChrome.tsx](https://github.com/pingdotgg/t3code/pull/9159/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11) is now hidden by default and shown as inline-flex once the `sidebar-header` container reaches 15rem. This prevents the pill from crowding narrow sidebars.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9634f07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->