### PR TITLE
feat(web): new environment artwork that follows every theme and dissolves into the sidebar

### DIFF
--- a/apps/web/src/components/SidebarStageBackdrop.tsx
+++ b/apps/web/src/components/SidebarStageBackdrop.tsx
@@ -74,8 +74,8 @@ export function StageBackdropButtonArt({ variant }: { variant: SidebarStageBackd
   return variant === "nightly" ? <NightlySkyArt compact /> : <DevBlueprintArt compact />;
 }
 
-/** The sidebar background the artwork dissolves into; the send-button crop has no stage wrapper, so fall back to the chrome. */
-const STAGE_FADE = "var(--stage-fade, var(--app-chrome-background))";
+/** The sidebar background the header art dissolves into, set by the sidebar-stage-backdrop utility. */
+const STAGE_FADE = "var(--stage-fade)";
 
 /** A dissolve into the sidebar across the lower part of the art, stepping in OKLCH so light sidebars pass through tints of the art's own hue instead of gray. */
 function StageDissolve({ id, anchor }: { id: string; anchor: string }) {
@@ -200,7 +200,8 @@ function NightlySkyArt({ compact = false }: { compact?: boolean }) {
       <rect width="100%" height="96" fill={`url(#${skyId})`} />
       <rect width="100%" height="96" fill={`url(#${hazePatternId})`} />
       <rect width="100%" height="96" fill={`url(#${starsId})`} />
-      <rect width="100%" height="96" fill={`url(#${fadeId})`} />
+      {/* The send-button crop sits on the composer, not the sidebar, so it keeps the raw art. */}
+      {compact ? null : <rect width="100%" height="96" fill={`url(#${fadeId})`} />}
     </svg>
   );
 }
@@ -383,7 +384,8 @@ function DevBlueprintArt({ compact = false }: { compact?: boolean }) {
       <rect width="100%" height="96" fill={`url(#${majorGridId})`} />
       <rect width="100%" height="6" fill={`url(#${rulerId})`} />
       <rect width="100%" height="96" fill={`url(#${annotationsId})`} />
-      <rect width="100%" height="96" fill={`url(#${fadeId})`} />
+      {/* The send-button crop sits on the composer, not the sidebar, so it keeps the raw art. */}
+      {compact ? null : <rect width="100%" height="96" fill={`url(#${fadeId})`} />}
     </svg>
   );
 }

--- a/apps/web/src/components/SidebarStageBackdrop.tsx
+++ b/apps/web/src/components/SidebarStageBackdrop.tsx
@@ -74,49 +74,61 @@ export function StageBackdropButtonArt({ variant }: { variant: SidebarStageBackd
   return variant === "nightly" ? <NightlySkyArt compact /> : <DevBlueprintArt compact />;
 }
 
-const NIGHTLY_STARS: ReadonlyArray<{
-  cx: number;
-  cy: number;
-  r: number;
-  opacity: number;
-}> = [
-  { cx: 14, cy: 10, r: 0.6, opacity: 0.85 },
-  { cx: 38, cy: 22, r: 0.4, opacity: 0.55 },
-  { cx: 58, cy: 8, r: 0.5, opacity: 0.7 },
-  { cx: 84, cy: 16, r: 0.4, opacity: 0.5 },
-  { cx: 104, cy: 7, r: 0.6, opacity: 0.8 },
-  { cx: 126, cy: 20, r: 0.4, opacity: 0.55 },
-  { cx: 148, cy: 11, r: 0.5, opacity: 0.7 },
-  { cx: 170, cy: 24, r: 0.4, opacity: 0.5 },
-  { cx: 192, cy: 9, r: 0.6, opacity: 0.8 },
-  { cx: 214, cy: 18, r: 0.4, opacity: 0.55 },
-  { cx: 236, cy: 8, r: 0.5, opacity: 0.7 },
-  { cx: 258, cy: 20, r: 0.45, opacity: 0.6 },
-  { cx: 278, cy: 11, r: 0.55, opacity: 0.75 },
-  { cx: 26, cy: 34, r: 0.4, opacity: 0.45 },
-  { cx: 118, cy: 34, r: 0.4, opacity: 0.45 },
-  { cx: 202, cy: 32, r: 0.4, opacity: 0.5 },
-  { cx: 268, cy: 34, r: 0.4, opacity: 0.45 },
-];
+/** The sidebar background the artwork dissolves into; the send-button crop has no stage wrapper, so fall back to the chrome. */
+const STAGE_FADE = "var(--stage-fade, var(--app-chrome-background))";
 
-const NIGHTLY_SPARKLES: ReadonlyArray<{ x: number; y: number }> = [
-  { x: 70, y: 28 },
-  { x: 160, y: 36 },
-  { x: 246, y: 26 },
-];
+/** A dissolve into the sidebar across the lower part of the art, stepping in OKLCH so light sidebars pass through tints of the art's own hue instead of gray. */
+function StageDissolve({ id, anchor }: { id: string; anchor: string }) {
+  const mix = (pct: number) => `color-mix(in oklch, ${STAGE_FADE} ${pct}%, ${anchor})`;
+  return (
+    <linearGradient id={id} x1="0" y1="20" x2="0" y2="96" gradientUnits="userSpaceOnUse">
+      <stop style={{ stopColor: mix(15) }} stopOpacity="0" />
+      <stop offset="0.25" style={{ stopColor: mix(30) }} stopOpacity="0.35" />
+      <stop offset="0.5" style={{ stopColor: mix(55) }} stopOpacity="0.7" />
+      <stop offset="0.75" style={{ stopColor: mix(80) }} stopOpacity="0.92" />
+      <stop offset="1" style={{ stopColor: STAGE_FADE }} />
+    </linearGradient>
+  );
+}
+
+type Star = { cx: number; cy: number; r: number; opacity: number };
+
+/**
+ * Deterministic star field for one 640-unit tile, kept out of the wordmark corner and
+ * the lower half where the sky dissolves. Three size classes; the largest get a glint.
+ */
+function createStarField(seed: number, count: number): ReadonlyArray<Star> {
+  const stars: Star[] = [];
+  let n = seed;
+  const random = () => {
+    n = (n * 1103515245 + 12345) % 2147483648;
+    return n / 2147483648;
+  };
+  while (stars.length < count) {
+    const cx = Math.round(random() * 640);
+    const cy = Math.round(random() * 70 + 2);
+    if ((cx < 96 && cy < 36) || cy > 50) continue;
+    const k = random();
+    const r = k > 0.94 ? 0.95 : k > 0.72 ? 0.62 : 0.38;
+    const opacity = k > 0.94 ? 0.95 : k > 0.72 ? 0.75 : 0.35 + random() * 0.3;
+    stars.push({ cx, cy, r, opacity: Number(opacity.toFixed(2)) });
+  }
+  return stars;
+}
+
+const NIGHTLY_STARS = createStarField(79, 28);
 
 function NightlySkyArt({ compact = false }: { compact?: boolean }) {
   const idPrefix = useId().replaceAll(":", "");
   const skyId = `${idPrefix}-stage-night-sky`;
-  const glowId = `${idPrefix}-stage-night-glow`;
-  const cloudId = `${idPrefix}-stage-night-cloud`;
-  const softId = `${idPrefix}-stage-night-soft`;
+  const hazeId = `${idPrefix}-stage-night-haze`;
+  const hazePatternId = `${idPrefix}-stage-night-haze-pattern`;
   const starsId = `${idPrefix}-stage-night-stars`;
-  const glowsId = `${idPrefix}-stage-night-glows`;
+  const fadeId = `${idPrefix}-stage-night-fade`;
 
   return (
     <svg
-      className="stage-art stage-nightly h-full w-full"
+      className={`stage-art stage-nightly h-full w-full${compact ? " scale-110 blur-[1.6px]" : ""}`}
       fill="none"
       preserveAspectRatio="xMinYMin slice"
       viewBox={compact ? "96 0 8192 96" : STAGE_BACKDROP_VIEW_BOX}
@@ -136,35 +148,27 @@ function NightlySkyArt({ compact = false }: { compact?: boolean }) {
           <stop offset="0.5" style={{ stopColor: "var(--stage-night-mid)" }} />
           <stop offset="1" style={{ stopColor: "var(--stage-night-top)" }} />
         </linearGradient>
-        <radialGradient
-          id={glowId}
-          cx="0"
-          cy="0"
-          r="1"
-          gradientTransform="translate(216 18) rotate(137) scale(120 84)"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop style={{ stopColor: "var(--stage-night-glow-highlight)" }} stopOpacity="0.4" />
-          <stop
-            offset="0.5"
-            style={{ stopColor: "var(--stage-night-glow-secondary)" }}
-            stopOpacity="0.16"
-          />
-          <stop offset="1" style={{ stopColor: "var(--stage-night-bottom)" }} stopOpacity="0" />
-        </radialGradient>
-        <linearGradient id={cloudId} x1="0" y1="60" x2="288" y2="96" gradientUnits="userSpaceOnUse">
-          <stop style={{ stopColor: "var(--stage-night-highlight)" }} stopOpacity="0.5" />
-          <stop
-            offset="0.52"
-            style={{ stopColor: "var(--stage-night-secondary)" }}
-            stopOpacity="0.62"
-          />
-          <stop offset="1" style={{ stopColor: "var(--stage-night-tertiary)" }} stopOpacity="0.5" />
-        </linearGradient>
-        <filter id={softId} x="-24" y="-24" width="336" height="144" filterUnits="userSpaceOnUse">
-          <feGaussianBlur stdDeviation="4" />
+        {/* Soft diagonal haze instead of a radial glow, blurred once and tiled. */}
+        <filter id={hazeId} x="-10%" y="-60%" width="120%" height="220%">
+          <feGaussianBlur stdDeviation="9" />
         </filter>
-        <pattern id={starsId} width="288" height="96" patternUnits="userSpaceOnUse">
+        <pattern id={hazePatternId} width="640" height="96" patternUnits="userSpaceOnUse">
+          <g filter={`url(#${hazeId})`} fill="none" strokeLinecap="round">
+            <path
+              d="M-40 72C80 30 170 92 300 40S520 18 680 58"
+              style={{ stroke: "var(--stage-night-glow-highlight)" }}
+              strokeOpacity="0.26"
+              strokeWidth="24"
+            />
+            <path
+              d="M-40 18C100 62 220 -4 360 52S560 92 680 28"
+              style={{ stroke: "var(--stage-night-glow-secondary)" }}
+              strokeOpacity="0.22"
+              strokeWidth="34"
+            />
+          </g>
+        </pattern>
+        <pattern id={starsId} width="640" height="96" patternUnits="userSpaceOnUse">
           <g style={{ fill: "var(--stage-night-line)" }}>
             {NIGHTLY_STARS.map((star) => (
               <circle
@@ -179,39 +183,24 @@ function NightlySkyArt({ compact = false }: { compact?: boolean }) {
           <g
             style={{ stroke: "var(--stage-night-sparkle)" }}
             strokeLinecap="round"
-            strokeOpacity="0.7"
+            strokeOpacity="0.85"
             strokeWidth="0.6"
           >
-            {NIGHTLY_SPARKLES.map((sparkle) => (
-              <g key={`${sparkle.x}-${sparkle.y}`}>
-                <path d={`M${sparkle.x - 1.5} ${sparkle.y}H${sparkle.x + 1.5}`} />
-                <path d={`M${sparkle.x} ${sparkle.y - 1.5}V${sparkle.y + 1.5}`} />
+            {NIGHTLY_STARS.filter((star) => star.r > 0.9).map((star) => (
+              <g key={`${star.cx}-${star.cy}`}>
+                <path d={`M${star.cx - 2.4} ${star.cy}H${star.cx + 2.4}`} />
+                <path d={`M${star.cx} ${star.cy - 2.4}V${star.cy + 2.4}`} />
               </g>
             ))}
           </g>
         </pattern>
-        <pattern id={glowsId} width="640" height="96" patternUnits="userSpaceOnUse">
-          <rect width="640" height="96" fill={`url(#${glowId})`} />
-        </pattern>
+        <StageDissolve id={fadeId} anchor="var(--stage-night-mid)" />
       </defs>
 
       <rect width="100%" height="96" fill={`url(#${skyId})`} />
-      <rect width="100%" height="96" fill={`url(#${glowsId})`} />
+      <rect width="100%" height="96" fill={`url(#${hazePatternId})`} />
       <rect width="100%" height="96" fill={`url(#${starsId})`} />
-
-      <g filter={`url(#${softId})`}>
-        <path
-          d="M-12 88C-12 74 0 63 14 63C18 50 30 41 44 41C58 41 70 49 74 62C79 57 86 54 94 54C110 54 123 66 124 82C132 83 138 88 141 96H-12V88Z"
-          fill={`url(#${cloudId})`}
-        />
-      </g>
-      <g filter={`url(#${softId})`}>
-        <path
-          d="M150 96C151 84 161 75 173 75C176 64 186 57 198 57C210 57 220 64 223 75C231 75 238 80 241 87C250 87 257 91 260 96H150Z"
-          fill={`url(#${cloudId})`}
-          fillOpacity="0.8"
-        />
-      </g>
+      <rect width="100%" height="96" fill={`url(#${fadeId})`} />
     </svg>
   );
 }
@@ -227,10 +216,11 @@ function DevBlueprintArt({ compact = false }: { compact?: boolean }) {
   const rulerId = `${idPrefix}-stage-bp-ruler`;
   const glowsId = `${idPrefix}-stage-bp-glows`;
   const annotationsId = `${idPrefix}-stage-bp-annotations`;
+  const fadeId = `${idPrefix}-stage-bp-fade`;
 
   return (
     <svg
-      className="stage-art stage-blueprint h-full w-full"
+      className={`stage-art stage-blueprint h-full w-full${compact ? " scale-110 blur-[1.6px]" : ""}`}
       fill="none"
       preserveAspectRatio="xMinYMin slice"
       viewBox={compact ? "64 0 8192 96" : STAGE_BACKDROP_VIEW_BOX}
@@ -384,6 +374,7 @@ function DevBlueprintArt({ compact = false }: { compact?: boolean }) {
             <path d="M648 26V38M642 32H654" strokeOpacity="0.6" strokeWidth="0.4" />
           </g>
         </pattern>
+        <StageDissolve id={fadeId} anchor="var(--stage-art-mid)" />
       </defs>
 
       <rect width="100%" height="96" fill={`url(#${paperId})`} />
@@ -392,6 +383,7 @@ function DevBlueprintArt({ compact = false }: { compact?: boolean }) {
       <rect width="100%" height="96" fill={`url(#${majorGridId})`} />
       <rect width="100%" height="6" fill={`url(#${rulerId})`} />
       <rect width="100%" height="96" fill={`url(#${annotationsId})`} />
+      <rect width="100%" height="96" fill={`url(#${fadeId})`} />
     </svg>
   );
 }

--- a/apps/web/src/hooks/useEnvironmentThemeSync.test.ts
+++ b/apps/web/src/hooks/useEnvironmentThemeSync.test.ts
@@ -155,7 +155,7 @@ describe("published theme refresh", () => {
       palette.getThemeDefinition(NIGHTFALL_THEME.id)?.colors.canvas,
     );
     expect(root.classList.contains("dark")).toBe(true);
-    expect(palette.getThemePreviewSidebarArtwork()).toBeNull();
+    expect(root.dataset.themeArtwork).toBe("derived");
   });
 
   it("keeps a draft visible when default adoption changes the theme and appearance", async () => {
@@ -176,6 +176,6 @@ describe("published theme refresh", () => {
     current.refreshTheme();
     expect(root.dataset.themeId).toBe("ocean");
     expect(root.classList.contains("dark")).toBe(false);
-    expect(palette.getThemePreviewSidebarArtwork()).toBeNull();
+    expect(root.dataset.themeArtwork).toBeUndefined();
   });
 });

--- a/apps/web/src/hooks/useSettings.test.ts
+++ b/apps/web/src/hooks/useSettings.test.ts
@@ -337,35 +337,10 @@ describe("resolveEnvironmentIdentificationMode", () => {
     );
   });
 
-  it("uses a pill instead of artwork with a palette theme", () => {
-    expect(
-      resolveEnvironmentIdentificationMode({
-        mode: "artwork",
-        settingsHydrated: true,
-        paletteThemeActive: true,
-      }),
-    ).toBe("pill");
-  });
-
-  it("respects none with a palette theme", () => {
-    expect(
-      resolveEnvironmentIdentificationMode({
-        mode: "none",
-        settingsHydrated: true,
-        paletteThemeActive: true,
-      }),
-    ).toBe("none");
-  });
-
-  it("keeps artwork when the palette theme opts into it", () => {
-    expect(
-      resolveEnvironmentIdentificationMode({
-        mode: "artwork",
-        settingsHydrated: true,
-        paletteThemeActive: true,
-        paletteThemeAllowsArtwork: true,
-      }),
-    ).toBe("artwork");
+  it("keeps the chosen mode once settings hydrate", () => {
+    for (const mode of ["artwork", "pill", "none"] as const) {
+      expect(resolveEnvironmentIdentificationMode({ mode, settingsHydrated: true })).toBe(mode);
+    }
   });
 });
 

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -33,20 +33,12 @@ import {
   supportsSharedSettingsSync,
 } from "@t3tools/client-runtime/state/shared-settings";
 import { ensureLocalApi } from "~/localApi";
-import {
-  getThemeDefinition,
-  getThemePreviewSidebarArtwork,
-  resolveThemeHalf,
-  subscribeToThemePreview,
-  themeAllowsSidebarArtwork,
-} from "~/themePalette";
 import * as Struct from "effect/Struct";
 import { toastManager } from "~/components/ui/toast";
 import { isHostedStaticApp } from "~/hostedPairing";
 import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
 import { useEnvironments, usePrimaryEnvironment } from "~/state/environments";
 import { useAtomCommand } from "~/state/use-atom-command";
-import { useTheme } from "./useTheme";
 
 const CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE = "[CLIENT_SETTINGS]";
 
@@ -335,35 +327,15 @@ export function useClientSettings<T = ClientSettings>(
 export function resolveEnvironmentIdentificationMode(input: {
   mode: EnvironmentIdentificationMode;
   settingsHydrated: boolean;
-  paletteThemeActive?: boolean;
-  paletteThemeAllowsArtwork?: boolean;
 }): EnvironmentIdentificationMode {
   // Avoid briefly rendering the default artwork before a persisted pill/none choice loads.
-  if (!input.settingsHydrated) return "none";
-  // Artwork palettes are maintained for built-ins only. Keep an explicit
-  // "none", but use the theme-aware pill for user-controlled palettes.
-  return input.paletteThemeActive && !input.paletteThemeAllowsArtwork && input.mode === "artwork"
-    ? "pill"
-    : input.mode;
+  return input.settingsHydrated ? input.mode : "none";
 }
 
 export function useEnvironmentIdentificationMode(): EnvironmentIdentificationMode {
   const settingsHydrated = useClientSettingsHydrated();
   const mode = useClientSettingsValue().environmentIdentificationMode;
-  const { resolvedTheme, theme, themeHalves } = useTheme();
-  const previewSidebarArtwork = useSyncExternalStore(
-    subscribeToThemePreview,
-    getThemePreviewSidebarArtwork,
-    () => null,
-  );
-  const activeTheme = resolveThemeHalf(theme, themeHalves, resolvedTheme);
-  const activeThemeDefinition = getThemeDefinition(activeTheme);
-  return resolveEnvironmentIdentificationMode({
-    mode,
-    settingsHydrated,
-    paletteThemeActive: previewSidebarArtwork !== null || activeThemeDefinition !== null,
-    paletteThemeAllowsArtwork: previewSidebarArtwork ?? themeAllowsSidebarArtwork(activeTheme),
-  });
+  return resolveEnvironmentIdentificationMode({ mode, settingsHydrated });
 }
 
 /**

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -555,7 +555,9 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
   :root {
     /* Keep the original T3 Code artwork palettes as the defaults. Built-in
-       themes override them with their own pigments in the components layer. */
+       themes override them with their own pigments in the components layer;
+       custom themes get pigments derived from their palette, set inline by
+       applyThemePalette. */
     --stage-art-top: oklch(0.782169 0.123386 240.226);
     --stage-art-mid: oklch(0.616111 0.195824 259.735);
     --stage-art-bottom: oklch(0.441553 0.232394 265.474);
@@ -753,7 +755,12 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     }
   }
 
-  :is(html[data-theme-id="t3-chat"], html[data-theme-id="ocean"], html[data-theme-id="iris"]) {
+  :is(
+    html[data-theme-id="t3-chat"],
+    html[data-theme-id="ocean"],
+    html[data-theme-id="iris"],
+    html[data-theme-artwork="derived"]
+  ) {
     --stage-night-top: color-mix(in oklch, var(--stage-art-top) 38%, var(--stage-night-base-top));
     --stage-night-mid: color-mix(in oklch, var(--stage-art-mid) 38%, var(--stage-night-base-mid));
     --stage-night-bottom: color-mix(
@@ -780,7 +787,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     html[data-theme-id="grove"],
     html[data-theme-id="ocean"],
     html[data-theme-id="ember"],
-    html[data-theme-id="iris"]
+    html[data-theme-id="iris"],
+    html[data-theme-artwork="derived"]
   ) {
     --stage-art-celeste-highlight: var(--stage-art-highlight);
     --stage-art-celeste-secondary: var(--stage-art-secondary);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -556,8 +556,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   :root {
     /* Keep the original T3 Code artwork palettes as the defaults. Built-in
        themes override them with their own pigments in the components layer;
-       custom themes get pigments derived from their palette, set inline by
-       applyThemePalette. */
+       custom themes get every pigment derived from their palette, set inline
+       by applyThemePalette. */
     --stage-art-top: oklch(0.782169 0.123386 240.226);
     --stage-art-mid: oklch(0.616111 0.195824 259.735);
     --stage-art-bottom: oklch(0.441553 0.232394 265.474);
@@ -755,12 +755,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     }
   }
 
-  :is(
-    html[data-theme-id="t3-chat"],
-    html[data-theme-id="ocean"],
-    html[data-theme-id="iris"],
-    html[data-theme-artwork="derived"]
-  ) {
+  :is(html[data-theme-id="t3-chat"], html[data-theme-id="ocean"], html[data-theme-id="iris"]) {
     --stage-night-top: color-mix(in oklch, var(--stage-art-top) 38%, var(--stage-night-base-top));
     --stage-night-mid: color-mix(in oklch, var(--stage-art-mid) 38%, var(--stage-night-base-mid));
     --stage-night-bottom: color-mix(

--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -7,7 +7,6 @@ import {
   getThemeColorsForMode,
   getThemeDefinition,
   getThemeModes,
-  getThemePreviewSidebarArtwork,
   getThemePreferenceMode,
   isKnownThemePreference,
   getCustomThemes,
@@ -24,9 +23,7 @@ import {
   resolveDesktopTheme,
   resolveThemeAppearance,
   serializeThemeFile,
-  subscribeToThemePreview,
   subscribeToCustomThemes,
-  themeAllowsSidebarArtwork,
   T3_CHAT_THEME,
   EMBER_THEME,
   GROVE_THEME,
@@ -35,6 +32,7 @@ import {
   updateCustomTheme,
   CUSTOM_THEMES_STORAGE_KEY,
   createVividThemeColors,
+  deriveStageArtworkColors,
   getDefaultThemeColors,
   themeColorToHex,
   toCanonicalThemeColor,
@@ -46,6 +44,12 @@ function asHex(value: string): string {
   const hex = themeColorToHex(value);
   if (!hex) throw new Error(`Expected a theme color, received ${value}`);
   return hex.slice(0, 7);
+}
+
+function parseOklch(value: string): { L: number; C: number; h: number } {
+  const match = value.match(/^oklch\(([\d.]+) ([\d.]+) ([\d.]+)\)$/);
+  if (!match) throw new Error(`Not a bare oklch color: ${value}`);
+  return { L: Number(match[1]), C: Number(match[2]), h: Number(match[3]) };
 }
 
 function canonical(value: string): string {
@@ -318,40 +322,71 @@ describe("theme files", () => {
     expect(parseThemeFile(JSON.parse(serialized)).collection).toEqual(theme.collection);
   });
 
-  it("keeps sidebar artwork disabled for custom theme files", () => {
-    const theme = parseThemeFile({
-      version: THEME_FILE_VERSION,
-      name: "Art sidebar",
-      appearance: "light",
-      colors: { accent: "#5b6cff" },
-      sidebarArtwork: true,
-    });
-
-    expect(theme.sidebarArtwork).toBeUndefined();
-    expect(JSON.parse(serializeThemeFile(theme))).not.toHaveProperty("sidebarArtwork");
-  });
-
-  it("suppresses sidebar artwork during a live custom-theme preview", () => {
-    const listener = vi.fn();
-    const unsubscribe = subscribeToThemePreview(listener);
-    vi.stubGlobal("document", {
-      documentElement: {
-        classList: { toggle: vi.fn() },
-        dataset: {},
-        style: { removeProperty: vi.fn(), setProperty: vi.fn() },
+  it("derives environment artwork for user themes and clears it for built-ins", () => {
+    const styles = new Map<string, string>();
+    const root = {
+      classList: { toggle: vi.fn() },
+      dataset: {} as Record<string, string | undefined>,
+      style: {
+        removeProperty: (name: string) => styles.delete(name),
+        setProperty: (name: string, value: string) => styles.set(name, value),
+      },
+    };
+    vi.stubGlobal("document", { documentElement: root });
+    const stored = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => stored.get(key) ?? null,
+        setItem: (key: string, value: string) => stored.set(key, value),
       },
     });
+    invalidateCustomThemes();
+    const custom = installCustomTheme(
+      parseThemeFile({
+        version: THEME_FILE_VERSION,
+        id: "meadow",
+        name: "Meadow",
+        appearance: "light",
+        colors: { canvas: "#f6fbf4", accent: "oklch(0.55 0.14 145)" },
+      }),
+    );
 
-    applyThemeColorPreview(T3_CHAT_THEME.colors, "light");
-    expect(getThemePreviewSidebarArtwork()).toBe(false);
-    expect(listener).toHaveBeenCalledTimes(1);
+    applyThemePalette(custom.id);
+    expect(root.dataset.themeArtwork).toBe("derived");
+    const artwork = deriveStageArtworkColors(custom.colors, "light");
+    expect(styles.get("--stage-art-mid")).toBe(artwork["--stage-art-mid"]);
+    expect(artwork["--stage-art-mid"]).toMatch(/^oklch\(0\.59 /);
+    expect(parseOklch(artwork["--stage-art-mid"]).h).toBeCloseTo(145, 0);
+    // The tertiary glow follows the generated companion action color, not the accent.
+    expect(parseOklch(artwork["--stage-art-tertiary"]).h).not.toBeCloseTo(145, 0);
+
+    applyThemePalette("ocean");
+    expect(root.dataset.themeArtwork).toBeUndefined();
+    expect(styles.has("--stage-art-mid")).toBe(false);
+
+    applyThemeColorPreview(T3_CHAT_THEME.colors, "dark");
+    expect(root.dataset.themeArtwork).toBe("derived");
+    expect(styles.get("--stage-art-top")).toBe(
+      deriveStageArtworkColors(T3_CHAT_THEME.colors, "dark")["--stage-art-top"],
+    );
 
     applyThemePalette("system");
-    expect(getThemePreviewSidebarArtwork()).toBeNull();
-    expect(listener).toHaveBeenCalledTimes(2);
+    expect(root.dataset.themeArtwork).toBeUndefined();
+    expect(styles.has("--stage-art-top")).toBe(false);
 
-    unsubscribe();
+    removeCustomTheme(custom.id);
+    invalidateCustomThemes();
     vi.unstubAllGlobals();
+  });
+
+  it("keeps a gray accent's artwork grayscale", () => {
+    const artwork = deriveStageArtworkColors(
+      { ...getDefaultThemeColors("dark"), accent: "#9a9a9a", messageAction: "#777777" },
+      "dark",
+    );
+    for (const value of Object.values(artwork)) {
+      expect(parseOklch(value).C).toBeLessThan(0.005);
+    }
   });
 
   it("keeps optional light and dark palettes under one theme id", () => {
@@ -430,8 +465,6 @@ describe("theme files", () => {
     for (const theme of [T3_CHAT_THEME, GROVE_THEME, OCEAN_THEME, EMBER_THEME, IRIS_THEME]) {
       expect(getThemeDefinition(theme.id)).toBe(theme);
       expect(getThemeModes(theme)).toEqual(["light", "dark"]);
-      expect(theme.sidebarArtwork).toBe(true);
-      expect(themeAllowsSidebarArtwork(theme.id)).toBe(true);
       expect(theme.colors.accent).toMatch(/^oklch\(/);
       expect(theme.variants?.dark?.accent).toMatch(/^oklch\(/);
 
@@ -466,7 +499,6 @@ describe("theme files", () => {
         );
       }
     }
-    expect(themeAllowsSidebarArtwork("my-custom-theme")).toBe(false);
   });
 
   it("rejects a variant that repeats the base appearance", () => {
@@ -729,7 +761,6 @@ describe("theme files", () => {
         name: "Aurora",
         appearance: "light",
         colors: { canvas: "#f8fbff", accent: "#5b6cff" },
-        sidebarArtwork: true,
       }),
     );
     const updatedTheme = updateCustomTheme({
@@ -743,7 +774,6 @@ describe("theme files", () => {
       label: "Aurora Night",
       colors: { accent: canonical("hsl(263 70% 58%)") },
     });
-    expect(updatedTheme).not.toHaveProperty("sidebarArtwork");
     const storedThemes = JSON.parse(stored.get(CUSTOM_THEMES_STORAGE_KEY) ?? "[]");
     expect(storedThemes[0]).toEqual(untouchedTheme);
     expect(storedThemes[1]).toMatchObject({
@@ -751,7 +781,6 @@ describe("theme files", () => {
       label: "Aurora Night",
       colors: { accent: canonical("hsl(263 70% 58%)") },
     });
-    expect(storedThemes[1]).not.toHaveProperty("sidebarArtwork");
     invalidateCustomThemes();
     expect(getCustomThemes().find((theme) => theme.id === "aurora")).toMatchObject({
       id: "aurora",

--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -379,6 +379,20 @@ describe("theme files", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps the Nightly sky in a warm theme's own hue", () => {
+    const artwork = deriveStageArtworkColors(
+      { ...getDefaultThemeColors("light"), accent: "oklch(0.58 0.15 40)" },
+      "light",
+    );
+    for (const variable of [
+      "--stage-night-top",
+      "--stage-night-mid",
+      "--stage-night-bottom",
+    ] as const) {
+      expect(parseOklch(artwork[variable]).h).toBeCloseTo(40, 0);
+    }
+  });
+
   it("keeps a gray accent's artwork grayscale", () => {
     const artwork = deriveStageArtworkColors(
       { ...getDefaultThemeColors("dark"), accent: "#9a9a9a", messageAction: "#777777" },

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -75,23 +75,6 @@ type CustomThemeLibrarySnapshot =
   | Readonly<{ status: "unavailable"; reason: "storage-unavailable"; cause: unknown }>;
 
 let customThemeLibrarySnapshot: CustomThemeLibrarySnapshot | null = null;
-const themePreviewListeners = new Set<() => void>();
-let themePreviewSidebarArtwork: boolean | null = null;
-
-export function getThemePreviewSidebarArtwork(): boolean | null {
-  return themePreviewSidebarArtwork;
-}
-
-export function subscribeToThemePreview(listener: () => void): () => void {
-  themePreviewListeners.add(listener);
-  return () => themePreviewListeners.delete(listener);
-}
-
-function setThemePreviewSidebarArtwork(next: boolean | null): void {
-  if (themePreviewSidebarArtwork === next) return;
-  themePreviewSidebarArtwork = next;
-  for (const listener of themePreviewListeners) listener();
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -1204,13 +1187,8 @@ export function getThemeDefinition(theme: ThemePreference): ThemeDefinition | nu
   );
 }
 
-/** Artwork palettes are reviewed alongside built-ins; user themes always use the pill fallback. */
-export function themeAllowsSidebarArtwork(theme: ThemePreference): boolean {
-  const themeId = themeIdFromPreference(theme);
-  return (
-    BUILT_IN_THEME_DEFINITIONS.find((definition) => definition.id === themeId)?.sidebarArtwork ===
-    true
-  );
+function isBuiltInThemeId(themeId: string): boolean {
+  return BUILT_IN_THEME_DEFINITIONS.some((definition) => definition.id === themeId);
 }
 
 /**
@@ -1612,6 +1590,70 @@ export function getThemeColorVariable(role: ThemeColorRole): string {
   return APP_THEME_VARIABLES[role];
 }
 
+/** Pigments the Dev blueprint reads; the Nightly sky is mixed from them in CSS. */
+const STAGE_ARTWORK_VARIABLES = [
+  "--stage-art-top",
+  "--stage-art-mid",
+  "--stage-art-bottom",
+  "--stage-art-highlight",
+  "--stage-art-secondary",
+  "--stage-art-tertiary",
+  "--stage-art-line",
+] as const;
+type StageArtworkVariable = (typeof STAGE_ARTWORK_VARIABLES)[number];
+export type StageArtworkColors = Readonly<Record<StageArtworkVariable, string>>;
+
+/**
+ * Environment artwork pigments for a palette T3 Code does not hand-tune.
+ * Built-ins keep reviewed values in index.css; this follows their structure so
+ * a user theme gets the same kind of art: a fixed lightness ladder per
+ * appearance keeps the white wordmark readable whatever the accent, hue and
+ * chroma come from the accent, and the tertiary glow takes the companion
+ * action color's hue. A gray accent yields a grayscale blueprint.
+ */
+export function deriveStageArtworkColors(
+  colors: ThemeColors,
+  appearance: ThemeAppearance,
+): StageArtworkColors {
+  const dark = appearance === "dark";
+  const canvas = parseThemeColor(colors.canvas)?.color ?? { L: dark ? 0.2 : 0.98, C: 0, h: 0 };
+  const accent = parseThemeColor(colors.accent)?.color ?? canvas;
+  const action = parseThemeColor(colors.messageAction)?.color ?? accent;
+  const h = accent.C < 0.03 ? canvas.h : accent.h;
+  const c = Math.min(0.19, accent.C);
+  const tertiaryHue = action.C < 0.03 ? (h + 50) % 360 : action.h;
+  const pigment = (color: ThemeOklch) => themeOklchToThemeColor(color);
+  return {
+    "--stage-art-top": pigment({ L: dark ? 0.58 : 0.77, C: c * 0.8, h }),
+    "--stage-art-mid": pigment({ L: dark ? 0.44 : 0.59, C: c, h }),
+    "--stage-art-bottom": pigment({ L: dark ? 0.28 : 0.39, C: c * 0.75, h }),
+    "--stage-art-highlight": pigment({ L: dark ? 0.93 : 0.96, C: Math.min(0.035, c), h }),
+    "--stage-art-secondary": pigment({ L: dark ? 0.7 : 0.79, C: c * 0.85, h }),
+    "--stage-art-tertiary": pigment({
+      L: dark ? 0.66 : 0.73,
+      C: Math.min(0.18, action.C),
+      h: tertiaryHue,
+    }),
+    "--stage-art-line": pigment({ L: dark ? 0.95 : 0.97, C: Math.min(0.028, c), h }),
+  };
+}
+
+/**
+ * Inline pigments outrank the built-in rules in index.css, so a built-in must
+ * clear them or it would keep wearing the previous custom theme's art. The
+ * attribute tells CSS to mix the Nightly sky and glow aliases from them.
+ */
+function applyStageArtwork(root: HTMLElement, artwork: StageArtworkColors | null): void {
+  if (artwork) {
+    root.dataset.themeArtwork = "derived";
+    for (const [variable, value] of Object.entries(artwork))
+      root.style.setProperty(variable, value);
+    return;
+  }
+  delete root.dataset.themeArtwork;
+  for (const variable of STAGE_ARTWORK_VARIABLES) root.style.removeProperty(variable);
+}
+
 /** Marks the document as wearing an unsaved draft rather than a stored theme. */
 export const THEME_PREVIEW_ID = "__preview";
 
@@ -1625,15 +1667,15 @@ export function applyThemeColorPreview(colors: ThemeColors, appearance: ThemeApp
   const root = document.documentElement;
   if (!root?.style) return;
 
-  // Drafts become user-controlled themes when saved, so their preview keeps
-  // the fixed stage artwork hidden even when it was seeded from a built-in.
-  setThemePreviewSidebarArtwork(false);
   root.dataset.themeId = THEME_PREVIEW_ID;
   root.classList.toggle("dark", appearance === "dark");
   for (const [role, value] of Object.entries(colors) as Array<[ThemeColorRole, string]>) {
     // A half-typed hex keeps the last good value instead of blanking the role.
     if (isThemeColor(value)) root.style.setProperty(APP_THEME_VARIABLES[role], value);
   }
+  // Drafts become user-controlled themes when saved, so they preview with
+  // derived art even when seeded from a built-in.
+  applyStageArtwork(root, deriveStageArtworkColors(colors, appearance));
 }
 
 export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppearance): void {
@@ -1642,7 +1684,6 @@ export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppe
   const root = document.documentElement;
   if (!root?.style) return;
 
-  setThemePreviewSidebarArtwork(null);
   const palette = getThemeDefinition(theme);
 
   if (palette) {
@@ -1652,6 +1693,10 @@ export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppe
     for (const [role, value] of Object.entries(colors) as Array<[ThemeColorRole, string]>) {
       root.style.setProperty(APP_THEME_VARIABLES[role], value);
     }
+    applyStageArtwork(
+      root,
+      isBuiltInThemeId(palette.id) ? null : deriveStageArtworkColors(colors, mode),
+    );
     return;
   }
 
@@ -1659,6 +1704,7 @@ export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppe
   for (const variable of Object.values(APP_THEME_VARIABLES)) {
     root.style.removeProperty(variable);
   }
+  applyStageArtwork(root, null);
 }
 
 export function resolveThemeAppearance(

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -1590,7 +1590,7 @@ export function getThemeColorVariable(role: ThemeColorRole): string {
   return APP_THEME_VARIABLES[role];
 }
 
-/** Pigments the Dev blueprint reads; the Nightly sky is mixed from them in CSS. */
+/** Every pigment the Dev blueprint and Nightly sky read. */
 const STAGE_ARTWORK_VARIABLES = [
   "--stage-art-top",
   "--stage-art-mid",
@@ -1599,6 +1599,13 @@ const STAGE_ARTWORK_VARIABLES = [
   "--stage-art-secondary",
   "--stage-art-tertiary",
   "--stage-art-line",
+  "--stage-night-top",
+  "--stage-night-mid",
+  "--stage-night-bottom",
+  "--stage-night-highlight",
+  "--stage-night-secondary",
+  "--stage-night-tertiary",
+  "--stage-night-line",
 ] as const;
 type StageArtworkVariable = (typeof STAGE_ARTWORK_VARIABLES)[number];
 export type StageArtworkColors = Readonly<Record<StageArtworkVariable, string>>;
@@ -1606,10 +1613,12 @@ export type StageArtworkColors = Readonly<Record<StageArtworkVariable, string>>;
 /**
  * Environment artwork pigments for a palette T3 Code does not hand-tune.
  * Built-ins keep reviewed values in index.css; this follows their structure so
- * a user theme gets the same kind of art: a fixed lightness ladder per
- * appearance keeps the white wordmark readable whatever the accent, hue and
+ * a user theme gets the same kind of art: fixed lightness ladders per
+ * appearance keep the white wordmark readable whatever the accent, hue and
  * chroma come from the accent, and the tertiary glow takes the companion
- * action color's hue. A gray accent yields a grayscale blueprint.
+ * action color's hue. The Nightly sky stays in the theme's own hue rather
+ * than the stock violet, so a gray accent yields a grayscale blueprint and a
+ * slate sky.
  */
 export function deriveStageArtworkColors(
   colors: ThemeColors,
@@ -1621,7 +1630,8 @@ export function deriveStageArtworkColors(
   const action = parseThemeColor(colors.messageAction)?.color ?? accent;
   const h = accent.C < 0.03 ? canvas.h : accent.h;
   const c = Math.min(0.19, accent.C);
-  const tertiaryHue = action.C < 0.03 ? (h + 50) % 360 : action.h;
+  const th = action.C < 0.03 ? (h + 50) % 360 : action.h;
+  const tc = Math.min(0.18, action.C);
   const pigment = (color: ThemeOklch) => themeOklchToThemeColor(color);
   return {
     "--stage-art-top": pigment({ L: dark ? 0.58 : 0.77, C: c * 0.8, h }),
@@ -1629,19 +1639,26 @@ export function deriveStageArtworkColors(
     "--stage-art-bottom": pigment({ L: dark ? 0.28 : 0.39, C: c * 0.75, h }),
     "--stage-art-highlight": pigment({ L: dark ? 0.93 : 0.96, C: Math.min(0.035, c), h }),
     "--stage-art-secondary": pigment({ L: dark ? 0.7 : 0.79, C: c * 0.85, h }),
-    "--stage-art-tertiary": pigment({
-      L: dark ? 0.66 : 0.73,
-      C: Math.min(0.18, action.C),
-      h: tertiaryHue,
-    }),
+    "--stage-art-tertiary": pigment({ L: dark ? 0.66 : 0.73, C: tc, h: th }),
     "--stage-art-line": pigment({ L: dark ? 0.95 : 0.97, C: Math.min(0.028, c), h }),
+    "--stage-night-top": pigment({ L: dark ? 0.4 : 0.46, C: c * 0.6, h }),
+    "--stage-night-mid": pigment({ L: dark ? 0.28 : 0.36, C: c * 0.5, h }),
+    "--stage-night-bottom": pigment({ L: dark ? 0.2 : 0.25, C: c * 0.35, h }),
+    "--stage-night-highlight": pigment({ L: dark ? 0.86 : 0.9, C: Math.min(0.06, c * 0.45), h }),
+    "--stage-night-secondary": pigment({ L: dark ? 0.57 : 0.65, C: c * 0.8, h }),
+    "--stage-night-tertiary": pigment({
+      L: dark ? 0.55 : 0.62,
+      C: Math.min(0.13, tc * 0.8),
+      h: th,
+    }),
+    "--stage-night-line": pigment({ L: dark ? 0.9 : 0.93, C: Math.min(0.045, c * 0.33), h }),
   };
 }
 
 /**
  * Inline pigments outrank the built-in rules in index.css, so a built-in must
  * clear them or it would keep wearing the previous custom theme's art. The
- * attribute tells CSS to mix the Nightly sky and glow aliases from them.
+ * attribute tells CSS to alias the glow and grid pigments from them.
  */
 function applyStageArtwork(root: HTMLElement, artwork: StageArtworkColors | null): void {
   if (artwork) {
@@ -1674,8 +1691,15 @@ export function applyThemeColorPreview(colors: ThemeColors, appearance: ThemeApp
     if (isThemeColor(value)) root.style.setProperty(APP_THEME_VARIABLES[role], value);
   }
   // Drafts become user-controlled themes when saved, so they preview with
-  // derived art even when seeded from a built-in.
-  applyStageArtwork(root, deriveStageArtworkColors(colors, appearance));
+  // derived art even when seeded from a built-in. A half-typed color keeps
+  // the last good pigment here too, so the art does not snap to gray mid-edit.
+  const lastGood = Object.fromEntries(
+    (Object.entries(colors) as Array<[ThemeColorRole, string]>).map(([role, value]) => [
+      role,
+      isThemeColor(value) ? value : root.style.getPropertyValue(APP_THEME_VARIABLES[role]) || value,
+    ]),
+  ) as ThemeColors;
+  applyStageArtwork(root, deriveStageArtworkColors(lastGood, appearance));
 }
 
 export function applyThemePalette(theme: ThemePreference, appearance?: ThemeAppearance): void {

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -120,3 +120,7 @@ On web and desktop, use **Agents** to follow work delegated to subagents.
 Expand a tool call in the conversation to see its full command and output.
 Summaries shorten shell wrappers and can still describe the latest call after it
 finishes; the call's own result shows its status.
+
+Dev and Nightly environments can identify themselves with artwork at the top of the sidebar and in
+the send button. Choose **Artwork**, **Version pill**, or **None** in Settings under environment
+identification. Artwork is recolored to match the active theme, including custom and imported ones.

--- a/packages/shared/src/themePalettes.ts
+++ b/packages/shared/src/themePalettes.ts
@@ -115,8 +115,6 @@ export type ThemeDefinition = Readonly<{
   variants?: ThemeVariants;
   /** Groups related imported variants into one library card. */
   collection?: Readonly<{ id: string; label: string }>;
-  /** Allows reviewed built-ins to render product artwork over their sidebar. */
-  sidebarArtwork?: boolean;
   /** Generated from the guided editor's canvas and accent roles. */
   managed?: boolean;
 }>;
@@ -245,7 +243,6 @@ export const T3_CHAT_THEME: ThemeDefinition = {
       terminalScrollbarHover: "oklch(0.360924 0.021469 316.83)",
     },
   },
-  sidebarArtwork: true,
 };
 
 export const GROVE_THEME: ThemeDefinition = {
@@ -372,7 +369,6 @@ export const GROVE_THEME: ThemeDefinition = {
       terminalScrollbarHover: "oklch(0.687968 0.00354 193.55)",
     },
   },
-  sidebarArtwork: true,
 };
 
 export const OCEAN_THEME: ThemeDefinition = {
@@ -499,7 +495,6 @@ export const OCEAN_THEME: ThemeDefinition = {
       terminalScrollbarHover: "oklch(0.681569 0.010909 276.465)",
     },
   },
-  sidebarArtwork: true,
 };
 
 export const EMBER_THEME: ThemeDefinition = {
@@ -626,7 +621,6 @@ export const EMBER_THEME: ThemeDefinition = {
       terminalScrollbarHover: "oklch(0.682876 0.009156 9.796)",
     },
   },
-  sidebarArtwork: true,
 };
 
 export const IRIS_THEME: ThemeDefinition = {
@@ -753,7 +747,6 @@ export const IRIS_THEME: ThemeDefinition = {
       terminalScrollbarHover: "oklch(0.676012 0.015271 305.433)",
     },
   },
-  sidebarArtwork: true,
 };
 
 export const BUILT_IN_THEMES: ReadonlyArray<ThemeDefinition> = [


### PR DESCRIPTION
Custom, imported and server-published themes never got the Dev blueprint or Nightly sky in the sidebar header and send button. The artwork only had hand-tuned pigments for the five built-in themes, so any other theme was silently downgraded to the version pill. On top of that, both artworks ended in a hard edge against light sidebars.

Two changes:

1. **Every theme gets artwork.** The artwork already paints through CSS variables, so this derives those variables from the active palette when it is not a built-in: a fixed lightness ladder per appearance keeps the white wordmark readable whatever the accent is, hue and chroma come from the accent, and the tertiary glow follows the companion action color. The Nightly sky is emitted in the theme's own hue, so a gray accent gets a slate sky and a warm accent stays warm. Built-ins keep their reviewed pigments untouched, switching back to one clears the inline values, and the editor's live preview shows the derived art while keeping last-good colors as you type. The built-in-only artwork gate, the preview artwork flag and the per-theme `sidebarArtwork` field are gone.

2. **Artwork dissolves into the sidebar.** The Nightly sky is now the gradient with stars in its upper part and a soft diagonal haze instead of a radial glow. The Dev blueprint is unchanged. Both dissolve into the sidebar background across their lower half, stepping in OKLCH so light sidebars pass through tints of the art's own hue rather than gray. The send-button crops carry a light blur so they read as soft color rather than detail. Picked with Maria from the proposal rounds.

The Settings → Appearance → Environment identification control is unchanged: Artwork, Version pill, or None.

## Before

Custom theme with identification set to Artwork fell back to the pill.

![Version pill fallback on a custom theme](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/aaa54ab6-18d7-4fd7-bd6e-15364b883087/stage-artwork-before-pill.png)

## After

Nightly sky on a custom violet theme and on the stock theme in light and dark.

![Nightly sky on a custom theme](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/37a066f0-7219-4cd1-9d8d-eede551306d8/stage-artwork-v2-nightly-violet.png)

![Nightly sky on the stock light theme](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/8c29ffe5-c7b7-4585-b5b1-7030f9a5e915/stage-artwork-v2-nightly-default-light.png)

![Nightly sky on the stock dark theme](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/3c29df52-2c27-4bcb-8729-be73274b6e8b/stage-artwork-v2-nightly-default-dark.png)

Dev blueprint on the same three themes.

![Dev blueprint on a custom theme](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/19d01262-47a8-4fa5-ad11-19935c316b7b/stage-artwork-v2-dev-violet.png)

![Dev blueprint on the stock light theme](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/aedb0ea2-113c-47f9-9913-94a0d8bcff0b/stage-artwork-v2-dev-default-light.png)

![Dev blueprint on the stock dark theme](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/878be89c-f122-48d3-b334-5c6c6a523bb4/stage-artwork-v2-dev-default-dark.png)

Written by Claude Fable 5.1 running in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentation and theme CSS variables; identification behavior simplifies rather than touching auth or data paths.
> 
> **Overview**
> **Custom and preview themes** can show Dev/Nightly sidebar artwork again: non–built-in palettes get `--stage-*` pigments derived from accent and message-action colors (with `data-theme-artwork="derived"`), while built-ins keep hand-tuned CSS. The old `sidebarArtwork` flag, preview artwork store, and logic that forced the version pill for custom themes are removed—identification mode is honored once client settings hydrate.
> 
> **Visual polish:** Nightly art swaps clouds/radial glow for a tiled diagonal haze and a seeded star field with glints on large stars; both variants add a lower **OKLCH `StageDissolve`** into `--stage-fade`. Compact (send-button) crops use light blur/scale and skip the dissolve overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e2d697092b1eaafe816719c7dfd525e05b9b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generate environment artwork from theme colors in `web` sidebar
> - Removes `sidebarArtwork` metadata from `ThemeDefinition` and derives stage artwork colors dynamically from theme accent and message colors using OKLCH.
> - Updates `NightlySkyArt` and `DevBlueprintArt` to use a new `StageDissolve` layer that blends the artwork into the sidebar background.
> - Replaces fixed star coordinate lists with a deterministic seeded generator (`createStarField`).
> - Behavioral Change: `resolveEnvironmentIdentificationMode` in `useSettings.ts` no longer coerces `Artwork` to `Version` for custom palettes; it preserves the hydrated user selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15e2d69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom themes now automatically generate matching stage artwork colors from the selected palette.
  * Nightly and Dev environment artwork features procedurally generated star fields and updated visual effects.
  * Environment identification settings now consistently preserve the selected mode after settings load.

* **Bug Fixes**
  * Improved theme artwork synchronization when themes are refreshed or cleared.
  * Refined compact artwork rendering for clearer visual presentation.

* **Documentation**
  * Documented environment identification artwork, version pills, and “None” options in the thread sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->