### PR TITLE
perf(web): index file-link parent suffixes

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -36,6 +36,49 @@ import ChatMarkdown, {
   shouldUseMarkdownFileBrowserPrimaryAction,
 } from "./ChatMarkdown";
 
+function runtimeGrowth({
+  smallInput,
+  largeInput,
+  repetitions = 1,
+}: {
+  smallInput: ReadonlyArray<string>;
+  largeInput: ReadonlyArray<string>;
+  repetitions?: number;
+}): number {
+  const smallSamples: number[] = [];
+  const largeSamples: number[] = [];
+  const measure = (input: ReadonlyArray<string>) => {
+    const startedAt = performance.now();
+    for (let repetition = 0; repetition < repetitions; repetition += 1) {
+      buildFileLinkParentSuffixByPath(input);
+    }
+    return performance.now() - startedAt;
+  };
+
+  for (let iteration = 0; iteration < 7; iteration += 1) {
+    let smallElapsedMs: number;
+    let largeElapsedMs: number;
+    if (iteration % 2 === 0) {
+      smallElapsedMs = measure(smallInput);
+      largeElapsedMs = measure(largeInput);
+    } else {
+      largeElapsedMs = measure(largeInput);
+      smallElapsedMs = measure(smallInput);
+    }
+
+    if (iteration >= 2) {
+      smallSamples.push(smallElapsedMs);
+      largeSamples.push(largeElapsedMs);
+    }
+  }
+
+  const median = (samples: number[]) => {
+    const sortedSamples = samples.toSorted((a, b) => a - b);
+    return sortedSamples[Math.floor(sortedSamples.length / 2)]!;
+  };
+  return median(largeSamples) / median(smallSamples);
+}
+
 describe("buildFileLinkParentSuffixByPath", () => {
   it.each([
     {
@@ -74,39 +117,27 @@ describe("buildFileLinkParentSuffixByPath", () => {
       );
     const smallPaths = paths(1_000);
     const largePaths = paths(4_000);
-    const smallSamples: number[] = [];
-    const largeSamples: number[] = [];
-
-    for (let iteration = 0; iteration < 7; iteration += 1) {
-      const measure = (input: string[]) => {
-        const startedAt = performance.now();
-        buildFileLinkParentSuffixByPath(input);
-        return performance.now() - startedAt;
-      };
-      let smallElapsedMs: number;
-      let largeElapsedMs: number;
-      if (iteration % 2 === 0) {
-        smallElapsedMs = measure(smallPaths);
-        largeElapsedMs = measure(largePaths);
-      } else {
-        largeElapsedMs = measure(largePaths);
-        smallElapsedMs = measure(smallPaths);
-      }
-
-      if (iteration >= 2) {
-        smallSamples.push(smallElapsedMs);
-        largeSamples.push(largeElapsedMs);
-      }
-    }
-
-    const median = (samples: number[]) => {
-      const sortedSamples = samples.toSorted((a, b) => a - b);
-      return sortedSamples[Math.floor(sortedSamples.length / 2)]!;
-    };
-    const growthRatio = median(largeSamples) / median(smallSamples);
 
     expect(buildFileLinkParentSuffixByPath(largePaths).size).toBe(largePaths.length);
-    expect(growthRatio).toBeLessThan(10);
+    expect(runtimeGrowth({ smallInput: smallPaths, largeInput: largePaths })).toBeLessThan(10);
+  });
+
+  it("scales linearly with path depth", () => {
+    const nestedPaths = (depth: number) => {
+      const commonParents = Array.from({ length: depth }, () => "seg").join("/");
+      return [
+        `/${commonParents}/first/shared/index.ts`,
+        `/${commonParents}/second/shared/index.ts`,
+      ];
+    };
+    const shallowPaths = nestedPaths(225);
+    const deepPaths = nestedPaths(900);
+    const deepSuffixes = buildFileLinkParentSuffixByPath(deepPaths);
+
+    expect([...deepSuffixes.values()]).toEqual(["first/shared", "second/shared"]);
+    expect(
+      runtimeGrowth({ smallInput: shallowPaths, largeInput: deepPaths, repetitions: 16 }),
+    ).toBeLessThan(10);
   });
 });
 

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -29,11 +29,86 @@ vi.mock("~/lib/openPullRequestLink", () => ({
 }));
 
 import ChatMarkdown, {
+  buildFileLinkParentSuffixByPath,
   canUseMarkdownFileShellActions,
   hasMarkdownFilePrimaryAction,
   orderedListGutterStyle,
   shouldUseMarkdownFileBrowserPrimaryAction,
 } from "./ChatMarkdown";
+
+describe("buildFileLinkParentSuffixByPath", () => {
+  it.each([
+    {
+      name: "mixed path depths, duplicates, bare files, and different basenames",
+      paths: [
+        "/repo/a/shared/index.ts",
+        "/repo/b/shared/index.ts",
+        "/b/shared/index.ts",
+        "/repo/a/shared/index.ts",
+        "index.ts",
+        "/repo/a/README.md",
+      ],
+      expected: new Map([
+        ["/repo/a/shared/index.ts", "a/shared"],
+        ["/repo/b/shared/index.ts", "repo/b/shared"],
+        ["/b/shared/index.ts", "b/shared"],
+      ]),
+    },
+    {
+      name: "mixed separators and Windows drive prefixes",
+      paths: [String.raw`C:\repo\src\index.ts`, "C:/repo/src/index.ts", "D:/repo/src/index.ts"],
+      expected: new Map([
+        ["C:/repo/src/index.ts", "C:/repo/src"],
+        ["D:/repo/src/index.ts", "D:/repo/src"],
+      ]),
+    },
+  ])("preserves suffix selection for $name", ({ paths, expected }) => {
+    expect(buildFileLinkParentSuffixByPath(paths)).toEqual(expected);
+  });
+
+  it("scales without pairwise growth for large same-basename groups", () => {
+    const paths = (count: number) =>
+      Array.from(
+        { length: count },
+        (_, index) => `/workspace/package-${index}/src/components/shared/index.ts`,
+      );
+    const smallPaths = paths(1_000);
+    const largePaths = paths(4_000);
+    const smallSamples: number[] = [];
+    const largeSamples: number[] = [];
+
+    for (let iteration = 0; iteration < 7; iteration += 1) {
+      const measure = (input: string[]) => {
+        const startedAt = performance.now();
+        buildFileLinkParentSuffixByPath(input);
+        return performance.now() - startedAt;
+      };
+      let smallElapsedMs: number;
+      let largeElapsedMs: number;
+      if (iteration % 2 === 0) {
+        smallElapsedMs = measure(smallPaths);
+        largeElapsedMs = measure(largePaths);
+      } else {
+        largeElapsedMs = measure(largePaths);
+        smallElapsedMs = measure(smallPaths);
+      }
+
+      if (iteration >= 2) {
+        smallSamples.push(smallElapsedMs);
+        largeSamples.push(largeElapsedMs);
+      }
+    }
+
+    const median = (samples: number[]) => {
+      const sortedSamples = samples.toSorted((a, b) => a - b);
+      return sortedSamples[Math.floor(sortedSamples.length / 2)]!;
+    };
+    const growthRatio = median(largeSamples) / median(smallSamples);
+
+    expect(buildFileLinkParentSuffixByPath(largePaths).size).toBe(largePaths.length);
+    expect(growthRatio).toBeLessThan(10);
+  });
+});
 
 describe("canUseMarkdownFileShellActions", () => {
   const environmentId = EnvironmentId.make("environment-1");

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1047,6 +1047,7 @@ function pathParentSegments(path: string): string[] {
   return segments.slice(0, -1);
 }
 
+/** Maps each ambiguous file path to the shortest parent suffix that distinguishes its basename. */
 export function buildFileLinkParentSuffixByPath(
   filePaths: ReadonlyArray<string>,
 ): Map<string, string> {
@@ -1069,12 +1070,25 @@ export function buildFileLinkParentSuffixByPath(
     const parentSegmentsByPath = new Map(
       uniquePaths.map((filePath) => [filePath, pathParentSegments(filePath)]),
     );
-    const suffixCounts = new Map<string, number>();
+    type SuffixTrieNode = {
+      pathCount: number;
+      children: Map<string, SuffixTrieNode>;
+    };
+    const suffixTrie: SuffixTrieNode = { pathCount: 0, children: new Map() };
 
     for (const segments of parentSegmentsByPath.values()) {
+      let node = suffixTrie;
       for (let depth = 1; depth <= segments.length; depth += 1) {
-        const suffix = segments.slice(-depth).join("/");
-        suffixCounts.set(suffix, (suffixCounts.get(suffix) ?? 0) + 1);
+        const segment = segments[segments.length - depth];
+        if (segment === undefined) break;
+
+        let child = node.children.get(segment);
+        if (child === undefined) {
+          child = { pathCount: 0, children: new Map() };
+          node.children.set(segment, child);
+        }
+        child.pathCount += 1;
+        node = child;
       }
     }
 
@@ -1083,12 +1097,18 @@ export function buildFileLinkParentSuffixByPath(
       if (segments.length === 0) continue;
 
       let minUniqueDepth = segments.length;
+      let node = suffixTrie;
       for (let depth = 1; depth <= segments.length; depth += 1) {
-        const suffix = segments.slice(-depth).join("/");
-        if (suffixCounts.get(suffix) === 1) {
+        const segment = segments[segments.length - depth];
+        if (segment === undefined) break;
+
+        const child = node.children.get(segment);
+        if (child === undefined) break;
+        if (child.pathCount === 1) {
           minUniqueDepth = depth;
           break;
         }
+        node = child;
       }
       const suffixDepth = Math.min(segments.length, Math.max(minUniqueDepth, 2));
       suffixByPath.set(filePath, segments.slice(-suffixDepth).join("/"));

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1047,7 +1047,9 @@ function pathParentSegments(path: string): string[] {
   return segments.slice(0, -1);
 }
 
-function buildFileLinkParentSuffixByPath(filePaths: ReadonlyArray<string>): Map<string, string> {
+export function buildFileLinkParentSuffixByPath(
+  filePaths: ReadonlyArray<string>,
+): Map<string, string> {
   const groups = new Map<string, Set<string>>();
   for (const filePath of filePaths) {
     const normalizedPath = filePath.replaceAll("\\", "/");
@@ -1067,30 +1069,27 @@ function buildFileLinkParentSuffixByPath(filePaths: ReadonlyArray<string>): Map<
     const parentSegmentsByPath = new Map(
       uniquePaths.map((filePath) => [filePath, pathParentSegments(filePath)]),
     );
-    const minUniqueDepthByPath = new Map<string, number>();
+    const suffixCounts = new Map<string, number>();
 
-    for (const filePath of uniquePaths) {
-      const segments = parentSegmentsByPath.get(filePath) ?? [];
-      let resolvedDepth = segments.length;
+    for (const segments of parentSegmentsByPath.values()) {
       for (let depth = 1; depth <= segments.length; depth += 1) {
-        const candidate = segments.slice(-depth).join("/");
-        const collision = uniquePaths.some((otherPath) => {
-          if (otherPath === filePath) return false;
-          const otherSegments = parentSegmentsByPath.get(otherPath) ?? [];
-          return otherSegments.slice(-depth).join("/") === candidate;
-        });
-        if (!collision) {
-          resolvedDepth = depth;
-          break;
-        }
+        const suffix = segments.slice(-depth).join("/");
+        suffixCounts.set(suffix, (suffixCounts.get(suffix) ?? 0) + 1);
       }
-      minUniqueDepthByPath.set(filePath, resolvedDepth);
     }
 
     for (const filePath of uniquePaths) {
       const segments = parentSegmentsByPath.get(filePath) ?? [];
       if (segments.length === 0) continue;
-      const minUniqueDepth = minUniqueDepthByPath.get(filePath) ?? 1;
+
+      let minUniqueDepth = segments.length;
+      for (let depth = 1; depth <= segments.length; depth += 1) {
+        const suffix = segments.slice(-depth).join("/");
+        if (suffixCounts.get(suffix) === 1) {
+          minUniqueDepth = depth;
+          break;
+        }
+      }
       const suffixDepth = Math.min(segments.length, Math.max(minUniqueDepth, 2));
       suffixByPath.set(filePath, segments.slice(-suffixDepth).join("/"));
     }


### PR DESCRIPTION
## What Changed

Replaced repeated pairwise suffix comparisons with a reverse suffix trie for Markdown file links that share a basename. Each trie node records how many paths share that suffix, so each path finds its shortest unique parent by walking segments instead of repeatedly slicing and joining full strings.

Added table-driven semantic coverage, a large-group scaling guard from 1,000 to 4,000 paths, and a path-depth scaling guard from 225 to 900 parent segments. Both performance guards validate their result outside the timed region.

## Why

Large agent responses can reference many files named `index.ts`. The original pairwise scan was quadratic in the number of same-basename paths; the first indexed version removed that factor but materialized every joined suffix, leaving quadratic work in path depth. The trie performs O(N × D) traversal for N paths with maximum parent depth D, plus the final suffix strings returned to the renderer.

On an Intel N95 with Node 24.15.0 and Linux x64, isolated runs used 5 warm-ups, 20 alternating-order samples, and median/p95 reporting:

| Workload | Before | Reverse trie | Improvement |
| --- | ---: | ---: | ---: |
| 2,000 same-basename paths, median | 815.51 ms | 4.02 ms | 202.7x faster |
| 2,000 same-basename paths, p95 | 878.96 ms | 5.58 ms | 157.4x faster |
| Two 3,622-byte paths, median | 24.23 ms | 0.24 ms | 100.7x faster |
| Two 3,622-byte paths, p95 | 28.43 ms | 0.34 ms | 84.5x faster |

The wide-path comparison uses the original pairwise implementation. The deep-path comparison uses the intermediate suffix-count implementation that materialized every progressively longer suffix. The final trie matched the original output on 300,000 deterministic generated fixtures.

The committed guards measure relative growth instead of imposing machine-specific millisecond ceilings. They reject growth at or above 10x when either the path count or path depth increases 4x.

## Verification

- `vp test run src/components/ChatMarkdown.test.tsx --project unit`, 50 passed
- `vp run --filter @t3tools/web typecheck`
- `vp lint apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.tsx --report-unused-disable-directives`
- `vp fmt --check apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.tsx`
- React Doctor `0.9.13` diff scan: no errors or React performance findings; five `only-export-components` warnings, four already present on `upstream/main`
- Final `gpt-daybreak-blue-latest` review after the trie change: PASS with no findings
- Open issue/PR search found no duplicate; #4349 and #8825 touch `ChatMarkdown` for unrelated behavior and do not modify this helper

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable: rendered output is unchanged)
- [x] I included a video for animation/interaction changes (not applicable: no motion or interaction change)

Model: GPT-5.6 Sol · Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-link disambiguation when multiple files share similar names or paths, including mixed path formats and Windows drive paths.
  * Improved performance for large groups of files with the same basename and deeply nested paths.

* **Tests**
  * Added coverage for path-depth variations, duplicate names, bare files, mixed separators, Windows paths, and large file groups.
  * Added performance checks to help ensure efficient handling of larger file sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->