### PR TITLE
fix(pull-requests): expand code tab diffs by default

### DIFF
--- a/apps/web/src/components/pullRequest/pullRequestDiff.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDiff.logic.test.ts
@@ -50,9 +50,9 @@ describe("isLineInFileDiff", () => {
 describe("isFileDiffCollapsed", () => {
   const NO_TOGGLES: ReadonlySet<string> = new Set();
 
-  it("folds every file before the reader has touched anything", () => {
-    expect(isFileDiffCollapsed("a.ts", null, NO_TOGGLES)).toBe(true);
-    expect(isFileDiffCollapsed("b.ts", null, NO_TOGGLES)).toBe(true);
+  it("opens every file before the reader has touched anything", () => {
+    expect(isFileDiffCollapsed("a.ts", null, NO_TOGGLES)).toBe(false);
+    expect(isFileDiffCollapsed("b.ts", null, NO_TOGGLES)).toBe(false);
   });
 
   it("opens every file once the toolbar has asked for it", () => {
@@ -66,12 +66,12 @@ describe("isFileDiffCollapsed", () => {
     expect(isFileDiffCollapsed("b.ts", "folded", NO_TOGGLES)).toBe(true);
   });
 
-  it("keeps a file the reader opened open as the next slice arrives", () => {
-    // The file keys grow with every slice, so the answer for one already open must not depend on
-    // how many of them there are by then.
+  it("keeps a file the reader folded closed as the next slice arrives", () => {
+    // The file keys grow with every slice, so the answer for one already folded must not depend
+    // on how many of them there are by then.
     const toggled = new Set(["b.ts"]);
-    expect(isFileDiffCollapsed("b.ts", null, toggled)).toBe(false);
-    expect(isFileDiffCollapsed("c.ts", null, toggled)).toBe(true);
+    expect(isFileDiffCollapsed("b.ts", null, toggled)).toBe(true);
+    expect(isFileDiffCollapsed("c.ts", null, toggled)).toBe(false);
   });
 
   it("still answers to a toggle after either toolbar press", () => {

--- a/apps/web/src/components/pullRequest/pullRequestDiff.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDiff.logic.ts
@@ -30,15 +30,14 @@ export type DiffFoldOverride = "expanded" | "folded" | null;
  * A diff arrives a slice at a time, so the reader's own choices are kept as the difference from
  * what the toolbar last said rather than as the set of folded files: a file that has not loaded
  * yet cannot be in a set, and would otherwise land expanded moments after the reader folded
- * everything. Folded is the starting point whatever the change's size, because laying out every
- * file of it costs the reader the seconds before the tab is usable and buries the file they came
- * for among the ones they did not.
+ * everything. Files start expanded so opening the Code tab immediately shows the change; the
+ * reader can still fold individual files or the whole diff from the toolbar.
  */
 export function isFileDiffCollapsed(
   fileKey: string,
   foldOverride: DiffFoldOverride,
   toggledFileKeys: ReadonlySet<string>,
 ): boolean {
-  const foldedByDefault = foldOverride !== "expanded";
+  const foldedByDefault = foldOverride === "folded";
   return toggledFileKeys.has(fileKey) ? !foldedByDefault : foldedByDefault;
 }


### PR DESCRIPTION
Pull request code diffs opened with every file collapsed, so entering the Code tab showed only filenames. This makes untouched files start expanded while preserving individual toggles, collapse-all behavior, and the state inherited by later diff pages. Verified with the focused pull request diff tests, web typecheck, lint, and formatting. Built with gpt-5.6-sol through the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX default change in PR diff folding logic with matching unit tests and no auth or data-path impact.
> 
> **Overview**
> **Pull request Code tab diffs now open with every file expanded** instead of collapsed, so readers see hunks immediately rather than a list of filenames.
> 
> The change is in `isFileDiffCollapsed`: the default when the toolbar has not set a global override (`foldOverride === null`) is now *not* folded (`foldedByDefault` only when `foldOverride === "folded"`). **Expand all**, **collapse all**, and per-file toggles (including as new diff slices stream in) keep the same interaction model; only the untouched baseline flips. Unit tests in `pullRequestDiff.logic.test.ts` are updated for the new defaults and toggle semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316e180363aa9088d6793cd94a74db9218a7ae7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand pull request code tab diffs by default
> Updates `isFileDiffCollapsed` in [pullRequestDiff.logic.ts](https://github.com/pingdotgg/t3code/pull/9174/files#diff-649a5e91c117152116822343399c96a121e95252ae1887b2378f0ebeaed7cdd9) so the null state starts files expanded rather than folded. Explicit toolbar overrides and individual file toggles still work as before. Tests in [pullRequestDiff.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9174/files#diff-e8069be0836c745cc1b5f532050f2b070fd90cb6da369f7a2bac725f26eb115a) are updated to match the new default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 316e180.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->