### PR TITLE
feat(chat): scannable tool call rows for every provider

### DIFF
--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -9,6 +9,7 @@ import type {
   OrchestrationLatestTurn,
   OrchestrationThread,
   OrchestrationThreadActivity,
+  ToolCallFacts,
   ToolLifecycleItemType,
   TurnId,
   UserInputQuestion,
@@ -117,6 +118,8 @@ export interface WorkLogEntry {
     }>;
   };
   toolData?: unknown;
+  /** Server-derived, provider-neutral facts (cwd, exit code, duration, output, files). */
+  facts?: ToolCallFacts;
 }
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
@@ -505,6 +508,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     asTrimmedString(payload?.toolCallId) ?? asTrimmedString(asRecord(payload?.data)?.toolCallId);
   if (toolCallId) {
     entry.toolCallId = toolCallId;
+  }
+  const facts = asRecord(payload?.facts);
+  if (facts) {
+    entry.facts = facts as ToolCallFacts;
   }
   if (isTaskActivity && payload) {
     if (payload.agentKind !== "agent") {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -16,6 +16,7 @@ import {
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
   RuntimeRequestId,
+  type ToolCallFacts,
 } from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
@@ -50,6 +51,7 @@ import {
 } from "../Services/ProviderRuntimeIngestion.ts";
 import { projectActivityPayload } from "../ActivityPayloadProjection.ts";
 import { forkParked } from "../../serverActivation.ts";
+import { deriveToolCallFacts } from "../toolCallFacts.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { canReplaceThreadTitle } from "../threadTitles.ts";
 
@@ -161,6 +163,18 @@ function maxCheckpointTurnCount(
     }
   }
   return maxTurnCount;
+}
+
+/**
+ * Provider-neutral facts (cwd, exit code, duration, bounded output, file
+ * stats) derived from the item's native data. Lives beside `data` so the
+ * payload projection keeps it while slimming `data` for the wire.
+ */
+function toolCallFactsField(
+  event: Extract<ProviderRuntimeEvent, { type: "item.updated" | "item.completed" }>,
+): { facts?: ToolCallFacts } {
+  const facts = deriveToolCallFacts({ provider: event.provider, data: event.payload.data });
+  return facts ? { facts } : {};
 }
 
 function truncateDetail(value: string, limit = 180): string {
@@ -815,6 +829,7 @@ export function runtimeEventToActivities(
             ...(event.payload.toolIcon ? { toolIcon: event.payload.toolIcon } : {}),
             ...(event.payload.toolSource ? { toolSource: event.payload.toolSource } : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+            ...toolCallFactsField(event),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
               ? { parentToolUseId: event.payload.parentToolUseId }
@@ -847,6 +862,7 @@ export function runtimeEventToActivities(
             ...(event.payload.toolIcon ? { toolIcon: event.payload.toolIcon } : {}),
             ...(event.payload.toolSource ? { toolSource: event.payload.toolSource } : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+            ...toolCallFactsField(event),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
               ? { parentToolUseId: event.payload.parentToolUseId }

--- a/apps/server/src/orchestration/toolCallFacts.test.ts
+++ b/apps/server/src/orchestration/toolCallFacts.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  boundFiles,
   boundToolOutput,
   deriveToolCallFacts,
   textPairStat,
+  TOOL_DIFF_TOTAL_MAX_CHARS,
+  TOOL_FILES_MAX,
   TOOL_OUTPUT_MAX_LINES,
   unifiedDiffStat,
 } from "./toolCallFacts.ts";
@@ -159,5 +162,35 @@ describe("diff stats", () => {
   it("counts before/after line changes", () => {
     expect(textPairStat("a\nb\nc", "a\nc\nd")).toEqual({ additions: 1, deletions: 1 });
     expect(textPairStat("", "one\ntwo")).toEqual({ additions: 2, deletions: 0 });
+  });
+
+  it("still detects a same-sized rewrite of a large file", () => {
+    const before = Array.from({ length: 700 }, (_, i) => `a${i}`).join("\n");
+    const after = Array.from({ length: 700 }, (_, i) => `b${i}`).join("\n");
+    expect(textPairStat(before, after)).toEqual({ additions: 700, deletions: 700 });
+  });
+
+  it("bounds file count and total hunk size", () => {
+    const hunk = "+".repeat(10_000);
+    const files = Array.from({ length: 30 }, (_, i) => ({
+      path: `f${i}.ts`,
+      additions: 1,
+      deletions: 0,
+      diff: hunk,
+    }));
+    const bounded = boundFiles(files);
+    expect(bounded).toHaveLength(TOOL_FILES_MAX);
+    const kept = bounded.filter((file) => file.diff !== undefined);
+    expect(kept.length * hunk.length).toBeLessThanOrEqual(TOOL_DIFF_TOTAL_MAX_CHARS);
+    expect(bounded.every((file) => file.additions === 1)).toBe(true);
+  });
+
+  it("combines ACP stdout and stderr", () => {
+    expect(
+      deriveToolCallFacts({
+        provider: "cursor",
+        data: { kind: "execute", rawOutput: { stdout: "ok", stderr: "warn: x" } },
+      })?.output?.text,
+    ).toBe("ok\nwarn: x");
   });
 });

--- a/apps/server/src/orchestration/toolCallFacts.test.ts
+++ b/apps/server/src/orchestration/toolCallFacts.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  boundToolOutput,
+  deriveToolCallFacts,
+  textPairStat,
+  TOOL_OUTPUT_MAX_LINES,
+  unifiedDiffStat,
+} from "./toolCallFacts.ts";
+
+const DIFF = `--- a/src/app.ts
++++ b/src/app.ts
+@@ -1,3 +1,4 @@
+ import x from "x";
+-const a = 1;
++const a = 2;
++const b = 3;
+`;
+
+describe("deriveToolCallFacts", () => {
+  it("reads Codex command items verbatim", () => {
+    expect(
+      deriveToolCallFacts({
+        provider: "codex",
+        data: {
+          item: {
+            type: "commandExecution",
+            command: "pnpm test",
+            cwd: "/repo/apps/web",
+            exitCode: 1,
+            durationMs: 4210,
+            aggregatedOutput: "FAIL src/a.test.ts\n  expected 1 to be 2\n",
+          },
+        },
+      }),
+    ).toEqual({
+      cwd: "/repo/apps/web",
+      exitCode: 1,
+      durationMs: 4210,
+      output: { text: "FAIL src/a.test.ts\n  expected 1 to be 2", lineCount: 2, truncated: false },
+    });
+  });
+
+  it("keeps Codex file changes with diff stats and a bounded hunk", () => {
+    const facts = deriveToolCallFacts({
+      provider: "codex",
+      data: {
+        item: { type: "fileChange", changes: [{ path: "src/app.ts", kind: "update", diff: DIFF }] },
+      },
+    });
+    expect(facts?.files).toEqual([
+      { path: "src/app.ts", kind: "update", additions: 2, deletions: 1, diff: DIFF },
+    ]);
+  });
+
+  it("reads Claude Bash intent and tool_result text", () => {
+    expect(
+      deriveToolCallFacts({
+        provider: "claudeAgent",
+        data: {
+          toolName: "Bash",
+          input: { command: "ls", description: "List the project root" },
+          result: {
+            type: "tool_result",
+            content: [{ type: "text", text: "a\nb" }],
+            is_error: false,
+          },
+        },
+      }),
+    ).toEqual({
+      intent: "List the project root",
+      output: { text: "a\nb", lineCount: 2, truncated: false },
+    });
+  });
+
+  it("derives edit stats for Claude Edit and Write calls", () => {
+    expect(
+      deriveToolCallFacts({
+        provider: "claudeAgent",
+        data: {
+          toolName: "Edit",
+          input: { file_path: "/repo/a.ts", old_string: "x\ny", new_string: "x\nz\nw" },
+        },
+      })?.files,
+    ).toEqual([{ path: "/repo/a.ts", kind: "update", additions: 2, deletions: 1 }]);
+    expect(
+      deriveToolCallFacts({
+        provider: "claudeAgent",
+        data: { toolName: "Write", input: { file_path: "/repo/b.ts", content: "1\n2\n3" } },
+      })?.files,
+    ).toEqual([{ path: "/repo/b.ts", kind: "write", additions: 3, deletions: 0 }]);
+  });
+
+  it("reads ACP content text and diff parts for Cursor and Grok", () => {
+    const data = {
+      kind: "edit",
+      content: [
+        { type: "content", content: { type: "text", text: "Applied" } },
+        { type: "diff", path: "src/x.ts", oldText: "a\nb", newText: "a\nc" },
+      ],
+    };
+    for (const provider of ["cursor", "grok"]) {
+      expect(deriveToolCallFacts({ provider, data })).toEqual({
+        output: { text: "Applied", lineCount: 1, truncated: false },
+        files: [{ path: "src/x.ts", additions: 1, deletions: 1 }],
+      });
+    }
+  });
+
+  it("reads OpenCode state timing, output, and exit metadata", () => {
+    expect(
+      deriveToolCallFacts({
+        provider: "opencode",
+        data: {
+          tool: "bash",
+          state: {
+            status: "completed",
+            input: { command: "make" },
+            output: "ok",
+            metadata: { exit: 0 },
+            time: { start: 1000, end: 1750 },
+          },
+        },
+      }),
+    ).toEqual({
+      exitCode: 0,
+      durationMs: 750,
+      output: { text: "ok", lineCount: 1, truncated: false },
+    });
+  });
+
+  it("returns nothing for unknown providers or empty data", () => {
+    expect(deriveToolCallFacts({ provider: "codex", data: {} })).toBeUndefined();
+    expect(deriveToolCallFacts({ provider: "other", data: { item: {} } })).toBeUndefined();
+  });
+});
+
+describe("boundToolOutput", () => {
+  it("caps lines, strips ANSI, and reports the real size", () => {
+    const raw = Array.from({ length: 100 }, (_, i) => `[32mline ${i}[0m`).join("\n");
+    const output = boundToolOutput(raw);
+    expect(output?.lineCount).toBe(100);
+    expect(output?.truncated).toBe(true);
+    expect(output?.text.split("\n")).toHaveLength(TOOL_OUTPUT_MAX_LINES);
+    expect(output?.text.startsWith("line 0")).toBe(true);
+  });
+
+  it("drops empty output", () => {
+    expect(boundToolOutput("  \n ")).toBeUndefined();
+    expect(boundToolOutput(undefined)).toBeUndefined();
+  });
+});
+
+describe("diff stats", () => {
+  it("counts unified diff lines without headers", () => {
+    expect(unifiedDiffStat(DIFF)).toEqual({ additions: 2, deletions: 1 });
+  });
+
+  it("counts before/after line changes", () => {
+    expect(textPairStat("a\nb\nc", "a\nc\nd")).toEqual({ additions: 1, deletions: 1 });
+    expect(textPairStat("", "one\ntwo")).toEqual({ additions: 2, deletions: 0 });
+  });
+});

--- a/apps/server/src/orchestration/toolCallFacts.test.ts
+++ b/apps/server/src/orchestration/toolCallFacts.test.ts
@@ -94,7 +94,7 @@ describe("deriveToolCallFacts", () => {
     ).toEqual([{ path: "/repo/b.ts", kind: "write", additions: 3, deletions: 0 }]);
   });
 
-  it("reads ACP content text and diff parts for Cursor and Grok", () => {
+  it("reads ACP content text and diff parts for Cursor, Grok, and Antigravity", () => {
     const data = {
       kind: "edit",
       content: [
@@ -102,7 +102,7 @@ describe("deriveToolCallFacts", () => {
         { type: "diff", path: "src/x.ts", oldText: "a\nb", newText: "a\nc" },
       ],
     };
-    for (const provider of ["cursor", "grok"]) {
+    for (const provider of ["cursor", "grok", "antigravity"]) {
       expect(deriveToolCallFacts({ provider, data })).toEqual({
         output: { text: "Applied", lineCount: 1, truncated: false },
         files: [{ path: "src/x.ts", additions: 1, deletions: 1 }],

--- a/apps/server/src/orchestration/toolCallFacts.ts
+++ b/apps/server/src/orchestration/toolCallFacts.ts
@@ -1,0 +1,310 @@
+/**
+ * Derive provider-neutral `ToolCallFacts` from a runtime item's native data.
+ *
+ * Each provider reports tool calls in its own vocabulary. Codex sends
+ * `cwd`/`exitCode`/`durationMs`/`aggregatedOutput`/`changes[].diff` on the
+ * item; Claude sends the tool input plus a `tool_result` block; the ACP
+ * providers (Cursor, Grok) send `rawInput`/`rawOutput`/`content`; OpenCode
+ * sends `state` with `input`/`output`/`time`. This module is the one place
+ * that knows those shapes, so clients only ever read `payload.facts`.
+ *
+ * Output is bounded at derivation time (lines and bytes) because the facts
+ * ride on every activity broadcast.
+ *
+ * @module orchestration/toolCallFacts
+ */
+import type {
+  ProviderDriverKind,
+  ToolCallFacts,
+  ToolCallFactsFile,
+  ToolCallFactsOutput,
+} from "@t3tools/contracts";
+
+export const TOOL_OUTPUT_MAX_LINES = 40;
+export const TOOL_OUTPUT_MAX_CHARS = 4_000;
+export const TOOL_DIFF_MAX_CHARS = 8_000;
+const DIFF_STAT_MAX_LINES = 600;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asInt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) ? value : undefined;
+}
+
+function asNonNegativeInt(value: unknown): number | undefined {
+  const int = asInt(value);
+  return int !== undefined && int >= 0 ? int : undefined;
+}
+
+const ANSI_ESCAPE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[A-Za-z]`, "g");
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE, "");
+}
+
+/** Bound text to the first N lines and M chars, remembering the real size. */
+export function boundToolOutput(raw: string | undefined): ToolCallFactsOutput | undefined {
+  if (raw === undefined) return undefined;
+  const text = stripAnsi(raw).replace(/\r\n?/g, "\n").replace(/\s+$/u, "");
+  if (text.length === 0) return undefined;
+  const lines = text.split("\n");
+  let excerpt = lines.slice(0, TOOL_OUTPUT_MAX_LINES).join("\n");
+  let truncated = lines.length > TOOL_OUTPUT_MAX_LINES;
+  if (excerpt.length > TOOL_OUTPUT_MAX_CHARS) {
+    excerpt = excerpt.slice(0, TOOL_OUTPUT_MAX_CHARS);
+    truncated = true;
+  }
+  return { text: excerpt, lineCount: lines.length, truncated };
+}
+
+function boundDiff(diff: string | undefined): string | undefined {
+  if (diff === undefined || diff.trim().length === 0) return undefined;
+  return diff.length > TOOL_DIFF_MAX_CHARS ? `${diff.slice(0, TOOL_DIFF_MAX_CHARS)}\n` : diff;
+}
+
+/** Count `+`/`-` lines of a unified diff, ignoring file headers. */
+export function unifiedDiffStat(diff: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) additions += 1;
+    else if (line.startsWith("-")) deletions += 1;
+  }
+  return { additions, deletions };
+}
+
+/**
+ * Line-level stat for a before/after pair. Uses an LCS on lines for small
+ * inputs and falls back to a length difference for large ones so a huge
+ * rewrite never stalls ingestion.
+ */
+export function textPairStat(
+  before: string,
+  after: string,
+): { additions: number; deletions: number } {
+  const a = before.length === 0 ? [] : before.split("\n");
+  const b = after.length === 0 ? [] : after.split("\n");
+  if (a.length > DIFF_STAT_MAX_LINES || b.length > DIFF_STAT_MAX_LINES) {
+    return {
+      additions: Math.max(0, b.length - a.length),
+      deletions: Math.max(0, a.length - b.length),
+    };
+  }
+  let previous = Array.from({ length: b.length + 1 }, () => 0);
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = Array.from({ length: b.length + 1 }, () => 0);
+    for (let j = 1; j <= b.length; j += 1) {
+      current[j] =
+        a[i - 1] === b[j - 1] ? previous[j - 1]! + 1 : Math.max(previous[j]!, current[j - 1]!);
+    }
+    previous = current;
+  }
+  const common = previous[b.length]!;
+  return { additions: b.length - common, deletions: a.length - common };
+}
+
+function fileFact(input: {
+  readonly path: string;
+  readonly kind?: string | undefined;
+  readonly diff?: string | undefined;
+  readonly stat?: { additions: number; deletions: number } | undefined;
+}): ToolCallFactsFile {
+  const stat = input.stat ?? (input.diff ? unifiedDiffStat(input.diff) : undefined);
+  const diff = boundDiff(input.diff);
+  return {
+    path: input.path,
+    ...(input.kind ? { kind: input.kind } : {}),
+    ...(stat ? { additions: stat.additions, deletions: stat.deletions } : {}),
+    ...(diff ? { diff } : {}),
+  };
+}
+
+function compact(facts: ToolCallFacts): ToolCallFacts | undefined {
+  return Object.keys(facts).length > 0 ? facts : undefined;
+}
+
+/** Codex app-server items carry everything as typed fields. */
+function fromCodex(data: Record<string, unknown>): ToolCallFacts | undefined {
+  const item = asRecord(data.item);
+  if (!item) return undefined;
+  const output = boundToolOutput(asString(item.aggregatedOutput));
+  const changes = Array.isArray(item.changes) ? item.changes : [];
+  const files = changes.flatMap((change) => {
+    const record = asRecord(change);
+    const path = asString(record?.path);
+    return path
+      ? [fileFact({ path, kind: asString(record?.kind), diff: asString(record?.diff) })]
+      : [];
+  });
+  const cwd = asString(item.cwd);
+  const exitCode = asInt(item.exitCode);
+  const durationMs = asNonNegativeInt(item.durationMs);
+  return compact({
+    ...(cwd ? { cwd } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(output ? { output } : {}),
+    ...(files.length > 0 ? { files } : {}),
+  });
+}
+
+function claudeResultText(result: unknown): string | undefined {
+  const block = asRecord(result);
+  const content = block?.content ?? result;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const text = content
+      .map((part) => asString(asRecord(part)?.text))
+      .filter((part): part is string => part !== undefined)
+      .join("\n");
+    return text.length > 0 ? text : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Claude Agent SDK tool calls: `input` is the tool's argument object
+ * (`command`/`description` for Bash, `file_path` + `old_string`/`new_string`
+ * for Edit, `content` for Write) and `result` is the `tool_result` block.
+ */
+function fromClaude(data: Record<string, unknown>): ToolCallFacts | undefined {
+  const input = asRecord(data.input);
+  const intent = asString(input?.description);
+  const output = boundToolOutput(claudeResultText(data.result));
+  const path = asString(input?.file_path) ?? asString(input?.path);
+  const files: ToolCallFactsFile[] = [];
+  if (path && input) {
+    const before = asString(input.old_string);
+    const after = asString(input.new_string);
+    const written = asString(input.content);
+    if (before !== undefined || after !== undefined) {
+      files.push(fileFact({ path, kind: "update", stat: textPairStat(before ?? "", after ?? "") }));
+    } else if (written !== undefined) {
+      files.push(fileFact({ path, kind: "write", stat: textPairStat("", written) }));
+    }
+  }
+  return compact({
+    ...(intent ? { intent } : {}),
+    ...(output ? { output } : {}),
+    ...(files.length > 0 ? { files } : {}),
+  });
+}
+
+function acpOutputText(data: Record<string, unknown>): string | undefined {
+  const rawOutput = data.rawOutput;
+  if (typeof rawOutput === "string") return rawOutput;
+  const rawRecord = asRecord(rawOutput);
+  const direct =
+    asString(rawRecord?.output) ??
+    asString(rawRecord?.stdout) ??
+    asString(rawRecord?.content) ??
+    asString(rawRecord?.stderr);
+  if (direct) return direct;
+  if (Array.isArray(data.content)) {
+    const text = data.content
+      .map((entry) => {
+        const record = asRecord(entry);
+        return record?.type === "content" ? asString(asRecord(record.content)?.text) : undefined;
+      })
+      .filter((part): part is string => part !== undefined)
+      .join("\n");
+    return text.length > 0 ? text : undefined;
+  }
+  return undefined;
+}
+
+/** ACP (Cursor, Grok): `content[]` carries text and `{type:"diff"}` parts. */
+function fromAcp(data: Record<string, unknown>): ToolCallFacts | undefined {
+  const output = boundToolOutput(acpOutputText(data));
+  const files: ToolCallFactsFile[] = [];
+  if (Array.isArray(data.content)) {
+    for (const entry of data.content) {
+      const record = asRecord(entry);
+      const path = asString(record?.path);
+      if (record?.type !== "diff" || !path) continue;
+      files.push(
+        fileFact({
+          path,
+          stat: textPairStat(asString(record.oldText) ?? "", asString(record.newText) ?? ""),
+        }),
+      );
+    }
+  }
+  const rawInput = asRecord(data.rawInput);
+  const cwd = asString(rawInput?.cwd) ?? asString(rawInput?.workingDirectory);
+  const exitCode =
+    asInt(asRecord(data.rawOutput)?.exitCode) ?? asInt(asRecord(data.rawOutput)?.exit_code);
+  return compact({
+    ...(cwd ? { cwd } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(output ? { output } : {}),
+    ...(files.length > 0 ? { files } : {}),
+  });
+}
+
+/** OpenCode: `state` has `input`, `output`/`error`, `metadata`, `time`. */
+function fromOpenCode(data: Record<string, unknown>): ToolCallFacts | undefined {
+  const state = asRecord(data.state);
+  if (!state) return undefined;
+  const stateInput = asRecord(state.input);
+  const metadata = asRecord(state.metadata);
+  const time = asRecord(state.time);
+  const start = typeof time?.start === "number" ? time.start : undefined;
+  const end = typeof time?.end === "number" ? time.end : undefined;
+  const durationMs =
+    start !== undefined && end !== undefined && end >= start ? Math.round(end - start) : undefined;
+  const output = boundToolOutput(asString(state.output) ?? asString(state.error));
+  const exitCode = asInt(metadata?.exit) ?? asInt(metadata?.exitCode);
+  const cwd = asString(stateInput?.cwd) ?? asString(stateInput?.workdir);
+  const path = asString(stateInput?.filePath) ?? asString(stateInput?.path);
+  const files: ToolCallFactsFile[] = [];
+  if (path && stateInput) {
+    const diff = asString(metadata?.diff);
+    const before = asString(stateInput.oldString);
+    const after = asString(stateInput.newString);
+    const written = asString(stateInput.content);
+    if (diff) files.push(fileFact({ path, diff }));
+    else if (before !== undefined || after !== undefined) {
+      files.push(fileFact({ path, kind: "update", stat: textPairStat(before ?? "", after ?? "") }));
+    } else if (written !== undefined) {
+      files.push(fileFact({ path, kind: "write", stat: textPairStat("", written) }));
+    }
+  }
+  return compact({
+    ...(cwd ? { cwd } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(output ? { output } : {}),
+    ...(files.length > 0 ? { files } : {}),
+  });
+}
+
+export function deriveToolCallFacts(input: {
+  readonly provider: ProviderDriverKind | string;
+  readonly data: unknown;
+}): ToolCallFacts | undefined {
+  const data = asRecord(input.data);
+  if (!data) return undefined;
+  switch (input.provider) {
+    case "codex":
+      return fromCodex(data);
+    case "claudeAgent":
+      return fromClaude(data);
+    case "cursor":
+    case "grok":
+      return fromAcp(data);
+    case "opencode":
+      return fromOpenCode(data);
+    default:
+      return undefined;
+  }
+}

--- a/apps/server/src/orchestration/toolCallFacts.ts
+++ b/apps/server/src/orchestration/toolCallFacts.ts
@@ -23,6 +23,10 @@ import type {
 export const TOOL_OUTPUT_MAX_LINES = 40;
 export const TOOL_OUTPUT_MAX_CHARS = 4_000;
 export const TOOL_DIFF_MAX_CHARS = 8_000;
+/** Most files a single call may list; bulk edits keep the first N with stats. */
+export const TOOL_FILES_MAX = 20;
+/** Total hunk bytes across a call's files; later hunks are dropped, stats stay. */
+export const TOOL_DIFF_TOTAL_MAX_CHARS = 24_000;
 const DIFF_STAT_MAX_LINES = 600;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -94,10 +98,14 @@ export function textPairStat(
   const a = before.length === 0 ? [] : before.split("\n");
   const b = after.length === 0 ? [] : after.split("\n");
   if (a.length > DIFF_STAT_MAX_LINES || b.length > DIFF_STAT_MAX_LINES) {
-    return {
-      additions: Math.max(0, b.length - a.length),
-      deletions: Math.max(0, a.length - b.length),
-    };
+    // Too large for an LCS: compare positionally so a same-sized rewrite
+    // still counts as changed, at the cost of over-counting shifted blocks.
+    const shared = Math.min(a.length, b.length);
+    let changed = 0;
+    for (let i = 0; i < shared; i += 1) {
+      if (a[i] !== b[i]) changed += 1;
+    }
+    return { additions: changed + (b.length - shared), deletions: changed + (a.length - shared) };
   }
   let previous = Array.from({ length: b.length + 1 }, () => 0);
   for (let i = 1; i <= a.length; i += 1) {
@@ -128,7 +136,24 @@ function fileFact(input: {
   };
 }
 
+/** Keep at most `TOOL_FILES_MAX` files and `TOOL_DIFF_TOTAL_MAX_CHARS` of hunks. */
+export function boundFiles(files: ReadonlyArray<ToolCallFactsFile>): ToolCallFactsFile[] {
+  let budget = TOOL_DIFF_TOTAL_MAX_CHARS;
+  return files.slice(0, TOOL_FILES_MAX).map((file) => {
+    if (file.diff === undefined) return file;
+    if (file.diff.length <= budget) {
+      budget -= file.diff.length;
+      return file;
+    }
+    const { diff: _diff, ...withoutDiff } = file;
+    return withoutDiff;
+  });
+}
+
 function compact(facts: ToolCallFacts): ToolCallFacts | undefined {
+  if (facts.files !== undefined) {
+    return { ...facts, files: boundFiles(facts.files) };
+  }
   return Object.keys(facts).length > 0 ? facts : undefined;
 }
 
@@ -203,11 +228,12 @@ function acpOutputText(data: Record<string, unknown>): string | undefined {
   const rawOutput = data.rawOutput;
   if (typeof rawOutput === "string") return rawOutput;
   const rawRecord = asRecord(rawOutput);
+  const stdout = asString(rawRecord?.stdout);
+  const stderr = asString(rawRecord?.stderr);
   const direct =
-    asString(rawRecord?.output) ??
-    asString(rawRecord?.stdout) ??
-    asString(rawRecord?.content) ??
-    asString(rawRecord?.stderr);
+    stdout !== undefined || stderr !== undefined
+      ? [stdout, stderr].filter((part): part is string => part !== undefined).join("\n")
+      : (asString(rawRecord?.output) ?? asString(rawRecord?.content));
   if (direct) return direct;
   if (Array.isArray(data.content)) {
     const text = data.content

--- a/apps/server/src/orchestration/toolCallFacts.ts
+++ b/apps/server/src/orchestration/toolCallFacts.ts
@@ -4,7 +4,8 @@
  * Each provider reports tool calls in its own vocabulary. Codex sends
  * `cwd`/`exitCode`/`durationMs`/`aggregatedOutput`/`changes[].diff` on the
  * item; Claude sends the tool input plus a `tool_result` block; the ACP
- * providers (Cursor, Grok) send `rawInput`/`rawOutput`/`content`; OpenCode
+ * providers (Cursor, Grok, Antigravity) send `rawInput`/`rawOutput`/`content`;
+ * OpenCode
  * sends `state` with `input`/`output`/`time`. This module is the one place
  * that knows those shapes, so clients only ever read `payload.facts`.
  *
@@ -327,6 +328,7 @@ export function deriveToolCallFacts(input: {
       return fromClaude(data);
     case "cursor":
     case "grok":
+    case "antigravity":
       return fromAcp(data);
     case "opencode":
       return fromOpenCode(data);

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -2540,6 +2540,54 @@ describe("deriveMessagesTimelineRows", () => {
     expect(rows.at(-1)).toMatchObject({ kind: "thinking" });
   });
 
+  it("sums tool call durations and failures into the collapsed group row", () => {
+    const rows = deriveMessagesTimelineRows({
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaries: [],
+      supportsConversationRollback: false,
+      timelineEntries: [
+        {
+          id: "work-entry-1",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:01Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:01Z",
+            label: "Ran command",
+            command: "pnpm test",
+            tone: "tool" as const,
+            itemType: "command_execution" as const,
+            toolLifecycleStatus: "completed" as const,
+            facts: { durationMs: 1200, exitCode: 1 },
+          },
+        },
+        {
+          id: "work-entry-2",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:02Z",
+          entry: {
+            id: "work-2",
+            createdAt: "2026-01-01T00:00:02Z",
+            label: "Ran command",
+            command: "pnpm lint",
+            tone: "tool" as const,
+            itemType: "command_execution" as const,
+            toolLifecycleStatus: "completed" as const,
+            durationMs: 300,
+          },
+        },
+      ],
+    });
+
+    expect(rows[0]).toMatchObject({
+      kind: "work-toggle",
+      summary: "Ran 2 commands",
+      failureCount: 1,
+      durationMs: 1500,
+    });
+  });
+
   it.each([
     ["tools", "tool", "Used 3 tools"],
     ["tools and status updates", "info", "Used 2 tools and received 1 update"],
@@ -2847,6 +2895,8 @@ describe("computeStableMessagesTimelineRows", () => {
       summaryKind: "other",
       toolSurface: "browser",
       hasFailure: false,
+      failureCount: 0,
+      durationMs: null,
     };
     const initial = computeStableMessagesTimelineRows([initialRow], {
       byId: new Map(),

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -9,6 +9,7 @@ import {
   resolveWorkEntryToolPresentation,
   summarizeToolGroup,
   toolGroupAction,
+  toolGroupStats,
   toolGroupSummaryKind,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
@@ -339,6 +340,10 @@ export type MessagesTimelineRow =
       toolIcon?: WorkLogEntry["toolIcon"];
       summaryToolIcon?: "browser" | "t3-code";
       hasFailure: boolean;
+      /** Tool calls in the group that failed (non-zero exit or failed status). */
+      failureCount: number;
+      /** Total duration when every tool call in the group reported one. */
+      durationMs: number | null;
     }
   | {
       kind: "turn-fold";
@@ -1146,6 +1151,7 @@ export function deriveMessagesTimelineRows(input: {
           const summaryToolIcon = usesSingleToolCallLabel
             ? resolveWorkEntryToolPresentation(singleEntry, "completed")?.icon
             : undefined;
+          const groupStats = toolGroupStats(visibleGroupedEntries);
           nextRows.push({
             kind: "work-toggle",
             id: `work-toggle:${timelineEntry.id}`,
@@ -1166,6 +1172,8 @@ export function deriveMessagesTimelineRows(input: {
             hasFailure:
               latestToolEntry !== undefined &&
               workEntryDisplayIndicatesToolFailure(latestToolEntry),
+            failureCount: groupStats.failureCount,
+            durationMs: groupStats.durationMs,
           });
           if (expanded) {
             nextRows.push(
@@ -1398,7 +1406,9 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
         a.summaryKind === bw.summaryKind &&
         a.toolSurface === bw.toolSurface &&
         Equal.equals(a.toolIcon, bw.toolIcon) &&
-        a.hasFailure === bw.hasFailure
+        a.hasFailure === bw.hasFailure &&
+        a.failureCount === bw.failureCount &&
+        a.durationMs === bw.durationMs
       );
     }
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -24,6 +24,7 @@ import {
   CommandText,
   CwdChip,
   firstOutputLine,
+  TOOL_ROW_META_CLASS,
   TOOL_ROW_MONO_CLASS,
   ToolFileDiffs,
   ToolOutputBlock,
@@ -2295,7 +2296,7 @@ function WorkGroupToggleTimelineRow({
       </span>
       <span className="min-w-0 flex-1 truncate text-secondary-label">{row.summary}</span>
       {failureLabel || durationLabel ? (
-        <span className="ms-2 flex shrink-0 items-center gap-2 text-[0.6875rem] tabular-nums text-muted-foreground">
+        <span className={TOOL_ROW_META_CLASS}>
           {failureLabel ? <span>{failureLabel}</span> : null}
           {durationLabel ? <span>{durationLabel}</span> : null}
         </span>
@@ -3461,7 +3462,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         </span>
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <div className="min-w-0 flex-1 overflow-hidden">
-            {commandParts && !expanded ? (
+            {commandParts && !expanded && !showWarningIndicator && !showDestructiveRowStyle ? (
               <p className="flex min-w-0 w-full items-baseline text-sm leading-relaxed">
                 {commandParts.cwd ? (
                   <CwdChip cwd={commandParts.cwd} workspaceRoot={workspaceRoot} />
@@ -3486,6 +3487,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
               </p>
             )}
           </div>
+          {showFailedIndicator && toolPresentation ? (
+            <XIcon aria-hidden className="size-3 shrink-0 text-icon-muted" />
+          ) : null}
           {isToolLike ? (
             <ToolRowMeta
               durationMs={durationMs}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3348,7 +3348,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   // Plain progress notes ("Probe which subpaths Metro can resolve") are the
   // agent's intent for the calls that follow. Inside an expanded group they
   // read as a quiet section label rather than another tool row.
-  const isIntentLabel =
+  const looksLikeIntentNote =
     isExpandedToolGroupEntry && action === "update" && !showWarningIndicator && !isToolLike;
 
   // The command, with any leading `cd <dir> &&` pulled into a cwd chip.
@@ -3375,9 +3375,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
     Boolean(
       (!commandMatchesVisibleLabel &&
         (workEntryRawCommand(workEntry) || workEntry.command?.trim())) ||
-        workEntry.detail?.trim() ||
-        workEntry.changedFiles?.length ||
-        viewedImage,
+      workEntry.detail?.trim() ||
+      workEntry.changedFiles?.length ||
+      viewedImage,
     );
   const expandedBody = expanded
     ? buildToolCallExpandedBody(
@@ -3425,7 +3425,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       }
     : {};
 
-  if (isIntentLabel) {
+  // Only a note with nothing else to show collapses to a label; a row that
+  // carries an answer, an image, or a body still renders in full.
+  if (looksLikeIntentNote && !workEntry.questionAnswer && !canExpand && !viewedImage) {
     return (
       <div className="flex items-baseline gap-2 ps-2 pt-2 pb-0.5 text-[0.8125rem] leading-relaxed text-secondary-label">
         <span
@@ -3487,9 +3489,6 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
               </p>
             )}
           </div>
-          {showFailedIndicator && toolPresentation ? (
-            <XIcon aria-hidden className="size-3 shrink-0 text-icon-muted" />
-          ) : null}
           {isToolLike ? (
             <ToolRowMeta
               durationMs={durationMs}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -12,8 +12,23 @@ import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifa
 import {
   resolveWorkEntryToolPresentation,
   resolveViewedImageAsset,
+  splitLeadingCd,
+  toolEntryDiffStat,
+  toolEntryDurationMs,
+  toolEntryExitCode,
+  workEntryFailed,
   workEntryViewedImagePath,
 } from "@t3tools/client-runtime/work-log/presentation";
+import { formatDuration as formatToolDuration } from "@t3tools/shared/orchestrationTiming";
+import {
+  CommandText,
+  CwdChip,
+  firstOutputLine,
+  TOOL_ROW_MONO_CLASS,
+  ToolFileDiffs,
+  ToolOutputBlock,
+  ToolRowMeta,
+} from "./ToolCallRow";
 import { resolveWorkGroupScrollAnchor } from "@t3tools/client-runtime/work-log/scroll-anchor";
 import type { AgentPanelModel } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
@@ -2257,11 +2272,14 @@ function WorkGroupToggleTimelineRow({
   row: Extract<TimelineRow, { kind: "work-toggle" }>;
 }) {
   const ctx = use(TimelineRowCtx);
+  const failureLabel =
+    row.failureCount > 0 ? `${row.failureCount} failed` : row.hasFailure ? "failed" : null;
+  const durationLabel = row.durationMs !== null ? formatToolDuration(row.durationMs) : null;
   return (
     <button
       type="button"
       className="group/tool-group flex min-h-6 w-full cursor-pointer items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-sm leading-relaxed transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
-      aria-label={row.hasFailure ? `${row.summary}, tool call failed` : undefined}
+      aria-label={failureLabel ? `${row.summary}, tool call failed` : undefined}
       aria-expanded={row.expanded}
       onClick={() => ctx.onToggleWorkGroup(row.groupId, row.id)}
     >
@@ -2276,6 +2294,20 @@ function WorkGroupToggleTimelineRow({
         />
       </span>
       <span className="min-w-0 flex-1 truncate text-secondary-label">{row.summary}</span>
+      {failureLabel || durationLabel ? (
+        <span className="ms-2 flex shrink-0 items-center gap-2 text-[0.6875rem] tabular-nums text-muted-foreground">
+          {failureLabel ? <span>{failureLabel}</span> : null}
+          {durationLabel ? <span>{durationLabel}</span> : null}
+        </span>
+      ) : null}
+      <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden>
+        <ChevronDownIcon
+          className={cn(
+            "size-3 shrink-0 text-icon-muted opacity-70 transition-transform duration-200",
+            row.expanded && "rotate-180",
+          )}
+        />
+      </span>
     </button>
   );
 }
@@ -3270,7 +3302,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   onToggleEntry?: ((collapsed: boolean) => void) | undefined;
 }) {
   const { workEntry, workspaceRoot, isExpandedToolGroupEntry, displayLabel } = props;
-  const { threadRef, onImageExpand } = use(TimelineRowCtx);
+  const { threadRef, onImageExpand, resolvedTheme } = use(TimelineRowCtx);
   const groupView = use(WorkGroupViewCtx);
   const [expanded, setExpanded] = useState(
     () => groupView?.state.expandedEntries.has(workEntry.id) ?? false,
@@ -3288,7 +3320,8 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   };
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
-  const showFailedIndicator = workEntryDisplayIndicatesToolFailure(workEntry);
+  const showFailedIndicator =
+    workEntryDisplayIndicatesToolFailure(workEntry) || workEntryFailed(workEntry);
   const showDestructiveRowStyle =
     showFailedIndicator &&
     (workEntrySignalsSevereFailure(workEntry) || !workLogEntryIsToolLike(workEntry));
@@ -3301,6 +3334,29 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const previewText = workEntry.questionAnswer
     ? "Question answer submitted"
     : (displayLabel ?? workEntryDisplayLabel(workEntry, workspaceRoot));
+  const action = toolGroupAction(workEntry);
+  const isToolLike = workLogEntryIsToolLike(workEntry);
+  const running = workEntry.toolLifecycleStatus === "inProgress";
+  const facts = workEntry.facts;
+  const durationMs = toolEntryDurationMs(workEntry);
+  const exitCode = toolEntryExitCode(workEntry);
+  const diffStat = action === "edit" ? toolEntryDiffStat(workEntry) : null;
+  const errorLine = showFailedIndicator ? firstOutputLine(facts?.output) : null;
+  const filesWithDiff = facts?.files ?? [];
+
+  // Plain progress notes ("Probe which subpaths Metro can resolve") are the
+  // agent's intent for the calls that follow. Inside an expanded group they
+  // read as a quiet section label rather than another tool row.
+  const isIntentLabel =
+    isExpandedToolGroupEntry && action === "update" && !showWarningIndicator && !isToolLike;
+
+  // The command, with any leading `cd <dir> &&` pulled into a cwd chip.
+  const commandParts = useMemo(() => {
+    const command = workEntry.command?.trim();
+    if (!command || action !== "command") return null;
+    const split = splitLeadingCd(command);
+    return { command: split.command, cwd: facts?.cwd ?? split.cwd };
+  }, [action, facts?.cwd, workEntry.command]);
   const viewedImagePath = workEntryViewedImagePath(workEntry);
   const viewedImage =
     viewedImagePath && threadRef
@@ -3311,14 +3367,16 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       : null;
   const commandMatchesVisibleLabel = workEntry.command?.trim() === previewText.trim();
   const canExpand =
+    facts?.output !== undefined ||
+    filesWithDiff.length > 0 ||
     (showFailedIndicator && previewText.trim().length > 0) ||
     (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
     Boolean(
       (!commandMatchesVisibleLabel &&
         (workEntryRawCommand(workEntry) || workEntry.command?.trim())) ||
-      workEntry.detail?.trim() ||
-      workEntry.changedFiles?.length ||
-      viewedImage,
+        workEntry.detail?.trim() ||
+        workEntry.changedFiles?.length ||
+        viewedImage,
     );
   const expandedBody = expanded
     ? buildToolCallExpandedBody(
@@ -3328,7 +3386,6 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         viewedImage ? viewedImagePath : null,
       )
     : null;
-  // Reserve destructive row styling for severe failures, not routine tool errors.
   const iconWrapperClass = cn(
     "flex size-6 shrink-0 items-center justify-center",
     showWarningIndicator
@@ -3345,7 +3402,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
     ? "font-medium text-warning"
     : showDestructiveRowStyle
       ? "font-medium text-destructive"
-      : workLogEntryIsToolLike(workEntry)
+      : isToolLike
         ? "text-secondary-label"
         : "text-foreground/80";
   const accessibleDisplayText = showFailedIndicator
@@ -3367,6 +3424,18 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       }
     : {};
 
+  if (isIntentLabel) {
+    return (
+      <div className="flex items-baseline gap-2 ps-2 pt-2 pb-0.5 text-[0.8125rem] leading-relaxed text-secondary-label">
+        <span
+          className="size-1.5 shrink-0 translate-y-[-2px] rounded-full bg-icon-muted/70"
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1 truncate">{previewText}</span>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -3377,7 +3446,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       )}
       {...rowToggleProps}
     >
-      <div className="flex select-none items-center gap-1.5 transition-[opacity,translate] duration-200">
+      <div className="flex select-none items-center gap-1.5">
         <span
           className={iconWrapperClass}
           role={showFailedIndicator ? "img" : undefined}
@@ -3392,22 +3461,39 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         </span>
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <div className="min-w-0 flex-1 overflow-hidden">
-            <p className="flex min-w-0 w-full items-baseline gap-1.5 text-sm leading-relaxed">
-              <span
-                className={cn(
-                  "min-w-0 flex-1",
-                  expanded || (commandMatchesVisibleLabel && !canExpand)
-                    ? "whitespace-pre-wrap break-words select-text"
-                    : "truncate",
-                  headingClass,
-                )}
-                onClick={expanded ? stopRowToggle : undefined}
-                onPointerDown={expanded ? stopRowToggle : undefined}
-              >
-                {previewText}
-              </span>
-            </p>
+            {commandParts && !expanded ? (
+              <p className="flex min-w-0 w-full items-baseline text-sm leading-relaxed">
+                {commandParts.cwd ? (
+                  <CwdChip cwd={commandParts.cwd} workspaceRoot={workspaceRoot} />
+                ) : null}
+                <CommandText command={commandParts.command} className="min-w-0 flex-1 truncate" />
+              </p>
+            ) : (
+              <p className="flex min-w-0 w-full items-baseline gap-1.5 text-sm leading-relaxed">
+                <span
+                  className={cn(
+                    "min-w-0 flex-1",
+                    expanded || (commandMatchesVisibleLabel && !canExpand)
+                      ? "whitespace-pre-wrap break-words select-text"
+                      : "truncate",
+                    headingClass,
+                  )}
+                  onClick={expanded ? stopRowToggle : undefined}
+                  onPointerDown={expanded ? stopRowToggle : undefined}
+                >
+                  {previewText}
+                </span>
+              </p>
+            )}
           </div>
+          {isToolLike ? (
+            <ToolRowMeta
+              durationMs={durationMs}
+              exitCode={exitCode}
+              diffStat={diffStat}
+              running={running}
+            />
+          ) : null}
           {showFailedIndicator &&
           !showDestructiveRowStyle &&
           !toolIconAcceptsTint(entryIconName, entryToolIcon) ? (
@@ -3429,33 +3515,45 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           </span>
         </div>
       </div>
-      {expanded && viewedImage && threadRef ? (
-        <div
-          className="mt-1 ms-7 cursor-default"
-          onClick={stopRowToggle}
-          onPointerDown={stopRowToggle}
-        >
-          <ChatMarkdownAssetImage
-            environmentId={threadRef.environmentId}
-            resource={viewedImage.resource}
-            alt={viewedImage.alt}
-            srcFragment={viewedImage.srcFragment}
-            workspaceRoot={workspaceRoot}
-            maxHeightRem={16}
-            onImageExpand={onImageExpand}
-          />
-        </div>
-      ) : null}
       {workEntry.questionAnswer ? (
         <QuestionAnswerHistory answer={workEntry.questionAnswer} />
       ) : null}
-      {expanded && canExpand && expandedBody ? (
+      {errorLine && !expanded ? (
+        <p className={cn(TOOL_ROW_MONO_CLASS, "ms-7 truncate text-secondary-label")}>{errorLine}</p>
+      ) : null}
+      {expanded && canExpand ? (
         <div
-          className="mt-1 ms-7 cursor-default rounded-md bg-muted/40 px-3 py-2"
+          className="mt-1 ms-7 flex cursor-default flex-col gap-2"
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          <pre className={toolCallExpandedBodyClassName}>{expandedBody}</pre>
+          {viewedImage && threadRef ? (
+            <ChatMarkdownAssetImage
+              environmentId={threadRef.environmentId}
+              resource={viewedImage.resource}
+              alt={viewedImage.alt}
+              srcFragment={viewedImage.srcFragment}
+              workspaceRoot={workspaceRoot}
+              maxHeightRem={16}
+              onImageExpand={onImageExpand}
+            />
+          ) : null}
+          {facts?.output ? (
+            <ToolOutputBlock output={facts.output} failed={showFailedIndicator} />
+          ) : null}
+          {filesWithDiff.length > 0 ? (
+            <ToolFileDiffs
+              files={filesWithDiff}
+              workspaceRoot={workspaceRoot}
+              resolvedTheme={resolvedTheme}
+              cacheKey={workEntry.id}
+            />
+          ) : null}
+          {!facts?.output && filesWithDiff.length === 0 && expandedBody ? (
+            <pre className={cn(toolCallExpandedBodyClassName, "rounded-md bg-muted/40 px-3 py-2")}>
+              {expandedBody}
+            </pre>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/chat/ToolCallRow.tsx
+++ b/apps/web/src/components/chat/ToolCallRow.tsx
@@ -47,7 +47,7 @@ export const CwdChip = memo(function CwdChip(props: {
     <Tooltip>
       <TooltipTrigger
         render={
-          <span className="me-1.5 inline-flex max-w-40 shrink-0 truncate rounded border border-border/60 bg-muted/40 px-1 align-[1px] text-[0.625rem] leading-4 text-muted-foreground">
+          <span className="me-1.5 inline-block max-w-40 shrink-0 truncate rounded border border-border/60 bg-muted/40 px-1 align-[1px] text-[0.625rem] leading-4 text-muted-foreground">
             {label}
           </span>
         }
@@ -208,9 +208,11 @@ export const ToolFileDiffs = memo(function ToolFileDiffs(props: {
     () =>
       props.files.map((file) => ({
         file,
-        renderable: file.diff ? getRenderablePatch(file.diff, `tool-row:${props.cacheKey}`) : null,
+        renderable: file.diff
+          ? getRenderablePatch(file.diff, `tool-row:${props.resolvedTheme}:${props.cacheKey}`)
+          : null,
       })),
-    [props.cacheKey, props.files],
+    [props.cacheKey, props.files, props.resolvedTheme],
   );
   return (
     <div className="flex min-w-0 flex-col gap-2">

--- a/apps/web/src/components/chat/ToolCallRow.tsx
+++ b/apps/web/src/components/chat/ToolCallRow.tsx
@@ -1,0 +1,248 @@
+/**
+ * Building blocks for a tool-call row in the chat timeline: the working
+ * directory chip, the lightly coloured command text, the right-aligned meta
+ * (duration, exit code, diff stat), and the expanded output / diff body.
+ * All of it reads `ToolCallFacts`, so Codex, Claude, Cursor, Grok and
+ * OpenCode calls render identically.
+ */
+import type { ToolCallFacts, ToolCallFactsFile, ToolCallFactsOutput } from "@t3tools/contracts";
+import { formatDuration } from "@t3tools/shared/orchestrationTiming";
+import { FileDiff } from "@pierre/diffs/react";
+import { memo, useMemo } from "react";
+
+import { formatWorkspaceRelativePath } from "../../filePathDisplay";
+import {
+  getRenderablePatch,
+  resolveDiffThemeName,
+  resolveFileDiffPath,
+} from "../../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../../lib/syntaxHighlighting";
+import { cn } from "~/lib/utils";
+import { DiffStatLabel } from "./DiffStatLabel";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+export const TOOL_ROW_MONO_CLASS =
+  "font-mono text-[length:var(--font-size-code,0.6875rem)] leading-relaxed";
+
+/** Working directory as a short chip: workspace-relative, root shown as its basename. */
+export const CwdChip = memo(function CwdChip(props: {
+  cwd: string;
+  workspaceRoot: string | undefined;
+}) {
+  const label = useMemo(() => {
+    const relative = formatWorkspaceRelativePath(props.cwd, props.workspaceRoot);
+    if (relative === "." || relative.length === 0 || relative === props.workspaceRoot) {
+      const base = props.cwd
+        .replace(/[\\/]+$/u, "")
+        .split(/[\\/]/u)
+        .at(-1);
+      return base && base.length > 0 ? base : props.cwd;
+    }
+    return relative;
+  }, [props.cwd, props.workspaceRoot]);
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span className="me-1.5 inline-flex max-w-40 shrink-0 truncate rounded border border-border/60 bg-muted/40 px-1 align-[1px] text-[0.625rem] leading-4 text-muted-foreground">
+            {label}
+          </span>
+        }
+      />
+      <TooltipPopup side="top">{props.cwd}</TooltipPopup>
+    </Tooltip>
+  );
+});
+
+type CommandToken = {
+  readonly kind: "bin" | "flag" | "string" | "plain";
+  readonly text: string;
+  /** Character offset in the command; doubles as a stable render key. */
+  readonly start: number;
+};
+
+/**
+ * Three muted colours are enough for a row to scan as a command: the
+ * program, its flags, and quoted strings. Anything richer competes with the
+ * status colours that actually matter.
+ */
+export function tokenizeCommand(command: string): CommandToken[] {
+  const tokens: CommandToken[] = [];
+  const pattern = /("(?:[^"\\]|\\.)*"|'[^']*'|\s+|[^\s"']+)/gu;
+  let sawWord = false;
+  let afterSeparator = true;
+  for (const match of command.matchAll(pattern)) {
+    const text = match[0];
+    const start = match.index;
+    if (/^\s+$/u.test(text)) {
+      tokens.push({ kind: "plain", text, start });
+      continue;
+    }
+    if (text.startsWith('"') || text.startsWith("'")) {
+      tokens.push({ kind: "string", text, start });
+      afterSeparator = false;
+      continue;
+    }
+    if (/^(?:&&|\|\||[|;])$/u.test(text)) {
+      tokens.push({ kind: "plain", text, start });
+      afterSeparator = true;
+      continue;
+    }
+    if (afterSeparator || !sawWord) {
+      tokens.push({ kind: "bin", text, start });
+      sawWord = true;
+      afterSeparator = false;
+      continue;
+    }
+    tokens.push({ kind: text.startsWith("-") ? "flag" : "plain", text, start });
+  }
+  return tokens;
+}
+
+export const CommandText = memo(function CommandText(props: {
+  command: string;
+  className?: string;
+}) {
+  const tokens = useMemo(() => tokenizeCommand(props.command), [props.command]);
+  return (
+    <span className={cn(TOOL_ROW_MONO_CLASS, "text-foreground/90", props.className)}>
+      {tokens.map((token) => (
+        <span
+          key={token.start}
+          className={
+            token.kind === "bin"
+              ? "text-info-foreground"
+              : token.kind === "flag"
+                ? "text-secondary-label"
+                : token.kind === "string"
+                  ? "text-warning"
+                  : undefined
+          }
+        >
+          {token.text}
+        </span>
+      ))}
+    </span>
+  );
+});
+
+/** Right edge of a row: duration, non-zero exit code, or +/- stat for edits. */
+export const ToolRowMeta = memo(function ToolRowMeta(props: {
+  durationMs: number | undefined;
+  exitCode: number | undefined;
+  diffStat: { additions: number; deletions: number } | null;
+  running: boolean;
+}) {
+  const showExit = props.exitCode !== undefined && props.exitCode !== 0;
+  if (!showExit && !props.diffStat && props.durationMs === undefined && !props.running) {
+    return null;
+  }
+  return (
+    <span className="ms-2 flex shrink-0 items-center gap-2 text-[0.6875rem] tabular-nums text-muted-foreground">
+      {props.diffStat ? (
+        <DiffStatLabel
+          additions={props.diffStat.additions}
+          deletions={props.diffStat.deletions}
+          layout="inline"
+        />
+      ) : null}
+      {showExit ? (
+        <span className="rounded bg-destructive/10 px-1 font-medium text-destructive">
+          exit {props.exitCode}
+        </span>
+      ) : null}
+      {props.running ? (
+        <span className="rounded bg-info/10 px-1 font-medium text-info-foreground">running</span>
+      ) : props.durationMs !== undefined ? (
+        <span>{formatDuration(props.durationMs)}</span>
+      ) : null}
+    </span>
+  );
+});
+
+/** First non-empty line of a failed call's output, shown without expanding. */
+export function firstOutputLine(output: ToolCallFacts["output"] | undefined): string | null {
+  const line = output?.text.split("\n").find((candidate) => candidate.trim().length > 0);
+  return line ? line.trim() : null;
+}
+
+export const ToolOutputBlock = memo(function ToolOutputBlock(props: {
+  output: ToolCallFactsOutput;
+  failed: boolean;
+}) {
+  const hiddenLines = props.output.truncated
+    ? Math.max(0, props.output.lineCount - props.output.text.split("\n").length)
+    : 0;
+  return (
+    <div className="min-w-0">
+      <pre
+        className={cn(
+          TOOL_ROW_MONO_CLASS,
+          "max-h-64 cursor-text overflow-auto whitespace-pre rounded-md bg-code-background/60 px-2.5 py-1.5 select-text",
+          props.failed ? "text-foreground/85" : "text-secondary-label",
+        )}
+      >
+        {props.output.text}
+      </pre>
+      {hiddenLines > 0 ? (
+        <p className="mt-1 text-[0.6875rem] text-muted-foreground">
+          {hiddenLines} more {hiddenLines === 1 ? "line" : "lines"} in the full output
+        </p>
+      ) : null}
+    </div>
+  );
+});
+
+export const ToolFileDiffs = memo(function ToolFileDiffs(props: {
+  files: ReadonlyArray<ToolCallFactsFile>;
+  workspaceRoot: string | undefined;
+  resolvedTheme: "light" | "dark";
+  cacheKey: string;
+}) {
+  const patches = useMemo(
+    () =>
+      props.files.map((file) => ({
+        file,
+        renderable: file.diff ? getRenderablePatch(file.diff, `tool-row:${props.cacheKey}`) : null,
+      })),
+    [props.cacheKey, props.files],
+  );
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      {patches.map(({ file, renderable }) => (
+        <div key={file.path} className="min-w-0">
+          <div className={cn(TOOL_ROW_MONO_CLASS, "mb-1 flex items-center gap-2")}>
+            <span className="min-w-0 truncate text-secondary-label">
+              {formatWorkspaceRelativePath(file.path, props.workspaceRoot)}
+            </span>
+            {file.additions !== undefined || file.deletions !== undefined ? (
+              <DiffStatLabel
+                additions={file.additions ?? 0}
+                deletions={file.deletions ?? 0}
+                layout="inline"
+              />
+            ) : null}
+          </div>
+          {renderable?.kind === "files" ? (
+            renderable.files.map((fileDiff) => (
+              <FileDiff
+                key={resolveFileDiffPath(fileDiff)}
+                fileDiff={fileDiff}
+                options={{
+                  collapsed: false,
+                  diffStyle: "unified",
+                  theme: resolveDiffThemeName(props.resolvedTheme),
+                  preferredHighlighter: PREFERRED_HIGHLIGHTER,
+                }}
+              />
+            ))
+          ) : renderable?.kind === "raw" ? (
+            <pre className={cn(TOOL_ROW_MONO_CLASS, "overflow-x-auto rounded-md bg-muted/40 p-2")}>
+              {renderable.text}
+            </pre>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/ToolCallRow.tsx
+++ b/apps/web/src/components/chat/ToolCallRow.tsx
@@ -23,6 +23,9 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 export const TOOL_ROW_MONO_CLASS =
   "font-mono text-[length:var(--font-size-code,0.6875rem)] leading-relaxed";
+/** Right-edge meta strip shared by the group header and each call row. */
+export const TOOL_ROW_META_CLASS =
+  "ms-2 flex shrink-0 items-center gap-2 text-[0.6875rem] tabular-nums text-muted-foreground";
 
 /** Working directory as a short chip: workspace-relative, root shown as its basename. */
 export const CwdChip = memo(function CwdChip(props: {
@@ -138,7 +141,7 @@ export const ToolRowMeta = memo(function ToolRowMeta(props: {
     return null;
   }
   return (
-    <span className="ms-2 flex shrink-0 items-center gap-2 text-[0.6875rem] tabular-nums text-muted-foreground">
+    <span className={TOOL_ROW_META_CLASS}>
       {props.diffStat ? (
         <DiffStatLabel
           additions={props.diffStat.additions}
@@ -178,15 +181,17 @@ export const ToolOutputBlock = memo(function ToolOutputBlock(props: {
       <pre
         className={cn(
           TOOL_ROW_MONO_CLASS,
-          "max-h-64 cursor-text overflow-auto whitespace-pre rounded-md bg-code-background/60 px-2.5 py-1.5 select-text",
+          "max-h-64 cursor-text overflow-auto whitespace-pre rounded-md bg-[var(--code-background)] px-2.5 py-1.5 select-text",
           props.failed ? "text-foreground/85" : "text-secondary-label",
         )}
       >
         {props.output.text}
       </pre>
-      {hiddenLines > 0 ? (
+      {props.output.truncated ? (
         <p className="mt-1 text-[0.6875rem] text-muted-foreground">
-          {hiddenLines} more {hiddenLines === 1 ? "line" : "lines"} in the full output
+          {hiddenLines > 0
+            ? `${hiddenLines} more ${hiddenLines === 1 ? "line" : "lines"} in the full output`
+            : "Output cut short; the full output is longer"}
         </p>
       ) : null}
     </div>

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -170,3 +170,53 @@ describe("deriveWorkLogEntries command output", () => {
     expect(entry?.detail).toBeUndefined();
   });
 });
+
+describe("deriveWorkLogEntries tool call facts", () => {
+  it("carries server-derived facts and fills the exit code from the detail suffix", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("claude-command", {
+        itemType: "command_execution",
+        title: "Command run",
+        detail: "Bash: pnpm test\n<exited with exit code 2>",
+        toolCallId: "toolu_1",
+        facts: {
+          intent: "Run the unit tests",
+          durationMs: 4200,
+          output: { text: "FAIL a.test.ts", lineCount: 1, truncated: false },
+        },
+        data: { toolName: "Bash", input: { command: "pnpm test" } },
+      }),
+    ]);
+
+    expect(entry?.facts).toEqual({
+      intent: "Run the unit tests",
+      durationMs: 4200,
+      exitCode: 2,
+      output: { text: "FAIL a.test.ts", lineCount: 1, truncated: false },
+    });
+  });
+
+  it("measures wall-clock duration from tool.started when the provider reports none", () => {
+    const started: OrchestrationThreadActivity = {
+      id: EventId.make("started"),
+      createdAt: "2026-07-17T10:00:00.000Z",
+      kind: "tool.started",
+      summary: "Ran command started",
+      tone: "tool",
+      payload: { itemType: "command_execution", toolCallId: "call-1", status: "inProgress" },
+      turnId: TurnId.make("turn-1"),
+    };
+    const completed: OrchestrationThreadActivity = {
+      ...makeCommandActivity("completed", {
+        itemType: "command_execution",
+        toolCallId: "call-1",
+        status: "completed",
+        data: { command: "ls" },
+      }),
+      createdAt: "2026-07-17T10:00:03.500Z",
+    };
+
+    const [entry] = deriveWorkLogEntries([started, completed]);
+    expect(entry?.durationMs).toBe(3500);
+  });
+});

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -25,6 +25,10 @@ import {
   type OrchestrationLatestTurn,
   type OrchestrationThreadActivity,
   type OrchestrationProposedPlanId,
+  ProviderDriverKind,
+  ProviderApprovalOption,
+  ProviderRequestKind,
+  type ToolCallFacts,
   type ToolLifecycleItemType,
   type ThreadId,
   type TurnId,
@@ -92,6 +96,10 @@ export interface WorkLogEntry {
     workflowId: string | null;
     agentTaskIds: ReadonlyArray<string>;
   };
+  /** Server-derived, provider-neutral facts (cwd, exit code, duration, output, files). */
+  facts?: ToolCallFacts;
+  /** Wall-clock duration from `tool.started` to completion when the server had none. */
+  durationMs?: number;
 }
 
 const workLogCollapseKey = Symbol();
@@ -451,6 +459,16 @@ export function deriveWorkLogEntries(
 ): WorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries: DerivedWorkLogEntry[] = [];
+  // `tool.started` rows never render, but their timestamps give every
+  // provider a wall-clock duration when the runtime reports none.
+  const toolStartedAt = new Map<string, string>();
+  for (const activity of ordered) {
+    if (activity.kind !== "tool.started") continue;
+    const toolCallId = extractToolCallId(asRecord(activity.payload));
+    if (toolCallId && !toolStartedAt.has(toolCallId)) {
+      toolStartedAt.set(toolCallId, activity.createdAt);
+    }
+  }
   for (const activity of ordered) {
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
     if (activity.kind === "tool.started") continue;
@@ -467,7 +485,22 @@ export function deriveWorkLogEntries(
     if (isNoContentRuntimeWarning(activity)) continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
     if (isAgentInternalActivity(activity)) continue;
-    entries.push(toDerivedWorkLogEntry(activity));
+    const entry = toDerivedWorkLogEntry(activity);
+    if (
+      activity.kind === "tool.completed" &&
+      entry.toolCallId &&
+      entry.facts?.durationMs === undefined &&
+      entry.durationMs === undefined
+    ) {
+      const startedAt = toolStartedAt.get(entry.toolCallId);
+      const elapsed =
+        startedAt !== undefined ? Date.parse(activity.createdAt) - Date.parse(startedAt) : NaN;
+      if (Number.isFinite(elapsed) && elapsed >= 0) {
+        entries.push({ ...entry, durationMs: elapsed });
+        continue;
+      }
+    }
+    entries.push(entry);
   }
   return collapseDerivedWorkLogEntries(entries);
 }
@@ -605,6 +638,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   }
   if (toolCallId) {
     entry.toolCallId = toolCallId;
+  }
+  const facts = extractToolCallFacts(payload);
+  if (facts) {
+    entry.facts = facts;
   }
   let toolLifecycleStatus = extractWorkLogToolLifecycleStatus(payload);
   if (!toolLifecycleStatus && activity.kind === "tool.completed") {
@@ -1170,6 +1207,20 @@ function summarizeToolRawOutput(payload: Record<string, unknown> | null): string
   }
 
   return null;
+}
+
+function extractToolCallFacts(payload: Record<string, unknown> | null): ToolCallFacts | null {
+  const facts = asRecord(payload?.facts);
+  if (!facts) return null;
+  const detailExit =
+    typeof payload?.detail === "string"
+      ? stripTrailingExitCode(payload.detail).exitCode
+      : undefined;
+  const merged = {
+    ...(facts as ToolCallFacts),
+    ...(facts.exitCode === undefined && detailExit !== undefined ? { exitCode: detailExit } : {}),
+  };
+  return Object.keys(merged).length > 0 ? merged : null;
 }
 
 function extractToolOutput(payload: Record<string, unknown> | null): string | null {

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -7,8 +7,11 @@ import {
   extractCommandOutputText,
   resolveViewedImageAsset,
   resolveWorkEntryToolPresentation,
+  splitLeadingCd,
   summarizeToolGroup,
+  toolEntryDiffStat,
   toolGroupAction,
+  toolGroupStats,
   toolGroupSummaryKind,
   type WorkLogPresentationEntry,
   workEntryViewedImagePath,
@@ -569,5 +572,70 @@ describe("resolveViewedImageAsset", () => {
       srcFragment: "#mark",
     });
     expect(resolveViewedImageAsset("https://example.com/logo.png", { threadId })).toBeNull();
+  });
+});
+
+describe("splitLeadingCd", () => {
+  it.each([
+    ["cd /repo/apps/mobile; pnpm test", "/repo/apps/mobile", "pnpm test"],
+    ["cd /repo && ls -la", "/repo", "ls -la"],
+    ['cd "/My Repo/app" && make', "/My Repo/app", "make"],
+    ["cd /My\\ Repo && make", "/My Repo", "make"],
+  ])("splits %s", (command, cwd, rest) => {
+    expect(splitLeadingCd(command)).toEqual({ cwd, command: rest });
+  });
+
+  it("leaves commands without a leading cd alone", () => {
+    expect(splitLeadingCd("ls -la && cd /tmp")).toEqual({
+      cwd: null,
+      command: "ls -la && cd /tmp",
+    });
+    expect(splitLeadingCd("cd /repo")).toEqual({ cwd: null, command: "cd /repo" });
+  });
+});
+
+describe("toolGroupStats", () => {
+  const command = (overrides: Partial<WorkLogPresentationEntry>): WorkLogPresentationEntry => ({
+    label: "Ran command",
+    tone: "tool",
+    itemType: "command_execution",
+    command: "ls",
+    toolLifecycleStatus: "completed",
+    ...overrides,
+  });
+
+  it("counts failures from status and exit code and sums durations", () => {
+    expect(
+      toolGroupStats([
+        command({ facts: { durationMs: 1000, exitCode: 0 } }),
+        command({ facts: { durationMs: 250, exitCode: 1 } }),
+        command({ toolLifecycleStatus: "failed", durationMs: 50 }),
+        { label: "Thinking about it", tone: "info" },
+      ]),
+    ).toEqual({ failureCount: 2, durationMs: 1300 });
+  });
+
+  it("reports no duration when any tool call lacks one", () => {
+    expect(toolGroupStats([command({ facts: { durationMs: 1000 } }), command({})])).toEqual({
+      failureCount: 0,
+      durationMs: null,
+    });
+  });
+
+  it("sums diff stats across changed files", () => {
+    expect(
+      toolEntryDiffStat(
+        command({
+          facts: {
+            files: [
+              { path: "a.ts", additions: 2, deletions: 1 },
+              { path: "b.ts", additions: 3, deletions: 0 },
+              { path: "c.ts" },
+            ],
+          },
+        }),
+      ),
+    ).toEqual({ additions: 5, deletions: 1 });
+    expect(toolEntryDiffStat(command({}))).toBeNull();
   });
 });

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -615,6 +615,15 @@ describe("toolGroupStats", () => {
     ).toEqual({ failureCount: 2, durationMs: 1300 });
   });
 
+  it("ignores thinking notes when summing durations", () => {
+    expect(
+      toolGroupStats([
+        command({ facts: { durationMs: 1000 } }),
+        { label: "Considering the failing test", tone: "thinking" },
+      ]),
+    ).toEqual({ failureCount: 0, durationMs: 1000 });
+  });
+
   it("reports no duration when any tool call lacks one", () => {
     expect(toolGroupStats([command({ facts: { durationMs: 1000 } }), command({})])).toEqual({
       failureCount: 0,

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -593,7 +593,8 @@ export function toolGroupStats(entries: ReadonlyArray<WorkLogPresentationEntry>)
   let missingDuration = false;
   let sawTool = false;
   for (const entry of entries) {
-    if (!workLogEntryIsToolLike(entry)) continue;
+    // Thinking rows are tool-like for grouping but are notes, not calls.
+    if (!workLogEntryIsToolLike(entry) || entry.tone === "thinking") continue;
     sawTool = true;
     if (workEntryFailed(entry)) failureCount += 1;
     const duration = toolEntryDurationMs(entry);

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -4,6 +4,7 @@ import {
   type RuntimeItemStatus,
   type ThreadId,
   type ToolActivitySource,
+  type ToolCallFacts,
   type ToolLifecycleItemType,
 } from "@t3tools/contracts";
 import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
@@ -33,6 +34,10 @@ export interface WorkLogPresentationEntry {
   readonly sourceActivityKind?: string;
   readonly taskId?: string;
   readonly toolSource?: ToolActivitySource;
+  /** Server-derived, provider-neutral facts (cwd, exit code, duration, output, files). */
+  readonly facts?: ToolCallFacts;
+  /** Wall-clock duration when the server did not report one (started→completed). */
+  readonly durationMs?: number;
 }
 
 export type ToolGroupAction =
@@ -521,6 +526,81 @@ function toolGroupActionLabel(action: ToolGroupAction, count: number): string {
     case "update":
       return `Received ${count} ${count === 1 ? "update" : "updates"}`;
   }
+}
+
+/**
+ * Agents usually prefix commands with `cd <dir> && …` or `cd <dir>; …`.
+ * Pull that prefix out so the directory can render as a chip and the real
+ * command gets the width. Quoted paths and `\ ` escapes are honoured.
+ */
+export function splitLeadingCd(command: string): { cwd: string | null; command: string } {
+  const match =
+    /^\s*cd\s+(?<dir>"(?:[^"\\]|\\.)*"|'[^']*'|(?:[^\s;&|\\]|\\.)+)\s*(?:&&|;)\s*(?<rest>[\s\S]+)$/u.exec(
+      command,
+    );
+  const dir = match?.groups?.dir;
+  const rest = match?.groups?.rest?.trim();
+  if (!dir || !rest) return { cwd: null, command };
+  const unquoted =
+    (dir.startsWith('"') && dir.endsWith('"')) || (dir.startsWith("'") && dir.endsWith("'"))
+      ? dir.slice(1, -1)
+      : dir.replace(/\\(.)/g, "$1");
+  return { cwd: unquoted, command: rest };
+}
+
+export function toolEntryDurationMs(entry: WorkLogPresentationEntry): number | undefined {
+  return entry.facts?.durationMs ?? entry.durationMs;
+}
+
+export function toolEntryExitCode(entry: WorkLogPresentationEntry): number | undefined {
+  return entry.facts?.exitCode;
+}
+
+export function toolEntryDiffStat(
+  entry: WorkLogPresentationEntry,
+): { additions: number; deletions: number } | null {
+  const files = entry.facts?.files;
+  if (!files || files.length === 0) return null;
+  let additions = 0;
+  let deletions = 0;
+  let counted = false;
+  for (const file of files) {
+    if (file.additions === undefined && file.deletions === undefined) continue;
+    counted = true;
+    additions += file.additions ?? 0;
+    deletions += file.deletions ?? 0;
+  }
+  return counted ? { additions, deletions } : null;
+}
+
+export function workEntryFailed(entry: WorkLogPresentationEntry): boolean {
+  if (entry.toolLifecycleStatus === "failed") return true;
+  const exitCode = toolEntryExitCode(entry);
+  return exitCode !== undefined && exitCode !== 0;
+}
+
+/**
+ * Group-level numbers for the collapsed header: how many calls failed and
+ * how long the group took in total. Duration sums per-call durations when
+ * every tool call reports one, otherwise it is unknown rather than partial.
+ */
+export function toolGroupStats(entries: ReadonlyArray<WorkLogPresentationEntry>): {
+  failureCount: number;
+  durationMs: number | null;
+} {
+  let failureCount = 0;
+  let durationMs = 0;
+  let missingDuration = false;
+  let sawTool = false;
+  for (const entry of entries) {
+    if (!workLogEntryIsToolLike(entry)) continue;
+    sawTool = true;
+    if (workEntryFailed(entry)) failureCount += 1;
+    const duration = toolEntryDurationMs(entry);
+    if (duration === undefined) missingDuration = true;
+    else durationMs += duration;
+  }
+  return { failureCount, durationMs: sawTool && !missingDuration ? durationMs : null };
 }
 
 export function summarizeToolGroup(entries: ReadonlyArray<WorkLogPresentationEntry>): string {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -562,6 +562,43 @@ export const OrchestrationThreadActivityTone = Schema.Literals([
 ]);
 export type OrchestrationThreadActivityTone = typeof OrchestrationThreadActivityTone.Type;
 
+export const ToolCallFactsFile = Schema.Struct({
+  path: Schema.String,
+  /** Provider's change kind when reported: `add`, `delete`, `update`, `move`. */
+  kind: Schema.optionalKey(Schema.String),
+  additions: Schema.optionalKey(NonNegativeInt),
+  deletions: Schema.optionalKey(NonNegativeInt),
+  /** Bounded unified diff for this file when the provider reports one. */
+  diff: Schema.optionalKey(Schema.String),
+});
+export type ToolCallFactsFile = typeof ToolCallFactsFile.Type;
+
+export const ToolCallFactsOutput = Schema.Struct({
+  /** Head of the tool output, bounded in lines and bytes. */
+  text: Schema.String,
+  lineCount: NonNegativeInt,
+  truncated: Schema.Boolean,
+});
+export type ToolCallFactsOutput = typeof ToolCallFactsOutput.Type;
+
+/**
+ * Provider-neutral facts about one tool call, derived on the server from
+ * each runtime's native item data so every client renders Codex, Claude,
+ * Cursor, Grok and OpenCode calls through one shape. Every field is
+ * optional: a provider that does not report exit codes simply omits them.
+ */
+export const ToolCallFacts = Schema.Struct({
+  /** Directory the command ran in, when known. */
+  cwd: Schema.optionalKey(Schema.String),
+  exitCode: Schema.optionalKey(Schema.Int),
+  durationMs: Schema.optionalKey(NonNegativeInt),
+  /** The agent's stated purpose for the call when the runtime carries one. */
+  intent: Schema.optionalKey(Schema.String),
+  output: Schema.optionalKey(ToolCallFactsOutput),
+  files: Schema.optionalKey(Schema.Array(ToolCallFactsFile)),
+});
+export type ToolCallFacts = typeof ToolCallFacts.Type;
+
 export const OrchestrationThreadActivity = Schema.Struct({
   id: EventId,
   tone: OrchestrationThreadActivityTone,


### PR DESCRIPTION
## Problem

Tool calls in the chat read as a wall of shell. Every command row carries the agent's full `cd /Users/me/Documents/repos/app/apps/mobile; …` prefix, the agent's progress notes get the same hammer icon and weight as the commands they describe, and a row tells you nothing about whether it worked, how long it took, or what it changed unless you expand it, at which point you get a single summarised line. It looks the same for every provider only because everyone gets the same minimal treatment.

## What this does

**Server: one shape for every provider.** A new `ToolCallFacts` block (cwd, exit code, duration, bounded output excerpt, changed files with +/- stats and a bounded unified hunk, and the agent's stated intent) is derived at ingestion from each runtime's native item data and attached next to `data` on `tool.updated` / `tool.completed` activities. The existing payload projection keeps it as-is. Per provider:

- Codex: `cwd`, `exitCode`, `durationMs`, `aggregatedOutput`, `changes[].diff` all come straight off the item.
- Claude: Bash `description` becomes the intent, `tool_result` text becomes the output, Edit/Write inputs give line stats. No exit code or cwd is available from the SDK.
- Cursor and Grok (ACP): text content becomes the output, `diff` parts give line stats. No exit code from the agents since T3 does not expose a terminal to them.
- OpenCode: `state.time` gives the duration, `state.output`/`error` the output, `metadata.exit` the exit code when present.
- Every provider: duration falls back to `tool.started` → completion wall-clock on the client when the runtime reports none, and an exit code in the `<exited with exit code N>` detail suffix is picked up.

Output is capped at 40 lines / 4 KB and hunks at 8 KB at derivation time, so the facts stay cheap on the wire.

**Web: the rows.**
- Group header: existing summary, plus "1 failed" and total duration on the right, and a chevron.
- Progress notes inside an expanded group render as quiet section labels with a dot, so you read intent first and commands second.
- Commands: the leading `cd <dir> &&` / `cd <dir>;` is pulled into a small cwd chip (Codex's authoritative `cwd` wins when present), and the command gets program / flag / string colouring in three muted tones.
- Right edge: duration, a non-zero exit pill, or +/- line counts for edits, in tabular numerals.
- A failed call shows the first line of its output under the command without expanding. Ordinary tool failures stay muted per the existing taste; only severe orchestration failures keep the red alert treatment.
- Expanding a row shows the output excerpt as a real code block, or the file diff via the existing `FileDiff` renderer, with the old concatenated text body as a fallback for calls with no facts.

**Mobile.** The shared summary helpers already flow through; `facts` is carried on mobile's `WorkLogEntry` so its rows can pick this up in a follow-up. No mobile UI change here.

## Testing

- `toolCallFacts.test.ts`: derivation for all five providers, output bounding, diff stats.
- `presentation.test.ts`: `cd` prefix splitting (quoted and escaped paths), group failure/duration stats, diff stat summing.
- `session-logic.command-output.test.ts`: facts carried onto entries, exit code from detail suffix, wall-clock duration fallback.
- `MessagesTimeline.logic.test.ts`: collapsed row carries `failureCount` / `durationMs`.
- Existing `MessagesTimeline.test.tsx` cases still pass, including the muted-failure ones.
- Targeted typecheck: server, web, client-runtime, contracts, mobile.

Design reference for the row layout: the mockup I built before implementing is at https://claude.ai/code/artifact/819ce5c7-f828-40de-a10f-6640e1a566ca. Before screenshot is the flat list from today's build; I'll attach an after screenshot from a real thread as a comment.

Follow-up PR (separate concern): a Continue button for interrupted turns that resumes from the tool call that was cut off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration ingestion and activity broadcast shape for all providers; output/diff bounding limits wire cost, but incorrect derivation would mislead users about command success and file changes.
> 
> **Overview**
> Introduces **`ToolCallFacts`** on orchestration activities so tool **`tool.updated` / `tool.completed`** payloads carry a single, bounded shape (cwd, exit code, duration, output excerpt, file stats/diffs, intent) regardless of Codex, Claude, ACP, or OpenCode native data. The server derives these in **`toolCallFacts.ts`** at ingestion and attaches them beside raw **`data`**; clients read **`payload.facts`** instead of parsing provider-specific blobs.
> 
> **Web chat** gets richer tool UX: collapsed groups show **failure count and total duration**; expanded rows use **`ToolCallRow`** for cwd chips, tokenized commands, status icons, meta (duration/exit/diff), inline first-line errors, and expanded output or **`FileDiff`** views, with a legacy text fallback when facts are missing. **Work-log derivation** copies **`facts`**, merges exit codes from detail suffixes, and fills duration from **`tool.started` → completion** when the runtime omits timing. **Mobile** threads carry **`facts`** on work-log entries for a follow-up UI pass; user docs for tool activity are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37ccc6bc51f3fe60390f860e47969fc5b54c8412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider-neutral `ToolCallFacts` for scannable tool-call rows across providers
> - Defines a common `ToolCallFacts` schema in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/9186/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) covering cwd, exit code, duration, intent, bounded output, and per-file diffs
> - Server derives facts from native runtime data for Codex, Claude, Cursor/Grok (ACP), and OpenCode via provider adapters in [toolCallFacts.ts](https://github.com/pingdotgg/t3code/pull/9186/files#diff-533032b61a1c5d6b8850124ddd0876e8698ab5e7ed3dd6d86ca78d70fd6097c9), with output capped at 40 lines / 4,000 chars and diffs capped at 20 files / 24,000 chars
> - [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/9186/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) attaches the derived facts to `tool.updated` and `tool.completed` activity payloads
> - Web ([MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9186/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), [ToolCallRow.tsx](https://github.com/pingdotgg/t3code/pull/9186/files#diff-26a8f93d3ce6dd32acf0a48eaf2345577574ba4857c76df996b3635fe5a78312)) and mobile render facts as cwd chips, command tokens, status icons, timing/exit metadata, collapsed failure previews, and expandable output/diffs; tool-group rows aggregate failure counts and total duration
> - Presentation layer in [presentation.ts](https://github.com/pingdotgg/t3code/pull/9186/files#diff-b6852793cd3916fd7bb7704e9bfe1391f7ca44403063a0502eb92d59f5060972) parses leading `cd` prefixes and computes group-level failure/duration/file-change metrics
> - Behavioral Change: [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/9186/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) row reuse now invalidates on `failureCount`/`durationMs` changes; [session-logic.ts](https://github.com/pingdotgg/t3code/pull/9186/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) computes a fallback wall-clock duration from `tool.started`/`tool.completed` timestamps and merges detail-suffix exit codes when facts omit one
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37ccc6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added richer tool-call details across chat activity, including working directory, duration, exit status, running state, and failure indicators.
  - Tool output is now shown with concise previews, truncation notices, and clearer error information.
  - File changes display additions, deletions, file paths, and expandable unified diffs.
  - Collapsed tool groups summarize total duration, failures, and combined file-change statistics.
  - Tool-call details are normalized across supported providers for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->