### PR TITLE
feat(sidebar): group threads by environment

### DIFF
--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -228,6 +228,7 @@ export function HomeRouteScreen() {
           onThreadSortOrderChange={setThreadSortOrder}
           pendingTasks={pendingTasks}
           projectGroupingMode={listOptions.projectGroupingMode}
+          environmentGroupingEnabled={listOptions.environmentGroupingEnabled}
           projects={projects}
           projectSortOrder={listOptions.projectSortOrder}
           savedConnectionsById={savedConnectionsById}

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -83,17 +83,33 @@ export function HomeRouteScreen() {
   } = useHomeListOptions(availableEnvironmentIds);
   const selectedEnvironmentId = listOptions.selectedEnvironmentId;
   const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
+  const environmentLabelById = useMemo(
+    () =>
+      new Map(environments.map((environment) => [environment.environmentId, environment.label])),
+    [environments],
+  );
   const projectFilterOptions = useMemo(
     () =>
       buildHomeProjectScopes({
         projects,
         environmentId: selectedEnvironmentId,
         projectGroupingMode: listOptions.projectGroupingMode,
+        environmentGroupingEnabled:
+          listOptions.environmentGroupingEnabled && selectedEnvironmentId === null,
       }).map((scope) => ({
         key: scope.key,
-        label: scope.title,
+        label:
+          listOptions.environmentGroupingEnabled && selectedEnvironmentId === null
+            ? `${scope.title} · ${environmentLabelById.get(scope.representative.environmentId) ?? "Unknown environment"}`
+            : scope.title,
       })),
-    [listOptions.projectGroupingMode, projects, selectedEnvironmentId],
+    [
+      environmentLabelById,
+      listOptions.environmentGroupingEnabled,
+      listOptions.projectGroupingMode,
+      projects,
+      selectedEnvironmentId,
+    ],
   );
   useEffect(() => {
     if (

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -91,6 +91,7 @@ interface HomeScreenProps {
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
   readonly projectGroupingMode: SidebarProjectGroupingMode;
+  readonly environmentGroupingEnabled: boolean;
   readonly onSearchQueryChange: (query: string) => void;
   readonly onEnvironmentChange: (environmentId: EnvironmentId | null) => void;
   readonly onProjectChange: (projectKey: string | null) => void;
@@ -378,9 +379,12 @@ export function HomeScreen(props: HomeScreenProps) {
         projectSortOrder: props.projectSortOrder,
         threadSortOrder: props.threadSortOrder,
         projectGroupingMode: props.projectGroupingMode,
+        environmentGroupingEnabled:
+          props.environmentGroupingEnabled && props.selectedEnvironmentId === null,
       }),
     [
       props.projectGroupingMode,
+      props.environmentGroupingEnabled,
       props.projectSortOrder,
       props.searchQuery,
       props.selectedEnvironmentId,
@@ -399,8 +403,24 @@ export function HomeScreen(props: HomeScreenProps) {
         groups: projectGroups,
         displayStates: effectiveGroupDisplayStates,
         showAllThreads: hasSearchQuery,
+        environmentLabelById:
+          props.environmentGroupingEnabled && props.selectedEnvironmentId === null
+            ? new Map(
+                props.environments.map((environment) => [
+                  String(environment.environmentId),
+                  environment.label,
+                ]),
+              )
+            : undefined,
       }),
-    [projectGroups, effectiveGroupDisplayStates, hasSearchQuery],
+    [
+      effectiveGroupDisplayStates,
+      hasSearchQuery,
+      projectGroups,
+      props.environmentGroupingEnabled,
+      props.environments,
+      props.selectedEnvironmentId,
+    ],
   );
 
   const projectCwdByKey = useMemo(() => {
@@ -910,6 +930,13 @@ export function HomeScreen(props: HomeScreenProps) {
   const renderItem = useCallback(
     ({ item }: LegendListRenderItemProps<HomeListItem>) => {
       switch (item.type) {
+        case "environment-header":
+          return (
+            <View className="mx-4 mt-4 flex-row items-center gap-2">
+              <Text className="text-xs font-t3-medium text-foreground-muted">{item.label}</Text>
+              <View className="h-px flex-1 bg-border-subtle" />
+            </View>
+          );
         case "header":
           return (
             <ThreadListGroupHeader

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -308,8 +308,15 @@ export function HomeScreen(props: HomeScreenProps) {
         projects: props.projects,
         environmentId: props.selectedEnvironmentId,
         projectGroupingMode: props.projectGroupingMode,
+        environmentGroupingEnabled:
+          props.environmentGroupingEnabled && props.selectedEnvironmentId === null,
       }),
-    [props.projectGroupingMode, props.projects, props.selectedEnvironmentId],
+    [
+      props.environmentGroupingEnabled,
+      props.projectGroupingMode,
+      props.projects,
+      props.selectedEnvironmentId,
+    ],
   );
   const selectedProjectScope = useMemo(
     () =>

--- a/apps/mobile/src/features/home/home-list-options.ts
+++ b/apps/mobile/src/features/home/home-list-options.ts
@@ -29,6 +29,7 @@ export interface HomeListOptions {
 
 export interface ResolvedHomeListOptions extends HomeListOptions {
   readonly projectGroupingMode: SidebarProjectGroupingMode;
+  readonly environmentGroupingEnabled: boolean;
 }
 
 export const PROJECT_SORT_OPTIONS: ReadonlyArray<{
@@ -62,6 +63,7 @@ interface HomeListOptionsContextValue {
   readonly options: HomeListOptions;
   readonly setOptions: Dispatch<SetStateAction<HomeListOptions>>;
   readonly projectGroupingMode: SidebarProjectGroupingMode;
+  readonly environmentGroupingEnabled: boolean;
 }
 
 const HomeListOptionsContext = createContext<HomeListOptionsContextValue | null>(null);
@@ -70,13 +72,15 @@ const HomeListOptionsContext = createContext<HomeListOptionsContextValue | null>
 export function HomeListOptionsProvider({
   children,
   projectGroupingMode,
+  environmentGroupingEnabled,
 }: PropsWithChildren<{
   readonly projectGroupingMode: SidebarProjectGroupingMode;
+  readonly environmentGroupingEnabled: boolean;
 }>) {
   const [options, setOptions] = useState<HomeListOptions>(defaultHomeListOptions);
   const value = useMemo(
-    () => ({ options, setOptions, projectGroupingMode }),
-    [options, projectGroupingMode],
+    () => ({ options, setOptions, projectGroupingMode, environmentGroupingEnabled }),
+    [environmentGroupingEnabled, options, projectGroupingMode],
   );
   return createElement(HomeListOptionsContext, { value }, children);
 }
@@ -115,6 +119,7 @@ export function useHomeListOptions(availableEnvironmentIds: ReadonlySet<Environm
   const resolvedOptions: ResolvedHomeListOptions = {
     ...availableOptions,
     projectGroupingMode: shared?.projectGroupingMode ?? "repository",
+    environmentGroupingEnabled: shared?.environmentGroupingEnabled ?? false,
   };
 
   const setSelectedEnvironmentId = useCallback((value: EnvironmentId | null) => {

--- a/apps/mobile/src/features/home/homeListItems.test.ts
+++ b/apps/mobile/src/features/home/homeListItems.test.ts
@@ -87,6 +87,43 @@ function displayStates(
 }
 
 describe("buildHomeListLayout", () => {
+  it("adds an environment header before each environment's project groups", () => {
+    const local = makeGroup("local", 1);
+    const remoteEnvironmentId = EnvironmentId.make("environment-2");
+    const remoteProject = {
+      ...makeProject("remote", "remote"),
+      environmentId: remoteEnvironmentId,
+    };
+    const remote = {
+      ...makeGroup("remote", 1),
+      representative: remoteProject,
+      projects: [remoteProject],
+      newThreadTarget: remoteProject,
+    };
+
+    const layout = buildHomeListLayout({
+      groups: [local, remote],
+      displayStates: displayStates({}),
+      environmentLabelById: new Map([
+        [String(environmentId), "MacBook Pro"],
+        [String(remoteEnvironmentId), "Linux VM"],
+      ]),
+    });
+
+    expect(layout.items.filter((item) => item.type === "environment-header")).toEqual([
+      {
+        type: "environment-header",
+        key: `environment-header:${environmentId}`,
+        label: "MacBook Pro",
+      },
+      {
+        type: "environment-header",
+        key: `environment-header:${remoteEnvironmentId}`,
+        label: "Linux VM",
+      },
+    ]);
+  });
+
   it("renders a header plus all threads for a small group without a show-more row", () => {
     const layout = buildHomeListLayout({
       groups: [makeGroup("alpha", 3)],

--- a/apps/mobile/src/features/home/homeListItems.ts
+++ b/apps/mobile/src/features/home/homeListItems.ts
@@ -27,6 +27,12 @@ export interface HomeHeaderListItem {
   readonly isFirst: boolean;
 }
 
+export interface HomeEnvironmentHeaderListItem {
+  readonly type: "environment-header";
+  readonly key: string;
+  readonly label: string;
+}
+
 export interface HomeThreadListItem {
   readonly type: "thread";
   readonly key: string;
@@ -52,6 +58,7 @@ export interface HomeShowMoreListItem {
 }
 
 export type HomeListItem =
+  | HomeEnvironmentHeaderListItem
   | HomeHeaderListItem
   | HomePendingTaskListItem
   | HomeThreadListItem
@@ -87,6 +94,8 @@ export function nextGroupDisplayState(
  */
 export function homeListItemsAreEqual(previous: HomeListItem, item: HomeListItem): boolean {
   switch (item.type) {
+    case "environment-header":
+      return previous.type === "environment-header" && previous.label === item.label;
     case "header":
       return (
         previous.type === "header" &&
@@ -123,11 +132,24 @@ export function buildHomeListLayout(input: {
    * When searching, pagination is suspended so every match stays visible.
    */
   readonly showAllThreads?: boolean;
+  readonly environmentLabelById?: ReadonlyMap<string, string>;
 }): HomeListLayout {
   const items: HomeListItem[] = [];
   const stickyHeaderIndices: number[] = [];
 
+  let previousEnvironmentId: string | null = null;
   for (const [groupIndex, group] of input.groups.entries()) {
+    const environmentId = String(group.representative.environmentId);
+    const environmentLabel = input.environmentLabelById?.get(environmentId);
+    const startsEnvironment = Boolean(environmentLabel && environmentId !== previousEnvironmentId);
+    if (environmentLabel && startsEnvironment) {
+      items.push({
+        type: "environment-header",
+        key: `environment-header:${environmentId}`,
+        label: environmentLabel,
+      });
+      previousEnvironmentId = environmentId;
+    }
     const display = input.displayStates.get(group.key) ?? DEFAULT_GROUP_DISPLAY_STATE;
     const collapsed = display.collapsed && input.showAllThreads !== true;
 
@@ -137,7 +159,7 @@ export function buildHomeListLayout(input: {
       key: `header:${group.key}`,
       group,
       collapsed,
-      isFirst: groupIndex === 0,
+      isFirst: groupIndex === 0 || startsEnvironment,
     });
 
     if (collapsed) {

--- a/apps/mobile/src/features/home/homeThreadList.test.ts
+++ b/apps/mobile/src/features/home/homeThreadList.test.ts
@@ -115,6 +115,44 @@ describe("buildHomeThreadGroups", () => {
     );
   });
 
+  it("keeps matching repositories in separate environment sections", () => {
+    const localEnvironmentId = EnvironmentId.make("environment-local");
+    const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+    const repositoryIdentity = {
+      canonicalKey: "github.com/pingdotgg/t3code",
+      locator: {
+        source: "git-remote" as const,
+        remoteName: "origin",
+        remoteUrl: "git@github.com:pingdotgg/t3code.git",
+      },
+    };
+    const projects = [
+      makeProject({
+        environmentId: localEnvironmentId,
+        id: ProjectId.make("project-local"),
+        title: "t3code",
+        repositoryIdentity,
+      }),
+      makeProject({
+        environmentId: remoteEnvironmentId,
+        id: ProjectId.make("project-remote"),
+        title: "t3code",
+        repositoryIdentity,
+      }),
+    ];
+
+    const scopes = buildHomeProjectScopes({
+      projects,
+      environmentId: null,
+      projectGroupingMode: "repository",
+      environmentGroupingEnabled: true,
+    });
+
+    expect(scopes).toHaveLength(2);
+    expect(scopes.map((scope) => scope.projects)).toEqual([[projects[0]], [projects[1]]]);
+    expect(new Set(scopes.map((scope) => scope.key)).size).toBe(2);
+  });
+
   it("routes stale duplicate project refs through the canonical repository group", () => {
     const localEnvironmentId = EnvironmentId.make("environment-local");
     const remoteEnvironmentId = EnvironmentId.make("environment-remote");

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -52,25 +52,40 @@ export function buildHomeProjectScopes(input: {
   readonly projects: ReadonlyArray<EnvironmentProject>;
   readonly environmentId: EnvironmentId | null;
   readonly projectGroupingMode: SidebarProjectGroupingMode;
+  readonly environmentGroupingEnabled?: boolean;
 }): ReadonlyArray<HomeProjectScope> {
   const projects = input.projects.filter(
     (project) => input.environmentId === null || project.environmentId === input.environmentId,
   );
-  return buildProjectGroups({
-    projects,
-    settings: {
-      sidebarProjectGroupingMode: input.projectGroupingMode,
-      sidebarProjectGroupingOverrides: {},
-    },
-  }).map((group) => {
-    return {
-      key: group.key,
+  const projectsByEnvironment = new Map<EnvironmentId, EnvironmentProject[]>();
+  if (input.environmentGroupingEnabled) {
+    for (const project of projects) {
+      const environmentProjects = projectsByEnvironment.get(project.environmentId);
+      if (environmentProjects) {
+        environmentProjects.push(project);
+      } else {
+        projectsByEnvironment.set(project.environmentId, [project]);
+      }
+    }
+  }
+  const projectSets = input.environmentGroupingEnabled
+    ? [...projectsByEnvironment]
+    : ([[null, projects]] as const);
+  return projectSets.flatMap(([environmentId, environmentProjects]) =>
+    buildProjectGroups({
+      projects: environmentProjects,
+      settings: {
+        sidebarProjectGroupingMode: input.projectGroupingMode,
+        sidebarProjectGroupingOverrides: {},
+      },
+    }).map((group) => ({
+      key: environmentId === null ? group.key : JSON.stringify([environmentId, group.key]),
       title: group.label,
       representative: group.representative,
       projects: group.members.map((member) => member.project),
       projectRefs: group.memberProjectRefs,
-    };
-  });
+    })),
+  );
 }
 
 export function sortHomeProjectScopes(input: {
@@ -210,6 +225,7 @@ export function buildHomeThreadGroups(input: {
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
   readonly projectGroupingMode: SidebarProjectGroupingMode;
+  readonly environmentGroupingEnabled?: boolean;
   /** Current time used for the recency window; defaults to now. Injectable for tests. */
   readonly now?: number;
 }): ReadonlyArray<HomeThreadGroup> {
@@ -369,7 +385,7 @@ export function buildHomeThreadGroups(input: {
     });
   }
 
-  return Arr.sort(
+  const sortedGroups = Arr.sort(
     result,
     Order.mapInput(
       Order.Struct({
@@ -384,4 +400,18 @@ export function buildHomeThreadGroups(input: {
       }),
     ),
   );
+  if (!input.environmentGroupingEnabled) {
+    return sortedGroups;
+  }
+
+  const groupsByEnvironment = new Map<EnvironmentId, HomeThreadGroup[]>();
+  for (const group of sortedGroups) {
+    const environmentGroups = groupsByEnvironment.get(group.representative.environmentId);
+    if (environmentGroups) {
+      environmentGroups.push(group);
+    } else {
+      groupsByEnvironment.set(group.representative.environmentId, [group]);
+    }
+  }
+  return [...groupsByEnvironment.values()].flat();
 }

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -198,6 +198,7 @@ export function AdaptiveWorkspaceLayout(props: {
       <AdaptiveWorkspaceLayoutContent
         {...props}
         projectGroupingMode={DEFAULT_MOBILE_PROJECT_GROUPING_SETTINGS.sidebarProjectGroupingMode}
+        environmentGroupingEnabled={false}
       />
     ) : null;
   }
@@ -206,6 +207,7 @@ export function AdaptiveWorkspaceLayout(props: {
     <AdaptiveWorkspaceLayoutContent
       {...props}
       projectGroupingMode={groupingSettings.sidebarProjectGroupingMode}
+      environmentGroupingEnabled={preferencesResult.value.environmentGroupingEnabled ?? false}
     />
   );
 }
@@ -216,6 +218,7 @@ function AdaptiveWorkspaceLayoutContent(
     readonly pathname: string;
   } & {
     readonly projectGroupingMode: SidebarProjectGroupingMode;
+    readonly environmentGroupingEnabled: boolean;
   },
 ) {
   const projectGroupingMode = props.projectGroupingMode;
@@ -519,7 +522,10 @@ function AdaptiveWorkspaceLayoutContent(
   );
 
   return (
-    <HomeListOptionsProvider projectGroupingMode={projectGroupingMode}>
+    <HomeListOptionsProvider
+      projectGroupingMode={projectGroupingMode}
+      environmentGroupingEnabled={props.environmentGroupingEnabled}
+    >
       <AdaptiveWorkspaceContext.Provider value={contextValue}>
         <View testID="adaptive-workspace-layout" className="flex-1 flex-row">
           {shouldRenderPrimarySidebar && layout.listPaneWidth !== null ? (

--- a/apps/mobile/src/features/settings/SettingsProjectGroupingRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsProjectGroupingRouteScreen.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../state/project-grouping";
 import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
 import { SettingsSection } from "./components/SettingsSection";
+import { SettingsSwitchRow } from "./components/SettingsSwitchRow";
 
 const GROUPING_OPTIONS: ReadonlyArray<{
   readonly mode: SidebarProjectGroupingMode;
@@ -47,6 +48,9 @@ export function SettingsProjectGroupingRouteScreen() {
   const selectedMode = AsyncResult.isSuccess(preferencesResult)
     ? resolveMobileProjectGroupingSettings(preferencesResult.value).sidebarProjectGroupingMode
     : null;
+  const environmentGroupingEnabled = AsyncResult.isSuccess(preferencesResult)
+    ? (preferencesResult.value.environmentGroupingEnabled ?? false)
+    : false;
 
   return (
     <View collapsable={false} className="flex-1 bg-sheet">
@@ -63,6 +67,16 @@ export function SettingsProjectGroupingRouteScreen() {
         contentContainerClassName="gap-3 px-5 pt-4"
         contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 18) + 18 }}
       >
+        <SettingsSection title="Environment sections">
+          <SettingsSwitchRow
+            disabled={!preferencesReady}
+            icon="desktopcomputer"
+            label="Group by environment"
+            subtitle="Show environments above project groups in the legacy thread list."
+            value={environmentGroupingEnabled}
+            onValueChange={(value) => savePreferences({ environmentGroupingEnabled: value })}
+          />
+        </SettingsSection>
         <SettingsSection title="Default grouping">
           {GROUPING_OPTIONS.map((option, index) => (
             <Pressable

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -308,6 +308,8 @@ function ThreadNavigationSidebarPane(
         projectSortOrder: options.projectSortOrder,
         threadSortOrder: options.threadSortOrder,
         projectGroupingMode: options.projectGroupingMode,
+        environmentGroupingEnabled:
+          options.environmentGroupingEnabled && options.selectedEnvironmentId === null,
       }),
     [
       matchedThreadKeys,
@@ -338,8 +340,24 @@ function ThreadNavigationSidebarPane(
         groups,
         displayStates: groupDisplayStates,
         showAllThreads: hasSearchQuery,
+        environmentLabelById:
+          options.environmentGroupingEnabled && options.selectedEnvironmentId === null
+            ? new Map(
+                environments.map((environment) => [
+                  String(environment.environmentId),
+                  environment.label,
+                ]),
+              )
+            : undefined,
       }),
-    [groups, groupDisplayStates, hasSearchQuery],
+    [
+      environments,
+      groupDisplayStates,
+      groups,
+      hasSearchQuery,
+      options.environmentGroupingEnabled,
+      options.selectedEnvironmentId,
+    ],
   );
   const projectCwdByKey = useMemo(() => {
     const map = new Map<string, string>();
@@ -803,6 +821,13 @@ function ThreadNavigationSidebarPane(
   const renderListItem = useCallback(
     ({ item }: { readonly item: SidebarListItem }) => {
       switch (item.type) {
+        case "environment-header":
+          return (
+            <View className="mx-4 mt-4 flex-row items-center gap-2">
+              <Text className="text-xs font-t3-medium text-foreground-muted">{item.label}</Text>
+              <View className="h-px flex-1 bg-border-subtle" />
+            </View>
+          );
         case "v2-pending": {
           const pendingScopeKey = scopedProjectKey(
             item.pendingTask.message.environmentId,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -215,16 +215,31 @@ function ThreadNavigationSidebarPane(
         projects,
         environmentId: options.selectedEnvironmentId,
         projectGroupingMode: options.projectGroupingMode,
+        environmentGroupingEnabled:
+          options.environmentGroupingEnabled && options.selectedEnvironmentId === null,
       }),
-    [options.projectGroupingMode, options.selectedEnvironmentId, projects],
+    [
+      options.environmentGroupingEnabled,
+      options.projectGroupingMode,
+      options.selectedEnvironmentId,
+      projects,
+    ],
   );
   const projectFilterOptions = useMemo(
     () =>
       projectScopes.map((scope) => ({
         key: scope.key,
-        label: scope.title,
+        label:
+          options.environmentGroupingEnabled && options.selectedEnvironmentId === null
+            ? `${scope.title} · ${environments.find((environment) => environment.environmentId === scope.representative.environmentId)?.label ?? "Unknown environment"}`
+            : scope.title,
       })),
-    [projectScopes],
+    [
+      environments,
+      options.environmentGroupingEnabled,
+      options.selectedEnvironmentId,
+      projectScopes,
+    ],
   );
   const projectTitleByProjectKey = useMemo(
     () =>

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -31,6 +31,7 @@ export interface Preferences {
   /** @deprecated Kept temporarily so older OTA bundles retain the selected mode. */
   readonly projectGroupingEnabled?: boolean;
   readonly projectGroupingMode?: SidebarProjectGroupingMode;
+  readonly environmentGroupingEnabled?: boolean;
   /**
    * Device-local mirror of the web `legacySidebarEnabled` setting. Mobile has
    * no client-settings sync, so the legacy grouped thread list is opted into
@@ -100,6 +101,7 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     collapsedProjectGroups?: readonly string[];
     projectGroupingEnabled?: boolean;
     projectGroupingMode?: SidebarProjectGroupingMode;
+    environmentGroupingEnabled?: boolean;
     legacyThreadListEnabled?: boolean;
     planModeEnabled?: boolean;
     threadListV2SettledShelfExpanded?: boolean;
@@ -164,6 +166,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     parsed.projectGroupingMode === "separate"
   ) {
     preferences.projectGroupingMode = parsed.projectGroupingMode;
+  }
+  if (typeof parsed.environmentGroupingEnabled === "boolean") {
+    preferences.environmentGroupingEnabled = parsed.environmentGroupingEnabled;
   }
   if (typeof parsed.legacyThreadListEnabled === "boolean") {
     preferences.legacyThreadListEnabled = parsed.legacyThreadListEnabled;

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -205,8 +205,7 @@ import {
 } from "../logicalProject";
 import type { SidebarThreadSummary } from "../types";
 import {
-  buildPhysicalToLogicalProjectKeyMap,
-  buildSidebarProjectSnapshots,
+  buildSidebarProjectGrouping,
   type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
@@ -2650,6 +2649,7 @@ type SortableProjectHandleProps = Pick<
 
 function ProjectSortMenu({
   projectSortOrder,
+  environmentGroupingEnabled,
   threadSortOrder,
   threadPreviewCount,
   onProjectSortOrderChange,
@@ -2657,6 +2657,7 @@ function ProjectSortMenu({
   onThreadPreviewCountChange,
 }: {
   projectSortOrder: SidebarProjectSortOrder;
+  environmentGroupingEnabled: boolean;
   threadSortOrder: SidebarThreadSortOrder;
   threadPreviewCount: SidebarThreadPreviewCount;
   onProjectSortOrderChange: (sortOrder: SidebarProjectSortOrder) => void;
@@ -2702,8 +2703,15 @@ function ProjectSortMenu({
           >
             {(Object.entries(SIDEBAR_SORT_LABELS) as Array<[SidebarProjectSortOrder, string]>).map(
               ([value, label]) => (
-                <MenuRadioItem key={value} value={value} className="min-h-7 py-1 sm:text-xs">
-                  {label}
+                <MenuRadioItem
+                  key={value}
+                  value={value}
+                  disabled={environmentGroupingEnabled && value === "manual"}
+                  className="min-h-7 py-1 sm:text-xs"
+                >
+                  {environmentGroupingEnabled && value === "manual"
+                    ? "Manual (unavailable with environment grouping)"
+                    : label}
                 </MenuRadioItem>
               ),
             )}
@@ -2828,6 +2836,8 @@ interface SidebarProjectsContentProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
+  environmentGroupingEnabled: boolean;
+  environmentLabelById: ReadonlyMap<string, string>;
   expandedThreadListsByProject: ReadonlySet<string>;
   activeRouteProjectKey: string | null;
   routeThreadKey: string | null;
@@ -2870,6 +2880,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     archiveThread,
     deleteThread,
     sortedProjects,
+    environmentGroupingEnabled,
+    environmentLabelById,
     expandedThreadListsByProject,
     activeRouteProjectKey,
     routeThreadKey,
@@ -2905,6 +2917,26 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     },
     [updateSettings],
   );
+  const projectSections = useMemo(() => {
+    if (!environmentGroupingEnabled) {
+      return [{ environmentId: null, label: null, projects: sortedProjects }] as const;
+    }
+
+    const projectsByEnvironment = new Map<string, SidebarProjectSnapshot[]>();
+    for (const project of sortedProjects) {
+      const projects = projectsByEnvironment.get(project.environmentId);
+      if (projects) {
+        projects.push(project);
+      } else {
+        projectsByEnvironment.set(project.environmentId, [project]);
+      }
+    }
+    return [...projectsByEnvironment].map(([environmentId, projects]) => ({
+      environmentId,
+      label: environmentLabelById.get(environmentId) ?? "Unknown environment",
+      projects,
+    }));
+  }, [environmentGroupingEnabled, environmentLabelById, sortedProjects]);
 
   return (
     <SidebarContent
@@ -2966,6 +2998,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           <div className="flex items-center gap-1">
             <ProjectSortMenu
               projectSortOrder={projectSortOrder}
+              environmentGroupingEnabled={environmentGroupingEnabled}
               threadSortOrder={threadSortOrder}
               threadPreviewCount={threadPreviewCount}
               onProjectSortOrderChange={handleProjectSortOrderChange}
@@ -2992,7 +3025,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </div>
         </div>
 
-        {isManualProjectSorting ? (
+        {isManualProjectSorting && !environmentGroupingEnabled ? (
           <DndContext
             sensors={projectDnDSensors}
             collisionDetection={projectCollisionDetection}
@@ -3040,30 +3073,43 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </DndContext>
         ) : (
           <SidebarMenu ref={attachProjectListAutoAnimateRef}>
-            {sortedProjects.map((project) => (
-              <SidebarProjectListRow
-                key={project.projectKey}
-                project={project}
-                isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
-                activeRouteThreadKey={
-                  activeRouteProjectKey === project.projectKey ? routeThreadKey : null
-                }
-                openPullRequestsInRightPanel={openPullRequestsInRightPanel}
-                newThreadShortcutLabel={newThreadShortcutLabel}
-                handleNewThread={handleNewThread}
-                archiveThread={archiveThread}
-                deleteThread={deleteThread}
-                threadJumpLabelByKey={threadJumpLabelByKey}
-                attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
-                expandThreadListForProject={expandThreadListForProject}
-                collapseThreadListForProject={collapseThreadListForProject}
-                dragInProgressRef={dragInProgressRef}
-                suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
-                suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
-                isManualProjectSorting={isManualProjectSorting}
-                dragHandleProps={null}
-              />
-            ))}
+            {projectSections.flatMap((section) => [
+              section.label ? (
+                <li
+                  key={`environment:${section.environmentId}`}
+                  className="mb-1 mt-3 flex items-center gap-2 px-2 first:mt-0"
+                >
+                  <span className="min-w-0 truncate text-xs font-medium text-sidebar-muted-foreground/80">
+                    {section.label}
+                  </span>
+                  <span className="h-px flex-1 bg-sidebar-border/60" />
+                </li>
+              ) : null,
+              ...section.projects.map((project) => (
+                <SidebarProjectListRow
+                  key={project.projectKey}
+                  project={project}
+                  isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
+                  activeRouteThreadKey={
+                    activeRouteProjectKey === project.projectKey ? routeThreadKey : null
+                  }
+                  openPullRequestsInRightPanel={openPullRequestsInRightPanel}
+                  newThreadShortcutLabel={newThreadShortcutLabel}
+                  handleNewThread={handleNewThread}
+                  archiveThread={archiveThread}
+                  deleteThread={deleteThread}
+                  threadJumpLabelByKey={threadJumpLabelByKey}
+                  attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
+                  expandThreadListForProject={expandThreadListForProject}
+                  collapseThreadListForProject={collapseThreadListForProject}
+                  dragInProgressRef={dragInProgressRef}
+                  suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
+                  suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
+                  isManualProjectSorting={isManualProjectSorting}
+                  dragHandleProps={null}
+                />
+              )),
+            ])}
           </SidebarMenu>
         )}
 
@@ -3085,6 +3131,9 @@ export default function LegacySidebar() {
   const sidebarThreadSortOrder = useClientSettings((s) => s.sidebarThreadSortOrder);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const sidebarEnvironmentGroupingEnabled = useClientSettings(
+    (s) => s.sidebarEnvironmentGroupingEnabled,
+  );
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
   const updateSettings = useUpdateClientSettings();
   const handleNewThread = useNewThreadHandler();
@@ -3159,13 +3208,24 @@ export default function LegacySidebar() {
   // Build a mapping from physical project key → logical project key for
   // cross-environment grouping.  Projects that share a repositoryIdentity
   // canonicalKey are treated as one logical project in the sidebar.
-  const physicalToLogicalKey = useMemo(() => {
-    return buildPhysicalToLogicalProjectKeyMap({
+  const sidebarProjectGrouping = useMemo(() => {
+    return buildSidebarProjectGrouping({
       projects: orderedProjects,
       settings: projectGroupingSettings,
       primaryEnvironmentId,
+      resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
+      isDesktopLocalEnvironment: (environmentId) => desktopLocalEnvironmentIds.has(environmentId),
+      groupByEnvironment: sidebarEnvironmentGroupingEnabled,
     });
-  }, [orderedProjects, projectGroupingSettings, primaryEnvironmentId]);
+  }, [
+    desktopLocalEnvironmentIds,
+    environmentLabelById,
+    orderedProjects,
+    primaryEnvironmentId,
+    projectGroupingSettings,
+    sidebarEnvironmentGroupingEnabled,
+  ]);
+  const physicalToLogicalKey = sidebarProjectGrouping.physicalToLogicalKey;
   const projectPhysicalKeyByScopedRef = useMemo(
     () =>
       new Map(
@@ -3177,21 +3237,7 @@ export default function LegacySidebar() {
     [orderedProjects],
   );
 
-  const sidebarProjects = useMemo<SidebarProjectSnapshot[]>(() => {
-    return buildSidebarProjectSnapshots({
-      projects: orderedProjects,
-      settings: projectGroupingSettings,
-      primaryEnvironmentId,
-      resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
-      isDesktopLocalEnvironment: (environmentId) => desktopLocalEnvironmentIds.has(environmentId),
-    });
-  }, [
-    environmentLabelById,
-    desktopLocalEnvironmentIds,
-    orderedProjects,
-    projectGroupingSettings,
-    primaryEnvironmentId,
-  ]);
+  const sidebarProjects = sidebarProjectGrouping.projects;
 
   const sidebarProjectByKey = useMemo(
     () => new Map(sidebarProjects.map((project) => [project.projectKey, project] as const)),
@@ -3383,7 +3429,8 @@ export default function LegacySidebar() {
     sidebarProjects,
     visibleThreads,
   ]);
-  const isManualProjectSorting = sidebarProjectSortOrder === "manual";
+  const isManualProjectSorting =
+    sidebarProjectSortOrder === "manual" && !sidebarEnvironmentGroupingEnabled;
   const visibleSidebarThreadKeys = useMemo(
     () =>
       sortedProjects.flatMap((project) => {
@@ -3732,6 +3779,8 @@ export default function LegacySidebar() {
         archiveThread={archiveThread}
         deleteThread={deleteThread}
         sortedProjects={sortedProjects}
+        environmentGroupingEnabled={sidebarEnvironmentGroupingEnabled}
+        environmentLabelById={environmentLabelById}
         expandedThreadListsByProject={expandedThreadListsByProject}
         activeRouteProjectKey={activeRouteProjectKey}
         routeThreadKey={routeThreadKey}

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -192,6 +192,7 @@ import {
 } from "./Sidebar.logic";
 import { sortThreads } from "../lib/threadSort";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
+import { SidebarSectionHeading } from "./sidebar/SidebarSectionHeading";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
@@ -2191,7 +2192,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         if (isMobile) setOpenMobile(false);
         void router.navigate({
           to: "/projects/$projectKey",
-          params: { projectKey: project.projectKey },
+          params: { projectKey: project.logicalProjectKey },
         });
         return;
       }
@@ -2931,11 +2932,20 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
         projectsByEnvironment.set(project.environmentId, [project]);
       }
     }
-    return [...projectsByEnvironment].map(([environmentId, projects]) => ({
-      environmentId,
-      label: environmentLabelById.get(environmentId) ?? "Unknown environment",
-      projects,
-    }));
+    const environmentOrder = new Map(
+      [...environmentLabelById.keys()].map((environmentId, index) => [environmentId, index]),
+    );
+    return [...projectsByEnvironment]
+      .sort(
+        ([leftId], [rightId]) =>
+          (environmentOrder.get(leftId) ?? environmentOrder.size) -
+          (environmentOrder.get(rightId) ?? environmentOrder.size),
+      )
+      .map(([environmentId, projects]) => ({
+        environmentId,
+        label: environmentLabelById.get(environmentId) ?? "Unknown environment",
+        projects,
+      }));
   }, [environmentGroupingEnabled, environmentLabelById, sortedProjects]);
 
   return (
@@ -3075,15 +3085,11 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           <SidebarMenu ref={attachProjectListAutoAnimateRef}>
             {projectSections.flatMap((section) => [
               section.label ? (
-                <li
+                <SidebarSectionHeading
                   key={`environment:${section.environmentId}`}
-                  className="mb-1 mt-3 flex items-center gap-2 px-2 first:mt-0"
-                >
-                  <span className="min-w-0 truncate text-xs font-medium text-sidebar-muted-foreground/80">
-                    {section.label}
-                  </span>
-                  <span className="h-px flex-1 bg-sidebar-border/60" />
-                </li>
+                  label={section.label}
+                  className="mt-3 px-2 first:mt-0"
+                />
               ) : null,
               ...section.projects.map((project) => (
                 <SidebarProjectListRow

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -25,6 +25,8 @@ import {
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
   searchSidebarThreadsByTitle,
+  selectPinnedReorderSection,
+  shouldApplyOptimisticPinnedOrder,
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
@@ -910,6 +912,45 @@ describe("pinOrderKeyBetween", () => {
     expect(pinOrderKeyBetween("A!", null)).toBeNull();
     expect(pinOrderKeyBetween(null, "ma")).toBeNull();
     expect(pinOrderKeyBetween("m", "m")).toBeNull();
+  });
+});
+
+describe("selectPinnedReorderSection", () => {
+  const threads = [
+    { key: "local-a", environmentId: "local" },
+    { key: "remote-a", environmentId: "remote" },
+    { key: "local-b", environmentId: "local" },
+  ];
+
+  it("keeps the reorder plan inside the active environment when grouping is enabled", () => {
+    expect(
+      selectPinnedReorderSection({
+        threads,
+        activeKey: "local-b",
+        groupByEnvironment: true,
+        getKey: (thread) => thread.key,
+      }).map((thread) => thread.key),
+    ).toEqual(["local-a", "local-b"]);
+  });
+
+  it("keeps the global reorder plan when grouping is disabled", () => {
+    expect(
+      selectPinnedReorderSection({
+        threads,
+        activeKey: "local-b",
+        groupByEnvironment: false,
+        getKey: (thread) => thread.key,
+      }),
+    ).toEqual(threads);
+  });
+});
+
+describe("shouldApplyOptimisticPinnedOrder", () => {
+  it("rejects optimistic order from the previous grouping mode", () => {
+    expect(shouldApplyOptimisticPinnedOrder("local", true)).toBe(true);
+    expect(shouldApplyOptimisticPinnedOrder(null, false)).toBe(true);
+    expect(shouldApplyOptimisticPinnedOrder("local", false)).toBe(false);
+    expect(shouldApplyOptimisticPinnedOrder(null, true)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -603,6 +603,26 @@ export function sortThreadsForSidebar<
   );
 }
 
+export function selectPinnedReorderSection<T extends { readonly environmentId: string }>(input: {
+  readonly threads: readonly T[];
+  readonly activeKey: string;
+  readonly groupByEnvironment: boolean;
+  readonly getKey: (thread: T) => string;
+}): readonly T[] {
+  if (!input.groupByEnvironment) return input.threads;
+  const activeThread = input.threads.find((thread) => input.getKey(thread) === input.activeKey);
+  return activeThread === undefined
+    ? []
+    : input.threads.filter((thread) => thread.environmentId === activeThread.environmentId);
+}
+
+export function shouldApplyOptimisticPinnedOrder(
+  environmentId: string | null,
+  groupByEnvironment: boolean,
+): boolean {
+  return (environmentId !== null) === groupByEnvironment;
+}
+
 // Pinned-reorder key math and the keyed sort live in client-runtime
 // (state/thread-sort) so web and mobile compute identical pinned orders.
 export {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -137,6 +137,8 @@ import {
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
+  selectPinnedReorderSection,
+  shouldApplyOptimisticPinnedOrder,
   shouldCreateNewThreadInCurrentProject,
   resolveWorkingStartedAt,
   sortLogicalProjectsForSidebar,
@@ -192,6 +194,7 @@ import {
 } from "./ui/combobox";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
+import { SidebarSectionHeading } from "./sidebar/SidebarSectionHeading";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import {
@@ -2718,6 +2721,7 @@ export default function Sidebar() {
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
   const [optimisticPinnedOrder, setOptimisticPinnedOrder] = useState<{
+    readonly environmentId: EnvironmentId | null;
     readonly order: readonly string[];
     /** pinOrderKey per thread as of the drop — the baseline that tells a
         concurrent client's write apart from one of our own landing. */
@@ -2727,13 +2731,24 @@ export default function Sidebar() {
     readonly assignedKeys: ReadonlyMap<string, string>;
   } | null>(null);
   const orderedPinnedThreads = useMemo(() => {
-    if (optimisticPinnedOrder === null) return pinnedThreads;
+    if (
+      optimisticPinnedOrder === null ||
+      !shouldApplyOptimisticPinnedOrder(
+        optimisticPinnedOrder.environmentId,
+        sidebarEnvironmentGroupingEnabled,
+      )
+    ) {
+      return pinnedThreads;
+    }
     return orderItemsByPreferredIds({
       items: pinnedThreads,
       preferredIds: optimisticPinnedOrder.order,
       getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
     });
-  }, [optimisticPinnedOrder, pinnedThreads]);
+  }, [optimisticPinnedOrder, pinnedThreads, sidebarEnvironmentGroupingEnabled]);
+  useEffect(() => {
+    setOptimisticPinnedOrder(null);
+  }, [sidebarEnvironmentGroupingEnabled]);
   const pinnedThreadSections = useMemo(
     () =>
       groupSidebarThreadsByEnvironment({
@@ -2745,8 +2760,11 @@ export default function Sidebar() {
   );
   useEffect(() => {
     if (optimisticPinnedOrder === null) return;
-    const canonical = pinnedThreads.filter((thread) =>
-      reorderablePinnedKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
+    const canonical = pinnedThreads.filter(
+      (thread) =>
+        (optimisticPinnedOrder.environmentId === null ||
+          thread.environmentId === optimisticPinnedOrder.environmentId) &&
+        reorderablePinnedKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
     );
     const canonicalKeys = canonical.map((thread) =>
       scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
@@ -2827,7 +2845,12 @@ export default function Sidebar() {
       const activeKey = String(event.active.id);
       const overKey = event.over === null ? null : String(event.over.id);
       if (overKey === null || activeKey === overKey) return;
-      const reorderable = orderedPinnedThreads.filter((thread) =>
+      const reorderable = selectPinnedReorderSection({
+        threads: orderedPinnedThreads,
+        activeKey,
+        groupByEnvironment: sidebarEnvironmentGroupingEnabled,
+        getKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      }).filter((thread) =>
         reorderablePinnedKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
       );
       const keys = reorderable.map((thread) =>
@@ -2848,6 +2871,9 @@ export default function Sidebar() {
       });
       if (assignments.length === 0) return;
       setOptimisticPinnedOrder({
+        environmentId: sidebarEnvironmentGroupingEnabled
+          ? (reorderable[0]?.environmentId ?? null)
+          : null,
         order: newOrder,
         keysAtDrop,
         assignedKeys: new Map(
@@ -2886,7 +2912,12 @@ export default function Sidebar() {
         }
       })();
     },
-    [orderedPinnedThreads, reorderPinnedThread, reorderablePinnedKeys],
+    [
+      orderedPinnedThreads,
+      reorderPinnedThread,
+      reorderablePinnedKeys,
+      sidebarEnvironmentGroupingEnabled,
+    ],
   );
   // One snooze per thread at a time — same double-dispatch guard as settle.
   const snoozingThreadKeysRef = useRef(new Set<string>());
@@ -3972,15 +4003,11 @@ export default function Sidebar() {
                     }
                     for (const environment of sections) {
                       items.push(
-                        <li
+                        <SidebarSectionHeading
                           key={`environment:${section}:${environment.environmentId}`}
-                          className="mb-1 mt-3 flex list-none items-center gap-2 px-2.5"
-                        >
-                          <span className="min-w-0 truncate text-xs font-medium text-sidebar-muted-foreground/80">
-                            {environment.label}
-                          </span>
-                          <span className="h-px flex-1 bg-sidebar-border/60" />
-                        </li>,
+                          label={environment.label}
+                          className="mt-3 list-none px-2.5"
+                        />,
                       );
                       for (const thread of environment.threads) {
                         items.push(renderThreadRow(thread, section));
@@ -3989,6 +4016,7 @@ export default function Sidebar() {
                   };
                   const renderPinnedRows = (
                     sectionThreads: ReadonlyArray<EnvironmentThreadShell>,
+                    environmentLabel?: string,
                   ) => (
                     <DndContext
                       sensors={pinnedDndSensors}
@@ -4006,7 +4034,11 @@ export default function Sidebar() {
                       >
                         <ul
                           role="list"
-                          aria-label="Pinned threads"
+                          aria-label={
+                            environmentLabel
+                              ? `Pinned threads in ${environmentLabel}`
+                              : "Pinned threads"
+                          }
                           className="flex flex-col gap-px"
                         >
                           {sectionThreads.map((thread) => {
@@ -4048,13 +4080,12 @@ export default function Sidebar() {
                         {sidebarEnvironmentGroupingEnabled
                           ? pinnedThreadSections.map((environment) => (
                               <div key={environment.environmentId} className="mt-3 first:mt-0">
-                                <div className="mb-1 flex items-center gap-2 px-2.5">
-                                  <span className="min-w-0 truncate text-xs font-medium text-sidebar-muted-foreground/80">
-                                    {environment.label}
-                                  </span>
-                                  <span className="h-px flex-1 bg-sidebar-border/60" />
-                                </div>
-                                {renderPinnedRows(environment.threads)}
+                                <SidebarSectionHeading
+                                  as="div"
+                                  label={environment.label}
+                                  className="px-2.5"
+                                />
+                                {renderPinnedRows(environment.threads, environment.label)}
                               </div>
                             ))
                           : renderPinnedRows(orderedPinnedThreads)}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -28,7 +28,7 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
@@ -1630,6 +1630,42 @@ function latestTurnDiff(
   return null;
 }
 
+interface SidebarEnvironmentThreadSection {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly threads: ReadonlyArray<EnvironmentThreadShell>;
+}
+
+function groupSidebarThreadsByEnvironment(input: {
+  readonly threads: ReadonlyArray<EnvironmentThreadShell>;
+  readonly environmentIds: ReadonlyArray<EnvironmentId>;
+  readonly environmentLabelById: ReadonlyMap<EnvironmentId, string>;
+}): ReadonlyArray<SidebarEnvironmentThreadSection> {
+  const threadsByEnvironment = new Map<EnvironmentId, EnvironmentThreadShell[]>();
+  for (const environmentId of input.environmentIds) {
+    threadsByEnvironment.set(environmentId, []);
+  }
+  for (const thread of input.threads) {
+    const environmentThreads = threadsByEnvironment.get(thread.environmentId);
+    if (environmentThreads) {
+      environmentThreads.push(thread);
+    } else {
+      threadsByEnvironment.set(thread.environmentId, [thread]);
+    }
+  }
+  return [...threadsByEnvironment].flatMap(([environmentId, threads]) =>
+    threads.length === 0
+      ? []
+      : [
+          {
+            environmentId,
+            label: input.environmentLabelById.get(environmentId) ?? "Unknown environment",
+            threads,
+          },
+        ],
+  );
+}
+
 const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   thread: SidebarThreadSummary;
   projectCwd: string | null;
@@ -1754,6 +1790,9 @@ export default function Sidebar() {
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
+  const sidebarEnvironmentGroupingEnabled = useClientSettings(
+    (s) => s.sidebarEnvironmentGroupingEnabled,
+  );
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const {
@@ -2283,9 +2322,68 @@ export default function Sidebar() {
     return routeThread === undefined ? [] : [routeThread];
   }, [routeThreadKey, snoozedShelfExpanded, snoozedThreads]);
 
+  const environmentIds = useMemo(
+    () => environments.map((environment) => environment.environmentId),
+    [environments],
+  );
+  const activeThreadSections = useMemo(
+    () =>
+      groupSidebarThreadsByEnvironment({
+        threads: activeThreads,
+        environmentIds,
+        environmentLabelById,
+      }),
+    [activeThreads, environmentIds, environmentLabelById],
+  );
+  const pinnedCanonicalThreadSections = useMemo(
+    () =>
+      groupSidebarThreadsByEnvironment({
+        threads: pinnedThreads,
+        environmentIds,
+        environmentLabelById,
+      }),
+    [environmentIds, environmentLabelById, pinnedThreads],
+  );
+  const snoozedThreadSections = useMemo(
+    () =>
+      groupSidebarThreadsByEnvironment({
+        threads: visibleSnoozedThreads,
+        environmentIds,
+        environmentLabelById,
+      }),
+    [environmentIds, environmentLabelById, visibleSnoozedThreads],
+  );
+  const settledThreadSections = useMemo(
+    () =>
+      groupSidebarThreadsByEnvironment({
+        threads: renderedSettledThreads,
+        environmentIds,
+        environmentLabelById,
+      }),
+    [environmentIds, environmentLabelById, renderedSettledThreads],
+  );
+
   const orderedThreads = useMemo(
-    () => [...pinnedThreads, ...activeThreads, ...visibleSnoozedThreads, ...renderedSettledThreads],
-    [pinnedThreads, activeThreads, visibleSnoozedThreads, renderedSettledThreads],
+    () =>
+      sidebarEnvironmentGroupingEnabled
+        ? [
+            ...pinnedCanonicalThreadSections.flatMap((section) => section.threads),
+            ...activeThreadSections.flatMap((section) => section.threads),
+            ...snoozedThreadSections.flatMap((section) => section.threads),
+            ...settledThreadSections.flatMap((section) => section.threads),
+          ]
+        : [...pinnedThreads, ...activeThreads, ...visibleSnoozedThreads, ...renderedSettledThreads],
+    [
+      activeThreads,
+      activeThreadSections,
+      pinnedThreads,
+      pinnedCanonicalThreadSections,
+      renderedSettledThreads,
+      settledThreadSections,
+      sidebarEnvironmentGroupingEnabled,
+      snoozedThreadSections,
+      visibleSnoozedThreads,
+    ],
   );
   const orderedThreadKeys = useMemo(
     () =>
@@ -2636,6 +2734,15 @@ export default function Sidebar() {
       getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
     });
   }, [optimisticPinnedOrder, pinnedThreads]);
+  const pinnedThreadSections = useMemo(
+    () =>
+      groupSidebarThreadsByEnvironment({
+        threads: orderedPinnedThreads,
+        environmentIds,
+        environmentLabelById,
+      }),
+    [environmentIds, environmentLabelById, orderedPinnedThreads],
+  );
   useEffect(() => {
     if (optimisticPinnedOrder === null) return;
     const canonical = pinnedThreads.filter((thread) =>
@@ -3853,6 +3960,72 @@ export default function Sidebar() {
                       />
                     );
                   };
+                  const pushThreadSections = (
+                    items: ReactNode[],
+                    threads: ReadonlyArray<EnvironmentThreadShell>,
+                    sections: ReadonlyArray<SidebarEnvironmentThreadSection>,
+                    section: "active" | "snoozed" | "settled",
+                  ) => {
+                    if (!sidebarEnvironmentGroupingEnabled) {
+                      for (const thread of threads) items.push(renderThreadRow(thread, section));
+                      return;
+                    }
+                    for (const environment of sections) {
+                      items.push(
+                        <li
+                          key={`environment:${section}:${environment.environmentId}`}
+                          className="mb-1 mt-3 flex list-none items-center gap-2 px-2.5"
+                        >
+                          <span className="min-w-0 truncate text-xs font-medium text-sidebar-muted-foreground/80">
+                            {environment.label}
+                          </span>
+                          <span className="h-px flex-1 bg-sidebar-border/60" />
+                        </li>,
+                      );
+                      for (const thread of environment.threads) {
+                        items.push(renderThreadRow(thread, section));
+                      }
+                    }
+                  };
+                  const renderPinnedRows = (
+                    sectionThreads: ReadonlyArray<EnvironmentThreadShell>,
+                  ) => (
+                    <DndContext
+                      sensors={pinnedDndSensors}
+                      collisionDetection={closestCenter}
+                      modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+                      onDragEnd={handlePinnedDragEnd}
+                    >
+                      <SortableContext
+                        items={sectionThreads
+                          .map((thread) =>
+                            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+                          )
+                          .filter((threadKey) => reorderablePinnedKeys.has(threadKey))}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        <ul
+                          role="list"
+                          aria-label="Pinned threads"
+                          className="flex flex-col gap-px"
+                        >
+                          {sectionThreads.map((thread) => {
+                            const threadKey = scopedThreadKey(
+                              scopeThreadRef(thread.environmentId, thread.id),
+                            );
+                            if (!reorderablePinnedKeys.has(threadKey)) {
+                              return renderThreadRow(thread, "pinned");
+                            }
+                            return (
+                              <SortablePinnedThreadRow key={threadKey} id={threadKey}>
+                                {(bag) => renderThreadRow(thread, "pinned", bag)}
+                              </SortablePinnedThreadRow>
+                            );
+                          })}
+                        </ul>
+                      </SortableContext>
+                    </DndContext>
+                  );
                   // Draft block above everything, then the pinned block:
                   // full cards above the inbox, closed by a thin divider (the
                   // pin glyphs carry the meaning, so no header text). Both
@@ -3872,41 +4045,19 @@ export default function Sidebar() {
                     />,
                     pinnedThreads.length > 0 ? (
                       <li key="pinned-dnd" className="list-none">
-                        <DndContext
-                          sensors={pinnedDndSensors}
-                          collisionDetection={closestCenter}
-                          modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
-                          onDragEnd={handlePinnedDragEnd}
-                        >
-                          <SortableContext
-                            items={orderedPinnedThreads
-                              .map((thread) =>
-                                scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-                              )
-                              .filter((threadKey) => reorderablePinnedKeys.has(threadKey))}
-                            strategy={verticalListSortingStrategy}
-                          >
-                            <ul
-                              role="list"
-                              aria-label="Pinned threads"
-                              className="flex flex-col gap-px"
-                            >
-                              {orderedPinnedThreads.map((thread) => {
-                                const threadKey = scopedThreadKey(
-                                  scopeThreadRef(thread.environmentId, thread.id),
-                                );
-                                if (!reorderablePinnedKeys.has(threadKey)) {
-                                  return renderThreadRow(thread, "pinned");
-                                }
-                                return (
-                                  <SortablePinnedThreadRow key={threadKey} id={threadKey}>
-                                    {(bag) => renderThreadRow(thread, "pinned", bag)}
-                                  </SortablePinnedThreadRow>
-                                );
-                              })}
-                            </ul>
-                          </SortableContext>
-                        </DndContext>
+                        {sidebarEnvironmentGroupingEnabled
+                          ? pinnedThreadSections.map((environment) => (
+                              <div key={environment.environmentId} className="mt-3 first:mt-0">
+                                <div className="mb-1 flex items-center gap-2 px-2.5">
+                                  <span className="min-w-0 truncate text-xs font-medium text-sidebar-muted-foreground/80">
+                                    {environment.label}
+                                  </span>
+                                  <span className="h-px flex-1 bg-sidebar-border/60" />
+                                </div>
+                                {renderPinnedRows(environment.threads)}
+                              </div>
+                            ))
+                          : renderPinnedRows(orderedPinnedThreads)}
                       </li>
                     ) : null,
                   ];
@@ -3920,9 +4071,7 @@ export default function Sidebar() {
                       />,
                     );
                   }
-                  for (const thread of activeThreads) {
-                    items.push(renderThreadRow(thread, "active"));
-                  }
+                  pushThreadSections(items, activeThreads, activeThreadSections, "active");
                   // Snoozed shelf: between the inbox and Settled — out of the
                   // way, never gone. The header always renders while anything
                   // is snoozed (the count is the whole footprint when
@@ -3958,9 +4107,12 @@ export default function Sidebar() {
                         </button>
                       </li>,
                     );
-                    for (const thread of visibleSnoozedThreads) {
-                      items.push(renderThreadRow(thread, "snoozed"));
-                    }
+                    pushThreadSections(
+                      items,
+                      visibleSnoozedThreads,
+                      snoozedThreadSections,
+                      "snoozed",
+                    );
                   }
                   if (settledThreads.length > 0) {
                     items.push(
@@ -3993,9 +4145,12 @@ export default function Sidebar() {
                       </li>,
                     );
                   }
-                  for (const thread of renderedSettledThreads) {
-                    items.push(renderThreadRow(thread, "settled"));
-                  }
+                  pushThreadSections(
+                    items,
+                    renderedSettledThreads,
+                    settledThreadSections,
+                    "settled",
+                  );
                   return items;
                 })()}
                 {settledShelfExpanded && hiddenSettledCount > 0 ? (

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -507,6 +507,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
         : []),
+      ...(settings.sidebarEnvironmentGroupingEnabled !==
+      DEFAULT_UNIFIED_SETTINGS.sidebarEnvironmentGroupingEnabled
+        ? ["Environment grouping"]
+        : []),
       ...(settings.sidebarAutoSettleAfterDays !==
       DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
         ? ["Auto-settle inactive threads"]
@@ -599,6 +603,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.sidebarAutoSettleAfterDays,
       settings.sidebarAutoSettleOnMerge,
       settings.sidebarProjectGroupingMode,
+      settings.sidebarEnvironmentGroupingEnabled,
       settings.sidebarThreadPreviewCount,
       settings.showSkillsInSlashMenu,
       settings.timestampFormat,
@@ -682,6 +687,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+      sidebarEnvironmentGroupingEnabled: DEFAULT_UNIFIED_SETTINGS.sidebarEnvironmentGroupingEnabled,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
       sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
@@ -1989,6 +1995,38 @@ export function GeneralSettingsPanel() {
                 });
               }}
               aria-label="Project grouping"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("environment-grouping")}
+          description={
+            settings.legacySidebarEnabled
+              ? "Section projects by environment. Environments appear above projects when both are enabled."
+              : "Section sidebar threads by the environment where they run."
+          }
+          resetAction={
+            settings.sidebarEnvironmentGroupingEnabled !==
+            DEFAULT_UNIFIED_SETTINGS.sidebarEnvironmentGroupingEnabled ? (
+              <SettingResetButton
+                label="environment grouping"
+                onClick={() =>
+                  updateSettings({
+                    sidebarEnvironmentGroupingEnabled:
+                      DEFAULT_UNIFIED_SETTINGS.sidebarEnvironmentGroupingEnabled,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.sidebarEnvironmentGroupingEnabled}
+              onCheckedChange={(checked) =>
+                updateSettings({ sidebarEnvironmentGroupingEnabled: Boolean(checked) })
+              }
+              aria-label="Environment grouping"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -146,6 +146,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["combine matching repositories environments sidebar"],
   },
   {
+    id: "environment-grouping",
+    title: "Environment grouping",
+    to: "/settings/general",
+    searchTerms: ["computer machine vm sections sidebar projects"],
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/apps/web/src/components/sidebar/SidebarSectionHeading.tsx
+++ b/apps/web/src/components/sidebar/SidebarSectionHeading.tsx
@@ -1,0 +1,17 @@
+import { cn } from "~/lib/utils";
+
+export function SidebarSectionHeading(props: {
+  readonly as?: "div" | "li";
+  readonly className?: string;
+  readonly label: string;
+}) {
+  const Component = props.as ?? "li";
+  return (
+    <Component className={cn("mb-1 flex items-center gap-2", props.className)}>
+      <span className="min-w-0 truncate text-xs font-medium text-sidebar-muted-foreground/80">
+        {props.label}
+      </span>
+      <span className="h-px flex-1 bg-sidebar-border/60" />
+    </Component>
+  );
+}

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./logicalProject";
 import {
   buildPhysicalToLogicalProjectKeyMap,
+  buildSidebarProjectGrouping,
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
 } from "./sidebarProjectGrouping";
@@ -79,6 +80,32 @@ describe("environment grouping", () => {
     }).length;
 
     expect(projectGroupCount).toBe(1);
+  });
+
+  it("keeps matching repositories in separate environment sections", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+
+    const result = buildSidebarProjectGrouping({
+      projects: [primary, remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: (environmentId) =>
+        environmentId === primaryEnvironmentId ? "Primary" : "Remote",
+      groupByEnvironment: true,
+    });
+
+    expect(result.projects).toHaveLength(2);
+    expect(new Set(result.projects.map((project) => project.projectKey)).size).toBe(2);
+    expect(
+      result.projects.map((project) =>
+        project.memberProjects.map((member) => [member.environmentId, member.id]),
+      ),
+    ).toEqual([[[primary.environmentId, primary.id]], [[remote.environmentId, remote.id]]]);
   });
 
   it("keeps projects without repository identity physically scoped", () => {

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -101,6 +101,10 @@ describe("environment grouping", () => {
 
     expect(result.projects).toHaveLength(2);
     expect(new Set(result.projects.map((project) => project.projectKey)).size).toBe(2);
+    expect(result.projects.map((project) => project.logicalProjectKey)).toEqual([
+      repositoryIdentity.canonicalKey,
+      repositoryIdentity.canonicalKey,
+    ]);
     expect(
       result.projects.map((project) =>
         project.memberProjects.map((member) => [member.environmentId, member.id]),

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -11,6 +11,7 @@ export interface SidebarProjectGroupMember extends Project {
 
 export interface SidebarProjectSnapshot extends Project {
   projectKey: string;
+  logicalProjectKey: string;
   displayName: string;
   groupedProjectCount: number;
   environmentPresence: EnvironmentPresence;
@@ -150,6 +151,7 @@ export function buildSidebarProjectSnapshots(input: {
     return {
       ...representative,
       projectKey: group.key,
+      logicalProjectKey: group.key,
       displayName: group.label,
       groupedProjectCount: members.length,
       environmentPresence:

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -31,6 +31,54 @@ export interface SidebarProjectPickerEntry {
   isPreferred: boolean;
 }
 
+export interface SidebarProjectGroupingResult {
+  readonly projects: ReadonlyArray<SidebarProjectSnapshot>;
+  readonly physicalToLogicalKey: ReadonlyMap<string, string>;
+}
+
+export function buildSidebarProjectGrouping(input: {
+  projects: ReadonlyArray<Project>;
+  settings: ProjectGroupingSettings;
+  primaryEnvironmentId: EnvironmentId | null;
+  resolveEnvironmentLabel: (environmentId: EnvironmentId) => string | null;
+  isDesktopLocalEnvironment?: (environmentId: EnvironmentId) => boolean;
+  groupByEnvironment: boolean;
+}): SidebarProjectGroupingResult {
+  if (!input.groupByEnvironment) {
+    return {
+      projects: buildSidebarProjectSnapshots(input),
+      physicalToLogicalKey: buildPhysicalToLogicalProjectKeyMap(input),
+    };
+  }
+
+  const projectsByEnvironment = new Map<EnvironmentId, Project[]>();
+  for (const project of input.projects) {
+    const projects = projectsByEnvironment.get(project.environmentId);
+    if (projects) {
+      projects.push(project);
+    } else {
+      projectsByEnvironment.set(project.environmentId, [project]);
+    }
+  }
+
+  const projects: SidebarProjectSnapshot[] = [];
+  const physicalToLogicalKey = new Map<string, string>();
+  for (const [environmentId, environmentProjects] of projectsByEnvironment) {
+    for (const project of buildSidebarProjectSnapshots({
+      ...input,
+      projects: environmentProjects,
+    })) {
+      const projectKey = JSON.stringify([environmentId, project.projectKey]);
+      projects.push({ ...project, projectKey });
+      for (const member of project.memberProjects) {
+        physicalToLogicalKey.set(member.physicalProjectKey, projectKey);
+      }
+    }
+  }
+
+  return { projects, physicalToLogicalKey };
+}
+
 export function buildPhysicalToLogicalProjectKeyMap(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -1,5 +1,19 @@
 # Organizing threads
 
+## Grouping by environment
+
+On web and desktop, enable **Settings > General > Environment grouping** to section the sidebar by
+the computer or VM where each thread runs. The default sidebar adds environment headings within its
+pinned, active, snoozed, and settled areas. When the legacy per-project sidebar is enabled, the
+hierarchy is environment, then project, then thread. Matching repositories are still grouped within
+each environment, but never combined across environment sections.
+
+On mobile, use **Settings > Project Grouping > Group by environment**. Environment sections apply to
+the legacy thread list.
+
+This preference is stored on the current client. Web browser profiles, desktop installations, and
+mobile devices can each use a different grouping choice.
+
 Pin a thread from its context menu to keep it in the pinned section above your active work.
 `mod+shift+p` pins or unpins the thread you have open. Pinned threads are shown independently of
 their project, including when you connect to more than one environment.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -165,6 +165,7 @@ describe("ClientSettings environment identification", () => {
 describe("ClientSettings sidebar", () => {
   it("defaults to the current sidebar", () => {
     expect(decodeClientSettings({}).legacySidebarEnabled).toBe(false);
+    expect(decodeClientSettings({}).sidebarEnvironmentGroupingEnabled).toBe(false);
   });
 
   it("drops the retired sidebar v2 beta keys, resetting everyone to the default", () => {
@@ -182,6 +183,18 @@ describe("ClientSettings sidebar", () => {
     expect(decodeClientSettingsPatch({ legacySidebarEnabled: true }).legacySidebarEnabled).toBe(
       true,
     );
+  });
+
+  it("preserves an explicit environment grouping preference", () => {
+    expect(
+      decodeClientSettings({ sidebarEnvironmentGroupingEnabled: true })
+        .sidebarEnvironmentGroupingEnabled,
+    ).toBe(true);
+    expect(
+      decodeClientSettingsPatch({ sidebarEnvironmentGroupingEnabled: true })
+        .sidebarEnvironmentGroupingEnabled,
+    ).toBe(true);
+    expect(() => decodeClientSettingsPatch({ sidebarEnvironmentGroupingEnabled: "yes" })).toThrow();
   });
 
   it("keeps unpin confirmation opt-in and patchable", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -277,6 +277,9 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  sidebarEnvironmentGroupingEnabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -1000,6 +1003,7 @@ export const ClientSettingsPatch = Schema.Struct({
   contextWindowMeterEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  sidebarEnvironmentGroupingEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
Users connected to multiple computers could identify a thread's environment, but could not section the sidebar by where work runs.

Add a client-local environment grouping preference across web, desktop, and mobile. The default sidebar keeps its pinned, active, snoozed, and settled structure while adding environment headings; the project-tree sidebar nests projects under environment sections and scopes repository grouping within each environment.

Tests:
- `vp test run packages/contracts/src/settings.test.ts apps/web/src/environmentGrouping.test.ts apps/web/src/components/Sidebar.logic.test.ts apps/mobile/src/features/home/homeThreadList.test.ts apps/mobile/src/features/home/homeListItems.test.ts`
- `vp run typecheck` in `apps/web`, `apps/mobile`, and `packages/contracts`
- Manually tested the feature frontend against an active T3 server

Model: GPT-5.6 Sol
Harness: OpenCode

Section headers look like this:

<img width="250" height="338" alt="image" src="https://github.com/user-attachments/assets/ac5b1e6f-5551-416c-bbc2-9220f4c5ebf2" />

Enable in Settings / General:

<img width="1191" height="314" alt="image" src="https://github.com/user-attachments/assets/a7efdd1e-64fb-4da4-bba8-efdeded15bd5" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sidebar ordering, grouping keys, and pinned reorder semantics across web and mobile; incorrect scoping could mis-filter threads or merge projects across environments, but changes are gated behind an opt-in default-off setting.
> 
> **Overview**
> Adds a **client-local “group by environment”** preference (`sidebarEnvironmentGroupingEnabled` on web, `environmentGroupingEnabled` on mobile) so multi-machine workspaces can section the sidebar by where work runs.
> 
> On **web**, the default sidebar inserts environment headings inside pinned, active, snoozed, and settled areas; pinned drag-reorder is limited to threads in the same environment, with helpers to keep optimistic pinned order in sync when toggling the mode. The **legacy project-tree sidebar** nests projects under environment sections via `buildSidebarProjectGrouping`, keeps repository grouping **within** each environment (no cross-environment merge), disables manual project sort while grouping is on, and routes project settings using `logicalProjectKey`.
> 
> On **mobile** (legacy grouped list only, when viewing all environments), scopes and thread groups are built per environment, the list gains **environment-header** rows, and project filters show `title · environment` labels. The toggle lives under **Settings → Project Grouping**.
> 
> **Settings** surfaces the control on web General settings (search + restore-defaults) and persist it in mobile preferences. Tests and user docs cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1814284551d9858a96d82cd6f60cb74cff50667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group sidebar threads and projects by environment
> - Adds the `sidebarEnvironmentGroupingEnabled` client setting (default `false`) with toggle UI in web General settings and the mobile Project Grouping screen, plus settings-search support.
> - Web `Sidebar` and `LegacySidebar` render active, pinned, snoozed, and settled threads under environment headings when enabled; pinned drag-and-drop is scoped to the active thread's environment, and manual project sort is disabled in that mode.
> - Mobile `HomeScreen` and `ThreadNavigationSidebar` build environment-separated project scopes and thread groups, inserting environment-header list rows; grouping applies only when no specific environment filter is selected.
> - Replaces the separate sidebar snapshot and key-map builders with `buildSidebarProjectGrouping`, which partitions projects by environment and adds `logicalProjectKey` to each snapshot.
> - Behavioral Change: when grouping is enabled, matching projects from different environments become separate sidebar snapshots with environment-prefixed `projectKey`s and no manual sort; switching the setting clears pinned optimistic order. The `selectPinnedReorderSection` and `shouldApplyOptimisticPinnedOrder` helpers in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/9213/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) enforce the environment-mode match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a181428.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->