### PR TITLE
fix(server): release compatible writers before cross-instance resume

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -637,6 +637,116 @@ it.effect("ProviderServiceLive rejects new sessions for disabled custom instance
   }).pipe(Effect.provide(NodeServices.layer)),
 );
 
+it.effect(
+  "ProviderServiceLive releases a compatible Codex writer before resuming on another instance",
+  () =>
+    Effect.gen(function* () {
+      const personalInstanceId = ProviderInstanceId.make("codex_personal");
+      const workInstanceId = ProviderInstanceId.make("codex_work");
+      const personal = makeFakeCodexAdapter();
+      const work = makeFakeCodexAdapter();
+      const workStartSession = work.startSession.getMockImplementation();
+      assert.isDefined(workStartSession);
+      const lifecycle: string[] = [];
+
+      const personalStopSession = personal.stopSession.getMockImplementation();
+      assert.isDefined(personalStopSession);
+      personal.stopSession.mockImplementation((threadId) =>
+        Effect.sync(() => lifecycle.push("personal.stop")).pipe(
+          Effect.andThen(personalStopSession(threadId)),
+        ),
+      );
+      work.startSession.mockImplementation((input) =>
+        Effect.gen(function* () {
+          lifecycle.push("work.start");
+          if (yield* personal.hasSession(input.threadId)) {
+            return yield* Effect.die(
+              new Error(`thread ${String(input.threadId)} already has an active writer`),
+            );
+          }
+          return yield* workStartSession(input);
+        }),
+      );
+
+      const adapters = new Map([
+        [personalInstanceId, personal.adapter],
+        [workInstanceId, work.adapter],
+      ]);
+      const unsupported = () =>
+        new ProviderUnsupportedError({
+          provider: CODEX_DRIVER,
+        });
+      const registry: ProviderAdapterRegistry.ProviderAdapterRegistry["Service"] = {
+        getByInstance: (instanceId) => {
+          const adapter = adapters.get(instanceId);
+          return adapter ? Effect.succeed(adapter) : Effect.fail(unsupported());
+        },
+        getInstanceInfo: (instanceId) =>
+          adapters.has(instanceId)
+            ? Effect.succeed({
+                instanceId,
+                driverKind: CODEX_DRIVER,
+                displayName: undefined,
+                enabled: true,
+                continuationIdentity: {
+                  driverKind: CODEX_DRIVER,
+                  continuationKey: "codex:home:/shared-codex",
+                },
+              })
+            : Effect.fail(unsupported()),
+        listInstances: () => Effect.succeed(Array.from(adapters.keys())),
+        subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
+          PubSub.subscribe(pubsub),
+        ),
+      };
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const providerLayer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(serverConfigTestLayer),
+        Layer.provide(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      );
+
+      yield* Effect.gen(function* () {
+        const provider = yield* ProviderService.ProviderService;
+        const threadId = asThreadId("thread-compatible-codex-writer");
+        const initial = yield* provider.startSession(threadId, {
+          provider: CODEX_DRIVER,
+          providerInstanceId: personalInstanceId,
+          threadId,
+          runtimeMode: "full-access",
+        });
+
+        lifecycle.length = 0;
+        const resumed = yield* provider.startSession(threadId, {
+          provider: CODEX_DRIVER,
+          providerInstanceId: workInstanceId,
+          threadId,
+          runtimeMode: "full-access",
+        });
+
+        assert.equal(resumed.providerInstanceId, workInstanceId);
+        assert.deepEqual(resumed.resumeCursor, initial.resumeCursor);
+        assert.deepEqual(work.startSession.mock.calls[0]?.[0].resumeCursor, initial.resumeCursor);
+        assert.deepEqual(lifecycle, ["personal.stop", "work.start"]);
+        assert.equal(yield* personal.hasSession(threadId), false);
+        assert.equal(yield* work.hasSession(threadId), true);
+      }).pipe(Effect.provide(providerLayer));
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
+
 const routing = makeProviderServiceLayer();
 
 it.effect(

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -620,33 +620,60 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           );
         }
         const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        const previousInstanceId = persistedBinding?.providerInstanceId;
+        const previousInfo =
+          previousInstanceId === undefined
+            ? undefined
+            : previousInstanceId === resolvedInstanceId
+              ? instanceInfo
+              : Option.getOrUndefined(
+                  yield* registry.getInstanceInfo(previousInstanceId).pipe(Effect.option),
+                );
+        const persistedContinuationCompatible =
+          previousInfo?.driverKind === instanceInfo.driverKind &&
+          previousInfo.continuationIdentity.continuationKey ===
+            instanceInfo.continuationIdentity.continuationKey;
         const effectiveResumeCursor =
           input.resumeCursor ??
-          (persistedBinding?.providerInstanceId === resolvedInstanceId
-            ? persistedBinding.resumeCursor
-            : undefined);
+          (persistedContinuationCompatible ? persistedBinding?.resumeCursor : undefined);
         const effectiveCwd =
           input.cwd ??
-          (persistedBinding?.providerInstanceId === resolvedInstanceId
+          (persistedContinuationCompatible && persistedBinding
             ? readPersistedCwd(persistedBinding.runtimePayload)
             : undefined);
+        if (
+          effectiveResumeCursor !== undefined &&
+          previousInstanceId !== undefined &&
+          previousInstanceId !== resolvedInstanceId &&
+          persistedContinuationCompatible
+        ) {
+          const previousAdapter = yield* registry.getByInstance(previousInstanceId);
+          if (yield* previousAdapter.hasSession(threadId)) {
+            yield* Effect.logInfo(
+              "provider session releasing compatible stale writer before resume",
+              {
+                threadId,
+                previousInstanceId,
+                resolvedInstanceId,
+              },
+            );
+            yield* previousAdapter.stopSession(threadId);
+            yield* analytics.record("provider.session.stopped", {
+              provider: previousAdapter.provider,
+            });
+          }
+        }
         yield* Effect.annotateCurrentSpan({
           "provider.kind": resolvedProvider,
           "provider.resume_cursor.source":
             input.resumeCursor !== undefined
               ? "request"
-              : effectiveResumeCursor !== undefined &&
-                  persistedBinding?.providerInstanceId === resolvedInstanceId
+              : effectiveResumeCursor !== undefined
                 ? "persisted"
                 : "none",
           "provider.resume_cursor.present": effectiveResumeCursor !== undefined,
           "provider.cwd.source":
-            input.cwd !== undefined
-              ? "request"
-              : effectiveCwd !== undefined &&
-                  persistedBinding?.providerInstanceId === resolvedInstanceId
-                ? "persisted"
-                : "none",
+            input.cwd !== undefined ? "request" : effectiveCwd !== undefined ? "persisted" : "none",
           "provider.cwd.effective": effectiveCwd ?? "",
         });
         const adapter = yield* registry.getByInstance(resolvedInstanceId);


### PR DESCRIPTION
## What Changed

When resuming a thread on another compatible Codex provider instance, T3 Code now:

- reuses the persisted resume cursor
- stops the previous provider session before starting the replacement
- preserves the existing Codex thread and its context

Added a regression test covering account switching while the original session still owns the Codex thread.

## Why

Codex allows only one active writer per thread. T3 Code previously started the replacement session before stopping the original one, causing an `already has an active writer` error. A retry could then create a fresh Codex thread and lose the conversation context.

Compatible provider instances share the same continuation identity, so releasing the previous writer before resuming is safe and keeps the thread intact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
- [x] No animation or interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release compatible writers before cross-instance resume in `ProviderService.startSession`
> Allows a persisted session to resume on a different compatible provider instance by matching on driver kind and continuation identity rather than requiring identical instance IDs.
> - When resuming with a persisted cursor across instances, retrieves the previous adapter, checks whether it still owns the thread, stops that session, and records a session-stopped analytics event before starting the new instance.
> - Preserves the resume cursor and working directory for compatible cross-instance resumes.
> - Adds an integration test in [ProviderService.test.ts](https://github.com/pingdotgg/t3code/pull/9211/files#diff-cbac8cf0b9c33ddbfff2137001d4b9ef6d645a0b205efcf6c714b12efab70f14) using two fake Codex adapters to verify the personal session is stopped before the work session starts.
> - Risk: cross-instance resume now depends on correct compatibility detection via `driverKind` and continuation identity; a false positive could stop a live session on the wrong adapter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7bc29b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->