### PR TITLE
fix(desktop): skip cached monitor compiler check

### DIFF
--- a/docs/internals/scripts.md
+++ b/docs/internals/scripts.md
@@ -144,6 +144,8 @@ rustup target add aarch64-pc-windows-msvc
 
 Windows supplies `tar.exe`; it is checked when `--wsl-prebuild` makes the artifact include the WSL
 runtime. NSIS is downloaded by electron-builder and does not need a separate installation.
+When `T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR=true` points the build at an existing resource monitor,
+the artifact script skips the Rust and Visual Studio checks because it does not compile the monitor.
 Unsigned local builds need no Azure credentials. Builds using `--signed` additionally require the
 Azure Trusted Signing configuration described below.
 

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -930,6 +930,48 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     ),
   );
 
+  it.effect("does not require MSVC when reusing a prebuilt Windows resource monitor", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-windows-preflight-" });
+        const pythonPath = path.join(tempDir, "python.exe");
+        yield* fs.writeFileString(pythonPath, "python");
+        const commands: string[] = [];
+        const spawner = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make((command) => {
+            const childProcess = command as unknown as { readonly command: string };
+            commands.push(childProcess.command);
+            return Effect.succeed(mockProcess(childProcess.command === "powershell.exe" ? 1 : 0));
+          }),
+        );
+
+        yield* preflightWindowsDesktopBuild({
+          arch: "x64",
+          bundlesWslRuntime: true,
+        }).pipe(
+          Effect.provide(
+            Layer.merge(
+              spawner,
+              ConfigProvider.layer(
+                ConfigProvider.fromEnv({
+                  env: {
+                    npm_config_python: pythonPath,
+                    T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR: "true",
+                  },
+                }),
+              ),
+            ),
+          ),
+        );
+
+        assert.notInclude(commands, "powershell.exe");
+      }),
+    ),
+  );
+
   it.effect("rejects a PATH-discovered Python executable that is not Python 3", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1730,16 +1730,18 @@ export const preflightWindowsDesktopBuild = Effect.fn("preflightWindowsDesktopBu
               rustTargetIsInstalled(rustTarget),
             ]).pipe(Effect.map(([cargo, target]) => cargo && target)),
         python: Effect.succeed(python !== undefined),
-        msvc: desktopBuildProbeSucceeds(
-          ChildProcess.make("powershell.exe", [
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            windowsVswherePrerequisiteScript(input.arch),
-          ]),
-          "Visual Studio Build Tools",
-        ),
+        msvc: reuseResourceMonitor
+          ? Effect.succeed(true)
+          : desktopBuildProbeSucceeds(
+              ChildProcess.make("powershell.exe", [
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                windowsVswherePrerequisiteScript(input.arch),
+              ]),
+              "Visual Studio Build Tools",
+            ),
         tar: input.bundlesWslRuntime
           ? desktopBuildProbeSucceeds(ChildProcess.make("tar.exe", ["--version"]), "tar")
           : Effect.succeed(true),


### PR DESCRIPTION
The Windows release build failed during desktop preflight because the resource monitor cache hit skipped Rust setup, but the artifact script still required the full Visual Studio toolchain. The preceding release completed the same packaging path with the cached monitor and npmRebuild disabled.

Treat T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR as satisfying both the Rust and Visual Studio checks on Windows. Python and tar checks still run, and source builds remain strict. Added focused regression coverage and documented the behavior.

Verified with:
- vp test run scripts/build-desktop-artifact.test.ts
- vp lint scripts/build-desktop-artifact.ts scripts/build-desktop-artifact.test.ts
- vp exec tsc -p scripts/tsconfig.json --noEmit
- vp fmt --check on the changed files

Built with GPT-5.6 via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows Windows prerequisite checks only when an existing env flag skips monitor compilation; Python/tar and non-reuse builds unchanged.
> 
> **Overview**
> Windows desktop **preflight** now treats **`T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR=true`** the same for **Visual Studio** as it already did for **Rust**: when the build reuses a cached resource monitor and does not compile it, the **vswhere / MSVC** probe is skipped so release jobs do not fail on missing Build Tools.
> 
> **Python** and **tar** (when bundling the WSL runtime) checks still run; full source builds remain strict. Contributor docs note that Rust and VS checks are skipped in reuse mode, and a regression test asserts **`powershell.exe`** is not invoked for MSVC preflight when reuse is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 652d7bab3dadfc6d79035130a9eaaf7149d23dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip MSVC prerequisite check in `preflightWindowsDesktopBuild` when resource monitor is reused
> When `T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR` is set, the Windows preflight now treats the MSVC/Visual Studio Build Tools check as available, matching the existing reuse-specific behavior for Rust. The PowerShell probe is no longer invoked in that mode; Python and optional tar checks still run.
> - Adds an effect-based regression test in [build-desktop-artifact.test.ts](https://github.com/pingdotgg/t3code/pull/9184/files#diff-a199d37af35c35dd3b48cf71436cb06b23acccd6857a9fe74db6d48cb73c7663) that mocks child-process execution and verifies PowerShell is not called during reuse.
> - Documents the reuse behavior in [scripts.md](https://github.com/pingdotgg/t3code/pull/9184/files#diff-e96bcd8be67e46ebdfbb43cd2996f544400f2c88e1c7c30ab5ee8a05b1ff4cbf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 652d7ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->