### PR TITLE
fix(mobile): show filled filter icon on Android when filters are active

### DIFF
--- a/apps/mobile/src/components/AppSymbol.tsx
+++ b/apps/mobile/src/components/AppSymbol.tsx
@@ -39,6 +39,7 @@ import IconExternalLink from "@tabler/icons-react-native/IconExternalLink";
 import IconEye from "@tabler/icons-react-native/IconEye";
 import IconFileText from "@tabler/icons-react-native/IconFileText";
 import IconFilter from "@tabler/icons-react-native/IconFilter";
+import IconFilterFilled from "@tabler/icons-react-native/IconFilterFilled";
 import IconFolder from "@tabler/icons-react-native/IconFolder";
 import IconFolderOpen from "@tabler/icons-react-native/IconFolderOpen";
 import IconFolderPlus from "@tabler/icons-react-native/IconFolderPlus";
@@ -130,7 +131,7 @@ const ANDROID_ICON_BY_SF_SYMBOL: Partial<Record<SFSymbol, Icon>> = {
   "info.circle": IconInfoCircle,
   link: IconLink,
   "line.3.horizontal.decrease.circle": IconFilter,
-  "line.3.horizontal.decrease.circle.fill": IconFilter,
+  "line.3.horizontal.decrease.circle.fill": IconFilterFilled,
   magnifyingglass: IconSearch,
   paintbrush: IconPalette,
   "person.crop.circle": IconUserCircle,


### PR DESCRIPTION
## What Changed

Use Tabler's filled filter icon on Android when a filter control requests the filled SF Symbol variant. iOS continues to use its native SF Symbol.

## Why

Android currently maps both filter symbol variants to the outline icon. Filter controls that request the filled variant therefore still look inactive.

Fixes https://github.com/pingdotgg/t3code/issues/9218

## UI Changes

| Before | After |
| --- | --- |
| ![Before: an active filter uses the outline icon](https://github-pr-attachments.none23.workers.dev/a/4fd59df7-90f0-4c0a-a2e1-e45960b49d7d/pr-before-filter-applied.png) | ![After: an active filter uses the filled icon](https://github-pr-attachments.none23.workers.dev/a/f248a83b-4a43-40af-b494-0b14b45de7eb/pr-after-filter-applied.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable: this is a static icon change)

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single icon mapping change in the Android SF Symbol fallback with no auth, data, or business-logic impact.
> 
> **Overview**
> On Android, **`AppSymbol`** now maps the filled SF Symbol `line.3.horizontal.decrease.circle.fill` to Tabler’s **`IconFilterFilled`** instead of the outline **`IconFilter`**. Outline and filled filter variants were previously identical on Android, so active filter controls (e.g. in **HomeHeader** and **ArchivedThreadsScreen**) looked inactive even when filters were applied.
> 
> iOS behavior is unchanged—it still renders the native filled SF Symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ea429abeb877ed4dfadab822e3aa78c00ff7399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android mapping for filled filter SF symbol to use `IconFilterFilled`
> Updates the `ANDROID_ICON_BY_SF_SYMBOL` mapping in [AppSymbol.tsx](https://github.com/pingdotgg/t3code/pull/9217/files#diff-0467e2f7db105dd39d77324805e7df721b1334a9629ced647d2ef2c28b01df9d) so the `line.3.horizontal.decrease.circle.fill` symbol renders as `IconFilterFilled` on Android instead of the regular `IconFilter`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ea429a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->