### PR TITLE
fix(web): model info button opens its details on click

### DIFF
--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -254,7 +254,7 @@ export function ProviderModelsSection({
                         <Button
                           size="icon-micro"
                           variant="ghost"
-                          className="text-muted-foreground/60 hover:text-muted-foreground data-pressed:text-muted-foreground"
+                          className="text-muted-foreground/60 hover:text-muted-foreground"
                           aria-label={`Details for ${model.name}`}
                         />
                       }

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -23,6 +23,7 @@ import { sortModelsForProviderInstance } from "../../modelOrdering";
 import { MAX_CUSTOM_MODEL_LENGTH } from "../../modelSelection";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 /**
@@ -244,20 +245,23 @@ export function ProviderModelsSection({
                   {model.name}
                 </span>
                 {hasDetails ? (
-                  <Tooltip>
-                    <TooltipTrigger
+                  <Popover>
+                    <PopoverTrigger
+                      openOnHover
+                      delay={250}
+                      closeDelay={100}
                       render={
                         <Button
                           size="icon-micro"
                           variant="ghost"
-                          className="text-muted-foreground/60 hover:text-muted-foreground"
+                          className="text-muted-foreground/60 hover:text-muted-foreground data-pressed:text-muted-foreground"
                           aria-label={`Details for ${model.name}`}
                         />
                       }
                     >
                       <InfoIcon className="size-3" />
-                    </TooltipTrigger>
-                    <TooltipPopup side="top" className="max-w-56">
+                    </PopoverTrigger>
+                    <PopoverPopup side="top" tooltipStyle className="max-w-56">
                       <div className="space-y-1">
                         <code className="block text-[11px] text-foreground">{model.slug}</code>
                         {capLabels.length > 0 ? (
@@ -270,8 +274,8 @@ export function ProviderModelsSection({
                           </div>
                         ) : null}
                       </div>
-                    </TooltipPopup>
-                  </Tooltip>
+                    </PopoverPopup>
+                  </Popover>
                 ) : null}
                 {isHidden ? (
                   <span className="text-[10px] text-muted-foreground">hidden</span>


### PR DESCRIPTION
The info button next to each model in Settings > Providers > Models showed nothing when clicked or tapped. It was a hover-only tooltip, and Base UI tooltips cancel on pointer down and never open for touch, so the only way to see a model's slug and capabilities was to hover and not click.

The control now uses the same hover-and-click popover pattern as the context window meter. Hover still opens it after a short delay, clicking or tapping opens it too, and Escape or clicking away closes it. Content and styling are unchanged.

## Before

Clicking the info button: nothing appears.

![before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/d9ac6c3b-9b30-4180-a612-d5e7ceaa4251/model-info-click-before.png)

## After

Clicking the info button opens the details.

![after](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/6e2c52e0-31bc-413b-bba6-a47e428b8d8c/model-info-click-after.png)

Made with Claude Fable 5.1 in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI interaction change in settings with no auth, data, or API impact.
> 
> **Overview**
> The model **info** control in **Settings → Providers → Models** no longer uses a hover-only `Tooltip`, which ignored clicks/taps and showed nothing on touch devices.
> 
> It now uses a **`Popover`** with the same hover-and-click pattern as the context window meter (`openOnHover`, 250ms open / 100ms close delay). Slug and capability labels are unchanged; `PopoverPopup` keeps **`tooltipStyle`** so the panel still looks like the old tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b1ad48f1620574370413a8cb9585ac8dcf96a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model info button to open details via `Popover` in `ProviderModelsSection`
> Replaces the `Tooltip` wrapper around model detail controls with a `Popover` in [ProviderModelsSection.tsx](https://github.com/pingdotgg/t3code/pull/9177/files#diff-9fcf1c8de4ed79e2e714793beba3ce13ac2b99ce4d1a51781f270d7377ab90be). The trigger opens on hover with a 250 ms open delay and 100 ms close delay, and the content retains the existing model slug and capability labels with popover tooltip styling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63b1ad4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->