### PR TITLE
fix(server): discover project skills for Claude

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -57,6 +57,7 @@ import {
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
 import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
@@ -212,6 +213,17 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
             }),
         ),
       );
+      const snapshotForCwd = (cwd: string) =>
+        !effectiveConfig.enabled
+          ? snapshot.getSnapshot
+          : Effect.all([
+              snapshot.getSnapshot,
+              discoverClaudeSkills(effectiveConfig, cwd, processEnv),
+            ]).pipe(
+              Effect.map(([machineSnapshot, skills]) => ({ ...machineSnapshot, skills })),
+              Effect.provideService(FileSystem.FileSystem, fileSystem),
+              Effect.provideService(Path.Path, path),
+            );
 
       return {
         instanceId,
@@ -224,6 +236,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
+        snapshotForCwd,
         adapter,
         textGeneration,
       } satisfies ProviderInstance;


### PR DESCRIPTION
Closes #6449

## What changed

The Claude driver now exposes `snapshotForCwd`, so the workspace snapshot plumbing that #8778 added for Codex and OpenCode applies to Claude as well. The hook reuses the existing filesystem scanner (`discoverClaudeSkills`) with the thread's working directory and overlays the result on the machine snapshot. Thirteen lines in `ClaudeDriver.ts`, nothing else.

## Why

Claude project skills were scanned from the server's own startup directory (`ServerConfig.cwd`), so a project's `.claude/skills` never reached the `$` picker or the `/` menu. #8778 by @UtkarshUsername built the per-cwd snapshot mechanism (registry, reactor trigger, client resolvers) but only wired Codex and OpenCode into it. This is the minimal follow-up for Claude; no subprocess is needed because the scanner already knows Claude Code's discovery rules, so there is no timeout or error mapping either.

Slash commands stay machine-level, matching the Codex and OpenCode implementations. Related but not fixed here: #8757 (scope label collision when the packaged server cwd is `$HOME`).

Overlaps with #9090 and #9180, which take on more (chip styling, docs, Cursor, Grok, mobile, registry cache changes). This one is offered as the smallest change that closes the Claude gap on its own.

## Surfaces

- Web and desktop: fixed, they already read workspace snapshots.
- Mobile: not covered. It reads the machine-level skills list directly for every provider, so it needs its own change regardless of this PR.

## Verification

- `ClaudeSkills.test.ts` and `ProviderRegistry.test.ts` pass (61 tests).
- Server typecheck and targeted lint clean.
- Manual pass on web over the tailnet: a `.claude/skills/hello-project` skill in a project outside the server cwd appears in the `$` picker after the session starts.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] Screenshots: server-only change, verified manually in the web client

Built with GPT-5.6 Sol in the Codex harness, orchestrated by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small driver-only change reusing existing skill discovery and snapshot overlay pattern; no auth or data-handling changes.
> 
> **Overview**
> **Claude now participates in the per-workspace snapshot path** so project-local `.claude/skills` show up in the client instead of only skills scanned from the server’s startup directory.
> 
> The driver exposes **`snapshotForCwd`**, matching Codex and OpenCode: when the provider is enabled it runs **`getSnapshot`** and **`discoverClaudeSkills`** for the thread’s cwd, then merges the discovered **skills** onto the machine snapshot (with filesystem/path services provided). When disabled it keeps using the plain machine snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a868fcddb4b591aff67ddbe3554f3456c50f788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ClaudeDriver.create` to discover project skills per working directory
> The provider factory now returns an instance with a `snapshotForCwd` function. Enabled instances load the base machine snapshot, run Claude skill discovery scoped to the supplied working directory, and merge discovered skills into the snapshot before returning it. Disabled instances expose the same function but return the existing snapshot without running discovery.
> - Behavioral Change: enabled Claude provider instances now produce cwd-specific snapshots that include newly discovered skills, whereas they previously returned a static snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a868fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->