### PR TITLE
fix(codex): treat usage-limit stops as quota, not errors

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -970,6 +970,175 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  const usageLimitErrorCases = [
+    ["plan-limit", "You've hit your usage limit. Your limit will reset at 6:00 PM."],
+    [
+      "workspace-credits",
+      "Your workspace is out of credits. Ask your workspace owner to refill in order to continue.",
+    ],
+  ] as const;
+
+  for (const [label, message] of usageLimitErrorCases) {
+    it.effect(
+      `maps a ${label} usage-limit error to runtime.warning with the provider message`,
+      () =>
+        Effect.gen(function* () {
+          const { adapter, runtime } = yield* startLifecycleRuntime();
+          const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(
+            Effect.forkChild,
+          );
+
+          yield* runtime.emit({
+            id: asEventId(`evt-usage-limit-${label}`),
+            kind: "notification",
+            provider: ProviderDriverKind.make("codex"),
+            threadId: asThreadId("thread-1"),
+            createdAt: "2026-01-01T00:00:00.000Z",
+            method: "error",
+            turnId: asTurnId("turn-1"),
+            payload: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              error: { message, codexErrorInfo: "usageLimitExceeded" },
+              willRetry: false,
+            },
+          } satisfies ProviderEvent);
+
+          const firstEvent = yield* Fiber.join(firstEventFiber);
+
+          NodeAssert.equal(firstEvent._tag, "Some");
+          if (firstEvent._tag !== "Some") {
+            return;
+          }
+          NodeAssert.equal(firstEvent.value.type, "runtime.warning");
+          if (firstEvent.value.type !== "runtime.warning") {
+            return;
+          }
+          NodeAssert.equal(firstEvent.value.turnId, "turn-1");
+          NodeAssert.equal(firstEvent.value.payload.message, message);
+        }),
+    );
+  }
+
+  it.effect("keeps non-usage-limit Codex error notifications as runtime.error", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-provider-error"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "error",
+        turnId: asTurnId("turn-1"),
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          error: { message: "Stream disconnected", codexErrorInfo: "internalServerError" },
+          willRetry: false,
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.type, "runtime.error");
+      if (firstEvent.value.type !== "runtime.error") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.payload.class, "provider_error");
+      NodeAssert.equal(firstEvent.value.payload.message, "Stream disconnected");
+    }),
+  );
+
+  it.effect("ends a usage-limited turn as cancelled without an error message", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-usage-limit-turn-completed"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "turn/completed",
+        turnId: asTurnId("turn-1"),
+        payload: {
+          threadId: "thread-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            items: [],
+            error: {
+              message:
+                "Your workspace is out of credits. Ask your workspace owner to refill in order to continue.",
+              codexErrorInfo: "usageLimitExceeded",
+            },
+          },
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.type, "turn.completed");
+      if (firstEvent.value.type !== "turn.completed") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.turnId, "turn-1");
+      NodeAssert.equal(firstEvent.value.payload.state, "cancelled");
+      NodeAssert.equal(firstEvent.value.payload.errorMessage, undefined);
+    }),
+  );
+
+  it.effect("keeps other failed turns failed with their error message", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-failed-turn-completed"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "turn/completed",
+        turnId: asTurnId("turn-1"),
+        payload: {
+          threadId: "thread-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            items: [],
+            error: { message: "Stream disconnected", codexErrorInfo: "internalServerError" },
+          },
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.type, "turn.completed");
+      if (firstEvent.value.type !== "turn.completed") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.payload.state, "failed");
+      NodeAssert.equal(firstEvent.value.payload.errorMessage, "Stream disconnected");
+    }),
+  );
+
   it.effect("maps retryable Codex error notifications to runtime.warning", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -193,6 +193,19 @@ function normalizeCodexTokenUsage(
   };
 }
 
+/**
+ * Codex reports plan windows, Business workspace credits, and spend caps alike
+ * as `usageLimitExceeded`: the account is out of quota, nothing malfunctioned.
+ * Such a stop surfaces as a warning row carrying Codex's own sentence (which
+ * names the reset time or the workspace owner), and the turn it ends is
+ * cancelled rather than failed, so the thread never turns red over quota.
+ */
+function isCodexUsageLimitError(
+  error: { readonly codexErrorInfo?: unknown } | null | undefined,
+): boolean {
+  return error?.codexErrorInfo === "usageLimitExceeded";
+}
+
 function toTurnStatus(
   value: EffectCodexSchema.V2TurnCompletedNotification["turn"]["status"] | "cancelled",
 ): "completed" | "failed" | "cancelled" | "interrupted" {
@@ -1061,13 +1074,15 @@ function mapToRuntimeEvents(
     if (!payload) {
       return [];
     }
-    const errorMessage = trimText(payload.turn.error?.message);
+    // The usage-limit warning row already told the user why the turn ended.
+    const usageLimited = isCodexUsageLimitError(payload.turn.error);
+    const errorMessage = usageLimited ? undefined : trimText(payload.turn.error?.message);
     return [
       {
         ...runtimeEventBase(event, canonicalThreadId),
         type: "turn.completed",
         payload: {
-          state: toTurnStatus(payload.turn.status),
+          state: usageLimited ? "cancelled" : toTurnStatus(payload.turn.status),
           ...(errorMessage ? { errorMessage } : {}),
         },
       },
@@ -1540,6 +1555,18 @@ function mapToRuntimeEvents(
     const payload = readPayload(EffectCodexSchema.V2ErrorNotification, event.payload);
     const message = payload?.error.message ?? event.message ?? "Provider runtime error";
     const willRetry = payload?.willRetry === true;
+    if (isCodexUsageLimitError(payload?.error)) {
+      return [
+        {
+          type: "runtime.warning",
+          ...runtimeEventBase(event, canonicalThreadId),
+          payload: {
+            message,
+            ...(event.payload !== undefined ? { detail: event.payload } : {}),
+          },
+        },
+      ];
+    }
     return [
       {
         type: willRetry ? "runtime.warning" : "runtime.error",

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -28,6 +28,18 @@ Log in with Codex normally:
 codex login
 ```
 
+## Codex Says I Hit A Limit Or My Workspace Is Out Of Credits
+
+When Codex refuses a turn because the account is out of quota, the thread shows a warning line
+with Codex's own message and the turn ends. Nothing broke, so the thread does not show an error.
+
+What the message means depends on the account:
+
+- On a personal plan, it names when the limit resets. Wait for the reset, or switch to another
+  Codex account for the next turn.
+- On a Business or Enterprise workspace, it says the workspace is out of credits or hit its spend
+  cap. Ask the workspace owner to add credits or raise the cap, then send your message again.
+
 ## Send feedback to OpenAI
 
 In an existing Codex thread, send `/feedback` or `/feedback` followed by a description of the


### PR DESCRIPTION
## What Changed

When Codex stops a turn because the account is out of quota, the thread now shows a warning row with Codex's own sentence and the turn ends quietly, instead of the thread going red with a generic runtime error banner.

Codex reports three different stops under one error code, `usageLimitExceeded`: personal plan windows ("Your limit will reset at 6:00 PM"), Business/Enterprise workspace credits ("Your workspace is out of credits. Ask your workspace owner to refill…"), and workspace spend caps. `CodexAdapter` now recognizes that code in both places it arrives:

- the `error` notification becomes a `runtime.warning` (the labeled work-log row the clients already render) rather than a `runtime.error`, so the session is not marked errored;
- the `turn/completed` that follows is reported as `cancelled` rather than `failed`, with no `errorMessage`, so `session.lastError` stays empty and no red banner appears. The warning row already said why the turn ended.

Every other Codex error keeps its existing path: `runtime.error` with `provider_error`, failed turn, red banner. Adapter-only — no contract, schema, migration, or client changes. A short FAQ in `docs/user/providers-codex.md` explains what the two kinds of message mean and what to do.

## Why

Fixes #9234. Out of quota is not a malfunction. Painting it as one makes users chase a crash that never happened, and for Business accounts (which stop on credits, not on a resetting window) the red banner is the only thing they see. Codex already tells us it is a limit; the adapter was throwing that classification away.

Handling it at the adapter boundary keeps orchestration untouched: ingestion already maps a non-failed turn to `ready` / `lastError: null`, and the projection derives `latestTurn.state` from the session status, so the thread lands as a settled turn with the warning row as its last entry. `cancelled` is used rather than `interrupted` because clients label an interrupted latest turn "You stopped this response", which would be false here.

This is the Codex half of the problem #7165 addresses for Claude; that PR will be trimmed to Claude only so each provider is one concern.

## UI Changes

No new components: the after-state is the existing `runtime.warning` row in the work log. Both captures below come from the same local T3 server driving a fake `codex app-server` that replays, byte for byte in the vendored schema, the sequence codex-rs emits for a Business workspace credit stop (`error` with `codexErrorInfo: "usageLimitExceeded"`, `account/rateLimits/updated` with `workspace_member_credits_depleted`, then `turn/completed` `failed`). Only the branch differs.

**Before (main)** — generic thread error banner, red "Runtime error" row, thread badged *Failed* in the sidebar:

<img src="https://github.com/user-attachments/assets/16e0788f-5112-43f0-92a7-d57e85484925" alt="Before: red banner reading Your workspace is out of credits, and a red Runtime error row in the work log" width="760" />

**After (this branch)** — the same sentence as a warning row, no banner, no error state, composer ready:

<img src="https://github.com/user-attachments/assets/de173a34-52db-4bed-867c-82f4361492a9" alt="After: the credit message shown as a warning row under Worked for 2.0s, with no banner" width="760" />

For reference, the original report from a real Business account (#9234) shows the same red banner as the before state.

## Related work

- #758 (merged) established that retryable Codex `error` notifications are warnings; this PR extends the same boundary to quota stops.
- #7308 and #8577 (open) detect the same `usageLimitExceeded` code but for recovery and auto-resume; they do not change how a stop is presented. #8897 / #8875 concern a different code (`rateLimitExceeded`) on thread resume.
- #8358 (merged) is the Grok precedent: a usage-limit stop fails the turn with a visible message. See discussion below on why Codex is handled at the adapter boundary instead.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes — n/a, no motion

Built with Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adapter-only event classification with broad test coverage; no API, schema, or client contract changes.
> 
> **Overview**
> Codex quota stops (`codexErrorInfo: usageLimitExceeded`) are no longer surfaced as thread failures. **`CodexAdapter`** adds `isCodexUsageLimitError` and uses it when mapping Codex **`error`** notifications to **`runtime.warning`** with Codex’s message (plan reset time or workspace credits), instead of **`runtime.error`** / `provider_error`.
> 
> When the following **`turn/completed`** arrives for the same stop, the adapter emits **`turn.completed`** with state **`cancelled`** and omits **`errorMessage`**, so the UI keeps a warning row without a red banner or failed thread badge. Other Codex errors keep the existing warning-vs-error and failed-turn behavior.
> 
> Lifecycle tests cover personal and workspace credit messages plus regression cases for real provider errors. **`docs/user/providers-codex.md`** adds a short FAQ on what those messages mean and what to do next.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7093c99f85c7effda39d4032a90d672567d424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->