### PR TITLE
feat(web): copy the full error report from the error page

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,9 +8,10 @@ import {
   useLocation,
   useNavigate,
 } from "@tanstack/react-router";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 
-import { APP_BASE_NAME, APP_DISPLAY_NAME, APP_STAGE_LABEL } from "../branding";
+import { APP_BASE_NAME, APP_DISPLAY_NAME, APP_STAGE_LABEL, APP_VERSION } from "../branding";
 import { resolveServerBackedAppDisplayName } from "../branding.logic";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
@@ -22,6 +23,7 @@ import { DesktopAppActivationCoordinator } from "../components/desktop/DesktopAp
 import { ProviderUpdateLaunchNotification } from "../components/ProviderUpdateLaunchNotification";
 import { SlowRpcRequestToastCoordinator } from "../components/SlowRpcRequestToastCoordinator";
 import { ThemeEditorHost } from "../components/settings/ThemeEditorHost";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useDefaultThemeAdoption } from "../hooks/useDefaultTheme";
 import { useEnvironmentThemeSync } from "../hooks/useEnvironmentTheme";
 import { Button } from "../components/ui/button";
@@ -267,7 +269,7 @@ function HostedStaticEnvironmentBootstrap() {
 
 function RootRouteErrorView({ error, reset }: ErrorComponentProps) {
   const message = errorMessage(error);
-  const details = errorDetails(error);
+  const report = useMemo(() => errorReport(error), [error]);
 
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
@@ -292,19 +294,29 @@ function RootRouteErrorView({ error, reset }: ErrorComponentProps) {
           <Button size="sm" variant="outline" onClick={() => window.location.reload()}>
             Reload app
           </Button>
+          <CopyErrorButton report={report} />
         </div>
 
-        <details className="group mt-5 overflow-hidden rounded-lg border border-border/70 bg-background/55">
-          <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-muted-foreground">
-            <span className="group-open:hidden">Show error details</span>
-            <span className="hidden group-open:inline">Hide error details</span>
-          </summary>
-          <pre className="max-h-56 overflow-auto border-t border-border/70 bg-background/80 px-3 py-2 text-xs text-foreground/85">
-            {details}
+        <div className="mt-5 overflow-hidden rounded-lg border border-border/70 bg-background/55">
+          <p className="px-3 py-1.5 text-xs font-medium text-muted-foreground">Error report</p>
+          <pre className="max-h-64 overflow-auto border-t border-border/70 bg-background/80 px-3 py-2 text-xs whitespace-pre-wrap text-foreground/85">
+            {report}
           </pre>
-        </details>
+        </div>
       </section>
     </div>
+  );
+}
+
+/** Copies the full error report and swaps to a check mark for a moment as confirmation. */
+function CopyErrorButton({ report }: { report: string }) {
+  const { copyToClipboard, isCopied } = useCopyToClipboard({ target: "error-report" });
+
+  return (
+    <Button size="sm" variant="outline" onClick={() => copyToClipboard(report)}>
+      {isCopied ? <CheckIcon className="text-success" /> : <CopyIcon />}
+      {isCopied ? "Copied" : "Copy error"}
+    </Button>
   );
 }
 
@@ -334,6 +346,29 @@ function errorDetails(error: unknown): string {
   } catch {
     return "No additional error details are available.";
   }
+}
+
+const MAX_ERROR_CAUSE_DEPTH = 5;
+
+/**
+ * Full error text for bug reports: app build, page path, time, then the stack
+ * and any cause chain. Uses the pathname only so tokens in the query never
+ * land on the clipboard.
+ */
+function errorReport(error: unknown): string {
+  const lines = [
+    `${APP_DISPLAY_NAME} ${APP_VERSION}`,
+    `Path: ${window.location.pathname}`,
+    `Time: ${new Date().toISOString()}`,
+    "",
+    errorDetails(error),
+  ];
+  let cause = error instanceof Error ? error.cause : undefined;
+  for (let depth = 0; cause !== undefined && depth < MAX_ERROR_CAUSE_DEPTH; depth += 1) {
+    lines.push("", "Caused by:", errorDetails(cause));
+    cause = cause instanceof Error ? cause.cause : undefined;
+  }
+  return lines.join("\n");
 }
 
 function AuthenticatedTracingBootstrap() {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -269,7 +269,9 @@ function HostedStaticEnvironmentBootstrap() {
 
 function RootRouteErrorView({ error, reset }: ErrorComponentProps) {
   const message = errorMessage(error);
-  const report = useMemo(() => errorReport(error), [error]);
+  // Router pathname rather than window.location: desktop uses hash history, where the window path is always "/".
+  const pathname = useLocation({ select: (location) => location.pathname });
+  const report = useMemo(() => errorReport(error, pathname), [error, pathname]);
 
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
@@ -352,13 +354,13 @@ const MAX_ERROR_CAUSE_DEPTH = 5;
 
 /**
  * Full error text for bug reports: app build, page path, time, then the stack
- * and any cause chain. Uses the pathname only so tokens in the query never
+ * and any cause chain. Takes the pathname only so tokens in the query never
  * land on the clipboard.
  */
-function errorReport(error: unknown): string {
+function errorReport(error: unknown, pathname: string): string {
   const lines = [
     `${APP_DISPLAY_NAME} ${APP_VERSION}`,
-    `Path: ${window.location.pathname}`,
+    `Path: ${pathname}`,
     `Time: ${new Date().toISOString()}`,
     "",
     errorDetails(error),


### PR DESCRIPTION
When the app hits the root error page, the stack trace is hidden behind a collapsed "Show error details" toggle and there is no way to copy it. Users reporting a crash have to select text out of a scrolling pre by hand, and lose the app version and page they were on.

The error page now shows an always-open error report and a Copy error button next to Try again and Reload app. The report contains the app name and version, the page path, an ISO timestamp, the stack, and up to five levels of the cause chain. The path excludes the query string so pairing tokens never reach the clipboard. Copying uses the existing clipboard hook and flips the button to a check mark for two seconds.

## Before

![Error page before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/94a35d1f-3c75-4228-8ecf-d071bd9f3df8/error-page-before.png)

## After

![Error page after](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/af94855e-8b70-4bd5-8ae3-eb54d27ce737/error-page-after.png)

Made with Claude Fable 5.1 in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes on the error boundary and clipboard copy of client-side error text; no auth, persistence, or core routing logic changes.
> 
> **Overview**
> The root router error page now surfaces a **always-visible error report** instead of a collapsed “Show error details” section, so users can see context without expanding a `<details>` block.
> 
> A **Copy error** action (via `useCopyToClipboard`) copies a formatted report that includes app name/version, router **pathname** (not the query string, to avoid leaking tokens), ISO timestamp, stack/details, and up to five **`Error.cause`** levels. Pathname comes from TanStack Router so desktop hash history still records the real route. The copy button shows brief “Copied” / check feedback.
> 
> The report panel uses wrapping and a slightly taller scroll area than the old hidden pre block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ff7bf8f0b6f959d7052ed0b073d5841f27ca112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add copy-to-clipboard button for full error report on error page
> Replaces the expandable error-details disclosure in `RootRouteErrorView` with an always-visible error report panel and a new `CopyErrorButton` that copies the report and shows a copied confirmation state.
> - The `errorReport` formatter assembles app name and version, router pathname, ISO timestamp, error details, and up to five nested `Error` cause entries into a newline-separated string.
> - The pathname is taken from router state rather than `window.location`, so query-string content is excluded from the report.
> - Behavioral Change: error details are now always visible instead of behind a disclosure toggle.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9ff7bf8. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->