### PR TITLE
fix(web): keep sidebar timer on the response segment

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1072,44 +1072,62 @@ describe("resolveWorkingStartedAt", () => {
     updatedAt: "2026-03-09T10:02:00.000Z",
   };
 
-  it("uses the running turn's start time", () => {
+  it("counts from the user message, not the running turn's start time", () => {
     expect(
       resolveWorkingStartedAt({
+        latestUserMessageAt: "2026-03-09T09:55:00.000Z",
         latestTurn: makeLatestTurn({ completedAt: null }),
         session,
       }),
-    ).toBe("2026-03-09T10:00:00.000Z");
+    ).toBe("2026-03-09T09:55:00.000Z");
   });
 
-  it("uses the request time while a turn awaits adoption", () => {
+  it("uses the request time while a turn awaits adoption without a user message", () => {
     expect(
       resolveWorkingStartedAt({
+        latestUserMessageAt: null,
         latestTurn: makeLatestTurn({ startedAt: null, completedAt: null }),
         session,
       }),
     ).toBe("2026-03-09T10:00:00.000Z");
   });
 
+  // A synthetic turn can complete mid-response; the timer must not restart
+  // from the session transition while the user's message still stands.
+  it("keeps the user message when the latest synthetic turn already completed", () => {
+    expect(
+      resolveWorkingStartedAt({
+        latestUserMessageAt: "2026-03-09T09:55:00.000Z",
+        latestTurn: makeLatestTurn(),
+        session,
+      }),
+    ).toBe("2026-03-09T09:55:00.000Z");
+  });
+
   it("falls back to the session transition when the latest turn already completed", () => {
     expect(
       resolveWorkingStartedAt({
+        latestUserMessageAt: null,
         latestTurn: makeLatestTurn(),
         session,
       }),
     ).toBe("2026-03-09T10:02:00.000Z");
   });
 
-  it("skips a malformed startedAt instead of returning it", () => {
+  it("skips malformed timestamps instead of returning them", () => {
     expect(
       resolveWorkingStartedAt({
-        latestTurn: makeLatestTurn({ startedAt: "not-a-date", completedAt: null }),
+        latestUserMessageAt: "not-a-date",
+        latestTurn: makeLatestTurn({ startedAt: "also-not-a-date", completedAt: null }),
         session,
       }),
     ).toBe("2026-03-09T10:00:00.000Z");
   });
 
-  it("returns null with neither a running turn nor a session", () => {
-    expect(resolveWorkingStartedAt({ latestTurn: null, session: null })).toBeNull();
+  it("returns null with neither a user message, a running turn, nor a session", () => {
+    expect(
+      resolveWorkingStartedAt({ latestUserMessageAt: null, latestTurn: null, session: null }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -706,18 +706,22 @@ export function sortSettledThreadsForSidebar<
   );
 }
 
-/** The timestamp a working thread's elapsed label counts from: the running
-    turn's start (request time until adoption), falling back to the session's
-    last transition when the turn projection lags behind. Malformed
-    timestamps fall through to the next candidate, not just missing ones. */
+/** The timestamp a working thread's elapsed label counts from: the user
+    message that started the response. Providers mint fresh turn ids mid-
+    response, so the running turn's start (request time until adoption) and
+    the session's last transition are only fallbacks for when the message
+    projection is missing. Malformed timestamps fall through to the next
+    candidate, not just missing ones. */
 export function resolveWorkingStartedAt(
-  thread: Pick<SidebarThreadSummary, "latestTurn" | "session">,
+  thread: Pick<SidebarThreadSummary, "latestUserMessageAt" | "latestTurn" | "session">,
 ): string | null {
-  const turn = thread.latestTurn;
-  if (turn && turn.completedAt === null) {
-    return firstValidTimestamp(turn.startedAt, turn.requestedAt, thread.session?.updatedAt);
-  }
-  return firstValidTimestamp(thread.session?.updatedAt);
+  const runningTurn = thread.latestTurn?.completedAt === null ? thread.latestTurn : null;
+  return firstValidTimestamp(
+    thread.latestUserMessageAt,
+    runningTurn?.startedAt,
+    runningTurn?.requestedAt,
+    thread.session?.updatedAt,
+  );
 }
 
 export function formatWorkingDurationLabel(elapsedMs: number): string {


### PR DESCRIPTION
## What Changed

Anchor the sidebar's Working timer to `latestUserMessageAt`, the user
message that started the current response, instead of the running
turn's start time. The turn's `startedAt`/`requestedAt` and the
session's `updatedAt` remain as fallbacks when the message projection
is missing or malformed.

Sidebar only. The chat view's "Working for" line and the mobile app
keep their turn-based timer.

## Why

The Claude adapter mints a fresh synthetic turn id whenever the parent
agent is woken after its turn has closed, for example when a background
subagent finishes or a stop hook retries. Each wake-up reset the
sidebar timer, so a response running for three minutes showed
"Working 1m".

One behavior change for other providers: a steer message now restarts
the sidebar timer for every provider. Codex already did this because it
opens a new turn on steer; Cursor, Grok and OpenCode keep the turn id
and previously kept counting.

## UI Changes

Same prompt sent to both builds at the same moment. The agent spawns a
background subagent, replies "waiting" and ends its turn; the
subagent's completion wakes it and it starts a 170 s wait. Captured
90 s into that wait.

Before: ![before](https://raw.githubusercontent.com/orbitingflea/t3code/5ad409f395744d1efc30341813cdb37e9e60a6b4/shots/before-sidebar-timer.png)

After: ![after](https://raw.githubusercontent.com/orbitingflea/t3code/5ad409f395744d1efc30341813cdb37e9e60a6b4/shots/after-sidebar-timer.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable)

Model: Claude Fable 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar display-only timing logic with expanded unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> The sidebar **Working** elapsed timer now anchors to **`latestUserMessageAt`** (the user message that started the current response) instead of the active turn’s `startedAt` / `requestedAt`.
> 
> Turn and session timestamps remain fallbacks when that projection is missing or invalid, and the resolver still ignores malformed values in the chain. A new test covers mid-response synthetic turn completion so the label does not jump to the session transition while the same user message is still in flight.
> 
> **Behavior note:** steer messages restart the sidebar timer for providers that keep the same turn id (Cursor, Grok, OpenCode); chat and mobile timers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39cb52e171a7c730558b8571bc5820d031782623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar timer to stay anchored to latest user message timestamp
> Updates the `resolveWorkingStartedAt` test suite to verify that elapsed working time remains anchored to the latest valid user message timestamp across synthetic turn completion. Tests now confirm fallback through running-turn and session timestamps when the message timestamp is absent or malformed, and add broader coverage for malformed timestamps on both message and turn fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39cb52e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->