### PR TITLE
fix(server): keep Codex SQLite files in shared home

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -7,11 +7,8 @@
  *   - `adapter`    — the Codex session/turn/approval runtime;
  *   - `textGeneration` — commit/PR/branch/title generation via `codex exec`.
  *
- * Each call to `create()` captures the `codexConfig` argument in closures
- * owned by the returned instance. Two instances created with different
- * `homePath`s (e.g. `codex_personal` + `codex_work`) therefore run with
- * fully independent Codex app-server processes and `CODEX_HOME`
- * environments — no shared mutable state.
+ * Each instance owns its app-server process and `CODEX_HOME`. Auth overlays
+ * share session and SQLite state while keeping account credentials private.
  *
  * Resource lifecycle: `create()` runs in a scope handed in by the registry.
  * Closing that scope releases the adapter's child processes, the managed
@@ -112,8 +109,11 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const modelManifest = yield* ModelManifest.ModelManifest;
-      const processEnv = mergeProviderInstanceEnvironment(environment);
+      let processEnv = mergeProviderInstanceEnvironment(environment);
       const homeLayout = yield* resolveCodexHomeLayout(config);
+      if (homeLayout.mode === "authOverlay") {
+        processEnv = { ...processEnv, CODEX_SQLITE_HOME: homeLayout.sharedHomePath };
+      }
       const continuationIdentity = codexContinuationIdentity(homeLayout);
       const stampIdentity = withInstanceIdentity({
         instanceId,

--- a/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
@@ -230,6 +230,94 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
       }),
     );
 
+    it.effect("keeps both homes' SQLite files intact across repeated materialization", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const sharedHome = yield* makeTempDir("t3code-codex-shared-");
+        const shadowRoot = yield* makeTempDir("t3code-codex-shadow-root-");
+        const shadowHome = path.join(shadowRoot, "shadow");
+        const layout = yield* resolveCodexHomeLayout(
+          decodeCodexSettings({
+            homePath: sharedHome,
+            shadowHomePath: shadowHome,
+          }),
+        );
+
+        yield* materializeCodexShadowHome(layout);
+
+        // Codex adds a runtime database to both homes after the first pass.
+        const sqliteSuffixes = ["", "-wal", "-shm"];
+        for (const suffix of sqliteSuffixes) {
+          yield* writeTextFile(path.join(sharedHome, `queue_1.sqlite${suffix}`), `shared${suffix}`);
+          yield* writeTextFile(path.join(shadowHome, `queue_1.sqlite${suffix}`), `shadow${suffix}`);
+          yield* writeTextFile(
+            path.join(sharedHome, `future_runtime.sqlite${suffix}`),
+            `future-shared${suffix}`,
+          );
+        }
+        yield* writeTextFile(path.join(shadowHome, "future_runtime.sqlite"), "future-shadow");
+
+        yield* materializeCodexShadowHome(layout);
+        yield* materializeCodexShadowHome(layout);
+
+        for (const suffix of sqliteSuffixes) {
+          const entryName = `queue_1.sqlite${suffix}`;
+          const shadowPath = path.join(shadowHome, entryName);
+          expect(yield* fileSystem.readFileString(path.join(sharedHome, entryName))).toBe(
+            `shared${suffix}`,
+          );
+          expect(yield* fileSystem.readFileString(shadowPath)).toBe(`shadow${suffix}`);
+          expect((yield* fileSystem.readLink(shadowPath).pipe(Effect.result))._tag).toBe("Failure");
+        }
+
+        expect(
+          yield* fileSystem.readFileString(path.join(shadowHome, "future_runtime.sqlite")),
+        ).toBe("future-shadow");
+        expect(yield* fileSystem.exists(path.join(shadowHome, "future_runtime.sqlite-wal"))).toBe(
+          false,
+        );
+        expect(yield* fileSystem.exists(path.join(shadowHome, "future_runtime.sqlite-shm"))).toBe(
+          false,
+        );
+      }),
+    );
+
+    it.effect("clears stale SQLite links when the shadow home has no database of its own", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const sharedHome = yield* makeTempDir("t3code-codex-shared-");
+        const shadowRoot = yield* makeTempDir("t3code-codex-shadow-root-");
+        const shadowHome = path.join(shadowRoot, "shadow");
+        const staleWalLink = path.join(shadowHome, "state.sqlite-wal");
+
+        yield* writeTextFile(path.join(sharedHome, "state.sqlite"), "shared");
+        yield* fileSystem.makeDirectory(shadowHome, { recursive: true });
+        // An earlier launch linked sidecars only, and the shared WAL has since gone.
+        yield* fileSystem.symlink(path.join(sharedHome, "state.sqlite-wal"), staleWalLink);
+        yield* writeTextFile(path.join(shadowHome, "state.sqlite-shm"), "shadow-shm");
+
+        const layout = yield* resolveCodexHomeLayout(
+          decodeCodexSettings({
+            homePath: sharedHome,
+            shadowHomePath: shadowHome,
+          }),
+        );
+
+        yield* materializeCodexShadowHome(layout);
+
+        expect(yield* fileSystem.exists(path.join(shadowHome, "state.sqlite"))).toBe(false);
+        expect((yield* fileSystem.readLink(staleWalLink).pipe(Effect.result))._tag).toBe("Failure");
+        expect(yield* fileSystem.readFileString(path.join(shadowHome, "state.sqlite-shm"))).toBe(
+          "shadow-shm",
+        );
+        expect(yield* fileSystem.readFileString(path.join(sharedHome, "state.sqlite"))).toBe(
+          "shared",
+        );
+      }),
+    );
+
     it.effect("rejects shadow homes that point at the shared home", () =>
       Effect.gen(function* () {
         const sharedHome = yield* makeTempDir("t3code-codex-shared-");
@@ -255,6 +343,7 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
 
     it.effect("rejects shared entries that already exist in the shadow home as real files", () =>
       Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         const sharedHome = yield* makeTempDir("t3code-codex-shared-");
         const shadowRoot = yield* makeTempDir("t3code-codex-shadow-root-");
@@ -281,6 +370,19 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
         });
         expect(error.message).toBe(
           `Cannot create Codex shadow home entry 'config.toml' because '${path.join(shadowHome, "config.toml")}' already exists and is not a symlink.`,
+        );
+        expect(yield* fileSystem.readFileString(path.join(sharedHome, "config.toml"))).toBe(
+          'model = "gpt-5-codex"\n',
+        );
+        expect(yield* fileSystem.readFileString(path.join(shadowHome, "config.toml"))).toBe(
+          'model = "local"\n',
+        );
+
+        yield* fileSystem.remove(path.join(shadowHome, "config.toml"));
+        yield* materializeCodexShadowHome(layout);
+
+        expect(yield* fileSystem.readLink(path.join(shadowHome, "config.toml"))).toBe(
+          path.join(sharedHome, "config.toml"),
         );
       }),
     );

--- a/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
@@ -96,12 +96,26 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
         yield* writeTextFile(path.join(sharedHome, "config.toml"), 'model = "gpt-5-codex"\n');
         yield* writeTextFile(path.join(sharedHome, "models_cache.json"), '{"models":["shared"]}\n');
         yield* writeTextFile(path.join(sharedHome, "auth.json"), '{"shared":true}\n');
+        const sqliteEntryNames = ["state_5.sqlite", "state_5.sqlite-shm", "state_5.sqlite-wal"];
+        yield* Effect.forEach(
+          sqliteEntryNames,
+          (entryName) => writeTextFile(path.join(sharedHome, entryName), "sqlite"),
+          { discard: true },
+        );
         yield* fileSystem.makeDirectory(shadowHome, { recursive: true });
         yield* writeTextFile(path.join(shadowHome, "auth.json"), '{"shadow":true}\n');
         yield* fileSystem.symlink(
           path.join(sharedHome, "models_cache.json"),
           path.join(shadowHome, "models_cache.json"),
         );
+        yield* Effect.forEach(
+          sqliteEntryNames,
+          (entryName) =>
+            fileSystem.symlink(path.join(sharedHome, entryName), path.join(shadowHome, entryName)),
+          { discard: true },
+        );
+        const shadowLocalSqlite = path.join(shadowHome, "shadow-local.sqlite");
+        yield* writeTextFile(shadowLocalSqlite, "shadow-local");
 
         const layout = yield* resolveCodexHomeLayout(
           decodeCodexSettings({
@@ -124,6 +138,10 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
           .readLink(path.join(shadowHome, "auth.json"))
           .pipe(Effect.result);
         const authContents = yield* fileSystem.readFileString(path.join(shadowHome, "auth.json"));
+        const sqliteLinksExist = yield* Effect.forEach(sqliteEntryNames, (entryName) =>
+          fileSystem.exists(path.join(shadowHome, entryName)),
+        );
+        const shadowLocalSqliteContents = yield* fileSystem.readFileString(shadowLocalSqlite);
 
         expect(sessionsTarget).toBe(path.join(sharedHome, "sessions"));
         expect(configTarget).toBe(path.join(sharedHome, "config.toml"));
@@ -131,6 +149,8 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
         expect(modelsCacheExists).toBe(false);
         expect(authLinkResult._tag).toBe("Failure");
         expect(authContents).toContain("shadow");
+        expect(sqliteLinksExist).toEqual([false, false, false]);
+        expect(shadowLocalSqliteContents).toBe("shadow-local");
       }),
     );
 

--- a/apps/server/src/provider/Drivers/CodexHomeLayout.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.ts
@@ -32,6 +32,7 @@ const KNOWN_SHARED_DIRECTORIES = [
 const PRIVATE_ENTRY_NAMES = new Set(["auth.json", "models_cache.json"]);
 const SHADOW_LOCAL_ENTRY_NAMES = new Set(["log", "memories", "tmp"]);
 const REPLACEABLE_SHARED_RUNTIME_DIRECTORIES = new Set(["mcp-oauth-locks"]);
+const SQLITE_ENTRY_NAME_PATTERN = /\.sqlite(?:-(?:journal|shm|wal))?$/;
 
 function resolveHomePath(path: Path.Path, value: string | undefined): string {
   const expanded =
@@ -370,15 +371,34 @@ export const materializeCodexShadowHome = Effect.fn("materializeCodexShadowHome"
         }),
     }),
   );
+  const shadowEntryNames = yield* fileSystem.readDirectory(effectiveHomePath).pipe(
+    Effect.catchTags({
+      PlatformError: (cause) =>
+        new CodexShadowHomeFileSystemError({
+          sharedHomePath: layout.sharedHomePath,
+          effectiveHomePath,
+          operation: "readDirectory",
+          path: effectiveHomePath,
+          cause,
+        }),
+    }),
+  );
   const entries = new Set<string>(KNOWN_SHARED_DIRECTORIES);
   for (const entryName of sharedEntryNames) {
-    if (!PRIVATE_ENTRY_NAMES.has(entryName) && !SHADOW_LOCAL_ENTRY_NAMES.has(entryName)) {
+    if (
+      !PRIVATE_ENTRY_NAMES.has(entryName) &&
+      !SHADOW_LOCAL_ENTRY_NAMES.has(entryName) &&
+      !SQLITE_ENTRY_NAME_PATTERN.test(entryName)
+    ) {
       entries.add(entryName);
     }
   }
 
   yield* Effect.forEach(
-    PRIVATE_ENTRY_NAMES,
+    [
+      ...PRIVATE_ENTRY_NAMES,
+      ...shadowEntryNames.filter((entryName) => SQLITE_ENTRY_NAME_PATTERN.test(entryName)),
+    ],
     (entryName) =>
       entryName === "auth.json"
         ? Effect.void


### PR DESCRIPTION
## Problem

Codex auth overlays currently symlink SQLite databases and their WAL/SHM sidecars into each account-specific shadow home. On Windows, opening those databases through shadow symlink paths can repeatedly fail, and deleting the links does not stick because the next provider startup recreates them.

## Fix

Set `CODEX_SQLITE_HOME` to the shared Codex home for auth-overlay instances, keep SQLite files out of shadow-home materialization, and remove stale SQLite symlinks left by earlier launches. Real shadow-local SQLite files are preserved.

Materialization now also reads the shadow home so pre-existing SQLite symlinks are cleaned up; a failure to list it surfaces as `CodexShadowHomeFileSystemError` rather than a raw platform error.

## Verification

- `pnpm exec vp test run apps/server/src/provider/Drivers/CodexHomeLayout.test.ts`
- `pnpm exec vp run --filter t3 typecheck`
- focused `vp lint` and `vp fmt --check`
- Codex CLI 0.152.1 `doctor --json` with disposable homes confirmed that a shadow `CODEX_HOME` plus shared `CODEX_SQLITE_HOME` resolves every SQLite database path to the shared home

Implemented with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex auth-overlay filesystem layout and provider env for SQLite paths; existing shadow homes may lose stale SQLite symlinks on next startup.
> 
> **Overview**
> Auth-overlay Codex instances now point SQLite at the **shared** home via `CODEX_SQLITE_HOME`, while each instance still uses its shadow `CODEX_HOME` for per-account auth.
> 
> Shadow-home materialization **stops** symlinking `.sqlite` files (and journal/shm/wal sidecars) from shared into shadow, and on each run **removes stale SQLite symlinks** already in the shadow home without touching real shadow-local database files. Listing the shadow directory is now part of that pass, with failures wrapped as `CodexShadowHomeFileSystemError`.
> 
> Tests cover no SQLite links after materialization, repeated materialization preserving separate shared/shadow DBs, stale-link cleanup, and conflict recovery after removing blocking files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a6f4343a6319afbaaa683027ef07694db616d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep Codex SQLite files in shared home for auth-overlay instances
> - Auth-overlay Codex provider instances now set `CODEX_SQLITE_HOME` to the shared home path so SQLite state stays shared while account credentials remain private in `CodexDriver.create` ([CodexDriver.ts](https://github.com/pingdotgg/t3code/pull/9229/files#diff-c705233bf69322a30e4a04be3428cd51dc6fa014d5a03b852da94c6ab9b6ae35)).
> - `materializeCodexShadowHome` in [CodexHomeLayout.ts](https://github.com/pingdotgg/t3code/pull/9229/files#diff-17973143128131a5e3f30fc3e32012a3a86aee719917b08d60615a47558fb8d5) excludes `.sqlite` databases and their journal/WAL/shared-memory sidecars from the shared-entry symlink set, and removes stale matching shadow symlinks instead of replacing local files.
> - Adds `SQLITE_ENTRY_NAME_PATTERN` to classify SQLite filenames, and wraps shadow-directory read failures as `CodexShadowHomeFileSystemError`.
> - Behavioral Change: auth-overlay instances now share SQLite state via `CODEX_SQLITE_HOME`; direct-home instances are unaffected. Reviewers should verify `SQLITE_ENTRY_NAME_PATTERN` covers all expected sidecar suffixes and that consumers of `CODEX_SQLITE_HOME` handle the shared path correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10a6f43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
