### PR TITLE
fix(server): render async Codex messages

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1085,6 +1085,63 @@ describe("ProviderRuntimeIngestion", () => {
     expect(message?.streaming).toBe(false);
   });
 
+  it("preserves an async assistant message before the final response", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-commentary"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-async-message"),
+      itemId: asItemId("commentary"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "Working on it.",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-async-message"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-async-message"),
+      itemId: asItemId("async-message"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "Still investigating.",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-commentary-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-async-message"),
+      itemId: asItemId("commentary"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "Working on it.",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.text === "Working on it." && !message.streaming,
+      ),
+    );
+    expect(
+      thread.messages.map((message: ProviderRuntimeTestMessage) => message.text).toSorted(),
+    ).toEqual(["Working on it.", "Still investigating."].toSorted());
+  });
+
   it("preserves completed tool metadata on projected tool activities", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1798,15 +1798,22 @@ const make = Effect.gen(function* () {
         const detailedThread = yield* getLoadedThreadDetail();
         const messages = detailedThread?.messages ?? [];
         const turnId = toTurnId(event.turnId);
-        const activeAssistantMessageId = turnId
-          ? yield* getActiveAssistantMessageIdForTurn(thread.id, turnId)
-          : Option.none<MessageId>();
-        const hasAssistantMessagesForTurn =
-          turnId !== undefined ? hasAssistantMessageForTurn(messages, turnId) : false;
+        const activeAssistantSegment = turnId
+          ? yield* getAssistantSegmentStateForTurn(thread.id, turnId)
+          : Option.none<AssistantSegmentState>();
+        const completingAssistantSegment = Option.filter(
+          activeAssistantSegment,
+          (segment) => segment.baseKey === assistantSegmentBaseKeyFromEvent(event),
+        );
+        const activeAssistantMessageId = Option.flatMap(completingAssistantSegment, (segment) =>
+          segment.activeMessageId ? Option.some(segment.activeMessageId) : Option.none(),
+        );
         const assistantMessageId = Option.getOrElse(
           activeAssistantMessageId,
           () => assistantCompletion.messageId,
         );
+        const hasAssistantMessagesForTurn =
+          turnId !== undefined ? hasAssistantMessageForTurn(messages, turnId) : false;
         const existingAssistantMessage = findMessageById(messages, assistantMessageId);
         const shouldApplyFallbackCompletionText =
           !existingAssistantMessage || existingAssistantMessage.text.length === 0;
@@ -1841,7 +1848,7 @@ const make = Effect.gen(function* () {
           }
         }
 
-        if (turnId) {
+        if (turnId && Option.isSome(completingAssistantSegment)) {
           yield* clearAssistantSegmentStateForTurn(thread.id, turnId);
         }
       }


### PR DESCRIPTION
Codex emits `send_user_message_async` as a separate completed agent message during an active turn. Provider ingestion always matched assistant completions to the active streamed segment, so it discarded the async message text whenever commentary was already buffered.

This matches completions to active segments by provider item ID. A different item now becomes its own assistant message while the original segment stays active. Focused coverage reproduces buffered commentary, an async message, and the original completion in one turn.

Fixes #9222.

## Verification

- `vp test run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts` (51 passed)
- server typecheck
- targeted lint and formatting
- diff whitespace check

Implemented with `gpt-5.6-sol` in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes assistant message completion and segment lifecycle in provider ingestion, which affects how all multi-item turns are projected; scope is narrow but message ordering/content is user-visible.
> 
> **Overview**
> Fixes **Codex async assistant messages** (`send_user_message_async`) being dropped when a turn already had buffered/streaming commentary on another item.
> 
> **Provider runtime ingestion** now ties `item.completed` for assistant messages to the **active segment only when the completion’s provider item id matches** that segment’s `baseKey`. A completion for a different item finalizes as its **own** assistant message and no longer reuses or overwrites the in-flight segment. **Segment state is cleared** only when the completing event matches that active segment, so commentary can keep streaming after an interleaved async message completes.
> 
> Adds an integration test that streams commentary, completes a separate async assistant item, then completes the commentary item and asserts both texts appear in the thread projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4be4d728b36c08ef362b7fabd79de5025582cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix async assistant message preservation in `ProviderRuntimeIngestion`
> Assistant completion events were updating the wrong active message when a turn contained separate async assistant messages. The completion handler now matches the active assistant segment by its segment base key, and derives the assistant message ID from that matching segment. Segment state is cleared only when a matching completing segment is found.
> - Adds an integration test in [ProviderRuntimeIngestion.test.ts](https://github.com/pingdotgg/t3code/pull/9227/files#diff-ea511ca36a45f5254c8f22ac107b5469fed67d652de6af2c5d2763bf00ce53c3) that emits commentary text, completes a separate async assistant message, then verifies both texts remain projected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4be4d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->