### PR TITLE
fix(mobile): prevent message and composer overlap

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -151,6 +151,11 @@ export const COMPOSER_LAYOUT_TRANSITION =
     ? undefined
     : LinearTransition.duration(COMPOSER_TRANSITION_DURATION_MS).reduceMotion(ReduceMotion.System);
 
+const COMPOSER_ATTACHMENT_ENTERING =
+  Platform.OS === "android"
+    ? FadeIn.duration(160)
+    : FadeIn.delay(COMPOSER_TRANSITION_DURATION_MS).duration(160).reduceMotion(ReduceMotion.System);
+
 const AnimatedGlassSurface = Animated.createAnimatedComponent(GlassSurface);
 
 export function ComposerSurface(props: {
@@ -623,10 +628,10 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                 onPickFiles={props.onPickDraftFiles}
               />
             ) : null}
-            {isExpanded ? (
+            {isExpanded && props.draftAttachments.length > 0 ? (
               <Animated.View
-                className={props.draftAttachments.length > 0 ? "px-[14px] pb-2.5" : undefined}
-                entering={FadeIn.duration(160)}
+                className="px-[14px] pb-2.5"
+                entering={COMPOSER_ATTACHMENT_ENTERING}
                 exiting={FadeOut.duration(120)}
               >
                 <ComposerAttachmentStrip

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -178,6 +178,10 @@ import {
 import { MARKDOWN_IMAGE_MAX_WIDTH, resolveMarkdownImageDisplaySize } from "./markdownImageSize";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
+  // Native iOS blockquotes and adjacent selectable text are separate layout
+  // chunks. Giving their shrink-to-fit bubble a definite width keeps both
+  // chunks measured against the width at which UIKit draws them.
+  includeBlockquotes: Platform.OS === "ios",
   includeOrderedLists: Platform.OS === "android",
 } as const;
 

--- a/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
@@ -41,6 +41,14 @@ describe("hasWideMarkdownBlock", () => {
     );
   });
 
+  it("detects blockquotes only when the native renderer needs width pinning", () => {
+    expect(hasWideMarkdownBlock("> quoted", { includeBlockquotes: true })).toBe(true);
+    expect(hasWideMarkdownBlock("  > quoted", { includeBlockquotes: true })).toBe(true);
+    expect(hasWideMarkdownBlock("> quoted")).toBe(false);
+    expect(hasWideMarkdownBlock("prose > quoted", { includeBlockquotes: true })).toBe(false);
+    expect(hasWideMarkdownBlock("    > indented code", { includeBlockquotes: true })).toBe(false);
+  });
+
   it("detects GFM tables", () => {
     expect(hasWideMarkdownBlock("| a | b |\n| --- | --- |\n| 1 | 2 |")).toBe(true);
     expect(hasWideMarkdownBlock("a | b\n:-- | --:\n1 | 2")).toBe(true);

--- a/apps/mobile/src/lib/wideMarkdownBlocks.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.ts
@@ -1,6 +1,7 @@
 /**
- * Detects markdown that the JS renderer draws as a block requiring a definite
- * user-bubble width — fenced code blocks, GFM tables, and ordered lists.
+ * Detects markdown that the renderer draws as a block requiring a definite
+ * user-bubble width: fenced code blocks, GFM tables, ordered lists, and
+ * blockquotes when requested by the caller.
  *
  * Fenced code blocks and tables report an intrinsic width equal to their
  * widest line, which is effectively unbounded. A user bubble sizes itself
@@ -31,6 +32,7 @@ const BLOCKQUOTE_PREFIX = /^ {0,3}>[ \t]?/;
 
 export interface WideMarkdownBlockOptions {
   readonly includeOrderedLists?: boolean;
+  readonly includeBlockquotes?: boolean;
 }
 
 function stripBlockquotePrefixes(line: string): string {
@@ -39,6 +41,10 @@ function stripBlockquotePrefixes(line: string): string {
     content = content.replace(BLOCKQUOTE_PREFIX, "");
   }
   return content;
+}
+
+function hasBlockquote(text: string): boolean {
+  return text.split("\n").some((line) => BLOCKQUOTE_PREFIX.test(line));
 }
 
 function hasOrderedListItem(text: string): boolean {
@@ -78,6 +84,9 @@ export function hasWideMarkdownBlock(
   options: WideMarkdownBlockOptions = {},
 ): boolean {
   if (FENCED_CODE_BLOCK.test(text)) {
+    return true;
+  }
+  if (options.includeBlockquotes === true && hasBlockquote(text)) {
     return true;
   }
   if (options.includeOrderedLists !== false && hasOrderedListItem(text)) {


### PR DESCRIPTION
## Problem

On iOS, a user message containing a blockquote followed by prose could measure at its shrink-to-fit width and then draw at the capped bubble width. The final wrapped line escaped the bubble and overlapped the timestamp.

The expanded composer also showed its attachment preview while the editor was still moving into its new row, so the two briefly drew over each other.

## Fix

- Give iOS blockquoted user messages the existing definite max bubble width so UIKit measures and draws every markdown chunk at the same width.
- Mount the expanded attachment row only when it has content, then reveal it after the 220 ms composer layout transition. Android keeps the immediate reveal because its composer layout snaps.
- Cover blockquote detection, including indented markers and false positives, in the focused markdown-width tests.

## Verification

- `vp test run apps/mobile/src/lib/wideMarkdownBlocks.test.ts`
- `vp run -F @t3tools/mobile typecheck`
- Targeted lint and formatting checks
- `git diff --check`

Model: GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile layout and animation tweaks with unit tests for blockquote heuristics; no auth, data, or API changes.
> 
> **Overview**
> Fixes two mobile UI overlap bugs: **iOS user messages with blockquotes** and **expanded composer attachment previews**.
> 
> On iOS, blockquoted user bubbles now use the same **definite max-width pinning** as other “wide” markdown (code, tables, Android ordered lists). `hasWideMarkdownBlock` gains an opt-in `includeBlockquotes` flag; the thread feed enables it only on iOS so blockquote and adjacent text chunks measure at the width UIKit actually draws.
> 
> In **ThreadComposer**, the expanded attachment strip mounts only when there are draft attachments, and on iOS its fade-in is **delayed by the 220 ms layout transition** (`COMPOSER_ATTACHMENT_ENTERING`); Android keeps an immediate fade because the composer layout snaps with the keyboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c2e90d7a926e8ca97d472d443edf046131a5ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix message and composer overlap in `ThreadComposer`
> - Renders the attachment-strip wrapper in `ThreadComposer` only when the composer is expanded and has at least one draft attachment, preventing an empty animated wrapper from causing overlap
> - Adds platform-specific entering animation: Android uses a 160 ms fade, iOS delays by the composer transition duration and honors system reduce-motion
> - Adds an optional `includeBlockquotes` flag to `hasWideMarkdownBlock` so `ThreadFeed` can pin blockquote widths on iOS via `WIDE_MARKDOWN_BLOCK_OPTIONS`; Android keeps blockquote detection off
> - Adds test coverage for blockquote detection in [wideMarkdownBlocks.test.ts](https://github.com/pingdotgg/t3code/pull/9195/files#diff-c8af21aee33bb3c60b6d07f0e4d42d02f606587180286f971c1a742c85bfbcc6)
> - Risk: iOS blockquote width-pinning is a new heuristic in `hasWideMarkdownBlock`; threads with blockquotes on iOS may render wider than before
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08c2e90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->