### PR TITLE
fix(server): stop titling linked PR threads from local git history

### DIFF
--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -188,6 +188,24 @@ describe("buildThreadTitlePrompt", () => {
     expect(result.prompt).toContain("67890 bytes");
   });
 
+  it.each([
+    { mode: "initial", previousTitle: undefined },
+    { mode: "regeneration", previousTitle: "Open Projects in Desktop App" },
+  ])(
+    "tells the $mode prompt not to title linked PRs from local git history",
+    ({ previousTitle }) => {
+      const result = buildThreadTitlePrompt({
+        message: "$takeover https://github.com/pingdotgg/t3code/pull/8588",
+        ...(previousTitle === undefined ? {} : { previousTitle }),
+      });
+
+      expect(result.prompt).toContain(
+        "Local git history is not evidence of what a linked PR or issue is about.",
+      );
+      expect(result.prompt).toContain('such as "Take Over PR 8588"');
+    },
+  );
+
   it("regenerates from recent thread contents and identifies the previous title", () => {
     const result = buildThreadTitlePrompt({
       message: `USER:\nInvestigate reconnect regressions\n\nASSISTANT:\nThe remaining issue is stale session state`,

--- a/apps/server/src/textGeneration/TextGenerationPrompts.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.ts
@@ -238,7 +238,9 @@ Editorial rules:
 - Do not copy and truncate the user's message.
 - Avoid project names already visible in the UI, quotes, labels, filler, and trailing punctuation.
 - Use attached images as primary context for UI issues.
-- When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.`;
+- When a URL or attachment is the only source of the subject, use available tools to inspect it directly.
+- Local git history is not evidence of what a linked PR or issue is about. Never title the thread after branch names, commit messages, or merged commits found in the checkout.
+- If a linked PR or issue cannot be read, fall back to the user's stated action plus its number, such as "Take Over PR 8588". This is the one case where a PR or issue number belongs in the title.`;
 
 function regenerateThreadTitlePrompt(previousTitle: string): string {
   return `Regenerate the title for an existing T3 Code thread so the user can recognize it weeks later.
@@ -265,7 +267,9 @@ Editorial rules:
 - Do not copy and truncate a thread message.
 - Avoid project names already visible in the UI, PR numbers, quotes, labels, filler, and trailing punctuation.
 - Use attached images as primary context for UI issues.
-- When a URL or attachment is the only source of the subject, use available tools to inspect it. If it cannot be resolved, remain accurate rather than guessing.
+- When a URL or attachment is the only source of the subject, use available tools to inspect it directly.
+- Local git history is not evidence of what a linked PR or issue is about. Never title the thread after branch names, commit messages, or merged commits found in the checkout.
+- If a linked PR or issue cannot be read, fall back to the user's stated action plus its number, such as "Take Over PR 8588". This is the one case where a PR or issue number belongs in the title.
 - Return a meaningfully improved title, not a cosmetic paraphrase of the previous title.
 
 Examples of the distinction:


### PR DESCRIPTION
When a user starts a thread with a PR link and a generic action such as "take over", the title generator tries to read the PR with `gh`. That call fails inside the Codex read-only sandbox, which has no network. The model then falls back to `git log` in the checkout and titles the thread after whatever it finds there. On a fresh takeover branch that is the tip of `main`, so the title names an unrelated change that already merged.

Real examples from this machine:

| Thread message | Generated title | Actual PR |
|---|---|---|
| `$takeover https://github.com/pingdotgg/t3code/pull/8588` | Open Projects in Desktop App | fix(desktop): show newest changes in nightly previews |
| `https://github.com/pingdotgg/t3code/pull/8235` Take over this PR. | Limit OpenCode Native Attachments | feat(server): accept PDF, ZIP, and other file uploads |

The fix adds two rules to both the initial and regeneration title prompts. Local git history is not evidence of what a linked PR is about. When the linked item cannot be read, the title falls back to the user's action plus the PR number, such as "Take Over PR 8588".

## Testing

I ran the real prompt through `codex exec` with the same flags the server uses, from this worktree, with the exact messages above.

Before: 1 of 4 runs for PR 8235 produced "Fix automatic thread title generation" from unrelated commits in the checkout. Other runs varied between "Support 50MB File Uploads" (found via a local ref) and "Take Over PR 8235".

After: 5 of 5 runs for PR 8235 returned "Take Over PR 8235". 5 of 5 runs for PR 8588 returned "Take Over PR 8588" (one said "Taking Over"). 8 of 8 runs in a synthetic repo whose branch tip is a merge from main returned takeover titles with no git log calls.

`vp test run apps/server/src/textGeneration/TextGenerationPrompts.test.ts` passes.

Written by Claude Fable 5.1 through Claude Code in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to automatic thread titles with no auth, data, or API behavior changes; risk is limited to title wording quality.
> 
> **Overview**
> **Thread title prompts** now tell the model not to infer linked PR or issue subjects from local git history (branch names, commits on `main`, etc.) when `gh` or other tools cannot fetch the link—common in read-only sandboxes.
> 
> When the linked item still cannot be read, titles should fall back to the user’s stated action plus the PR/issue number (e.g. **Take Over PR 8588**), which is explicitly allowed as the only case where a number belongs in the title. The same rules were added to **initial** and **regeneration** title prompts, with a small tweak to prefer inspecting URLs/attachments directly instead of guessing.
> 
> Parameterized tests assert both prompt paths include the new guidance for takeover-style messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06061e98e6ea7657cba89ad846e74407fc07be1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop using local git history for linked-PR thread titles in `buildThreadTitlePrompt`
> - Updates `buildThreadTitlePrompt` and `regenerateThreadTitlePrompt` to instruct the model to inspect URL or attachment sources directly instead of using local checkout history (branch names, commit messages, merged commits)
> - Adds an action-plus-PR-number fallback title (e.g. a takeover title) when the linked resource cannot be read
> - Adds parameterized test coverage in [TextGenerationPrompts.test.ts](https://github.com/pingdotgg/t3code/pull/9191/files#diff-3370c77b2b53a8cdbaf383d0974b9406a33e2657414f9663004e0c3a64ada519) for both initial and regeneration prompts
> - Behavioral Change: thread titles for linked PR/issue threads may now differ from previous outputs since the model is told to ignore local git history
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06061e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->