### PR TITLE
fix(desktop): find user-installed CLIs when shell probing fails

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -299,6 +299,75 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  it.effect("falls back to known CLI directories on macOS when neither probe returns a PATH", () =>
+    Effect.gen(function* () {
+      // The Finder-launch environment: no SHELL, and the bare PATH launchd hands a .app.
+      const env: NodeJS.ProcessEnv = {
+        HOME: "/Users/test",
+        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () => "",
+      });
+
+      assert.equal(
+        env.PATH,
+        "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/Users/test/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+      );
+    }),
+  );
+
+  it.effect("falls back to known CLI directories on linux when the login shell is silent", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { HOME: "/home/test", PATH: "/usr/bin:/bin" };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        handler: () => "",
+      });
+
+      assert.equal(
+        env.PATH,
+        "/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/home/test/.local/bin:/usr/bin:/bin",
+      );
+    }),
+  );
+
+  it.effect("omits the known CLI directories when the login shell reports a PATH", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { SHELL: "/bin/zsh", HOME: "/Users/test", PATH: "/usr/bin" };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () => envOutput({ PATH: "/Users/test/.rvm/bin:/usr/bin" }),
+      });
+
+      assert.equal(env.PATH, "/Users/test/.rvm/bin:/usr/bin");
+    }),
+  );
+
+  it.effect("omits the known CLI directories when only launchctl reports a PATH", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { SHELL: "/bin/zsh", HOME: "/Users/test", PATH: "/usr/bin" };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: (command) =>
+          command._tag === "StandardCommand" && command.command === "/bin/launchctl"
+            ? "/usr/local/opt/bin:/usr/bin"
+            : "",
+      });
+
+      assert.equal(env.PATH, "/usr/local/opt/bin:/usr/bin");
+    }),
+  );
+
   it.effect("loads PowerShell profile environment on Windows", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -8,6 +8,8 @@ import * as Schema from "effect/Schema";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
+import { resolveKnownPosixCliDirs } from "@t3tools/shared/shell";
+
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 
 type EnvironmentPatch = Record<string, string>;
@@ -442,7 +444,16 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
         ? yield* readLaunchctlPath
         : Option.none<string>();
     const mergedPath = mergePaths(config.platform, [
-      trimNonEmpty(shellEnvironment.PATH).pipe(Option.orElse(() => launchctlPath)),
+      trimNonEmpty(shellEnvironment.PATH).pipe(
+        Option.orElse(() => launchctlPath),
+        Option.orElse(() =>
+          trimNonEmpty(
+            resolveKnownPosixCliDirs(config.env, config.platform).join(
+              pathDelimiter(config.platform),
+            ),
+          ),
+        ),
+      ),
       readEnvPath(config.env),
     ]);
 

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -4,6 +4,7 @@ import {
   mergePathEntries,
   readPathFromLoginShell,
   readPathFromLaunchctl,
+  resolveKnownPosixCliDirs,
   resolveWindowsEnvironment,
 } from "@t3tools/shared/shell";
 import * as Effect from "effect/Effect";
@@ -30,7 +31,12 @@ function hydratePosixPath(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): vo
   }
 
   const launchctlPath = platform === "darwin" && !shellPath ? readPathFromLaunchctl() : undefined;
-  const mergedPath = mergePathEntries(shellPath ?? launchctlPath, env.PATH, platform);
+  const knownCliPath = resolveKnownPosixCliDirs(env, platform).join(":");
+  const mergedPath = mergePathEntries(
+    shellPath ?? launchctlPath ?? knownCliPath,
+    env.PATH,
+    platform,
+  );
   if (mergedPath) {
     env.PATH = mergedPath;
   }

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -17,6 +17,7 @@ import {
   readPathFromLaunchctl,
   readPathFromLoginShell,
   resolveCommandPath,
+  resolveKnownPosixCliDirs,
   resolveKnownWindowsCliDirs,
   resolveSpawnCommand,
   resolveWindowsEnvironment,
@@ -349,6 +350,33 @@ describe("resolveKnownWindowsCliDirs", () => {
       "C:\\Users\\testuser\\.local\\bin",
       "C:\\Users\\testuser\\.bun\\bin",
       "C:\\Users\\testuser\\scoop\\shims",
+    ]);
+  });
+});
+
+describe("resolveKnownPosixCliDirs", () => {
+  it("returns known macOS CLI install directories in priority order", () => {
+    expect(resolveKnownPosixCliDirs({ HOME: "/Users/testuser" }, "darwin")).toEqual([
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/Users/testuser/.local/bin",
+    ]);
+  });
+
+  it("returns known Linux CLI install directories in priority order", () => {
+    expect(resolveKnownPosixCliDirs({ HOME: "/home/testuser" }, "linux")).toEqual([
+      "/home/linuxbrew/.linuxbrew/bin",
+      "/usr/local/bin",
+      "/home/testuser/.local/bin",
+    ]);
+  });
+
+  it("omits the home directory entry when HOME is unset or blank", () => {
+    expect(resolveKnownPosixCliDirs({ HOME: "   " }, "darwin")).toEqual([
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
     ]);
   });
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -692,6 +692,21 @@ export function resolveKnownWindowsCliDirs(env: NodeJS.ProcessEnv): ReadonlyArra
   ];
 }
 
+// Both PATH probes can come back empty: a slow profile trips the login-shell timeout, and
+// `launchctl getenv PATH` is unset on recent macOS. That leaves a GUI launch on the bare
+// `/usr/bin:/bin:/usr/sbin:/sbin` PATH where no user-installed CLI can be spawned.
+export function resolveKnownPosixCliDirs(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): ReadonlyArray<string> {
+  const home = env.HOME?.trim();
+  const homeDirs = home ? [`${home}/.local/bin`] : [];
+
+  return platform === "darwin"
+    ? ["/opt/homebrew/bin", "/opt/homebrew/sbin", "/usr/local/bin", ...homeDirs]
+    : ["/home/linuxbrew/.linuxbrew/bin", "/usr/local/bin", ...homeDirs];
+}
+
 function readWindowsEnvironmentSafely(
   readEnvironment: WindowsShellEnvironmentReader,
   names: ReadonlyArray<string>,


### PR DESCRIPTION
## What Changed

`resolveKnownPosixCliDirs` in `packages/shared/src/shell.ts` returns the standard CLI directories for macOS and Linux, beside the existing `resolveKnownWindowsCliDirs`. Both POSIX PATH hydration paths now fall back to it when neither the login shell nor `launchctl getenv PATH` answers: `installPosixEnvironment` in `apps/desktop/src/shell/DesktopShellEnvironment.ts` and `hydratePosixPath` in `apps/server/src/os-jank.ts`.

The fallback is last in the chain, so a shell that did answer still decides the order. Directories are not checked for existence, matching `resolveKnownWindowsCliDirs`.

## Why

A Finder launch starts the app with `/usr/bin:/bin:/usr/sbin:/sbin`. Both hydration paths repair that from the login shell, but the probe collapses failures and timeouts into an empty result, so a profile slower than the 5s timeout leaves PATH untouched. `launchctl getenv PATH` is unset on recent macOS, so the second probe returns nothing either. Every bare-name spawn then fails with ENOENT: #7618 counted 1246 failed `gh` spawns and zero successes over 14 hours, with `gh auth status` never running.

#1799 built this chain and added the `launchctl` probe as its last step. This adds the next step, for machines where that probe is also empty. Raising the timeout does not help, since the probe fails for reasons unrelated to how long it is given.

Both Windows paths already end in `resolveKnownWindowsCliDirs`. POSIX ended in nothing.

Closes #7618

## Verification

- `vp test run apps/desktop/src/shell/DesktopShellEnvironment.test.ts packages/shared/src/shell.test.ts apps/server/src/os-jank.test.ts`: 54 passed.
- Typecheck for `@t3tools/desktop`, `@t3tools/shared`, and the server.
- `vp lint` on the five changed files with `--report-unused-disable-directives`.
- `git diff --check`: clean.
- Seven added tests: the macOS and Linux fallbacks in both hydration paths, and guards that the known directories stay out of the merge when either probe answers. Reverting the source change fails the fallback tests and leaves the guards passing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because nothing visual changed
- [x] A video is not applicable because no motion or interaction changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process `PATH` for all POSIX desktop and server startups when probes fail; behavior shifts from minimal system PATH to hard-coded install locations, which could affect spawn resolution in edge environments but addresses widespread CLI spawn failures.
> 
> **Overview**
> When login-shell and (on macOS) `launchctl` PATH probes return nothing—common for GUI/Finder launches with a minimal PATH—POSIX hydration no longer leaves only `/usr/bin:/bin:…`.
> 
> **Shared:** Adds `resolveKnownPosixCliDirs` (macOS Homebrew/`/usr/local`/`~/.local/bin`, Linux Linuxbrew/`/usr/local`/`~/.local/bin`; skips `~/.local` if `HOME` is blank), mirroring the existing Windows known-CLI helper and without checking that directories exist.
> 
> **Desktop & server:** `installPosixEnvironment` and `hydratePosixPath` use that list as the **last** preferred PATH segment before merging with the inherited PATH. Any PATH from the login shell or `launchctl` still wins and does not inject these defaults.
> 
> New unit tests cover macOS/Linux fallback merges and assert the known dirs are **not** added when either probe succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ead921397c0aed88c214de3047c5d1e8eb3f9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add known CLI directory fallback to `hydratePosixPath` and `installPosixEnvironment`
> - Adds shared `resolveKnownPosixCliDirs` resolver that returns platform-specific CLI install directories (Homebrew on macOS, Linuxbrew on Linux, plus system-local and HOME-local `bin`).
> - Both desktop POSIX environment installation and server PATH hydration now prepend these known directories as a final fallback when neither the login shell nor `launchctl` produces a PATH.
> - A PATH from the login shell or `launchctl` remains preferred and is used directly without adding the fallback directories.
> - Risk: any caller relying on an empty PATH when probes fail will now receive a non-empty PATH composed of known CLI directories; the HOME-local entry is omitted when `HOME` is blank or unset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10ead92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->