### PR TITLE
fix(release): pin patched expo-sharing version

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -97,7 +97,7 @@
     "expo-paste-input": "^0.1.15",
     "expo-quick-actions": "^6.0.2",
     "expo-secure-store": "~57.0.2",
-    "expo-sharing": "~57.0.16",
+    "expo-sharing": "57.0.16",
     "expo-splash-screen": "~57.0.8",
     "expo-sqlite": "~57.0.2",
     "expo-symbols": "~57.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,7 +368,7 @@ importers:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.18)
       expo-sharing:
-        specifier: ~57.0.16
+        specifier: 57.0.16
         version: 57.0.16(patch_hash=8d2e3b10eb3f52036a9a086800180ec6cebf3b75bccc5b1775117a7244d4ac45)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       expo-splash-screen:
         specifier: ~57.0.8


### PR DESCRIPTION
## Problem

Fresh lockfile generation resolves expo-sharing 57.0.17, while patchedDependencies targets 57.0.16. pnpm then fails with ERR_PNPM_UNUSED_PATCH, which blocks Release Smoke on current main and all rebased pull requests.

## Fix

Pin expo-sharing to the patched 57.0.16 release.

## Verification

- pnpm exec node scripts/release-smoke.ts
- Release smoke checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version pin only; no runtime or app logic changes beyond locking to the already-patched release.
> 
> **Overview**
> **Pins `expo-sharing` to exact `57.0.16`** in the mobile app so installs stay on the version that has a `patchedDependencies` entry (`expo-sharing@57.0.16`).
> 
> The dependency was previously `~57.0.16`, which let pnpm resolve **57.0.17** on a fresh lockfile. That mismatch triggers **`ERR_PNPM_UNUSED_PATCH`** and breaks release smoke. The lockfile specifier is updated to match the exact pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebcef17710bb41e06b48c781106015fdc79cf6b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `expo-sharing` to version 57.0.16 in mobile dependency manifest
> Changes the `expo-sharing` dependency in [package.json](https://github.com/pingdotgg/t3code/pull/9250/files#diff-179bbaeea9e8295a4abee862073776f87f7dc3c78066c787b8fcdb8be71d5d83) from a tilde range (`~57.0.16`) to an exact version pin. This ensures installs get the patched 57.0.16 release rather than any newer compatible patch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebcef17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->