### PR TITLE
feat(mobile): add a Clear filters action to the thread list menu

### DIFF
--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -24,6 +24,7 @@ import type { HomeProjectSortOrder } from "./homeThreadList";
 import { WorkspaceConnectionTitle } from "./WorkspaceConnectionTitle";
 import {
   buildHomeListFilterMenu,
+  hasActiveHomeListFilters,
   type HomeListFilterMenuEnvironment,
   type HomeListFilterMenuProject,
 } from "./home-list-filter-menu";
@@ -135,6 +136,9 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
               })),
             },
           ] satisfies MenuAction[])),
+      ...(hasActiveHomeListFilters(props)
+        ? [{ id: "clear-filters", title: "Clear filters" } satisfies MenuAction]
+        : []),
     ],
     [
       props.environments,
@@ -149,6 +153,11 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
   const handleMenuAction = useCallback(
     (event: { nativeEvent: { event: string } }) => {
       const id = event.nativeEvent.event;
+      if (id === "clear-filters") {
+        props.onEnvironmentChange(null);
+        props.onProjectChange(null);
+        return;
+      }
       if (id === "environment:all") {
         props.onEnvironmentChange(null);
         return;
@@ -470,6 +479,19 @@ function IosHomeHeader(props: HomeHeaderProps) {
                 ))}
               </NativeHeaderToolbar.Menu>
             )}
+            {hasActiveHomeListFilters(props) ? (
+              <NativeHeaderToolbar.Menu inline>
+                <NativeHeaderToolbar.MenuAction
+                  onPress={() => {
+                    props.onEnvironmentChange(null);
+                    props.onProjectChange(null);
+                  }}
+                  subtitle="Show all environments and projects"
+                >
+                  <NativeHeaderToolbar.Label>Clear filters</NativeHeaderToolbar.Label>
+                </NativeHeaderToolbar.MenuAction>
+              </NativeHeaderToolbar.Menu>
+            ) : null}
           </NativeHeaderToolbar.Menu>
           <NativeHeaderToolbar.Spacer flexible />
           <NativeHeaderToolbar.Button

--- a/apps/mobile/src/features/home/home-list-filter-menu.test.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.test.ts
@@ -41,3 +41,35 @@ describe("buildHomeListFilterMenu", () => {
     expect(onProjectChange).toHaveBeenNthCalledWith(2, "environment-1:project-2");
   });
 });
+
+describe("buildHomeListFilterMenu clear action", () => {
+  it("offers a top-level Clear filters action only while a scope is active", () => {
+    const onEnvironmentChange = vi.fn();
+    const onProjectChange = vi.fn();
+    const build = (selectedProjectKey: string | null) =>
+      buildHomeListFilterMenu({
+        environments: [],
+        projects: [{ key: "p", label: "P" }],
+        selectedEnvironmentId: null,
+        selectedProjectKey,
+        projectSortOrder: "updated_at",
+        threadSortOrder: "updated_at",
+        onEnvironmentChange,
+        onProjectChange,
+        onProjectSortOrderChange: vi.fn(),
+        onThreadSortOrderChange: vi.fn(),
+      });
+
+    expect(build(null).items.at(-1)).toMatchObject({ type: "submenu", title: "Sort threads" });
+    const group = build("p").items.at(-1);
+    expect(group).toMatchObject({
+      type: "submenu",
+      displayInline: true,
+      items: [{ type: "action", title: "Clear filters" }],
+    });
+    if (group?.type !== "submenu") throw new Error("Expected inline group");
+    group.items[0]?.onPress();
+    expect(onEnvironmentChange).toHaveBeenCalledWith(null);
+    expect(onProjectChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/mobile/src/features/home/home-list-filter-menu.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.ts
@@ -25,11 +25,22 @@ type HomeListFilterMenuSubmenu = {
   readonly type: "submenu";
   readonly title: string;
   readonly items: HomeListFilterMenuAction[];
+  /** Renders the items inline as a divider-separated group instead of nesting. */
+  readonly displayInline?: boolean;
 };
 
 export interface HomeListFilterMenu {
   readonly title: string;
   readonly items: Array<HomeListFilterMenuAction | HomeListFilterMenuSubmenu>;
+}
+
+/** True when the environment or project scope narrows the list. Sort order
+    is a preference, not a filter, so it never counts here. */
+export function hasActiveHomeListFilters(scope: {
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly selectedProjectKey: string | null;
+}): boolean {
+  return scope.selectedEnvironmentId !== null || scope.selectedProjectKey !== null;
 }
 
 export function buildHomeListFilterMenu(props: {
@@ -118,6 +129,26 @@ export function buildHomeListFilterMenu(props: {
         })),
       },
     );
+  }
+
+  // Reset lives in its own trailing group, where iOS puts reset actions.
+  if (hasActiveHomeListFilters(props)) {
+    items.push({
+      type: "submenu",
+      title: "",
+      displayInline: true,
+      items: [
+        {
+          type: "action",
+          title: "Clear filters",
+          subtitle: "Show all environments and projects",
+          onPress: () => {
+            props.onEnvironmentChange(null);
+            props.onProjectChange(null);
+          },
+        },
+      ],
+    });
   }
 
   return {

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -41,7 +41,7 @@ import {
   THREAD_SORT_OPTIONS,
   useHomeListOptions,
 } from "../home/home-list-options";
-import { buildHomeListFilterMenu } from "../home/home-list-filter-menu";
+import { buildHomeListFilterMenu, hasActiveHomeListFilters } from "../home/home-list-filter-menu";
 import {
   buildHomeListLayout,
   DEFAULT_GROUP_DISPLAY_STATE,
@@ -637,12 +637,23 @@ function ThreadNavigationSidebarPane(
               })),
             },
           ] satisfies MenuAction[])),
+      ...(hasActiveHomeListFilters({
+        selectedEnvironmentId: options.selectedEnvironmentId,
+        selectedProjectKey,
+      })
+        ? [{ id: "clear-filters", title: "Clear filters" } satisfies MenuAction]
+        : []),
     ],
     [environments, options, projectFilterOptions, selectedProjectKey, threadListV2Enabled],
   );
   const handleListMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
       const event = nativeEvent.event;
+      if (event === "clear-filters") {
+        setSelectedEnvironmentId(null);
+        setSelectedProjectKey(null);
+        return;
+      }
       if (event === "environment:all") {
         setSelectedEnvironmentId(null);
         return;

--- a/apps/mobile/src/features/threads/sidebar-native-header-items.ts
+++ b/apps/mobile/src/features/threads/sidebar-native-header-items.ts
@@ -26,6 +26,7 @@ function toNativeHeaderMenuItems(items: HomeListFilterMenu["items"]): NativeHead
       : {
           type: "submenu" as const,
           label: item.title,
+          inline: item.displayInline,
           items: toNativeHeaderMenuItems(item.items),
         },
   );


### PR DESCRIPTION
## What Changed

- Add a "Clear filters" action in its own group at the end of the thread filter menu. It resets the environment and project filters at once.
- Show it only while a filter is active, on every menu surface: Android home header, iOS toolbar and pre-Liquid-Glass bottom toolbar, and the split-view sidebar. iOS renders it after a divider; Android has no divider primitive, so it is the last item.
- Keep sort and grouping preferences unchanged when filters are cleared.

## Why

After selecting an environment or project, returning to the full list requires opening each submenu and resetting the selections separately. One action fixes that. It sits at the end of the menu, where iOS puts reset actions, so the submenus keep stable positions whether or not a filter is active.


## UI Changes


### Active filters

| Before | After |
| --- | --- |
| ![Before: active filters show a filled filter icon and no Clear filters action](https://github-pr-attachments.none23.workers.dev/a/0ba1198f-7b38-46f7-89ca-f3f18540a051/pr9216-before-active-filters.png) | ![After: active filters show a filled filter icon and a Clear filters action](https://github-pr-attachments.none23.workers.dev/a/99108bec-ffd0-47c5-9e13-a8a6ad04f6f8/pr9216-after-active-filters.png) |

### Inactive filters

| Before | After |
| --- | --- |
| ![Before: inactive filters show an outline filter icon and no Clear filters action](https://github-pr-attachments.none23.workers.dev/a/656ac32d-581c-4ec4-b08a-5c6a6414f4f2/pr9216-before-inactive-filters.png) | ![After: inactive filters show an outline filter icon and no Clear filters action](https://github-pr-attachments.none23.workers.dev/a/811df4b2-345d-4d96-b4ed-0d605a95d22e/pr9216-after-inactive-filters.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (after screenshot needs a re-capture)
- [x] I included a video for animation/interaction changes (not applicable: no motion changes)

Built with Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile UI and list-filter state; no auth, data, or API changes.
> 
> **Overview**
> Makes **environment and project** scope on the mobile thread list easier to see and reset, without touching sort/group preferences.
> 
> Introduces **`hasActiveHomeListFilters`** so “active filter” means narrowed environment or project scope only (sort order stays a preference). **Thread List v2** uses that for the filled filter button instead of treating custom sort as “filtered.” **Android** maps the filled SF symbol to **`IconFilterFilled`** so the active state is visually distinct.
> 
> When filters are active, **Clear filters** appears at the top of the filter menu (shared **`buildHomeListFilterMenu`**, **Home** Android/iOS header, and **thread navigation sidebar**), resetting both scopes in one action. Unit tests cover the helper and conditional menu item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f60f59020a8ae8311e6cf2bed92262e9d368c7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Clear filters` action to mobile thread list menus
> - Adds a `Clear filters` menu item to the Android, iOS, and sidebar thread list menus that resets active environment and project scopes.
> - Introduces `hasActiveHomeListFilters` to detect active scopes, driving the clear action visibility and the customized-filter indicator.
> - Fixes `AppSymbol` mapping to use the filled Tabler filter icon for the filled SFSymbol variant.
> - Behavioral Change: The v2 customized-filter indicator now only reflects environment and project scopes, not sort-order preferences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f60f590. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Clear filters** action to the home screen menus and thread navigation sidebar.
  - The action appears when an environment or project filter is active and resets both selections.
  - Clear filters is available in both Android and iOS menu presentations.
  - Updated menu presentation to display the action inline where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->