### PR TITLE
fix(server): include symlinked directories in browse

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -701,6 +701,37 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
 
+    it.effect("includes symlinked directories and ignores non-directory targets", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-symlink-" });
+        const realDirectory = path.join(cwd, "projects");
+        const linkedDirectory = path.join(cwd, "linked-projects");
+        const linkedFile = path.join(cwd, "linked-file");
+        const brokenLink = path.join(cwd, "broken-projects");
+
+        yield* fileSystem.makeDirectory(realDirectory);
+        yield* fileSystem.writeFileString(path.join(cwd, "README.md"), "");
+        yield* fileSystem.symlink(realDirectory, linkedDirectory);
+        yield* fileSystem.symlink(path.join(cwd, "README.md"), linkedFile);
+        yield* fileSystem.symlink(path.join(cwd, "missing"), brokenLink);
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+        });
+
+        expect(result).toEqual({
+          parentPath: cwd,
+          entries: [
+            { name: "linked-projects", fullPath: linkedDirectory },
+            { name: "projects", fullPath: realDirectory },
+          ],
+        });
+      }),
+    );
+
     it.effect("rejects relative paths without cwd", () =>
       Effect.gen(function* () {
         const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -209,10 +209,26 @@ export const make = Effect.gen(function* () {
       const entries: Array<{ readonly name: string; readonly fullPath: string }> = [];
       for (const dirent of dirents) {
         if (
-          dirent.isDirectory() &&
-          dirent.name.toLowerCase().startsWith(lowerPrefix) &&
-          (showHidden || !dirent.name.startsWith("."))
+          !dirent.name.toLowerCase().startsWith(lowerPrefix) ||
+          (!showHidden && dirent.name.startsWith("."))
         ) {
+          continue;
+        }
+
+        let isDirectory = dirent.isDirectory();
+        if (!isDirectory && dirent.isSymbolicLink()) {
+          // `readdir` reports symlinks as non-directories. Follow the target
+          // only to classify it; broken or cyclic links are not browseable.
+          isDirectory = yield* Effect.promise(async () => {
+            try {
+              return (await NodeFSP.stat(path.join(parentPath, dirent.name))).isDirectory();
+            } catch {
+              return false;
+            }
+          });
+        }
+
+        if (isDirectory) {
           entries.push({
             name: dirent.name,
             fullPath: path.join(parentPath, dirent.name),


### PR DESCRIPTION
## Problem

`WorkspaceEntries.browse` only accepted `Dirent.isDirectory()`. Node reports symlink entries as symlinks even when their targets are directories, so valid project roots exposed through symlinks were missing from the project browser and path autocomplete.

## Fix

- Filter names and hidden entries before doing extra filesystem I/O.
- Follow symlink targets with `stat` only for classification, while returning the symlink path to the client.
- Ignore broken, cyclic, or otherwise unresolvable links and non-directory targets.
- Add integration coverage for real directories, directory symlinks, file symlinks, and broken symlinks.

Fixes #8408

## Validation

- `vp test run apps/server/src/workspace/WorkspaceEntries.test.ts` (31 tests)
- `vp fmt --check apps/server/src/workspace/WorkspaceEntries.ts apps/server/src/workspace/WorkspaceEntries.test.ts`
- `vp lint --report-unused-disable-directives apps/server/src/workspace/WorkspaceEntries.ts apps/server/src/workspace/WorkspaceEntries.test.ts`
- `vp run --filter t3 typecheck` (passes; existing suggestions only)

Implemented with GPT-5.6 Sol via Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to directory listing in browse with guarded stat-on-symlink only; no auth or data-path changes, though extra I/O runs per matching symlink entry.
> 
> **Overview**
> **`WorkspaceEntries.browse`** now treats symlink entries whose targets are directories as browseable folders, fixing missing project roots and path autocomplete when repos are exposed via symlinks.
> 
> The loop applies prefix and hidden-name filtering first, then **`stat`**s symlink targets only when `readdir` does not mark them as directories; results still use the symlink path. Broken links, file symlinks, and other non-directory targets are skipped. An integration test covers directory symlinks, file symlinks, and broken symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb4756ea6e66017d8c9776e1e5f1b2436d97da28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include directory symlinks in `WorkspaceEntries.browse` results
> The browse method now follows each matching symlink with a `stat` call to check whether its target is a directory. Directory symlinks are included; symlinks to regular files, broken links, or cyclic links are excluded. A test in [WorkspaceEntries.test.ts](https://github.com/pingdotgg/t3code/pull/9203/files#diff-6d95ae743d3d76a69c3093d3bfe3097cfa1d2a7e58a9e45e5f26d304479160b8) verifies the four cases. Behavioral Change: browse results now contain directory symlinks that were previously omitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb4756e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->