### PR TITLE
feat(chat): continue an interrupted turn from the tool call it stopped at

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1473,6 +1473,20 @@ function renderFeedEntry(
       !assistantTurnStillInProgress &&
       !message.streaming;
 
+    if (isUser && message.origin === "continuation") {
+      // Hidden prompt sent by Continue after an interrupted turn: a marker,
+      // never a bubble, mirroring the web timeline.
+      return (
+        <View className="my-2 flex-row items-center gap-2">
+          <View className="h-px flex-1 bg-border" />
+          <NativeText className="text-xs text-muted-foreground">
+            Continued from the interrupted step
+          </NativeText>
+          <View className="h-px flex-1 bg-border" />
+        </View>
+      );
+    }
+
     if (isUser) {
       return (
         <View className="mb-5 items-end">

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1028,6 +1028,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               role: event.payload.role,
               text: event.payload.text,
               ...(attachments !== undefined ? { attachments: [...attachments] } : {}),
+              ...(event.payload.origin !== undefined ? { origin: event.payload.origin } : {}),
               createdAt: event.payload.createdAt,
               updatedAt: event.payload.updatedAt,
             });
@@ -1056,6 +1057,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             role: event.payload.role,
             text: nextText,
             ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
+            ...(event.payload.origin !== undefined
+              ? { origin: event.payload.origin }
+              : previousMessage?.origin !== undefined
+                ? { origin: previousMessage.origin }
+                : {}),
             isStreaming: false,
             createdAt: previousMessage?.createdAt ?? event.payload.createdAt,
             updatedAt: event.payload.updatedAt,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -2,6 +2,7 @@ import {
   AgentSessionImportSource,
   ApprovalRequestId,
   ChatAttachment,
+  OrchestrationMessageOrigin,
   CheckpointRef,
   IsoDateTime,
   MessageId,
@@ -106,6 +107,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    origin: Schema.NullOr(OrchestrationMessageOrigin),
   }),
 );
 const ProjectionTurnStartMessageDbRowSchema = ProjectionThreadMessageDbRowSchema.mapFields(
@@ -622,6 +624,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          origin,
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1179,6 +1182,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          origin,
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1536,6 +1540,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          origin,
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -1935,6 +1940,7 @@ pending_approval_requests AS (
                   role: row.role,
                   text: row.text,
                   ...(row.attachments !== null ? { attachments: row.attachments } : {}),
+                  ...(row.origin !== null ? { origin: row.origin } : {}),
                   turnId: row.turnId,
                   streaming: row.isStreaming === 1,
                   createdAt: row.createdAt,
@@ -3212,10 +3218,12 @@ pending_approval_requests AS (
             createdAt: row.createdAt,
             updatedAt: row.updatedAt,
           };
+          const withOrigin =
+            row.origin !== null ? Object.assign(message, { origin: row.origin }) : message;
           if (row.attachments !== null) {
-            return Object.assign(message, { attachments: row.attachments });
+            return Object.assign(withOrigin, { attachments: row.attachments });
           }
-          return message;
+          return withOrigin;
         }),
         proposedPlans: proposedPlanRows.map(mapProposedPlanRow),
         activities,

--- a/apps/server/src/orchestration/decider.continue.test.ts
+++ b/apps/server/src/orchestration/decider.continue.test.ts
@@ -1,0 +1,105 @@
+import {
+  CommandId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationReadModel,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+
+const NOW = "2026-01-01T00:00:00.000Z";
+
+const readModel: OrchestrationReadModel = {
+  snapshotSequence: 0,
+  projects: [],
+  threads: [
+    {
+      id: ThreadId.make("thread-1"),
+      projectId: ProjectId.make("project-1"),
+      title: "Thread",
+      modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      branch: null,
+      worktreePath: null,
+      latestTurn: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+      archivedAt: null,
+      settledOverride: null,
+      settledAt: null,
+      snoozedUntil: null,
+      snoozedAt: null,
+      pinnedAt: null,
+      deletedAt: null,
+      messages: [],
+      proposedPlans: [],
+      activities: [],
+      checkpoints: [],
+      session: null,
+    },
+  ],
+  updatedAt: NOW,
+};
+
+it.layer(NodeServices.layer)("continuation turn start decider", (it) => {
+  it.effect("stamps the continuation origin on the user message it records", () =>
+    Effect.gen(function* () {
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-continue"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: MessageId.make("msg-continue"),
+            role: "user",
+            text: "Your previous turn was stopped before it finished. Continue from that step.",
+            attachments: [],
+            origin: "continuation",
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: NOW,
+        },
+        readModel,
+      });
+      const events = Array.isArray(result) ? result : [result];
+      const sent = events.find((event) => event.type === "thread.message-sent");
+      expect(sent?.payload).toMatchObject({
+        messageId: "msg-continue",
+        role: "user",
+        origin: "continuation",
+      });
+    }),
+  );
+
+  it.effect("leaves ordinary messages without an origin", () =>
+    Effect.gen(function* () {
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-plain"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: MessageId.make("msg-plain"),
+            role: "user",
+            text: "Hello",
+            attachments: [],
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: NOW,
+        },
+        readModel,
+      });
+      const events = Array.isArray(result) ? result : [result];
+      const sent = events.find((event) => event.type === "thread.message-sent");
+      expect(sent?.payload).not.toHaveProperty("origin");
+    }),
+  );
+});

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1098,6 +1098,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           role: "user",
           text: command.message.text,
           attachments: command.message.attachments,
+          ...(command.message.origin !== undefined ? { origin: command.message.origin } : {}),
           turnId: null,
           streaming: false,
           createdAt: command.createdAt,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -571,6 +571,7 @@ export function projectEvent(
             role: payload.role,
             text: payload.text,
             ...(payload.attachments !== undefined ? { attachments: payload.attachments } : {}),
+            ...(payload.origin !== undefined ? { origin: payload.origin } : {}),
             turnId: payload.turnId,
             streaming: payload.streaming,
             createdAt: payload.createdAt,

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Struct from "effect/Struct";
-import { ChatAttachment } from "@t3tools/contracts";
+import { ChatAttachment, OrchestrationMessageOrigin } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
@@ -23,6 +23,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    origin: Schema.NullOr(OrchestrationMessageOrigin),
   }),
 );
 const ProjectionThreadMessageExistsDbRowSchema = Schema.Struct({ exists: Schema.Number });
@@ -40,6 +41,7 @@ function toProjectionThreadMessage(
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     ...(row.attachments !== null ? { attachments: row.attachments } : {}),
+    ...(row.origin !== null ? { origin: row.origin } : {}),
   };
 }
 
@@ -59,6 +61,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json,
+          origin,
           is_streaming,
           created_at,
           updated_at
@@ -77,6 +80,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
               WHERE message_id = ${row.messageId}
             )
           ),
+          ${row.origin ?? null},
           ${row.isStreaming ? 1 : 0},
           ${row.createdAt},
           ${row.updatedAt}
@@ -91,6 +95,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
             excluded.attachments_json,
             projection_thread_messages.attachments_json
           ),
+          origin = COALESCE(excluded.origin, projection_thread_messages.origin),
           is_streaming = excluded.is_streaming,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at
@@ -111,6 +116,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json,
+          origin,
           is_streaming,
           created_at,
           updated_at
@@ -122,6 +128,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           ${row.role},
           ${row.text},
           ${nextAttachmentsJson},
+          ${row.origin ?? null},
           1,
           ${row.createdAt},
           ${row.updatedAt}
@@ -154,6 +161,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          origin,
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
@@ -192,6 +200,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           role,
           text,
           attachments_json AS "attachments",
+          origin,
           is_streaming AS "isStreaming",
           created_at AS "createdAt",
           updated_at AS "updatedAt"

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -61,6 +61,7 @@ import Migration0046 from "./Migrations/046_RepairAutomaticSettlementTimestamps.
 import Migration0047 from "./Migrations/047_ProjectionProjectIcon.ts";
 import Migration0048 from "./Migrations/048_ProjectionThreadBranchPullRequest.ts";
 import Migration0049 from "./Migrations/049_ProjectionThreadsActiveOrderKey.ts";
+import Migration0050 from "./Migrations/050_ProjectionThreadMessageOrigin.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -122,6 +123,7 @@ const migrationEntries = [
   [47, "ProjectionProjectIcon", Migration0047],
   [48, "ProjectionThreadBranchPullRequest", Migration0048],
   [49, "ProjectionThreadsActiveOrderKey", Migration0049],
+  [50, "ProjectionThreadMessageOrigin", Migration0050],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/050_ProjectionThreadMessageOrigin.test.ts
+++ b/apps/server/src/persistence/Migrations/050_ProjectionThreadMessageOrigin.test.ts
@@ -1,0 +1,30 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("050_ProjectionThreadMessageOrigin", (it) => {
+  it.effect("adds a nullable origin column to projection_thread_messages", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 49 });
+      const before = yield* sql<{
+        readonly name: string;
+      }>`PRAGMA table_info(projection_thread_messages)`;
+      assert.isFalse(before.some((column) => column.name === "origin"));
+
+      yield* runMigrations({ toMigrationInclusive: 50 });
+      const after = yield* sql<{ readonly name: string; readonly notnull: number }>`
+        PRAGMA table_info(projection_thread_messages)
+      `;
+      const origin = after.find((column) => column.name === "origin");
+      assert.isDefined(origin);
+      assert.equal(origin?.notnull, 0);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/050_ProjectionThreadMessageOrigin.test.ts
+++ b/apps/server/src/persistence/Migrations/050_ProjectionThreadMessageOrigin.test.ts
@@ -1,14 +1,11 @@
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as NodeSqliteClient from "@t3tools/shared/nodeSqliteClient";
 
 import { runMigrations } from "../Migrations.ts";
-import * as NodeSqliteClient from "../NodeSqliteClient.ts";
 
-const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
-
-layer("050_ProjectionThreadMessageOrigin", (it) => {
+it.layer(NodeSqliteClient.layerMemory())("050_ProjectionThreadMessageOrigin", (it) => {
   it.effect("adds a nullable origin column to projection_thread_messages", () =>
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;

--- a/apps/server/src/persistence/Migrations/050_ProjectionThreadMessageOrigin.ts
+++ b/apps/server/src/persistence/Migrations/050_ProjectionThreadMessageOrigin.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_thread_messages)
+  `;
+
+  if (!columns.some((column) => column.name === "origin")) {
+    yield* sql`
+      ALTER TABLE projection_thread_messages
+      ADD COLUMN origin TEXT
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -9,6 +9,7 @@
 import {
   ChatAttachment,
   MessageId,
+  OrchestrationMessageOrigin,
   OrchestrationMessageRole,
   ThreadId,
   TurnId,
@@ -29,6 +30,7 @@ export const ProjectionThreadMessage = Schema.Struct({
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  origin: Schema.optional(OrchestrationMessageOrigin),
   isStreaming: Schema.Boolean,
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5914,6 +5914,9 @@ export default function ChatView(props: ChatViewProps) {
     // Same optimistic side effects as a normal send: the composer goes busy,
     // the working row appears, and live-follow is re-armed.
     sendInFlightRef.current = true;
+    // A lingering session error would mark the local dispatch as already
+    // acknowledged, so the composer never went busy; clear it like onSend.
+    setThreadError(activeThread.id, null);
     beginLocalDispatch({ preparingWorktree: false });
     scrollToEnd();
     const createdAt = new Date().toISOString();
@@ -5937,11 +5940,14 @@ export default function ChatView(props: ChatViewProps) {
     sendInFlightRef.current = false;
     if (result._tag === "Failure") {
       resetLocalDispatch();
-      toastManager.add({
-        type: "error",
-        title: "Could not continue",
-        description: "The turn could not be restarted. Send a message to continue instead.",
-      });
+      // An interrupted command never reached the server; only real failures toast.
+      if (!isAtomCommandInterrupted(result)) {
+        toastManager.add({
+          type: "error",
+          title: "Could not continue",
+          description: "The turn could not be restarted. Send a message to continue instead.",
+        });
+      }
       setDismissedContinueTurnIds((ids) => {
         const next = new Set(ids);
         next.delete(continueTurnId);
@@ -5955,6 +5961,7 @@ export default function ChatView(props: ChatViewProps) {
     continueTurnId,
     resetLocalDispatch,
     scrollToEnd,
+    setThreadError,
     startThreadTurn,
     workLogEntries,
   ]);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5889,12 +5889,20 @@ export default function ChatView(props: ChatViewProps) {
       : null;
   const handleContinueInterruptedTurn = useCallback(async () => {
     if (!activeThread || !activeLatestTurn || continueTurnId === null) return;
-    const turnEntries = workLogEntries.filter((entry) => entry.turnId === continueTurnId);
+    if (sendInFlightRef.current) return;
+    // The step that was cut off: prefer a call that never finished (stopped,
+    // failed, or still marked in progress), else the last tool call of the
+    // turn, whether or not it carried a command.
+    const turnEntries = workLogEntries.filter(
+      (entry) => entry.turnId === continueTurnId && entry.tone === "tool",
+    );
     const cutOff =
-      turnEntries.findLast((entry) => entry.toolLifecycleStatus === "inProgress") ??
       turnEntries.findLast(
-        (entry) => entry.command !== undefined || entry.changedFiles !== undefined,
-      );
+        (entry) =>
+          entry.toolLifecycleStatus === "inProgress" ||
+          entry.toolLifecycleStatus === "stopped" ||
+          entry.toolLifecycleStatus === "failed",
+      ) ?? turnEntries.at(-1);
     const split = cutOff?.command ? splitLeadingCdForPrompt(cutOff.command) : null;
     const text = buildContinuationPrompt({
       reason: activeLatestTurn.state === "error" ? "error" : "interrupted",
@@ -5903,6 +5911,11 @@ export default function ChatView(props: ChatViewProps) {
       toolLabel: cutOff && !cutOff.command ? cutOff.label : undefined,
     });
     setDismissedContinueTurnIds((ids) => new Set(ids).add(continueTurnId));
+    // Same optimistic side effects as a normal send: the composer goes busy,
+    // the working row appears, and live-follow is re-armed.
+    sendInFlightRef.current = true;
+    beginLocalDispatch({ preparingWorktree: false });
+    scrollToEnd();
     const createdAt = new Date().toISOString();
     const result = await startThreadTurn({
       environmentId: activeThread.environmentId,
@@ -5921,7 +5934,9 @@ export default function ChatView(props: ChatViewProps) {
         createdAt,
       },
     });
+    sendInFlightRef.current = false;
     if (result._tag === "Failure") {
+      resetLocalDispatch();
       toastManager.add({
         type: "error",
         title: "Could not continue",
@@ -5933,7 +5948,16 @@ export default function ChatView(props: ChatViewProps) {
         return next;
       });
     }
-  }, [activeLatestTurn, activeThread, continueTurnId, startThreadTurn, workLogEntries]);
+  }, [
+    activeLatestTurn,
+    activeThread,
+    beginLocalDispatch,
+    continueTurnId,
+    resetLocalDispatch,
+    scrollToEnd,
+    startThreadTurn,
+    workLogEntries,
+  ]);
   const continueBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
     if (continueTurnId === null || dismissedContinueTurnIds.has(continueTurnId)) return null;
     const stopped = activeLatestTurn?.state === "interrupted";

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -217,6 +217,7 @@ import {
   GitBranchIcon,
   Minimize2Icon,
   PaperclipIcon,
+  PlayIcon,
   WifiOffIcon,
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
@@ -352,6 +353,10 @@ import {
   ThreadErrorBanner,
 } from "./chat/ThreadErrorBanner";
 import type { ComposerBannerStackItem } from "./chat/ComposerBannerStack";
+import {
+  buildContinuationPrompt,
+  splitLeadingCdForPrompt,
+} from "@t3tools/client-runtime/continuation-prompt";
 import { ComposerSurface } from "./chat/ComposerSurface";
 import {
   hasAvailableCompactionProvider,
@@ -5865,6 +5870,95 @@ export default function ChatView(props: ChatViewProps) {
     resumeCompactionPermanentlyDismissed,
     selectedProvider,
   ]);
+  // Continue after an interrupted or failed turn. The prompt is hidden from
+  // the transcript (rendered as a marker) and names the tool call that was
+  // cut off so the agent resumes from that step.
+  const [dismissedContinueTurnIds, setDismissedContinueTurnIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+  const continueTurnId =
+    activeThread &&
+    isServerThread &&
+    activeLatestTurn &&
+    (activeLatestTurn.state === "interrupted" || activeLatestTurn.state === "error") &&
+    !isWorking &&
+    pendingApprovals.length === 0 &&
+    pendingUserInputs.length === 0 &&
+    activeThread.messages.some((message) => message.role === "user")
+      ? activeLatestTurn.turnId
+      : null;
+  const handleContinueInterruptedTurn = useCallback(async () => {
+    if (!activeThread || !activeLatestTurn || continueTurnId === null) return;
+    const turnEntries = workLogEntries.filter((entry) => entry.turnId === continueTurnId);
+    const cutOff =
+      turnEntries.findLast((entry) => entry.toolLifecycleStatus === "inProgress") ??
+      turnEntries.findLast(
+        (entry) => entry.command !== undefined || entry.changedFiles !== undefined,
+      );
+    const split = cutOff?.command ? splitLeadingCdForPrompt(cutOff.command) : null;
+    const text = buildContinuationPrompt({
+      reason: activeLatestTurn.state === "error" ? "error" : "interrupted",
+      command: split?.command,
+      cwd: split?.cwd ?? undefined,
+      toolLabel: cutOff && !cutOff.command ? cutOff.label : undefined,
+    });
+    setDismissedContinueTurnIds((ids) => new Set(ids).add(continueTurnId));
+    const createdAt = new Date().toISOString();
+    const result = await startThreadTurn({
+      environmentId: activeThread.environmentId,
+      input: {
+        threadId: activeThread.id,
+        message: {
+          messageId: newMessageId(),
+          role: "user",
+          text,
+          attachments: [],
+          origin: "continuation",
+        },
+        modelSelection: activeThread.modelSelection,
+        runtimeMode: activeThread.runtimeMode,
+        interactionMode: activeThread.interactionMode,
+        createdAt,
+      },
+    });
+    if (result._tag === "Failure") {
+      toastManager.add({
+        type: "error",
+        title: "Could not continue",
+        description: "The turn could not be restarted. Send a message to continue instead.",
+      });
+      setDismissedContinueTurnIds((ids) => {
+        const next = new Set(ids);
+        next.delete(continueTurnId);
+        return next;
+      });
+    }
+  }, [activeLatestTurn, activeThread, continueTurnId, startThreadTurn, workLogEntries]);
+  const continueBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
+    if (continueTurnId === null || dismissedContinueTurnIds.has(continueTurnId)) return null;
+    const stopped = activeLatestTurn?.state === "interrupted";
+    return {
+      id: `continue-turn:${continueTurnId}`,
+      variant: "info",
+      icon: <PlayIcon />,
+      title: stopped ? "Pick up where it stopped" : "Pick up after the error",
+      description: stopped
+        ? "Resume from the step that was interrupted without retyping anything."
+        : "Retry from the step that failed without retyping anything.",
+      actions: (
+        <Button size="xs" variant="ghost" onClick={() => void handleContinueInterruptedTurn()}>
+          Continue
+        </Button>
+      ),
+      dismissLabel: "Dismiss continue prompt",
+      onDismiss: () => setDismissedContinueTurnIds((ids) => new Set(ids).add(continueTurnId)),
+    };
+  }, [
+    activeLatestTurn?.state,
+    continueTurnId,
+    dismissedContinueTurnIds,
+    handleContinueInterruptedTurn,
+  ]);
   const handleRestoreThreadBranch = useCallback(() => {
     if (gitStatusQuery.data?.hasWorkingTreeChanges) {
       setBranchRestoreConfirmOpen(true);
@@ -5892,6 +5986,7 @@ export default function ChatView(props: ChatViewProps) {
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
     const resumeCompactionItems =
       resumeCompactionBannerItem === null ? [] : [resumeCompactionBannerItem];
+    const continueItems = continueBannerItem === null ? [] : [continueBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
     // The user asked for this one, so it leads the notice tier instead of trailing it.
@@ -5902,6 +5997,7 @@ export default function ChatView(props: ChatViewProps) {
         ...usageLimitsItems,
         ...systemComposerBannerItems,
         ...backgroundLivenessItems,
+        ...continueItems,
         ...resumeCompactionItems,
         ...wokeThreadItems,
         ...parkedThreadItems,
@@ -5912,6 +6008,7 @@ export default function ChatView(props: ChatViewProps) {
       ...usageLimitsItems,
       ...systemComposerBannerItems,
       ...backgroundLivenessItems,
+      ...continueItems,
       ...resumeCompactionItems,
       ...wokeThreadItems,
       {
@@ -5957,6 +6054,7 @@ export default function ChatView(props: ChatViewProps) {
   }, [
     activeBranchMismatchKey,
     backgroundLivenessBannerItem,
+    continueBannerItem,
     feedbackBannerItems,
     handleRestoreThreadBranch,
     isRestoringThreadBranch,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -95,6 +95,7 @@ import {
   Minimize2Icon,
   MousePointerClickIcon,
   PaintbrushIcon,
+  PlayIcon,
   SearchIcon,
   SquarePenIcon,
   TerminalIcon,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -932,7 +932,11 @@ function deriveTimelineMinimapItems(
   const items: TimelineMinimapItem[] = [];
   for (let index = 0; index < rows.length; index += 1) {
     const row = rows[index];
-    if (row?.kind !== "message" || row.message.role !== "user") {
+    if (
+      row?.kind !== "message" ||
+      row.message.role !== "user" ||
+      row.message.origin === "continuation"
+    ) {
       continue;
     }
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1307,7 +1307,16 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
       {row.kind === "work-toggle" ? <WorkGroupToggleTimelineRow row={row} /> : null}
       {row.kind === "turn-fold" ? <TurnFoldTimelineRow row={row} /> : null}
       {row.kind === "context-compaction" ? <ContextCompactionTimelineRow row={row} /> : null}
-      {row.kind === "message" && row.message.role === "user" ? <UserTimelineRow row={row} /> : null}
+      {row.kind === "message" &&
+      row.message.role === "user" &&
+      row.message.origin === "continuation" ? (
+        <ContinuationTimelineRow row={row} />
+      ) : null}
+      {row.kind === "message" &&
+      row.message.role === "user" &&
+      row.message.origin !== "continuation" ? (
+        <UserTimelineRow row={row} />
+      ) : null}
       {row.kind === "message" && row.message.role === "assistant" ? (
         <AssistantTimelineRow row={row} />
       ) : null}
@@ -2249,6 +2258,33 @@ function toolGroupSummaryIconName(
     case "mixed":
       return "hammer";
   }
+}
+
+/**
+ * A continuation is the hidden prompt sent by the Continue button after an
+ * interrupted or failed turn. It renders as a marker, not a bubble: the user
+ * did not write it, and the words only matter to the agent.
+ */
+function ContinuationTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
+  const ctx = use(TimelineRowCtx);
+  return (
+    <div
+      className="flex items-center gap-2 py-1 text-xs text-muted-foreground"
+      data-message-id={row.message.id}
+      data-message-role="user"
+      data-message-origin="continuation"
+    >
+      <span className="h-px flex-1 bg-border/60" aria-hidden />
+      <span className="flex shrink-0 items-center gap-1.5">
+        <PlayIcon className="size-3" aria-hidden />
+        <span>Continued from the interrupted step</span>
+        <span className="tabular-nums opacity-70">
+          {formatDayAwareTimestamp(row.message.createdAt, ctx.timestampFormat)}
+        </span>
+      </span>
+      <span className="h-px flex-1 bg-border/60" aria-hidden />
+    </div>
+  );
 }
 
 function WorkGroupToggleTimelineRow({

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -69,6 +69,14 @@ the text is an unedited recalled prompt, with the caret on the first visual line
 the last visual line for `ArrowDown`, counting wrapped lines. Editing a recalled prompt turns it
 into a normal draft.
 
+## Continue an interrupted turn
+
+When you stop a turn, or it ends with an error, the composer offers to pick up where it stopped.
+Press **Continue** to resume without retyping anything.
+T3 Code tells the agent which command or file change was in flight and asks it to carry on from that step without repeating finished work.
+The conversation marks the resumed point instead of adding a message you did not write.
+The offer goes away once you continue or send something yourself.
+
 ## Prompt stash
 
 On web and desktop, press `Cmd+S` on macOS or `Ctrl+S` on Windows and Linux to save

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -27,6 +27,10 @@
       "types": "./src/environment/index.ts",
       "default": "./src/environment/index.ts"
     },
+    "./continuation-prompt": {
+      "types": "./src/continuation-prompt.ts",
+      "default": "./src/continuation-prompt.ts"
+    },
     "./markdown-images": {
       "types": "./src/markdownImages.ts",
       "default": "./src/markdownImages.ts"

--- a/packages/client-runtime/src/continuation-prompt.test.ts
+++ b/packages/client-runtime/src/continuation-prompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildContinuationPrompt, splitLeadingCdForPrompt } from "./continuation-prompt";
+
+describe("splitLeadingCdForPrompt", () => {
+  it("separates a leading cd from the command", () => {
+    expect(splitLeadingCdForPrompt("cd /repo/apps/mobile && pnpm test")).toEqual({
+      cwd: "/repo/apps/mobile",
+      command: "pnpm test",
+    });
+    expect(splitLeadingCdForPrompt("ls -la")).toEqual({ cwd: null, command: "ls -la" });
+  });
+});
+
+describe("buildContinuationPrompt", () => {
+  it("names the interrupted command and directory", () => {
+    expect(
+      buildContinuationPrompt({
+        reason: "interrupted",
+        command: "pnpm expo start --clear",
+        cwd: "apps/mobile",
+      }),
+    ).toBe(
+      "Your previous turn was stopped before it finished. You were running `pnpm expo start --clear` in apps/mobile. Continue from that step. Do not repeat work that already completed, and do not re-run commands whose results are already in this conversation unless you need fresh output.",
+    );
+  });
+
+  it("falls back to the tool label, then to a bare continuation", () => {
+    expect(
+      buildContinuationPrompt({ reason: "error", toolLabel: "Changed files: src/a.ts" }),
+    ).toContain("You were in the middle of: Changed files: src/a.ts.");
+    expect(buildContinuationPrompt({ reason: "error" })).toBe(
+      "Your previous turn ended with an error before it finished. Continue from that step. Do not repeat work that already completed, and do not re-run commands whose results are already in this conversation unless you need fresh output.",
+    );
+  });
+});

--- a/packages/client-runtime/src/continuation-prompt.test.ts
+++ b/packages/client-runtime/src/continuation-prompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildContinuationPrompt, splitLeadingCdForPrompt } from "./continuation-prompt";
+import { buildContinuationPrompt, splitLeadingCdForPrompt } from "./continuation-prompt.js";
 
 describe("splitLeadingCdForPrompt", () => {
   it("separates a leading cd from the command", () => {

--- a/packages/client-runtime/src/continuation-prompt.ts
+++ b/packages/client-runtime/src/continuation-prompt.ts
@@ -1,0 +1,54 @@
+/**
+ * Build the hidden prompt sent when the user presses Continue after an
+ * interrupted or failed turn. The prompt names the tool call that was cut
+ * off so the agent resumes from that step instead of from vague memory.
+ * Shared by web and mobile so both surfaces send the same words.
+ */
+export interface ContinuationPromptInput {
+  /** Command that was running when the turn stopped, if any. */
+  readonly command?: string | undefined;
+  /** Directory the command ran in, when known. */
+  readonly cwd?: string | undefined;
+  /** Human label for a non-command tool call (e.g. "Changed files: src/a.ts"). */
+  readonly toolLabel?: string | undefined;
+  /** Why the turn ended: the user stopped it, or the provider failed. */
+  readonly reason: "interrupted" | "error";
+}
+
+/**
+ * Agents usually prefix commands with `cd <dir> && …`. Pull the directory
+ * out so the prompt can say "in <dir>" and quote the real command.
+ */
+export function splitLeadingCdForPrompt(command: string): { cwd: string | null; command: string } {
+  const match =
+    /^\s*cd\s+("(?:[^"\\]|\\.)*"|'[^']*'|(?:[^\s;&|\\]|\\.)+)\s*(?:&&|;)\s*([\s\S]+)$/u.exec(
+      command,
+    );
+  const dir = match?.[1];
+  const rest = match?.[2]?.trim();
+  if (!dir || !rest) return { cwd: null, command };
+  const unquoted =
+    (dir.startsWith('"') && dir.endsWith('"')) || (dir.startsWith("'") && dir.endsWith("'"))
+      ? dir.slice(1, -1)
+      : dir.replace(/\\(.)/g, "$1");
+  return { cwd: unquoted, command: rest };
+}
+
+export function buildContinuationPrompt(input: ContinuationPromptInput): string {
+  const opener =
+    input.reason === "interrupted"
+      ? "Your previous turn was stopped before it finished."
+      : "Your previous turn ended with an error before it finished.";
+  const where = input.command
+    ? `You were running \`${input.command.trim()}\`${input.cwd ? ` in ${input.cwd}` : ""}.`
+    : input.toolLabel
+      ? `You were in the middle of: ${input.toolLabel.trim()}.`
+      : null;
+  return [
+    opener,
+    where,
+    "Continue from that step. Do not repeat work that already completed, and do not re-run commands whose results are already in this conversation unless you need fresh output.",
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" ");
+}

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -407,6 +407,36 @@ describe("applyThreadDetailEvent", () => {
   });
 
   describe("thread.message-sent", () => {
+    it("keeps the continuation origin on the appended message", () => {
+      const result = applyThreadDetailEvent(baseThread, {
+        ...baseEventFields,
+        sequence: 6,
+        occurredAt: "2026-04-01T06:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.message-sent",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("msg-continue"),
+          role: "user",
+          text: "Continue from that step.",
+          origin: "continuation",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-04-01T06:00:00.000Z",
+          updatedAt: "2026-04-01T06:00:00.000Z",
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.at(-1)).toMatchObject({
+          id: "msg-continue",
+          origin: "continuation",
+        });
+      }
+    });
+
     it("appends a new message", () => {
       const result = applyThreadDetailEvent(baseThread, {
         ...baseEventFields,

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -320,6 +320,7 @@ export function applyThreadDetailEvent(
         ...(event.payload.attachments !== undefined
           ? { attachments: event.payload.attachments }
           : {}),
+        ...(event.payload.origin !== undefined ? { origin: event.payload.origin } : {}),
         turnId: event.payload.turnId,
         streaming: event.payload.streaming,
         createdAt: event.payload.createdAt,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -476,11 +476,21 @@ export type OrchestrationProject = typeof OrchestrationProject.Type;
 export const OrchestrationMessageRole = Schema.Literals(["user", "assistant", "system"]);
 export type OrchestrationMessageRole = typeof OrchestrationMessageRole.Type;
 
+/**
+ * Why a user-role message exists beyond the person typing it. A
+ * `continuation` is the hidden prompt sent when the user presses Continue
+ * after an interrupted or failed turn: clients render it as a marker, not a
+ * bubble. Optional so payloads from older servers still decode.
+ */
+export const OrchestrationMessageOrigin = Schema.Literals(["continuation"]);
+export type OrchestrationMessageOrigin = typeof OrchestrationMessageOrigin.Type;
+
 export const OrchestrationMessage = Schema.Struct({
   id: MessageId,
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  origin: Schema.optional(OrchestrationMessageOrigin),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,
   createdAt: IsoDateTime,
@@ -1101,6 +1111,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(ChatAttachment),
+    origin: Schema.optional(OrchestrationMessageOrigin),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -1122,6 +1133,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(Schema.Union([UploadChatAttachment, ChatAttachment])),
+    origin: Schema.optional(OrchestrationMessageOrigin),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -1566,6 +1578,7 @@ export const ThreadMessageSentPayload = Schema.Struct({
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  origin: Schema.optional(OrchestrationMessageOrigin),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,
   createdAt: IsoDateTime,


### PR DESCRIPTION
## Problem

When you stop a turn, or it dies with an error, the only way to get the agent moving again is to type another message. Two things are wrong with that: you have to retype, and the agent has no idea which step it was on when it got cut off, so it tends to re-run everything or wander.

None of the five providers can resume a half-finished tool call, so "Continue" has to be a new turn under the hood. This PR makes that turn invisible in the transcript and precise about where to pick up.

## What this does

**Messages get an optional `origin`.** `thread.turn.start` accepts `message.origin: "continuation"`. The decider stamps it on the `thread.message-sent` event, the projection stores it (migration 045 adds a nullable `origin` column on `projection_thread_messages`), and the in-memory projector and client reducer carry it through. Nothing else in the pipeline changes: the provider still receives it as a normal user prompt on the resumed session, so it works for Codex, Claude, Cursor, Grok and OpenCode alike.

**Continue banner.** When the latest turn is `interrupted` or `error`, nothing is running and no approval is pending, the composer stack shows "Pick up where it stopped" (or "Pick up after the error") with a Continue button. The client builds the prompt from the thread's work log: the last in-flight tool call of that turn, its command with any leading `cd` split off into "in `<dir>`", or the tool label for non-command calls. The words come from one builder in `client-runtime` so web and mobile send the same prompt. The turn is sent with the thread's current model, runtime mode and interaction mode.

**Marker, not bubble.** Web renders a continuation message as a thin "Continued from the interrupted step" divider with the timestamp; mobile renders the same divider. No optimistic bubble is pushed.

**Reverse state.** The banner is dismissable per turn and disappears once a message is sent or a turn is running.

Mobile gets the marker in this PR; the mobile Continue button can follow once the composer banner pattern exists there.

## Testing

- `decider.continue.test.ts`: origin stamped on the recorded message, absent otherwise.
- `045_ProjectionThreadMessageOrigin.test.ts`: migration adds the nullable column.
- `threadReducer.test.ts`: origin kept on the appended message.
- `continuation-prompt.test.ts`: prompt wording with command + directory, tool label, and bare fallback; `cd` splitting.
- Existing `ProjectionThreadMessages`, `ProjectionPipeline`, decider and timeline suites pass.
- Targeted typecheck: server, web, client-runtime, contracts, mobile.

Related: #9186 (tool rows) gives the interrupted row its visual state; this PR does not depend on it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches turn-start events, message projection upserts, and a new DB column; incorrect origin handling could mislabel transcripts or drop metadata on streaming completion, but changes are additive and optional for older clients.
> 
> **Overview**
> Adds an optional **`origin: "continuation"`** on user messages so **Continue** after an interrupted or errored turn is stored and projected like a normal turn start, but shown in the transcript as a divider instead of a user bubble (web and mobile). Contracts, decider, in-memory projector, client reducer, and **`projection_thread_messages`** (migration **045**, nullable `origin`) all carry the field through streaming and upsert paths, preserving origin when later writes omit it.
> 
> On **web**, when the latest turn is **interrupted** or **error** and nothing else is blocking work, the composer shows a **Continue** banner. It builds a shared **`buildContinuationPrompt`** (plus **`splitLeadingCdForPrompt`**) from the cut-off tool/work-log entry and calls **`thread.turn.start`** with that origin. The timeline minimap skips continuation messages. User docs describe the flow.
> 
> **Medium scope**: new user-facing orchestration path and DB column, but backward-compatible optional metadata and targeted tests (decider, migration, reducer, prompt builder).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e158da75be85884502bca268ad59b2a46aaaaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Continue` banner to resume interrupted chat turns with `origin=continuation`
> - Adds `OrchestrationMessageOrigin` to contracts and propagates the optional `origin=continuation` through `thread.turn.start` commands, `thread.message-sent` events, the decider, projector, persistence layer, and the client thread reducer.
> - Adds migration 045, which adds a nullable `origin` column to `projection_thread_messages`; subsequent upserts preserve an existing origin when the incoming row omits one.
> - Adds a shared `buildContinuationPrompt` helper in `client-runtime` that produces a reason-specific prompt using the interrupted tool call, command, or directory context and instructs the agent not to repeat completed work.
> - Adds a `Continue` composer banner in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9189/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) for interrupted or errored latest server turns; pressing `Continue` dispatches a new user turn carrying the generated prompt and `origin=continuation`.
> - Web and mobile timelines render continuation-origin user messages as a labeled marker with a play icon instead of a user bubble, and the web minimap excludes them.
> - Behavioral Change: the new `origin` column is nullable and defaults to absent; readers in `ProjectionSnapshotQuery.ts` and `ProjectionThreadMessages.ts` are updated, but any out-of-tree consumers of `projection_thread_messages` must tolerate the new column.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6e158d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Continue** option for interrupted or failed turns, allowing users to resume without retyping.
  * Added clear continuation markers in chat and timeline views.
  * Continuation prompts now include relevant command, tool, and directory context.
* **Documentation**
  * Added guidance for continuing interrupted turns.
* **Bug Fixes**
  * Continuation messages now retain their origin consistently across chat history and streaming updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->