### PR TITLE
fix(providers): discover workspace skills everywhere

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1053,7 +1053,7 @@ export function NewTaskDraftScreen(props: {
       multiline
       scrollEnabled
       value={flow.prompt}
-      skills={flow.selectedProviderStatus?.skills ?? []}
+      skills={composerMenu.skills}
       selection={composerMenu.selection}
       onChangeText={flow.setPrompt}
       onSelectionChange={composerMenu.onSelectionChange}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -652,7 +652,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                 multiline
                 value={props.draftMessage}
                 readOnly={voiceInput.freezesEditor}
-                skills={selectedProviderStatus?.skills ?? []}
+                skills={composerMenu.skills}
                 selection={composerMenu.selection}
                 onChangeText={props.onChangeDraftMessage}
                 onSelectionChange={composerMenu.onSelectionChange}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/client-runtime/codex-artifact-templates";
 import type { EnvironmentThreadStatus } from "@t3tools/client-runtime/state/threads";
 import { useKeyboardChatComposerInset, useKeyboardScrollToEnd } from "@legendapp/list/keyboard";
+import { resolveProviderSkillsForCwd } from "@t3tools/client-runtime/providerSkills";
 import type { LegendListRef } from "@legendapp/list/react-native";
 import { HeaderHeightContext } from "@react-navigation/elements";
 import type {
@@ -510,12 +511,14 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
   const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
   useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
-  const selectedProviderSkills = useMemo(
-    () =>
-      props.serverConfig?.providers.find((provider) => provider.instanceId === selectedInstanceId)
-        ?.skills ?? [],
-    [props.serverConfig, selectedInstanceId],
-  );
+  const selectedProviderSkills = useMemo(() => {
+    const provider = props.serverConfig?.providers.find(
+      (candidate) => candidate.instanceId === selectedInstanceId,
+    );
+    return provider
+      ? resolveProviderSkillsForCwd(provider, props.threadCwd ?? props.projectWorkspaceRoot)
+      : [];
+  }, [props.projectWorkspaceRoot, props.serverConfig, props.threadCwd, selectedInstanceId]);
 
   useLayoutEffect(() => {
     selectedThreadKeyRef.current = selectedThreadKey;
@@ -809,7 +812,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                   serverConfig={props.serverConfig}
                   queueCount={props.selectedThreadQueueCount}
                   environmentId={props.environmentId}
-                  projectCwd={props.projectWorkspaceRoot}
+                  projectCwd={props.threadCwd ?? props.projectWorkspaceRoot}
                   bottomInset={composerBottomInset}
                   onChangeDraftMessage={props.onChangeDraftMessage}
                   onPickDraftMedia={props.onPickDraftMedia}

--- a/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it, vi } from "vite-plus/test";
 vi.mock("../../state/queries", () => ({
   useComposerPathSearch: () => ({ entries: [], isPending: false }),
 }));
+vi.mock("../../state/server", () => ({
+  serverEnvironment: { refreshProviders: Symbol("refreshProviders") },
+}));
+vi.mock("../../state/use-atom-command", () => ({
+  useAtomCommand: () => vi.fn(),
+}));
 
 import { composerSelectionAtEnd } from "./use-composer-command-menu";
 

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -13,13 +13,18 @@ import {
   dedupeProviderSkillsByName,
   getProviderSkillsForSlashMenu,
   isProviderSkillUserInvocable,
+  resolveProviderSkillsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ComposerEditorSelection } from "../../components/ComposerEditor";
+import { serverEnvironment } from "../../state/server";
+import { useAtomCommand } from "../../state/use-atom-command";
 import { useComposerPathSearch } from "../../state/queries";
 import type { ComposerCommandItem } from "./ComposerCommandPopover";
 import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
+
+const WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS = 10_000;
 
 export function composerSelectionAtEnd(draftMessage: string): ComposerEditorSelection {
   return { start: draftMessage.length, end: draftMessage.length };
@@ -68,6 +73,72 @@ export function useComposerCommandMenu({
     previousOwnerKeyRef.current = ownerKey;
     setSelection(composerSelectionAtEnd(draftMessage));
   }, [draftMessage, ownerKey]);
+
+  const skills = useMemo(
+    () =>
+      selectedProviderStatus ? resolveProviderSkillsForCwd(selectedProviderStatus, projectCwd) : [],
+    [projectCwd, selectedProviderStatus],
+  );
+  const slashCommands = selectedProviderStatus?.slashCommands ?? [];
+  const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
+    reportFailure: false,
+  });
+  const selectedProviderInstanceId = selectedProviderStatus?.instanceId;
+  const hasWorkspaceSnapshot = Boolean(
+    projectCwd &&
+    selectedProviderStatus?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === projectCwd),
+  );
+  const workspaceRefreshKeyRef = useRef<string | null>(null);
+  const workspaceRefreshRetryRef = useRef<{ key: string; notBefore: number } | null>(null);
+  const hadWorkspaceSnapshotRef = useRef(false);
+  useEffect(() => {
+    if (hadWorkspaceSnapshotRef.current && !hasWorkspaceSnapshot) {
+      workspaceRefreshKeyRef.current = null;
+      workspaceRefreshRetryRef.current = null;
+    }
+    hadWorkspaceSnapshotRef.current = hasWorkspaceSnapshot;
+  }, [hasWorkspaceSnapshot]);
+  useEffect(() => {
+    if (!environmentId || !projectCwd || !selectedProviderInstanceId) return;
+    const key = `${environmentId}:${selectedProviderInstanceId}:${projectCwd}`;
+    if (workspaceRefreshKeyRef.current === key) return;
+    if (hasWorkspaceSnapshot) {
+      workspaceRefreshKeyRef.current = key;
+      workspaceRefreshRetryRef.current = null;
+      return;
+    }
+    const retry = workspaceRefreshRetryRef.current;
+    if (retry?.key === key && Date.now() < retry.notBefore) return;
+    workspaceRefreshKeyRef.current = key;
+    const retryLater = () => {
+      if (workspaceRefreshKeyRef.current !== key) return;
+      workspaceRefreshKeyRef.current = null;
+      workspaceRefreshRetryRef.current = {
+        key,
+        notBefore: Date.now() + WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS,
+      };
+    };
+    void refreshProviders({
+      environmentId,
+      input: { instanceId: selectedProviderInstanceId, cwd: projectCwd },
+    }).then((result) => {
+      const refreshed =
+        result._tag === "Success" &&
+        result.value.providers
+          .find((provider) => provider.instanceId === selectedProviderInstanceId)
+          ?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === projectCwd);
+      if (!refreshed && workspaceRefreshKeyRef.current === key) {
+        retryLater();
+      }
+    }, retryLater);
+  }, [
+    draftMessage,
+    environmentId,
+    hasWorkspaceSnapshot,
+    projectCwd,
+    refreshProviders,
+    selectedProviderInstanceId,
+  ]);
 
   const trigger = useMemo(() => {
     if (!enabled || selection.start !== selection.end) {
@@ -120,8 +191,7 @@ export function useComposerCommandMenu({
       // locally and skills insert a `$` mention the server dispatches from
       // any position, so only provider commands are position-gated.
       const providerCommands: ComposerCommandItem[] = [];
-      const expandableCommands =
-        trigger.rangeStart === 0 ? (selectedProviderStatus?.slashCommands ?? []) : [];
+      const expandableCommands = trigger.rangeStart === 0 ? slashCommands : [];
       for (const command of expandableCommands) {
         if (!command.name.toLowerCase().includes(q)) continue;
         // Codex feedback uploads an existing thread's session and logs.
@@ -141,7 +211,7 @@ export function useComposerCommandMenu({
         });
       }
 
-      const skillItems = getProviderSkillsForSlashMenu(selectedProviderStatus?.skills ?? [], true)
+      const skillItems = getProviderSkillsForSlashMenu(skills, true)
         .filter((skill) => matchesSlashSkillQuery(skill, q))
         .map((skill) => ({
           id: `skill:${skill.name}`,
@@ -155,9 +225,7 @@ export function useComposerCommandMenu({
     }
 
     if (trigger.kind === "skill") {
-      const enabledSkills = dedupeProviderSkillsByName(
-        (selectedProviderStatus?.skills ?? []).filter(isProviderSkillUserInvocable),
-      );
+      const enabledSkills = dedupeProviderSkillsByName(skills.filter(isProviderSkillUserInvocable));
       const normalizedQuery = normalizeSearchQuery(trigger.query, {
         trimLeadingPattern: /^\$+/,
       });
@@ -254,7 +322,15 @@ export function useComposerCommandMenu({
     }
 
     return [];
-  }, [hasThread, onUpdateInteractionMode, pathSearch.entries, selectedProviderStatus, trigger]);
+  }, [
+    hasThread,
+    onUpdateInteractionMode,
+    pathSearch.entries,
+    selectedProviderStatus,
+    skills,
+    slashCommands,
+    trigger,
+  ]);
 
   const onSelect = useCallback(
     (item: ComposerCommandItem) => {
@@ -299,6 +375,7 @@ export function useComposerCommandMenu({
     onSelectionChange,
     trigger,
     items,
+    skills,
     isLoading: pathSearch.isPending,
     onSelect,
   };

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -50,6 +50,7 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
+import { probeCursorSkills } from "./CursorSkills.ts";
 const decodeCursorSettings = Schema.decodeSync(CursorSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("cursor");
@@ -166,6 +167,25 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
+        snapshotForCwd: (cwd) =>
+          !effectiveConfig.enabled
+            ? snapshot.getSnapshot
+            : Effect.all([
+                snapshot.getSnapshot,
+                probeCursorSkills(cwd, processEnv).pipe(
+                  Effect.provideService(FileSystem.FileSystem, fileSystem),
+                  Effect.provideService(Path.Path, path),
+                  Effect.mapError(
+                    (cause) =>
+                      new ProviderDriverError({
+                        driver: DRIVER_KIND,
+                        instanceId,
+                        detail: `Failed to discover Cursor skills for '${cwd}'`,
+                        cause,
+                      }),
+                  ),
+                ),
+              ]).pipe(Effect.map(([machineSnapshot, skills]) => ({ ...machineSnapshot, skills }))),
         adapter,
         textGeneration,
       } satisfies ProviderInstance;

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -1,0 +1,283 @@
+/**
+ * CursorSkills — workspace-aware discovery and native invocation for Cursor.
+ *
+ * Cursor discovers Agent Skills recursively from user and project roots but
+ * its ACP command catalog only appears after opening a real session. Scanning
+ * the same roots avoids starting an agent and its MCP servers just to populate
+ * a composer menu.
+ *
+ * @module provider/Drivers/CursorSkills
+ */
+import * as NodeOS from "node:os";
+
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
+import { parse as parseYamlDocument } from "yaml";
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+const SKILL_MENTION_PATTERN = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
+const HAS_SKILL_MENTION_PATTERN = /(^|\s)\$[a-zA-Z][a-zA-Z0-9:_-]*(?=\s|$)/;
+const MAX_SKILL_DEPTH = 10;
+const MAX_SKILL_BYTES = FileSystem.Size(1_000_000);
+const MAX_SKILL_SCAN_ENTRIES = 10_000;
+const MAX_SKILL_SCAN_BYTES = FileSystem.Size(8_000_000);
+
+interface CursorSkillFrontmatter {
+  readonly description?: string;
+  readonly displayName?: string;
+  readonly userInvocationOnly?: boolean;
+  readonly userInvocable?: boolean;
+  readonly cliVisible: boolean;
+}
+
+interface CursorSkillScanBudget {
+  remainingEntries: number;
+  remainingBytes: bigint;
+  exhausted: boolean;
+  incomplete: boolean;
+}
+
+class CursorSkillsProbeError extends Schema.TaggedErrorClass<CursorSkillsProbeError>()(
+  "CursorSkillsProbeError",
+  {
+    reason: Schema.Literals(["scan-budget-exhausted", "filesystem-error"]),
+    cwd: Schema.optional(Schema.String),
+  },
+) {
+  override get message(): string {
+    const location = this.cwd === undefined ? "" : ` for '${this.cwd}'`;
+    return `Cursor skill discovery${location} was incomplete (${this.reason}).`;
+  }
+}
+
+const orUndefined = <A, R>(
+  effect: Effect.Effect<A, PlatformError.PlatformError, R>,
+  budget?: CursorSkillScanBudget,
+): Effect.Effect<A | undefined, never, R> =>
+  effect.pipe(
+    Effect.map((value): A | undefined => value),
+    Effect.catchTags({
+      PlatformError: (error) => {
+        if (error.reason._tag !== "NotFound" && budget) budget.incomplete = true;
+        return Effect.void.pipe(Effect.as(undefined));
+      },
+    }),
+  );
+
+function parseFrontmatterBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1 ? true : value === 0 ? false : undefined;
+  if (typeof value !== "string") return undefined;
+  switch (value.trim().toLowerCase()) {
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    case "false":
+    case "no":
+    case "off":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+function parseSkillFrontmatter(contents: string): CursorSkillFrontmatter | undefined {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  if (!match) return { cliVisible: true };
+
+  let parsed: unknown;
+  try {
+    parsed = parseYamlDocument(match[1] ?? "");
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+
+  const record = parsed as Record<string, unknown>;
+  const metadata =
+    typeof record.metadata === "object" && record.metadata !== null
+      ? (record.metadata as Record<string, unknown>)
+      : undefined;
+  const rawSurfaces = metadata?.surfaces;
+  const surfaces = Array.isArray(rawSurfaces)
+    ? rawSurfaces.filter((surface): surface is string => typeof surface === "string")
+    : typeof rawSurfaces === "string"
+      ? rawSurfaces.split(",")
+      : [];
+  const description = typeof record.description === "string" ? record.description.trim() : "";
+  const displayName = typeof record.name === "string" ? record.name.trim() : "";
+  return {
+    cliVisible:
+      surfaces.length === 0 || surfaces.some((surface) => surface.trim().toLowerCase() === "cli"),
+    ...(description ? { description } : {}),
+    ...(displayName ? { displayName } : {}),
+    ...(parseFrontmatterBoolean(record["disable-model-invocation"]) === true
+      ? { userInvocationOnly: true }
+      : {}),
+    ...(parseFrontmatterBoolean(record["user-invocable"]) === false
+      ? { userInvocable: false }
+      : {}),
+  };
+}
+
+const discoverSkillsInRoot = Effect.fn("discoverCursorSkillsInRoot")(function* (input: {
+  readonly directory: string;
+  readonly scope: "user" | "project";
+  readonly budget: CursorSkillScanBudget;
+}): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skills: ServerProviderSkill[] = [];
+  if (input.budget.exhausted) return skills;
+  const rootDirectory = yield* orUndefined(fileSystem.realPath(input.directory), input.budget);
+  if (!rootDirectory) return skills;
+  const visitedDirectories = new Set<string>();
+
+  const visit = Effect.fn("visitCursorSkillDirectory")(function* (
+    directory: string,
+    depth: number,
+  ): Effect.fn.Return<void, never> {
+    if (input.budget.exhausted) return;
+    const resolvedDirectory = yield* orUndefined(fileSystem.realPath(directory), input.budget);
+    if (!resolvedDirectory) {
+      return;
+    }
+    if (
+      visitedDirectories.has(resolvedDirectory) ||
+      (resolvedDirectory !== rootDirectory &&
+        !resolvedDirectory.startsWith(`${rootDirectory}${path.sep}`))
+    ) {
+      return;
+    }
+    visitedDirectories.add(resolvedDirectory);
+
+    const skillPath = path.join(resolvedDirectory, "SKILL.md");
+    const skillInfo = yield* orUndefined(fileSystem.stat(skillPath), input.budget);
+    if (skillInfo?.type === "File") {
+      let frontmatter: CursorSkillFrontmatter | undefined = { cliVisible: true };
+      if (skillInfo.size <= MAX_SKILL_BYTES && skillInfo.size <= input.budget.remainingBytes) {
+        const contents = yield* orUndefined(fileSystem.readFileString(skillPath));
+        if (contents !== undefined) {
+          input.budget.remainingBytes -= skillInfo.size;
+          frontmatter = parseSkillFrontmatter(contents);
+        }
+      }
+      const name = path.basename(resolvedDirectory).trim();
+      if (frontmatter?.cliVisible && name) {
+        skills.push({
+          name,
+          path: skillPath,
+          scope: input.scope,
+          enabled: true,
+          ...(frontmatter.displayName && frontmatter.displayName !== name
+            ? { displayName: frontmatter.displayName }
+            : {}),
+          ...(frontmatter.description ? { description: frontmatter.description } : {}),
+          ...(frontmatter.userInvocationOnly ? { userInvocationOnly: true } : {}),
+          ...(frontmatter.userInvocable === false ? { userInvocable: false } : {}),
+        });
+      }
+    }
+
+    const entries = yield* orUndefined(fileSystem.readDirectory(resolvedDirectory), input.budget);
+    if (!entries) {
+      return;
+    }
+    for (const entry of [...entries].sort()) {
+      if (input.budget.remainingEntries === 0) {
+        input.budget.exhausted = true;
+        return;
+      }
+      input.budget.remainingEntries -= 1;
+      const child = path.join(resolvedDirectory, entry);
+      const info = yield* orUndefined(fileSystem.stat(child), input.budget);
+      if (info?.type !== "Directory") continue;
+      if (depth >= MAX_SKILL_DEPTH) {
+        input.budget.exhausted = true;
+        return;
+      }
+      yield* visit(child, depth + 1);
+    }
+  });
+
+  yield* visit(rootDirectory, 0);
+  return skills;
+});
+
+const inspectCursorSkills = Effect.fn("inspectCursorSkills")(function* (
+  cwd?: string,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const path = yield* Path.Path;
+  const userHome = environment.HOME?.trim() || environment.USERPROFILE?.trim() || NodeOS.homedir();
+  const rootsBelow = (base: string, scope: "user" | "project") => [
+    { directory: path.join(base, ".cursor", "skills"), scope },
+    { directory: path.join(base, ".agents", "skills"), scope },
+    { directory: path.join(base, ".codex", "skills"), scope },
+    { directory: path.join(base, ".claude", "skills"), scope },
+  ];
+  const roots = [...(cwd ? rootsBelow(cwd, "project") : []), ...rootsBelow(userHome, "user")];
+
+  const skillsByName = new Map<string, ServerProviderSkill>();
+  const budget: CursorSkillScanBudget = {
+    remainingEntries: MAX_SKILL_SCAN_ENTRIES,
+    remainingBytes: MAX_SKILL_SCAN_BYTES,
+    exhausted: false,
+    incomplete: false,
+  };
+  for (const root of roots) {
+    if (budget.exhausted) break;
+    const skills = yield* discoverSkillsInRoot({ ...root, budget });
+    for (const skill of skills) {
+      if (!skillsByName.has(skill.name)) skillsByName.set(skill.name, skill);
+    }
+  }
+  return {
+    skills: [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name)),
+    failureReason: budget.exhausted
+      ? ("scan-budget-exhausted" as const)
+      : budget.incomplete
+        ? ("filesystem-error" as const)
+        : undefined,
+  };
+});
+
+export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* (
+  cwd?: string,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  return (yield* inspectCursorSkills(cwd, environment)).skills;
+});
+
+export const probeCursorSkills = Effect.fn("probeCursorSkills")(function* (
+  cwd?: string,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const inspection = yield* inspectCursorSkills(cwd, environment);
+  if (inspection.failureReason) {
+    return yield* new CursorSkillsProbeError({
+      reason: inspection.failureReason,
+      ...(cwd ? { cwd } : {}),
+    });
+  }
+  return inspection.skills;
+});
+
+/** Cursor invokes Agent Skills with `/name`; T3 composers insert `$name`. */
+export function hasCursorSkillMention(prompt: string): boolean {
+  return HAS_SKILL_MENTION_PATTERN.test(prompt);
+}
+
+export function rewriteCursorSkillMentions(
+  prompt: string,
+  skillNames: ReadonlySet<string>,
+): string {
+  return prompt.replace(SKILL_MENTION_PATTERN, (match, prefix: string, name: string) =>
+    skillNames.has(name) ? `${prefix}/${name}` : match,
+  );
+}

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -27,6 +27,7 @@ import {
 } from "../ProviderDriver.ts";
 import { withInstanceIdentity } from "./instanceIdentity.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { discoverGrokSkills } from "./GrokSkills.ts";
 import {
   makeManualOnlyProviderMaintenanceCapabilities,
   makeStaticProviderMaintenanceResolver,
@@ -133,6 +134,24 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
             }),
         ),
       );
+      const snapshotForCwd = (workspaceCwd: string) =>
+        !effectiveConfig.enabled
+          ? snapshot.getSnapshot
+          : Effect.all([
+              snapshot.getSnapshot,
+              discoverGrokSkills(effectiveConfig, processEnv, workspaceCwd).pipe(
+                Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+                Effect.mapError(
+                  (cause) =>
+                    new ProviderDriverError({
+                      driver: DRIVER_KIND,
+                      instanceId,
+                      detail: `Failed to discover Grok skills for '${workspaceCwd}'`,
+                      cause,
+                    }),
+                ),
+              ),
+            ]).pipe(Effect.map(([machineSnapshot, skills]) => ({ ...machineSnapshot, skills })));
 
       return {
         instanceId,
@@ -142,6 +161,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
+        snapshotForCwd,
         adapter,
         textGeneration,
       } satisfies ProviderInstance;

--- a/apps/server/src/provider/Drivers/GrokSkills.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.test.ts
@@ -93,14 +93,15 @@ describe("parseGrokInspectSkills", () => {
 });
 
 describe("discoverGrokSkills", () => {
-  it.effect("spawns the inspect probe in the configured cwd", () => {
+  it.effect("spawns in the configured cwd and rejects a failed probe", () => {
     const spawnCwds: Array<string | undefined> = [];
+    let exitCode = 0;
     const spawner = ChildProcessSpawner.make((command) => {
       spawnCwds.push(command._tag === "StandardCommand" ? command.options.cwd : undefined);
       return Effect.succeed(
         ChildProcessSpawner.makeHandle({
           pid: ChildProcessSpawner.ProcessId(1),
-          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
           isRunning: Effect.succeed(false),
           kill: () => Effect.void,
           unref: Effect.succeed(Effect.void),
@@ -130,6 +131,13 @@ describe("discoverGrokSkills", () => {
 
       expect(spawnCwds).toEqual(["/workspaces/demo"]);
       expect(skills.map((skill) => skill.name)).toEqual(["kept"]);
+
+      exitCode = 1;
+      const failed = yield* discoverGrokSkills({ binaryPath: "grok" }).pipe(
+        Effect.result,
+        Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+      );
+      expect(failed._tag).toBe("Failure");
     });
   });
 });

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -9,41 +9,57 @@
  * (ignore lists, disabled skills) and includes plugin skills, which live
  * three levels deep under `~/.grok/installed-plugins/` where a flat scan
  * cannot see them. This mirrors how the Codex app-server reports skills over
- * `skills/list`. Discovery is best-effort: an older CLI without `inspect`,
- * a timeout, or malformed output yields an empty list, never a degraded
- * provider snapshot.
+ * `skills/list`. Probe failures stay typed so workspace snapshots do not
+ * cache an empty catalog; machine-level discovery recovers them to an empty
+ * list without degrading the provider.
  *
  * @module provider/Drivers/GrokSkills
  */
 import type { GrokSettings, ServerProviderSkill } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
-import * as Result from "effect/Result";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as Schema from "effect/Schema";
+import { ChildProcess } from "effect/unstable/process";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
 import { spawnAndCollect } from "../providerSnapshot.ts";
 
 const GROK_SKILLS_PROBE_TIMEOUT_MS = 4_000;
 
+class GrokSkillsProbeError extends Schema.TaggedErrorClass<GrokSkillsProbeError>()(
+  "GrokSkillsProbeError",
+  {
+    stage: Schema.Literals(["spawn", "timeout", "exit", "decode"]),
+    cwd: Schema.optional(Schema.String),
+    exitCode: Schema.optional(Schema.Number),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    const location = this.cwd === undefined ? "" : ` for '${this.cwd}'`;
+    const exitCode = this.exitCode === undefined ? "" : ` with exit code ${this.exitCode}`;
+    return `\`grok inspect --json\` failed during ${this.stage}${location}${exitCode}.`;
+  }
+}
+
 /**
  * Map `grok inspect --json` output onto provider skills. Entries without a
  * name or a filesystem path are skipped; `userInvocable: false` skills are
  * kept but disabled so pickers that filter on `enabled` hide them.
  */
-export function parseGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSkill> {
+function decodeGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSkill> | undefined {
   let parsed: unknown;
   try {
     parsed = JSON.parse(stdout);
   } catch {
-    return [];
+    return undefined;
   }
   if (typeof parsed !== "object" || parsed === null) {
-    return [];
+    return undefined;
   }
   const entries = (parsed as Record<string, unknown>).skills;
   if (!Array.isArray(entries)) {
-    return [];
+    return undefined;
   }
 
   const skillsByName = new Map<string, ServerProviderSkill>();
@@ -75,20 +91,20 @@ export function parseGrokInspectSkills(stdout: string): ReadonlyArray<ServerProv
   return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
+export function parseGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSkill> {
+  return decodeGrokInspectSkills(stdout) ?? [];
+}
+
 /**
  * Run `grok inspect --json` and map the reported catalog onto provider
- * skills. Never fails: any spawn error, non-zero exit, or timeout resolves
- * to an empty list.
+ * skills. Callers that need best-effort discovery can recover this effect to
+ * an empty list; workspace callers leave failures typed so they are not cached.
  */
 export const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (
   grokSettings: Pick<GrokSettings, "binaryPath">,
   environment: NodeJS.ProcessEnv = process.env,
   cwd?: string,
-): Effect.fn.Return<
-  ReadonlyArray<ServerProviderSkill>,
-  never,
-  ChildProcessSpawner.ChildProcessSpawner
-> {
+) {
   const command = grokSettings.binaryPath || "grok";
   const inspectResult = yield* Effect.gen(function* () {
     const spawnCommand = yield* resolveSpawnCommand(command, ["inspect", "--json"], {
@@ -102,18 +118,38 @@ export const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (
         shell: spawnCommand.shell,
       }),
     );
-  }).pipe(Effect.timeoutOption(GROK_SKILLS_PROBE_TIMEOUT_MS), Effect.result);
+  }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new GrokSkillsProbeError({
+          stage: "spawn",
+          ...(cwd ? { cwd } : {}),
+          cause,
+        }),
+    ),
+    Effect.timeoutOption(GROK_SKILLS_PROBE_TIMEOUT_MS),
+  );
 
-  if (Result.isFailure(inspectResult) || Option.isNone(inspectResult.success)) {
-    yield* Effect.logDebug("Grok skill discovery failed; continuing without skills.");
-    return [];
+  if (Option.isNone(inspectResult)) {
+    return yield* new GrokSkillsProbeError({
+      stage: "timeout",
+      ...(cwd ? { cwd } : {}),
+    });
   }
-  const output = inspectResult.success.value;
+  const output = inspectResult.value;
   if (output.code !== 0) {
-    yield* Effect.logDebug("Grok skill discovery exited non-zero; continuing without skills.", {
+    return yield* new GrokSkillsProbeError({
+      stage: "exit",
+      ...(cwd ? { cwd } : {}),
       exitCode: output.code,
     });
-    return [];
   }
-  return parseGrokInspectSkills(output.stdout);
+  const skills = decodeGrokInspectSkills(output.stdout);
+  if (!skills) {
+    return yield* new GrokSkillsProbeError({
+      stage: "decode",
+      ...(cwd ? { cwd } : {}),
+    });
+  }
+  return skills;
 });

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -250,6 +250,52 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
     }),
   );
 
+  it.effect("sends selected project skills in Cursor's native slash form", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-skill-dispatch");
+      const workspace = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-skill-dispatch-")),
+      );
+      const requestLogPath = NodePath.join(workspace, "requests.ndjson");
+      const argvLogPath = NodePath.join(workspace, "argv.txt");
+      const skillDirectory = NodePath.join(workspace, ".cursor", "skills", "review");
+      yield* Effect.promise(() => NodeFSP.mkdir(skillDirectory, { recursive: true }));
+      yield* Effect.promise(() =>
+        NodeFSP.writeFile(NodePath.join(skillDirectory, "SKILL.md"), "# Review\n", "utf8"),
+      );
+      yield* Effect.promise(() => NodeFSP.writeFile(requestLogPath, "", "utf8"));
+      const wrapperPath = yield* Effect.promise(() =>
+        makeProbeWrapper(requestLogPath, argvLogPath),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: workspace,
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "please $review this",
+        attachments: [],
+      });
+      yield* adapter.stopSession(threadId);
+
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const promptRequests = requests.filter((entry) => entry.method === "session/prompt");
+      assert.deepStrictEqual(
+        promptRequests.map(
+          (request) => (request.params as Record<string, unknown> | undefined)?.prompt,
+        ),
+        [[{ type: "text", text: "please /review this" }]],
+      );
+    }),
+  );
+
   it.effect("steers a running turn instead of opening a new one on mid-turn sendTurn", () =>
     Effect.gen(function* () {
       const adapter = yield* CursorAdapter;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -77,6 +77,11 @@ import {
 import { type CursorAdapterShape } from "../Services/CursorAdapter.ts";
 import { resolveCursorAcpBaseModelId } from "./CursorProvider.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import {
+  discoverCursorSkills,
+  hasCursorSkillMention,
+  rewriteCursorSkillMentions,
+} from "../Drivers/CursorSkills.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 
 const PROVIDER = ProviderDriverKind.make("cursor");
@@ -133,6 +138,7 @@ interface CursorSessionContext {
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
   activeTurnId: TurnId | undefined;
+  cursorSkillNames: ReadonlySet<string> | undefined;
   /** Number of sendTurn prompts currently in flight or being prepared.
    * >0 means a turn is actively running, so a new sendTurn is a steer that
    * continues it, and only the last remaining prompt settles the turn. */
@@ -778,6 +784,7 @@ export function makeCursorAdapter(
             turns: [],
             lastPlanFingerprint: undefined,
             activeTurnId: undefined,
+            cursorSkillNames: undefined,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -967,8 +974,28 @@ export function makeCursorAdapter(
           }
 
           const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-          if (input.input?.trim()) {
-            promptParts.push({ type: "text", text: input.input.trim() });
+          const rawPrompt = input.input?.trim() ?? "";
+          if (rawPrompt) {
+            let cursorSkillNames = ctx.cursorSkillNames;
+            if (hasCursorSkillMention(rawPrompt) && cursorSkillNames === undefined) {
+              const skills = yield* discoverCursorSkills(
+                ctx.session.cwd,
+                options?.environment,
+              ).pipe(
+                Effect.provideService(FileSystem.FileSystem, fileSystem),
+                Effect.provideService(Path.Path, path),
+              );
+              cursorSkillNames = new Set(
+                skills
+                  .filter((skill) => skill.enabled && skill.userInvocable !== false)
+                  .map((skill) => skill.name),
+              );
+              ctx.cursorSkillNames = cursorSkillNames;
+            }
+            const prompt = cursorSkillNames
+              ? rewriteCursorSkillMentions(rawPrompt, cursorSkillNames)
+              : rawPrompt;
+            promptParts.push({ type: "text", text: prompt });
           }
           if (input.attachments && input.attachments.length > 0) {
             for (const attachment of input.attachments) {

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -24,6 +24,12 @@ import {
   resolveCursorAcpBaseModelId,
   resolveCursorAcpConfigUpdates,
 } from "./CursorProvider.ts";
+import {
+  discoverCursorSkills,
+  hasCursorSkillMention,
+  probeCursorSkills,
+  rewriteCursorSkillMentions,
+} from "../Drivers/CursorSkills.ts";
 
 const runNode = <A, E>(
   effect: Effect.Effect<
@@ -311,6 +317,98 @@ const cursorCliCommandMissingMessage = [
   `Install or enable the Cursor CLI, make sure \`${missingCursorBinaryPath}\` is on PATH, then restart T3 Code.`,
   "See https://cursor.com/docs/cli/installation.",
 ].join(" ");
+
+describe("Cursor skills", () => {
+  it("discovers recursive project skills with project precedence", async () =>
+    await runNode(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const userHome = yield* fileSystem.makeTempDirectory({
+          directory: NodeOS.tmpdir(),
+          prefix: "cursor-skills-home-",
+        });
+        const workspace = yield* fileSystem.makeTempDirectory({
+          directory: NodeOS.tmpdir(),
+          prefix: "cursor-skills-workspace-",
+        });
+        const writeSkill = Effect.fn("writeCursorSkill")(function* (
+          root: string,
+          name: string,
+          contents: string,
+        ) {
+          const skillDirectory = path.join(root, name);
+          yield* fileSystem.makeDirectory(skillDirectory, { recursive: true });
+          yield* fileSystem.writeFileString(path.join(skillDirectory, "SKILL.md"), contents);
+        });
+
+        yield* writeSkill(
+          path.join(userHome, ".cursor", "skills"),
+          "review",
+          "---\ndescription: user review\n---\n",
+        );
+        yield* writeSkill(
+          path.join(workspace, ".agents", "skills", "nested"),
+          "review",
+          "---\nname: Review changes\ndescription: project review\n---\n",
+        );
+        yield* writeSkill(
+          path.join(workspace, ".cursor", "skills"),
+          "internal",
+          "---\nuser-invocable: false\n---\n",
+        );
+        yield* writeSkill(
+          path.join(workspace, ".cursor", "skills"),
+          "oversized",
+          "x".repeat(1_000_001),
+        );
+        yield* fileSystem.makeDirectory(path.join(userHome, ".codex"), { recursive: true });
+        yield* fileSystem.writeFileString(
+          path.join(userHome, ".codex", "skills"),
+          "not a directory",
+        );
+
+        const skills = yield* discoverCursorSkills(workspace, { HOME: userHome });
+        expect(skills).toEqual([
+          {
+            name: "internal",
+            path: path.join(workspace, ".cursor", "skills", "internal", "SKILL.md"),
+            scope: "project",
+            enabled: true,
+            userInvocable: false,
+          },
+          {
+            name: "oversized",
+            path: path.join(workspace, ".cursor", "skills", "oversized", "SKILL.md"),
+            scope: "project",
+            enabled: true,
+          },
+          {
+            name: "review",
+            displayName: "Review changes",
+            description: "project review",
+            path: path.join(workspace, ".agents", "skills", "nested", "review", "SKILL.md"),
+            scope: "project",
+            enabled: true,
+          },
+        ]);
+        expect(
+          (yield* probeCursorSkills(workspace, { HOME: userHome }).pipe(Effect.result))._tag,
+        ).toBe("Failure");
+      }),
+    ));
+
+  it("rewrites only discovered skill mentions into Cursor slash invocations", () => {
+    expect(hasCursorSkillMention("use $Review_Pr:V2 here")).toBe(true);
+    expect(hasCursorSkillMention("please $review this")).toBe(true);
+    expect(
+      rewriteCursorSkillMentions("use $review, keep $HOME and 5$review", new Set(["review"])),
+    ).toBe("use $review, keep $HOME and 5$review");
+    expect(rewriteCursorSkillMentions("please $review this", new Set(["review"]))).toBe(
+      "please /review this",
+    );
+  });
+});
 
 describe("getCursorFallbackModels", () => {
   it("does not publish any built-in cursor models before ACP discovery", () => {

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -453,7 +453,10 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
         ? { status: "unauthenticated" }
         : { status: "unknown" };
 
-  const skills = yield* discoverGrokSkills(grokSettings, environment, cwd);
+  const skills = yield* discoverGrokSkills(grokSettings, environment, cwd).pipe(
+    Effect.tapError((cause) => Effect.logDebug("Grok skill discovery failed.", { cause })),
+    Effect.orElseSucceed(() => []),
+  );
 
   const acpExit = yield* discoverGrokModelsViaAcpInitialize(grokSettings, environment).pipe(
     Effect.timeoutOption(GROK_ACP_INITIALIZE_TIMEOUT_MS),

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -346,6 +346,8 @@ import { useAtomCommand } from "../../state/use-atom-command";
 import { serverEnvironment } from "../../state/server";
 import type { ReviewCommentContext } from "../../reviewCommentContext";
 
+const WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS = 10_000;
+
 const runtimeModeConfig: Record<
   RuntimeMode,
   { label: string; description: string; icon: LucideIcon }
@@ -1130,6 +1132,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     reportFailure: false,
   });
   const workspaceRefreshKeyRef = useRef<string | null>(null);
+  const workspaceRefreshRetryRef = useRef<{ key: string; notBefore: number } | null>(null);
   const hadWorkspaceSnapshotRef = useRef(false);
   useEffect(() => {
     const hasWorkspaceSnapshot = Boolean(
@@ -1138,6 +1141,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     );
     if (hadWorkspaceSnapshotRef.current && !hasWorkspaceSnapshot) {
       workspaceRefreshKeyRef.current = null;
+      workspaceRefreshRetryRef.current = null;
     }
     hadWorkspaceSnapshotRef.current = hasWorkspaceSnapshot;
   }, [gitCwd, selectedProviderStatus]);
@@ -1150,28 +1154,34 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (workspaceRefreshKeyRef.current === key) return;
     if (hasWorkspaceSnapshot) {
       workspaceRefreshKeyRef.current = key;
+      workspaceRefreshRetryRef.current = null;
       return;
     }
+    const retry = workspaceRefreshRetryRef.current;
+    if (retry?.key === key && Date.now() < retry.notBefore) return;
     workspaceRefreshKeyRef.current = key;
+    const retryLater = () => {
+      if (workspaceRefreshKeyRef.current !== key) return;
+      workspaceRefreshKeyRef.current = null;
+      workspaceRefreshRetryRef.current = {
+        key,
+        notBefore: Date.now() + WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS,
+      };
+    };
     void refreshProviders({
       environmentId,
       input: { instanceId: selectedProviderEntry.instanceId, cwd: gitCwd },
-    }).then(
-      (result) => {
-        const hasWorkspaceSnapshot =
-          result._tag === "Success" &&
-          result.value.providers
-            .find((provider) => provider.instanceId === selectedProviderEntry.instanceId)
-            ?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === gitCwd);
-        if (!hasWorkspaceSnapshot && workspaceRefreshKeyRef.current === key) {
-          workspaceRefreshKeyRef.current = null;
-        }
-      },
-      () => {
-        if (workspaceRefreshKeyRef.current === key) workspaceRefreshKeyRef.current = null;
-      },
-    );
-  }, [environmentId, gitCwd, refreshProviders, selectedProviderEntry]);
+    }).then((result) => {
+      const hasWorkspaceSnapshot =
+        result._tag === "Success" &&
+        result.value.providers
+          .find((provider) => provider.instanceId === selectedProviderEntry.instanceId)
+          ?.workspaceSnapshots?.some((snapshot) => snapshot.cwd === gitCwd);
+      if (!hasWorkspaceSnapshot && workspaceRefreshKeyRef.current === key) {
+        retryLater();
+      }
+    }, retryLater);
+  }, [environmentId, gitCwd, prompt, refreshProviders, selectedProviderEntry]);
   const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
     () => selectedProviderEntry?.models ?? [],
     [selectedProviderEntry],


### PR DESCRIPTION
PR #8778 added cwd-aware skill discovery for Codex and OpenCode, and current main now covers Claude. This closes the remaining gaps: Cursor discovers project skills and translates selected `$skill` mentions to native `/skill` invocations, Grok probes its catalog in the project cwd, and mobile requests and resolves workspace snapshots.

| before | after |
| --- | --- |
| ![Cursor project skill missing before](https://uploads-production-47e4.up.railway.app/files/ad728204-3544-4236-8dd9-ae7a4ce788d9/t3-skills-before-crop.png) | ![Cursor project skill discovered after](https://uploads-production-47e4.up.railway.app/files/a359b3a7-0dab-4f0d-9dc4-15b9144316ca/t3-skills-after-crop.png) |

Verified with 71 focused provider/client/mobile tests, targeted lint and formatting, and server/mobile typechecks.

Built with `gpt-5.6-sol` through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds filesystem scans and CLI probes on provider refresh plus prompt rewriting in Cursor ACP; probe failures can block workspace snapshot caching until retry succeeds.
> 
> **Overview**
> Closes workspace-aware skill gaps for **Cursor** and **Grok** and wires **mobile/web composers** to cwd-specific catalogs instead of machine-level provider skills.
> 
> **Server:** Cursor gets filesystem discovery of `SKILL.md` under standard skill roots (with scan budgets and frontmatter parsing), exposed via `snapshotForCwd` and used at send time to rewrite composer `$skill` mentions into Cursor’s `/skill` form. Grok’s `grok inspect --json` probe now **fails explicitly** on spawn/timeout/exit/decode errors so workspace snapshots are not cached as empty; machine-level Grok status still falls back to an empty list.
> 
> **Clients:** `useComposerCommandMenu` (and web `ChatComposer`) resolve skills with `resolveProviderSkillsForCwd`, export `skills` to editors, and call `refreshProviders` for the active cwd when no matching workspace snapshot exists, with a **10s retry cooldown**. Thread detail passes **thread cwd** into the composer and feed skill lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ddc9653f022bcb1f43a7ab5a63c7c1792037d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add workspace-aware skill discovery for Cursor and Grok providers
> - Mobile composers ([NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/9180/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2), [ThreadComposer.tsx](https://github.com/pingdotgg/t3code/pull/9180/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024), [ThreadDetailScreen.tsx](https://github.com/pingdotgg/t3code/pull/9180/files#diff-4a36307d6c720c14cd36832a71a74b980215a01d29282c4f03d82889219d2fae)) now source skills from the `useComposerCommandMenu` hook, which resolves provider skills against the active thread cwd and requests a provider refresh when no matching workspace snapshot exists.
> - [CursorDriver](https://github.com/pingdotgg/t3code/pull/9180/files#diff-0b170344a3fe14a0680129b8c4a48317ca4a65346ddb307888262f6b3956b3ee) and [GrokDriver](https://github.com/pingdotgg/t3code/pull/9180/files#diff-0b86a3e67f98dbf93f42e8168829458b1cdde63a0486e43e2bebcdaaf32f64e8) gain workspace-specific snapshot functions that run skill discovery in the requested cwd when the instance is enabled; disabled instances reuse the machine snapshot.
> - [CursorSkills.ts](https://github.com/pingdotgg/t3code/pull/9180/files#diff-528e28e34e83cfb127b20e204b245df257b3295b01f91ac1ceed4d8219baf928) adds recursive `SKILL.md` scanning with depth, entry, and byte budgets, frontmatter metadata parsing, project-over-user dedup across four root conventions, and typed `CursorSkillsProbeError` for incomplete scans.
> - [CursorAdapter](https://github.com/pingdotgg/t3code/pull/9180/files#diff-363bf2a012a813301f31ff1d94657c457c86fad16a4c210da894eb7ae2deb3fb) now caches per-session discovered skill names and rewrites known dollar-prefixed mentions into Cursor slash invocations before sending to ACP.
> - [GrokSkills.ts](https://github.com/pingdotgg/t3code/pull/9180/files#diff-b9a91917429e16fdadd1583ee3bb784e862cc270fd9ffa70002cf175bbef35ab) changes discovery to a typed effect that fails explicitly on spawn, timeout, non-zero-exit, and decode errors; [GrokProvider](https://github.com/pingdotgg/t3code/pull/9180/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f) recovers these at the machine status boundary.
> - Behavioral Change: `discoverGrokSkills` now fails instead of returning an empty list on probe errors; callers that expected empty-list fallbacks are updated but out-of-tree consumers may break. Strict `probeCursorSkills` fails when scan budgets are exhausted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee69cf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->