### PR TITLE
fix(server): scope PDF asset links to exact file

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -573,6 +573,42 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.effect("issues exact workspace URLs for PDF previews", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-pdf-workspace-",
+      });
+      const docsDirectory = path.join(root, "docs");
+      const pdfPath = path.join(docsDirectory, "report.pdf");
+      const siblingPath = path.join(docsDirectory, "private.pdf");
+      yield* fileSystem.makeDirectory(docsDirectory, { recursive: true });
+      yield* fileSystem.writeFileString(pdfPath, "report");
+      yield* fileSystem.writeFileString(siblingPath, "private");
+      const canonicalPdfPath = yield* fileSystem.realPath(pdfPath);
+
+      const result = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: pdfPath,
+        },
+        workspaceRoot: root,
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "report.pdf")).toEqual({
+        kind: "file",
+        path: canonicalPdfPath,
+      });
+      expect(yield* resolveAsset(token, "private.pdf")).toBeNull();
+      expect(yield* resolveAsset(token, "../report.pdf")).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("issues exact attachment capabilities by attachment id", () =>
     Effect.gen(function* () {
       const config = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -399,19 +399,21 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       if (HEADER_IMAGE_EXTENSIONS.has(path.extname(resolved.relativePath).toLowerCase())) {
         imageDimensions = yield* readImageDimensionsFromHeader(canonicalFile);
       }
-      claims = isWorkspaceImagePreviewPath(resolved.relativePath)
+      const needsSiblingAssets =
+        hostPreviewMimeTypeFromExtension(path.extname(resolved.relativePath)) === "text/html";
+      claims = needsSiblingAssets
         ? {
-            version: 1,
-            kind: "workspace-file-exact",
-            workspaceRoot: canonicalWorkspaceRoot,
-            relativePath: resolved.relativePath,
-            expiresAt,
-          }
-        : {
             version: 1,
             kind: "workspace-file",
             workspaceRoot: canonicalWorkspaceRoot,
             baseRelativePath: path.dirname(resolved.relativePath),
+            expiresAt,
+          }
+        : {
+            version: 1,
+            kind: "workspace-file-exact",
+            workspaceRoot: canonicalWorkspaceRoot,
+            relativePath: resolved.relativePath,
             expiresAt,
           };
       fileName = path.basename(resolved.relativePath);


### PR DESCRIPTION
## What Changed

- Mint exact-file claims for PDF workspace previews and other non-HTML preview entries.
- Keep directory-scoped claims only for HTML previews that need sibling CSS, JavaScript, or font resources.
- Add regression coverage proving the requested PDF resolves while a substituted sibling PDF and traversal paths do not.
- Preserve coverage for HTML sibling assets.

## Why

PDF asset links previously inherited a directory-scoped capability because PDFs shared the browser-preview category with HTML. Replacing the filename in a valid signed PDF URL could therefore expose another previewable PDF in the same directory.

Selecting directory scope only for HTML preserves required sibling-resource loading while making every other preview entry exact-file by default.

Fixes #9228

## Verification

- `pnpm exec vp test run apps/server/src/assets/AssetAccess.test.ts`
- `pnpm exec vp fmt --check apps/server/src/assets/AssetAccess.ts apps/server/src/assets/AssetAccess.test.ts`
- `pnpm exec vp lint --report-unused-disable-directives apps/server/src/assets/AssetAccess.ts apps/server/src/assets/AssetAccess.test.ts`
- `pnpm --filter t3 typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots and video are not applicable

Built with gpt-5.6-sol via the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope `AssetAccess.issueAssetUrl` to exact file for non-HTML workspace files
> - Changes workspace-file claim selection in [AssetAccess.ts](https://github.com/pingdotgg/t3code/pull/9260/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1) from an image-preview path check to an HTML MIME-type check.
> - HTML workspace files keep directory-based claims; all other workspace files (including PDFs) now get exact-file claims with the resolved relative path.
> - Adds a test in [AssetAccess.test.ts](https://github.com/pingdotgg/t3code/pull/9260/files#diff-3e248bf73b1190cf86ee6fda71efa01343c3a1f70aa874b545ec1e7184157710) verifying the issued URL resolves to the target file only, rejecting sibling files and parent-directory traversal.
> - Behavioral Change: non-HTML workspace assets that previously received directory-based claims now receive exact-file claims.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3f2e90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace PDF previews so generated asset links resolve only to the intended PDF.
  - Prevented access to neighboring files and parent-path locations through manipulated preview URLs.
  - Preserved correct handling for other workspace previews, including image previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->