### PR TITLE
fix(pull-requests): align checkout control with author

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -16,7 +16,6 @@ import {
   BookOpenIcon,
   CircleDotIcon,
   ChevronDownIcon,
-  CopyIcon,
   ExternalLinkIcon,
   FileDiffIcon,
   FolderGit2Icon,
@@ -284,6 +283,68 @@ const openNumberContextMenu = (
   });
 };
 
+function PullRequestCopyableCode({
+  value,
+  target,
+  copyLabel,
+  copiedLabel,
+  className,
+  tooltipSide = "top",
+  onError,
+}: {
+  readonly value: string;
+  readonly target: string;
+  readonly copyLabel: string;
+  readonly copiedLabel: string;
+  readonly className?: string;
+  readonly tooltipSide?: "top" | "bottom";
+  readonly onError?: (error: Error) => void;
+}) {
+  const { copyToClipboard, isCopied } = useCopyToClipboard({
+    target,
+    timeout: 1600,
+    ...(onError ? { onError } : {}),
+  });
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            className={cn(
+              "relative grid w-fit min-w-0 max-w-full shrink cursor-pointer rounded px-1 py-0.5 text-left outline-none transition-colors pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:bg-accent/45 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+              className,
+            )}
+            aria-label={isCopied ? copiedLabel : copyLabel}
+            onClick={() => copyToClipboard(value)}
+          />
+        }
+      >
+        <code
+          className={cn(
+            "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-150 motion-reduce:transition-none",
+            isCopied ? "opacity-0" : "opacity-100",
+          )}
+        >
+          {value}
+        </code>
+        <span
+          aria-hidden="true"
+          className={cn(
+            "col-start-1 row-start-1 truncate text-center transition-opacity duration-150 motion-reduce:transition-none",
+            isCopied ? "opacity-100" : "opacity-0",
+          )}
+        >
+          Copied
+        </span>
+      </TooltipTrigger>
+      <TooltipPopup className="max-w-96 wrap-anywhere font-mono" side={tooltipSide}>
+        {`${isCopied ? "Copied" : copyLabel}: ${value}`}
+      </TooltipPopup>
+    </Tooltip>
+  );
+}
+
 /**
  * The stale-branch warning, said beside the branch it is about rather than as a bar of its own.
  * The banner this replaces held a row of chrome open across the top of every pull request that
@@ -466,20 +527,6 @@ export function PullRequestDetailPanel({
   // Which handoff is preparing, keyed so a per-finding button can say "Preparing..." on itself
   // alone. One at a time whatever the key: they all check the same pull request out.
   const [handoff, setHandoff] = useState<string | null>(null);
-  const { copyToClipboard: copyBranchToClipboard, isCopied: isBranchCopied } = useCopyToClipboard({
-    target: "branch name",
-    timeout: 1600,
-  });
-  const { copyToClipboard: copyCheckoutCommandToClipboard } = useCopyToClipboard({
-    target: "pull request checkout command",
-    onCopy: () => toastManager.add({ type: "success", title: "Checkout command copied" }),
-    onError: (error) =>
-      toastManager.add({
-        type: "error",
-        title: "Could not copy checkout command",
-        description: error.message,
-      }),
-  });
   // The chunk is fetched as soon as the panel exists rather than waiting for the Code tab to be
   // clicked, so a reader who does click it lands on a chunk already in the module cache.
   useEffect(() => {
@@ -1697,10 +1744,30 @@ export function PullRequestDetailPanel({
                     </div>
                   </div>
                 )}
-                <PullRequestMetaLine className="mt-2 text-xs text-muted-foreground">
-                  <PullRequestActorLabel actor={detail.author} className="font-medium" />
-                  <span>updated {formatRelativeTimeLabel(detail.updatedAt)}</span>
-                </PullRequestMetaLine>
+                <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                  <PullRequestMetaLine className="min-w-0 whitespace-nowrap">
+                    <PullRequestActorLabel actor={detail.author} className="font-medium" />
+                    <span>updated {formatRelativeTimeLabel(detail.updatedAt)}</span>
+                  </PullRequestMetaLine>
+                  {checkoutCommand ? (
+                    <PullRequestCopyableCode
+                      key={checkoutCommand}
+                      value={checkoutCommand}
+                      target="pull request checkout command"
+                      copyLabel="Copy checkout command"
+                      copiedLabel="Checkout command copied"
+                      className="ml-auto font-mono"
+                      tooltipSide="bottom"
+                      onError={(error) =>
+                        toastManager.add({
+                          type: "error",
+                          title: "Could not copy checkout command",
+                          description: error.message,
+                        })
+                      }
+                    />
+                  ) : null}
+                </div>
 
                 <div className="mt-4 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
                   <span className="flex min-w-0 flex-1 items-center gap-1.5 font-mono text-xs text-muted-foreground/70">
@@ -1736,62 +1803,13 @@ export function PullRequestDetailPanel({
                       aria-label="receives changes from"
                       className="size-3.5 shrink-0 opacity-60"
                     />
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <button
-                            type="button"
-                            className="grid w-fit min-w-0 max-w-full shrink cursor-pointer rounded px-1 py-0.5 text-left outline-none transition-colors hover:bg-accent/45 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                            aria-label={
-                              isBranchCopied ? "Branch name copied" : "Copy pull request branch"
-                            }
-                            onClick={() => copyBranchToClipboard(detail.headBranch)}
-                          />
-                        }
-                      >
-                        <code
-                          className={cn(
-                            "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-150 motion-reduce:transition-none",
-                            isBranchCopied ? "opacity-0" : "opacity-100",
-                          )}
-                        >
-                          {detail.headBranch}
-                        </code>
-                        <span
-                          aria-hidden="true"
-                          className={cn(
-                            "col-start-1 row-start-1 truncate text-center transition-opacity duration-150 motion-reduce:transition-none",
-                            isBranchCopied ? "opacity-100" : "opacity-0",
-                          )}
-                        >
-                          Copied
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipPopup side="top">
-                        {`${isBranchCopied ? "Copied" : "Copy pull request branch"}: ${detail.headBranch}`}
-                      </TooltipPopup>
-                    </Tooltip>
-                    {checkoutCommand ? (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              size="micro"
-                              variant="outline"
-                              className="ml-1 min-w-0 basis-40 shrink-[0.75] gap-1 font-normal text-muted-foreground"
-                              aria-label={`Copy checkout command: ${checkoutCommand}`}
-                              onClick={() => copyCheckoutCommandToClipboard(checkoutCommand)}
-                            />
-                          }
-                        >
-                          <code className="min-w-0 truncate">{checkoutCommand}</code>
-                          <CopyIcon aria-hidden />
-                        </TooltipTrigger>
-                        <TooltipPopup className="max-w-96 wrap-anywhere font-mono" side="bottom">
-                          {checkoutCommand}
-                        </TooltipPopup>
-                      </Tooltip>
-                    ) : null}
+                    <PullRequestCopyableCode
+                      key={detail.headBranch}
+                      value={detail.headBranch}
+                      target="branch name"
+                      copyLabel="Copy pull request branch"
+                      copiedLabel="Branch name copied"
+                    />
                   </span>
                   <span className="ml-auto inline-flex shrink-0 items-center justify-end gap-2">
                     <span className="inline-flex items-center gap-1.5 tabular-nums">


### PR DESCRIPTION
Moves the pull request checkout command onto the author metadata row, leaving the branch and file stats together below. The command now uses the same plain click-to-copy treatment and inline copied feedback as the branch name.\n\nVerified with the web typecheck, targeted lint, formatting, and live browser checks at 1280×800 and 1024×800.\n\n### Before\n\n![Before: checkout command on the branch and file stats row](https://uploads-production-47e4.up.railway.app/files/1d7dd642-575e-4511-a587-1ab2a3fc3119/t3-pr-header-before-crop.png)\n\n### After\n\n![After: plain checkout command beside the author metadata](https://uploads-production-47e4.up.railway.app/files/5497d5ab-431f-4339-b2f3-5dfa18fb655b/t3-pr-header-after-plain-crop.png)\n\nGenerated with gpt-5.6-sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and copy affordances in the pull request detail header; no API, auth, or data-path changes.
> 
> **Overview**
> **Moves the PR checkout command** onto the author/“updated” metadata row and **keeps the branch line** focused on base → head plus file/diff stats.
> 
> Introduces **`PullRequestCopyableCode`** so branch name and checkout command share the same **click-to-copy** pattern: truncated monospace label, inline **“Copied”** swap, tooltip, focus/hover styling, and larger touch targets. The old outline button with **`CopyIcon`** on the branch row is removed.
> 
> **Copy feedback changes:** successful checkout copies no longer raise a success toast (inline state only); copy failures still show an error toast via **`onError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c02c31de8c50e059866b12a810a4c334a3a163f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move checkout control to author row and add `PullRequestCopyableCode`
> - Adds `PullRequestCopyableCode`, a reusable copy-to-clipboard control with a 1600ms copied state, configurable labels, optional error callback, and shared hover/focus/coarse-pointer styling
> - Refactors [PullRequestDetailPanel.tsx](https://github.com/pingdotgg/t3code/pull/9196/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a) to use `PullRequestCopyableCode` for both the head branch name and the checkout command, removing inline clipboard hooks and `CopyIcon`
> - Moves the checkout command from the branch metadata row into the author/update metadata row
> - Behavioral Change: successful checkout-command copies no longer show a success toast; clipboard failures still show an error toast. The checkout control is keyed by its command so copied state resets when the command changes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c02c31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->