### PR TITLE
fix(server): reset terminal modes a dead shell leaves in inherited history

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1425,6 +1425,118 @@ it.layer(
     }),
   );
 
+  it.effect("clears Kitty keyboard flags a dead process left in inherited history", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // Codex CLI pushes event-type reporting, then the shell dies before it
+      // can pop (server restart). The query is stripped; the push survives.
+      process.emitData("prompt % codex\n\u001b[>7u\u001b[?u");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      expect(ptyAdapter.spawnInputs).toHaveLength(2);
+      assert.equal(reopened.history, "prompt % codex\n\u001b[>7u\u001b[=0;1u");
+    }),
+  );
+
+  it.effect("resets mouse and focus modes a dead process left in inherited history", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // Claude Code tracks mouse motion and focus; replaying that into a fresh
+      // shell would make the client send reports the shell echoes as junk.
+      process.emitData("prompt % claude\n\u001b[?1004h\u001b[?1003;1006h");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(
+        reopened.history,
+        "prompt % claude\n\u001b[?1004h\u001b[?1003;1006h\u001b[?1004l\u001b[?1003l\u001b[?1006l",
+      );
+    }),
+  );
+
+  it.effect("leaves the alternate screen before restoring the cursor in inherited history", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // DECSTR leaves every tracked mode alone in libghostty-vt, so it must not
+      // be mistaken for a reset.
+      process.emitData("prompt % nvim\n\u001b[?25l\u001b[?1049h\u001b[!p");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(
+        reopened.history,
+        "prompt % nvim\n\u001b[?25l\u001b[?1049h\u001b[!p\u001b[?1049l\u001b[?25h",
+      );
+    }),
+  );
+
+  it.effect("leaves inherited history alone when its process restored the terminal", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // A clean exit pops its flags and resets its modes; a later RIS wipes
+      // everything before it, including a dangling alternate screen.
+      process.emitData("\u001b[>7u\u001b[?1003h\u001b[<u\u001b[?1003l");
+      process.emitData("\u001b[?1049h\u001b[=1;1u\u001bc");
+      process.emitData("prompt % ");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(
+        reopened.history,
+        "\u001b[>7u\u001b[?1003h\u001b[<u\u001b[?1003l\u001b[?1049h\u001b[=1;1u\u001bcprompt % ",
+      );
+    }),
+  );
+
+  it.effect("neutralizes inherited history once across repeated restarts", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // Two pushes with one pop, as a TUI that spawned a child and then died leaves.
+      process.emitData("\u001b[>1u\u001b[>7u\u001b[<u\u001b[?1004h");
+
+      yield* manager.close({ threadId: "thread-1" });
+      const first = yield* manager.open(openInput());
+      yield* manager.close({ threadId: "thread-1" });
+      const second = yield* manager.open(openInput());
+
+      assert.equal(
+        first.history,
+        "\u001b[>1u\u001b[>7u\u001b[<u\u001b[?1004h\u001b[?1004l\u001b[=0;1u",
+      );
+      assert.equal(second.history, first.history);
+    }),
+  );
+
   it.effect("strips replayable CSI and DCS traffic while preserving setters", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1513,6 +1513,45 @@ it.layer(
     }),
   );
 
+  it.effect("keeps Kitty keyboard stacks per screen while neutralizing inherited history", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // A push on the main screen survives an alternate-screen round trip even
+      // when the app pops while on the alternate screen (libghostty keeps one
+      // stack per screen), so the main screen still needs its reset.
+      process.emitData("\u001b[>7u\u001b[?1049h\u001b[<u\u001b[?1049l");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(reopened.history, "\u001b[>7u\u001b[?1049h\u001b[<u\u001b[?1049l\u001b[=0;1u");
+    }),
+  );
+
+  it.effect("leaves the alternate screen without resetting Kitty flags pushed only there", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // Dying inside the alternate screen with flags pushed there: leaving the
+      // screen makes the untouched main stack active, so no Kitty reset is due.
+      process.emitData("\u001b[?1049h\u001b[>7u");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(reopened.history, "\u001b[?1049h\u001b[>7u\u001b[?1049l");
+    }),
+  );
+
   it.effect("neutralizes inherited history once across repeated restarts", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1576,6 +1576,33 @@ it.layer(
       yield* cleared.manager.close({ threadId: "thread-1" });
       const afterCleared = yield* cleared.manager.open(openInput());
       assert.equal(afterCleared.history, "\u001b[>7u\u001b[=7;3u");
+
+      // libghostty-vt ignores set modes other than 1, 2, and 3, so the flags stay.
+      const unsupported = yield* createManager();
+      yield* unsupported.manager.open(openInput());
+      unsupported.ptyAdapter.processes[0]!.emitData("\u001b[>7u\u001b[=0;4u");
+      yield* unsupported.manager.close({ threadId: "thread-1" });
+      const afterUnsupported = yield* unsupported.manager.open(openInput());
+      assert.equal(afterUnsupported.history, "\u001b[>7u\u001b[=0;4u\u001b[=0;1u");
+    }),
+  );
+
+  it.effect("ignores the 8-bit CSI byte like the client's replay parser does", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      // A U+009B introducer is not a sequence to libghostty-vt, so a "clear"
+      // written that way never happened and the push still needs its reset.
+      process.emitData("\u001b[>7u\u009b=0;1u");
+
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      assert.equal(reopened.history, "\u001b[>7u\u009b=0;1u\u001b[=0;1u");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1552,6 +1552,33 @@ it.layer(
     }),
   );
 
+  it.effect("applies Kitty set modes when tracking inherited flags", () =>
+    Effect.gen(function* () {
+      // Mode 3 clears only the named bits, so clearing none leaves 7 active.
+      const clearNone = yield* createManager();
+      yield* clearNone.manager.open(openInput());
+      clearNone.ptyAdapter.processes[0]!.emitData("\u001b[>7u\u001b[=0;3u");
+      yield* clearNone.manager.close({ threadId: "thread-1" });
+      const afterClearNone = yield* clearNone.manager.open(openInput());
+      assert.equal(afterClearNone.history, "\u001b[>7u\u001b[=0;3u\u001b[=0;1u");
+
+      // Clearing every bit set by the push needs no reset; OR-ing bits in does.
+      const clearAll = yield* createManager();
+      yield* clearAll.manager.open(openInput());
+      clearAll.ptyAdapter.processes[0]!.emitData("\u001b[>7u\u001b[=7;3u\u001b[=2;2u");
+      yield* clearAll.manager.close({ threadId: "thread-1" });
+      const afterOr = yield* clearAll.manager.open(openInput());
+      assert.equal(afterOr.history, "\u001b[>7u\u001b[=7;3u\u001b[=2;2u\u001b[=0;1u");
+
+      const cleared = yield* createManager();
+      yield* cleared.manager.open(openInput());
+      cleared.ptyAdapter.processes[0]!.emitData("\u001b[>7u\u001b[=7;3u");
+      yield* cleared.manager.close({ threadId: "thread-1" });
+      const afterCleared = yield* cleared.manager.open(openInput());
+      assert.equal(afterCleared.history, "\u001b[>7u\u001b[=7;3u");
+    }),
+  );
+
   it.effect("neutralizes inherited history once across repeated restarts", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1027,18 +1027,17 @@ const INHERITED_DEC_MODE_DEFAULTS = new Map<number, boolean>([
 const ALTERNATE_SCREEN_DEC_MODES = [47, 1047, 1049];
 // Kitty keyboard flags live on a stack: `CSI > flags u` pushes, `CSI < n u`
 // pops, `CSI = flags ; mode u` edits the top (mode 1 replaces, 2 sets bits,
-// 3 clears bits). The main and alternate screens keep separate stacks, and
-// the encoder only reads the active top, so zeroing it is enough; only RIS
-// clears the stacks.
+// 3 clears bits; libghostty-vt ignores any other mode). The main and
+// alternate screens keep separate stacks, and the encoder only reads the
+// active top, so zeroing it is enough; only RIS clears the stacks.
 const KITTY_KEYBOARD_CLEAR = "\u001b[=0;1u";
-// Every sequence of interest starts with ESC (after folding the 8-bit CSI
-// byte into ESC `[`), so the history is split there and each fragment's head
-// is matched: DEC mode set/reset, Kitty keyboard push/pop/set, or RIS (`c`).
-// RIS is the only reset that touches these in libghostty-vt; DECSTR
-// (`CSI ! p`) leaves every one of them alone, so it is deliberately not
-// tracked.
+// Every sequence of interest starts with ESC, so the history is split there
+// and each fragment's head is matched: DEC mode set/reset, Kitty keyboard
+// push/pop/set, or RIS (`c`). The scanner tracks only what the client's
+// replay parser acts on: libghostty-vt ignores the 8-bit CSI byte (U+009B,
+// which the UTF-8 history would carry as C2 9B) and leaves every tracked
+// mode alone on DECSTR (`CSI ! p`), so neither is treated as a sequence.
 const ESCAPE = "\u001b";
-const CSI_8BIT = "\u009b";
 const INHERITED_MODE_SEQUENCE =
   /^(?:\[(?:\?([0-9;]+)([hl])|([<>=])([0-9]*)(?:;([0-9]*))?[0-9;]*u)|(c))/u;
 
@@ -1047,8 +1046,7 @@ function neutralizeInheritedHistory(history: string): string {
   const modes = new Map<number, boolean>();
   const kittyStacks = { main: [0], alternate: [0] };
   let screen: keyof typeof kittyStacks = "main";
-  const fragments = history.replaceAll(CSI_8BIT, `${ESCAPE}[`).split(ESCAPE);
-  for (const fragment of fragments.slice(1)) {
+  for (const fragment of history.split(ESCAPE).slice(1)) {
     const match = INHERITED_MODE_SEQUENCE.exec(fragment);
     if (match === null) continue;
     if (match[6] !== undefined) {
@@ -1067,8 +1065,11 @@ function neutralizeInheritedHistory(history: string): string {
         const flags = Number.isNaN(parameter) ? 0 : parameter;
         const top = stack.length - 1;
         const current = stack[top] ?? 0;
-        const setMode = Number.parseInt(match[5] ?? "", 10);
-        stack[top] = setMode === 2 ? current | flags : setMode === 3 ? current & ~flags : flags;
+        const setMode =
+          match[5] === undefined || match[5] === "" ? 1 : Number.parseInt(match[5], 10);
+        if (setMode === 1) stack[top] = flags;
+        else if (setMode === 2) stack[top] = current | flags;
+        else if (setMode === 3) stack[top] = current & ~flags;
       } else {
         const count = Number.isNaN(parameter) ? 1 : parameter;
         stack.length = Math.max(1, stack.length - count);

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -994,6 +994,98 @@ export class BoundedTerminalHistory {
   }
 }
 
+// A shell that dies mid-app (server restart or crash while Codex CLI, Claude
+// Code, or another TUI runs) never gets to restore the terminal modes the app
+// set. The next shell inherits that history on open, the client replays it
+// into a fresh emulator, and the renderer then encodes key releases, mouse
+// motion, or focus changes for a shell that never asked. Undo whatever the
+// inherited history leaves deviating from power-on defaults; a program that
+// wants a mode again sets its own.
+//
+// DEC private modes worth restoring, with their power-on defaults. Frame-scoped
+// modes such as synchronized output (2026) are excluded: they never outlive
+// the frame that opened them.
+const INHERITED_DEC_MODE_DEFAULTS = new Map<number, boolean>([
+  [1, false], // application cursor keys
+  [6, false], // origin mode
+  [7, true], // autowrap
+  [9, false], // X10 mouse reporting
+  [25, true], // cursor visible
+  [47, false], // legacy alternate screen
+  [1000, false], // mouse press/release tracking
+  [1002, false], // mouse button-event tracking
+  [1003, false], // mouse any-event tracking
+  [1004, false], // focus reporting
+  [1005, false], // UTF-8 mouse encoding
+  [1006, false], // SGR mouse encoding
+  [1015, false], // urxvt mouse encoding
+  [1047, false], // alternate screen buffer
+  [1049, false], // alternate screen with cursor save
+  [2004, false], // bracketed paste
+]);
+// The three alternate-screen modes toggle one underlying screen.
+const ALTERNATE_SCREEN_DEC_MODES = [47, 1047, 1049];
+// Kitty keyboard flags live on a stack: `CSI > flags u` pushes, `CSI < n u`
+// pops, `CSI = flags ; mode u` rewrites the top. The encoder only reads the
+// top, so zeroing it is enough; only RIS clears the stack.
+const KITTY_KEYBOARD_CLEAR = "\u001b[=0;1u";
+// DEC mode set/reset, Kitty keyboard push/pop/set, and RIS (`ESC c`). RIS is
+// the only reset that touches these in libghostty-vt; DECSTR (`CSI ! p`)
+// leaves every one of them alone, so it is deliberately not tracked.
+const INHERITED_MODE_PATTERN =
+  // eslint-disable-next-line no-control-regex -- matches ESC / CSI control sequences.
+  /(?:\u001b\[|\u009b)(?:\?([0-9;]+)([hl])|([<>=])([0-9]*)[0-9;]*u)|\u001b(c)/gu;
+
+function neutralizeInheritedHistory(history: string): string {
+  if (history.length === 0) return history;
+  const modes = new Map<number, boolean>();
+  const kittyStack = [0];
+  for (const match of history.matchAll(INHERITED_MODE_PATTERN)) {
+    if (match[5] !== undefined) {
+      modes.clear();
+      kittyStack.length = 1;
+      kittyStack[0] = 0;
+      continue;
+    }
+    if (match[3] !== undefined) {
+      const parameter = Number.parseInt(match[4] ?? "", 10);
+      if (match[3] === ">") {
+        kittyStack.push(Number.isNaN(parameter) ? 0 : parameter);
+      } else if (match[3] === "=") {
+        kittyStack[kittyStack.length - 1] = Number.isNaN(parameter) ? 0 : parameter;
+      } else {
+        const count = Number.isNaN(parameter) ? 1 : parameter;
+        kittyStack.length = Math.max(1, kittyStack.length - count);
+      }
+      continue;
+    }
+    const enabled = match[2] === "h";
+    for (const parameter of (match[1] ?? "").split(";")) {
+      const mode = Number.parseInt(parameter, 10);
+      if (!INHERITED_DEC_MODE_DEFAULTS.has(mode)) continue;
+      if (ALTERNATE_SCREEN_DEC_MODES.includes(mode)) {
+        for (const alias of ALTERNATE_SCREEN_DEC_MODES) modes.delete(alias);
+      }
+      modes.set(mode, enabled);
+    }
+  }
+  const deviations = [...modes].filter(
+    ([mode, enabled]) => enabled !== INHERITED_DEC_MODE_DEFAULTS.get(mode),
+  );
+  // Leave the alternate screen before the other resets: exiting it restores
+  // saved cursor state, which must not undo a cursor-show reset.
+  deviations.sort(
+    ([left], [right]) =>
+      Number(!ALTERNATE_SCREEN_DEC_MODES.includes(left)) -
+      Number(!ALTERNATE_SCREEN_DEC_MODES.includes(right)),
+  );
+  const decReset = deviations
+    .map(([mode]) => `\u001b[?${mode}${INHERITED_DEC_MODE_DEFAULTS.get(mode) ? "h" : "l"}`)
+    .join("");
+  const kittyReset = kittyStack[kittyStack.length - 1] === 0 ? "" : KITTY_KEYBOARD_CLEAR;
+  return `${history}${decReset}${kittyReset}`;
+}
+
 function isCsiFinalByte(codePoint: number): boolean {
   return codePoint >= 0x40 && codePoint <= 0x7e;
 }
@@ -2524,7 +2616,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const existing = yield* getSession(input.threadId, terminalId);
     if (Option.isNone(existing)) {
       yield* flushPersist(input.threadId, terminalId);
-      const history = yield* readHistory(input.threadId, terminalId);
+      const history = neutralizeInheritedHistory(yield* readHistory(input.threadId, terminalId));
       const cols = input.cols ?? DEFAULT_OPEN_COLS;
       const rows = input.rows ?? DEFAULT_OPEN_ROWS;
       const session: TerminalSessionState = {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1026,9 +1026,10 @@ const INHERITED_DEC_MODE_DEFAULTS = new Map<number, boolean>([
 // The three alternate-screen modes toggle one underlying screen.
 const ALTERNATE_SCREEN_DEC_MODES = [47, 1047, 1049];
 // Kitty keyboard flags live on a stack: `CSI > flags u` pushes, `CSI < n u`
-// pops, `CSI = flags ; mode u` rewrites the top. The main and alternate
-// screens keep separate stacks, and the encoder only reads the active top, so
-// zeroing it is enough; only RIS clears the stacks.
+// pops, `CSI = flags ; mode u` edits the top (mode 1 replaces, 2 sets bits,
+// 3 clears bits). The main and alternate screens keep separate stacks, and
+// the encoder only reads the active top, so zeroing it is enough; only RIS
+// clears the stacks.
 const KITTY_KEYBOARD_CLEAR = "\u001b[=0;1u";
 // Every sequence of interest starts with ESC (after folding the 8-bit CSI
 // byte into ESC `[`), so the history is split there and each fragment's head
@@ -1038,7 +1039,8 @@ const KITTY_KEYBOARD_CLEAR = "\u001b[=0;1u";
 // tracked.
 const ESCAPE = "\u001b";
 const CSI_8BIT = "\u009b";
-const INHERITED_MODE_SEQUENCE = /^(?:\[(?:\?([0-9;]+)([hl])|([<>=])([0-9]*)[0-9;]*u)|(c))/u;
+const INHERITED_MODE_SEQUENCE =
+  /^(?:\[(?:\?([0-9;]+)([hl])|([<>=])([0-9]*)(?:;([0-9]*))?[0-9;]*u)|(c))/u;
 
 function neutralizeInheritedHistory(history: string): string {
   if (history.length === 0) return history;
@@ -1049,7 +1051,7 @@ function neutralizeInheritedHistory(history: string): string {
   for (const fragment of fragments.slice(1)) {
     const match = INHERITED_MODE_SEQUENCE.exec(fragment);
     if (match === null) continue;
-    if (match[5] !== undefined) {
+    if (match[6] !== undefined) {
       modes.clear();
       kittyStacks.main = [0];
       kittyStacks.alternate = [0];
@@ -1062,7 +1064,11 @@ function neutralizeInheritedHistory(history: string): string {
       if (match[3] === ">") {
         stack.push(Number.isNaN(parameter) ? 0 : parameter);
       } else if (match[3] === "=") {
-        stack[stack.length - 1] = Number.isNaN(parameter) ? 0 : parameter;
+        const flags = Number.isNaN(parameter) ? 0 : parameter;
+        const top = stack.length - 1;
+        const current = stack[top] ?? 0;
+        const setMode = Number.parseInt(match[5] ?? "", 10);
+        stack[top] = setMode === 2 ? current | flags : setMode === 3 ? current & ~flags : flags;
       } else {
         const count = Number.isNaN(parameter) ? 1 : parameter;
         stack.length = Math.max(1, stack.length - count);

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -2636,7 +2636,12 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const existing = yield* getSession(input.threadId, terminalId);
     if (Option.isNone(existing)) {
       yield* flushPersist(input.threadId, terminalId);
-      const history = neutralizeInheritedHistory(yield* readHistory(input.threadId, terminalId));
+      const inherited = yield* readHistory(input.threadId, terminalId);
+      const history = new BoundedTerminalHistory(
+        historyLineLimit,
+        neutralizeInheritedHistory(inherited.value()),
+        historyByteLimit,
+      );
       const cols = input.cols ?? DEFAULT_OPEN_COLS;
       const rows = input.rows ?? DEFAULT_OPEN_ROWS;
       const session: TerminalSessionState = {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1030,19 +1030,25 @@ const ALTERNATE_SCREEN_DEC_MODES = [47, 1047, 1049];
 // screens keep separate stacks, and the encoder only reads the active top, so
 // zeroing it is enough; only RIS clears the stacks.
 const KITTY_KEYBOARD_CLEAR = "\u001b[=0;1u";
-// DEC mode set/reset, Kitty keyboard push/pop/set, and RIS (`ESC c`). RIS is
-// the only reset that touches these in libghostty-vt; DECSTR (`CSI ! p`)
-// leaves every one of them alone, so it is deliberately not tracked.
-const INHERITED_MODE_PATTERN =
-  // eslint-disable-next-line no-control-regex -- matches ESC / CSI control sequences.
-  /(?:\u001b\[|\u009b)(?:\?([0-9;]+)([hl])|([<>=])([0-9]*)[0-9;]*u)|\u001b(c)/gu;
+// Every sequence of interest starts with ESC (after folding the 8-bit CSI
+// byte into ESC `[`), so the history is split there and each fragment's head
+// is matched: DEC mode set/reset, Kitty keyboard push/pop/set, or RIS (`c`).
+// RIS is the only reset that touches these in libghostty-vt; DECSTR
+// (`CSI ! p`) leaves every one of them alone, so it is deliberately not
+// tracked.
+const ESCAPE = "\u001b";
+const CSI_8BIT = "\u009b";
+const INHERITED_MODE_SEQUENCE = /^(?:\[(?:\?([0-9;]+)([hl])|([<>=])([0-9]*)[0-9;]*u)|(c))/u;
 
 function neutralizeInheritedHistory(history: string): string {
   if (history.length === 0) return history;
   const modes = new Map<number, boolean>();
   const kittyStacks = { main: [0], alternate: [0] };
   let screen: keyof typeof kittyStacks = "main";
-  for (const match of history.matchAll(INHERITED_MODE_PATTERN)) {
+  const fragments = history.replaceAll(CSI_8BIT, `${ESCAPE}[`).split(ESCAPE);
+  for (const fragment of fragments.slice(1)) {
+    const match = INHERITED_MODE_SEQUENCE.exec(fragment);
+    if (match === null) continue;
     if (match[5] !== undefined) {
       modes.clear();
       kittyStacks.main = [0];

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1026,8 +1026,9 @@ const INHERITED_DEC_MODE_DEFAULTS = new Map<number, boolean>([
 // The three alternate-screen modes toggle one underlying screen.
 const ALTERNATE_SCREEN_DEC_MODES = [47, 1047, 1049];
 // Kitty keyboard flags live on a stack: `CSI > flags u` pushes, `CSI < n u`
-// pops, `CSI = flags ; mode u` rewrites the top. The encoder only reads the
-// top, so zeroing it is enough; only RIS clears the stack.
+// pops, `CSI = flags ; mode u` rewrites the top. The main and alternate
+// screens keep separate stacks, and the encoder only reads the active top, so
+// zeroing it is enough; only RIS clears the stacks.
 const KITTY_KEYBOARD_CLEAR = "\u001b[=0;1u";
 // DEC mode set/reset, Kitty keyboard push/pop/set, and RIS (`ESC c`). RIS is
 // the only reset that touches these in libghostty-vt; DECSTR (`CSI ! p`)
@@ -1039,23 +1040,26 @@ const INHERITED_MODE_PATTERN =
 function neutralizeInheritedHistory(history: string): string {
   if (history.length === 0) return history;
   const modes = new Map<number, boolean>();
-  const kittyStack = [0];
+  const kittyStacks = { main: [0], alternate: [0] };
+  let screen: keyof typeof kittyStacks = "main";
   for (const match of history.matchAll(INHERITED_MODE_PATTERN)) {
     if (match[5] !== undefined) {
       modes.clear();
-      kittyStack.length = 1;
-      kittyStack[0] = 0;
+      kittyStacks.main = [0];
+      kittyStacks.alternate = [0];
+      screen = "main";
       continue;
     }
     if (match[3] !== undefined) {
+      const stack = kittyStacks[screen];
       const parameter = Number.parseInt(match[4] ?? "", 10);
       if (match[3] === ">") {
-        kittyStack.push(Number.isNaN(parameter) ? 0 : parameter);
+        stack.push(Number.isNaN(parameter) ? 0 : parameter);
       } else if (match[3] === "=") {
-        kittyStack[kittyStack.length - 1] = Number.isNaN(parameter) ? 0 : parameter;
+        stack[stack.length - 1] = Number.isNaN(parameter) ? 0 : parameter;
       } else {
         const count = Number.isNaN(parameter) ? 1 : parameter;
-        kittyStack.length = Math.max(1, kittyStack.length - count);
+        stack.length = Math.max(1, stack.length - count);
       }
       continue;
     }
@@ -1065,6 +1069,7 @@ function neutralizeInheritedHistory(history: string): string {
       if (!INHERITED_DEC_MODE_DEFAULTS.has(mode)) continue;
       if (ALTERNATE_SCREEN_DEC_MODES.includes(mode)) {
         for (const alias of ALTERNATE_SCREEN_DEC_MODES) modes.delete(alias);
+        screen = enabled ? "alternate" : "main";
       }
       modes.set(mode, enabled);
     }
@@ -1082,7 +1087,9 @@ function neutralizeInheritedHistory(history: string): string {
   const decReset = deviations
     .map(([mode]) => `\u001b[?${mode}${INHERITED_DEC_MODE_DEFAULTS.get(mode) ? "h" : "l"}`)
     .join("");
-  const kittyReset = kittyStack[kittyStack.length - 1] === 0 ? "" : KITTY_KEYBOARD_CLEAR;
+  // The alternate screen has been left by now, so the main stack is active.
+  const mainStack = kittyStacks.main;
+  const kittyReset = mainStack[mainStack.length - 1] === 0 ? "" : KITTY_KEYBOARD_CLEAR;
   return `${history}${decReset}${kittyReset}`;
 }
 

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -700,6 +700,17 @@ describe("vendored libghostty-vt WebAssembly", () => {
     free(releaseOutput, releaseSize);
     free(reportEventsPointer, reportEvents.length);
 
+    // Zeroing the active flags, which the server appends to history a dead
+    // process left enabled, silences releases again without a full reset.
+    const clearFlags = new TextEncoder().encode("\u001b[=0;1u");
+    const clearFlagsPointer = alloc(clearFlags.length);
+    new Uint8Array(memory.buffer, clearFlagsPointer, clearFlags.length).set(clearFlags);
+    call("ghostty_terminal_vt_write", terminal, clearFlagsPointer, clearFlags.length);
+    call("ghostty_key_encoder_setopt_from_terminal", keyEncoder, terminal);
+    expect(call("ghostty_key_encoder_encode", keyEncoder, keyEvent, 0, 0, written)).toBe(0);
+    expect(new DataView(memory.buffer, written, 4).getUint32(0, true)).toBe(0);
+    free(clearFlagsPointer, clearFlags.length);
+
     free(remappedOutput, remappedOutputSize);
     free(remappedTextPointer, remappedText.length);
     free(output, outputSize);


### PR DESCRIPTION
## What Changed

When the server loads persisted history for a session it has no live process for, it now neutralizes what the dead process left on before the new shell starts:

- Appends `CSI ? n l` or `CSI ? n h` for every tracked DEC private mode the history leaves away from its power-on default: mouse tracking and encodings (9, 1000, 1002, 1003, 1005, 1006, 1015), focus reporting (1004), alternate screen (47, 1047, 1049), cursor visibility (25), cursor keys (1), origin (6), autowrap (7), bracketed paste (2004). The alternate screen is left first so its cursor restore cannot undo a cursor-show.
- Replays the Kitty keyboard stack (push, pop, set, RIS) and appends `CSI = 0 ; 1 u` when the stack ends with flags set.
- RIS clears the tracking. DECSTR is ignored, because libghostty-vt leaves all of these modes alone on DECSTR (measured against the vendored wasm).

About 95 lines in `apps/server/src/terminal/Manager.ts`. Tests: five Manager cases (Codex Kitty push, Claude mouse and focus, alternate screen with hidden cursor and a DECSTR that must not count, a clean exit that must be left alone, idempotency across two restarts) and one ABI assertion that `CSI = 0 ; 1 u` silences key releases in the vendored libghostty-vt.

## Why

Fixes #9219. Fixes #8574.

A server restart while Codex CLI or Claude Code is running leaves their modes in the persisted history with no teardown. The fresh shell inherits that history, the client replays it, and key releases or mouse reports reach zsh as junk until the terminal is recreated.

The reset sits at the one boundary where the server knows a new process is inheriting a dead one's history. Restart-in-place, exit-then-reopen, and UI close already wipe history, so no other path needs it. Resetting on the server means web, desktop, and mobile clients all get a clean replay from the same snapshot.

The Kitty sequence was chosen from measurement: `CSI = 0 ; 1 u` zeroes the active flags without a full reset, whereas RIS would also drop scrollback. The mode table matches the one in #9027 so that PR can absorb this on rebase.

Verified in a T3 Code (Dev) build against the real broken histories: the logs gained the resets after the dangling sequences, and the fresh shells took typing and scrolling cleanly.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes, so no screenshots or video

Fable 5.1 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted history replay for new terminal opens after restarts; behavior is narrow and heavily tested but affects all clients that inherit server history.
> 
> **Overview**
> When a terminal session is opened with **no in-memory session** but persisted scrollback from a prior process, the server now runs **`neutralizeInheritedHistory`** on that history before the client replays it.
> 
> The helper walks escape sequences in the transcript (DEC private mode set/reset, Kitty keyboard push/pop/set, and RIS) and **appends corrective CSI** so mouse, focus, alternate-screen, cursor, and Kitty keyboard state match power-on defaults. Alternate-screen exits are emitted before other DEC resets; **`CSI =0;1u`** clears leftover Kitty flags on the active main-screen stack when needed. History that already self-restored (e.g. clean exit plus RIS) is left unchanged, and a second open does not stack duplicate resets.
> 
> **`openLocked`** is the only integration point—running sessions are untouched. **Manager** effect tests cover Codex/Claude/nvim-style leftovers, per-screen Kitty stacks, DECSTR not counting as reset, and idempotency; **ghostty runtime ABI** asserts that **`CSI =0;1u`** silences Kitty key releases after replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 261a948f222b2f6ea37f190663fe91c4bef32532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset terminal modes left by dead shells in inherited history
> - Adds `neutralizeInheritedHistory` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/9221/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) to scan terminal history fragments for recognized DEC private mode changes, Kitty keyboard push/pop/set operations, and RIS, then append default-restoring sequences for any tracked modes that differ from power-on defaults
> - Kitty keyboard state is tracked on separate stacks for main and alternate screens; alternate-screen exits are ordered before other DEC resets, and a Kitty clear is appended only when active main-screen flags remain nonzero
> - `openLocked` passes new-session history through `neutralizeInheritedHistory` before assigning it to `TerminalSessionState`; existing running sessions are unaffected
> - Adds effect tests covering inherited Kitty/mouse/focus cleanup, alternate-screen restoration ordering, RIS-based state clearing, per-screen Kitty stacks, Kitty mode-set semantics, and idempotent neutralization across repeated restarts
> - Behavioral Change: new terminal sessions now start with cleanup sequences for inherited terminal modes and Kitty flags; existing sessions bypass this transform
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 261a948.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Terminal history replay now resets modes left enabled by a crashed or restarted shell.
  - Prevents inherited Kitty keyboard, keypad, mouse, focus, alternate-screen, and cursor states from affecting new terminal sessions.
  - Terminal input encoding now correctly resynchronizes after Kitty keyboard modes are cleared.
  - Improves restoration of terminal history across repeated process restarts.
  - Handles supported and unsupported terminal modes more consistently, including 8-bit control sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->