### PR TITLE
fix: support skills whose names start with a number

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -195,7 +195,7 @@ function appendRun(
   return runs;
 }
 
-const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
+const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s|$)/g;
 
 function formatSkillLabel(skill: SelectableMarkdownSkill): string {
   const displayName = skill.displayName?.trim();

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -209,18 +209,18 @@ describe("nativeMarkdownDocumentRuns", () => {
       children: [
         {
           type: "paragraph",
-          children: [{ type: "text", content: "Use $ui for this." }],
+          children: [{ type: "text", content: "Use $2spec for this." }],
         },
       ],
     };
 
-    expect(nativeMarkdownDocumentRuns(node, [{ name: "ui", displayName: "UI" }])).toEqual([
+    expect(nativeMarkdownDocumentRuns(node, [{ name: "2spec", displayName: "2Spec" }])).toEqual([
       { text: "Use ", role: "body" },
       {
-        text: "$ui",
+        text: "$2spec",
         role: "body",
-        skillName: "ui",
-        skillLabel: "UI",
+        skillName: "2spec",
+        skillLabel: "2Spec",
       },
       { text: " for this.", role: "body" },
     ]);

--- a/apps/server/src/provider/Drivers/ClaudeSkillDispatch.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkillDispatch.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { planClaudeSkillDispatch } from "./ClaudeSkillDispatch.ts";
 
-const SKILLS = new Set(["implement", "review", "re-release-version"]);
+const SKILLS = new Set(["2spec", "implement", "review", "re-release-version"]);
 
 describe("planClaudeSkillDispatch", () => {
   it("leaves a prompt without a known skill untouched", () => {
@@ -24,6 +24,14 @@ describe("planClaudeSkillDispatch", () => {
       leadingText: undefined,
       commandText: "/review\nfocus on auth",
       skillName: "review",
+    });
+  });
+
+  it("dispatches a skill whose name starts with a number", () => {
+    expect(planClaudeSkillDispatch("$2spec review this", SKILLS)).toEqual({
+      leadingText: undefined,
+      commandText: "/2spec review this",
+      skillName: "2spec",
     });
   });
 

--- a/apps/server/src/provider/Drivers/ClaudeSkillDispatch.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkillDispatch.ts
@@ -29,7 +29,7 @@
  * (`packages/shared/src/composerInlineTokens.ts`), so a rendered chip and a
  * dispatched skill are always the same set.
  */
-const SKILL_MENTION_PATTERN = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
+const SKILL_MENTION_PATTERN = /(^|\s)\$([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s|$)/g;
 
 export interface ClaudeSkillDispatch {
   /** Text before the dispatched mention, or `undefined` when it opens the prompt. */

--- a/apps/web/src/components/chat/SkillInlineText.tsx
+++ b/apps/web/src/components/chat/SkillInlineText.tsx
@@ -10,7 +10,7 @@ import {
 } from "../composerInlineChip";
 import { cn } from "~/lib/utils";
 
-const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
+const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s|$)/g;
 
 type InlineSkill = Pick<ServerProviderSkill, "name" | "displayName">;
 

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -31,6 +31,16 @@ describe("collectComposerInlineTokens", () => {
     ]);
   });
 
+  it("collects skills whose names start with a number", () => {
+    expect(collectComposerInlineTokens("Use $2spec now")).toContainEqual({
+      type: "skill",
+      value: "2spec",
+      source: "$2spec",
+      start: 4,
+      end: 10,
+    });
+  });
+
   it("does not convert incomplete trailing tokens", () => {
     expect(collectComposerInlineTokens("Use $ui")).toEqual([]);
     expect(collectComposerInlineTokens("Inspect @AGENTS.md")).toEqual([]);

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -41,6 +41,10 @@ describe("collectComposerInlineTokens", () => {
     });
   });
 
+  it.each(["$1", "$100"])("keeps numeric expression %s as plain text", (expression) => {
+    expect(collectComposerInlineTokens(`Use ${expression} now`)).toEqual([]);
+  });
+
   it("does not convert incomplete trailing tokens", () => {
     expect(collectComposerInlineTokens("Use $ui")).toEqual([]);
     expect(collectComposerInlineTokens("Inspect @AGENTS.md")).toEqual([]);

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -18,7 +18,7 @@ export interface CollectComposerInlineTokensOptions {
   readonly preserveTrailingFrom?: ReadonlyArray<ComposerInlineToken>;
 }
 
-const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s)/g;
+const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s)/g;
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 /**
  * The label body is bounded rather than `*`. Unbounded, every whitespace in

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -18,7 +18,7 @@ export interface CollectComposerInlineTokensOptions {
   readonly preserveTrailingFrom?: ReadonlyArray<ComposerInlineToken>;
 }
 
-const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s)/g;
+const SKILL_TOKEN_REGEX = /(^|\s)\$(?![0-9]+(?=\s))([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s)/g;
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 /**
  * The label body is bounded rather than `*`. Unbounded, every whitespace in


### PR DESCRIPTION
Skill discovery accepts directory names such as `2spec`, but every `$skill` token pattern required an ASCII letter first. That left `$2spec` as plain text in the composer and timelines, and Claude did not dispatch the selected skill.

## Fix

Allow an ASCII digit in the first position of the existing skill token pattern across shared composer parsing, web and mobile rendering, and Claude dispatch. This keeps all current delimiters and known-skill checks unchanged.

## Before and after

| Before | After |
| --- | --- |
| ![Before: $2spec remains plain text](https://github.com/user-attachments/assets/12555b14-3286-4407-8ea7-fdc1f68d92d5) | ![After: $2spec renders as a skill chip](https://github.com/user-attachments/assets/abf27d51-6c1f-4679-9ab8-b078a37903ee) |

## Verification

- Regression-first checks failed on all three affected seams before the fix; 59 focused tests pass after it.
- Shared, server, web, and mobile typechecks pass.
- Targeted lint, format, and `git diff --check` pass.
- In an isolated real T3 Code app, a discovered `.claude/skills/2spec` entry changed from plain text to a selectable composer chip. No provider prompt was sent.

Closes #9235

Implemented with `gpt-5.6-sol` in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow regex and parsing alignment with new tests; composer still filters pure-numeric `$` tokens and unknown names remain literal.
> 
> **Overview**
> **Digit-leading skill names** (e.g. `2spec`) are now recognized everywhere `$skill` tokens are parsed, rendered, and dispatched.
> 
> The first character after `$` may be a digit in the shared composer matcher (with a lookahead so bare numeric tokens like `$1` / `$100` stay plain text), web chat chips, mobile markdown skill decoration, and Claude skill dispatch. Tests were updated to use `$2spec` and cover dispatch plus composer collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa163527a8203ac284dc03f3b845f35c643db3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix skill token matchers to allow names starting with a digit
> - Updates skill-token regexes in mobile, web, shared, and server components to accept an ASCII digit as the first character after the `$` sign.
> - `collectComposerInlineTokens` adds a lookahead so tokens consisting only of digits (e.g. `$1`, `$100`) are not collected as skill tokens.
> - `planClaudeSkillDispatch` now dispatches digit-leading skill mentions, including at the start of a prompt.
> - Adds test coverage across all four areas using digit-leading skill names like `2spec`.
> - Behavioral Change: `$1spec` is now a valid skill token where it was previously ignored; pure numeric tokens like `$1` remain uncollected as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fa1635.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
