### PR TITLE
fix(web): preserve composer draft during worktree setup

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1458,17 +1458,18 @@ describe("composerDraftStore project draft thread mapping", () => {
     expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.prompt).toBe("keep me");
   });
 
-  it("finalizes a promoted draft after the canonical thread route is active", () => {
+  it("moves composer edits made during promotion to the canonical thread", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectRef, draftId, { threadId });
-    store.setPrompt(draftId, "promote me");
     markPromotedDraftThread(threadId);
+    store.setPrompt(draftId, "typed during setup");
 
     finalizePromotedDraftThreadByRef(scopeThreadRef(TEST_ENVIRONMENT_ID, threadId));
 
     expect(useComposerDraftStore.getState().getDraftThreadByProjectRef(projectRef)).toBeNull();
     expect(useComposerDraftStore.getState().getDraftThread(draftId)).toBeNull();
     expect(draftByKey(draftId)).toBeUndefined();
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.prompt).toBe("typed during setup");
   });
 
   it("finalizes a matching materialized draft even when promotion was not pre-marked", () => {
@@ -1481,6 +1482,7 @@ describe("composerDraftStore project draft thread mapping", () => {
     expect(useComposerDraftStore.getState().getDraftThreadByProjectRef(projectRef)).toBeNull();
     expect(useComposerDraftStore.getState().getDraftThread(draftId)).toBeNull();
     expect(draftByKey(draftId)).toBeUndefined();
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.prompt).toBe("promote me");
   });
 
   it("updates branch context on an existing draft thread", () => {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1583,6 +1583,7 @@ function removeDraftThreadReferences(
     | "logicalProjectDraftThreadKeyByLogicalProjectKey"
   >,
   threadKey: string,
+  composerDestination?: ScopedThreadRef,
 ): Pick<
   ComposerDraftStoreState,
   | "draftThreadsByThreadKey"
@@ -1597,7 +1598,11 @@ function removeDraftThreadReferences(
   const { [threadKey]: _removedDraftThread, ...restDraftThreadsByThreadKey } =
     state.draftThreadsByThreadKey;
   const { [threadKey]: removedComposerDraft, ...restDraftsByThreadKey } = state.draftsByThreadKey;
-  revokeDraftThreadPreviewUrls(removedComposerDraft);
+  if (composerDestination && removedComposerDraft) {
+    restDraftsByThreadKey[composerTargetKey(composerDestination)] = removedComposerDraft;
+  } else {
+    revokeDraftThreadPreviewUrls(removedComposerDraft);
+  }
   return {
     draftsByThreadKey: restDraftsByThreadKey,
     draftThreadsByThreadKey: restDraftThreadsByThreadKey,
@@ -2785,10 +2790,10 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
           }
           set((state) => {
             const existing = state.draftThreadsByThreadKey[threadKey];
-            if (!isDraftThreadPromoting(existing)) {
+            if (!existing || !isDraftThreadPromoting(existing)) {
               return state;
             }
-            return removeDraftThreadReferences(state, threadKey);
+            return removeDraftThreadReferences(state, threadKey, existing.promotedTo ?? undefined);
           });
         },
         clearDraftThread: (threadRef) => {


### PR DESCRIPTION
> [!NOTE]
> Written by `gpt-5.6-sol` on behalf of Maria

Draft promotion deleted composer state when setup completed, so follow-up text typed while a remote worktree action was running disappeared. This moves the draft to the canonical scoped thread key when promotion finalizes and covers edits made during promotion in the existing store tests.

Verification: 101 focused store tests, web typecheck, targeted lint, and a real app flow with an eight-second worktree setup passed. [Real T3 Code verification video](https://uploads-production-47e4.up.railway.app/files/10ec953e-84c4-4f7d-8678-33a0aeec490e/composer-draft-survives-worktree-setup.mp4).

Implemented with `gpt-5.6-sol` in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer draft lifecycle during promotion finalization; wrong key handling could duplicate or leak drafts, but scope is limited to the promoting-draft cleanup path with added test coverage.
> 
> **Overview**
> Fixes composer text disappearing when a draft thread finishes promoting (for example while a remote worktree setup is still running). **Finalizing promotion** used to drop the draft’s composer state when cleaning up draft-thread mappings; it now **relocates** that state onto the canonical scoped thread key from `promotedTo` instead of revoking attachments and deleting the draft entry.
> 
> `removeDraftThreadReferences` accepts an optional destination ref for that move. `finalizePromotedDraftThread` only runs when a promoting draft exists and passes `promotedTo` through. Store tests now assert prompts survive on the real thread after finalize, including text typed on the draft id after `markPromotedDraftThread`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b080411bc9ba49c7fdc254f3585da072814af004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `finalizePromotedDraftThread` to preserve composer data on canonical thread
> - Composer text written while a draft is being promoted was lost when the draft thread was removed during finalization.
> - `removeDraftThreadReferences` now accepts an optional canonical destination; when supplied, it re-keys the draft's composer data to the canonical thread instead of revoking preview URLs.
> - `finalizePromotedDraftThread` passes the promoted destination to the helper so the composer data survives cleanup.
> - Risk: removals without a destination still revoke preview URLs, but any caller that previously relied on composer data being discarded during promotion will now see it retained under the canonical key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b080411.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->