### PR TITLE
fix(desktop): detach window menu on Windows to prevent vertical layout shift

### DIFF
--- a/apps/desktop/src/electron/ElectronMenu.ts
+++ b/apps/desktop/src/electron/ElectronMenu.ts
@@ -190,6 +190,13 @@ export const make = Effect.gen(function* () {
       Effect.try({
         try: () => {
           Electron.Menu.setApplicationMenu(Electron.Menu.buildFromTemplate([...template]));
+          if (platform === "win32") {
+            for (const window of Electron.BrowserWindow.getAllWindows()) {
+              if (!window.isDestroyed()) {
+                window.setMenu(null);
+              }
+            }
+          }
         },
         catch: (cause) =>
           new ElectronMenuOperationError({

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -109,6 +109,7 @@ function makeFakeBrowserWindow() {
     setOpacity: vi.fn(),
     setTitle: vi.fn(),
     setTitleBarOverlay: vi.fn(),
+    setMenu: vi.fn(),
     show: vi.fn(),
     webContents,
   };
@@ -131,6 +132,7 @@ function makeFakeBrowserWindow() {
     setAutoHideCursor: window.setAutoHideCursor,
     setFullScreen: window.setFullScreen,
     setOpacity: window.setOpacity,
+    setMenu: window.setMenu,
     webContentsListeners,
     windowListeners,
   };
@@ -209,6 +211,7 @@ function makeTestLayer(input: {
   ) => Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
   readonly previewZoomReapplies?: number[];
+  readonly environmentLayer?: Layer.Layer<DesktopEnvironment.DesktopEnvironment>;
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -267,7 +270,7 @@ function makeTestLayer(input: {
     Layer.provide(
       Layer.mergeAll(
         desktopAssetsLayer,
-        desktopEnvironmentLayer,
+        input.environmentLayer ?? desktopEnvironmentLayer,
         desktopAppSettingsLayer,
         desktopClientSettingsLayer,
         desktopServerExposureLayer,
@@ -1256,6 +1259,42 @@ describe("DesktopWindow", () => {
         assert.equal(yield* Ref.get(scenario.createCalls), 3);
         assert.deepEqual(main.send.mock.calls, [[MENU_ACTION_CHANNEL, "open-settings"]]);
       }).pipe(Effect.provide(scenario.layer));
+    }),
+  );
+
+  it.effect("detaches window menu on Windows during syncAppearance", () =>
+    Effect.gen(function* () {
+      const { window, setMenu } = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make(Option.some(window));
+      const windowsEnvironmentLayer = DesktopEnvironment.layer({
+        ...environmentInput,
+        platform: "win32",
+      }).pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            NodeServices.layer,
+            DesktopConfig.layerTest({
+              T3CODE_PORT: "3773",
+              VITE_DEV_SERVER_URL: "http://127.0.0.1:5733",
+            }),
+          ),
+        ),
+      );
+
+      const layer = makeTestLayer({
+        window,
+        createCount,
+        mainWindow,
+        environmentLayer: windowsEnvironmentLayer,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.syncAppearance;
+        assert.equal(setMenu.mock.calls.length, 1);
+        assert.deepEqual(setMenu.mock.calls[0], [null]);
+      }).pipe(Effect.provide(layer));
     }),
   );
 });

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -1303,7 +1303,7 @@ describe("DesktopWindow", () => {
     Effect.gen(function* () {
       const fake = makeFakeBrowserWindow();
       const createCount = yield* Ref.make(0);
-      const mainWindow = yield* Ref.make(Option.none());
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
       const windowsEnvironmentLayer = DesktopEnvironment.layer({
         ...environmentInput,
         platform: "win32",

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -211,7 +211,7 @@ function makeTestLayer(input: {
   ) => Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
   readonly previewZoomReapplies?: number[];
-  readonly environmentLayer?: Layer.Layer<DesktopEnvironment.DesktopEnvironment>;
+  readonly environmentLayer?: Layer.Layer<DesktopEnvironment.DesktopEnvironment, never, never>;
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -1280,6 +1280,7 @@ describe("DesktopWindow", () => {
             }),
           ),
         ),
+        Layer.orDie,
       );
 
       const layer = makeTestLayer({
@@ -1294,6 +1295,99 @@ describe("DesktopWindow", () => {
         yield* desktopWindow.syncAppearance;
         assert.equal(setMenu.mock.calls.length, 1);
         assert.deepEqual(setMenu.mock.calls[0], [null]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("handles settings and zoom shortcuts on Windows via before-input-event", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make(Option.none());
+      const windowsEnvironmentLayer = DesktopEnvironment.layer({
+        ...environmentInput,
+        platform: "win32",
+      }).pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            NodeServices.layer,
+            DesktopConfig.layerTest({
+              T3CODE_PORT: "3773",
+              VITE_DEV_SERVER_URL: "http://127.0.0.1:5733",
+            }),
+          ),
+        ),
+        Layer.orDie,
+      );
+
+      const layer = makeTestLayer({
+        window: fake.window,
+        createCount,
+        mainWindow,
+        environmentLayer: windowsEnvironmentLayer,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        const beforeInput = fake.webContentsListeners.get("before-input-event");
+        if (!beforeInput) {
+          return yield* Effect.die("before-input-event listener was not registered");
+        }
+
+        let prevented = false;
+        beforeInput({ preventDefault: () => { prevented = true; } }, {
+          type: "keyDown",
+          isAutoRepeat: false,
+          key: ",",
+          control: true,
+          meta: false,
+          alt: false,
+          shift: false,
+        });
+        assert.isTrue(prevented);
+        assert.deepEqual(fake.send.mock.calls, [[MENU_ACTION_CHANNEL, "open-settings"]]);
+
+        prevented = false;
+        beforeInput({ preventDefault: () => { prevented = true; } }, {
+          type: "keyDown",
+          isAutoRepeat: false,
+          key: "=",
+          control: true,
+          meta: false,
+          alt: false,
+          shift: false,
+        });
+        assert.isTrue(prevented);
+        assert.equal(fake.window.webContents.getZoomLevel(), 0.5);
+
+        prevented = false;
+        beforeInput({ preventDefault: () => { prevented = true; } }, {
+          type: "keyDown",
+          isAutoRepeat: false,
+          key: "-",
+          control: true,
+          meta: false,
+          alt: false,
+          shift: false,
+        });
+        assert.isTrue(prevented);
+        assert.equal(fake.window.webContents.getZoomLevel(), 0);
+
+        fake.window.webContents.setZoomLevel(1.5);
+        prevented = false;
+        beforeInput({ preventDefault: () => { prevented = true; } }, {
+          type: "keyDown",
+          isAutoRepeat: false,
+          key: "0",
+          control: true,
+          meta: false,
+          alt: false,
+          shift: false,
+        });
+        assert.isTrue(prevented);
+        assert.equal(fake.window.webContents.getZoomLevel(), 0);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -1336,7 +1336,7 @@ describe("DesktopWindow", () => {
           return yield* Effect.die("before-input-event listener was not registered");
         }
 
-        const sendKey = (key: string) => {
+        const sendKey = (key: string, shift = false) => {
           let prevented = false;
           beforeInput(
             { preventDefault: () => (prevented = true) },
@@ -1347,7 +1347,7 @@ describe("DesktopWindow", () => {
               control: true,
               meta: false,
               alt: false,
-              shift: false,
+              shift,
             },
           );
           return prevented;
@@ -1359,8 +1359,11 @@ describe("DesktopWindow", () => {
         assert.isTrue(sendKey("="));
         assert.equal(fake.window.webContents.getZoomLevel(), 0.5);
 
+        assert.isTrue(sendKey("+", true));
+        assert.equal(fake.window.webContents.getZoomLevel(), 1);
+
         assert.isTrue(sendKey("-"));
-        assert.equal(fake.window.webContents.getZoomLevel(), 0);
+        assert.equal(fake.window.webContents.getZoomLevel(), 0.5);
 
         fake.window.webContents.setZoomLevel(1.5);
         assert.isTrue(sendKey("0"));

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -1336,57 +1336,34 @@ describe("DesktopWindow", () => {
           return yield* Effect.die("before-input-event listener was not registered");
         }
 
-        let prevented = false;
-        beforeInput({ preventDefault: () => { prevented = true; } }, {
-          type: "keyDown",
-          isAutoRepeat: false,
-          key: ",",
-          control: true,
-          meta: false,
-          alt: false,
-          shift: false,
-        });
-        assert.isTrue(prevented);
+        const sendKey = (key: string) => {
+          let prevented = false;
+          beforeInput(
+            { preventDefault: () => (prevented = true) },
+            {
+              type: "keyDown",
+              isAutoRepeat: false,
+              key,
+              control: true,
+              meta: false,
+              alt: false,
+              shift: false,
+            },
+          );
+          return prevented;
+        };
+
+        assert.isTrue(sendKey(","));
         assert.deepEqual(fake.send.mock.calls, [[MENU_ACTION_CHANNEL, "open-settings"]]);
 
-        prevented = false;
-        beforeInput({ preventDefault: () => { prevented = true; } }, {
-          type: "keyDown",
-          isAutoRepeat: false,
-          key: "=",
-          control: true,
-          meta: false,
-          alt: false,
-          shift: false,
-        });
-        assert.isTrue(prevented);
+        assert.isTrue(sendKey("="));
         assert.equal(fake.window.webContents.getZoomLevel(), 0.5);
 
-        prevented = false;
-        beforeInput({ preventDefault: () => { prevented = true; } }, {
-          type: "keyDown",
-          isAutoRepeat: false,
-          key: "-",
-          control: true,
-          meta: false,
-          alt: false,
-          shift: false,
-        });
-        assert.isTrue(prevented);
+        assert.isTrue(sendKey("-"));
         assert.equal(fake.window.webContents.getZoomLevel(), 0);
 
         fake.window.webContents.setZoomLevel(1.5);
-        prevented = false;
-        beforeInput({ preventDefault: () => { prevented = true; } }, {
-          type: "keyDown",
-          isAutoRepeat: false,
-          key: "0",
-          control: true,
-          meta: false,
-          alt: false,
-          shift: false,
-        });
-        assert.isTrue(prevented);
+        assert.isTrue(sendKey("0"));
         assert.equal(fake.window.webContents.getZoomLevel(), 0);
       }).pipe(Effect.provide(layer));
     }),

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -258,6 +258,9 @@ function syncWindowAppearance(
     if (typeof titleBarOverlay === "object") {
       window.setTitleBarOverlay(titleBarOverlay);
     }
+    if (platform === "win32") {
+      window.setMenu?.(null);
+    }
   });
 }
 
@@ -389,6 +392,9 @@ export const make = Effect.gen(function* () {
 
     if (environment.platform === "darwin") {
       window.setAutoHideCursor(false);
+    }
+    if (environment.platform === "win32") {
+      window.setMenu?.(null);
     }
     let boundsPersistFiber: Fiber.Fiber<void, never> | undefined;
     let pendingBoundsPersistFiber: Fiber.Fiber<void, never> | undefined;

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -600,37 +600,40 @@ export const make = Effect.gen(function* () {
     });
     window.webContents.on("before-input-event", (event, input) => {
       quitShortcutHandler(event, input);
-      if (input.type !== "keyDown") return;
-
-      const modifier = environment.platform === "darwin" ? input.meta : input.control;
-      if (input.isAutoRepeat && modifier && !input.alt && !input.shift && input.key.toLowerCase() === "w") {
-        event.preventDefault();
+      if (input.type !== "keyDown") {
         return;
       }
 
-      if (environment.platform === "win32" && input.control && !input.alt) {
-        if (!input.shift && input.key === ",") {
+      const modifier = environment.platform === "darwin" ? input.meta : input.control;
+      if (input.isAutoRepeat) {
+        if (modifier && !input.alt && !input.shift && input.key.toLowerCase() === "w") {
+          event.preventDefault();
+        }
+        return;
+      }
+
+      if (environment.platform === "win32" && input.control && !input.alt && !input.shift) {
+        if (input.key === ",") {
           event.preventDefault();
           window.webContents.send(MENU_ACTION_CHANNEL, "open-settings");
           return;
         }
-        if (!input.shift && (input.key === "=" || input.key === "+")) {
+        if (input.key === "=" || input.key === "+") {
           event.preventDefault();
           window.webContents.setZoomLevel(window.webContents.getZoomLevel() + 0.5);
           void runPromise(previewManager.reapplyZoom());
           return;
         }
-        if (!input.shift && (input.key === "-" || input.key === "_")) {
+        if (input.key === "-" || input.key === "_") {
           event.preventDefault();
           window.webContents.setZoomLevel(window.webContents.getZoomLevel() - 0.5);
           void runPromise(previewManager.reapplyZoom());
           return;
         }
-        if (!input.shift && input.key === "0") {
+        if (input.key === "0") {
           event.preventDefault();
           window.webContents.setZoomLevel(0);
           void runPromise(previewManager.reapplyZoom());
-          return;
         }
       }
     });

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -612,8 +612,8 @@ export const make = Effect.gen(function* () {
         return;
       }
 
-      if (environment.platform === "win32" && input.control && !input.alt && !input.shift) {
-        if (input.key === ",") {
+      if (environment.platform === "win32" && input.control && !input.alt) {
+        if (!input.shift && input.key === ",") {
           event.preventDefault();
           window.webContents.send(MENU_ACTION_CHANNEL, "open-settings");
           return;
@@ -624,13 +624,13 @@ export const make = Effect.gen(function* () {
           void runPromise(previewManager.reapplyZoom());
           return;
         }
-        if (input.key === "-" || input.key === "_") {
+        if (!input.shift && (input.key === "-" || input.key === "_")) {
           event.preventDefault();
           window.webContents.setZoomLevel(window.webContents.getZoomLevel() - 0.5);
           void runPromise(previewManager.reapplyZoom());
           return;
         }
-        if (input.key === "0") {
+        if (!input.shift && input.key === "0") {
           event.preventDefault();
           window.webContents.setZoomLevel(0);
           void runPromise(previewManager.reapplyZoom());

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -600,10 +600,38 @@ export const make = Effect.gen(function* () {
     });
     window.webContents.on("before-input-event", (event, input) => {
       quitShortcutHandler(event, input);
-      if (input.type !== "keyDown" || !input.isAutoRepeat) return;
+      if (input.type !== "keyDown") return;
+
       const modifier = environment.platform === "darwin" ? input.meta : input.control;
-      if (modifier && !input.alt && !input.shift && input.key.toLowerCase() === "w") {
+      if (input.isAutoRepeat && modifier && !input.alt && !input.shift && input.key.toLowerCase() === "w") {
         event.preventDefault();
+        return;
+      }
+
+      if (environment.platform === "win32" && input.control && !input.alt) {
+        if (!input.shift && input.key === ",") {
+          event.preventDefault();
+          window.webContents.send(MENU_ACTION_CHANNEL, "open-settings");
+          return;
+        }
+        if (!input.shift && (input.key === "=" || input.key === "+")) {
+          event.preventDefault();
+          window.webContents.setZoomLevel(window.webContents.getZoomLevel() + 0.5);
+          void runPromise(previewManager.reapplyZoom());
+          return;
+        }
+        if (!input.shift && (input.key === "-" || input.key === "_")) {
+          event.preventDefault();
+          window.webContents.setZoomLevel(window.webContents.getZoomLevel() - 0.5);
+          void runPromise(previewManager.reapplyZoom());
+          return;
+        }
+        if (!input.shift && input.key === "0") {
+          event.preventDefault();
+          window.webContents.setZoomLevel(0);
+          void runPromise(previewManager.reapplyZoom());
+          return;
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes #5369

### Cause
On Windows, when Electron creates a `BrowserWindow` with custom `titleBarStyle: "hidden"` and `titleBarOverlay` (Window Controls Overlay), calling `Electron.Menu.setApplicationMenu(...)` attaches a native Win32 `HMENU` to top-level windows. Even with `autoHideMenuBar: true`, the Win32 `HWND` retains the menu handle.

When the window loses focus (`WM_NCACTIVATE(FALSE)` / blur), Windows DWM recalculates the non-client frame and reserves/displaces the client area vertically by the menu bar height (~40px / 1cm), resulting in a visible vertical shift and an interactive hit-test coordinate mismatch. When the window is re-focused (`WM_NCACTIVATE(TRUE)`), Electron's custom frame procedure reasserts control and the window abruptly snaps back down.

### Solution
- Explicitly call `window.setMenu(null)` on Windows during window creation and appearance synchronization in `DesktopWindow.ts`.
- In `ElectronMenu.ts`, detach the in-window `HMENU` from top-level windows after setting the application menu on Windows, preserving application-level keyboard accelerators without attaching a native menu bar to the window frame.
- Add unit test coverage in `DesktopWindow.test.ts` verifying that `setMenu(null)` is called on Windows during appearance synchronization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows window chrome and global input handling; any feature that relied on a per-window menu on Windows could break, though the app menu remains set at the application level.
> 
> **Overview**
> Fixes a Windows layout bug where attaching a native menu to hidden-title-bar windows causes the client area to jump on focus/blur. The PR **detaches the per-window `HMENU`** while still installing the global application menu so accelerators can work without reserving menu-bar space in the frame.
> 
> **Menu detach:** `DesktopWindow` calls `window.setMenu(null)` when creating the main window and during `syncAppearance` on `win32`. `ElectronMenu.setApplicationMenu` does the same for every live `BrowserWindow` immediately after rebuilding the app menu.
> 
> **Windows shortcuts:** Because the window no longer owns the native menu bar, `before-input-event` now handles **Ctrl+,** (open settings), **Ctrl+= / Ctrl++** (zoom in), **Ctrl+-** (zoom out), and **Ctrl+0** (reset zoom), with preview zoom reapplied like the existing zoom path. Cmd+W auto-repeat blocking is unchanged but only runs on repeats after the broader `keyDown` guard.
> 
> Tests add a `win32` environment override and cover menu detach on sync and the new keyboard shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8843764b8e8bfb5bd04a2ff2927a73648b2c0fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detach window menu on Windows to prevent vertical layout shift and add Windows zoom/settings shortcuts
> - On Windows, clears the menu from all live browser windows after installing the application menu in [ElectronMenu.ts](https://github.com/pingdotgg/t3code/pull/9257/files#diff-d9b8a78ba725e2cc1682eccd9670045b20399b4c32a90c6f152c6b6d11396148), removes the menu at window creation and during appearance sync in [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/9257/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429)
> - Adds Windows-only `before-input-event` handling for non-repeated Ctrl keydowns without Alt: Ctrl-comma opens settings, Ctrl-equals/plus and Ctrl-minus adjust `webContents` zoom by ±0.5, Ctrl-zero resets zoom to 0, each followed by preview-zoom reapplication
> - Adds test fixtures and Windows-configured tests covering menu detachment in `syncAppearance` and the new keyboard shortcuts
> - Behavioral Change: Windows windows no longer carry a per-window application menu; auto-repeated Ctrl+W handling is preserved but other auto-repeated Ctrl keydowns are now skipped past the repeat guard
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8843764.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->