### PR TITLE
fix(chat): replace failed tools with thinking

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1198,7 +1198,9 @@ describe("deriveMessagesTimelineRows", () => {
   });
 
   it("reuses one activity row for initial thinking and the latest tool", () => {
-    const deriveRows = (toolLifecycleStatus: "inProgress" | "completed" | "declined" | null) =>
+    const deriveRows = (
+      toolLifecycleStatus: "inProgress" | "completed" | "failed" | "declined" | null,
+    ) =>
       deriveMessagesTimelineRows({
         timelineEntries:
           toolLifecycleStatus === null
@@ -1235,6 +1237,7 @@ describe("deriveMessagesTimelineRows", () => {
     const initialRows = deriveRows(null);
     const runningRows = deriveRows("inProgress");
     const completedRows = deriveRows("completed");
+    const failedRows = deriveRows("failed");
     const declinedRows = deriveRows("declined");
     const initialActivityRow = initialRows.find((row) => row.id === "live-activity-row");
     const runningActivityRow = runningRows.find((row) => row.id === "live-activity-row");
@@ -1243,11 +1246,14 @@ describe("deriveMessagesTimelineRows", () => {
     expect(initialActivityRow).toMatchObject({ kind: "thinking" });
     expect(runningActivityRow).toMatchObject({ kind: "work-live", active: true });
     expect(completedActivityRow).toMatchObject({ kind: "work-live", active: true });
+    expect(failedRows.some((row) => row.kind === "work-live")).toBe(false);
+    expect(failedRows.at(-1)).toMatchObject({ kind: "thinking", id: "live-activity-row" });
     expect(declinedRows.find((row) => row.kind === "work-live")).toMatchObject({ active: false });
     expect(declinedRows.at(-1)).toMatchObject({ kind: "thinking", id: "live-activity-row" });
     expect(initialRows.filter((row) => row.id === "live-activity-row")).toHaveLength(1);
     expect(runningRows.filter((row) => row.id === "live-activity-row")).toHaveLength(1);
     expect(completedRows.filter((row) => row.id === "live-activity-row")).toHaveLength(1);
+    expect(failedRows.filter((row) => row.id === "live-activity-row")).toHaveLength(1);
     expect(declinedRows.filter((row) => row.id === "live-activity-row")).toHaveLength(1);
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1219,6 +1219,7 @@ describe("deriveMessagesTimelineRows", () => {
                     requestKind: "command",
                     tone: "tool" as const,
                     toolLifecycleStatus,
+                    ...(toolLifecycleStatus === "inProgress" ? { detail: "exit code 1" } : {}),
                   },
                 },
               ],

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -602,6 +602,7 @@ export function deriveMessagesTimelineRows(input: {
     workEntryIsActiveTurnActivity(entry.entry),
   );
   const latestToolFailed =
+    latestRunningToolEntry === undefined &&
     latestVisibleToolEntry !== undefined &&
     latestVisibleToolEntry.entry.toolLifecycleStatus !== "declined" &&
     workEntryDisplayIndicatesToolFailure(latestVisibleToolEntry.entry);
@@ -844,7 +845,7 @@ export function deriveMessagesTimelineRows(input: {
   if (input.isWorking && activeTurnHeaderIndex === input.timelineEntries.length) {
     appendWorkingRow();
   }
-  if (input.isWorking && !hasActivityRow) {
+  if (input.isWorking && (!hasActivityRow || latestToolFailed)) {
     nextRows.push({
       kind: "thinking",
       id: LIVE_ACTIVITY_ROW_ID,

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -601,13 +601,17 @@ export function deriveMessagesTimelineRows(input: {
   const latestRunningToolEntry = visibleActiveToolEntries.findLast((entry) =>
     workEntryIsActiveTurnActivity(entry.entry),
   );
+  const latestToolFailed =
+    latestVisibleToolEntry !== undefined &&
+    latestVisibleToolEntry.entry.toolLifecycleStatus !== "declined" &&
+    workEntryDisplayIndicatesToolFailure(latestVisibleToolEntry.entry);
   const latestToolKeepsActivityLive =
     latestRunningToolEntry !== undefined ||
     (latestVisibleToolEntry !== undefined &&
       workEntryIndicatesToolSuccess(latestVisibleToolEntry.entry));
   const activeWorkPlacementEntryId = latestVisibleToolEntry?.id;
   const activeWorkRow =
-    activeWorkAnchor && latestVisibleToolEntry
+    activeWorkAnchor && latestVisibleToolEntry && !latestToolFailed
       ? (() => {
           const groupId = workGroupId(activeWorkAnchor.id, activeWorkAnchor.entry);
           return {
@@ -625,7 +629,7 @@ export function deriveMessagesTimelineRows(input: {
         })()
       : null;
   const activeWorkEntryIds = new Set(
-    activeWorkRow === null ? [] : activeToolEntries.map((entry) => entry.id),
+    activeWorkRow !== null || latestToolFailed ? activeToolEntries.map((entry) => entry.id) : [],
   );
   const appendWorkingRow = () => {
     nextRows.push({


### PR DESCRIPTION
Failed tool calls stayed visible as a terminal activity row while `Thinking` was appended beneath them. This returns the shared live activity row to `Thinking` after a failure, while preserving the failed tool in history once the active run moves on.

Verified with the focused timeline test, web typecheck, targeted lint and formatting, and the same seeded browser fixture at 1280x800 in dark mode.

| before | after |
| --- | --- |
| ![failed tool above thinking](https://uploads-production-47e4.up.railway.app/files/037078ba-7b4f-4e51-9c6e-47fcf172648f/t3-failed-tool-before.png) | ![thinking replaces failed tool](https://uploads-production-47e4.up.railway.app/files/5ff095b7-924e-4f68-81fd-003335a65875/t3-failed-tool-after.png) |

Implemented by `gpt-5.6-sol` in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat timeline row derivation and covered by a focused unit test; no auth, data, or API changes.
> 
> **Overview**
> While a turn is still running, a **failed** latest tool no longer occupies the shared live activity slot as a terminal `work-live` row with **Thinking** stacked underneath.
> 
> `deriveMessagesTimelineRows` now treats the latest visible non-declined tool as failed when nothing is still running and `workEntryDisplayIndicatesToolFailure` applies. In that case it skips building the active `work-live` row, still consumes those tool timeline entries so they are not duplicated inline, and emits the single `live-activity-row` as **thinking** (same pattern as declined tools). In-progress and successful tools keep the existing live tool behavior.
> 
> Tests cover the `failed` lifecycle path and assert there is no `work-live` row and only one thinking activity row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ceea1e08d905938b3c63a5e5af83a1155f0d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace failed tool rows with thinking activity in `deriveMessagesTimelineRows`
> When the latest visible tool fails (and is not declined, with no tool running), the timeline now appends a live thinking activity row instead of a work-live row. Failed tools remain in the active-work entry set so they still appear in the timeline. Added test coverage for the failed-tool lifecycle in [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9165/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75ceea1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->