### PR TITLE
fix(web): prevent loading ssh environments from overriding navigation

### DIFF
--- a/apps/web/src/hooks/useHandleNewThread.test.ts
+++ b/apps/web/src/hooks/useHandleNewThread.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => {
+  let completeProjectFileRead: (value: null) => void = () => undefined;
+  let projectFileRead = Promise.resolve<null>(null);
+  let storedDraft: {
+    readonly draftId: string;
+    readonly environmentId: string;
+    readonly promotedTo: null;
+    readonly threadId: string;
+  } | null = null;
+  const router = {
+    state: {
+      location: { href: "/" },
+      matches: [{ params: {} }],
+    },
+    navigate: vi.fn(async (request: { readonly params: { readonly draftId: string } }) => {
+      router.state.location.href = `/draft/${request.params.draftId}`;
+    }),
+  };
+  const draftStore = {
+    getComposerDraft: vi.fn(() => ({})),
+    getDraftSessionByLogicalProjectKey: vi.fn(() => storedDraft),
+    getDraftSession: vi.fn(() => null),
+    getDraftThread: vi.fn(() => null),
+    applyStickyState: vi.fn(),
+    setDraftThreadContext: vi.fn(),
+    setLogicalProjectDraftThreadId: vi.fn(),
+    setModelSelection: vi.fn(),
+  };
+
+  return {
+    completeProjectFileRead: (value: null) => completeProjectFileRead(value),
+    draftStore,
+    get projectFileRead() {
+      return projectFileRead;
+    },
+    reset(nextStoredDraft: typeof storedDraft) {
+      storedDraft = nextStoredDraft;
+      router.state.location.href = "/";
+      router.navigate.mockClear();
+      draftStore.setLogicalProjectDraftThreadId.mockClear();
+      projectFileRead = new Promise<null>((resolve) => {
+        completeProjectFileRead = resolve;
+      });
+    },
+    router,
+  };
+});
+
+vi.mock("@effect/atom-react", () => ({
+  useAtomValue: () => ({ defaultThreadEnvMode: "local", newWorktreesStartFromOrigin: false }),
+}));
+vi.mock("@t3tools/client-runtime/environment", () => ({
+  scopedProjectKey: () => "remote-project",
+  scopeProjectRef: (environmentId: string, projectId: string) => ({ environmentId, projectId }),
+  scopeThreadRef: (environmentId: string, threadId: string) => ({ environmentId, threadId }),
+}));
+vi.mock("@t3tools/contracts", () => ({ DEFAULT_RUNTIME_MODE: "default" }));
+vi.mock("@t3tools/shared/threadEnvMode", () => ({
+  resolveDefaultThreadEnvMode: (input: {
+    readonly projectFile: "local" | "worktree" | null;
+    readonly globalDefault: "local" | "worktree";
+  }) => input.projectFile ?? input.globalDefault,
+}));
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => null,
+  useRouter: () => testState.router,
+}));
+vi.mock("react", () => ({
+  useCallback: <T>(callback: T) => callback,
+  useMemo: <T>(factory: () => T) => factory(),
+}));
+vi.mock("../components/Sidebar.logic", () => ({ orderItemsByPreferredIds: () => [] }));
+vi.mock("../composerDraftStore", () => {
+  const useComposerDraftStore = Object.assign(() => null, {
+    getState: () => testState.draftStore,
+  });
+  return {
+    composerDraftHasUserContent: () => false,
+    markPromotedDraftThreadByRef: vi.fn(),
+    useComposerDraftStore,
+  };
+});
+vi.mock("../lib/chatThreadActions", () => ({
+  hasExplicitComposerModelSelection: () => false,
+  resolveNewDraftStartFromOrigin: () => false,
+  resolveNewThreadModelSelectionOverride: () => null,
+}));
+vi.mock("../lib/t3ProjectFileDefaults", () => ({
+  readT3ProjectFileDefaultThreadEnvMode: () => testState.projectFileRead,
+}));
+vi.mock("../lib/utils", () => ({
+  newDraftId: () => "draft-delayed",
+  newThreadId: () => "thread-delayed",
+}));
+vi.mock("../logicalProject", () => ({
+  deriveLogicalProjectKeyFromSettings: () => "remote-project",
+  getProjectOrderKey: () => "remote-project",
+  selectProjectGroupingSettings: () => ({}),
+}));
+vi.mock("../state/entities", () => ({
+  readProjects: () => [
+    {
+      id: "project-remote",
+      environmentId: "environment-ssh",
+      workspaceRoot: "/remote/project",
+      defaultThreadEnvMode: null,
+      defaultModelSelection: null,
+    },
+  ],
+  readThreadShell: () => null,
+  useProjects: () => [],
+  useThread: () => null,
+}));
+vi.mock("../state/server", () => ({ primaryServerSettingsAtom: {} }));
+vi.mock("../threadRoutes", () => ({ resolveThreadRouteTarget: () => null }));
+vi.mock("../uiStateStore", () => ({
+  legacyProjectCwdPreferenceKey: () => "remote-project",
+  useUiStateStore: () => [],
+}));
+vi.mock("./useSettings", () => ({ useClientSettings: () => ({}) }));
+
+import { useNewThreadHandler } from "./useHandleNewThread";
+
+describe("useNewThreadHandler", () => {
+  it.each([
+    ["new", null],
+    [
+      "reusable",
+      {
+        draftId: "draft-existing",
+        environmentId: "environment-ssh",
+        promotedTo: null,
+        threadId: "thread-existing",
+      },
+    ],
+  ])("abandons a delayed %s draft open when the user navigates elsewhere", async (_, draft) => {
+    testState.reset(draft);
+    const openThread = useNewThreadHandler();
+    const pendingOpen = openThread(
+      { environmentId: "environment-ssh", projectId: "project-remote" } as never,
+      { replace: true },
+    );
+
+    testState.router.state.location.href = "/usage";
+    testState.completeProjectFileRead(null);
+    await pendingOpen;
+
+    expect(testState.router.state.location.href).toBe("/usage");
+    expect(testState.router.navigate).not.toHaveBeenCalled();
+    expect(testState.draftStore.setLogicalProjectDraftThreadId).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -93,6 +93,8 @@ export function useNewThreadHandler() {
         setLogicalProjectDraftThreadId,
         setModelSelection,
       } = useComposerDraftStore.getState();
+      const requestingRouteHref = router.state.location.href;
+      const routeChangedSinceRequest = () => router.state.location.href !== requestingRouteHref;
       const currentRouteTarget = getCurrentRouteTarget();
       // A new thread carries the user's working mode from the thread being
       // viewed. The target project's configured model still wins; runtime and
@@ -219,6 +221,9 @@ export function useNewThreadHandler() {
             workspaceContext = pickExplicitWorkspaceOptions(options);
           } else if (!isDraftAlreadyOpen) {
             const defaultEnvMode = await resolveDefaultEnvMode();
+            if (routeChangedSinceRequest()) {
+              return null;
+            }
             // The await yields. If the draft was opened (a concurrent
             // invocation's navigation landed), promoted to a real thread,
             // remapped away (a concurrent invocation registered a fresh
@@ -355,6 +360,9 @@ export function useNewThreadHandler() {
       const createdAt = new Date().toISOString();
       return (async () => {
         const initialEnvMode = options?.envMode ?? (await resolveDefaultEnvMode());
+        if (routeChangedSinceRequest()) {
+          return null;
+        }
         // The await yields, so a concurrent invocation may have registered a
         // draft for this logical project in the meantime. Registering ours
         // too would evict that draft while its navigation is in flight —


### PR DESCRIPTION
Basically, the navigation jumps around once the remote environment lazily loads. This fixes it!

> [!NOTE]
> 🤖 **GPT-5.6 Sol on behalf of Oliver**

## Problem

Starting a new draft can pause before navigation finishes. For SSH projects, resolving the draft's default environment mode can wait on the remote `t3.json` read.

If the user navigates to another page or thread during that wait, the delayed draft handler still redirects them when the read finishes.

## Fix

Capture the route when a new-thread request starts. After a delayed project-default read finishes, stop the request if the user has navigated elsewhere.

The regression test covers both a new draft and a reusable empty draft while the user navigates elsewhere.

## UI changes

### Before

<!-- Add before recording here -->

https://github.com/user-attachments/assets/3084222c-0beb-4e2c-ab4e-cfb26414c2ad

### After

<!-- Add after recording here -->



https://github.com/user-attachments/assets/9789196a-a498-494e-863f-476b49c3d7de



## Verification

- `vp test run apps/web/src/hooks/useHandleNewThread.test.ts`, 2 tests passed
- `vp lint apps/web/src/hooks/useHandleNewThread.ts apps/web/src/hooks/useHandleNewThread.test.ts --report-unused-disable-directives`
- `vp fmt --check apps/web/src/hooks/useHandleNewThread.ts apps/web/src/hooks/useHandleNewThread.test.ts`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check origin/main...HEAD`

Changes prepared by GPT-5.6 Sol through Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `useNewThreadHandler` to abort on navigation during async default read
> - Captures the router URL when each new-thread request starts and returns null after the async default environment-mode read if the URL changed, preventing stale navigation or draft remapping.
> - Covers both the existing-draft workspace-context path and the new-draft creation path in [useHandleNewThread.ts](https://github.com/pingdotgg/t3code/pull/9168/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef).
> - Adds a parameterized regression test in [useHandleNewThread.test.ts](https://github.com/pingdotgg/t3code/pull/9168/files#diff-7fdc21ade7bcc925965469bbed3e2585ef0ec6a21df490998fccd65b3968203f) that simulates navigation during the pending read and asserts no navigation or draft assignment occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c6d881.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->