### PR TITLE
fix(grok): show context-window usage in the composer

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -46,6 +46,7 @@ const emitOverlappingXAiPromptCompleteOutOfOrder =
 const failPrompt = process.env.T3_ACP_FAIL_PROMPT === "1";
 const failSetConfigOption = process.env.T3_ACP_FAIL_SET_CONFIG_OPTION === "1";
 const exitOnSetConfigOption = process.env.T3_ACP_EXIT_ON_SET_CONFIG_OPTION === "1";
+const emitContextUsage = process.env.T3_ACP_EMIT_CONTEXT_USAGE === "1";
 const promptResponseText = process.env.T3_ACP_PROMPT_RESPONSE_TEXT;
 const initialGrokReasoningEffort =
   process.env.T3_ACP_INITIAL_GROK_REASONING_EFFORT?.trim() || undefined;
@@ -1061,6 +1062,7 @@ const program = Effect.gen(function* () {
 
       yield* agent.client.sessionUpdate({
         sessionId: requestedSessionId,
+        ...(emitContextUsage ? { _meta: { totalTokens: 1615 } } : {}),
         update: {
           sessionUpdate: "agent_message_chunk",
           content: { type: "text", text: promptResponseText ?? "hello from mock" },

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -57,6 +57,7 @@ import {
   makeAcpPlanUpdatedEvent,
   makeAcpRequestOpenedEvent,
   makeAcpRequestResolvedEvent,
+  makeAcpTokenUsageEvent,
   makeAcpToolCallEvent,
 } from "../acp/AcpCoreRuntimeEvents.ts";
 import {
@@ -867,6 +868,27 @@ export function makeCursorAdapter(
                       }),
                     );
                     return;
+                  case "UsageUpdated": {
+                    yield* logNative(
+                      ctx.threadId,
+                      "session/update",
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                    );
+                    const usageEvent = makeAcpTokenUsageEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: ctx.threadId,
+                      turnId: ctx.activeTurnId,
+                      used: event.used,
+                      size: event.size,
+                      rawPayload: event.rawPayload,
+                    });
+                    if (usageEvent) {
+                      yield* offerRuntimeEvent(usageEvent);
+                    }
+                    return;
+                  }
                 }
               }),
             ),

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -27,10 +27,13 @@ import {
 
 import { ServerConfig } from "../../config.ts";
 import {
+  GROK_DEFAULT_CONTEXT_WINDOW,
+  grokContextWindowAfterModelChange,
   grokPromptSettlementBelongsToContext,
   isGrokEnterPlanModeToolCall,
   makeGrokAdapter,
   nextGrokPlanModeActive,
+  resolveGrokContextUsage,
   selectGrokPermissionOptionId,
 } from "./GrokAdapter.ts";
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
@@ -177,6 +180,83 @@ it("prefers allow_always when Grok offers it", () => {
 
   assert.equal(selectGrokPermissionOptionId(request, "acceptForSession"), "allow-always");
   assert.equal(selectGrokPermissionOptionId(request, "accept"), "allow-once");
+});
+
+it("keeps occupancy snapshots when only the context window changes", () => {
+  assert.deepStrictEqual(
+    resolveGrokContextUsage({
+      used: 1615,
+      eventSize: 0,
+      lastUsed: 1615,
+      lastKnownMaxTokens: 500_000,
+      lastEmittedMaxTokens: 500_000,
+    }),
+    undefined,
+  );
+  assert.deepStrictEqual(
+    resolveGrokContextUsage({
+      used: 1615,
+      eventSize: 256_000,
+      lastUsed: 1615,
+      lastKnownMaxTokens: 500_000,
+      lastEmittedMaxTokens: 500_000,
+    }),
+    { used: 1615, size: 256_000 },
+  );
+  assert.deepStrictEqual(
+    resolveGrokContextUsage({
+      used: 1615,
+      eventSize: 0,
+      lastUsed: 1615,
+      lastKnownMaxTokens: 256_000,
+      lastEmittedMaxTokens: 500_000,
+    }),
+    { used: 1615, size: 256_000 },
+  );
+  assert.equal(
+    resolveGrokContextUsage({
+      used: 1_200,
+      eventSize: 0,
+      lastUsed: undefined,
+      lastKnownMaxTokens: undefined,
+      lastEmittedMaxTokens: undefined,
+    })?.size,
+    GROK_DEFAULT_CONTEXT_WINDOW,
+  );
+});
+
+it("refreshes the cached window when the Grok model changes", () => {
+  const windows = new Map([
+    ["grok-4.6", 500_000],
+    ["grok-code", 256_000],
+  ]);
+  assert.equal(
+    grokContextWindowAfterModelChange({
+      previousModelId: "grok-4.6",
+      nextModelId: "grok-4.6",
+      windows,
+      lastKnownMaxTokens: 500_000,
+    }),
+    500_000,
+  );
+  assert.equal(
+    grokContextWindowAfterModelChange({
+      previousModelId: "grok-4.6",
+      nextModelId: "grok-code",
+      windows,
+      lastKnownMaxTokens: 500_000,
+    }),
+    256_000,
+  );
+  assert.equal(
+    grokContextWindowAfterModelChange({
+      previousModelId: "grok-4.6",
+      nextModelId: "grok-unknown",
+      windows,
+      lastKnownMaxTokens: 500_000,
+    }),
+    undefined,
+  );
 });
 
 it("requires a settlement to match the live Grok turn", () => {

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -278,6 +278,56 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("emits context occupancy from session-update _meta.totalTokens", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-context-window-thread");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_EMIT_CONTEXT_USAGE: "1" }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "turn.completed"
+              ? Deferred.succeed(turnCompleted, undefined)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-4.6" },
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "hello grok",
+        attachments: [],
+      });
+
+      yield* Deferred.await(turnCompleted);
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const usageEvent = runtimeEvents.find((event) => event.type === "thread.token-usage.updated");
+      assert.equal(usageEvent?.type, "thread.token-usage.updated");
+      if (usageEvent?.type === "thread.token-usage.updated") {
+        assert.equal(usageEvent.payload.usage.usedTokens, 1615);
+        assert.equal(usageEvent.payload.usage.maxTokens, 500_000);
+      }
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("closes the ACP child process when a session stops", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-session-close");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -62,7 +62,9 @@ import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import {
   applyGrokAcpModelSelection,
+  contextWindowForGrokModelId,
   contextWindowFromGrokSessionSetup,
+  contextWindowsFromGrokSessionModels,
   currentGrokModelIdFromSessionSetup,
   currentGrokReasoningEffortFromSessionSetup,
   makeGrokAcpRuntime,
@@ -171,8 +173,10 @@ interface GrokSessionContext {
   promptResponsesReady: number;
   currentModelId: string | undefined;
   currentReasoningEffort: string | undefined;
+  contextWindows: ReadonlyMap<string, number>;
   lastContextTokens: number | undefined;
   lastKnownMaxTokens: number | undefined;
+  lastEmittedMaxTokens: number | undefined;
   stopped: boolean;
 }
 
@@ -318,7 +322,36 @@ function selectAutoApprovedPermissionOption(
   );
 }
 
-const GROK_DEFAULT_CONTEXT_WINDOW = 500_000;
+export const GROK_DEFAULT_CONTEXT_WINDOW = 500_000;
+
+export function resolveGrokContextUsage(input: {
+  readonly used: number;
+  readonly eventSize: number;
+  readonly lastUsed: number | undefined;
+  readonly lastKnownMaxTokens: number | undefined;
+  readonly lastEmittedMaxTokens: number | undefined;
+}): { readonly used: number; readonly size: number } | undefined {
+  const size =
+    input.eventSize > 0
+      ? input.eventSize
+      : (input.lastKnownMaxTokens ?? GROK_DEFAULT_CONTEXT_WINDOW);
+  if (input.lastUsed === input.used && input.lastEmittedMaxTokens === size) {
+    return undefined;
+  }
+  return { used: input.used, size };
+}
+
+export function grokContextWindowAfterModelChange(input: {
+  readonly previousModelId: string | undefined;
+  readonly nextModelId: string | undefined;
+  readonly windows: ReadonlyMap<string, number>;
+  readonly lastKnownMaxTokens: number | undefined;
+}): number | undefined {
+  if (input.nextModelId === input.previousModelId) {
+    return input.lastKnownMaxTokens;
+  }
+  return contextWindowForGrokModelId(input.windows, input.nextModelId);
+}
 
 function completedStopReasonFromPromptResponse(
   response: EffectAcpSchema.PromptResponse | undefined,
@@ -1306,11 +1339,13 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               requestedStartReasoningEffort !== undefined
                 ? normalizeGrokReasoningEffort(requestedStartReasoningEffort)
                 : currentStartReasoningEffort,
+            contextWindows: contextWindowsFromGrokSessionModels(started.sessionSetupResult.models),
             lastContextTokens: undefined,
             lastKnownMaxTokens: contextWindowFromGrokSessionSetup(
               started.sessionSetupResult,
               boundModelId,
             ),
+            lastEmittedMaxTokens: undefined,
             stopped: false,
           };
 
@@ -1339,23 +1374,28 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   if (usageTurnId !== undefined && ctx.interruptedTurnIds.has(usageTurnId)) {
                     return;
                   }
-                  if (ctx.lastContextTokens === event.used) {
+                  const snapshot = resolveGrokContextUsage({
+                    used: event.used,
+                    eventSize: event.size,
+                    lastUsed: ctx.lastContextTokens,
+                    lastKnownMaxTokens: ctx.lastKnownMaxTokens,
+                    lastEmittedMaxTokens: ctx.lastEmittedMaxTokens,
+                  });
+                  if (!snapshot) {
                     return;
                   }
-                  ctx.lastContextTokens = event.used;
+                  ctx.lastContextTokens = snapshot.used;
                   if (event.size > 0) {
                     ctx.lastKnownMaxTokens = event.size;
                   }
+                  ctx.lastEmittedMaxTokens = snapshot.size;
                   const usageEvent = makeAcpTokenUsageEvent({
                     stamp: yield* makeEventStamp(),
                     provider: PROVIDER,
                     threadId: ctx.threadId,
                     turnId: usageTurnId,
-                    used: event.used,
-                    size:
-                      event.size > 0
-                        ? event.size
-                        : (ctx.lastKnownMaxTokens ?? GROK_DEFAULT_CONTEXT_WINDOW),
+                    used: snapshot.used,
+                    size: snapshot.size,
                     rawPayload: event.rawPayload,
                   });
                   if (usageEvent) {
@@ -1615,6 +1655,12 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 requestedReasoningEffort: requestedTurnReasoningEffort,
                 mapError: (cause) =>
                   mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+              });
+              ctx.lastKnownMaxTokens = grokContextWindowAfterModelChange({
+                previousModelId: ctx.currentModelId,
+                nextModelId: currentModelId,
+                windows: ctx.contextWindows,
+                lastKnownMaxTokens: ctx.lastKnownMaxTokens,
               });
               ctx.currentModelId = currentModelId;
               if (requestedTurnReasoningEffort !== undefined) {

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -55,12 +55,14 @@ import {
   makeAcpPlanUpdatedEvent,
   makeAcpRequestOpenedEvent,
   makeAcpRequestResolvedEvent,
+  makeAcpTokenUsageEvent,
   makeAcpToolCallEvent,
 } from "../acp/AcpCoreRuntimeEvents.ts";
 import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import {
   applyGrokAcpModelSelection,
+  contextWindowFromGrokSessionSetup,
   currentGrokModelIdFromSessionSetup,
   currentGrokReasoningEffortFromSessionSetup,
   makeGrokAcpRuntime,
@@ -169,6 +171,8 @@ interface GrokSessionContext {
   promptResponsesReady: number;
   currentModelId: string | undefined;
   currentReasoningEffort: string | undefined;
+  lastContextTokens: number | undefined;
+  lastKnownMaxTokens: number | undefined;
   stopped: boolean;
 }
 
@@ -313,6 +317,8 @@ function selectAutoApprovedPermissionOption(
     selectGrokPermissionOptionId(request, "accept")
   );
 }
+
+const GROK_DEFAULT_CONTEXT_WINDOW = 500_000;
 
 function completedStopReasonFromPromptResponse(
   response: EffectAcpSchema.PromptResponse | undefined,
@@ -1300,6 +1306,11 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               requestedStartReasoningEffort !== undefined
                 ? normalizeGrokReasoningEffort(requestedStartReasoningEffort)
                 : currentStartReasoningEffort,
+            lastContextTokens: undefined,
+            lastKnownMaxTokens: contextWindowFromGrokSessionSetup(
+              started.sessionSetupResult,
+              boundModelId,
+            ),
             stopped: false,
           };
 
@@ -1313,12 +1324,43 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 if (
                   event._tag === "PlanUpdated" ||
                   event._tag === "ToolCallUpdated" ||
-                  event._tag === "ContentDelta"
+                  event._tag === "ContentDelta" ||
+                  event._tag === "UsageUpdated"
                 ) {
                   yield* logNative(ctx.threadId, "session/update", event.rawPayload);
                 }
 
                 if (event._tag === "ModeChanged") {
+                  return;
+                }
+
+                if (event._tag === "UsageUpdated") {
+                  const usageTurnId = resolveNotificationTurnId(ctx);
+                  if (usageTurnId !== undefined && ctx.interruptedTurnIds.has(usageTurnId)) {
+                    return;
+                  }
+                  if (ctx.lastContextTokens === event.used) {
+                    return;
+                  }
+                  ctx.lastContextTokens = event.used;
+                  if (event.size > 0) {
+                    ctx.lastKnownMaxTokens = event.size;
+                  }
+                  const usageEvent = makeAcpTokenUsageEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: ctx.threadId,
+                    turnId: usageTurnId,
+                    used: event.used,
+                    size:
+                      event.size > 0
+                        ? event.size
+                        : (ctx.lastKnownMaxTokens ?? GROK_DEFAULT_CONTEXT_WINDOW),
+                    rawPayload: event.rawPayload,
+                  });
+                  if (usageEvent) {
+                    yield* offerRuntimeEvent(usageEvent);
+                  }
                   return;
                 }
 

--- a/apps/server/src/provider/acp/AcpCoreRuntimeEvents.test.ts
+++ b/apps/server/src/provider/acp/AcpCoreRuntimeEvents.test.ts
@@ -7,6 +7,7 @@ import {
   makeAcpPlanUpdatedEvent,
   makeAcpRequestOpenedEvent,
   makeAcpRequestResolvedEvent,
+  makeAcpTokenUsageEvent,
   makeAcpToolCallEvent,
 } from "./AcpCoreRuntimeEvents.ts";
 
@@ -191,5 +192,37 @@ describe("AcpCoreRuntimeEvents", () => {
         status: "inProgress",
       },
     });
+
+    expect(
+      makeAcpTokenUsageEvent({
+        stamp,
+        provider: ProviderDriverKind.make("grok"),
+        threadId: "thread-1" as never,
+        turnId,
+        used: 12_345,
+        size: 200_000,
+        rawPayload: { sessionUpdate: "usage_update" },
+      }),
+    ).toMatchObject({
+      type: "thread.token-usage.updated",
+      payload: {
+        usage: {
+          usedTokens: 12_345,
+          maxTokens: 200_000,
+        },
+      },
+    });
+
+    expect(
+      makeAcpTokenUsageEvent({
+        stamp,
+        provider: ProviderDriverKind.make("grok"),
+        threadId: "thread-1" as never,
+        turnId,
+        used: 0,
+        size: 200_000,
+        rawPayload: { sessionUpdate: "usage_update" },
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/server/src/provider/acp/AcpCoreRuntimeEvents.ts
+++ b/apps/server/src/provider/acp/AcpCoreRuntimeEvents.ts
@@ -8,6 +8,7 @@ import {
   type ProviderRuntimeEvent,
   type RuntimeRequestId,
   type ThreadId,
+  type ThreadTokenUsageSnapshot,
   type TurnId,
 } from "@t3tools/contracts";
 
@@ -220,6 +221,44 @@ export function makeAcpContentDeltaEvent(input: {
     payload: {
       streamKind: "assistant_text",
       delta: input.text,
+    },
+    raw: {
+      source: "acp.jsonrpc",
+      method: "session/update",
+      payload: input.rawPayload,
+    },
+  };
+}
+
+export function makeAcpTokenUsageEvent(input: {
+  readonly stamp: AcpEventStamp;
+  readonly provider: ProviderDriverKind;
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId | undefined;
+  readonly used: number;
+  readonly size: number;
+  readonly rawPayload: unknown;
+}): ProviderRuntimeEvent | null {
+  if (!Number.isFinite(input.used) || input.used <= 0) {
+    return null;
+  }
+  const usedTokens = Math.round(input.used);
+  const maxTokens =
+    Number.isFinite(input.size) && input.size >= 1 ? Math.round(input.size) : undefined;
+  const clamped = maxTokens !== undefined ? Math.min(usedTokens, maxTokens) : usedTokens;
+  const usage: ThreadTokenUsageSnapshot = {
+    usedTokens: clamped,
+    lastUsedTokens: clamped,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+  };
+  return {
+    type: "thread.token-usage.updated",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    payload: {
+      usage,
     },
     raw: {
       source: "acp.jsonrpc",

--- a/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
@@ -339,6 +339,80 @@ describe("AcpRuntimeModel", () => {
     ]);
   });
 
+  it("reads Grok context occupancy from session-update _meta.totalTokens", () => {
+    const result = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      _meta: { totalTokens: 1615, contextWindowTokens: 500_000 },
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "hello",
+        },
+      },
+    } satisfies EffectAcpSchema.SessionNotification);
+
+    expect(result.events).toContainEqual({
+      _tag: "UsageUpdated",
+      used: 1615,
+      size: 500_000,
+      rawPayload: {
+        sessionId: "session-1",
+        _meta: { totalTokens: 1615, contextWindowTokens: 500_000 },
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: "hello",
+          },
+        },
+      },
+    });
+  });
+
+  it("does not treat billed prompt-response usage as context occupancy", () => {
+    const result = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      _meta: { usage: { totalTokens: 20_554, inputTokens: 18_000, outputTokens: 2_554 } },
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "hello",
+        },
+      },
+    } satisfies EffectAcpSchema.SessionNotification);
+
+    expect(result.events.some((event) => event._tag === "UsageUpdated")).toBe(false);
+  });
+
+  it("projects ACP usage updates for the context-window meter", () => {
+    const result = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 12_345,
+        size: 200_000,
+      },
+    } satisfies EffectAcpSchema.SessionNotification);
+
+    expect(result.events).toEqual([
+      {
+        _tag: "UsageUpdated",
+        used: 12_345,
+        size: 200_000,
+        rawPayload: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "usage_update",
+            used: 12_345,
+            size: 200_000,
+          },
+        },
+      },
+    ]);
+  });
+
   it("keeps permission request parsing compatible with loose extension payloads", () => {
     const request = parsePermissionRequest({
       sessionId: "session-1",

--- a/apps/server/src/provider/acp/AcpRuntimeModel.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.ts
@@ -108,6 +108,12 @@ export type AcpParsedSessionEvent =
       readonly itemId?: string;
       readonly text: string;
       readonly rawPayload: unknown;
+    }
+  | {
+      readonly _tag: "UsageUpdated";
+      readonly used: number;
+      readonly size: number;
+      readonly rawPayload: unknown;
     };
 
 type AcpSessionSetupResponse =
@@ -838,9 +844,58 @@ export function parseSessionUpdateEvent(params: EffectAcpSchema.SessionNotificat
       }
       break;
     }
+    case "usage_update": {
+      if (
+        Number.isFinite(upd.used) &&
+        upd.used >= 0 &&
+        Number.isFinite(upd.size) &&
+        upd.size >= 0
+      ) {
+        events.push({
+          _tag: "UsageUpdated",
+          used: upd.used,
+          size: upd.size,
+          rawPayload: params,
+        });
+      }
+      break;
+    }
     default:
       break;
   }
 
+  const metaTokens = readSessionMetaTotalTokens(params._meta);
+  if (metaTokens !== null && !events.some((event) => event._tag === "UsageUpdated")) {
+    events.push({
+      _tag: "UsageUpdated",
+      used: metaTokens,
+      size: readSessionMetaContextWindow(params._meta),
+      rawPayload: params,
+    });
+  }
+
   return { ...(modeId !== undefined ? { modeId } : {}), events };
+}
+
+function readSessionMetaTotalTokens(meta: unknown): number | null {
+  if (!isRecord(meta)) {
+    return null;
+  }
+  const totalTokens = meta.totalTokens;
+  return typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens >= 0
+    ? totalTokens
+    : null;
+}
+
+function readSessionMetaContextWindow(meta: unknown): number {
+  if (!isRecord(meta)) {
+    return 0;
+  }
+  for (const key of ["contextWindowTokens", "contextWindow", "maxTokens"] as const) {
+    const value = meta[key];
+    if (typeof value === "number" && Number.isFinite(value) && value >= 1) {
+      return value;
+    }
+  }
+  return 0;
 }

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -5,9 +5,11 @@ import * as EffectAcpErrors from "effect-acp/errors";
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
+  contextWindowFromGrokSessionSetup,
   grokAcpSpawnArgs,
   isValidGrokReasoningEffortToken,
   resolveGrokAcpBaseModelId,
+  totalContextTokensFromModelMeta,
 } from "./GrokAcpSupport.ts";
 
 describe("resolveGrokAcpBaseModelId", () => {
@@ -73,6 +75,42 @@ describe("buildGrokAcpSpawnInput", () => {
       "approval-required",
     );
     expect(spawn.args).toEqual(["--permission-mode", "default", "agent", "stdio"]);
+  });
+});
+
+describe("contextWindowFromGrokSessionSetup", () => {
+  it("reads totalContextTokens from the current model", () => {
+    expect(totalContextTokensFromModelMeta({ totalContextTokens: 500_000 })).toBe(500_000);
+    expect(
+      contextWindowFromGrokSessionSetup({
+        sessionId: "session-1",
+        models: {
+          currentModelId: "grok-4.6",
+          availableModels: [
+            { modelId: "grok-4.6", name: "Grok 4.6", _meta: { totalContextTokens: 500_000 } },
+            { modelId: "grok-code", name: "Grok Code", _meta: { totalContextTokens: 256_000 } },
+          ],
+        },
+      }),
+    ).toBe(500_000);
+  });
+
+  it("does not pick another model's window when the current model omits it", () => {
+    expect(
+      contextWindowFromGrokSessionSetup(
+        {
+          sessionId: "session-1",
+          models: {
+            currentModelId: "grok-4.6",
+            availableModels: [
+              { modelId: "grok-4.6", name: "Grok 4.6" },
+              { modelId: "grok-code", name: "Grok Code", _meta: { totalContextTokens: 256_000 } },
+            ],
+          },
+        },
+        "grok-4.6",
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -5,7 +5,9 @@ import * as EffectAcpErrors from "effect-acp/errors";
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
+  contextWindowForGrokModelId,
   contextWindowFromGrokSessionSetup,
+  contextWindowsFromGrokSessionModels,
   grokAcpSpawnArgs,
   isValidGrokReasoningEffortToken,
   resolveGrokAcpBaseModelId,
@@ -111,6 +113,19 @@ describe("contextWindowFromGrokSessionSetup", () => {
         "grok-4.6",
       ),
     ).toBeUndefined();
+  });
+
+  it("looks up a later model from the session model map", () => {
+    const windows = contextWindowsFromGrokSessionModels({
+      currentModelId: "grok-4.6",
+      availableModels: [
+        { modelId: "grok-4.6", name: "Grok 4.6", _meta: { totalContextTokens: 500_000 } },
+        { modelId: "grok-code", name: "Grok Code", _meta: { totalContextTokens: 256_000 } },
+      ],
+    });
+    expect(contextWindowForGrokModelId(windows, "grok-4.6")).toBe(500_000);
+    expect(contextWindowForGrokModelId(windows, "grok-code")).toBe(256_000);
+    expect(contextWindowForGrokModelId(windows, "missing")).toBeUndefined();
   });
 });
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -130,6 +130,46 @@ export function currentGrokModelIdFromSessionSetup(
   return sessionSetupResult.models?.currentModelId?.trim() || undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Model context window from Grok ACP `availableModels[]._meta.totalContextTokens`. */
+export function totalContextTokensFromModelMeta(meta: unknown): number | undefined {
+  if (!isRecord(meta)) {
+    return undefined;
+  }
+  const value = meta.totalContextTokens;
+  return typeof value === "number" && Number.isFinite(value) && value >= 1
+    ? Math.round(value)
+    : undefined;
+}
+
+export function contextWindowFromGrokSessionSetup(
+  sessionSetupResult:
+    | EffectAcpSchema.LoadSessionResponse
+    | EffectAcpSchema.NewSessionResponse
+    | EffectAcpSchema.ResumeSessionResponse,
+  modelId?: string,
+): number | undefined {
+  const models = sessionSetupResult.models;
+  if (!models) {
+    return undefined;
+  }
+  const currentId = (modelId ?? models.currentModelId)?.trim();
+  if (currentId) {
+    const match = models.availableModels.find((model) => model.modelId.trim() === currentId);
+    const size = totalContextTokensFromModelMeta(match?._meta);
+    if (size !== undefined) {
+      return size;
+    }
+  }
+  if (models.availableModels.length === 1) {
+    return totalContextTokensFromModelMeta(models.availableModels[0]?._meta);
+  }
+  return undefined;
+}
+
 export function currentGrokReasoningEffortFromSessionSetup(
   sessionSetupResult:
     | EffectAcpSchema.LoadSessionResponse

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -145,6 +145,39 @@ export function totalContextTokensFromModelMeta(meta: unknown): number | undefin
     : undefined;
 }
 
+export function contextWindowsFromGrokSessionModels(
+  models: EffectAcpSchema.SessionModelState | null | undefined,
+): ReadonlyMap<string, number> {
+  const windows = new Map<string, number>();
+  for (const model of models?.availableModels ?? []) {
+    const size = totalContextTokensFromModelMeta(model._meta);
+    if (size === undefined) {
+      continue;
+    }
+    const modelId = model.modelId.trim();
+    if (!modelId) {
+      continue;
+    }
+    windows.set(modelId, size);
+    const baseId = resolveGrokAcpBaseModelId(modelId);
+    if (baseId !== modelId) {
+      windows.set(baseId, size);
+    }
+  }
+  return windows;
+}
+
+export function contextWindowForGrokModelId(
+  windows: ReadonlyMap<string, number>,
+  modelId: string | undefined,
+): number | undefined {
+  const trimmed = modelId?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return windows.get(trimmed) ?? windows.get(resolveGrokAcpBaseModelId(trimmed));
+}
+
 export function contextWindowFromGrokSessionSetup(
   sessionSetupResult:
     | EffectAcpSchema.LoadSessionResponse
@@ -153,19 +186,14 @@ export function contextWindowFromGrokSessionSetup(
   modelId?: string,
 ): number | undefined {
   const models = sessionSetupResult.models;
-  if (!models) {
-    return undefined;
+  const windows = contextWindowsFromGrokSessionModels(models);
+  const currentId = (modelId ?? models?.currentModelId)?.trim();
+  const matched = contextWindowForGrokModelId(windows, currentId);
+  if (matched !== undefined) {
+    return matched;
   }
-  const currentId = (modelId ?? models.currentModelId)?.trim();
-  if (currentId) {
-    const match = models.availableModels.find((model) => model.modelId.trim() === currentId);
-    const size = totalContextTokensFromModelMeta(match?._meta);
-    if (size !== undefined) {
-      return size;
-    }
-  }
-  if (models.availableModels.length === 1) {
-    return totalContextTokensFromModelMeta(models.availableModels[0]?._meta);
+  if ((models?.availableModels.length ?? 0) === 1) {
+    return totalContextTokensFromModelMeta(models?.availableModels[0]?._meta);
   }
   return undefined;
 }


### PR DESCRIPTION
Closes #8382

## What Changed

Grok threads never showed the composer context-window meter. The live adapter did not emit `thread.token-usage.updated`, so `ContextWindowMeter` had nothing to render.

This maps occupancy onto that existing path:

- ACP `sessionUpdate: "usage_update"` when present
- Grok's actual path today: `session/update` `_meta.totalTokens`
- Window size from `_meta` (`contextWindowTokens` / `contextWindow` / `maxTokens`), else the current model's `availableModels[]._meta.totalContextTokens`, else 500k

Interrupted turns do not overwrite the last snapshot. Cursor gets the shared `UsageUpdated` case so the ACP union stays exhaustive.

No new UI. The existing composer meter is enough.

## Why

Codex already shows used / max / %. Grok did not, even though `grok agent stdio` already streams fill on `_meta.totalTokens`.

Live Grok ACP still does **not** send `usage_update`. Occupancy lives on session/update `_meta.totalTokens`. Prompt-response `usage.totalTokens` is billed API tokens, not context fill. On a greeting turn those were **1615 occupancy vs 20554 billed**. This PR does not use the prompt-response number, which is the difference from #5405.

## UI Changes

Uses the existing context-window meter in the composer.

- Before: Grok threads have no context fill indicator.
- After: After the first occupancy-bearing `session/update`, Grok shows the same ring + used/max tooltip as Codex.

## Validation

- `vp test run src/provider/acp/AcpRuntimeModel.test.ts src/provider/acp/AcpCoreRuntimeEvents.test.ts src/provider/acp/GrokAcpSupport.test.ts` — 50 passed
- Server typecheck: no new errors
- Live Grok session: `_meta.totalTokens` is occupancy; prompt `usage.totalTokens` is billed tokens; `signals.json` has `contextWindowTokens: 500000`
- GrokAdapter mock spawn tests fail on this Windows host (`spawn EFTYPE` on the `.sh` wrapper). That is existing, not introduced here. The new adapter test is in `GrokAdapter.test.ts` for Linux CI.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for the UI change (happy to add a Grok-thread capture)
- [x] A video is not applicable (no animation/timing change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Provider-adapter and event-mapping changes only; no auth or persistence changes, with deduplication and explicit exclusion of billed-token metadata reducing wrong-meter risk.
> 
> **Overview**
> Grok threads can now drive the existing composer **context-window meter** by emitting **`thread.token-usage.updated`** from ACP session traffic, matching what Codex already had.
> 
> ACP parsing gains a **`UsageUpdated`** path for explicit `usage_update` notifications and for Grok’s live signal: **`session/update` `_meta.totalTokens`** (with window size from `_meta` keys or model metadata). Prompt-response **`_meta.usage.totalTokens`** is intentionally ignored so billed API tokens are not shown as context fill. **`makeAcpTokenUsageEvent`** maps occupancy into the canonical runtime event (positive used tokens only, clamped to max).
> 
> **GrokAdapter** dedupes snapshots, seeds max window from session setup **`availableModels[]._meta.totalContextTokens`**, refreshes on model change, and skips updates for interrupted turns. **CursorAdapter** handles the same **`UsageUpdated`** branch for exhaustiveness. The mock ACP agent can simulate occupancy via **`T3_ACP_EMIT_CONTEXT_USAGE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2087c95f67c8133aac21c34b6157677dfd7057a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context-window usage events for Grok ACP adapter
> - Adds a canonical `makeAcpTokenUsageEvent` factory in [AcpCoreRuntimeEvents.ts](https://github.com/pingdotgg/t3code/pull/9206/files#diff-3d6e2bcae8bdd301c84447b19087bd4fe690da8dacfe492998f40b3e7c30f658) that converts positive usage measurements into `thread.token-usage.updated` events with rounded, maximum-bounded token counts
> - Extends ACP session-update parsing in [AcpRuntimeModel.ts](https://github.com/pingdotgg/t3code/pull/9206/files#diff-eeaad995c832e235bee0e6e8b2c9d7407ebdc0801887ed6a0e947cadbf6ce2b6) to project `usage_update` notifications and `totalTokens` metadata into `UsageUpdated` parsed events
> - Builds a model-to-context-window map from Grok session setup metadata in [GrokAcpSupport.ts](https://github.com/pingdotgg/t3code/pull/9206/files#diff-7753f9dffb0a8ad069a7e71c1fae3be3596c6a535c8a6108711f2c575bca5ac4), resolving window sizes by exact model ID or base model ID
> - `makeGrokAdapter` in [GrokAdapter.ts](https://github.com/pingdotgg/t3code/pull/9206/files#diff-1a00c5b795ace1b6633f05c6d3b900dc8d4778afd1879ebdbdf3fb41d04ed521) now processes `UsageUpdated` notifications, deduplicates snapshots, refreshes the cached window on model change, and emits token-usage events using the event-provided or model-derived window (default 500,000)
> - Risk: `parseSessionUpdateEvent` now emits `UsageUpdated` for any session-update containing `totalTokens` metadata; adapters or consumers that did not expect this event type on session updates need to handle it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2087c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->