### PR TITLE
fix(chat): align failed task progress test

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1370,7 +1370,7 @@ describe("deriveMessagesTimelineRows", () => {
     [undefined, true],
     ["inProgress", true],
     ["completed", false],
-    ["failed", false],
+    ["failed", null],
     ["declined", false],
     ["stopped", false],
   ] as const)(
@@ -1406,7 +1406,13 @@ describe("deriveMessagesTimelineRows", () => {
         revertTurnCountByUserMessageId: new Map(),
       });
 
-      expect(rows.find((row) => row.kind === "work-live")).toMatchObject({ active });
+      const workLiveRow = rows.find((row) => row.kind === "work-live");
+      if (active === null) {
+        expect(workLiveRow).toBeUndefined();
+        expect(rows.at(-1)).toMatchObject({ kind: "thinking", id: "live-activity-row" });
+      } else {
+        expect(workLiveRow).toMatchObject({ active });
+      }
     },
   );
 


### PR DESCRIPTION
the failed task progress case still expected a work-live row after the merged behavior replaced failed tools with thinking. this updates the existing lifecycle test to assert that failed progress removes work-live and restores the thinking row. verified with the 77-test timeline suite, targeted lint/format, and the web typecheck.

written by `gpt-5.6-sol` through the codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts unit test expectations in the messages timeline suite; no runtime chat UI behavior changes.
> 
> **Overview**
> Updates the parameterized **trailing task progress** lifecycle test so the **`failed`** case matches current timeline behavior: failed progress no longer produces a **`work-live`** row with `active: false`.
> 
> The test now treats **`failed`** like “no live work row” (`active: null`) and asserts the timeline ends with the shared **`thinking`** row (`live-activity-row`). Other lifecycle cases (`inProgress`, `completed`, `declined`, `stopped`) are unchanged.
> 
> **Test-only** change—no production timeline logic in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98056dfa09e475da161db8306c7f8057ee25172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix failed task progress assertion in `deriveMessagesTimelineRows` lifecycle test
> Updates the trailing task progress parameterized case in [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9172/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72) so failed tasks expect a live thinking activity row instead of an inactive work-live row. Active and inactive lifecycle states keep their existing work-live assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e98056d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->