### PR TITLE
fix(server): update mise-managed providers through mise

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -582,6 +582,95 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  const miseCapabilities = (tool: string) => ({
+    provider: driver("packageTool"),
+    packageName: "@example/package-tool",
+    update: {
+      command: `mise upgrade --bump ${tool}`,
+      executable: "mise",
+      args: ["upgrade", "--bump", tool],
+      lockKey: "mise",
+    },
+  });
+
+  it.effect("switches to mise upgrades when the binary lives in mise's install tree", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-mise-capabilities");
+      const installDir = NodePath.join(tempDir, "mise", "installs", "package-tool");
+      const versionBinDir = NodePath.join(installDir, "1.0.0", "bin");
+      NodeFS.mkdirSync(versionBinDir, { recursive: true });
+      const packageToolPath = NodePath.join(versionBinDir, "package-tool");
+      NodeFS.writeFileSync(packageToolPath, "ELF");
+      NodeFS.chmodSync(packageToolPath, 0o755);
+      NodeFS.symlinkSync("1.0.0", NodePath.join(installDir, "latest"));
+
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(packageToolUpdate, {
+        binaryPath: NodePath.join(installDir, "latest", "bin", "package-tool"),
+        env: { PATH: "" },
+      });
+
+      expect(capabilities).toEqual(miseCapabilities("package-tool"));
+    }),
+  );
+
+  it("maps mise's npm backend install directory back to the npm package", () => {
+    expect(
+      packageToolUpdate.resolve({
+        binaryPath:
+          "/home/u/.local/share/mise/installs/npm-example-package-tool/1.0.0/lib/node_modules/@example/package-tool/bin/package-tool.js",
+        env: { PATH: "" },
+      }),
+    ).toEqual(miseCapabilities("npm:@example/package-tool"));
+  });
+
+  it("keeps npm updates for globals installed under a mise-managed node", () => {
+    expect(
+      packageToolUpdate.resolve({
+        binaryPath:
+          "/home/u/.local/share/mise/installs/node/26.7.0/lib/node_modules/@example/package-tool/bin/package-tool.js",
+        env: { PATH: "" },
+      }).update?.executable,
+    ).toBe("npm");
+  });
+
+  it("names the tool by its bin name for mise shims", () => {
+    expect(
+      packageToolUpdate.resolve({
+        binaryPath: "C:\\Users\\u\\AppData\\Local\\mise\\shims\\package-tool.exe",
+        env: { PATH: "" },
+      }),
+    ).toEqual(miseCapabilities("package-tool"));
+  });
+
+  it.effect("prefers mise over native updates for wrapper scripts that exec through mise", () =>
+    Effect.gen(function* () {
+      const tempDir = yield* makeTempDir("t3-mise-wrapper-capabilities");
+      const nativeBinDir = NodePath.join(tempDir, ".local", "bin");
+      NodeFS.mkdirSync(nativeBinDir, { recursive: true });
+      const wrapperPath = NodePath.join(nativeBinDir, "native-package-tool");
+      NodeFS.writeFileSync(
+        wrapperPath,
+        '#!/bin/bash\nexport MISE_MINIMUM_RELEASE_AGE=0\nmise use -g --quiet "native-package-tool" || exit 1\nexec mise x "native-package-tool" -- "native-package-tool" "$@"\n',
+      );
+      NodeFS.chmodSync(wrapperPath, 0o755);
+
+      const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+        nativePackageToolUpdate,
+        {
+          binaryPath: "native-package-tool",
+          env: { PATH: nativeBinDir },
+        },
+      ).pipe(Effect.provideService(HostProcessPlatform, "darwin"));
+
+      expect(capabilities.update).toEqual({
+        command: "mise upgrade --bump native-package-tool",
+        executable: "mise",
+        args: ["upgrade", "--bump", "native-package-tool"],
+        lockKey: "mise",
+      });
+    }),
+  );
+
   it("disables one-click updates for explicit custom binary paths it cannot safely map", () => {
     expect(
       packageToolUpdate.resolve({

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -55,6 +55,8 @@ export interface ProviderMaintenanceCapabilityResolutionOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly resolvedCommandPath?: string | null;
   readonly realCommandPath?: string | null;
+  /** Contents of the resolved command when it is a small script, so wrappers can be recognised. */
+  readonly commandScript?: string | null;
 }
 
 export interface ProviderMaintenanceCapabilitiesResolver {
@@ -188,6 +190,21 @@ function makeVitePlusGlobalProviderMaintenanceCapabilities(
   });
 }
 
+function makeMiseProviderMaintenanceCapabilities(
+  definition: PackageManagedProviderMaintenanceDefinition,
+  tool: string,
+): ProviderMaintenanceCapabilities {
+  return makeProviderMaintenanceCapabilities({
+    provider: definition.provider,
+    packageName: definition.npmPackageName,
+    updateExecutable: "mise",
+    // `--bump` moves past an exact version pin in the user's config; the
+    // usual `latest` pin stays `latest`.
+    updateArgs: ["upgrade", "--bump", tool],
+    updateLockKey: "mise",
+  });
+}
+
 function makeHomebrewProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
 ): ProviderMaintenanceCapabilities {
@@ -259,6 +276,40 @@ function isNpmGlobalCommandPath(commandPath: string): boolean {
   );
 }
 
+const MISE_INSTALL_PATH_PATTERN = /\/mise\/installs\/([^/]+)\//;
+const MISE_SHIM_PATH_PATTERN = /\/mise\/shims\/([^/]+)$/;
+// Wrapper scripts such as Omarchy's `exec mise x "codex" -- "codex" "$@"`.
+const MISE_EXEC_SCRIPT_PATTERN = /\bmise\s+(?:x|exec)\s+"?([^\s"]+)"?/;
+
+/**
+ * Maps a mise-managed command to the tool spec `mise upgrade` expects, or
+ * null when mise does not manage it. Recognises binaries under mise's install
+ * tree, mise shims, and small wrapper scripts that `mise x` the tool. Binaries
+ * under mise's `node` install are ordinary npm globals and are left to npm.
+ * Install directories are kebab-cased tool specs, so only the npm backend can
+ * be mapped back to a spec; shims and wrappers name the tool by its bin name.
+ */
+function resolveMiseTool(input: {
+  readonly commandPaths: ReadonlyArray<string>;
+  readonly commandScript: string | null | undefined;
+  readonly npmPackageName: string;
+}): string | null {
+  for (const commandPath of input.commandPaths) {
+    const normalized = normalizeCommandPath(commandPath);
+    const installDir = MISE_INSTALL_PATH_PATTERN.exec(normalized)?.[1];
+    if (installDir && installDir !== "node") {
+      return installDir.startsWith("npm-") ? `npm:${input.npmPackageName}` : installDir;
+    }
+    const shim = MISE_SHIM_PATH_PATTERN.exec(normalized)?.[1];
+    if (shim) {
+      return shim.replace(/\.(exe|cmd)$/, "");
+    }
+  }
+  return input.commandScript
+    ? (MISE_EXEC_SCRIPT_PATTERN.exec(input.commandScript)?.[1] ?? null)
+    : null;
+}
+
 function isHomebrewCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
   return (
@@ -291,6 +342,17 @@ export function resolvePackageManagedProviderMaintenance(
       ...(options?.realCommandPath ? [options.realCommandPath] : []),
     ];
 
+    // Checked before native installers: a mise wrapper for claude lives at
+    // `~/.local/bin/claude`, where the native check would otherwise send
+    // `claude update` at a binary that mise owns.
+    const miseTool = resolveMiseTool({
+      commandPaths,
+      commandScript: options?.commandScript,
+      npmPackageName: definition.npmPackageName,
+    });
+    if (miseTool) {
+      return makeMiseProviderMaintenanceCapabilities(definition, miseTool);
+    }
     const nativeUpdate = definition.nativeUpdate;
     if (
       nativeUpdate &&
@@ -353,11 +415,28 @@ function makeManualProviderMaintenanceCapabilities(
   });
 }
 
+const COMMAND_SCRIPT_MAX_BYTES = 4_096n;
+
+/** Reads the resolved command when it is a small file; binaries and large launchers yield null. */
+const readCommandScript = Effect.fn("readCommandScript")(function* (
+  fileSystem: FileSystem.FileSystem,
+  commandPath: string,
+) {
+  const info = yield* fileSystem.stat(commandPath).pipe(Effect.orElseSucceed(() => null));
+  if (!info || info.type !== "File" || info.size > COMMAND_SCRIPT_MAX_BYTES) {
+    return null;
+  }
+  return yield* fileSystem.readFileString(commandPath).pipe(Effect.orElseSucceed(() => null));
+});
+
 export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   "resolveProviderMaintenanceCapabilitiesEffect",
 )(function* (
   resolver: ProviderMaintenanceCapabilitiesResolver,
-  options?: Omit<ProviderMaintenanceCapabilityResolutionOptions, "realCommandPath">,
+  options?: Omit<
+    ProviderMaintenanceCapabilityResolutionOptions,
+    "realCommandPath" | "commandScript"
+  >,
 ) {
   const binaryPath = nonEmptyString(options?.binaryPath);
   if (!binaryPath) {
@@ -377,11 +456,13 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   const realCommandPath = yield* fileSystem
     .realPath(resolvedCommandPath)
     .pipe(Effect.orElseSucceed(() => resolvedCommandPath));
+  const commandScript = yield* readCommandScript(fileSystem, realCommandPath);
   return resolver.resolve({
     ...options,
     env,
     resolvedCommandPath,
     realCommandPath,
+    commandScript,
   });
 });
 


### PR DESCRIPTION
## What Changed

Provider update detection now recognises tools that mise manages and updates them with `mise upgrade --bump <tool>` instead of `npm install -g`.

Detection covers the three ways a mise-managed binary shows up on `PATH`:

- binaries under mise's install tree (`~/.local/share/mise/installs/<tool>/<version>/`, including the `latest` symlink and the `npm:` backend, which maps back to the npm package)
- mise shims (`~/.local/share/mise/shims/<tool>`, also on Windows)
- small wrapper scripts that `mise x` the tool, which is what Omarchy's `omarchy-mise-install` writes to `~/.local/bin/<tool>`

Binaries under mise's own `node` install are plain npm globals and keep the npm command. The mise check runs before the native-installer check because an Omarchy wrapper for claude lives at `~/.local/bin/claude`, which the native check matched.

## Why

Ref #8051. On Omarchy, codex and claude are installed through mise by default, and several commenters on the issue report the same setup. The resolver only knew npm, bun, pnpm, vp, Homebrew, and native installers, so mise installs fell through to the npm command. That either fails or installs a second copy next to the one mise runs. Worse, for claude the wrapper path matched the native-installer check, so T3 Code would run `claude update` against a binary mise owns.

Reading the resolved command file is limited to files under 4 KiB and is skipped for binaries, so provider creation cost is one stat and one small read next to the existing `realPath` call.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which executable runs for one-click provider updates and reorders detection ahead of native installers; wrong classification could run the wrong upgrade command on user machines.
> 
> **Overview**
> Provider maintenance now detects **mise-managed** CLIs and offers **`mise upgrade --bump <tool>`** (lock key `mise`) instead of defaulting to **`npm install -g`**, which could fail or install a duplicate copy.
> 
> Detection covers binaries under **`mise/installs/`** (including **`npm-`** backends mapped to `npm:<package>`), **mise shims** (including Windows `.exe`), and **small wrapper scripts** that delegate via `mise x`/`mise exec`. Globals under mise’s **`node`** install still use npm. The mise branch runs **before** native-installer detection so wrappers at `~/.local/bin/<tool>` are not treated as native `claude update` targets.
> 
> Resolution optionally reads the resolved command file (≤4 KiB) after `realPath` so wrapper content can be classified; tests cover install tree, npm backend, shims, wrappers vs native, and mise-managed node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe545c1a8cbb39170aec7515dbe2c56239a3059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Work done by Claude Fable 5.1 (high) in T3 Code 0.0.39-nightly.20260902.1257.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mise upgrade capability for mise-managed providers in `providerMaintenance`
> - Adds `makeMiseProviderMaintenanceCapabilities` and `resolveMiseTool` to detect mise-managed install paths, shims, and wrapper scripts, then route them to `mise upgrade --bump` instead of native updaters
> - Adds `readCommandScript` to inspect small (≤4096 bytes) resolved command files so wrapper scripts that exec through mise are recognized
> - Mise detection runs before native installer classification in `resolvePackageManagedProviderMaintenance`; binaries under mise's Node install stay on npm, and unresolved commands fall back to existing branches
> - Risk: `resolveProviderMaintenanceCapabilitiesEffect` now reads the resolved command file during capability resolution — files that are non-regular, larger than 4096 bytes, or unreadable produce no script content but the stat/read attempts are new I/O on the resolution path
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fe545c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



