### PR TITLE
feat(terminal): use Ctrl+V for paste

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -325,8 +325,8 @@ describe("isTerminalPasteShortcut", () => {
     expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "MacIntel")).toBe(false);
   });
 
-  it("preserves Ctrl+V and uses Ctrl+Shift+V elsewhere", () => {
-    expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(false);
+  it("uses Ctrl+V and Ctrl+Shift+V elsewhere", () => {
+    expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(true);
     expect(isTerminalPasteShortcut(event({ ctrlKey: true, shiftKey: true }), "Linux x86_64")).toBe(
       true,
     );

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -387,7 +387,7 @@ export function isTerminalPasteShortcut(
     return event.shiftKey && !event.ctrlKey && !event.metaKey;
   }
   if (key !== "v") return false;
-  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
+  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey;
 }
 
 export function isTerminalCompositionCommitInput(event: Pick<InputEvent, "inputType">): boolean {


### PR DESCRIPTION
## What changed

On Linux and Windows, Ctrl+V now pastes clipboard text into T3 Code's embedded terminal. Ctrl+Shift+V and Shift+Insert still work, and Cmd+V is unchanged on macOS.

## Why

Ctrl+V means paste throughout T3 Code and in most desktop apps. In the embedded terminal, however, it currently sends `^V` to the shell and starts quoted input. That mismatch is easy to trip over, especially when Caps Lock is mapped to Control for familiar Caps+C and Caps+V shortcuts.

This change makes the physical Control key and a remapped Caps Lock behave consistently. It intentionally changes the terminal's quoted-insert shortcut. Users who need quoted insert will have to bind it to another key.

## Testing

- All 3,339 tests across 289 web test files pass
- Web typecheck passes
- Focused formatting check passes
- Diff check passes
