### PR TITLE
fix(web): copy code block selections without markdown

### DIFF
--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -309,6 +309,19 @@ function sanitizedHtmlFrom(container: Element): string {
   return `<meta charset="utf-8">${container.innerHTML}`;
 }
 
+function isSelectionInsideSingleCodeBlock(range: Range, container: Element): boolean {
+  const ancestor = range.commonAncestorContainer;
+  const ancestorElement =
+    ancestor.nodeType === Node.ELEMENT_NODE ? (ancestor as Element) : ancestor.parentElement;
+  if (ancestorElement?.closest("pre")) return true;
+
+  const remainder = container.cloneNode(true) as Element;
+  const codeBlocks = remainder.querySelectorAll("pre");
+  if (codeBlocks.length !== 1) return false;
+  codeBlocks[0]?.remove();
+  return serializeRenderedMarkdownFragment(remainder) === "";
+}
+
 export function chatMarkdownClipboardPayload(
   selection: Selection,
 ): MarkdownClipboardPayload | null {
@@ -319,10 +332,7 @@ export function chatMarkdownClipboardPayload(
     if (range.collapsed) continue;
     const container = document.createElement("div");
     container.appendChild(range.cloneContents());
-    const ancestor = range.commonAncestorContainer;
-    const ancestorElement =
-      ancestor.nodeType === Node.ELEMENT_NODE ? (ancestor as Element) : ancestor.parentElement;
-    if (ancestorElement?.closest("pre")) {
+    if (isSelectionInsideSingleCodeBlock(range, container)) {
       const text = range.toString();
       if (text) {
         texts.push(text);


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-5.6 Sol on behalf of Oliver**

## Problem

Selecting text inside a fenced code block can produce a browser range whose endpoint sits on the block wrapper. T3 treated that as a mixed Markdown selection, so copying a command could include the language tag, code fences, and extra blank lines instead of just the selected code.

For example,

copying
```
`bash cd ~/.t3/worktrees`
```
would copy the surrounding nmarkdown, not just "cd ~/.t3/worktrees"

## Fix

Check the first and last selected text nodes. When both belong to the same `<pre>` element, copy the browser selection as plain text. Selections that cross prose or multiple code blocks still use the existing Markdown serializer.

## UI changes

### Before

<!-- Attach before image or recording here -->

https://github.com/user-attachments/assets/338cf6db-6933-4910-a1d0-af8d5f757ab4


### After

<!-- Attach after image or recording here -->

https://github.com/user-attachments/assets/f33cb711-9d50-405c-8796-68fc70b6d010



## Verification

- `vp lint apps/web/src/markdown-clipboard.ts --report-unused-disable-directives`
- `vp fmt --check apps/web/src/markdown-clipboard.ts`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check origin/main...HEAD`

Changes prepared by GPT-5.6 Sol through Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix copying code block selections to include plain text only
> - Adds `isSelectionInsideSingleCodeBlock` in [markdown-clipboard.ts](https://github.com/pingdotgg/t3code/pull/9175/files#diff-4584df63e01a8b69a0505a0836c9272794c0385577c79484ce7e43b50c06adaa) to detect selections containing exactly one preformatted block with no serialized markdown outside it.
> - Updates `chatMarkdownClipboardPayload` to use this classifier, so single-code-block selections are copied as direct range text and sanitized HTML instead of rendered markdown.
> - Previously, selections whose common ancestor was outside the code block were treated as markdown and serialized incorrectly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2508f3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->