### PR TITLE
fix(mobile): render voice levels without smoothing

### DIFF
--- a/apps/mobile/src/features/voice-input/ComposerDictationControl.tsx
+++ b/apps/mobile/src/features/voice-input/ComposerDictationControl.tsx
@@ -87,11 +87,6 @@ const DICTATION_TOOLBAR_EXITING = toolbarFlip(0, -90);
 const WAVEFORM_BAR_HEIGHT = 32;
 const WAVEFORM_MIN_BAR_HEIGHT = 2;
 const WAVEFORM_BAR_SPACING = 5;
-const WAVEFORM_TIMING = {
-  duration: 100,
-  easing: Easing.out(Easing.quad),
-  reduceMotion: ReduceMotion.System,
-} as const;
 
 /** Rotates the compact draft away without unmounting or resizing its native editor. */
 export function ComposerDictationDraftContent(props: {
@@ -162,14 +157,12 @@ const WaveformBar = memo(function WaveformBar(props: {
   const animatedStyle = useAnimatedStyle(() => {
     const level = audioLevels.value[sampleIndex] ?? 0;
     return {
-      opacity: withTiming(0.22 + level * 0.78, WAVEFORM_TIMING),
+      opacity: 0.22 + level * 0.78,
       transform: [
         {
-          scaleY: withTiming(
+          scaleY:
             (WAVEFORM_MIN_BAR_HEIGHT + level * (WAVEFORM_BAR_HEIGHT - WAVEFORM_MIN_BAR_HEIGHT)) /
-              WAVEFORM_BAR_HEIGHT,
-            WAVEFORM_TIMING,
-          ),
+            WAVEFORM_BAR_HEIGHT,
         },
       ],
     };


### PR DESCRIPTION
The voice waveform interpolated every microphone sample for 100 ms, which made it lag behind live speech.

Render each bar directly from the current metering sample. The existing 80 ms sampling cadence and decibel normalization stay unchanged.

Checks:
- `vp fmt --check apps/mobile/src/features/voice-input/ComposerDictationControl.tsx`
- `vp run --filter @t3tools/mobile typecheck`
- `vp test run apps/mobile/src/features/voice-input/voiceInputMetering.test.ts` (15 passed)

Implemented with Codex (gpt-5.6-sol).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to waveform rendering in the voice composer; no auth, data, or recording pipeline logic touched.
> 
> **Overview**
> **Removes 100ms `withTiming` smoothing** on dictation waveform bars so opacity and `scaleY` track the latest metering samples immediately instead of lagging behind speech.
> 
> Deletes the unused `WAVEFORM_TIMING` config in `ComposerDictationControl.tsx`; toolbar flip and other dictation animations are unchanged. Metering cadence and level normalization are not part of this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b2fde6b09a9a5e0e40a84b50fd62afedfa3a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WaveformBar` to render voice levels without smoothing
> Removes the module-level timing configuration for opacity and scale animations in `WaveformBar`. Bars now apply the current audio-level sample directly instead of interpolating over a 100 ms eased animation.
> - Risk: bars no longer animate between samples; rapid level changes may appear jittery on some devices
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0b2fde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->