### PR TITLE
fix(web): compact project settings actions

### DIFF
--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -784,7 +784,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
 
   return (
     <>
-      <SettingsPageContainer>
+      <SettingsPageContainer width="wide" className="gap-8">
         <SettingsSection title="Project">
           <SettingsRow
             title="Name"
@@ -842,9 +842,6 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
               </div>
             }
           />
-        </SettingsSection>
-
-        <SettingsSection title="New threads">
           <SettingsRow
             title="Model"
             description="New threads in this project start with this model. Applies to every checkout in this group."
@@ -1131,10 +1128,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                         icon={script.icon}
                         className="size-4 shrink-0 text-muted-foreground"
                       />
-                      <span className="max-w-40 shrink-0 truncate">{script.name}</span>
-                      <code className="min-w-0 flex-1 truncate font-mono font-normal text-muted-foreground">
-                        {script.command}
-                      </code>
+                      <span className="min-w-0 truncate">{script.name}</span>
                       {script.runOnWorktreeCreate ? (
                         <span className="shrink-0 rounded-sm border border-border/60 px-1.5 py-px text-[11px] font-normal text-muted-foreground">
                           setup
@@ -1146,6 +1140,9 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                         </span>
                       ) : null}
                     </span>
+                  }
+                  description={
+                    <code className="block max-w-full truncate font-mono">{script.command}</code>
                   }
                   control={
                     <>


### PR DESCRIPTION
Long project action commands could push their row far outside the settings content, and the page split closely related defaults into an extra section.

This widens and tightens the project settings layout, keeps project defaults together, and moves action commands onto a constrained ellipsized line beneath the action name.

Verified in the web app at 1440x900 in dark mode and 390x844 in light mode, plus a targeted web typecheck and file-scoped lint/format checks.

### before

![full project settings before](https://uploads-production-47e4.up.railway.app/files/66245069-5dbf-4639-a82b-d88de0c2b931/t3-project-settings-full-before.png)

### after

![full project settings after](https://uploads-production-47e4.up.railway.app/files/5aa0a29c-ef85-41a5-90b0-3261add107ac/t3-project-settings-full-after.png)

Built with gpt-5.6-sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in project settings; no persistence, API, or auth behavior changes.
> 
> **Overview**
> **Project settings** uses a **wider** page container with **tighter vertical spacing** (`gap-8`), giving long controls more room without blowing out the layout.
> 
> **Model** and **Workspace** defaults are no longer under a separate **“New threads”** section—they sit in the main **Project** section with name and icon.
> 
> For **checkout actions**, the command string moves from the title row into the row **description** as a **truncated monospace** line, so long shell commands don’t stretch the row horizontally; name and badges stay on the title line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d3e13d99c01f0e475faeb837268980f7b0990f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compact project settings panel layout and script rows
> - Widens the settings page container and adds an explicit gap in [ProjectSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/9160/files#diff-0240d4863349583155edae77c3bfab65683d7e019508379850a5b96167960cdc)
> - Moves the "New threads" settings into the "Project" section, removing the separate boundary
> - Reworks script rows so the script name sits on the title line and the command renders as a truncated monospace description beneath it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72d3e13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->