### PR TITLE
feat(mcp): save preview snapshots to disk on request

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -38,6 +38,8 @@ export interface ServerDerivedPaths {
   readonly providerStatusCacheDir: string;
   readonly worktreesDir: string;
   readonly attachmentsDir: string;
+  /** Screenshots and recordings the collaborative browser saves for the user. */
+  readonly browserArtifactsDir: string;
   readonly logsDir: string;
   readonly serverLogPath: string;
   readonly serverTracePath: string;
@@ -125,6 +127,7 @@ export const deriveServerPaths = Effect.fn(function* (
     providerStatusCacheDir,
     worktreesDir: join(baseDir, "worktrees"),
     attachmentsDir,
+    browserArtifactsDir: join(stateDir, "browser-artifacts"),
     logsDir,
     serverLogPath: join(logsDir, "server.log"),
     serverTracePath: join(logsDir, "server.trace.ndjson"),

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -113,7 +113,9 @@ it.effect.each([{}, { includeImage: false }])(
           );
 
         expect(snapshot.isError).toBe(true);
-        expect(snapshot.content).toEqual([{ type: "text", text: "Preview snapshot failed: PreviewAutomationExecutionError." }]);
+        expect(snapshot.content).toEqual([
+          { type: "text", text: "Preview snapshot failed: PreviewAutomationExecutionError." },
+        ]);
         expect(snapshot.structuredContent).toEqual({
           error: {
             _tag: "PreviewAutomationExecutionError",

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -250,7 +250,7 @@ it.effect("rejects non-boolean snapshot image options before selecting a browser
   }).pipe(Effect.provide(TestLayer)),
 );
 
-it.effect("saves the snapshot screenshot to the browser artifacts directory on request", () =>
+it.effect.each([true, false])("saves the snapshot with includeImage=%s", (includeImage) =>
   Effect.scoped(
     Effect.gen(function* () {
       const server = yield* McpServer.McpServer;
@@ -259,12 +259,13 @@ it.effect("saves the snapshot screenshot to the browser artifacts directory on r
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const routedInputs: Array<unknown> = [];
+      const connected = yield* Deferred.make<void>();
       const events = yield* broker.connect({
         clientId: "mcp-save-client",
         environmentId,
       });
       yield* Stream.runForEach(events, (event) => {
-        if (event.type === "connected") return Effect.void;
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
         routedInputs.push(event.request.input);
         return broker.respond({
           clientId: "mcp-save-client",
@@ -274,16 +275,19 @@ it.effect("saves the snapshot screenshot to the browser artifacts directory on r
           result: snapshotResult,
         });
       }).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
+      yield* Deferred.await(connected);
 
       const snapshot = yield* server
-        .callTool({ name: "preview_snapshot", arguments: { save: true } })
+        .callTool({ name: "preview_snapshot", arguments: { save: true, includeImage } })
         .pipe(
           Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
           Effect.provideService(McpSchema.McpServerClient, client),
         );
 
       expect(snapshot.isError).toBe(false);
+      expect(snapshot.content.map((content) => content.type)).toEqual(
+        includeImage ? ["text", "image"] : ["text"],
+      );
       // The browser never receives the server-only `save` flag.
       expect(routedInputs).toEqual([{}]);
       const structured = snapshot.structuredContent as { readonly screenshotPath?: string };
@@ -308,13 +312,14 @@ it.effect("reports a tagged error when the screenshot cannot be saved", () =>
       const fileSystem = yield* FileSystem.FileSystem;
       // A regular file where the artifacts directory should be makes every write fail.
       yield* fileSystem.writeFileString(config.browserArtifactsDir, "");
+      const connected = yield* Deferred.make<void>();
       const events = yield* broker.connect({
         clientId: "mcp-save-failure-client",
         environmentId,
       });
       yield* Stream.runForEach(events, (event) =>
         event.type === "connected"
-          ? Effect.void
+          ? Deferred.succeed(connected, undefined)
           : broker.respond({
               clientId: "mcp-save-failure-client",
               connectionId: event.connectionId,
@@ -323,7 +328,7 @@ it.effect("reports a tagged error when the screenshot cannot be saved", () =>
               result: snapshotResult,
             }),
       ).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
+      yield* Deferred.await(connected);
 
       const snapshot = yield* server
         .callTool({ name: "preview_snapshot", arguments: { save: true } })

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -22,6 +22,9 @@ const environmentId = EnvironmentId.make("environment-mcp-test");
 const threadId = ThreadId.make("thread-mcp-test");
 const tabId = PreviewTabId.make("tab-mcp-test");
 const alternateTabId = PreviewTabId.make("tab-mcp-alternate");
+const decodeScreenshotPath = Schema.decodeUnknownSync(
+  Schema.Struct({ screenshotPath: Schema.String }),
+);
 const encodeJsonText = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 const invocation = {
   environmentId,
@@ -393,9 +396,7 @@ it.effect("retains concurrent same-host screenshots at a fixed clock time", () =
       );
       const paths = snapshots.map((snapshot) => {
         expect(snapshot.isError).toBe(false);
-        return Schema.decodeUnknownSync(Schema.Struct({ screenshotPath: Schema.String }))(
-          snapshot.structuredContent,
-        ).screenshotPath;
+        return decodeScreenshotPath(snapshot.structuredContent).screenshotPath;
       });
       expect(new Set(paths).size).toBe(2);
       const contents = yield* Effect.forEach(paths, (path) => fileSystem.readFileString(path));

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -464,8 +464,8 @@ it.effect("registers annotated tools and preserves authenticated request context
       expect(statusTool?.tool.annotations?.destructiveHint).toBe(false);
 
       const snapshotTool = server.tools.find(({ tool }) => tool.name === "preview_snapshot");
-      expect(snapshotTool?.tool.annotations?.readOnlyHint).toBe(true);
-      expect(snapshotTool?.tool.annotations?.idempotentHint).toBe(true);
+      expect(snapshotTool?.tool.annotations?.readOnlyHint).toBe(false);
+      expect(snapshotTool?.tool.annotations?.idempotentHint).toBe(false);
       expect(snapshotTool?.tool.annotations?.openWorldHint).toBe(true);
 
       const clickTool = server.tools.find(({ tool }) => tool.name === "preview_click");

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -378,13 +378,17 @@ it.effect("retains concurrent same-host screenshots at a fixed clock time", () =
       }).pipe(Effect.forkScoped);
       yield* Deferred.await(connected);
       const snapshots = yield* Effect.all(
-        [1, 2].map(() => server.callTool({
-          name: "preview_snapshot",
-          arguments: { save: true },
-        }).pipe(
-          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
-          Effect.provideService(McpSchema.McpServerClient, client),
-        )),
+        [1, 2].map(() =>
+          server
+            .callTool({
+              name: "preview_snapshot",
+              arguments: { save: true },
+            })
+            .pipe(
+              Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+              Effect.provideService(McpSchema.McpServerClient, client),
+            ),
+        ),
         { concurrency: 2 },
       );
       const paths = snapshots.map((snapshot) => {

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -113,7 +113,7 @@ it.effect.each([{}, { includeImage: false }])(
           );
 
         expect(snapshot.isError).toBe(true);
-        expect(snapshot.content).toEqual([{ type: "text", text: "Preview snapshot failed." }]);
+        expect(snapshot.content).toEqual([{ type: "text", text: "Preview snapshot failed: PreviewAutomationExecutionError." }]);
         expect(snapshot.structuredContent).toEqual({
           error: {
             _tag: "PreviewAutomationExecutionError",
@@ -242,7 +242,7 @@ it.effect("rejects non-boolean snapshot image options before selecting a browser
           Effect.provideService(McpSchema.McpServerClient, client),
         );
       expect(result.isError).toBe(true);
-      expect(result.content).toEqual([{ type: "text", text: "Preview snapshot failed." }]);
+      expect(result.content).toEqual([{ type: "text", text: "Preview snapshot failed: AiError." }]);
       expect(result.structuredContent).toEqual({
         error: { _tag: "AiError", operation: "snapshot", failureCount: 1 },
       });
@@ -333,6 +333,9 @@ it.effect("reports a tagged error when the screenshot cannot be saved", () =>
         );
 
       expect(snapshot.isError).toBe(true);
+      expect(snapshot.content).toEqual([
+        { type: "text", text: "Preview snapshot failed: PreviewScreenshotSaveError." },
+      ]);
       expect(snapshot.structuredContent).toEqual({
         error: { _tag: "PreviewScreenshotSaveError", operation: "snapshot", failureCount: 1 },
       });

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -8,6 +8,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 import * as Stream from "effect/Stream";
 import { McpProtocol, McpSchema, McpServer } from "effect/unstable/ai";
 import { HttpBody, HttpClient, HttpRouter, HttpServerResponse } from "effect/unstable/http";
@@ -297,7 +298,7 @@ it.effect.each([true, false])("saves the snapshot with includeImage=%s", (includ
       expect(typeof screenshotPath).toBe("string");
       expect(path.dirname(screenshotPath!)).toBe(config.browserArtifactsDir);
       expect(path.basename(screenshotPath!)).toMatch(
-        /^browser-screenshot-example-test-[0-9a-z]+\.png$/,
+        /^browser-screenshot-example-test-[0-9a-z]+-[0-9a-f-]+\.png$/,
       );
       expect(Buffer.from(yield* fileSystem.readFile(screenshotPath!)).toString()).toBe("png");
       const textContent = snapshot.content.find((content) => content.type === "text");
@@ -346,6 +347,56 @@ it.effect("reports a tagged error when the screenshot cannot be saved", () =>
       expect(snapshot.structuredContent).toEqual({
         error: { _tag: "PreviewScreenshotSaveError", operation: "snapshot", failureCount: 1 },
       });
+    }),
+  ).pipe(Effect.provide(TestLayer)),
+);
+
+it.effect("retains concurrent same-host screenshots at a fixed clock time", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const server = yield* McpServer.McpServer;
+      const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const connected = yield* Deferred.make<void>();
+      yield* TestClock.setTime(1000);
+      const events = yield* broker.connect({ clientId: "mcp-concurrent-save", environmentId });
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Deferred.succeed(connected, undefined);
+        return broker.respond({
+          clientId: "mcp-concurrent-save",
+          connectionId: event.connectionId,
+          requestId: event.request.requestId,
+          ok: true,
+          result: {
+            ...snapshotResult,
+            screenshot: {
+              ...snapshotResult.screenshot,
+              data: Buffer.from(event.request.requestId).toString("base64"),
+            },
+          },
+        });
+      }).pipe(Effect.forkScoped);
+      yield* Deferred.await(connected);
+      const snapshots = yield* Effect.all(
+        [1, 2].map(() => server.callTool({
+          name: "preview_snapshot",
+          arguments: { save: true },
+        }).pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        )),
+        { concurrency: 2 },
+      );
+      const paths = snapshots.map((snapshot) => {
+        expect(snapshot.isError).toBe(false);
+        return Schema.decodeUnknownSync(Schema.Struct({ screenshotPath: Schema.String }))(
+          snapshot.structuredContent,
+        ).screenshotPath;
+      });
+      expect(new Set(paths).size).toBe(2);
+      const contents = yield* Effect.forEach(paths, (path) => fileSystem.readFileString(path));
+      expect(new Set(contents).size).toBe(2);
+      expect(contents.every((content) => content.length > 0)).toBe(true);
     }),
   ).pipe(Effect.provide(TestLayer)),
 );

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -4,12 +4,15 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { EnvironmentId, PreviewTabId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { McpProtocol, McpSchema, McpServer } from "effect/unstable/ai";
 import { HttpBody, HttpClient, HttpRouter, HttpServerResponse } from "effect/unstable/http";
 
+import * as ServerConfig from "../config.ts";
 import * as McpHttpServer from "./McpHttpServer.ts";
 import * as McpInvocationContext from "./McpInvocationContext.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
@@ -39,8 +42,28 @@ const client = McpSchema.McpServerClient.of({
 });
 const TestLayer = McpHttpServer.PreviewToolkitRegistrationLive.pipe(
   Layer.provideMerge(McpServer.McpServer.layer),
-  Layer.provideMerge(PreviewAutomationBroker.layer.pipe(Layer.provide(NodeServices.layer))),
+  Layer.provideMerge(PreviewAutomationBroker.layer),
+  Layer.provideMerge(ServerConfig.layerTest(process.cwd(), { prefix: "t3-mcp-http-server-test-" })),
+  Layer.provideMerge(NodeServices.layer),
 );
+
+const snapshotResult = {
+  url: "http://example.test/",
+  title: "Example",
+  loading: false,
+  visibleText: "Example",
+  interactiveElements: [],
+  accessibilityTree: {},
+  consoleEntries: [],
+  networkEntries: [],
+  actionTimeline: [],
+  screenshot: {
+    mimeType: "image/png",
+    data: Buffer.from("png").toString("base64"),
+    width: 10,
+    height: 5,
+  },
+};
 
 it("normalizes empty successful notification responses to accepted", () => {
   const notificationResponse = McpHttpServer.normalizeMcpHttpResponse(
@@ -225,6 +248,96 @@ it.effect("rejects non-boolean snapshot image options before selecting a browser
       });
     }
   }).pipe(Effect.provide(TestLayer)),
+);
+
+it.effect("saves the snapshot screenshot to the browser artifacts directory on request", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const server = yield* McpServer.McpServer;
+      const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+      const config = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const routedInputs: Array<unknown> = [];
+      const events = yield* broker.connect({
+        clientId: "mcp-save-client",
+        environmentId,
+      });
+      yield* Stream.runForEach(events, (event) => {
+        if (event.type === "connected") return Effect.void;
+        routedInputs.push(event.request.input);
+        return broker.respond({
+          clientId: "mcp-save-client",
+          connectionId: event.connectionId,
+          requestId: event.request.requestId,
+          ok: true,
+          result: snapshotResult,
+        });
+      }).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      const snapshot = yield* server
+        .callTool({ name: "preview_snapshot", arguments: { save: true } })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+
+      expect(snapshot.isError).toBe(false);
+      // The browser never receives the server-only `save` flag.
+      expect(routedInputs).toEqual([{}]);
+      const structured = snapshot.structuredContent as { readonly screenshotPath?: string };
+      const screenshotPath = structured.screenshotPath;
+      expect(typeof screenshotPath).toBe("string");
+      expect(path.dirname(screenshotPath!)).toBe(config.browserArtifactsDir);
+      expect(path.basename(screenshotPath!)).toMatch(
+        /^browser-screenshot-example-test-[0-9a-z]+\.png$/,
+      );
+      expect(Buffer.from(yield* fileSystem.readFile(screenshotPath!)).toString()).toBe("png");
+      const textContent = snapshot.content.find((content) => content.type === "text");
+      expect(textContent?.type === "text" ? textContent.text : "").toContain(screenshotPath);
+    }),
+  ).pipe(Effect.provide(TestLayer)),
+);
+it.effect("reports a tagged error when the screenshot cannot be saved", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const server = yield* McpServer.McpServer;
+      const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+      const config = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      // A regular file where the artifacts directory should be makes every write fail.
+      yield* fileSystem.writeFileString(config.browserArtifactsDir, "");
+      const events = yield* broker.connect({
+        clientId: "mcp-save-failure-client",
+        environmentId,
+      });
+      yield* Stream.runForEach(events, (event) =>
+        event.type === "connected"
+          ? Effect.void
+          : broker.respond({
+              clientId: "mcp-save-failure-client",
+              connectionId: event.connectionId,
+              requestId: event.request.requestId,
+              ok: true,
+              result: snapshotResult,
+            }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      const snapshot = yield* server
+        .callTool({ name: "preview_snapshot", arguments: { save: true } })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+
+      expect(snapshot.isError).toBe(true);
+      expect(snapshot.structuredContent).toEqual({
+        error: { _tag: "PreviewScreenshotSaveError", operation: "snapshot", failureCount: 1 },
+      });
+    }),
+  ).pipe(Effect.provide(TestLayer)),
 );
 
 it.effect("terminates HTTP MCP sessions with DELETE", () =>

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -166,7 +166,8 @@ const previewSnapshotFailure = <E>(cause: Cause.Cause<E>) => {
         failureCount: failures.length,
       },
     },
-    content: [{ type: "text", text: "Preview snapshot failed." }],
+    // Agents usually see only the text content, so name the tag there too.
+    content: [{ type: "text", text: `Preview snapshot failed: ${errorTag}.` }],
   });
   return Effect.logWarning("preview snapshot failed", {
     operation: "snapshot",

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -14,7 +14,7 @@ import { McpProtocol, McpSchema, McpServer, Tool } from "effect/unstable/ai";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
 import packageJson from "../../package.json" with { type: "json" };
-import { ServerConfig } from "../config.ts";
+import * as ServerConfig from "../config.ts";
 import * as McpInvocationContext from "./McpInvocationContext.ts";
 import * as McpSessionRegistry from "./McpSessionRegistry.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
@@ -133,7 +133,7 @@ const saveScreenshot = Effect.fn("McpHttpServer.saveScreenshot")(function* (
   pageUrl: string,
   data: Uint8Array,
 ) {
-  const config = yield* ServerConfig;
+  const config = yield* ServerConfig.ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const millis = yield* Clock.currentTimeMillis;
@@ -182,7 +182,9 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
   const server = yield* McpServer.McpServer;
   const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
   // The MCP tool runner only supplies the client, so hand the save path its services here.
-  const saveServices = yield* Effect.context<ServerConfig | FileSystem.FileSystem | Path.Path>();
+  const saveServices = yield* Effect.context<
+    ServerConfig.ServerConfig | FileSystem.FileSystem | Path.Path
+  >();
   const built = yield* PreviewSnapshotToolkit;
   const tool = PreviewSnapshotTool;
   yield* server.addTool({

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -246,7 +246,9 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
                 structuredContent: metadata,
                 content: [
                   { type: "text", text: encodeJsonText(metadata) },
-                  ...(payload?.includeImage === false ? [] : [{ type: "image" as const, data: png, mimeType: screenshot.mimeType }]),
+                  ...(payload?.includeImage === false
+                    ? []
+                    : [{ type: "image" as const, data: png, mimeType: screenshot.mimeType }]),
                 ],
               });
             }),

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
@@ -113,7 +114,7 @@ const encodeJsonText = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
 const MAX_SCREENSHOT_SITE_SLUG_LENGTH = 40;
 
-/** Hostname reduced to a filename-safe slug, mirroring the desktop's own screenshot names. */
+/** Hostname reduced to a filename-safe slug, used in screenshot artifact names. */
 const screenshotSiteSlug = (rawUrl: string): string => {
   try {
     const slug = new URL(rawUrl).hostname
@@ -137,7 +138,7 @@ const saveScreenshot = Effect.fn("McpHttpServer.saveScreenshot")(function* (
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const millis = yield* Clock.currentTimeMillis;
-  const fileName = `browser-screenshot-${screenshotSiteSlug(pageUrl)}-${millis.toString(36)}.png`;
+  const fileName = `browser-screenshot-${screenshotSiteSlug(pageUrl)}-${millis.toString(36)}-${randomUUID()}.png`;
   const screenshotPath = path.join(config.browserArtifactsDir, fileName);
   yield* fileSystem.makeDirectory(config.browserArtifactsDir, { recursive: true }).pipe(
     Effect.andThen(fileSystem.writeFile(screenshotPath, data)),

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import * as NodeCrypto from "node:crypto";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
@@ -138,7 +138,7 @@ const saveScreenshot = Effect.fn("McpHttpServer.saveScreenshot")(function* (
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const millis = yield* Clock.currentTimeMillis;
-  const fileName = `browser-screenshot-${screenshotSiteSlug(pageUrl)}-${millis.toString(36)}-${randomUUID()}.png`;
+  const fileName = `browser-screenshot-${screenshotSiteSlug(pageUrl)}-${millis.toString(36)}-${NodeCrypto.randomUUID()}.png`;
   const screenshotPath = path.join(config.browserArtifactsDir, fileName);
   yield* fileSystem.makeDirectory(config.browserArtifactsDir, { recursive: true }).pipe(
     Effect.andThen(fileSystem.writeFile(screenshotPath, data)),

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -109,6 +109,8 @@ export class PreviewScreenshotSaveError extends Schema.TaggedErrorClass<PreviewS
   }
 }
 
+const encodeJsonText = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+
 const MAX_SCREENSHOT_SITE_SLUG_LENGTH = 40;
 
 /** Hostname reduced to a filename-safe slug, mirroring the desktop's own screenshot names. */
@@ -241,7 +243,7 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
                 isError: false,
                 structuredContent: metadata,
                 content: [
-                  { type: "text", text: JSON.stringify(metadata) },
+                  { type: "text", text: encodeJsonText(metadata) },
                   ...(payload?.includeImage === false ? [] : [{ type: "image" as const, data: png, mimeType: screenshot.mimeType }]),
                 ],
               });

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -1,8 +1,12 @@
 import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import type * as Types from "effect/Types";
@@ -10,6 +14,7 @@ import { McpProtocol, McpSchema, McpServer, Tool } from "effect/unstable/ai";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
 import packageJson from "../../package.json" with { type: "json" };
+import { ServerConfig } from "../config.ts";
 import * as McpInvocationContext from "./McpInvocationContext.ts";
 import * as McpSessionRegistry from "./McpSessionRegistry.ts";
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
@@ -95,6 +100,50 @@ const McpAuthMiddlewareLive = HttpRouter.middleware<{
   provides: McpInvocationContext.McpInvocationContext;
 }>()(makeMcpAuthMiddleware).layer;
 
+export class PreviewScreenshotSaveError extends Schema.TaggedErrorClass<PreviewScreenshotSaveError>()(
+  "PreviewScreenshotSaveError",
+  { screenshotPath: Schema.String, cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return `Could not save preview screenshot to ${this.screenshotPath}.`;
+  }
+}
+
+const MAX_SCREENSHOT_SITE_SLUG_LENGTH = 40;
+
+/** Hostname reduced to a filename-safe slug, mirroring the desktop's own screenshot names. */
+const screenshotSiteSlug = (rawUrl: string): string => {
+  try {
+    const slug = new URL(rawUrl).hostname
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, MAX_SCREENSHOT_SITE_SLUG_LENGTH)
+      .replace(/-+$/g, "");
+    return slug || "site";
+  } catch {
+    return "site";
+  }
+};
+
+/** Writes a snapshot PNG under the browser artifacts directory and returns its path. */
+const saveScreenshot = Effect.fn("McpHttpServer.saveScreenshot")(function* (
+  pageUrl: string,
+  data: Uint8Array,
+) {
+  const config = yield* ServerConfig;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const millis = yield* Clock.currentTimeMillis;
+  const fileName = `browser-screenshot-${screenshotSiteSlug(pageUrl)}-${millis.toString(36)}.png`;
+  const screenshotPath = path.join(config.browserArtifactsDir, fileName);
+  yield* fileSystem.makeDirectory(config.browserArtifactsDir, { recursive: true }).pipe(
+    Effect.andThen(fileSystem.writeFile(screenshotPath, data)),
+    Effect.mapError((cause) => new PreviewScreenshotSaveError({ screenshotPath, cause })),
+  );
+  return screenshotPath;
+});
+
 const previewSnapshotFailure = <E>(cause: Cause.Cause<E>) => {
   if (Cause.hasInterrupts(cause) || cause.reasons.some(Cause.isDieReason)) {
     return Effect.failCause(cause).pipe(Effect.orDie);
@@ -129,6 +178,8 @@ const previewSnapshotFailure = <E>(cause: Cause.Cause<E>) => {
 const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot")(function* () {
   const server = yield* McpServer.McpServer;
   const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+  // The MCP tool runner only supplies the client, so hand the save path its services here.
+  const saveServices = yield* Effect.context<ServerConfig | FileSystem.FileSystem | Path.Path>();
   const built = yield* PreviewSnapshotToolkit;
   const tool = PreviewSnapshotTool;
   yield* server.addTool({
@@ -160,10 +211,10 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
           Effect.flatMap(Effect.fromOption),
           Effect.provideService(PreviewAutomationBroker.PreviewAutomationBroker, broker),
           Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
-          Effect.matchCauseEffect({
-            onFailure: previewSnapshotFailure,
-            onSuccess: ({ encodedResult }) => {
+          Effect.flatMap(({ encodedResult }) =>
+            Effect.gen(function* () {
               const snapshot = encodedResult as {
+                readonly url: string;
                 readonly screenshot: {
                   readonly mimeType: "image/png";
                   readonly data: string;
@@ -173,6 +224,9 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
                 readonly [key: string]: unknown;
               };
               const { screenshot, ...page } = snapshot;
+              const png = new Uint8Array(Buffer.from(screenshot.data, "base64"));
+              const screenshotPath =
+                payload?.save === true ? yield* saveScreenshot(snapshot.url, png) : undefined;
               const metadata = {
                 ...page,
                 screenshot: {
@@ -180,26 +234,22 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
                   width: screenshot.width,
                   height: screenshot.height,
                 },
+                ...(screenshotPath === undefined ? {} : { screenshotPath }),
               };
-              return Effect.succeed(
-                new McpSchema.CallToolResult({
-                  isError: false,
-                  structuredContent: metadata,
-                  content: [
-                    { type: "text", text: JSON.stringify(metadata) },
-                    ...(payload?.includeImage === false
-                      ? []
-                      : [
-                          {
-                            type: "image" as const,
-                            data: new Uint8Array(Buffer.from(screenshot.data, "base64")),
-                            mimeType: screenshot.mimeType,
-                          },
-                        ]),
-                  ],
-                }),
-              );
-            },
+              return new McpSchema.CallToolResult({
+                isError: false,
+                structuredContent: metadata,
+                content: [
+                  { type: "text", text: JSON.stringify(metadata) },
+                  ...(payload?.includeImage === false ? [] : [{ type: "image" as const, data: png, mimeType: screenshot.mimeType }]),
+                ],
+              });
+            }),
+          ),
+          Effect.provide(saveServices),
+          Effect.matchCauseEffect({
+            onFailure: previewSnapshotFailure,
+            onSuccess: Effect.succeed,
           }),
         );
       }),

--- a/apps/server/src/mcp/toolkits/preview/handlers.ts
+++ b/apps/server/src/mcp/toolkits/preview/handlers.ts
@@ -77,9 +77,9 @@ const handlers = {
     invokeTargeted<PreviewAutomationResizeResult>("resize", input, input.timeoutMs),
   preview_set_appearance: (input) =>
     invokeTargeted<PreviewAutomationSetColorSchemeResult>("setColorScheme", input),
+  // Saving and image output selection are MCP-only options.
   preview_snapshot: (input) => {
-    // Output selection is MCP-only; the browser still produces a complete snapshot.
-    const { includeImage: _includeImage, ...operationInput } = input ?? {};
+    const { save: _save, includeImage: _includeImage, ...operationInput } = input ?? {};
     return invokeTargeted<PreviewAutomationSnapshot>("snapshot", operationInput);
   },
   preview_click: (input) =>

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -109,7 +109,7 @@ export const PreviewSetAppearanceTool = safeBrowserTool(
     .annotate(Tool.Idempotent, true),
 );
 
-export const PreviewSnapshotTool = readonlyBrowserTool(
+export const PreviewSnapshotTool = safeBrowserTool(
   Tool.make("preview_snapshot", {
     description:
       "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, action history, and a PNG screenshot. Set includeImage=false for text-only output with the same page metadata. Set save=true to also write the PNG to disk and get screenshotPath back; embed that path in your reply with markdown image syntax, ![screenshot](path), so the user sees it.",
@@ -117,7 +117,10 @@ export const PreviewSnapshotTool = readonlyBrowserTool(
     success: PreviewAutomationSnapshot,
     failure: PreviewAutomationError,
     dependencies,
-  }).annotate(Tool.Title, "Inspect browser page"),
+  })
+    .annotate(Tool.Title, "Inspect browser page")
+    .annotate(Tool.Readonly, false)
+    .annotate(Tool.Idempotent, false),
 );
 
 export const PreviewClickTool = browserTool(

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -13,6 +13,7 @@ import {
   PreviewAutomationSetColorSchemeInput,
   PreviewAutomationSetColorSchemeResult,
   PreviewAutomationSnapshot,
+  PreviewAutomationSnapshotInput,
   PreviewAutomationStatus,
   PreviewAutomationTabTargetInput,
   PreviewAutomationTypeInput,
@@ -111,16 +112,8 @@ export const PreviewSetAppearanceTool = safeBrowserTool(
 export const PreviewSnapshotTool = readonlyBrowserTool(
   Tool.make("preview_snapshot", {
     description:
-      "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, action history, and a PNG screenshot. Set includeImage=false for text-only output with the same page metadata.",
-    parameters: Schema.Struct({
-      ...PreviewAutomationTabTargetInput.fields,
-      includeImage: Schema.optional(
-        Schema.Boolean.annotate({
-          description:
-            "Include the PNG image in the tool response. Defaults to true. Set false for text-only output.",
-        }),
-      ),
-    }),
+      "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, action history, and a PNG screenshot. Set includeImage=false for text-only output with the same page metadata. Set save=true to also write the PNG to disk and get screenshotPath back; embed that path in your reply with markdown image syntax, ![screenshot](path), so the user sees it.",
+    parameters: PreviewAutomationSnapshotInput,
     success: PreviewAutomationSnapshot,
     failure: PreviewAutomationError,
     dependencies,
@@ -207,7 +200,7 @@ export const PreviewRecordingStartTool = safeBrowserTool(
 export const PreviewRecordingStopTool = safeBrowserTool(
   Tool.make("preview_recording_stop", {
     description:
-      "Stop recording the collaborative browser tab selected by tabId, or this agent session's current tab when omitted, and save it as a local evidence artifact.",
+      "Stop recording the collaborative browser tab selected by tabId, or this agent session's current tab when omitted, and save it as a local evidence artifact. Embed the returned path in your reply with markdown image syntax, ![recording](path), so the user sees it.",
     parameters: PreviewAutomationTabTargetInput,
     success: PreviewAutomationRecordingArtifact,
     failure: PreviewAutomationError,

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -63,6 +63,22 @@ const PreviewAutomationTabTargetFields = {
 export const PreviewAutomationTabTargetInput = Schema.Struct(PreviewAutomationTabTargetFields);
 export type PreviewAutomationTabTargetInput = typeof PreviewAutomationTabTargetInput.Type;
 
+export const PreviewAutomationSnapshotInput = Schema.Struct({
+  ...PreviewAutomationTabTargetFields,
+  includeImage: Schema.optional(
+    Schema.Boolean.annotate({
+      description: "Include the PNG image in the tool response. Defaults to true. Set false for text-only output.",
+    }),
+  ),
+  save: Schema.optional(
+    Schema.Boolean.annotate({
+      description:
+        "Also write the screenshot PNG to the browser artifacts directory and return its path as screenshotPath.",
+    }),
+  ),
+});
+export type PreviewAutomationSnapshotInput = typeof PreviewAutomationSnapshotInput.Type;
+
 export const PreviewAutomationStatus = Schema.Struct({
   available: Schema.Boolean,
   visible: Schema.Boolean,

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -67,7 +67,8 @@ export const PreviewAutomationSnapshotInput = Schema.Struct({
   ...PreviewAutomationTabTargetFields,
   includeImage: Schema.optional(
     Schema.Boolean.annotate({
-      description: "Include the PNG image in the tool response. Defaults to true. Set false for text-only output.",
+      description:
+        "Include the PNG image in the tool response. Defaults to true. Set false for text-only output.",
     }),
   ),
   save: Schema.optional(


### PR DESCRIPTION
## Problem

`preview_snapshot` returns a PNG to the agent, but the user never sees it: the image only lives inside the tool result. When the agent wants to show the user what the page looked like, it has nothing on disk to point at, unlike `preview_recording_stop`, which already writes a file.

## Fix

- `preview_snapshot` gains an opt-in `save` input. When set, the server writes the PNG it already holds in `McpHttpServer` to `<stateDir>/browser-artifacts` (the same directory the desktop uses for recordings) and adds `screenshotPath` to the structured and text results. Files are named `browser-screenshot-<host>-<time>.png`, matching the desktop's own naming.
- The `save` flag is stripped before the request reaches the browser, so there is no new automation op and no desktop change.
- A failed write returns an error result tagged `PreviewScreenshotSaveError` instead of silently succeeding without a path. The failure text now names the tag (`Preview snapshot failed: PreviewScreenshotSaveError.`) because agents usually only see the text content.
- The `preview_snapshot` and `preview_recording_stop` descriptions now tell the agent to embed the returned path with markdown image syntax so the user sees the capture inline.

`packages/contracts` gets a `PreviewAutomationSnapshotInput` schema and `apps/server` config gains a derived `browserArtifactsDir`.

## Verification

Unit tests in `McpHttpServer.test.ts` cover: the file lands in the artifacts dir with the expected name and bytes, `screenshotPath` appears in both result forms, the browser request arrives without `save`, no path is returned when `save` is omitted, and an unwritable artifacts path yields the tagged error result.

End to end on the desktop dev build (`vp run dev:desktop`), a Claude Sonnet 5 thread was asked to open example.com, snapshot with `save` enabled, and show the result, without being told the markdown syntax. The agent embedded the saved screenshot on its own from the tool description hint, then recorded a scroll and embedded the recording the same way. With the artifacts path replaced by a plain file, the same request produced an error result and the server trace logged `PreviewScreenshotSaveError`.

Agent reply with the saved path and the inline screenshot:

![Thread showing the agent reply with screenshotPath chip and the embedded example.com screenshot](https://github.com/jakeleventhal/t3code/releases/download/pr-evidence-save-snapshots/evidence-thread.png)

The PNG written to `browser-artifacts` by the new save path:

![Saved screenshot of example.com](https://github.com/jakeleventhal/t3code/releases/download/pr-evidence-save-snapshots/saved-screenshot.png)

`preview_recording_stop` embed following the updated description:

![Thread showing the recording embedded as a video player](https://github.com/jakeleventhal/t3code/releases/download/pr-evidence-save-snapshots/evidence-recording.png)

One observation from testing that is not caused by this change: while the dev Electron window was fully occluded by another app, snapshot requests timed out on the desktop side before reaching the save code. Bringing the window forward resolved it.

Note: in a remote setup the screenshot path is on the server machine, where the agent runs, while the recording path comes from the desktop hosting the browser.

Built with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in filesystem writes under state dir with explicit errors on failure; no change to browser automation protocol when save is not used.
> 
> **Overview**
> Adds an opt-in **`save`** flag on the MCP **`preview_snapshot`** tool so agents can persist the PNG the server already receives and surface it to users via a filesystem path.
> 
> When **`save=true`**, the MCP HTTP server writes the decoded screenshot under **`browserArtifactsDir`** (`<stateDir>/browser-artifacts`, matching desktop recordings), names files **`browser-screenshot-<host-slug>-<time>.png`**, and returns **`screenshotPath`** in structured metadata and JSON text (still returning the inline image). The **`save`** parameter is stripped in preview handlers so the collaborative browser automation path is unchanged.
> 
> Failed disk writes fail the tool with **`PreviewScreenshotSaveError`**; snapshot failure text now includes the error tag (e.g. **`Preview snapshot failed: PreviewAutomationExecutionError.`**). Contracts gain **`PreviewAutomationSnapshotInput`**; tool descriptions nudge agents to embed saved paths with markdown image syntax. Tests cover save success, omitted **`save`**, and unwritable artifact paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2065ed796e8237c006b37bfb2ae4bc7a8b48f0f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `save` option to `preview_snapshot` MCP tool to write PNG screenshots to disk
> - The `preview_snapshot` MCP tool now accepts a `save` boolean in `PreviewAutomationSnapshotInput`. When true, the server writes the screenshot PNG to `ServerConfig.browserArtifactsDir` using a filename derived from the site slug, timestamp, and a random UUID, and returns `screenshotPath` in both structured and text metadata.
> - The `save` and `includeImage` options are stripped before the request reaches the browser automation broker; save is handled at the MCP layer and `includeImage` remains a response-only concern.
> - The tool's annotations changed from read-only to `readOnlyHint=false` and `idempotentHint=false`, reflecting that it now writes to disk.
> - Failed preview snapshots now include the derived error tag (e.g. `PreviewAutomationExecutionError`, `AiError`) in MCP text content, not just a generic failure message.
> - Risk: `PreviewScreenshotSaveError` is a new tagged error type in [McpHttpServer.ts](apps/server/src/mcp/McpHttpServer.ts); directory-creation or file-write failures during save produce this tag in both text and structured content. Concurrent saves at the same millisecond rely on UUID suffixes for uniqueness — if UUID collision occurs, the second write overwrites the first file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edcce5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview snapshots can now be saved as PNG files and return the saved screenshot path.
  * Snapshot requests support options to include an image in the response and/or save it to disk.
  * Saved screenshots use unique filenames to prevent collisions.
  * Snapshot and recording results provide guidance for embedding returned files using Markdown images.

* **Bug Fixes**
  * Improved error reporting when saving preview screenshots fails, including the affected path and error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->