### PR TITLE
Add Sublime Text editor support

### DIFF
--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -461,6 +461,55 @@ export const VSCodium: Icon = (props) => {
   );
 };
 
+export const SublimeTextIcon: Icon = (props) => {
+  const id = useId();
+  const gradientId = `${id}-sublime-text-gradient`;
+
+  return (
+    <svg
+      {...props}
+      viewBox="0 0 36 46.759"
+      style={{
+        clipRule: "evenodd",
+        fillRule: "evenodd",
+        strokeLinejoin: "round",
+        strokeMiterlimit: 1.41421,
+      }}
+    >
+      <path
+        d="M35.995 26.563c0-.548-.405-.864-.902-.707L.902 36.698c-.498.158-.902.731-.902 1.278v11.081c0 .548.404.865.902.707l34.191-10.841c.497-.158.902-.731.902-1.279z"
+        fill={`url(#${gradientId})`}
+        transform="translate(0 -3.045)"
+      />
+      <path
+        d="M0 26.21c0 .548.404 1.121.902 1.279l34.196 10.843c.498.158.902-.159.902-.706V26.544c0-.547-.404-1.12-.902-1.278L.902 14.423c-.498-.158-.902.158-.902.706Z"
+        fill="#ff9800"
+        transform="translate(0 -3.045)"
+      />
+      <path
+        d="M35.995 3.793c0-.548-.405-.865-.902-.707L.902 13.927c-.498.158-.902.731-.902 1.279v11.081c0 .548.404.864.902.707l34.191-10.842c.497-.158.902-.731.902-1.278z"
+        fill="#ff9800"
+        transform="translate(0 -3.045)"
+      />
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="0"
+          x2="1"
+          y1="0"
+          y2="0"
+          gradientTransform="matrix(3.08228 -10.3064 8.72379 3.56577 19.84 42.498)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#ff9700" />
+          <stop offset=".53" stopColor="#f48e00" />
+          <stop offset="1" stopColor="#d06f00" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};
+
 export const Zed: Icon = (props) => {
   const id = useId();
   const clipPathId = `${id}-zed-logo-a`;

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -24,6 +24,7 @@ import {
   CursorIcon,
   Icon,
   KiroIcon,
+  SublimeTextIcon,
   TraeIcon,
   VisualStudioCode,
   VisualStudioCodeInsiders,
@@ -90,6 +91,11 @@ const resolveOptions = (platform: string, availableEditors: ReadonlyArray<Editor
     {
       Icon: Zed,
       value: "zed",
+      kind: "brand",
+    },
+    {
+      Icon: SublimeTextIcon,
+      value: "sublime-text",
       kind: "brand",
     },
     {

--- a/apps/web/src/editorLabels.test.ts
+++ b/apps/web/src/editorLabels.test.ts
@@ -5,6 +5,7 @@ import { editorLabelForPlatform, openInEditorMenuLabel } from "./editorLabels";
 describe("editorLabelForPlatform", () => {
   it("uses the editor name from the shared editor definitions", () => {
     expect(editorLabelForPlatform("cursor", "MacIntel")).toBe("Cursor");
+    expect(editorLabelForPlatform("sublime-text", "Linux x86_64")).toBe("Sublime Text");
     expect(editorLabelForPlatform("vscode-insiders", "Win32")).toBe("VS Code Insiders");
   });
 
@@ -20,6 +21,7 @@ describe("editorLabelForPlatform", () => {
 describe("openInEditorMenuLabel", () => {
   it("names the preferred editor", () => {
     expect(openInEditorMenuLabel("zed")).toBe("Open in Zed");
+    expect(openInEditorMenuLabel("sublime-text")).toBe("Open in Sublime Text");
   });
 
   it("keeps the generic label for the default file handler and missing preferences", () => {

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -987,14 +987,14 @@ describe("RpcSessionFactory", () => {
           { command: "terminal.toggle", shortcut },
         ],
         issues: [{ kind: "keybindings.future-issue", message: "From a newer server" }],
-        availableEditors: ["some-future-editor", "zed"],
+        availableEditors: ["some-future-editor", "sublime-text", "zed"],
       });
       yield* Fiber.join(readyFiber);
 
       const config = yield* session.initialConfig;
       expect(config.keybindings).toEqual([{ command: "terminal.toggle", shortcut }]);
       expect(config.issues).toEqual([]);
-      expect(config.availableEditors).toEqual(["zed"]);
+      expect(config.availableEditors).toEqual(["sublime-text", "zed"]);
     }),
   );
 

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -50,6 +50,12 @@ export const EDITORS = [
     remoteScheme: "vscodium",
   },
   { id: "zed", label: "Zed", commands: ["zed", "zeditor"], launchStyle: "direct-path" },
+  {
+    id: "sublime-text",
+    label: "Sublime Text",
+    commands: ["subl"],
+    launchStyle: "direct-path",
+  },
   { id: "antigravity", label: "Antigravity", commands: ["agy"], launchStyle: "goto" },
   { id: "idea", label: "IntelliJ IDEA", commands: ["idea"], launchStyle: "line-column" },
   { id: "aqua", label: "Aqua", commands: ["aqua"], launchStyle: "line-column" },

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -133,9 +133,9 @@ describe("server config forward compatibility", () => {
   });
 
   it("drops editor ids this build does not know", () => {
-    const parsed = decodeAvailableEditors(["zed", "some-future-editor", "vscode"]);
+    const parsed = decodeAvailableEditors(["zed", "some-future-editor", "sublime-text", "vscode"]);
 
-    expect(parsed).toEqual(["zed", "vscode"]);
+    expect(parsed).toEqual(["zed", "sublime-text", "vscode"]);
   });
 
   // A provider status this build has never seen (a new ServerProviderState,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added [Sublime Text](https://www.sublimetext.com/) editor support. Based on Zed editor support since they share approach on how to handle files and file lines.

## Why

Sublime Text is popular code/text editor with extensive plugin support for LSP and IDE capabilities.

## UI Changes

Add the Sublime Text icon to the open drop down

<img width="243" height="135" alt="Screenshot 2026-09-02 at 13 35 38" src="https://github.com/user-attachments/assets/fc49a956-a08d-4e13-a55f-94e363a62dc7" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive editor registration and UI only; no auth or data-path changes. Launch behavior depends on `subl` being on PATH when probed.
> 
> **Overview**
> Adds **Sublime Text** as a selectable target for the chat/workspace **Open in editor** flow.
> 
> The shared `EDITORS` contract now includes `sublime-text` with the `subl` CLI and **`direct-path`** launch style (same approach as Zed), so server probing and local launch can treat it like other path-based editors. The web **Open in** picker shows a new Sublime icon and menu entry when the server reports the editor as available.
> 
> Label tests cover **"Sublime Text"** / **"Open in Sublime Text"**, and config decode/session tests expect `sublime-text` to survive forward-compatible filtering alongside known editor ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e844e3b82ad0f8d15a5854fab89ec43f0cbb80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `sublime-text` editor support to open-in picker and shared editor definitions
> - Adds a `sublime-text` editor definition to the shared `EDITORS` map in [editor.ts](https://github.com/pingdotgg/t3code/pull/9220/files#diff-952d09e8dcc92b201e44f8f0b5edc71af952e9af9479b5853c41ce6e93d636f7) with the `subl` command and `direct-path` launch style
> - Adds a `SublimeTextIcon` SVG component in [Icons.tsx](https://github.com/pingdotgg/t3code/pull/9220/files#diff-d19962a9c1cb0bc3363e0d837062d1bd60923e4ea67f675a9f9fc3ec7f7e3442) and wires it into the open-in picker in [OpenInPicker.tsx](https://github.com/pingdotgg/t3code/pull/9220/files#diff-e2a98d212ae98eb3ec0902f11d6e8f0daeb2b1729c80a65a8792371f7605e802) so the option appears when `availableEditors` includes `sublime-text`
> - Updates tests in [editorLabels.test.ts](https://github.com/pingdotgg/t3code/pull/9220/files#diff-c7883823a5db958d0a3ec3e11040feecb9c98ce0ff5f3e7e0903c5aad21e91cc), [session.test.ts](https://github.com/pingdotgg/t3code/pull/9220/files#diff-867ecf14cf43c6fc8a519ffc1b3c7f937f715cfd2f77592bde4630c7499ba250), and [server.test.ts](https://github.com/pingdotgg/t3code/pull/9220/files#diff-216657714c4eb23464a421596ce2498fca0a6cf4159ff371d62798bbd5d80924) to assert the label, menu text, and config decoding for `sublime-text`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e844e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->