### PR TITLE
fix(desktop): reject opaque-origin renderer navigations

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -444,6 +444,24 @@ describe("DesktopWindow", () => {
     assert.isFalse(
       DesktopWindow.isSameOriginRendererNavigation({
         applicationUrl: "t3code://app/",
+        navigationUrl: "t3code://other/",
+      }),
+    );
+    assert.isFalse(
+      DesktopWindow.isSameOriginRendererNavigation({
+        applicationUrl: "t3code://app/",
+        navigationUrl: "file:///etc/passwd",
+      }),
+    );
+    assert.isFalse(
+      DesktopWindow.isSameOriginRendererNavigation({
+        applicationUrl: "t3code://app/",
+        navigationUrl: "vscode://vscode-remote/ssh-remote+host/tmp",
+      }),
+    );
+    assert.isFalse(
+      DesktopWindow.isSameOriginRendererNavigation({
+        applicationUrl: "t3code://app/",
         navigationUrl: "https://accounts.microsoft.com/oauth",
       }),
     );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -185,7 +185,12 @@ export function isSameOriginRendererNavigation(input: {
   readonly navigationUrl: string;
 }): boolean {
   try {
-    return new URL(input.applicationUrl).origin === new URL(input.navigationUrl).origin;
+    const applicationUrl = new URL(input.applicationUrl);
+    const navigationUrl = new URL(input.navigationUrl);
+    return (
+      applicationUrl.protocol === navigationUrl.protocol &&
+      applicationUrl.host === navigationUrl.host
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## What Changed

`isSameOriginRendererNavigation` now compares the parsed URL protocol and host instead of `URL.origin`.

The regression test now covers a different `t3code` host plus `file:` and `vscode:` navigations.

## Why

Node reports `"null"` as the origin for each of these opaque URLs. Comparing those values made unrelated URLs look same-origin, so Electron's `will-navigate` guard could allow them to replace the renderer.

Protocol and host match the authority used by the desktop protocol handler. The comparison still allows routes under `t3code://app/`, while different hosts and schemes fail closed.

## Blast Radius

The helper also gates development load completion and retry eligibility. Existing same-host and retry tests still pass, malformed URLs still return `false`, and the host comparison includes the port. No public contract, UI, or documented workflow changed.

## Verification

Before the production change:

```text
$ ./node_modules/.bin/vp test run apps/desktop/src/window/DesktopWindow.test.ts --reporter verbose
FAIL  DesktopWindow > recognizes only same-origin renderer navigations
AssertionError: expected true to be false
Test Files  1 failed (1)
Tests       1 failed | 25 passed (26)
```

After the production change:

```text
$ ./node_modules/.bin/vp test run apps/desktop/src/window/DesktopWindow.test.ts
Test Files  1 passed (1)
Tests       26 passed (26)
```

- `./node_modules/.bin/vp run --filter @t3tools/desktop typecheck` passed.
- `./node_modules/.bin/vp lint --report-unused-disable-directives apps/desktop/src/window/DesktopWindow.ts apps/desktop/src/window/DesktopWindow.test.ts` passed.
- `./node_modules/.bin/vp fmt --check apps/desktop/src/window/DesktopWindow.ts apps/desktop/src/window/DesktopWindow.test.ts` passed.
- `gpt-daybreak-blue-latest` reviewed the diff against the repo standards and the bug specification. Both reviews passed with no findings.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-5.6. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation security logic in the desktop renderer; incorrect matching could allow or block main-frame loads, though behavior is narrowed to fail closed for opaque origins.
> 
> **Overview**
> **`isSameOriginRendererNavigation`** no longer uses `URL.origin` equality. It now requires matching **protocol** and **host**, so custom-scheme URLs like `t3code://`, `file:`, and `vscode:` are not treated as same-origin when Node reports a null/opaque origin.
> 
> That tightens the Electron **`will-navigate`** guard (and related dev load/retry checks that call the same helper): in-app routes under `t3code://app/` still pass, while different hosts, other schemes, and external HTTPS URLs are blocked or opened externally as before.
> 
> Tests add regressions for `t3code://other/`, `file:///etc/passwd`, and a `vscode://` navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52d19a253aa1f4105fcca79dbbe1ed728479970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isSameOriginRendererNavigation` to reject opaque-origin renderer navigations
> Replaces direct URL-origin comparison in [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/9209/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) with explicit checks of parsed protocols and hosts. Renderer navigations are now rejected when the protocol or host differs from the application URL, including custom-scheme and file URLs. Adds test coverage for different-host, file-URL, and custom-scheme cases in [DesktopWindow.test.ts](https://github.com/pingdotgg/t3code/pull/9209/files#diff-b3e75608c40fd022814266304d4a9f2a00421cc93ba774668be3fad18bc4aa7e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b52d19a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation origin checks so URLs using the same protocol and host are treated consistently, even when their ports differ.
  * Added safeguards to reject navigation to different application paths, local files, and remote connection URLs when they are not same-origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->