### PR TITLE
fix(preview): preserve Fill panel when agents open tabs

### DIFF
--- a/apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts
@@ -63,10 +63,19 @@ describe("preview automation open readiness", () => {
     ).toBe(true);
   });
 
-  it("gives newly-created automation tabs a stable desktop viewport", () => {
+  it("uses the fallback for new automation tabs without a viewport", () => {
     expect(previewAutomationDefaultViewport(false, snapshot({ _tag: "Idle" }))).toEqual(
       DEFAULT_PREVIEW_AUTOMATION_VIEWPORT,
     );
+  });
+
+  it("preserves the configured fill viewport when opening an automation tab", () => {
+    expect(
+      previewAutomationDefaultViewport(false, {
+        ...snapshot({ _tag: "Idle" }),
+        viewport: { _tag: "fill" },
+      }),
+    ).toBeNull();
   });
 
   it("preserves reused and already-fixed browser viewports", () => {

--- a/apps/web/src/components/preview/previewAutomationOpenReadiness.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenReadiness.ts
@@ -1,16 +1,12 @@
-import {
-  FILL_PREVIEW_VIEWPORT,
-  type PreviewAutomationOperation,
-  type PreviewAutomationOpenInput,
-  type PreviewSessionSnapshot,
-  type PreviewViewportSetting,
+import type {
+  PreviewAutomationOperation,
+  PreviewAutomationOpenInput,
+  PreviewSessionSnapshot,
+  PreviewViewportSetting,
 } from "@t3tools/contracts";
 
 /**
- * Viewport an agent-opened tab falls back to when the user has no configured
- * browser default. Agents screenshot and assert against what they open, so a
- * brand-new tab left in fill mode would be sized by whatever the panel happens
- * to be — deterministic beats incidental here.
+ * Fallback for a new automation session whose snapshot omits its viewport.
  */
 export const DEFAULT_PREVIEW_AUTOMATION_VIEWPORT = {
   _tag: "freeform",
@@ -55,15 +51,14 @@ export function previewAutomationOpenNeedsOverlay(
  * Whether a freshly opened automation tab still needs a viewport applied.
  *
  * A configured browser default is sent with `preview.open`, so the snapshot
- * already carries it and nothing is needed here. Fill means the user has no
- * stated preference, which is where the agent fallback applies.
+ * already carries it and nothing is needed here. An explicit fill viewport is
+ * a configured default too; only a missing viewport needs the fallback.
  */
 export function previewAutomationDefaultViewport(
   reusedExistingTab: boolean,
   snapshot: PreviewSessionSnapshot,
 ): PreviewViewportSetting | null {
-  const viewport = snapshot.viewport ?? FILL_PREVIEW_VIEWPORT;
-  return !reusedExistingTab && viewport._tag === "fill"
+  return !reusedExistingTab && snapshot.viewport === undefined
     ? DEFAULT_PREVIEW_AUTOMATION_VIEWPORT
     : null;
 }


### PR DESCRIPTION
With Settings > Integrations > Browser > Default browser viewport set to **Fill panel**, `preview_open` still opens new tabs at 1280x800. The open path passes the configured viewport correctly, but `previewAutomationDefaultViewport` then treats an explicit `fill` value as missing and overwrites it.

This changes the fallback condition to check for an absent viewport. An explicit Fill panel setting survives; snapshots without a viewport still get the existing fallback. Reused tabs and fixed viewports keep their existing behavior.

## Scope

Two files, 19 additions and 15 deletions, including comments and a regression test. The production behavior change is one condition. There are no tool-schema, server, shared-contract, or resize-path changes.

The fix runs in the desktop preview automation host regardless of which agent provider or connected server sends the request. It adds no wire fields or capabilities and no new rendering waits. Manual browser opening already respects this setting; mobile browser behavior is unchanged.

## Why this matters

A user should be able to ask an agent to open pages alongside the conversation and have them use the available space. Requiring a follow-up resize or manual layout correction after each open interrupts that workflow. Preserving the existing Fill panel preference fixes the sizing part without expanding the API.

Explicit side-panel/floating/background presentation control would also help agents follow the user's request, but belongs in a separate change. This PR does not add docking controls. Agents can continue using `preview_resize` when they need an explicit size override.

## Validation

- Ran the existing preview-readiness suite with the new regression test against main: only the new Fill panel test failed, returning 1280x800.
- With the fix: all 14 tests passed.
- Targeted TypeScript check, formatting, lint, and `git diff --check` passed.
- Tests and typecheck used isolated tooling with the actual repository source and contracts. No packaged desktop build or full workspace check was run.

Reproduced the existing behavior in the installed nightly. This submission is based on main at `f8b4c464`.

Implemented with GPT-6-Astra through Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve configured Fill viewport for new automation tabs in `previewAutomationDefaultViewport`
> - Fixes a bug where an explicit fill viewport in a new automation tab was treated as missing and replaced with the default freeform viewport.
> - The fallback condition in [previewAutomationOpenReadiness.ts](https://github.com/pingdotgg/t3code/pull/9193/files#diff-b04a64ead65541fa783290ae40b0163777923b59996322546f1857a0eff229e1) now only applies when `snapshot.viewport` is `undefined`.
> - Removes the value import of `FILL_PREVIEW_VIEWPORT`, leaving only type-only contract imports.
> - Risk: none — the default fallback still applies for snapshots with no viewport; only explicitly configured fill viewports are now preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1056f09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->