### PR TITLE
fix(models): restore sticky new-thread selections

### DIFF
--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -102,7 +102,7 @@ describe("mobile model options", () => {
     ]);
   });
 
-  it("normalizes a legacy fallback selection against current capabilities", () => {
+  it("does not materialize catalog defaults for missing stored options", () => {
     const config = {
       providers: [
         {
@@ -140,11 +140,17 @@ describe("mobile model options", () => {
     const [option] = buildModelOptions(config, {
       instanceId: ProviderInstanceId.make("codex"),
       model: "gpt-test",
-      options: [{ id: "fastMode", value: true }],
     });
 
     expect(option?.capabilities?.optionDescriptors?.[0]?.id).toBe("serviceTier");
-    expect(option?.selection.options).toEqual([{ id: "serviceTier", value: "default" }]);
+    expect(option?.selection.options).toBeUndefined();
+
+    const [explicitOption] = buildModelOptions(config, {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-test",
+      options: [{ id: "serviceTier", value: "priority" }],
+    });
+    expect(explicitOption?.selection.options).toEqual([{ id: "serviceTier", value: "priority" }]);
   });
 
   it("rejects stored selections whose provider is not usable", () => {

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -4,7 +4,7 @@ import type {
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
 import {
-  buildProviderOptionSelectionsFromDescriptors,
+  buildExplicitProviderOptionSelectionsFromDescriptors,
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
 
@@ -45,11 +45,12 @@ function normalizeSelectionOptions(
   if (!capabilities) {
     return selection;
   }
-  const options = buildProviderOptionSelectionsFromDescriptors(
+  const options = buildExplicitProviderOptionSelectionsFromDescriptors(
     getProviderOptionDescriptors({
       caps: capabilities,
       selections: selection.options,
     }),
+    selection.options,
   );
   return options
     ? { ...selection, options }

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -30,7 +30,6 @@ import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSn
 import { OrchestrationLayerLive } from "../orchestration/runtimeLayer.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "../persistence/Layers/Sqlite.ts";
 import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
-import * as ServerRuntimeStartup from "../serverRuntimeStartup.ts";
 import {
   clearPersistedServerRuntimeState,
   readPersistedServerRuntimeState,
@@ -481,7 +480,6 @@ const projectAddCommand = Command.make("add", {
           projectId,
           title,
           workspaceRoot,
-          defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(),
           createdAt: DateTime.formatIso(yield* DateTime.now),
         });
         return `Added project ${projectId} (${title}) at ${workspaceRoot}.`;

--- a/apps/server/src/orchestration/decider.projectThreadEnvMode.test.ts
+++ b/apps/server/src/orchestration/decider.projectThreadEnvMode.test.ts
@@ -1,4 +1,11 @@
-import { CommandId, EventId, ProjectId, type OrchestrationEvent } from "@t3tools/contracts";
+import {
+  CommandId,
+  EventId,
+  ProjectId,
+  ProviderInstanceId,
+  type ModelSelection,
+  type OrchestrationEvent,
+} from "@t3tools/contracts";
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -31,7 +38,53 @@ const seedProjectCreated = (sequence: number): OrchestrationEvent => ({
   },
 });
 
-it.layer(NodeServices.layer)("decider project defaultThreadEnvMode", (it) => {
+it.layer(NodeServices.layer)("decider project defaults", (it) => {
+  it.effect("only treats metadata updates as explicit model defaults", () =>
+    Effect.gen(function* () {
+      const selection: ModelSelection = {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5.6-sol",
+        options: [{ id: "reasoningEffort", value: "high" }],
+      };
+      const created = yield* decideOrchestrationCommand({
+        command: {
+          type: "project.create",
+          commandId: CommandId.make("cmd-project-model-create"),
+          projectId,
+          title: "Model default",
+          workspaceRoot: "/tmp/model-default",
+          defaultModelSelection: selection,
+          createdAt: now,
+        },
+        readModel: createEmptyReadModel(now),
+      });
+      const createdEvent = Array.isArray(created) ? created[0] : created;
+      expect(createdEvent.type).toBe("project.created");
+      expect(
+        (createdEvent.payload as { defaultModelSelection?: unknown }).defaultModelSelection,
+      ).toBeNull();
+
+      const withProject = yield* projectEvent(createEmptyReadModel(now), {
+        ...createdEvent,
+        sequence: 1,
+      });
+      const updated = yield* decideOrchestrationCommand({
+        command: {
+          type: "project.meta.update",
+          commandId: CommandId.make("cmd-project-model-update"),
+          projectId,
+          defaultModelSelection: selection,
+        },
+        readModel: withProject,
+      });
+      const updatedEvent = Array.isArray(updated) ? updated[0] : updated;
+      expect(updatedEvent.type).toBe("project.meta-updated");
+      expect(
+        (updatedEvent.payload as { defaultModelSelection?: unknown }).defaultModelSelection,
+      ).toEqual(selection);
+    }),
+  );
+
   it.effect("propagates defaultThreadEnvMode through meta.update into the read model", () =>
     Effect.gen(function* () {
       const readModel = yield* projectEvent(createEmptyReadModel(now), seedProjectCreated(1));

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -219,7 +219,10 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           projectId: command.projectId,
           title: command.title,
           workspaceRoot: command.workspaceRoot,
-          defaultModelSelection: command.defaultModelSelection ?? null,
+          // Project creation has no user model choice. Older clients sent an
+          // automatic seed here, but only a metadata update records an
+          // explicit project default.
+          defaultModelSelection: null,
           faviconPath: null,
           scripts: [],
           createdAt: command.createdAt,

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -55,6 +55,7 @@ import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
 import Migration0041 from "./Migrations/041_AuthSessionClientConnection.ts";
 import Migration0042 from "./Migrations/042_ProjectionThreadLinkedPullRequest.ts";
 import Migration0043 from "./Migrations/043_ProjectionThreadsUnsettledAt.ts";
+import Migration0044 from "./Migrations/044_ClearAutomaticProjectModelDefaults.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -110,6 +111,7 @@ export const migrationEntries = [
   [41, "AuthSessionClientConnection", Migration0041],
   [42, "ProjectionThreadLinkedPullRequest", Migration0042],
   [43, "ProjectionThreadsUnsettledAt", Migration0043],
+  [44, "ClearAutomaticProjectModelDefaults", Migration0044],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/016_CanonicalizeModelSelections.test.ts
+++ b/apps/server/src/persistence/Migrations/016_CanonicalizeModelSelections.test.ts
@@ -380,3 +380,93 @@ layer("016_CanonicalizeModelSelections", (it) => {
       }),
   );
 });
+
+layer("044_ClearAutomaticProjectModelDefaults", (it) => {
+  it.effect("clears create-time seeds and preserves explicit project defaults", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 43 });
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          default_thread_env_mode,
+          favicon_path,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES
+          ('project-auto', 'Auto', '/tmp/auto', '{"instanceId":"codex","model":"gpt-5.6-sol"}', NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z', NULL),
+          ('project-title-only', 'Title only', '/tmp/title-only', '{"instanceId":"codex","model":"gpt-5.6-sol"}', NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z', NULL),
+          ('project-explicit', 'Explicit', '/tmp/explicit', '{"instanceId":"codex","model":"gpt-5.6-sol","options":[{"id":"reasoningEffort","value":"high"}]}', NULL, NULL, '[]', '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z', NULL)
+      `;
+
+      yield* sql`
+        INSERT INTO orchestration_events (
+          event_id,
+          aggregate_kind,
+          stream_id,
+          stream_version,
+          event_type,
+          occurred_at,
+          command_id,
+          causation_event_id,
+          correlation_id,
+          actor_kind,
+          payload_json,
+          metadata_json
+        )
+        VALUES
+          ('event-auto-create', 'project', 'project-auto', 0, 'project.created', '2026-08-01T00:00:00.000Z', 'command-auto-create', NULL, 'command-auto-create', 'client', '{"defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol"}}', '{}'),
+          ('event-title-create', 'project', 'project-title-only', 0, 'project.created', '2026-08-01T00:00:00.000Z', 'command-title-create', NULL, 'command-title-create', 'client', '{"defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol"}}', '{}'),
+          ('event-title-update', 'project', 'project-title-only', 1, 'project.meta-updated', '2026-08-02T00:00:00.000Z', 'command-title-update', NULL, 'command-title-update', 'client', '{"title":"Renamed"}', '{}'),
+          ('event-explicit-create', 'project', 'project-explicit', 0, 'project.created', '2026-08-01T00:00:00.000Z', 'command-explicit-create', NULL, 'command-explicit-create', 'client', '{"defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol"}}', '{}'),
+          ('event-explicit-update', 'project', 'project-explicit', 1, 'project.meta-updated', '2026-08-02T00:00:00.000Z', 'command-explicit-update', NULL, 'command-explicit-update', 'client', '{"defaultModelSelection":{"instanceId":"codex","model":"gpt-5.6-sol","options":[{"id":"reasoningEffort","value":"high"}]}}', '{}')
+      `;
+
+      yield* runMigrations({ toMigrationInclusive: 44 });
+
+      const projects = yield* sql<{
+        readonly projectId: string;
+        readonly selection: string | null;
+      }>`
+        SELECT
+          project_id AS "projectId",
+          default_model_selection_json AS "selection"
+        FROM projection_projects
+        ORDER BY project_id
+      `;
+      assert.deepStrictEqual(projects, [
+        { projectId: "project-auto", selection: null },
+        {
+          projectId: "project-explicit",
+          selection:
+            '{"instanceId":"codex","model":"gpt-5.6-sol","options":[{"id":"reasoningEffort","value":"high"}]}',
+        },
+        { projectId: "project-title-only", selection: null },
+      ]);
+
+      const createdEvents = yield* sql<{
+        readonly streamId: string;
+        readonly model: string | null;
+      }>`
+        SELECT
+          stream_id AS "streamId",
+          json_extract(payload_json, '$.defaultModelSelection.model') AS "model"
+        FROM orchestration_events
+        WHERE event_type = 'project.created'
+        ORDER BY stream_id
+      `;
+      assert.deepStrictEqual(createdEvents, [
+        { streamId: "project-auto", model: null },
+        { streamId: "project-explicit", model: "gpt-5.6-sol" },
+        { streamId: "project-title-only", model: null },
+      ]);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/044_ClearAutomaticProjectModelDefaults.ts
+++ b/apps/server/src/persistence/Migrations/044_ClearAutomaticProjectModelDefaults.ts
@@ -1,0 +1,51 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // Project creation never exposed a model choice. A later metadata event
+  // containing this field is the evidence that the user set or reset one.
+  yield* sql`
+    WITH automatically_seeded_projects AS (
+      SELECT created.stream_id AS project_id
+      FROM orchestration_events AS created
+      WHERE created.aggregate_kind = 'project'
+        AND created.event_type = 'project.created'
+        AND json_type(created.payload_json, '$.defaultModelSelection') IS NOT NULL
+        AND json_type(created.payload_json, '$.defaultModelSelection') <> 'null'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM orchestration_events AS configured
+          WHERE configured.aggregate_kind = 'project'
+            AND configured.stream_id = created.stream_id
+            AND configured.event_type = 'project.meta-updated'
+            AND json_type(configured.payload_json, '$.defaultModelSelection') IS NOT NULL
+        )
+    )
+    UPDATE projection_projects
+    SET default_model_selection_json = NULL
+    WHERE project_id IN (SELECT project_id FROM automatically_seeded_projects)
+  `;
+
+  yield* sql`
+    UPDATE orchestration_events AS created
+    SET payload_json = json_set(
+      created.payload_json,
+      '$.defaultModelSelection',
+      json('null')
+    )
+    WHERE created.aggregate_kind = 'project'
+      AND created.event_type = 'project.created'
+      AND json_type(created.payload_json, '$.defaultModelSelection') IS NOT NULL
+      AND json_type(created.payload_json, '$.defaultModelSelection') <> 'null'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM orchestration_events AS configured
+        WHERE configured.aggregate_kind = 'project'
+          AND configured.stream_id = created.stream_id
+          AND configured.event_type = 'project.meta-updated'
+          AND json_type(configured.payload_json, '$.defaultModelSelection') IS NOT NULL
+      )
+  `;
+});

--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -16,8 +16,8 @@ import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSna
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 
-it("uses the canonical Codex default for auto-bootstrapped model selection", () => {
-  assert.deepStrictEqual(ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(), {
+it("uses the canonical Codex default for the auto-bootstrapped welcome thread", () => {
+  assert.deepStrictEqual(ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(), {
     instanceId: ProviderInstanceId.make("codex"),
     model: DEFAULT_MODEL,
   });
@@ -158,7 +158,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
               id: bootstrapProjectId,
               title: "Startup Project",
               workspaceRoot: "/tmp/startup-project",
-              defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(),
+              defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(),
               scripts: [],
               createdAt: "2026-01-01T00:00:00.000Z",
               updatedAt: "2026-01-01T00:00:00.000Z",
@@ -197,7 +197,13 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
 
 it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when missing", () =>
   Effect.gen(function* () {
-    const dispatchCalls = yield* Ref.make<ReadonlyArray<string>>([]);
+    const dispatchCalls = yield* Ref.make<
+      ReadonlyArray<{
+        readonly type: string;
+        readonly defaultModelSelection?: unknown;
+        readonly modelSelection?: unknown;
+      }>
+    >([]);
     const targets = yield* ServerRuntimeStartup.resolveAutoBootstrapWelcomeTargets.pipe(
       Effect.provideService(ServerConfig.ServerConfig, {
         cwd: "/tmp/startup-project",
@@ -224,7 +230,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
       Effect.provideService(OrchestrationEngine.OrchestrationEngineService, {
         readEvents: () => Stream.empty,
         dispatch: (command) =>
-          Ref.update(dispatchCalls, (calls) => [...calls, command.type]).pipe(
+          Ref.update(dispatchCalls, (calls) => [...calls, command]).pipe(
             Effect.as({ sequence: 1 }),
           ),
         streamDomainEvents: Stream.empty,
@@ -236,7 +242,16 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
 
     assert.equal(typeof targets.bootstrapProjectId, "string");
     assert.equal(typeof targets.bootstrapThreadId, "string");
-    assert.deepStrictEqual(yield* Ref.get(dispatchCalls), ["project.create", "thread.create"]);
+    const commands = yield* Ref.get(dispatchCalls);
+    assert.deepStrictEqual(
+      commands.map((command) => command.type),
+      ["project.create", "thread.create"],
+    );
+    assert.equal("defaultModelSelection" in commands[0]!, false);
+    assert.deepStrictEqual(
+      commands[1]?.modelSelection,
+      ServerRuntimeStartup.getAutoBootstrapThreadModelSelection(),
+    );
   }),
 );
 

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -166,7 +166,7 @@ export const launchStartupHeartbeat = recordStartupHeartbeat.pipe(
   Effect.asVoid,
 );
 
-export const getAutoBootstrapDefaultModelSelection = (): ModelSelection => ({
+export const getAutoBootstrapThreadModelSelection = (): ModelSelection => ({
   instanceId: ProviderInstanceId.make("codex"),
   model: DEFAULT_MODEL,
 });
@@ -199,26 +199,25 @@ export const resolveAutoBootstrapWelcomeTargets = Effect.gen(function* () {
         serverConfig.cwd,
       );
       let nextProjectId: ProjectId;
-      let nextProjectDefaultModelSelection: ModelSelection;
+      let nextThreadModelSelection: ModelSelection;
 
       if (Option.isNone(existingProject)) {
         const createdAt = DateTime.formatIso(yield* DateTime.now);
         nextProjectId = ProjectId.make(yield* randomUUID);
         const bootstrapProjectTitle = path.basename(serverConfig.cwd) || "project";
-        nextProjectDefaultModelSelection = getAutoBootstrapDefaultModelSelection();
+        nextThreadModelSelection = getAutoBootstrapThreadModelSelection();
         yield* orchestrationEngine.dispatch({
           type: "project.create",
           commandId: CommandId.make(yield* randomUUID),
           projectId: nextProjectId,
           title: bootstrapProjectTitle,
           workspaceRoot: serverConfig.cwd,
-          defaultModelSelection: nextProjectDefaultModelSelection,
           createdAt,
         });
       } else {
         nextProjectId = existingProject.value.id;
-        nextProjectDefaultModelSelection =
-          existingProject.value.defaultModelSelection ?? getAutoBootstrapDefaultModelSelection();
+        nextThreadModelSelection =
+          existingProject.value.defaultModelSelection ?? getAutoBootstrapThreadModelSelection();
       }
 
       const existingThreadId =
@@ -232,7 +231,7 @@ export const resolveAutoBootstrapWelcomeTargets = Effect.gen(function* () {
           threadId: createdThreadId,
           projectId: nextProjectId,
           title: "New thread",
-          modelSelection: nextProjectDefaultModelSelection,
+          modelSelection: nextThreadModelSelection,
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "full-access",
           branch: null,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -157,11 +157,7 @@ import {
 } from "./ThreadCommandSubtitle";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
-import {
-  deriveProviderInstanceEntries,
-  resolveDefaultProviderModelSelection,
-  type ProviderInstanceEntry,
-} from "../providerInstances";
+import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
 import { resolveShortcutCommand, threadJumpIndexFromCommand } from "../keybindings";
 import { CommandDialog, CommandDialogPopup, CommandFooterAction } from "./ui/command";
 import { Button } from "./ui/button";
@@ -1873,10 +1869,6 @@ function OpenCommandPaletteDialog(props: {
       }
 
       const projectId = newProjectId();
-      const targetEnvironmentProviders =
-        environments.find((environment) => environment.environmentId === input.environmentId)
-          ?.serverConfig?.providers ??
-        (input.environmentId === primaryEnvironmentId ? providers : []);
       const createResult = await createProject({
         environmentId: input.environmentId,
         input: {
@@ -1884,10 +1876,7 @@ function OpenCommandPaletteDialog(props: {
           title: inferProjectTitleFromPath(cwd),
           workspaceRoot: cwd,
           createWorkspaceRootIfMissing: true,
-          defaultModelSelection: resolveDefaultProviderModelSelection(
-            targetEnvironmentProviders,
-            null,
-          ),
+          defaultModelSelection: null,
         },
       });
       if (createResult._tag === "Failure") {

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -69,7 +69,7 @@ describe("getComposerProviderState", () => {
     );
   });
 
-  it("returns descriptor defaults when no selections are provided", () => {
+  it("uses descriptor defaults for display without dispatching them as overrides", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,
       model: MODEL,
@@ -86,7 +86,7 @@ describe("getComposerProviderState", () => {
     expect(state).toEqual({
       provider: PROVIDER,
       promptEffort: "high",
-      modelOptionsForDispatch: selections(["effort", "high"]),
+      modelOptionsForDispatch: undefined,
     });
   });
 
@@ -165,9 +165,7 @@ describe("getComposerProviderState", () => {
     });
 
     expect(state.promptEffort).toBe("high");
-    expect(state.modelOptionsForDispatch).toEqual(
-      selections(["effort", "high"], ["contextWindow", "200k"], ["agent", "plan"]),
-    );
+    expect(state.modelOptionsForDispatch).toEqual(selections(["agent", "plan"]));
   });
 
   it("drops the plan agent from dispatch when legacy plan mode is disabled", () => {
@@ -219,7 +217,7 @@ describe("getComposerProviderState", () => {
       planModeEnabled: false,
     });
 
-    expect(state.modelOptionsForDispatch).toEqual(selections(["agent", "research"]));
+    expect(state.modelOptionsForDispatch).toBeUndefined();
   });
 
   it("returns undefined dispatch options when the model declares no descriptors", () => {

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -6,7 +6,7 @@ import {
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import {
-  buildProviderOptionSelectionsFromDescriptors,
+  buildExplicitProviderOptionSelectionsFromDescriptors,
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
@@ -94,7 +94,10 @@ export function getComposerProviderState(input: ComposerProviderStateInput): Com
   return {
     provider,
     promptEffort,
-    modelOptionsForDispatch: buildProviderOptionSelectionsFromDescriptors(descriptors),
+    modelOptionsForDispatch: buildExplicitProviderOptionSelectionsFromDescriptors(
+      descriptors,
+      modelOptions,
+    ),
     ...(ultrathinkActive
       ? {
           composerFrameClassName: "ultrathink-frame",

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -52,6 +52,16 @@ On mobile, the model picker shows each OpenCode model's upstream provider, such 
 GitHub Copilot, or OpenCode Zen, beneath its name. Search by that provider name to narrow the list
 when starting a thread or changing an existing thread's model.
 
+## Model defaults
+
+T3 Code remembers the last provider, model, and model options you selected and reuses that
+selection for new threads. A model configured in a project's settings overrides the remembered
+selection for that project; resetting the project setting returns it to the remembered selection.
+
+Model options shown as provider defaults remain display values until you choose them in T3 Code.
+T3 Code only sends options you selected explicitly, so an unset reasoning level or service tier can
+still come from the provider's own configuration.
+
 ## Quote an assistant response
 
 On web and desktop, select text in an assistant response, then choose **Cite in composer** from the

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -708,6 +708,8 @@ export const ProjectCreateCommand = Schema.Struct({
   title: TrimmedNonEmptyString,
   workspaceRoot: TrimmedNonEmptyString,
   createWorkspaceRootIfMissing: Schema.optional(Schema.Boolean),
+  // Retained for older clients that sent an automatic create-time seed. The
+  // server ignores it; explicit project defaults use project.meta.update.
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   createdAt: IsoDateTime,
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -3,6 +3,7 @@ import { ProviderInstanceId, type ModelCapabilities } from "@t3tools/contracts";
 
 import {
   applyClaudePromptEffortPrefix,
+  buildExplicitProviderOptionSelectionsFromDescriptors,
   buildProviderOptionSelectionsFromDescriptors,
   createModelCapabilities,
   createModelSelection,
@@ -109,6 +110,22 @@ describe("descriptor helpers", () => {
       { id: "reasoningEffort", value: "high" },
       { id: "fastMode", value: true },
     ]);
+  });
+
+  it("builds dispatch options only from explicit selections", () => {
+    const descriptors = getProviderOptionDescriptors({
+      caps: codexCaps,
+      selections: [{ id: "fastMode", value: true }],
+    });
+
+    expect(buildExplicitProviderOptionSelectionsFromDescriptors(descriptors, undefined)).toBe(
+      undefined,
+    );
+    expect(
+      buildExplicitProviderOptionSelectionsFromDescriptors(descriptors, [
+        { id: "fastMode", value: true },
+      ]),
+    ).toEqual([{ id: "fastMode", value: true }]);
   });
 
   it("stores option selection arrays in model selections", () => {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -204,6 +204,20 @@ export function buildProviderOptionSelectionsFromDescriptors(
   return nextSelections.length > 0 ? nextSelections : undefined;
 }
 
+export function buildExplicitProviderOptionSelectionsFromDescriptors(
+  descriptors: ReadonlyArray<ProviderOptionDescriptor> | null | undefined,
+  selections: ReadonlyArray<ProviderOptionSelection> | null | undefined,
+): Array<ProviderOptionSelection> | undefined {
+  if (!selections || selections.length === 0) {
+    return undefined;
+  }
+  const explicitIds = new Set(selections.map((selection) => selection.id));
+  const normalized = buildProviderOptionSelectionsFromDescriptors(descriptors)?.filter(
+    (selection) => explicitIds.has(selection.id),
+  );
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
 export function isClaudeUltrathinkPrompt(text: string | null | undefined): boolean {
   return typeof text === "string" && /\bultrathink\b/i.test(text);
 }


### PR DESCRIPTION
New projects were saving an automatically resolved model as a project override, so stale project records beat the app-wide last selection and missing options became catalog defaults such as Sol/Low.

Following the persistence issue identified in #8913, project creation now stays unconfigured: new threads reuse the last provider, model, and options unless the user explicitly sets a per-project override. Migration 44 clears old create-time seeds only when no later project-default write exists, and web and mobile send only options selected in T3, so real project overrides survive while the bad upgrade state disappears.

## How it works

T3 still remembers the last provider, model, and options across projects. A project setting wins only when the user explicitly sets one. New projects no longer save an inferred override, and migration 44 removes old create-time seeds without touching later explicit settings. The clients also dispatch only options the user selected, so a displayed catalog default does not become saved state.

## Before and after

Same browser, project, and database in both shots: select **High**, start a thread, then open another new thread.

### Before

The base commit reopened the next thread on **Low** because the project's inferred default overrode the remembered selection.

![Before: a new thread reset GPT-5.6-Sol to Low](https://uploads-production-47e4.up.railway.app/files/6bc3be6a-697a-496c-983c-5b84a842f9b7/sticky-model-before.png)

### After

After migration 44 and the sticky-selection fix, the next thread stays on **High**.

![After: a new thread keeps GPT-5.6-Sol on High](https://uploads-production-47e4.up.railway.app/files/495bf322-8f23-4804-9255-6346190b746a/sticky-model-after.png)

Verified with 158 focused tests, targeted lint and formatting, and typechecks for contracts, shared, server, web, and mobile. Built with gpt-5.6-sol through the Codex harness in T3 Code.

Closes #8829.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration event semantics, a data migration on existing SQLite stores, and what model/options are sent to providers—behavior changes for new threads and legacy project records, though explicit overrides are preserved.
> 
> **Overview**
> **Fixes sticky model selection** by stopping automatic project defaults from overriding the app-wide “last used” model and by not persisting catalog option defaults as if the user chose them.
> 
> **Project defaults** are now **explicit only**: `project.create` always records `defaultModelSelection: null` (older clients may still send the field; the server ignores it). Web command-palette and CLI project add, plus auto-bootstrap startup, no longer attach a resolved model to new projects; welcome bootstrap still seeds the **first thread** via `getAutoBootstrapThreadModelSelection`. **Migration 044** clears projection and `project.created` payloads for create-time seeds when no later `project.meta-updated` set a default, while keeping user-configured project defaults.
> 
> **Provider model options** use `buildExplicitProviderOptionSelectionsFromDescriptors` on web, mobile, and shared code: UI can show descriptor defaults, but dispatch and stored selections include **only options the user picked**. User docs describe remembered selection vs project override and explicit options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649672aad41be6b5b48f91746521e79b707d0b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sticky model selections by dispatching only explicit options and clearing inferred project defaults
> - Adds `buildExplicitProviderOptionSelectionsFromDescriptors` in [model.ts](https://github.com/pingdotgg/t3code/pull/9164/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505) to return only explicitly selected option IDs, replacing descriptor-default materialization across mobile, web, and server dispatch paths
> - Server `project.create` decider now always writes `null` for the default model selection in `project.created` events; the command field is retained for compatibility but ignored
> - Migration 044 in [044_ClearAutomaticProjectModelDefaults.ts](https://github.com/pingdotgg/t3code/pull/9164/files#diff-a5d98c4f4e58d76753b9a526403d3bfeb4b0fde08183120d79d698e73b16858e) clears inferred create-time model defaults from project projections and rewrites matching `project.created` event payloads to `null`, preserving streams with a later explicit metadata update
> - Auto-bootstrap welcome-thread creation no longer attaches a model default to the project; the welcome thread receives the canonical selection directly
> - **Behavioral Change:** `ProjectCreateCommand` default model field is now ignored by the server; clients must use project metadata updates to set explicit defaults. Existing projects with inferred defaults from create-time will have those defaults cleared by migration 044
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 649672a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
