### PR TITLE
fix(clients): keep model selection sticky across threads

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -931,7 +931,7 @@ export function NewTaskDraftScreen(props: {
         flow.finishEditingPendingTask();
       } else {
         // Drop draft-local model/workspace selections with the content. The
-        // next task re-resolves project defaults before sticky app defaults.
+        // next task re-resolves sticky app defaults before project defaults.
         clearComposerDraftContent(draftKey, {
           clearModelSelection: true,
           clearWorkspaceSelection: true,

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -438,18 +438,18 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     () =>
       buildModelOptions(
         selectedEnvironmentServerConfig,
-        draftModelSelection ?? projectDefaultModelSelection ?? stickyModelSelection,
+        draftModelSelection ?? stickyModelSelection ?? projectDefaultModelSelection,
       ),
     [
       selectedEnvironmentServerConfig,
       draftModelSelection,
-      projectDefaultModelSelection,
       stickyModelSelection,
+      projectDefaultModelSelection,
     ],
   );
 
   // An unsent draft keeps its explicit pick. Fresh drafts resolve the project
-  // default before the last manual app-wide selection and provider default.
+  // last manual app-wide selection before the project and provider defaults.
   const selectedModel = resolveNewTaskModelSelection({
     draftSelection: draftModelSelection,
     projectDefaultSelection: projectDefaultModelSelection,

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -223,7 +223,7 @@ describe("mobile model options", () => {
     expect(resolveDefaultableModelSelection(null, legacy)).toBe(legacy);
   });
 
-  it("resolves new tasks from draft, project, sticky, then provider defaults", () => {
+  it("resolves new tasks from draft, sticky, project, then provider defaults", () => {
     const draft = { instanceId: ProviderInstanceId.make("codex"), model: "draft" };
     const project = { instanceId: ProviderInstanceId.make("codex"), model: "project" };
     const sticky = { instanceId: ProviderInstanceId.make("codex"), model: "sticky" };
@@ -244,7 +244,8 @@ describe("mobile model options", () => {
       });
 
     expect(resolve(draft, project, sticky)).toBe(draft);
-    expect(resolve(null, project, sticky)).toBe(project);
+    expect(resolve(null, project, sticky)).toBe(sticky);
+    expect(resolve(null, project, null)).toBe(project);
     expect(resolve(null, null, sticky)).toBe(sticky);
     expect(resolve(null, null, null)).toBe(providerDefault.selection);
   });

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -112,8 +112,8 @@ export function resolveNewTaskModelSelection(input: {
 }): ModelSelection | null {
   return (
     input.draftSelection ??
-    input.projectDefaultSelection ??
     input.stickySelection ??
+    input.projectDefaultSelection ??
     input.modelOptions.find((option) => option.isDefault)?.selection ??
     input.modelOptions[0]?.selection ??
     null

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -201,7 +201,7 @@ export function decodePersistedComposerState(value: unknown): {
               // Stale new-task drafts left on disk by builds before the
               // model-precedence fix carry a bare modelSelection with no
               // other selector settings. Strip it so the next compose pass
-              // re-resolves project → sticky → provider defaults. Drafts
+              // re-resolves sticky → project → provider defaults. Drafts
               // with runtime/interaction/workspace settings or actual text /
               // attachments were deliberately configured and are left alone.
               key.startsWith("new-task:") &&

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -89,15 +89,17 @@ export function useNewThreadHandler() {
         getDraftSession,
         getDraftThread,
         applyStickyState,
+        stickyActiveProvider,
+        stickyModelSelectionByProvider,
         setDraftThreadContext,
         setLogicalProjectDraftThreadId,
         setModelSelection,
       } = useComposerDraftStore.getState();
       const currentRouteTarget = getCurrentRouteTarget();
       // A new thread carries the user's working mode from the thread being
-      // viewed. The target project's configured model still wins; runtime and
-      // interaction modes carry independently. Branch, worktree, and env mode
-      // come from configured defaults unless the caller passes them explicitly.
+      // viewed. Runtime and interaction modes carry independently. Branch,
+      // worktree, and env mode come from configured defaults unless the caller
+      // passes them explicitly.
       const carrySourceShell =
         currentRouteTarget?.kind === "server"
           ? readThreadShell(currentRouteTarget.threadRef)
@@ -134,9 +136,13 @@ export function useNewThreadHandler() {
           candidate.id === projectRef.projectId &&
           candidate.environmentId === projectRef.environmentId,
       );
+      const stickyModelSelection = stickyActiveProvider
+        ? (stickyModelSelectionByProvider[stickyActiveProvider] ?? null)
+        : null;
       const resolveModelSelectionOverride = (destinationDraftId: DraftId) =>
         resolveNewThreadModelSelectionOverride({
           projectDefaultSelection: project?.defaultModelSelection ?? null,
+          stickySelection: stickyModelSelection,
           carrySelection: carryModelSelection,
           carrySourceDraftId:
             currentRouteTarget?.kind === "draft" ? currentRouteTarget.draftId : null,
@@ -261,9 +267,9 @@ export function useNewThreadHandler() {
             });
           }
           // Model intent: an explicit human pick always stands. Seeds and
-          // legacy entries alike re-resolve here — sticky first, mirroring
-          // the mint-fresh path, then the project default or carried
-          // selection on top. This runs even when the draft is already open:
+          // legacy entries alike re-resolve here from the current thread,
+          // then the app-wide sticky choice, then the project default. This
+          // runs even when the draft is already open:
           // without it, a changed pin could never reach the draft the user
           // is looking at, because explicit picks are the only thing the
           // flag protects.
@@ -409,8 +415,8 @@ export function useNewThreadHandler() {
         applyStickyState(draftId);
         const modelSelectionOverride = resolveModelSelectionOverride(draftId);
         if (modelSelectionOverride) {
-          // Project defaults and carried selections both outrank global sticky
-          // state. The project default wins when both are present.
+          // The current thread wins over global sticky state. Project defaults
+          // only fill in when neither user-wide source has a selection.
           setModelSelection(draftId, modelSelectionOverride, { replaceOptions: true });
         }
         await router.navigate({

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -89,8 +89,6 @@ export function useNewThreadHandler() {
         getDraftSession,
         getDraftThread,
         applyStickyState,
-        stickyActiveProvider,
-        stickyModelSelectionByProvider,
         setDraftThreadContext,
         setLogicalProjectDraftThreadId,
         setModelSelection,
@@ -136,18 +134,20 @@ export function useNewThreadHandler() {
           candidate.id === projectRef.projectId &&
           candidate.environmentId === projectRef.environmentId,
       );
-      const stickyModelSelection = stickyActiveProvider
-        ? (stickyModelSelectionByProvider[stickyActiveProvider] ?? null)
-        : null;
-      const resolveModelSelectionOverride = (destinationDraftId: DraftId) =>
-        resolveNewThreadModelSelectionOverride({
+      const resolveModelSelectionOverride = (destinationDraftId: DraftId) => {
+        const { stickyActiveProvider, stickyModelSelectionByProvider } =
+          useComposerDraftStore.getState();
+        return resolveNewThreadModelSelectionOverride({
           projectDefaultSelection: project?.defaultModelSelection ?? null,
-          stickySelection: stickyModelSelection,
+          stickySelection: stickyActiveProvider
+            ? (stickyModelSelectionByProvider[stickyActiveProvider] ?? null)
+            : null,
           carrySelection: carryModelSelection,
           carrySourceDraftId:
             currentRouteTarget?.kind === "draft" ? currentRouteTarget.draftId : null,
           destinationDraftId,
         });
+      };
       // The shared resolver owns the priority order. The t3.json read is
       // skipped entirely when a higher-priority source decides, and its
       // query atom caches per project after the first call.

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -58,6 +58,7 @@ describe("chatThreadActions", () => {
     expect(
       resolveNewThreadModelSelectionOverride({
         projectDefaultSelection: null,
+        stickySelection: null,
         carrySelection: CARRIED_SELECTION,
         carrySourceDraftId: "draft-a",
         destinationDraftId: "draft-a",
@@ -69,6 +70,7 @@ describe("chatThreadActions", () => {
     expect(
       resolveNewThreadModelSelectionOverride({
         projectDefaultSelection: null,
+        stickySelection: null,
         carrySelection: CARRIED_SELECTION,
         carrySourceDraftId: "draft-a",
         destinationDraftId: "draft-b",
@@ -76,15 +78,28 @@ describe("chatThreadActions", () => {
     ).toEqual(CARRIED_SELECTION);
   });
 
-  it("keeps the project default above any carried selection", () => {
+  it("keeps a carried selection above the sticky and project defaults", () => {
     expect(
       resolveNewThreadModelSelectionOverride({
         projectDefaultSelection: PROJECT_DEFAULT_SELECTION,
+        stickySelection: PROJECT_DEFAULT_SELECTION,
         carrySelection: CARRIED_SELECTION,
         carrySourceDraftId: "draft-a",
         destinationDraftId: "draft-b",
       }),
-    ).toEqual(PROJECT_DEFAULT_SELECTION);
+    ).toEqual(CARRIED_SELECTION);
+  });
+
+  it("keeps the sticky selection above the project default", () => {
+    expect(
+      resolveNewThreadModelSelectionOverride({
+        projectDefaultSelection: PROJECT_DEFAULT_SELECTION,
+        stickySelection: CARRIED_SELECTION,
+        carrySelection: null,
+        carrySourceDraftId: null,
+        destinationDraftId: "draft-b",
+      }),
+    ).toEqual(CARRIED_SELECTION);
   });
 
   it("only applies the start-from-origin default to new worktree drafts", () => {

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -46,13 +46,15 @@ export function resolveNewDraftStartFromOrigin(input: {
 
 export function resolveNewThreadModelSelectionOverride(input: {
   readonly projectDefaultSelection: ModelSelection | null;
+  readonly stickySelection: ModelSelection | null;
   readonly carrySelection: ModelSelection | null;
   readonly carrySourceDraftId: string | null;
   readonly destinationDraftId: string;
 }): ModelSelection | null {
   return (
-    input.projectDefaultSelection ??
-    (input.carrySourceDraftId === input.destinationDraftId ? null : input.carrySelection)
+    (input.carrySourceDraftId === input.destinationDraftId ? null : input.carrySelection) ??
+    input.stickySelection ??
+    input.projectDefaultSelection
   );
 }
 


### PR DESCRIPTION
PR #6011 made every project default override the user's current and app-wide model choice. Because projects are commonly created with a stored model, new threads kept snapping back to that model and reasoning effort.

Restore the precedence used by the composer on web and mobile: explicit draft or current-thread selection, then the app-wide sticky selection, then the project default, then the provider default. Project defaults still apply when the user has no active global choice.

Focused verification:
- `pnpm exec vp test run apps/web/src/lib/chatThreadActions.test.ts apps/mobile/src/lib/modelOptions.test.ts`
- `pnpm typecheck` in `apps/web`
- `pnpm typecheck` in `apps/mobile`

Implemented with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default model behavior for new threads/tasks across web and mobile; `resolveNewThreadModelSelectionOverride` now requires `stickySelection`, though in-repo callers are updated.
> 
> **Overview**
> **Restores composer-aligned model precedence** after project defaults began overriding the user’s app-wide sticky choice when starting new tasks or threads.
> 
> On **mobile**, `resolveNewTaskModelSelection` and related fallbacks now resolve **draft → sticky → project → provider**, including `buildModelOptions` fallback ordering and comments/migration for stale `new-task:` drafts on disk.
> 
> On **web**, `resolveNewThreadModelSelectionOverride` gains a **`stickySelection`** argument and orders **carried current-thread model** (when switching drafts) **→ sticky → project default**. `useHandleNewThread` reads sticky state from the composer draft store when minting or refreshing empty drafts.
> 
> Tests on both platforms assert sticky beats project default and that project still applies when sticky is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9188f9d3c2116e98f32eeb88d7be265f703d4660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model selection to stay sticky across threads before project default
> - Reorders the model fallback chain in both mobile and web new-thread/new-task flows so the sticky app-wide selection outranks the project default. Draft selection still wins first, provider fallback remains last.
> - Mobile `resolveNewTaskModelSelection` in [modelOptions.ts](https://github.com/pingdotgg/t3code/pull/9163/files#diff-e728e5b82529c8d8d8ae7017fbd0ee4021eea3e722dc156b9f3b209951cc7dea) and the `NewTaskFlowProvider` in [new-task-flow-provider.tsx](https://github.com/pingdotgg/t3code/pull/9163/files#diff-70cedfb5c403f777ceda2ca120dd7f822b033acf06053841f85a63b7d0cd3192) apply the new precedence.
> - Web `resolveNewThreadModelSelectionOverride` in [chatThreadActions.ts](https://github.com/pingdotgg/t3code/pull/9163/files#diff-6e655e056adaf8605b1381f1a37651405db18539fe8abe8eb1e810e5f95608e1) and the handler in [useHandleNewThread.ts](https://github.com/pingdotgg/t3code/pull/9163/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef) now take the active sticky provider's model selection as input; carried cross-thread selection still outranks sticky.
> - Behavioral Change: new threads/tasks that previously fell back to the project default model will now pick up the last user-selected sticky model instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9188f9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->