### PR TITLE
fix(web): filter sidebar threads by environment

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -6,10 +6,12 @@ import {
   buildBulkTitleRegenerationContextMenuItem,
   buildMultiSelectThreadContextMenuItems,
   createThreadJumpHintVisibilityController,
+  filterSidebarProjectGroupsByEnvironment,
   filterSidebarProjectScopeItems,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
+  resolveSidebarEnvironmentScopeId,
   reduceSidebarProjectScopeMenuState,
   getFallbackThreadIdAfterDelete,
   getVisibleThreadsForProject,
@@ -25,6 +27,7 @@ import {
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
   searchSidebarThreadsByTitle,
+  sidebarEntryMatchesScope,
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
@@ -55,6 +58,7 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+const remoteEnvironmentId = EnvironmentId.make("environment-remote");
 
 describe("animatePinnedLayoutChanges", () => {
   const baseArgs: Parameters<AnimateLayoutChanges>[0] = {
@@ -776,6 +780,81 @@ describe("filterSidebarProjectScopeItems", () => {
   it("returns matching projects in source order and supports no-match results", () => {
     expect(filter(null, "WORK")).toEqual([items[1]]);
     expect(filter(null, "missing")).toEqual([]);
+  });
+});
+
+describe("sidebar environment scope", () => {
+  it("only keeps a selected environment while multiple environments remain available", () => {
+    expect(
+      resolveSidebarEnvironmentScopeId({
+        selectedEnvironmentId: remoteEnvironmentId,
+        availableEnvironmentIds: new Set([localEnvironmentId, remoteEnvironmentId]),
+      }),
+    ).toBe(remoteEnvironmentId);
+    expect(
+      resolveSidebarEnvironmentScopeId({
+        selectedEnvironmentId: remoteEnvironmentId,
+        availableEnvironmentIds: new Set([localEnvironmentId]),
+      }),
+    ).toBeNull();
+  });
+
+  it("drops a selection that is no longer in the environment catalog", () => {
+    expect(
+      resolveSidebarEnvironmentScopeId({
+        selectedEnvironmentId: EnvironmentId.make("environment-missing"),
+        availableEnvironmentIds: new Set([localEnvironmentId, remoteEnvironmentId]),
+      }),
+    ).toBeNull();
+  });
+
+  it("composes environment and project scopes", () => {
+    const projectScope = new Set([`${remoteEnvironmentId}:project-a`]);
+    expect(
+      sidebarEntryMatchesScope({
+        environmentId: remoteEnvironmentId,
+        projectId: "project-a",
+        selectedEnvironmentId: remoteEnvironmentId,
+        scopedProjectKeys: projectScope,
+      }),
+    ).toBe(true);
+    expect(
+      sidebarEntryMatchesScope({
+        environmentId: localEnvironmentId,
+        projectId: "project-a",
+        selectedEnvironmentId: remoteEnvironmentId,
+        scopedProjectKeys: projectScope,
+      }),
+    ).toBe(false);
+    expect(
+      sidebarEntryMatchesScope({
+        environmentId: remoteEnvironmentId,
+        projectId: "project-b",
+        selectedEnvironmentId: remoteEnvironmentId,
+        scopedProjectKeys: projectScope,
+      }),
+    ).toBe(false);
+  });
+
+  it("only offers project groups present in the selected environment", () => {
+    const localOnly = {
+      key: "local",
+      memberProjectRefs: [{ environmentId: localEnvironmentId }],
+    };
+    const shared = {
+      key: "shared",
+      memberProjectRefs: [
+        { environmentId: localEnvironmentId },
+        { environmentId: remoteEnvironmentId },
+      ],
+    };
+    expect(
+      filterSidebarProjectGroupsByEnvironment([localOnly, shared], remoteEnvironmentId),
+    ).toEqual([shared]);
+    expect(filterSidebarProjectGroupsByEnvironment([localOnly, shared], null)).toEqual([
+      localOnly,
+      shared,
+    ]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { defaultAnimateLayoutChanges, type AnimateLayoutChanges } from "@dnd-kit/sortable";
-import type { ContextMenuItem } from "@t3tools/contracts";
+import type { ContextMenuItem, EnvironmentId } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import {
   activeThreadAnchorTimestampMs,
@@ -995,5 +995,45 @@ export function sortScopedProjectsForSidebar<
       left.title.localeCompare(right.title) ||
       left.environmentId.localeCompare(right.environmentId) ||
       left.id.localeCompare(right.id),
+  );
+}
+
+export function resolveSidebarEnvironmentScopeId(input: {
+  selectedEnvironmentId: EnvironmentId | null;
+  availableEnvironmentIds: ReadonlySet<EnvironmentId>;
+}): EnvironmentId | null {
+  if (input.availableEnvironmentIds.size <= 1 || input.selectedEnvironmentId === null) {
+    return null;
+  }
+  return input.availableEnvironmentIds.has(input.selectedEnvironmentId)
+    ? input.selectedEnvironmentId
+    : null;
+}
+
+export function sidebarEntryMatchesScope(input: {
+  environmentId: EnvironmentId;
+  projectId: string;
+  selectedEnvironmentId: EnvironmentId | null;
+  scopedProjectKeys: ReadonlySet<string> | null;
+}): boolean {
+  if (input.selectedEnvironmentId !== null && input.environmentId !== input.selectedEnvironmentId) {
+    return false;
+  }
+  return (
+    input.scopedProjectKeys === null ||
+    input.scopedProjectKeys.has(`${input.environmentId}:${input.projectId}`)
+  );
+}
+
+export function filterSidebarProjectGroupsByEnvironment<
+  TGroup extends {
+    readonly memberProjectRefs: ReadonlyArray<{ readonly environmentId: EnvironmentId }>;
+  },
+>(groups: readonly TGroup[], selectedEnvironmentId: EnvironmentId | null): readonly TGroup[] {
+  if (selectedEnvironmentId === null) return groups;
+  return groups.filter((group) =>
+    group.memberProjectRefs.some(
+      (projectRef) => projectRef.environmentId === selectedEnvironmentId,
+    ),
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
@@ -126,6 +126,7 @@ import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
 import {
   animatePinnedLayoutChanges,
   buildBulkTitleRegenerationContextMenuItem,
+  filterSidebarProjectGroupsByEnvironment,
   filterSidebarProjectScopeItems,
   formatWorkingDurationLabel,
   firstValidTimestampMs,
@@ -136,9 +137,11 @@ import {
   planPinnedReorder,
   reduceSidebarProjectScopeMenuState,
   resolveAdjacentThreadId,
+  resolveSidebarEnvironmentScopeId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
+  sidebarEntryMatchesScope,
   shouldCreateNewThreadInCurrentProject,
   resolveWorkingStartedAt,
   sortLogicalProjectsForSidebar,
@@ -190,6 +193,18 @@ import {
   ComboboxTrigger,
   useComboboxFilter,
 } from "./ui/combobox";
+import {
+  Menu,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "./ui/menu";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
@@ -595,6 +610,7 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
   projectDisplayNameByKey: ReadonlyMap<string, string>;
   projectCwdByKey: ReadonlyMap<string, string>;
   projectFaviconPathByKey: ReadonlyMap<string, string | null | undefined>;
+  selectedEnvironmentId: EnvironmentId | null;
   scopedProjectKeys: ReadonlySet<string> | null;
   routeDraftId: string | null;
   onNavigateToDraft: (draftId: DraftId) => void;
@@ -636,8 +652,12 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
         continue;
       }
       if (
-        props.scopedProjectKeys !== null &&
-        !props.scopedProjectKeys.has(`${session.environmentId}:${session.projectId}`)
+        !sidebarEntryMatchesScope({
+          environmentId: session.environmentId,
+          projectId: session.projectId,
+          selectedEnvironmentId: props.selectedEnvironmentId,
+          scopedProjectKeys: props.scopedProjectKeys,
+        })
       ) {
         continue;
       }
@@ -663,6 +683,7 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
     draftsByThreadKey,
     frozenActive,
     props.routeDraftId,
+    props.selectedEnvironmentId,
     props.scopedProjectKeys,
   ]);
   const handleDiscard = useCallback(
@@ -1950,20 +1971,56 @@ export default function Sidebar() {
 
   const changeRequestSnapshotByKey = useAtomValue(threadChangeRequestSnapshotsAtom);
 
+  // Match mobile's thread-list filter: when several environments are known,
+  // the sidebar exposes Environment and Project as sibling submenus. Keep the
+  // configured value separate from the render-safe value so removing the
+  // selected environment cannot paint an empty list for a frame.
+  const [configuredEnvironmentScopeId, setConfiguredEnvironmentScopeId] =
+    useState<EnvironmentId | null>(null);
+  const availableEnvironmentIds = useMemo(
+    () => new Set(environments.map((environment) => environment.environmentId)),
+    [environments],
+  );
+  const environmentScopeId = resolveSidebarEnvironmentScopeId({
+    selectedEnvironmentId: configuredEnvironmentScopeId,
+    availableEnvironmentIds,
+  });
+  useEffect(() => {
+    if (configuredEnvironmentScopeId !== environmentScopeId) {
+      setConfiguredEnvironmentScopeId(environmentScopeId);
+    }
+  }, [configuredEnvironmentScopeId, environmentScopeId]);
+  const scopedEnvironment = useMemo(
+    () =>
+      environmentScopeId === null
+        ? null
+        : (environments.find((environment) => environment.environmentId === environmentScopeId) ??
+          null),
+    [environmentScopeId, environments],
+  );
+  const sortedSidebarEnvironments = useMemo(
+    () => [...environments].toSorted((left, right) => left.label.localeCompare(right.label)),
+    [environments],
+  );
+
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
   const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
+  const menuProjectGroups = useMemo(
+    () => filterSidebarProjectGroupsByEnvironment(projectGroups, environmentScopeId),
+    [environmentScopeId, projectGroups],
+  );
   // {value, label} items let Base UI drive the combobox selection contract
   // while the popup search filters the same collection.
   const projectScopeItems = useMemo(
     () => [
       { value: "all", label: "All projects" },
-      ...projectGroups.map((project) => ({
+      ...menuProjectGroups.map((project) => ({
         value: project.projectKey,
         label: project.displayName,
       })),
     ],
-    [projectGroups],
+    [menuProjectGroups],
   );
   const projectGroupByScopeKey = useMemo(
     () => new Map(projectGroups.map((project) => [project.projectKey, project] as const)),
@@ -1980,6 +2037,8 @@ export default function Sidebar() {
     { open: false, query: "" },
   );
   const projectScopeFilter = useComboboxFilter();
+  const [threadScopeMenuOpen, setThreadScopeMenuOpen] = useState(false);
+  const [nestedProjectScopeQuery, setNestedProjectScopeQuery] = useState("");
   // Filtering derives from the same React state that controls the input, so
   // the visible query and the visible list can never desync — the peer wiring
   // in DiffPanel and BranchToolbarBranchSelector. "All projects" is a scope
@@ -1998,12 +2057,21 @@ export default function Sidebar() {
       }),
     [projectScopeFilter, projectScopeItems, projectScopeKey, projectScopeMenuState.query],
   );
+  const nestedProjectScopeItems = useMemo(() => {
+    const query = nestedProjectScopeQuery.trim();
+    if (query.length === 0) return projectScopeItems;
+    return projectScopeItems.filter(
+      (item) =>
+        item.value !== "all" &&
+        projectScopeFilter.contains(item, query, (candidate) => candidate.label),
+    );
+  }, [nestedProjectScopeQuery, projectScopeFilter, projectScopeItems]);
   const scopedProjectGroup = useMemo(
     () =>
       projectScopeKey === null
         ? null
-        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
-    [projectGroups, projectScopeKey],
+        : (menuProjectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
+    [menuProjectGroups, projectScopeKey],
   );
   const scopedProjectKeys = useMemo(
     () =>
@@ -2038,8 +2106,12 @@ export default function Sidebar() {
         continue;
       }
       if (
-        scopedProjectKeys !== null &&
-        !scopedProjectKeys.has(`${session.environmentId}:${session.projectId}`)
+        !sidebarEntryMatchesScope({
+          environmentId: session.environmentId,
+          projectId: session.projectId,
+          selectedEnvironmentId: environmentScopeId,
+          scopedProjectKeys,
+        })
       ) {
         continue;
       }
@@ -2051,13 +2123,14 @@ export default function Sidebar() {
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {
     clearSelection();
-  }, [clearSelection, projectScopeKey]);
+  }, [clearSelection, environmentScopeId, projectScopeKey]);
 
   const handleProjectSettings = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
       event.preventDefault();
       event.stopPropagation();
       dispatchProjectScopeMenu({ type: "project-settings-opened" });
+      setThreadScopeMenuOpen(false);
       if (isMobile) {
         setOpenMobile(false);
       }
@@ -2091,8 +2164,12 @@ export default function Sidebar() {
     const visible = threads.filter(
       (thread) =>
         thread.archivedAt === null &&
-        (scopedProjectKeys === null ||
-          scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
+        sidebarEntryMatchesScope({
+          environmentId: thread.environmentId,
+          projectId: thread.projectId,
+          selectedEnvironmentId: environmentScopeId,
+          scopedProjectKeys,
+        }),
     );
     const pinned: EnvironmentThreadShell[] = [];
     const active: EnvironmentThreadShell[] = [];
@@ -2167,6 +2244,7 @@ export default function Sidebar() {
     autoSettleAfterDays,
     autoSettleOnMerge,
     changeRequestSnapshotByKey,
+    environmentScopeId,
     nowMinute,
     scopedProjectKeys,
     serverConfigs,
@@ -2224,7 +2302,7 @@ export default function Sidebar() {
   // filter context changes so a scope/search flip never inherits a deep
   // page state.
   const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
-  const settledResetKey = projectScopeKey ?? "all";
+  const settledResetKey = `${environmentScopeId ?? "all"}\0${projectScopeKey ?? "all"}`;
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -3547,117 +3625,335 @@ export default function Sidebar() {
             </div>
             {projectGroups.length > 0 ? (
               <div className="flex items-center gap-1">
-                <Combobox
-                  items={projectScopeItems}
-                  filteredItems={filteredProjectScopeItems}
-                  autoHighlight
-                  itemToStringLabel={(item) => item.label}
-                  isItemEqualToValue={(a, b) => a.value === b.value}
-                  open={projectScopeMenuState.open}
-                  onOpenChange={(open) => {
-                    dispatchProjectScopeMenu({ type: "open-changed", open });
-                  }}
-                  value={selectedProjectScopeItem}
-                  onValueChange={(item) => {
-                    if (!item) return;
-                    setProjectScopeKey(item.value === "all" ? null : item.value);
-                  }}
-                >
-                  <ComboboxTrigger
-                    render={
-                      <SidebarMenuButton
-                        aria-label="Filter threads by project"
-                        className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
-                      />
-                    }
+                {availableEnvironmentIds.size > 1 ? (
+                  <Menu
+                    open={threadScopeMenuOpen}
+                    onOpenChange={(open) => {
+                      setThreadScopeMenuOpen(open);
+                      if (!open) setNestedProjectScopeQuery("");
+                    }}
                   >
-                    {scopedProjectGroup ? (
-                      <ProjectFavicon
-                        environmentId={scopedProjectGroup.environmentId}
-                        cwd={scopedProjectGroup.workspaceRoot}
-                        faviconPath={scopedProjectGroup.faviconPath}
-                        className="size-4 shrink-0"
-                      />
-                    ) : (
-                      <FolderIcon className="size-4 shrink-0" />
-                    )}
-                    <span className="min-w-0 flex-1 truncate">
-                      {scopedProjectGroup?.displayName ?? "All projects"}
-                    </span>
-                    <ChevronDownIcon className="-mr-px size-4 shrink-0" />
-                  </ComboboxTrigger>
-                  <ComboboxPopup
-                    align="start"
-                    className="w-(--anchor-width) min-w-0 overflow-hidden"
-                  >
-                    <div className="shrink-0 px-3 pt-2.5">
-                      <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
-                        <SearchIcon
-                          aria-hidden="true"
-                          className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
+                    <MenuTrigger
+                      render={
+                        <SidebarMenuButton
+                          aria-label="Filter threads by project or environment"
+                          className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                         />
-                        <ComboboxInput
-                          aria-label="Search projects"
-                          className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
-                          inputClassName="rounded-none bg-transparent text-sm"
-                          placeholder="Search projects..."
-                          showTrigger={false}
-                          size="sm"
-                          unstyled
-                          value={projectScopeMenuState.query}
-                          onChange={(event) =>
-                            dispatchProjectScopeMenu({
-                              type: "query-changed",
-                              query: event.target.value,
-                            })
-                          }
+                      }
+                    >
+                      {scopedProjectGroup ? (
+                        <ProjectFavicon
+                          environmentId={scopedProjectGroup.environmentId}
+                          cwd={scopedProjectGroup.workspaceRoot}
+                          faviconPath={scopedProjectGroup.faviconPath}
+                          className="size-4 shrink-0"
                         />
-                      </div>
-                    </div>
-                    <ComboboxEmpty>No matching projects.</ComboboxEmpty>
-                    <ComboboxList>
-                      {(item: (typeof projectScopeItems)[number]) => {
-                        const project = projectGroupByScopeKey.get(item.value) ?? null;
-                        return (
-                          <ComboboxItem
-                            key={item.value}
-                            hideIndicator
-                            value={item}
-                            className="h-8 min-h-8 py-0 font-medium"
-                            contentClassName="flex min-w-0 items-center gap-2"
-                          >
-                            {project ? (
-                              <ProjectFavicon
-                                environmentId={project.environmentId}
-                                cwd={project.workspaceRoot}
-                                faviconPath={project.faviconPath}
-                                className="size-4 shrink-0"
-                              />
-                            ) : (
-                              <FolderIcon className="size-4 shrink-0" />
-                            )}
-                            <span className="min-w-0 flex-1 truncate text-sm">{item.label}</span>
-                            {project ? (
-                              <Button
-                                size="icon-xs"
-                                variant="ghost-muted"
-                                aria-label={`Project settings for ${project.displayName}`}
-                                title={`Project settings for ${project.displayName}`}
-                                className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
-                                onPointerDown={(event) => event.stopPropagation()}
-                                onClick={(event) => {
-                                  void handleProjectSettings(event, project);
+                      ) : scopedEnvironment ? (
+                        <ServerIcon className="size-4 shrink-0" />
+                      ) : (
+                        <FolderIcon className="size-4 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate">
+                        {scopedProjectGroup && scopedEnvironment
+                          ? `${scopedProjectGroup.displayName} · ${scopedEnvironment.label}`
+                          : (scopedProjectGroup?.displayName ??
+                            scopedEnvironment?.label ??
+                            "All projects")}
+                      </span>
+                      <ChevronDownIcon className="-mr-px size-4 shrink-0" />
+                    </MenuTrigger>
+                    <MenuPopup
+                      align="start"
+                      className="w-(--anchor-width) min-w-52 max-w-(--available-width)"
+                    >
+                      <MenuGroup>
+                        <MenuGroupLabel>Thread list options</MenuGroupLabel>
+                        <MenuSub>
+                          <MenuSubTrigger>Project</MenuSubTrigger>
+                          <MenuSubPopup className="w-72 max-w-(--available-width)">
+                            <MenuGroup>
+                              <MenuGroupLabel>Project</MenuGroupLabel>
+                              <div className="px-2 pb-1.5">
+                                <div className="relative border-b border-border/70 pb-1 transition-colors focus-within:border-ring">
+                                  <SearchIcon
+                                    aria-hidden="true"
+                                    className="pointer-events-none absolute top-1.5 left-0 size-4 text-muted-foreground/55"
+                                  />
+                                  <Input
+                                    nativeInput
+                                    unstyled
+                                    type="search"
+                                    aria-label="Search projects"
+                                    placeholder="Search projects..."
+                                    value={nestedProjectScopeQuery}
+                                    onChange={(event) =>
+                                      setNestedProjectScopeQuery(event.currentTarget.value)
+                                    }
+                                    onKeyDown={(event) => {
+                                      if (event.key !== "Escape") event.stopPropagation();
+                                    }}
+                                    className="[&_[data-slot=input]]:h-7 [&_[data-slot=input]]:ps-5 [&_[data-slot=input]]:text-sm"
+                                  />
+                                </div>
+                              </div>
+                              {nestedProjectScopeItems.length === 0 ? (
+                                <div className="px-2 py-3 text-center text-sm text-muted-foreground">
+                                  No matching projects.
+                                </div>
+                              ) : (
+                                <MenuRadioGroup
+                                  value={projectScopeKey ?? "all"}
+                                  onValueChange={(value) =>
+                                    setProjectScopeKey(value === "all" ? null : value)
+                                  }
+                                >
+                                  {nestedProjectScopeItems.map((item) => {
+                                    const project = projectGroupByScopeKey.get(item.value) ?? null;
+                                    const isSelected = item.value === (projectScopeKey ?? "all");
+                                    return (
+                                      <MenuRadioItem
+                                        key={item.value}
+                                        value={item.value}
+                                        closeOnClick
+                                        className="font-medium [&>span]:min-w-0"
+                                      >
+                                        <span className="flex min-w-0 items-center gap-2">
+                                          <CheckIcon
+                                            aria-hidden="true"
+                                            className={cn(
+                                              "size-4 shrink-0",
+                                              !isSelected && "invisible",
+                                            )}
+                                          />
+                                          {project ? (
+                                            <ProjectFavicon
+                                              environmentId={project.environmentId}
+                                              cwd={project.workspaceRoot}
+                                              faviconPath={project.faviconPath}
+                                              className="size-4 shrink-0"
+                                            />
+                                          ) : (
+                                            <FolderIcon className="size-4 shrink-0" />
+                                          )}
+                                          {item.value === "all" ? (
+                                            <span className="flex min-w-0 flex-1 flex-col">
+                                              <span>{item.label}</span>
+                                              <span className="text-xs font-normal text-muted-foreground">
+                                                Show threads from every project
+                                              </span>
+                                            </span>
+                                          ) : (
+                                            <span className="min-w-0 flex-1 truncate">
+                                              {item.label}
+                                            </span>
+                                          )}
+                                          {project ? (
+                                            <Button
+                                              size="icon-xs"
+                                              variant="ghost-muted"
+                                              aria-label={`Project settings for ${project.displayName}`}
+                                              title={`Project settings for ${project.displayName}`}
+                                              className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
+                                              onPointerDown={(event) => event.stopPropagation()}
+                                              onClick={(event) => {
+                                                void handleProjectSettings(event, project);
+                                              }}
+                                            >
+                                              <SettingsIcon className="size-3.5" />
+                                            </Button>
+                                          ) : null}
+                                        </span>
+                                      </MenuRadioItem>
+                                    );
+                                  })}
+                                </MenuRadioGroup>
+                              )}
+                            </MenuGroup>
+                          </MenuSubPopup>
+                        </MenuSub>
+                        <MenuSub>
+                          <MenuSubTrigger>Environment</MenuSubTrigger>
+                          <MenuSubPopup className="w-72 max-w-(--available-width)">
+                            <MenuGroup>
+                              <MenuGroupLabel>Environment</MenuGroupLabel>
+                              <MenuRadioGroup
+                                value={environmentScopeId ?? "all"}
+                                onValueChange={(value) => {
+                                  const environment = environments.find(
+                                    (candidate) => candidate.environmentId === value,
+                                  );
+                                  setConfiguredEnvironmentScopeId(
+                                    value === "all" ? null : (environment?.environmentId ?? null),
+                                  );
                                 }}
                               >
-                                <SettingsIcon className="size-3.5" />
-                              </Button>
-                            ) : null}
-                          </ComboboxItem>
-                        );
-                      }}
-                    </ComboboxList>
-                  </ComboboxPopup>
-                </Combobox>
+                                <MenuRadioItem
+                                  value="all"
+                                  closeOnClick
+                                  className="[&>span]:min-w-0"
+                                >
+                                  <span className="flex min-w-0 items-start gap-2">
+                                    <CheckIcon
+                                      aria-hidden="true"
+                                      className={cn(
+                                        "mt-0.5 size-4 shrink-0",
+                                        environmentScopeId !== null && "invisible",
+                                      )}
+                                    />
+                                    <span className="flex min-w-0 flex-1 flex-col">
+                                      <span className="font-medium">All environments</span>
+                                      <span className="text-xs text-muted-foreground">
+                                        Show threads from every environment
+                                      </span>
+                                    </span>
+                                  </span>
+                                </MenuRadioItem>
+                                {sortedSidebarEnvironments.map((environment) => {
+                                  const isSelected =
+                                    environment.environmentId === environmentScopeId;
+                                  return (
+                                    <MenuRadioItem
+                                      key={environment.environmentId}
+                                      value={environment.environmentId}
+                                      closeOnClick
+                                      className="font-medium [&>span]:min-w-0"
+                                    >
+                                      <span className="flex min-w-0 items-center gap-2">
+                                        <CheckIcon
+                                          aria-hidden="true"
+                                          className={cn(
+                                            "size-4 shrink-0",
+                                            !isSelected && "invisible",
+                                          )}
+                                        />
+                                        <ServerIcon className="size-4 shrink-0 text-muted-foreground" />
+                                        <span className="min-w-0 flex-1 truncate">
+                                          {environment.label}
+                                        </span>
+                                      </span>
+                                    </MenuRadioItem>
+                                  );
+                                })}
+                              </MenuRadioGroup>
+                            </MenuGroup>
+                          </MenuSubPopup>
+                        </MenuSub>
+                      </MenuGroup>
+                    </MenuPopup>
+                  </Menu>
+                ) : (
+                  <Combobox
+                    items={projectScopeItems}
+                    filteredItems={filteredProjectScopeItems}
+                    autoHighlight
+                    itemToStringLabel={(item) => item.label}
+                    isItemEqualToValue={(a, b) => a.value === b.value}
+                    open={projectScopeMenuState.open}
+                    onOpenChange={(open) => {
+                      dispatchProjectScopeMenu({ type: "open-changed", open });
+                    }}
+                    value={selectedProjectScopeItem}
+                    onValueChange={(item) => {
+                      if (!item) return;
+                      setProjectScopeKey(item.value === "all" ? null : item.value);
+                    }}
+                  >
+                    <ComboboxTrigger
+                      render={
+                        <SidebarMenuButton
+                          aria-label="Filter threads by project"
+                          className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                        />
+                      }
+                    >
+                      {scopedProjectGroup ? (
+                        <ProjectFavicon
+                          environmentId={scopedProjectGroup.environmentId}
+                          cwd={scopedProjectGroup.workspaceRoot}
+                          faviconPath={scopedProjectGroup.faviconPath}
+                          className="size-4 shrink-0"
+                        />
+                      ) : (
+                        <FolderIcon className="size-4 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate">
+                        {scopedProjectGroup?.displayName ?? "All projects"}
+                      </span>
+                      <ChevronDownIcon className="-mr-px size-4 shrink-0" />
+                    </ComboboxTrigger>
+                    <ComboboxPopup
+                      align="start"
+                      className="w-(--anchor-width) min-w-0 overflow-hidden"
+                    >
+                      <div className="shrink-0 px-3 pt-2.5">
+                        <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
+                          <SearchIcon
+                            aria-hidden="true"
+                            className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
+                          />
+                          <ComboboxInput
+                            aria-label="Search projects"
+                            className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
+                            inputClassName="rounded-none bg-transparent text-sm"
+                            placeholder="Search projects..."
+                            showTrigger={false}
+                            size="sm"
+                            unstyled
+                            value={projectScopeMenuState.query}
+                            onChange={(event) =>
+                              dispatchProjectScopeMenu({
+                                type: "query-changed",
+                                query: event.target.value,
+                              })
+                            }
+                          />
+                        </div>
+                      </div>
+                      <ComboboxEmpty>No matching projects.</ComboboxEmpty>
+                      <ComboboxList>
+                        {(item: (typeof projectScopeItems)[number]) => {
+                          const project = projectGroupByScopeKey.get(item.value) ?? null;
+                          return (
+                            <ComboboxItem
+                              key={item.value}
+                              hideIndicator
+                              value={item}
+                              className="h-8 min-h-8 py-0 font-medium"
+                              contentClassName="flex min-w-0 items-center gap-2"
+                            >
+                              {project ? (
+                                <ProjectFavicon
+                                  environmentId={project.environmentId}
+                                  cwd={project.workspaceRoot}
+                                  faviconPath={project.faviconPath}
+                                  className="size-4 shrink-0"
+                                />
+                              ) : (
+                                <FolderIcon className="size-4 shrink-0" />
+                              )}
+                              <span className="min-w-0 flex-1 truncate text-sm">{item.label}</span>
+                              {project ? (
+                                <Button
+                                  size="icon-xs"
+                                  variant="ghost-muted"
+                                  aria-label={`Project settings for ${project.displayName}`}
+                                  title={`Project settings for ${project.displayName}`}
+                                  className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
+                                  onPointerDown={(event) => event.stopPropagation()}
+                                  onClick={(event) => {
+                                    void handleProjectSettings(event, project);
+                                  }}
+                                >
+                                  <SettingsIcon className="size-3.5" />
+                                </Button>
+                              ) : null}
+                            </ComboboxItem>
+                          );
+                        }}
+                      </ComboboxList>
+                    </ComboboxPopup>
+                  </Combobox>
+                )}
                 <Tooltip>
                   <TooltipTrigger
                     render={
@@ -3872,6 +4168,7 @@ export default function Sidebar() {
                       projectDisplayNameByKey={projectDisplayNameByKey}
                       projectCwdByKey={projectCwdByKey}
                       projectFaviconPathByKey={projectFaviconPathByKey}
+                      selectedEnvironmentId={environmentScopeId}
                       scopedProjectKeys={scopedProjectKeys}
                       routeDraftId={routeDraftIdForRows}
                       onNavigateToDraft={navigateToDraft}
@@ -4041,6 +4338,8 @@ export default function Sidebar() {
                 </>
               ) : scopedProjectGroup ? (
                 `No threads in ${scopedProjectGroup.displayName} yet`
+              ) : scopedEnvironment ? (
+                `No threads in ${scopedEnvironment.label} yet`
               ) : (
                 "No threads yet"
               )}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -21,6 +21,10 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
+Use the filter above the web or desktop thread list to focus on one project. When T3 Code knows
+about more than one environment, the same control opens **Project** and **Environment** submenus.
+Choose **All projects** or **All environments** to clear that part of the filter.
+
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.


### PR DESCRIPTION
## Problem

The desktop sidebar only supported filtering threads by project, even when multiple remote environments were connected. This made macOS and Windows inconsistent with the mobile client and made it difficult to focus on one environment.

## Solution

Add a two-level thread filter menu that matches the mobile information hierarchy:

- show Project and Environment choices at the first level;
- show project or environment details in their respective submenus;
- display the environment filter only when multiple environments are available;
- compose project and environment selections so threads must match both scopes;
- keep the existing project combobox unchanged for single-environment users;
- clear stale selections when environments or available projects change.

The user documentation and focused sidebar filtering tests are updated alongside the UI.

## Testing

- `NODE_OPTIONS=--localstorage-file=/tmp/t3code-sidebar-tests-localstorage CI=true pnpm vp test run src/components/Sidebar.logic.test.ts` (114 tests passed)
- `pnpm --filter @t3tools/web typecheck`
- targeted lint and formatting checks for the changed files
- verified the single-environment and two-environment flows in an isolated T3 Code web client, including combined project/environment filtering

Closes #8948

Implemented by gpt-5.6-sol with the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 32c1c96f21465be95528ed002582cde3f7565243. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter sidebar threads by environment in web app
> - Adds `resolveSidebarEnvironmentScopeId`, `sidebarEntryMatchesScope`, and `filterSidebarProjectGroupsByEnvironment` helpers in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/9241/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to resolve, match, and filter by the selected environment
> - Replaces the multi-environment project combobox in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9241/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) with a menu containing Project and Environment submenus, radio selections, and project search; retains the existing combobox when zero or one environment exists
> - Filters thread rows, draft counts, project choices, selection state, and settled-thread pagination to the combined environment/project scope, and resets selection and pagination when the environment changes
> - Adds tests covering environment-scope validation, combined matching, and environment-specific project-group filtering in [Sidebar.logic.test.ts](https://github.com/pingdotgg/t3code/pull/9241/files#diff-32549f6f09ae3a1d9d846a62727c17b9f9ec246030982995fd972b497a87335a)
> - Documents the Project and Environment submenus and the "All" options in [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/9241/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a)
> - Risk: `resolveSidebarEnvironmentScopeId` returns no environment scope when fewer than two environments are available, so any out-of-tree caller relying on the old single-project-only scope will see project groups and threads no longer restricted by environment in that case
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 32c1c96. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->