### PR TITLE
feat(mobile): long-press file references for path and open actions

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/index.ts
+++ b/apps/mobile/modules/t3-markdown-text/index.ts
@@ -21,6 +21,8 @@ export {
   type MarkdownHighlightedToken,
 } from "./src/SelectableMarkdownText";
 export type {
+  MarkdownFileContextMenu,
+  MarkdownFileContextMenuAction,
   NativeMarkdownTextStyle,
   SelectableMarkdownSkill,
   SelectableMarkdownTextProps,

--- a/apps/mobile/modules/t3-markdown-text/ios/T3MarkdownText.mm
+++ b/apps/mobile/modules/t3-markdown-text/ios/T3MarkdownText.mm
@@ -198,6 +198,8 @@ T3MarkdownOutsideTapCoordinatorForWindow(UIWindow *window)
   BOOL _suppressSelectionChange;
   NSMutableDictionary<NSString *, UIImage *> * _attachmentImages;
   NSMutableSet<NSString *> * _pendingAttachmentUris;
+  UILongPressGestureRecognizer *_longPressGestureRecognizer;
+  UITapGestureRecognizer *_pressGestureRecognizer;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -223,21 +225,24 @@ T3MarkdownOutsideTapCoordinatorForWindow(UIWindow *window)
     _textView.textContainerInset = UIEdgeInsetsZero;
     _textView.textContainer.lineFragmentPadding = 0;
     _textView.delegate = self;
+    // Chat text supports selection and contextual actions, but not drag-and-drop.
+    _textView.textDragInteraction.enabled = NO;
+    _textView.linkTextAttributes = @{};
     // Must match RCTTextLayoutManager, which measures with usesFontLeading = NO.
     _textView.layoutManager.usesFontLeading = NO;
     [self addSubview:_textView];
 
-    const auto longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
-                                                                                          action:@selector(handleLongPressIfNecessary:)];
-    longPressGestureRecognizer.delegate = self;
+    _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
+                                                                                 action:@selector(handleLongPressIfNecessary:)];
+    _longPressGestureRecognizer.delegate = self;
 
-    const auto pressGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
-                                                                                action:@selector(handlePressIfNecessary:)];
-    pressGestureRecognizer.delegate = self;
-    [pressGestureRecognizer requireGestureRecognizerToFail:longPressGestureRecognizer];
+    _pressGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                       action:@selector(handlePressIfNecessary:)];
+    _pressGestureRecognizer.delegate = self;
+    [_pressGestureRecognizer requireGestureRecognizerToFail:_longPressGestureRecognizer];
 
-    [_textView addGestureRecognizer:pressGestureRecognizer];
-    [_textView addGestureRecognizer:longPressGestureRecognizer];
+    [_textView addGestureRecognizer:_pressGestureRecognizer];
+    [_textView addGestureRecognizer:_longPressGestureRecognizer];
   }
 
   return self;
@@ -312,6 +317,26 @@ T3MarkdownOutsideTapCoordinatorForWindow(UIWindow *window)
       convertedAttrString,
       _state->getData().attachmentRanges,
       _attachmentImages);
+  NSUInteger runLocation = 0;
+  for (UIView *child in self.subviews) {
+    if (![child isKindOfClass:[T3MarkdownTextRun class]]) {
+      continue;
+    }
+
+    T3MarkdownTextRun *textChild = (T3MarkdownTextRun *)child;
+    const NSRange runRange = NSMakeRange(runLocation, textChild.text.length);
+    runLocation = NSMaxRange(runRange);
+    if (![textChild hasContextMenu] || runRange.length == 0 ||
+        NSMaxRange(runRange) > convertedAttrString.length) {
+      continue;
+    }
+
+    NSURL *link = [NSURL URLWithString:
+        [NSString stringWithFormat:@"t3-markdown-run://%ld", (long)textChild.tag]];
+    if (link != nil) {
+      [convertedAttrString addAttribute:NSLinkAttributeName value:link range:runRange];
+    }
+  }
   [self loadAttachmentImages:_state->getData().attachmentRanges];
 
   // Setting attributedText clears any active text selection, and re-assigning
@@ -484,6 +509,18 @@ T3MarkdownOutsideTapCoordinatorForWindow(UIWindow *window)
   return YES;
 }
 
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+  if (gestureRecognizer != _longPressGestureRecognizer &&
+      gestureRecognizer != _pressGestureRecognizer) {
+    return YES;
+  }
+
+  const auto location = [self getLocationOfPress:gestureRecognizer];
+  const auto child = [self getTouchChild:location];
+  return ![child hasContextMenu];
+}
+
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
   return YES;
@@ -506,6 +543,24 @@ T3MarkdownOutsideTapCoordinatorForWindow(UIWindow *window)
 }
 
 // MARK: - Touch handling
+
+- (nullable T3MarkdownTextRun *)childForCharacterRange:(NSRange)characterRange
+{
+  NSUInteger location = 0;
+  for (UIView *child in self.subviews) {
+    if (![child isKindOfClass:[T3MarkdownTextRun class]]) {
+      continue;
+    }
+
+    T3MarkdownTextRun *textChild = (T3MarkdownTextRun *)child;
+    const NSRange range = NSMakeRange(location, textChild.text.length);
+    if (NSIntersectionRange(range, characterRange).length > 0) {
+      return textChild;
+    }
+    location = NSMaxRange(range);
+  }
+  return nil;
+}
 
 - (CGPoint)getLocationOfPress:(UIGestureRecognizer*)sender
 {
@@ -550,6 +605,10 @@ T3MarkdownOutsideTapCoordinatorForWindow(UIWindow *window)
 
 - (void)handleLongPressIfNecessary:(UILongPressGestureRecognizer*)sender
 {
+  if (sender.state != UIGestureRecognizerStateBegan) {
+    return;
+  }
+
   const auto location = [self getLocationOfPress:sender];
   const auto child = [self getTouchChild:location];
 
@@ -559,6 +618,30 @@ T3MarkdownOutsideTapCoordinatorForWindow(UIWindow *window)
 }
 
 // MARK: - UITextViewDelegate
+
+- (nullable UIAction *)textView:(UITextView *)textView
+    primaryActionForTextItem:(UITextItem *)textItem
+               defaultAction:(UIAction *)defaultAction API_AVAILABLE(ios(17.0))
+{
+  T3MarkdownTextRun *child = [self childForCharacterRange:textItem.range];
+  if (![child hasContextMenu]) {
+    return defaultAction;
+  }
+
+  __weak T3MarkdownTextRun *weakChild = child;
+  return [UIAction actionWithHandler:^(__kindof UIAction *action) {
+    [weakChild onPress];
+  }];
+}
+
+- (nullable UITextItemMenuConfiguration *)textView:(UITextView *)textView
+                      menuConfigurationForTextItem:(UITextItem *)textItem
+                                       defaultMenu:(UIMenu *)defaultMenu API_AVAILABLE(ios(17.0))
+{
+  T3MarkdownTextRun *child = [self childForCharacterRange:textItem.range];
+  UIMenu *menu = [child contextMenu];
+  return [UITextItemMenuConfiguration configurationWithMenu:menu ?: defaultMenu];
+}
 
 - (void)textViewDidChangeSelection:(UITextView *)textView
 {

--- a/apps/mobile/modules/t3-markdown-text/ios/T3MarkdownTextRun.h
+++ b/apps/mobile/modules/t3-markdown-text/ios/T3MarkdownTextRun.h
@@ -13,6 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nullable) NSString *text;
 
+- (nullable UIMenu *)contextMenu;
+- (BOOL)hasContextMenu;
+- (void)onContextMenuAction:(NSString *)actionIdentifier;
 - (void)onPress;
 - (void)onLongPress;
 

--- a/apps/mobile/modules/t3-markdown-text/ios/T3MarkdownTextRun.mm
+++ b/apps/mobile/modules/t3-markdown-text/ios/T3MarkdownTextRun.mm
@@ -15,8 +15,7 @@ using namespace facebook::react;
 
 @implementation T3MarkdownTextRun {
   NSString * _text;
-  RCTBubblingEventBlock _onPress;
-  RCTBubblingEventBlock _onLongPress;
+  NSString * _contextMenuConfig;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -43,7 +42,76 @@ using namespace facebook::react;
     _text = text;
   }
 
+  if (newViewProps.contextMenuConfig != oldViewProps.contextMenuConfig) {
+    _contextMenuConfig = [NSString stringWithUTF8String:newViewProps.contextMenuConfig.c_str()];
+  }
+
   [super updateProps:props oldProps:oldProps];
+}
+
+- (BOOL)hasContextMenu
+{
+  return _contextMenuConfig.length > 0;
+}
+
+- (nullable UIMenu *)contextMenu
+{
+  if (_contextMenuConfig.length == 0) {
+    return nil;
+  }
+
+  NSData *data = [_contextMenuConfig dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary *config = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+  if (![config isKindOfClass:[NSDictionary class]]) {
+    return nil;
+  }
+
+  NSArray *actionConfigs = config[@"actions"];
+  if (![actionConfigs isKindOfClass:[NSArray class]] || actionConfigs.count == 0) {
+    return nil;
+  }
+
+  NSMutableArray<UIMenuElement *> *actions = [NSMutableArray arrayWithCapacity:actionConfigs.count];
+  __weak T3MarkdownTextRun *weakSelf = self;
+  for (NSDictionary *actionConfig in actionConfigs) {
+    if (![actionConfig isKindOfClass:[NSDictionary class]]) {
+      continue;
+    }
+    NSString *actionIdentifier = actionConfig[@"id"];
+    NSString *title = actionConfig[@"title"];
+    if (![actionIdentifier isKindOfClass:[NSString class]] ||
+        ![title isKindOfClass:[NSString class]]) {
+      continue;
+    }
+
+    UIAction *action = [UIAction actionWithTitle:title
+                                           image:nil
+                                      identifier:actionIdentifier
+                                         handler:^(__kindof UIAction *selectedAction) {
+      [weakSelf onContextMenuAction:selectedAction.identifier];
+    }];
+    if ([actionConfig[@"disabled"] boolValue]) {
+      action.attributes = UIMenuElementAttributesDisabled;
+    }
+    [actions addObject:action];
+  }
+
+  if (actions.count == 0) {
+    return nil;
+  }
+  NSString *title = [config[@"title"] isKindOfClass:[NSString class]] ? config[@"title"] : @"";
+  return [UIMenu menuWithTitle:title children:actions];
+}
+
+- (void)onContextMenuAction:(NSString *)actionIdentifier
+{
+  if (_eventEmitter != nullptr) {
+    std::dynamic_pointer_cast<const facebook::react::T3MarkdownTextRunEventEmitter>(_eventEmitter)
+    ->onContextMenuAction(facebook::react::T3MarkdownTextRunEventEmitter::OnContextMenuAction{
+      static_cast<int>(self.tag),
+      actionIdentifier.UTF8String,
+    });
+  }
 }
 
 - (void)onPress {

--- a/apps/mobile/modules/t3-markdown-text/src/MarkdownTextPrimitive.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/MarkdownTextPrimitive.tsx
@@ -24,8 +24,14 @@ export type SelectionChangeEvent = {
   nativeEvent: { target: number; start: number; end: number };
 };
 
+export type ContextMenuActionEvent = {
+  nativeEvent: { target: number; actionIdentifier: string };
+};
+
 export type MarkdownTextPrimitiveProps = TextProps & {
   uiTextView?: boolean;
+  contextMenuConfig?: string;
+  onContextMenuAction?: (event: ContextMenuActionEvent) => void;
   /**
    * Fired when the native text selection changes. Only fires on iOS when
    * `uiTextView` is true. Note: fires on every selection-edge adjustment

--- a/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownSelectableText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownSelectableText.ios.tsx
@@ -3,7 +3,10 @@ import { Image, Linking, type TextStyle, useColorScheme } from "react-native";
 import { MarkdownTextPrimitive } from "./MarkdownTextPrimitive";
 import { markdownFileIconSource } from "./markdownFileIcons";
 import type { NativeMarkdownTextRun } from "./nativeMarkdownText";
-import type { NativeMarkdownTextStyle } from "./SelectableMarkdownText.types";
+import type {
+  MarkdownFileContextMenu,
+  NativeMarkdownTextStyle,
+} from "./SelectableMarkdownText.types";
 
 const EXTERNAL_LINK_PREFIX = "◉ ";
 const INLINE_ATTACHMENT_PREFIX = "\uFFFC\u00A0";
@@ -137,6 +140,8 @@ export function NativeMarkdownSelectableText(props: {
   readonly runs: ReadonlyArray<NativeMarkdownTextRun>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly onLinkPress?: (href: string) => void;
+  readonly fileContextMenu?: (href: string) => MarkdownFileContextMenu | undefined;
+  readonly onFileContextMenuAction?: (href: string, actionId: string) => void;
 }) {
   const colorScheme = useColorScheme();
   const occurrences = new Map<string, number>();
@@ -195,6 +200,7 @@ export function NativeMarkdownSelectableText(props: {
     >
       {keyedRuns.map(({ key, run, text }) => {
         const href = run.href;
+        const contextMenu = run.fileIcon && href ? props.fileContextMenu?.(href) : undefined;
         return (
           <MarkdownTextPrimitive
             key={key}
@@ -205,6 +211,7 @@ export function NativeMarkdownSelectableText(props: {
                   ? "t3-skill:sf:cube"
                   : undefined
             }
+            contextMenuConfig={contextMenu ? JSON.stringify(contextMenu) : undefined}
             style={runStyle(run, props.textStyle)}
             onPress={
               href
@@ -215,6 +222,12 @@ export function NativeMarkdownSelectableText(props: {
                       void Linking.openURL(href);
                     }
                   }
+                : undefined
+            }
+            onContextMenuAction={
+              contextMenu && href && props.onFileContextMenuAction
+                ? (event) =>
+                    props.onFileContextMenuAction?.(href, event.nativeEvent.actionIdentifier)
                 : undefined
             }
           >

--- a/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownSelectableText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownSelectableText.ios.tsx
@@ -1,3 +1,4 @@
+import { createContext, useContext } from "react";
 import { Image, Linking, type TextStyle, useColorScheme } from "react-native";
 
 import { MarkdownTextPrimitive } from "./MarkdownTextPrimitive";
@@ -7,6 +8,16 @@ import type {
   MarkdownFileContextMenu,
   NativeMarkdownTextStyle,
 } from "./SelectableMarkdownText.types";
+
+export interface MarkdownFileContextMenuHandlers {
+  readonly fileContextMenu: (href: string) => MarkdownFileContextMenu | undefined;
+  readonly onFileContextMenuAction: (href: string, actionId: string) => void;
+}
+
+/** Set by SelectableMarkdownText so file chips anywhere in the block tree get the same menu. */
+export const MarkdownFileContextMenuContext = createContext<MarkdownFileContextMenuHandlers | null>(
+  null,
+);
 
 const EXTERNAL_LINK_PREFIX = "◉ ";
 const INLINE_ATTACHMENT_PREFIX = "\uFFFC\u00A0";
@@ -140,10 +151,9 @@ export function NativeMarkdownSelectableText(props: {
   readonly runs: ReadonlyArray<NativeMarkdownTextRun>;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly onLinkPress?: (href: string) => void;
-  readonly fileContextMenu?: (href: string) => MarkdownFileContextMenu | undefined;
-  readonly onFileContextMenuAction?: (href: string, actionId: string) => void;
 }) {
   const colorScheme = useColorScheme();
+  const menu = useContext(MarkdownFileContextMenuContext);
   const occurrences = new Map<string, number>();
   const prefixedExternalLinks = new Set<string>();
   const keyedRuns = props.runs.map((run) => {
@@ -200,7 +210,7 @@ export function NativeMarkdownSelectableText(props: {
     >
       {keyedRuns.map(({ key, run, text }) => {
         const href = run.href;
-        const contextMenu = run.fileIcon && href ? props.fileContextMenu?.(href) : undefined;
+        const contextMenu = run.fileIcon && href ? menu?.fileContextMenu(href) : undefined;
         return (
           <MarkdownTextPrimitive
             key={key}
@@ -225,9 +235,8 @@ export function NativeMarkdownSelectableText(props: {
                 : undefined
             }
             onContextMenuAction={
-              contextMenu && href && props.onFileContextMenuAction
-                ? (event) =>
-                    props.onFileContextMenuAction?.(href, event.nativeEvent.actionIdentifier)
+              contextMenu && href && menu
+                ? (event) => menu.onFileContextMenuAction(href, event.nativeEvent.actionIdentifier)
                 : undefined
             }
           >

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -38,6 +38,8 @@ export function SelectableMarkdownText({
   highlightCode,
   preserveSoftBreaks = false,
   onLinkPress,
+  fileContextMenu,
+  onFileContextMenuAction,
   renderImage,
   marginTop = 0,
   marginBottom = 0,
@@ -83,6 +85,8 @@ export function SelectableMarkdownText({
                 runs={chunk.runs}
                 textStyle={textStyle}
                 onLinkPress={onLinkPress}
+                fileContextMenu={fileContextMenu}
+                onFileContextMenuAction={onFileContextMenuAction}
               />
             );
 

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -9,7 +9,11 @@ import {
   nativeMarkdownWithPreservedSoftBreaks,
 } from "./nativeMarkdownText";
 import { MarkdownImageRendererContext, NativeMarkdownBlock } from "./NativeMarkdownBlock.ios";
-import { NativeMarkdownSelectableText } from "./NativeMarkdownSelectableText.ios";
+import {
+  MarkdownFileContextMenuContext,
+  NativeMarkdownSelectableText,
+  type MarkdownFileContextMenuHandlers,
+} from "./NativeMarkdownSelectableText.ios";
 import type {
   SelectableMarkdownSkill,
   SelectableMarkdownTextProps,
@@ -63,43 +67,51 @@ export function SelectableMarkdownText({
     );
   }, [markdown, preserveSoftBreaks, skills]);
 
+  const fileContextMenuHandlers = useMemo<MarkdownFileContextMenuHandlers | null>(
+    () =>
+      fileContextMenu && onFileContextMenuAction
+        ? { fileContextMenu, onFileContextMenuAction }
+        : null,
+    [fileContextMenu, onFileContextMenuAction],
+  );
+
   return (
     <MarkdownImageRendererContext.Provider value={renderImage ?? null}>
-      {/* A percentage width here creates a cyclic intrinsic measurement inside
+      <MarkdownFileContextMenuContext.Provider value={fileContextMenuHandlers}>
+        {/* A percentage width here creates a cyclic intrinsic measurement inside
           shrink-to-fit containers such as user-message bubbles. Yoga then gives
           the native text node an unbounded second pass and the parent only clips
           the resulting single-line width instead of reflowing it. */}
-      <View style={{ flexShrink: 1, minWidth: 0, marginTop, marginBottom }}>
-        {chunks.map((chunk, index) => {
-          const content =
-            chunk.kind === "rich" ? (
-              <NativeMarkdownBlock
-                node={chunk.node}
-                skills={skills}
-                textStyle={textStyle}
-                highlightCode={highlightCode}
-                onLinkPress={onLinkPress}
-              />
-            ) : (
-              <NativeMarkdownSelectableText
-                runs={chunk.runs}
-                textStyle={textStyle}
-                onLinkPress={onLinkPress}
-                fileContextMenu={fileContextMenu}
-                onFileContextMenuAction={onFileContextMenuAction}
-              />
-            );
+        <View style={{ flexShrink: 1, minWidth: 0, marginTop, marginBottom }}>
+          {chunks.map((chunk, index) => {
+            const content =
+              chunk.kind === "rich" ? (
+                <NativeMarkdownBlock
+                  node={chunk.node}
+                  skills={skills}
+                  textStyle={textStyle}
+                  highlightCode={highlightCode}
+                  onLinkPress={onLinkPress}
+                />
+              ) : (
+                <NativeMarkdownSelectableText
+                  runs={chunk.runs}
+                  textStyle={textStyle}
+                  onLinkPress={onLinkPress}
+                />
+              );
 
-          return (
-            <View
-              key={chunk.key}
-              style={{ paddingTop: nativeMarkdownChunkSpacing(chunks[index - 1], chunk) }}
-            >
-              {content}
-            </View>
-          );
-        })}
-      </View>
+            return (
+              <View
+                key={chunk.key}
+                style={{ paddingTop: nativeMarkdownChunkSpacing(chunks[index - 1], chunk) }}
+              >
+                {content}
+              </View>
+            );
+          })}
+        </View>
+      </MarkdownFileContextMenuContext.Provider>
     </MarkdownImageRendererContext.Provider>
   );
 }

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
@@ -50,6 +50,17 @@ export interface MarkdownImageRequest {
  */
 export type MarkdownImageRenderer = (image: MarkdownImageRequest) => import("react").ReactNode;
 
+export interface MarkdownFileContextMenuAction {
+  readonly id: string;
+  readonly title: string;
+  readonly disabled?: boolean;
+}
+
+export interface MarkdownFileContextMenu {
+  readonly title?: string;
+  readonly actions: ReadonlyArray<MarkdownFileContextMenuAction>;
+}
+
 export interface SelectableMarkdownTextProps {
   readonly markdown: string;
   readonly textStyle: NativeMarkdownTextStyle;
@@ -57,6 +68,8 @@ export interface SelectableMarkdownTextProps {
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly preserveSoftBreaks?: boolean;
   readonly onLinkPress?: (href: string) => void;
+  readonly fileContextMenu?: (href: string) => MarkdownFileContextMenu | undefined;
+  readonly onFileContextMenuAction?: (href: string, actionId: string) => void;
   readonly renderImage?: MarkdownImageRenderer;
   readonly marginTop?: number;
   readonly marginBottom?: number;

--- a/apps/mobile/modules/t3-markdown-text/src/T3MarkdownTextRunNativeComponent.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/T3MarkdownTextRunNativeComponent.ts
@@ -11,6 +11,10 @@ interface TargetedEvent {
   target: Int32;
 }
 
+interface ContextMenuActionEvent extends TargetedEvent {
+  actionIdentifier: string;
+}
+
 type TextDecorationLine = "none" | "underline" | "line-through";
 
 type TextDecorationStyle = "solid" | "double" | "dotted" | "dashed";
@@ -42,8 +46,10 @@ interface NativeProps extends ViewProps {
   textDecorationColor?: ColorValue;
   textAlign?: WithDefault<TextAlign, "auto">;
   shadowRadius?: WithDefault<Float, 0>;
+  contextMenuConfig?: string;
   onPress?: BubblingEventHandler<TargetedEvent>;
   onLongPress?: BubblingEventHandler<TargetedEvent>;
+  onContextMenuAction?: BubblingEventHandler<ContextMenuActionEvent>;
 }
 
 export default codegenNativeComponent<NativeProps>("T3MarkdownTextRun", {

--- a/apps/mobile/src/features/files/filePath.test.ts
+++ b/apps/mobile/src/features/files/filePath.test.ts
@@ -32,6 +32,7 @@ describe("resolveWorkspaceRelativeFilePath", () => {
   it("rejects paths outside the workspace", () => {
     expect(resolveWorkspaceRelativeFilePath("/repo", "/other/main.ts")).toBeNull();
     expect(resolveWorkspaceRelativeFilePath("/repo", "../other/main.ts")).toBeNull();
+    expect(resolveWorkspaceRelativeFilePath("/repo", "/repo/../outside.txt")).toBeNull();
     expect(resolveWorkspaceRelativeFilePath(null, "/repo/main.ts")).toBeNull();
   });
 });

--- a/apps/mobile/src/features/files/filePath.ts
+++ b/apps/mobile/src/features/files/filePath.ts
@@ -88,7 +88,12 @@ export function resolveWorkspaceRelativeFilePath(
     return null;
   }
 
-  return normalizeRelativePath(normalizedTarget.slice(normalizedRoot.length + 1));
+  const relativePath = normalizedTarget.slice(normalizedRoot.length + 1);
+  // `/repo/../x` starts with the root but escapes it.
+  if (relativePath.split("/").includes("..")) {
+    return null;
+  }
+  return normalizeRelativePath(relativePath);
 }
 
 export function isVideoPreviewFile(path: string): boolean {

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -91,6 +91,7 @@ import { hasWideMarkdownBlock } from "../../lib/wideMarkdownBlocks";
 import {
   hasNativeSelectableMarkdownText,
   SelectableMarkdownText,
+  type MarkdownFileContextMenu,
   type MarkdownImageRenderer,
   type NativeMarkdownTextStyle,
   type SelectableMarkdownSkill,
@@ -176,6 +177,7 @@ import {
   resolveWorkspaceRelativeFilePath,
 } from "../files/filePath";
 import { MARKDOWN_IMAGE_MAX_WIDTH, resolveMarkdownImageDisplaySize } from "./markdownImageSize";
+import { fileChipMenu, resolveFileChipTarget, type FileChipAction } from "./fileChipMenu";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
   // Native iOS blockquotes and adjacent selectable text are separate layout
@@ -872,10 +874,17 @@ function ArtifactTemplateCard(props: {
   );
 }
 
+/** Tap opens a link; long-press on a native file chip shows its menu. Built once per feed. */
+interface MarkdownLinkHandlers {
+  readonly onLinkPress: (href: string) => void;
+  readonly fileContextMenu: (href: string) => MarkdownFileContextMenu | undefined;
+  readonly onFileContextMenuAction: (href: string, actionId: string) => void;
+}
+
 const AssistantMarkdownContent = memo(function AssistantMarkdownContent(props: {
   readonly markdown: string;
   readonly markdownStyles: MarkdownStyleSet;
-  readonly onLinkPress: (href: string) => void;
+  readonly linkHandlers: MarkdownLinkHandlers;
   readonly onUseArtifactTemplate?: ((template: CodexArtifactTemplate) => void) | undefined;
   readonly renderImage: MarkdownImageRenderer;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill> | undefined;
@@ -904,7 +913,7 @@ const AssistantMarkdownContent = memo(function AssistantMarkdownContent(props: {
         markdown={markdown}
         skills={props.skills}
         textStyle={props.markdownStyles.nativeTextStyle}
-        onLinkPress={props.onLinkPress}
+        {...props.linkHandlers}
         renderImage={props.renderImage}
       />
     ) : (
@@ -1465,7 +1474,7 @@ function renderFeedEntry(
     readonly onToggleTurnFold: (turnId: TurnId) => void;
     readonly onPressPreview: (source: FilePreviewSource) => void;
     readonly onPressVideo: (attachment: ChatFileAttachment, sourceIdentifier: string) => void;
-    readonly onMarkdownLinkPress: (href: string) => void;
+    readonly markdownLinkHandlers: MarkdownLinkHandlers;
     readonly renderMarkdownImage: MarkdownImageRenderer;
     readonly renderViewedImage: MarkdownImageRenderer;
     readonly iconSubtleColor: string | import("react-native").ColorValue;
@@ -1573,7 +1582,7 @@ function renderFeedEntry(
                 markdownStyles={styles}
                 reviewCommentColors={props.reviewCommentColors}
                 skills={props.skills}
-                onLinkPress={props.onMarkdownLinkPress}
+                linkHandlers={props.markdownLinkHandlers}
                 renderImage={props.renderMarkdownImage}
               />
             ) : null}
@@ -1634,7 +1643,7 @@ function renderFeedEntry(
           <AssistantMarkdownContent
             markdown={renderedText}
             markdownStyles={styles}
-            onLinkPress={props.onMarkdownLinkPress}
+            linkHandlers={props.markdownLinkHandlers}
             onUseArtifactTemplate={props.onUseArtifactTemplate}
             renderImage={props.renderMarkdownImage}
             skills={props.skills}
@@ -1704,7 +1713,7 @@ function UserMessageContent(props: {
   readonly markdownStyles: MarkdownStyleSet;
   readonly reviewCommentColors: ReviewCommentColors;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
-  readonly onLinkPress: (href: string) => void;
+  readonly linkHandlers: MarkdownLinkHandlers;
   readonly renderImage: MarkdownImageRenderer;
 }) {
   const segments = parseReviewCommentMessageSegments(props.text);
@@ -1717,7 +1726,7 @@ function UserMessageContent(props: {
           skills={props.skills}
           textStyle={props.markdownStyles.nativeTextStyle}
           preserveSoftBreaks
-          onLinkPress={props.onLinkPress}
+          {...props.linkHandlers}
           renderImage={props.renderImage}
         />
       );
@@ -1759,7 +1768,7 @@ function UserMessageContent(props: {
             skills={props.skills}
             textStyle={props.markdownStyles.nativeTextStyle}
             preserveSoftBreaks
-            onLinkPress={props.onLinkPress}
+            {...props.linkHandlers}
             renderImage={props.renderImage}
           />
         ) : (
@@ -2170,6 +2179,31 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       }
     },
     [props.environmentId, props.threadId, props.workspaceRoot, navigation],
+  );
+  const markdownLinkHandlers = useMemo<MarkdownLinkHandlers>(
+    () => ({
+      onLinkPress: onMarkdownLinkPress,
+      fileContextMenu: (href) => {
+        const target = resolveFileChipTarget(href, props.workspaceRoot);
+        return target ? fileChipMenu(target) : undefined;
+      },
+      onFileContextMenuAction: (href, actionId) => {
+        const target = resolveFileChipTarget(href, props.workspaceRoot);
+        if (!target) return;
+        switch (actionId as FileChipAction) {
+          case "copy-full-path":
+            if (target.fullPath) copyTextWithHaptic(target.fullPath);
+            return;
+          case "copy-relative-path":
+            if (target.relativePath) copyTextWithHaptic(target.relativePath);
+            return;
+          case "open-file":
+            onMarkdownLinkPress(href);
+            return;
+        }
+      },
+    }),
+    [onMarkdownLinkPress, props.workspaceRoot],
   );
   const renderMarkdownImage = useCallback<MarkdownImageRenderer>(
     (image) => {
@@ -2696,7 +2730,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             onToggleTurnFold,
             onPressPreview,
             onPressVideo,
-            onMarkdownLinkPress,
+            markdownLinkHandlers,
             renderMarkdownImage,
             renderViewedImage,
             iconSubtleColor,
@@ -2726,7 +2760,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       reviewCommentBubbleWidth,
       userBubbleMaxWidth,
       onCopyWorkRow,
-      onMarkdownLinkPress,
+      markdownLinkHandlers,
       onPressPreview,
       onPressVideo,
       onToggleTurnFold,

--- a/apps/mobile/src/features/threads/fileChipMenu.test.ts
+++ b/apps/mobile/src/features/threads/fileChipMenu.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { fileChipMenu, resolveFileChipTarget } from "./fileChipMenu";
+
+describe("resolveFileChipTarget", () => {
+  it("resolves a workspace-relative link to both paths", () => {
+    expect(resolveFileChipTarget("src/app.ts:12", "/repo")).toEqual({
+      fullPath: "/repo/src/app.ts",
+      relativePath: "src/app.ts",
+    });
+  });
+
+  it("keeps only the full path for a host file outside the workspace", () => {
+    expect(resolveFileChipTarget("/tmp/report.md", "/repo")).toEqual({
+      fullPath: "/tmp/report.md",
+    });
+  });
+
+  it("keeps only the relative path when the workspace root is unknown", () => {
+    expect(resolveFileChipTarget("src/app.ts", null)).toEqual({ relativePath: "src/app.ts" });
+  });
+
+  it("ignores links that are not files", () => {
+    expect(resolveFileChipTarget("https://example.com/app.ts", "/repo")).toBeNull();
+  });
+});
+
+describe("fileChipMenu", () => {
+  it("offers only the copies the target can satisfy", () => {
+    expect(fileChipMenu({ fullPath: "/tmp/report.md" })).toEqual({
+      title: "/tmp/report.md",
+      actions: [
+        { id: "copy-full-path", title: "Copy full path" },
+        { id: "open-file", title: "Open in file viewer" },
+      ],
+    });
+    expect(fileChipMenu({ relativePath: "src/app.ts" }).actions.map(({ id }) => id)).toEqual([
+      "copy-relative-path",
+      "open-file",
+    ]);
+  });
+});

--- a/apps/mobile/src/features/threads/fileChipMenu.test.ts
+++ b/apps/mobile/src/features/threads/fileChipMenu.test.ts
@@ -20,8 +20,10 @@ describe("resolveFileChipTarget", () => {
     expect(resolveFileChipTarget("src/app.ts", null)).toEqual({ relativePath: "src/app.ts" });
   });
 
-  it("ignores links that are not files", () => {
+  it("ignores links that are not files or cannot be opened", () => {
     expect(resolveFileChipTarget("https://example.com/app.ts", "/repo")).toBeNull();
+    expect(resolveFileChipTarget("~/report.md", "/repo")).toBeNull();
+    expect(resolveFileChipTarget("../other/file.ts", "/repo")).toBeNull();
   });
 });
 

--- a/apps/mobile/src/features/threads/fileChipMenu.test.ts
+++ b/apps/mobile/src/features/threads/fileChipMenu.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { fileChipMenu, resolveFileChipTarget } from "./fileChipMenu";
 

--- a/apps/mobile/src/features/threads/fileChipMenu.ts
+++ b/apps/mobile/src/features/threads/fileChipMenu.ts
@@ -1,0 +1,47 @@
+import { resolveMarkdownLinkPresentation } from "@t3tools/mobile-markdown-text/links";
+import type { MarkdownFileContextMenu } from "@t3tools/mobile-markdown-text/types";
+
+import {
+  isAbsolutePath,
+  resolveWorkspaceFilePath,
+  resolveWorkspaceRelativeFilePath,
+} from "../files/filePath";
+
+export type FileChipAction = "copy-full-path" | "copy-relative-path" | "open-file";
+
+export interface FileChipTarget {
+  /** The host path, when the link is absolute or the workspace root is known. */
+  readonly fullPath?: string;
+  /** The path inside the workspace, when the link resolves there. */
+  readonly relativePath?: string;
+}
+
+export function resolveFileChipTarget(
+  href: string,
+  workspaceRoot: string | null | undefined,
+): FileChipTarget | null {
+  const presentation = resolveMarkdownLinkPresentation(href);
+  if (presentation.kind !== "file") return null;
+  const relativePath = resolveWorkspaceRelativeFilePath(workspaceRoot, presentation.path);
+  const fullPath = isAbsolutePath(presentation.path)
+    ? presentation.path
+    : workspaceRoot && relativePath
+      ? resolveWorkspaceFilePath(workspaceRoot, relativePath)
+      : undefined;
+  return {
+    ...(fullPath ? { fullPath } : {}),
+    ...(relativePath ? { relativePath } : {}),
+  };
+}
+
+/** The same actions the web file chip offers on right-click. Opening is what a tap does. */
+export function fileChipMenu(target: FileChipTarget): MarkdownFileContextMenu {
+  return {
+    title: target.fullPath ?? target.relativePath ?? "",
+    actions: [
+      ...(target.fullPath ? [{ id: "copy-full-path", title: "Copy full path" }] : []),
+      ...(target.relativePath ? [{ id: "copy-relative-path", title: "Copy relative path" }] : []),
+      { id: "open-file", title: "Open in file viewer" },
+    ],
+  };
+}

--- a/apps/mobile/src/features/threads/fileChipMenu.ts
+++ b/apps/mobile/src/features/threads/fileChipMenu.ts
@@ -16,6 +16,7 @@ export interface FileChipTarget {
   readonly relativePath?: string;
 }
 
+/** Null when the link is not a file or resolves nowhere the feed can open, such as `~/x` or `../x`. */
 export function resolveFileChipTarget(
   href: string,
   workspaceRoot: string | null | undefined,
@@ -28,6 +29,7 @@ export function resolveFileChipTarget(
     : workspaceRoot && relativePath
       ? resolveWorkspaceFilePath(workspaceRoot, relativePath)
       : undefined;
+  if (!fullPath && !relativePath) return null;
   return {
     ...(fullPath ? { fullPath } : {}),
     ...(relativePath ? { relativePath } : {}),

--- a/apps/mobile/src/native/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/src/native/SelectableMarkdownText.ios.tsx
@@ -8,6 +8,8 @@ import { highlightCodeSnippet } from "../features/review/shikiReviewHighlighter"
 type MobileSelectableMarkdownTextProps = Omit<SelectableMarkdownTextProps, "highlightCode">;
 
 export type {
+  MarkdownFileContextMenu,
+  MarkdownFileContextMenuAction,
   MarkdownImageRenderer,
   MarkdownImageRequest,
   NativeMarkdownTextStyle,

--- a/apps/mobile/src/native/SelectableMarkdownText.tsx
+++ b/apps/mobile/src/native/SelectableMarkdownText.tsx
@@ -3,6 +3,8 @@ import type { SelectableMarkdownTextProps } from "@t3tools/mobile-markdown-text/
 type MobileSelectableMarkdownTextProps = Omit<SelectableMarkdownTextProps, "highlightCode">;
 
 export type {
+  MarkdownFileContextMenu,
+  MarkdownFileContextMenuAction,
   MarkdownImageRenderer,
   MarkdownImageRequest,
   NativeMarkdownTextStyle,

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -107,7 +107,8 @@ path** and **Open in file viewer**. These actions are available in expanded prev
 On mobile, touch and hold an inline image or use a preview's **Media actions** menu to see its
 source, copy the path or URL, or choose **Save or share**. Workspace media can open in the file
 viewer from the same menu. Saving downloads a copy only when you request it; it does not change
-how the video buffers during playback.
+how the video buffers during playback. On iOS, touch and hold a file reference in a message to
+copy its full or relative path or open it in the file viewer.
 
 Use Markdown image syntax to embed either kind of media:
 


### PR DESCRIPTION
## What changed

- File chips in iOS messages get a native long-press context menu with **Copy full path**, **Copy relative path**, and **Open in file viewer**, the same actions the web chip offers on right-click.
- `T3MarkdownTextRun` accepts a JSON `contextMenuConfig`; `T3MarkdownText` maps runs that carry one to `UITextItem` links so iOS 17's text-item menu owns the gesture. Tap and text selection keep working; text drag is disabled on chat text.
- `SelectableMarkdownText` gains `fileContextMenu` and `onFileContextMenuAction`. The feed builds the menu description and runs actions from one handler at the root, so rows subscribe to nothing extra per chip.

## Why

Tapping a file reference opened it and that was the only thing you could do with it. Users copying a path had to open the file first. Web has had a chip context menu for a while; this brings the same set to iOS through UIKit rather than a JS action sheet.

Split out of #9253 so the media refactor there stays a refactor.

## UI changes

<table>
  <tr>
    <th>Before: tap only</th>
    <th>After: native context menu</th>
  </tr>
  <tr>
    <td>No long-press affordance on file chips.</td>
    <td><img width="280" src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/63e0030c885fc1ad/dc1870f3-e797-44b6-b055-947260699ee9-5713d617-b119-468f-a571-9f54c3509895.png" /></td>
  </tr>
</table>

## Testing

- `fileChipMenu.test.ts` (5 tests)
- Mobile typecheck, lint, and format on changed files

Created with Claude Fable 5 using the Claude Code harness in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native gesture handling and iOS 17 text-item menus on chat text; disabling text drag and suppressing recognizers on menu runs could affect edge-case interactions outside file chips.
> 
> **Overview**
> Adds **native long-press context menus** on iOS for inline **file references** in chat markdown, matching web chip actions: copy full path, copy relative path, and open in the file viewer.
> 
> The **t3-markdown-text** native layer now accepts a JSON **`contextMenuConfig`** on text runs, builds a **`UIMenu`**, and wires **`T3MarkdownText`** (iOS 17 text-item delegates) so menu runs are exposed as links while **custom tap/long-press is skipped** on those runs. Chat **`UITextView`** also **disables text drag**. **`SelectableMarkdownText`** gains **`fileContextMenu`** / **`onFileContextMenuAction`** plus a React context so file chips in the tree share one handler.
> 
> **`ThreadFeed`** centralizes tap and menu behavior in **`markdownLinkHandlers`** via new **`fileChipMenu`** / **`resolveFileChipTarget`**. **`resolveWorkspaceRelativeFilePath`** now rejects paths that escape the workspace with **`..`** (e.g. `/repo/../outside.txt`). User docs note iOS touch-and-hold on file references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b0275618c923f77ecf1226e73e094b40f29204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add long-press context menu for file references in mobile markdown text
> - Native iOS `T3MarkdownText` and `T3MarkdownTextRun` build context menus from a serialized JSON config and emit a native event when an action is selected. Custom tap/long-press recognizers are suppressed on runs with a menu, while other runs keep existing gesture handling.
> - React Native wiring in [SelectableMarkdownText.ios.tsx](https://github.com/pingdotgg/t3code/pull/9258/files#diff-2be50c2e6add3afb551411b55430f31fe779bd9e3175acb4ca0dfacafcfd84e8) and [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/9258/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) resolves file-chip hrefs to menus and dispatches copy-path and open-file actions.
> - [fileChipMenu.ts](https://github.com/pingdotgg/t3code/pull/9258/files#diff-0f9c5c0a6541a9589c734e3a0b14e2212d7a1ea9a48cb318b1f656ddc8544426) classifies file links into full and relative paths and builds a menu with only the supported copy actions plus the file-viewer open action.
> - [filePath.ts](https://github.com/pingdotgg/t3code/pull/9258/files#diff-71ae342afb6f9bc2da0f7bc5f93e738beff48e65e361911e31b6d0e3d9bba285) now rejects absolute targets that escape the workspace via a `..` segment instead of normalizing them.
> - Risk: disabling drag interaction on `T3MarkdownText` means text drag-and-drop no longer works on iOS; `handleLongPressIfNecessary` now fires once at the began state rather than across all long-press transitions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67b0275.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->