### PR TITLE
feat(chat): render standalone media links inline

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -52,6 +52,7 @@ export function SelectableMarkdownText({
   const chunks = useMemo(() => {
     const parsedDocument = nativeMarkdownWithStandaloneMediaLinks(
       parseMarkdownWithOptions(markdown, { gfm: true, html: true, math: false }),
+      { embedLocalPaths: renderImage != null },
     );
     const document = preserveSoftBreaks
       ? nativeMarkdownWithPreservedSoftBreaks(parsedDocument)
@@ -64,7 +65,7 @@ export function SelectableMarkdownText({
           }
         : chunk,
     );
-  }, [markdown, preserveSoftBreaks, skills]);
+  }, [markdown, preserveSoftBreaks, renderImage, skills]);
 
   const fileContextMenuHandlers = useMemo<MarkdownFileContextMenuHandlers | null>(
     () =>

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -7,6 +7,7 @@ import {
   nativeMarkdownDocumentChunks,
   nativeMarkdownDocumentRuns,
   nativeMarkdownWithPreservedSoftBreaks,
+  nativeMarkdownWithStandaloneMediaLinks,
 } from "./nativeMarkdownText";
 import { MarkdownImageRendererContext, NativeMarkdownBlock } from "./NativeMarkdownBlock.ios";
 import {
@@ -49,11 +50,9 @@ export function SelectableMarkdownText({
   marginBottom = 0,
 }: SelectableMarkdownTextProps) {
   const chunks = useMemo(() => {
-    const parsedDocument = parseMarkdownWithOptions(markdown, {
-      gfm: true,
-      html: true,
-      math: false,
-    });
+    const parsedDocument = nativeMarkdownWithStandaloneMediaLinks(
+      parseMarkdownWithOptions(markdown, { gfm: true, html: true, math: false }),
+    );
     const document = preserveSoftBreaks
       ? nativeMarkdownWithPreservedSoftBreaks(parsedDocument)
       : parsedDocument;

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.ios.tsx
@@ -46,13 +46,14 @@ export function SelectableMarkdownText({
   fileContextMenu,
   onFileContextMenuAction,
   renderImage,
+  workspaceRoot,
   marginTop = 0,
   marginBottom = 0,
 }: SelectableMarkdownTextProps) {
   const chunks = useMemo(() => {
     const parsedDocument = nativeMarkdownWithStandaloneMediaLinks(
       parseMarkdownWithOptions(markdown, { gfm: true, html: true, math: false }),
-      { embedLocalPaths: renderImage != null },
+      { embedLocalPaths: renderImage != null, workspaceRoot },
     );
     const document = preserveSoftBreaks
       ? nativeMarkdownWithPreservedSoftBreaks(parsedDocument)
@@ -65,7 +66,7 @@ export function SelectableMarkdownText({
           }
         : chunk,
     );
-  }, [markdown, preserveSoftBreaks, renderImage, skills]);
+  }, [markdown, preserveSoftBreaks, renderImage, skills, workspaceRoot]);
 
   const fileContextMenuHandlers = useMemo<MarkdownFileContextMenuHandlers | null>(
     () =>

--- a/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/SelectableMarkdownText.types.ts
@@ -63,6 +63,7 @@ export interface MarkdownFileContextMenu {
 
 export interface SelectableMarkdownTextProps {
   readonly markdown: string;
+  readonly workspaceRoot?: string | null;
   readonly textStyle: NativeMarkdownTextStyle;
   readonly highlightCode: MarkdownCodeHighlighter;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;

--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -358,12 +358,13 @@ function isLineBoundary(node: MarkdownNode | undefined): boolean {
   return node === undefined || node.type === "soft_break" || node.type === "line_break";
 }
 
-function canEmbedStandaloneMediaLink(target: string, embedLocalPaths: boolean, workspaceRoot?: string | null): boolean {
+function canEmbedStandaloneMediaLink(
+  target: string,
+  embedLocalPaths: boolean,
+  workspaceRoot?: string | null,
+): boolean {
   if (markdownLinkMediaKind(target) !== "image") return false;
-  const source = classifyMarkdownImageSource(
-    target,
-    workspaceRoot,
-  );
+  const source = classifyMarkdownImageSource(target, workspaceRoot);
   return source._tag === "Direct" || (embedLocalPaths && source._tag === "WorkspaceFile");
 }
 

--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -1,3 +1,4 @@
+import { markdownLinkMediaKind } from "@t3tools/client-runtime/markdown-images";
 import type { MarkdownNode } from "react-native-nitro-markdown/headless";
 
 import type { SelectableMarkdownSkill } from "./SelectableMarkdownText.types";
@@ -348,6 +349,51 @@ export function nativeMarkdownWithPreservedSoftBreaks(node: MarkdownNode): Markd
     ...(node.type === "soft_break" ? { type: "line_break" as const } : {}),
     ...(children ? { children } : {}),
   };
+}
+
+function isLineBoundary(node: MarkdownNode | undefined): boolean {
+  return node === undefined || node.type === "soft_break" || node.type === "line_break";
+}
+
+/**
+ * A link that owns its line in a top-level paragraph and points at an image or video becomes
+ * that image, matching the web renderer. The breaks beside it go too, so the media does not
+ * leave an empty line behind.
+ */
+export function nativeMarkdownWithStandaloneMediaLinks(node: MarkdownNode): MarkdownNode {
+  const children = node.children?.map((block) => {
+    if (block.type !== "paragraph" || !block.children) return block;
+    const siblings = block.children;
+    const embedded = siblings.map(
+      (child, index) =>
+        child.type === "link" &&
+        child.href !== undefined &&
+        isLineBoundary(siblings[index - 1]) &&
+        isLineBoundary(siblings[index + 1]) &&
+        markdownLinkMediaKind(child.href) !== null,
+    );
+    if (!embedded.includes(true)) return block;
+    return {
+      ...block,
+      children: siblings.flatMap((child, index): MarkdownNode[] => {
+        if (embedded[index]) {
+          const text = nodeTextContent(child);
+          return [
+            {
+              type: "image",
+              href: child.href!,
+              ...(child.title !== undefined ? { title: child.title } : {}),
+              // An autolink's text is its URL, which is not worth repeating as alt text.
+              ...(text.length > 0 && text !== child.href ? { alt: text } : {}),
+            },
+          ];
+        }
+        if (isLineBoundary(child) && (embedded[index - 1] || embedded[index + 1])) return [];
+        return [child];
+      }),
+    };
+  });
+  return children ? { ...node, children } : node;
 }
 
 function appendBlockTerminator(

--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -377,7 +377,9 @@ export function nativeMarkdownWithStandaloneMediaLinks(node: MarkdownNode): Mark
       ...block,
       children: siblings.flatMap((child, index): MarkdownNode[] => {
         if (embedded[index]) {
-          const text = nodeTextContent(child);
+          // A label that is itself an image carries its text in `alt`.
+          const text =
+            nodeTextContent(child) || (child.children?.find((n) => n.type === "image")?.alt ?? "");
           return [
             {
               type: "image",

--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -359,7 +359,7 @@ function isLineBoundary(node: MarkdownNode | undefined): boolean {
 }
 
 function canEmbedStandaloneMediaLink(target: string, embedLocalPaths: boolean): boolean {
-  if (markdownLinkMediaKind(target) === null) return false;
+  if (markdownLinkMediaKind(target) !== "image") return false;
   const source = classifyMarkdownImageSource(
     target,
     embedLocalPaths ? "/__t3_workspace__" : undefined,
@@ -368,9 +368,9 @@ function canEmbedStandaloneMediaLink(target: string, embedLocalPaths: boolean): 
 }
 
 /**
- * A link that owns its line in a top-level paragraph and points at an image or video becomes
- * that image, matching the web renderer. The breaks beside it go too, so the media does not
- * leave an empty line behind.
+ * A link that owns its line in a top-level paragraph and points at an image becomes that image.
+ * The breaks beside it go too, so the media does not leave an empty line behind. Video links stay
+ * links because the native markdown image view cannot render them.
  */
 export function nativeMarkdownWithStandaloneMediaLinks(
   node: MarkdownNode,

--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -1,4 +1,7 @@
-import { markdownLinkMediaKind } from "@t3tools/client-runtime/markdown-images";
+import {
+  classifyMarkdownImageSource,
+  markdownLinkMediaKind,
+} from "@t3tools/client-runtime/markdown-images";
 import type { MarkdownNode } from "react-native-nitro-markdown/headless";
 
 import type { SelectableMarkdownSkill } from "./SelectableMarkdownText.types";
@@ -355,12 +358,25 @@ function isLineBoundary(node: MarkdownNode | undefined): boolean {
   return node === undefined || node.type === "soft_break" || node.type === "line_break";
 }
 
+function canEmbedStandaloneMediaLink(target: string, embedLocalPaths: boolean): boolean {
+  if (markdownLinkMediaKind(target) === null) return false;
+  const source = classifyMarkdownImageSource(
+    target,
+    embedLocalPaths ? "/__t3_workspace__" : undefined,
+  );
+  return source._tag === "Direct" || (embedLocalPaths && source._tag === "WorkspaceFile");
+}
+
 /**
  * A link that owns its line in a top-level paragraph and points at an image or video becomes
  * that image, matching the web renderer. The breaks beside it go too, so the media does not
  * leave an empty line behind.
  */
-export function nativeMarkdownWithStandaloneMediaLinks(node: MarkdownNode): MarkdownNode {
+export function nativeMarkdownWithStandaloneMediaLinks(
+  node: MarkdownNode,
+  options: { readonly embedLocalPaths?: boolean } = {},
+): MarkdownNode {
+  const embedLocalPaths = options.embedLocalPaths ?? true;
   const children = node.children?.map((block) => {
     if (block.type !== "paragraph" || !block.children) return block;
     const siblings = block.children;
@@ -370,7 +386,7 @@ export function nativeMarkdownWithStandaloneMediaLinks(node: MarkdownNode): Mark
         child.href !== undefined &&
         isLineBoundary(siblings[index - 1]) &&
         isLineBoundary(siblings[index + 1]) &&
-        markdownLinkMediaKind(child.href) !== null,
+        canEmbedStandaloneMediaLink(child.href, embedLocalPaths),
     );
     if (!embedded.includes(true)) return block;
     return {

--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -358,11 +358,11 @@ function isLineBoundary(node: MarkdownNode | undefined): boolean {
   return node === undefined || node.type === "soft_break" || node.type === "line_break";
 }
 
-function canEmbedStandaloneMediaLink(target: string, embedLocalPaths: boolean): boolean {
+function canEmbedStandaloneMediaLink(target: string, embedLocalPaths: boolean, workspaceRoot?: string | null): boolean {
   if (markdownLinkMediaKind(target) !== "image") return false;
   const source = classifyMarkdownImageSource(
     target,
-    embedLocalPaths ? "/__t3_workspace__" : undefined,
+    workspaceRoot,
   );
   return source._tag === "Direct" || (embedLocalPaths && source._tag === "WorkspaceFile");
 }
@@ -374,7 +374,7 @@ function canEmbedStandaloneMediaLink(target: string, embedLocalPaths: boolean): 
  */
 export function nativeMarkdownWithStandaloneMediaLinks(
   node: MarkdownNode,
-  options: { readonly embedLocalPaths?: boolean } = {},
+  options: { readonly embedLocalPaths?: boolean; readonly workspaceRoot?: string | null } = {},
 ): MarkdownNode {
   const embedLocalPaths = options.embedLocalPaths ?? true;
   const children = node.children?.map((block) => {
@@ -386,7 +386,7 @@ export function nativeMarkdownWithStandaloneMediaLinks(
         child.href !== undefined &&
         isLineBoundary(siblings[index - 1]) &&
         isLineBoundary(siblings[index + 1]) &&
-        canEmbedStandaloneMediaLink(child.href, embedLocalPaths),
+        canEmbedStandaloneMediaLink(child.href, embedLocalPaths, options.workspaceRoot),
     );
     if (!embedded.includes(true)) return block;
     return {

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -262,6 +262,7 @@ export function FileMarkdownPreview(props: {
             markdown={props.markdown}
             onLinkPress={onLinkPress}
             renderImage={renderImage}
+            workspaceRoot={markdownDirectory}
             textStyle={styles.nativeTextStyle}
           />
         ) : (

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -784,7 +784,9 @@ const AssistantMarkdownContent = memo(function AssistantMarkdownContent(props: {
       <Markdown
         key={`markdown:${segment.sourceOffset}`}
         options={{ gfm: true }}
-        astTransform={(node) => nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })}
+        astTransform={(node) =>
+          nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })
+        }
         renderers={props.markdownStyles.renderers}
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
@@ -1606,7 +1608,7 @@ function renderFeedEntry(
               markdown={renderedText}
               markdownStyles={styles}
               linkHandlers={props.markdownLinkHandlers}
-                  workspaceRoot={props.workspaceRoot}
+              workspaceRoot={props.workspaceRoot}
               onUseArtifactTemplate={props.onUseArtifactTemplate}
               renderImage={props.renderMarkdownImage}
               skills={props.skills}
@@ -1696,7 +1698,7 @@ function UserMessageContent(props: {
           textStyle={props.markdownStyles.nativeTextStyle}
           preserveSoftBreaks
           {...props.linkHandlers}
-        workspaceRoot={props.workspaceRoot}
+          workspaceRoot={props.workspaceRoot}
           renderImage={props.renderImage}
         />
       );
@@ -1704,7 +1706,9 @@ function UserMessageContent(props: {
     return (
       <Markdown
         options={{ gfm: true }}
-        astTransform={(node) => nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })}
+        astTransform={(node) =>
+          nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })
+        }
         renderers={props.markdownStyles.renderers}
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
@@ -1740,14 +1744,16 @@ function UserMessageContent(props: {
             textStyle={props.markdownStyles.nativeTextStyle}
             preserveSoftBreaks
             {...props.linkHandlers}
-        workspaceRoot={props.workspaceRoot}
+            workspaceRoot={props.workspaceRoot}
             renderImage={props.renderImage}
           />
         ) : (
           <Markdown
             key={segment.id}
             options={{ gfm: true }}
-            astTransform={(node) => nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })}
+            astTransform={(node) =>
+              nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })
+            }
             renderers={props.markdownStyles.renderers}
             styles={props.markdownStyles.styles}
             theme={props.markdownStyles.theme}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -747,6 +747,7 @@ const AssistantMarkdownContent = memo(function AssistantMarkdownContent(props: {
   readonly markdown: string;
   readonly markdownStyles: MarkdownStyleSet;
   readonly linkHandlers: MarkdownLinkHandlers;
+  readonly workspaceRoot?: string | null;
   readonly onUseArtifactTemplate?: ((template: CodexArtifactTemplate) => void) | undefined;
   readonly renderImage: MarkdownImageRenderer;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill> | undefined;
@@ -776,13 +777,14 @@ const AssistantMarkdownContent = memo(function AssistantMarkdownContent(props: {
         skills={props.skills}
         textStyle={props.markdownStyles.nativeTextStyle}
         {...props.linkHandlers}
+        workspaceRoot={props.workspaceRoot}
         renderImage={props.renderImage}
       />
     ) : (
       <Markdown
         key={`markdown:${segment.sourceOffset}`}
         options={{ gfm: true }}
-        astTransform={nativeMarkdownWithStandaloneMediaLinks}
+        astTransform={(node) => nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })}
         renderers={props.markdownStyles.renderers}
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
@@ -1345,6 +1347,7 @@ function renderFeedEntry(
     readonly onPressPreview: (source: FilePreviewSource) => void;
     readonly onPressVideo: (attachment: ChatFileAttachment, sourceIdentifier: string) => void;
     readonly markdownLinkHandlers: MarkdownLinkHandlers;
+    readonly workspaceRoot?: string | null;
     readonly renderMarkdownImage: MarkdownImageRenderer;
     readonly renderViewedImage: MarkdownImageRenderer;
     readonly iconSubtleColor: string | import("react-native").ColorValue;
@@ -1500,6 +1503,7 @@ function renderFeedEntry(
                   reviewCommentColors={props.reviewCommentColors}
                   skills={props.skills}
                   linkHandlers={props.markdownLinkHandlers}
+                  workspaceRoot={props.workspaceRoot}
                   renderImage={props.renderMarkdownImage}
                 />
               </MarkdownImageAvailableWidthContext>
@@ -1602,6 +1606,7 @@ function renderFeedEntry(
               markdown={renderedText}
               markdownStyles={styles}
               linkHandlers={props.markdownLinkHandlers}
+                  workspaceRoot={props.workspaceRoot}
               onUseArtifactTemplate={props.onUseArtifactTemplate}
               renderImage={props.renderMarkdownImage}
               skills={props.skills}
@@ -1677,6 +1682,7 @@ function UserMessageContent(props: {
   readonly reviewCommentColors: ReviewCommentColors;
   readonly skills?: ReadonlyArray<SelectableMarkdownSkill>;
   readonly linkHandlers: MarkdownLinkHandlers;
+  readonly workspaceRoot?: string | null;
   readonly renderImage: MarkdownImageRenderer;
 }) {
   const segments = parseReviewCommentMessageSegments(props.text);
@@ -1690,6 +1696,7 @@ function UserMessageContent(props: {
           textStyle={props.markdownStyles.nativeTextStyle}
           preserveSoftBreaks
           {...props.linkHandlers}
+        workspaceRoot={props.workspaceRoot}
           renderImage={props.renderImage}
         />
       );
@@ -1697,7 +1704,7 @@ function UserMessageContent(props: {
     return (
       <Markdown
         options={{ gfm: true }}
-        astTransform={nativeMarkdownWithStandaloneMediaLinks}
+        astTransform={(node) => nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })}
         renderers={props.markdownStyles.renderers}
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
@@ -1733,13 +1740,14 @@ function UserMessageContent(props: {
             textStyle={props.markdownStyles.nativeTextStyle}
             preserveSoftBreaks
             {...props.linkHandlers}
+        workspaceRoot={props.workspaceRoot}
             renderImage={props.renderImage}
           />
         ) : (
           <Markdown
             key={segment.id}
             options={{ gfm: true }}
-            astTransform={nativeMarkdownWithStandaloneMediaLinks}
+            astTransform={(node) => nativeMarkdownWithStandaloneMediaLinks(node, { workspaceRoot: props.workspaceRoot })}
             renderers={props.markdownStyles.renderers}
             styles={props.markdownStyles.styles}
             theme={props.markdownStyles.theme}
@@ -2720,6 +2728,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             onPressPreview,
             onPressVideo,
             markdownLinkHandlers,
+            workspaceRoot: props.workspaceRoot,
             renderMarkdownImage,
             renderViewedImage,
             iconSubtleColor,
@@ -2758,6 +2767,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       markdownContentWidth,
       onCopyWorkRow,
       markdownLinkHandlers,
+      props.workspaceRoot,
       onPressPreview,
       onPressVideo,
       onToggleTurnFold,

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -131,6 +131,7 @@ import { useAppearanceCodeSurface } from "../settings/appearance/useAppearanceCo
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
 import { PierreEntryIcon } from "../../components/PierreEntryIcon";
 import { markdownLinkIconSource } from "@t3tools/mobile-markdown-text/link-icons";
+import { nativeMarkdownWithStandaloneMediaLinks } from "@t3tools/mobile-markdown-text/markdown";
 import {
   normalizeNativeMarkdownUrl,
   resolveMarkdownInlineCodePresentation,
@@ -781,6 +782,7 @@ const AssistantMarkdownContent = memo(function AssistantMarkdownContent(props: {
       <Markdown
         key={`markdown:${segment.sourceOffset}`}
         options={{ gfm: true }}
+        astTransform={nativeMarkdownWithStandaloneMediaLinks}
         renderers={props.markdownStyles.renderers}
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
@@ -1695,6 +1697,7 @@ function UserMessageContent(props: {
     return (
       <Markdown
         options={{ gfm: true }}
+        astTransform={nativeMarkdownWithStandaloneMediaLinks}
         renderers={props.markdownStyles.renderers}
         styles={props.markdownStyles.styles}
         theme={props.markdownStyles.theme}
@@ -1736,6 +1739,7 @@ function UserMessageContent(props: {
           <Markdown
             key={segment.id}
             options={{ gfm: true }}
+            astTransform={nativeMarkdownWithStandaloneMediaLinks}
             renderers={props.markdownStyles.renderers}
             styles={props.markdownStyles.styles}
             theme={props.markdownStyles.theme}

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -46,6 +46,31 @@ describe("nativeMarkdownWithStandaloneMediaLinks", () => {
     );
   });
 
+  it("embeds every link in a run of consecutive lines", () => {
+    expect(
+      nativeMarkdownWithStandaloneMediaLinks(
+        document(link("/tmp/a.png", "a.png"), { type: "soft_break" }, link("/tmp/b.png", "b.png")),
+      ),
+    ).toEqual(
+      document(
+        { type: "image", href: "/tmp/a.png", alt: "a.png" },
+        { type: "image", href: "/tmp/b.png", alt: "b.png" },
+      ),
+    );
+  });
+
+  it("keeps the alt text of an image used as the link label", () => {
+    expect(
+      nativeMarkdownWithStandaloneMediaLinks(
+        document({
+          type: "link",
+          href: "/tmp/login.png",
+          children: [{ type: "image", href: "/tmp/thumb.png", alt: "Login page" }],
+        }),
+      ),
+    ).toEqual(document({ type: "image", href: "/tmp/login.png", alt: "Login page" }));
+  });
+
   it("embeds a bare URL without alt text and keeps a title", () => {
     expect(
       nativeMarkdownWithStandaloneMediaLinks(

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -8,7 +8,73 @@ import {
   nativeMarkdownListItemBlocks,
   nativeMarkdownTextRuns,
   nativeMarkdownWithPreservedSoftBreaks,
+  nativeMarkdownWithStandaloneMediaLinks,
 } from "@t3tools/mobile-markdown-text/markdown";
+
+describe("nativeMarkdownWithStandaloneMediaLinks", () => {
+  const link = (href: string, text = href): MarkdownNode => ({
+    type: "link",
+    href,
+    children: [{ type: "text", content: text }],
+  });
+  const document = (...children: MarkdownNode[]): MarkdownNode => ({
+    type: "document",
+    children: [{ type: "paragraph", children }],
+  });
+
+  it("embeds a media link that owns its line and drops the breaks beside it", () => {
+    expect(
+      nativeMarkdownWithStandaloneMediaLinks(
+        document(
+          { type: "text", content: "Here is the result:" },
+          { type: "soft_break" },
+          link("/tmp/shot.png", "shot.png"),
+          { type: "line_break" },
+          { type: "text", content: "See " },
+          link("/tmp/detail.png", "detail.png"),
+          { type: "text", content: " for details." },
+        ),
+      ),
+    ).toEqual(
+      document(
+        { type: "text", content: "Here is the result:" },
+        { type: "image", href: "/tmp/shot.png", alt: "shot.png" },
+        { type: "text", content: "See " },
+        link("/tmp/detail.png", "detail.png"),
+        { type: "text", content: " for details." },
+      ),
+    );
+  });
+
+  it("embeds a bare URL without alt text and keeps a title", () => {
+    expect(
+      nativeMarkdownWithStandaloneMediaLinks(
+        document({ ...link("https://cdn.example.com/clip.mp4"), title: "Clip" }),
+      ),
+    ).toEqual(document({ type: "image", href: "https://cdn.example.com/clip.mp4", title: "Clip" }));
+  });
+
+  it.each([
+    ["a non-media file", link("/tmp/report.pdf", "report.pdf")],
+    ["an editor scheme", link("vscode://file/tmp/shot.png", "shot.png")],
+  ])("keeps %s a link", (_label, node) => {
+    const input = document(node);
+    expect(nativeMarkdownWithStandaloneMediaLinks(input)).toEqual(input);
+  });
+
+  it("keeps links inside list items", () => {
+    const input: MarkdownNode = {
+      type: "document",
+      children: [
+        {
+          type: "list",
+          children: [{ type: "list_item", children: [link("/tmp/shot.png", "shot.png")] }],
+        },
+      ],
+    };
+    expect(nativeMarkdownWithStandaloneMediaLinks(input)).toEqual(input);
+  });
+});
 
 describe("nativeMarkdownTextRuns", () => {
   it("links a path-shaped code span without changing the same path in prose", () => {

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -82,9 +82,29 @@ describe("nativeMarkdownWithStandaloneMediaLinks", () => {
   it.each([
     ["a non-media file", link("/tmp/report.pdf", "report.pdf")],
     ["an editor scheme", link("vscode://file/tmp/shot.png", "shot.png")],
+    ["an unresolved home-relative path", link("~/Downloads/shot.png", "shot.png")],
   ])("keeps %s a link", (_label, node) => {
     const input = document(node);
     expect(nativeMarkdownWithStandaloneMediaLinks(input)).toEqual(input);
+  });
+
+  it("keeps local media links when the renderer cannot load workspace files", () => {
+    const input = document(
+      link("/tmp/shot.png", "absolute"),
+      { type: "soft_break" },
+      link("images/shot.png", "relative"),
+      { type: "soft_break" },
+      link("https://cdn.example.com/shot.png", "remote"),
+    );
+
+    expect(nativeMarkdownWithStandaloneMediaLinks(input, { embedLocalPaths: false })).toEqual(
+      document(
+        link("/tmp/shot.png", "absolute"),
+        { type: "soft_break" },
+        link("images/shot.png", "relative"),
+        { type: "image", href: "https://cdn.example.com/shot.png", alt: "remote" },
+      ),
+    );
   });
 
   it("keeps links inside list items", () => {

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -71,12 +71,10 @@ describe("nativeMarkdownWithStandaloneMediaLinks", () => {
     ).toEqual(document({ type: "image", href: "/tmp/login.png", alt: "Login page" }));
   });
 
-  it("embeds a bare URL without alt text and keeps a title", () => {
-    expect(
-      nativeMarkdownWithStandaloneMediaLinks(
-        document({ ...link("https://cdn.example.com/clip.mp4"), title: "Clip" }),
-      ),
-    ).toEqual(document({ type: "image", href: "https://cdn.example.com/clip.mp4", title: "Clip" }));
+  it("keeps video links because the native image view cannot render them", () => {
+    const input = document({ ...link("https://cdn.example.com/clip.mp4"), title: "Clip" });
+
+    expect(nativeMarkdownWithStandaloneMediaLinks(input)).toEqual(input);
   });
 
   it.each([

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -86,6 +86,15 @@ describe("nativeMarkdownWithStandaloneMediaLinks", () => {
     expect(nativeMarkdownWithStandaloneMediaLinks(input)).toEqual(input);
   });
 
+  it("only embeds relative media when its workspace root resolves it", () => {
+    const input = document(link("images/shot.png", "relative"));
+    expect(nativeMarkdownWithStandaloneMediaLinks(input)).toEqual(input);
+    expect(nativeMarkdownWithStandaloneMediaLinks(input, { workspaceRoot: null })).toEqual(input);
+    expect(nativeMarkdownWithStandaloneMediaLinks(input, { workspaceRoot: "/repo" })).toEqual(
+      document({ type: "image", href: "images/shot.png", alt: "relative" }),
+    );
+  });
+
   it("keeps local media links when the renderer cannot load workspace files", () => {
     const input = document(
       link("/tmp/shot.png", "absolute"),

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1378,6 +1378,7 @@ function ChatMarkdownImage(props: {
   readonly src: string | null;
   readonly sourceFailed?: boolean | undefined;
   readonly alt: string;
+  readonly title?: string | undefined;
   readonly copyMarkdown: string | undefined;
   readonly standalone: boolean;
   readonly className?: string | undefined;
@@ -1413,7 +1414,7 @@ function ChatMarkdownImage(props: {
 
   if (settled) {
     return (
-      <MediaActions source={props.actionsSource}>
+      <MediaActions source={props.actionsSource} tooltipContent={props.title || undefined}>
         <img
           {...props.imageProps}
           ref={markLoadedIfComplete}
@@ -1458,7 +1459,7 @@ function ChatMarkdownImage(props: {
     );
   }
   return (
-    <MediaActions source={props.actionsSource}>
+    <MediaActions source={props.actionsSource} tooltipContent={props.title || undefined}>
       <span
         id={props.imageProps?.id}
         data-markdown-copy={props.copyMarkdown}
@@ -1524,22 +1525,6 @@ function ChatMarkdownVideo(props: {
       onRetry={props.onRetry}
       actionsSource={props.actionsSource}
     />
-  );
-}
-
-function AuthoredImageTitleTooltip(
-  props: {
-    readonly title?: string | undefined;
-    readonly children: React.ReactElement;
-  } & Omit<React.ComponentProps<typeof TooltipTrigger>, "render">,
-) {
-  const { title, children, ...triggerProps } = props;
-  if (!title) return React.cloneElement(children, triggerProps);
-  return (
-    <Tooltip>
-      <TooltipTrigger render={children} {...triggerProps} />
-      <TooltipPopup side="top">{title}</TooltipPopup>
-    </Tooltip>
   );
 }
 
@@ -1626,6 +1611,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
       key={JSON.stringify([props.environmentId, props.resource, props.srcFragment])}
       src={src}
       sourceFailed={assetUrl._tag === "Failure"}
+      title={props.title}
       alt={props.alt}
       copyMarkdown={props.copyMarkdown}
       standalone={props.standalone ?? true}
@@ -3040,6 +3026,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
       return (
         <ChatMarkdownImage
           key={mediaSrc}
+          title={authoredTitle}
           src={mediaSrc}
           alt={altText}
           copyMarkdown={copyMarkdown}
@@ -3065,6 +3052,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
           alt={altText}
           kind={kind}
           copyMarkdown={copyMarkdown}
+          title={authoredTitle}
           srcFragment={markdownImageSourceFragment(classifiedSrc)}
           standalone={standalone}
           style={authoredSizeStyle}
@@ -3130,7 +3118,8 @@ function ChatMarkdown({
     localMediaPreview,
     setLocalMediaPreview,
   } = useChatMarkdownState({ text, ...props });
-  const embedLocalPaths = componentState.threadRef !== undefined;
+  const { cwd, imageBaseDir, threadRef } = componentState;
+  const embedLocalPaths = threadRef !== undefined;
   const remarkPlugins = useMemo((): NonNullable<ReactMarkdownOptions["remarkPlugins"]> => {
     return [
       ...(lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS),

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -129,6 +129,7 @@ import {
   serializeTableElementToMarkdown,
 } from "../markdown-clipboard";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
+import { remarkStandaloneMediaLinks } from "../markdown-media-links";
 import {
   extractMarkdownLinkHrefs,
   isWindowsDrivePathHref,
@@ -458,6 +459,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkGithubAlerts,
   remarkNormalizeListItemIndentation,
   remarkCodexDirectives,
+  remarkStandaloneMediaLinks,
   remarkPreserveCodeMeta,
   remarkNormalizeLinksAndTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
@@ -468,6 +470,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkNormalizeListItemIndentation,
   remarkCodexDirectives,
   remarkBreaks,
+  remarkStandaloneMediaLinks,
   remarkPreserveCodeMeta,
   remarkNormalizeLinksAndTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -3117,10 +3117,10 @@ function ChatMarkdown({
   const remarkPlugins = useMemo((): NonNullable<ReactMarkdownOptions["remarkPlugins"]> => {
     return [
       ...(lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS),
-      [remarkStandaloneMediaLinks, { embedLocalPaths }],
+      [remarkStandaloneMediaLinks, { embedLocalPaths, workspaceRoot: imageBaseDir ?? cwd }],
       ...extraRemarkPlugins,
     ];
-  }, [embedLocalPaths, extraRemarkPlugins, lineBreaks]);
+  }, [cwd, embedLocalPaths, extraRemarkPlugins, imageBaseDir, lineBreaks]);
 
   // react-markdown converts unparsed HTML nodes to text when skipHtml is false.
   // Keep that behavior explicit because literal mode depends on escaping the

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1527,6 +1527,19 @@ function ChatMarkdownVideo(props: {
   );
 }
 
+function AuthoredImageTitleTooltip(props: {
+  readonly title?: string | undefined;
+  readonly children: React.ReactElement;
+}) {
+  if (!props.title) return props.children;
+  return (
+    <Tooltip>
+      <TooltipTrigger render={props.children} />
+      <TooltipPopup side="top">{props.title}</TooltipPopup>
+    </Tooltip>
+  );
+}
+
 /** Environment-hosted media loads through an exact-file signed asset URL. */
 export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props: {
   readonly environmentId: EnvironmentId;
@@ -1536,6 +1549,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   >;
   readonly kind?: "image" | "video";
   readonly alt: string;
+  readonly title?: string | undefined;
   readonly copyMarkdown?: string;
   readonly srcFragment?: string;
   /** Reserve a slot while loading; off for images that share a line with text. */

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -459,7 +459,6 @@ const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkGithubAlerts,
   remarkNormalizeListItemIndentation,
   remarkCodexDirectives,
-  remarkStandaloneMediaLinks,
   remarkPreserveCodeMeta,
   remarkNormalizeLinksAndTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
@@ -470,7 +469,6 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkNormalizeListItemIndentation,
   remarkCodexDirectives,
   remarkBreaks,
-  remarkStandaloneMediaLinks,
   remarkPreserveCodeMeta,
   remarkNormalizeLinksAndTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
@@ -3115,13 +3113,14 @@ function ChatMarkdown({
     localMediaPreview,
     setLocalMediaPreview,
   } = useChatMarkdownState({ text, ...props });
-  const remarkPlugins = useMemo(
-    () => [
+  const embedLocalPaths = componentState.threadRef !== undefined;
+  const remarkPlugins = useMemo((): NonNullable<ReactMarkdownOptions["remarkPlugins"]> => {
+    return [
       ...(lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS),
+      [remarkStandaloneMediaLinks, { embedLocalPaths }],
       ...extraRemarkPlugins,
-    ],
-    [extraRemarkPlugins, lineBreaks],
-  );
+    ];
+  }, [embedLocalPaths, extraRemarkPlugins, lineBreaks]);
 
   // react-markdown converts unparsed HTML nodes to text when skipHtml is false.
   // Keep that behavior explicit because literal mode depends on escaping the

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1527,15 +1527,18 @@ function ChatMarkdownVideo(props: {
   );
 }
 
-function AuthoredImageTitleTooltip(props: {
-  readonly title?: string | undefined;
-  readonly children: React.ReactElement;
-}) {
-  if (!props.title) return props.children;
+function AuthoredImageTitleTooltip(
+  props: {
+    readonly title?: string | undefined;
+    readonly children: React.ReactElement;
+  } & Omit<React.ComponentProps<typeof TooltipTrigger>, "render">,
+) {
+  const { title, children, ...triggerProps } = props;
+  if (!title) return React.cloneElement(children, triggerProps);
   return (
     <Tooltip>
-      <TooltipTrigger render={props.children} />
-      <TooltipPopup side="top">{props.title}</TooltipPopup>
+      <TooltipTrigger render={children} {...triggerProps} />
+      <TooltipPopup side="top">{title}</TooltipPopup>
     </Tooltip>
   );
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1494,6 +1494,7 @@ function ChatMarkdownImage(props: {
 }
 
 function ChatMarkdownVideo(props: {
+  readonly title?: string | undefined;
   readonly src: string | null;
   readonly alt: string;
   readonly copyMarkdown: string | undefined;
@@ -1510,6 +1511,7 @@ function ChatMarkdownVideo(props: {
       src={props.src}
       sourceFailed={props.sourceFailed}
       label={props.alt}
+      title={props.title}
       originalUrl={props.originalUrl}
       style={props.style}
       copyMarkdown={props.copyMarkdown}
@@ -1594,6 +1596,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   if (props.kind === "video") {
     return (
       <ChatMarkdownVideo
+        title={props.title}
         src={src}
         sourceFailed={assetUrl._tag === "Failure"}
         alt={props.alt}
@@ -3014,6 +3017,7 @@ const CHAT_MARKDOWN_COMPONENTS = {
       if (kind === "video") {
         return (
           <ChatMarkdownVideo
+            title={authoredTitle}
             src={mediaSrc}
             alt={altText}
             copyMarkdown={copyMarkdown}

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -195,6 +195,21 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain('href="https://example.com/docs"');
   });
 
+  it("keeps a local media link as a chip when no thread can serve it", () => {
+    const html = renderWithoutThread(
+      [
+        "[shot.svg](.t3/workspace-image.svg)",
+        "",
+        "[clip.mp4](https://cdn.example.com/clip.mp4)",
+      ].join("\n"),
+    );
+
+    expect(testState.resources).toEqual([]);
+    expect(html).toContain("chat-markdown-file-link");
+    expect(html).toContain("<video");
+    expect(html).not.toContain("Image unavailable");
+  });
+
   it("normalizes a drive-absolute src in raw image HTML", () => {
     const html = render(String.raw`<img src="D:\screens\workspace-image.svg" alt="raw">`);
 

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -171,6 +171,30 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).not.toContain("Image unavailable");
   });
 
+  it("embeds a media link that owns its line and keeps the rest as chips and links", () => {
+    const html = render(
+      [
+        "[shot.svg](.t3/workspace-image.svg)",
+        "",
+        "[Recording](https://cdn.example.com/clip.mp4)",
+        "",
+        "Compare with [shot.svg](.t3/workspace-image.svg) and [docs](https://example.com/docs).",
+      ].join("\n"),
+    );
+
+    expect(testState.resources).toEqual([
+      {
+        _tag: "media-file",
+        threadId: threadRef.threadId,
+        path: "C:\\Users\\shawn\\project\\.t3\\workspace-image.svg",
+      },
+    ]);
+    expect(html).toContain('<img src="https://signed.test/workspace-image.svg"');
+    expect(html).toContain("<video");
+    expect(html.match(/chat-markdown-file-link/g)).toHaveLength(1);
+    expect(html).toContain('href="https://example.com/docs"');
+  });
+
   it("normalizes a drive-absolute src in raw image HTML", () => {
     const html = render(String.raw`<img src="D:\screens\workspace-image.svg" alt="raw">`);
 

--- a/apps/web/src/components/media/MediaActions.tsx
+++ b/apps/web/src/components/media/MediaActions.tsx
@@ -6,7 +6,7 @@ import {
 import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import type { AssetResource, ContextMenuItem, EnvironmentId } from "@t3tools/contracts";
-import { useCallback, useRef, useState, type ReactElement } from "react";
+import { useCallback, useRef, useState, type ReactElement, type ReactNode } from "react";
 
 import { writeTextToClipboard } from "../../hooks/useCopyToClipboard";
 import { readLocalApi } from "../../localApi";
@@ -73,15 +73,19 @@ function useMediaActions(source: MediaActionSource) {
 export function MediaActions({
   source,
   children,
+  tooltipContent,
 }: {
   source: MediaActionSource;
   children: ReactElement;
+  tooltipContent?: ReactNode;
 }) {
   const { save, copyImage } = useMediaActions(source);
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const menuOpen = useRef(false);
   const reference = source.reference;
-  const tooltip = reference?.kind === "file" ? reference.path : (reference?.url ?? source.name);
+  const tooltip =
+    tooltipContent ??
+    (reference?.kind === "file" ? reference.path : (reference?.url ?? source.name));
 
   const showMenu = async (position: { x: number; y: number }) => {
     const api = readLocalApi();

--- a/apps/web/src/components/media/MediaVideoPlayer.tsx
+++ b/apps/web/src/components/media/MediaVideoPlayer.tsx
@@ -10,6 +10,7 @@ import { MediaActions, type MediaActionSource } from "./MediaActions";
 interface MediaVideoPlayerProps {
   readonly src: string | null;
   readonly label: string;
+  readonly title?: string | undefined;
   readonly sourceFailed?: boolean | undefined;
   readonly originalUrl?: string | undefined;
   readonly revision?: string | null | undefined;
@@ -29,6 +30,7 @@ interface MediaVideoPlayerProps {
 export function MediaVideoPlayer({
   src: latestSrc,
   label,
+  title,
   sourceFailed = false,
   originalUrl,
   revision = null,
@@ -183,5 +185,5 @@ export function MediaVideoPlayer({
       )}
     </span>
   );
-  return actionsSource ? <MediaActions source={actionsSource}>{player}</MediaActions> : player;
+  return actionsSource ? <MediaActions source={actionsSource} tooltipContent={title}>{player}</MediaActions> : player;
 }

--- a/apps/web/src/components/media/MediaVideoPlayer.tsx
+++ b/apps/web/src/components/media/MediaVideoPlayer.tsx
@@ -185,5 +185,11 @@ export function MediaVideoPlayer({
       )}
     </span>
   );
-  return actionsSource ? <MediaActions source={actionsSource} tooltipContent={title}>{player}</MediaActions> : player;
+  return actionsSource ? (
+    <MediaActions source={actionsSource} tooltipContent={title}>
+      {player}
+    </MediaActions>
+  ) : (
+    player
+  );
 }

--- a/apps/web/src/components/media/MediaVideoPlayer.tsx
+++ b/apps/web/src/components/media/MediaVideoPlayer.tsx
@@ -186,7 +186,7 @@ export function MediaVideoPlayer({
     </span>
   );
   return actionsSource ? (
-    <MediaActions source={actionsSource} tooltipContent={title}>
+    <MediaActions source={actionsSource} tooltipContent={title || undefined}>
       {player}
     </MediaActions>
   ) : (

--- a/apps/web/src/markdown-media-links.test.tsx
+++ b/apps/web/src/markdown-media-links.test.tsx
@@ -8,14 +8,21 @@ import { remarkStandaloneMediaLinks } from "./markdown-media-links";
 
 function renderMarkdown(
   markdown: string,
-  options?: { lineBreaks?: boolean; embedLocalPaths?: boolean },
+  options?: { lineBreaks?: boolean; embedLocalPaths?: boolean; workspaceRoot?: string | null },
 ): string {
   return renderToStaticMarkup(
     <ReactMarkdown
       remarkPlugins={[
         remarkGfm,
         ...(options?.lineBreaks ? [remarkBreaks] : []),
-        [remarkStandaloneMediaLinks, { embedLocalPaths: options?.embedLocalPaths ?? true }],
+        [
+          remarkStandaloneMediaLinks,
+          {
+            embedLocalPaths: options?.embedLocalPaths ?? true,
+            workspaceRoot:
+              options?.workspaceRoot === undefined ? "/workspace" : options.workspaceRoot,
+          },
+        ],
       ]}
     >
       {markdown}
@@ -102,6 +109,16 @@ describe("remarkStandaloneMediaLinks", () => {
 
     expect(html).toContain('<a href="/tmp/shot.png">shot.png</a>');
     expect(html).toContain('<img src="https://cdn.example.com/clip.mp4"');
+  });
+
+  it("keeps a path link the image renderer could not load", () => {
+    expect(renderMarkdown("[shot.png](~/Downloads/shot.png)")).toContain(
+      '<a href="~/Downloads/shot.png">shot.png</a>',
+    );
+    expect(renderMarkdown("[shot.png](docs/shot.png)", { workspaceRoot: null })).toContain(
+      '<a href="docs/shot.png">shot.png</a>',
+    );
+    expect(renderMarkdown("[shot.png](docs/shot.png)")).toContain('<img src="docs/shot.png"');
   });
 
   it("keeps links in list items and quotes", () => {

--- a/apps/web/src/markdown-media-links.test.tsx
+++ b/apps/web/src/markdown-media-links.test.tsx
@@ -44,6 +44,27 @@ describe("remarkStandaloneMediaLinks", () => {
     expect(html).toContain('<img src="https://cdn.example.com/shot.png" alt=""');
   });
 
+  it("embeds every link in a run of consecutive lines", () => {
+    const html = renderMarkdown(
+      ["[a.png](https://cdn.example.com/a.png)", "[b.png](https://cdn.example.com/b.png)"].join(
+        "\n",
+      ),
+    );
+
+    expect(html).toContain(
+      '<img src="https://cdn.example.com/a.png" alt="a.png"/><br/>\n<img src="https://cdn.example.com/b.png" alt="b.png"/>',
+    );
+    expect(html).not.toContain("<a ");
+  });
+
+  it("keeps the alt text of an image used as the link label", () => {
+    const html = renderMarkdown(
+      "[![Login page](https://cdn.example.com/thumb.png)](https://cdn.example.com/login.png)",
+    );
+
+    expect(html).toContain('<img src="https://cdn.example.com/login.png" alt="Login page"');
+  });
+
   it("uses the link text as the alt text and keeps the title", () => {
     const html = renderMarkdown('[Login page](https://cdn.example.com/login.png "After sign-in")');
 

--- a/apps/web/src/markdown-media-links.test.tsx
+++ b/apps/web/src/markdown-media-links.test.tsx
@@ -6,13 +6,16 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { remarkStandaloneMediaLinks } from "./markdown-media-links";
 
-function renderMarkdown(markdown: string, options?: { lineBreaks?: boolean }): string {
+function renderMarkdown(
+  markdown: string,
+  options?: { lineBreaks?: boolean; embedLocalPaths?: boolean },
+): string {
   return renderToStaticMarkup(
     <ReactMarkdown
       remarkPlugins={[
         remarkGfm,
         ...(options?.lineBreaks ? [remarkBreaks] : []),
-        remarkStandaloneMediaLinks,
+        [remarkStandaloneMediaLinks, { embedLocalPaths: options?.embedLocalPaths ?? true }],
       ]}
     >
       {markdown}
@@ -90,6 +93,16 @@ describe("remarkStandaloneMediaLinks", () => {
       expect(html).toContain('<a href="https://cdn.example.com/detail.png">detail.png</a>');
     },
   );
+
+  it("keeps path links when the surface cannot load local files", () => {
+    const html = renderMarkdown(
+      ["[shot.png](/tmp/shot.png)", "", "[clip.mp4](https://cdn.example.com/clip.mp4)"].join("\n"),
+      { embedLocalPaths: false },
+    );
+
+    expect(html).toContain('<a href="/tmp/shot.png">shot.png</a>');
+    expect(html).toContain('<img src="https://cdn.example.com/clip.mp4"');
+  });
 
   it("keeps links in list items and quotes", () => {
     const html = renderMarkdown(

--- a/apps/web/src/markdown-media-links.test.tsx
+++ b/apps/web/src/markdown-media-links.test.tsx
@@ -1,0 +1,107 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+import { describe, expect, it } from "vite-plus/test";
+
+import { remarkStandaloneMediaLinks } from "./markdown-media-links";
+
+function renderMarkdown(markdown: string, options?: { lineBreaks?: boolean }): string {
+  return renderToStaticMarkup(
+    <ReactMarkdown
+      remarkPlugins={[
+        remarkGfm,
+        ...(options?.lineBreaks ? [remarkBreaks] : []),
+        remarkStandaloneMediaLinks,
+      ]}
+    >
+      {markdown}
+    </ReactMarkdown>,
+  );
+}
+
+describe("remarkStandaloneMediaLinks", () => {
+  it.each([
+    ["[shot.png](https://cdn.example.com/shot.png)", "https://cdn.example.com/shot.png"],
+    [
+      "[Recording](https://cdn.example.com/clip.mp4?sig=1)",
+      "https://cdn.example.com/clip.mp4?sig=1",
+    ],
+    [
+      "  [**Login** page](<https://cdn.example.com/login page.png>)  ",
+      "https://cdn.example.com/login%20page.png",
+    ],
+  ])("embeds %s", (markdown, src) => {
+    const html = renderMarkdown(markdown);
+
+    expect(html).toContain(`<img src="${src}"`);
+    expect(html).not.toContain("<a ");
+  });
+
+  it("embeds a bare URL without repeating it as alt text", () => {
+    const html = renderMarkdown("https://cdn.example.com/shot.png");
+
+    expect(html).toContain('<img src="https://cdn.example.com/shot.png" alt=""');
+  });
+
+  it("uses the link text as the alt text and keeps the title", () => {
+    const html = renderMarkdown('[Login page](https://cdn.example.com/login.png "After sign-in")');
+
+    expect(html).toContain('alt="Login page"');
+    expect(html).toContain('title="After sign-in"');
+  });
+
+  it.each([false, true])(
+    "embeds a link on its own line inside a paragraph (lineBreaks=%s)",
+    (lineBreaks) => {
+      const html = renderMarkdown(
+        [
+          "Here is the result:",
+          "[shot.png](https://cdn.example.com/shot.png)",
+          "See [detail.png](https://cdn.example.com/detail.png) for details.",
+        ].join("\n"),
+        { lineBreaks },
+      );
+
+      expect(html).toContain(
+        'Here is the result:<br/>\n<img src="https://cdn.example.com/shot.png" alt="shot.png"/><br/>\nSee ',
+      );
+      expect(html).toContain('<a href="https://cdn.example.com/detail.png">detail.png</a>');
+    },
+  );
+
+  it("keeps links in list items and quotes", () => {
+    const html = renderMarkdown(
+      [
+        "- [item.png](https://cdn.example.com/item.png)",
+        "",
+        "> [quote.png](https://cdn.example.com/quote.png)",
+      ].join("\n"),
+    );
+
+    expect(html).toContain('<a href="https://cdn.example.com/item.png">item.png</a>');
+    expect(html).toContain('<a href="https://cdn.example.com/quote.png">quote.png</a>');
+    expect(html).not.toContain("<img");
+  });
+
+  it.each([
+    "[report](https://cdn.example.com/report.pdf)",
+    "[docs](https://example.com/docs)",
+    "[shot.png](vscode://file/tmp/shot.png)",
+    "[a.png](https://cdn.example.com/a.png) [b.png](https://cdn.example.com/b.png)",
+  ])("keeps %s a link", (markdown) => {
+    const html = renderMarkdown(markdown);
+
+    expect(html).toContain("<a href=");
+    expect(html).not.toContain("<img");
+  });
+
+  it("leaves code untouched", () => {
+    const html = renderMarkdown(
+      ["```md", "[shot.png](https://cdn.example.com/shot.png)", "```"].join("\n"),
+    );
+
+    expect(html).toContain("<code");
+    expect(html).not.toContain("<img");
+  });
+});

--- a/apps/web/src/markdown-media-links.ts
+++ b/apps/web/src/markdown-media-links.ts
@@ -37,12 +37,19 @@ function isLineBoundary(node: MarkdownAstNode | undefined, edge: "before" | "aft
  * as line edges.
  *
  * A path or `file:` target only loads through a thread's asset URL, so surfaces without one
- * pass `embedLocalPaths: false` and keep the chip, which can still open the file.
+ * pass `embedLocalPaths: false` and keep the chip, which can still open the file. The
+ * target is classified against the same root the image renderer uses, so a link the
+ * renderer could not load, such as a tilde path, also keeps its chip.
  */
-export function remarkStandaloneMediaLinks(options: { readonly embedLocalPaths: boolean }) {
-  const embeddable = (url: string) =>
-    markdownLinkMediaKind(url) !== null &&
-    (options.embedLocalPaths || classifyMarkdownImageSource(url)._tag === "Direct");
+export function remarkStandaloneMediaLinks(options: {
+  readonly embedLocalPaths: boolean;
+  readonly workspaceRoot?: string | null | undefined;
+}) {
+  const embeddable = (url: string) => {
+    if (markdownLinkMediaKind(url) === null) return false;
+    const source = classifyMarkdownImageSource(url, options.workspaceRoot);
+    return source._tag === "Direct" || (options.embedLocalPaths && source._tag === "WorkspaceFile");
+  };
   return (tree: MarkdownAstNode) => {
     for (const block of tree.children ?? []) {
       if (block.type !== "paragraph" || !block.children) continue;

--- a/apps/web/src/markdown-media-links.ts
+++ b/apps/web/src/markdown-media-links.ts
@@ -1,0 +1,74 @@
+import { markdownLinkMediaKind } from "@t3tools/client-runtime/markdown-images";
+
+interface MarkdownAstNode {
+  type: string;
+  url?: string;
+  title?: string | null;
+  alt?: string | null;
+  value?: unknown;
+  children?: MarkdownAstNode[];
+}
+
+const TRAILING_NEWLINE_PATTERN = /\n[ \t]*$/u;
+const LEADING_NEWLINE_PATTERN = /^[ \t]*\n/u;
+
+function plainText(node: MarkdownAstNode): string {
+  if (typeof node.value === "string") return node.value;
+  return node.children?.map(plainText).join("") ?? "";
+}
+
+/** A paragraph edge, a hard break, or a text sibling that ends (or starts) with a newline. */
+function isLineBoundary(node: MarkdownAstNode | undefined, edge: "before" | "after"): boolean {
+  if (node === undefined || node.type === "break") return true;
+  if (node.type !== "text" || typeof node.value !== "string") return false;
+  return (edge === "before" ? TRAILING_NEWLINE_PATTERN : LEADING_NEWLINE_PATTERN).test(node.value);
+}
+
+/**
+ * A link that owns its line in a top-level paragraph and points at an image or video file
+ * becomes an image node, so the renderer embeds the media instead of a file chip. Links
+ * mixed into a sentence, list items, and quotes stay links. The soft breaks around an
+ * embedded link become hard breaks so the media keeps the line to itself. Runs after the
+ * Codex directives so a cited file is already a link, and after hard breaks so they count
+ * as line edges.
+ */
+export function remarkStandaloneMediaLinks() {
+  return (tree: MarkdownAstNode) => {
+    for (const block of tree.children ?? []) {
+      if (block.type !== "paragraph" || !block.children) continue;
+      const siblings = block.children;
+      const next: MarkdownAstNode[] = [];
+      siblings.forEach((child, index) => {
+        const before = next.at(-1);
+        const after = siblings[index + 1];
+        if (
+          child.type !== "link" ||
+          typeof child.url !== "string" ||
+          markdownLinkMediaKind(child.url) === null ||
+          !isLineBoundary(before, "before") ||
+          !isLineBoundary(after, "after")
+        ) {
+          next.push(child);
+          return;
+        }
+        if (before?.type === "text" && typeof before.value === "string") {
+          before.value = before.value.replace(TRAILING_NEWLINE_PATTERN, "");
+          next.push({ type: "break" });
+        }
+        const text = plainText(child);
+        next.push({
+          type: "image",
+          url: child.url,
+          title: child.title ?? null,
+          // An autolink's text is its URL, which is not worth repeating as alt text.
+          alt: text === child.url ? "" : text,
+        });
+        if (after?.type === "text" && typeof after.value === "string") {
+          after.value = after.value.replace(LEADING_NEWLINE_PATTERN, "");
+          next.push({ type: "break" });
+        }
+      });
+      block.children = next;
+    }
+  };
+}

--- a/apps/web/src/markdown-media-links.ts
+++ b/apps/web/src/markdown-media-links.ts
@@ -13,6 +13,7 @@ const TRAILING_NEWLINE_PATTERN = /\n[ \t]*$/u;
 const LEADING_NEWLINE_PATTERN = /^[ \t]*\n/u;
 
 function plainText(node: MarkdownAstNode): string {
+  if (node.type === "image" && typeof node.alt === "string") return node.alt;
   if (typeof node.value === "string") return node.value;
   return node.children?.map(plainText).join("") ?? "";
 }
@@ -39,6 +40,9 @@ export function remarkStandaloneMediaLinks() {
       const siblings = block.children;
       const next: MarkdownAstNode[] = [];
       siblings.forEach((child, index) => {
+        // A text sibling that an earlier embed emptied would hide the line edge from the
+        // next link, so it is dropped rather than carried along.
+        if (child.type === "text" && child.value === "") return;
         const before = next.at(-1);
         const after = siblings[index + 1];
         if (

--- a/apps/web/src/markdown-media-links.ts
+++ b/apps/web/src/markdown-media-links.ts
@@ -1,4 +1,7 @@
-import { markdownLinkMediaKind } from "@t3tools/client-runtime/markdown-images";
+import {
+  classifyMarkdownImageSource,
+  markdownLinkMediaKind,
+} from "@t3tools/client-runtime/markdown-images";
 
 interface MarkdownAstNode {
   type: string;
@@ -32,8 +35,14 @@ function isLineBoundary(node: MarkdownAstNode | undefined, edge: "before" | "aft
  * embedded link become hard breaks so the media keeps the line to itself. Runs after the
  * Codex directives so a cited file is already a link, and after hard breaks so they count
  * as line edges.
+ *
+ * A path or `file:` target only loads through a thread's asset URL, so surfaces without one
+ * pass `embedLocalPaths: false` and keep the chip, which can still open the file.
  */
-export function remarkStandaloneMediaLinks() {
+export function remarkStandaloneMediaLinks(options: { readonly embedLocalPaths: boolean }) {
+  const embeddable = (url: string) =>
+    markdownLinkMediaKind(url) !== null &&
+    (options.embedLocalPaths || classifyMarkdownImageSource(url)._tag === "Direct");
   return (tree: MarkdownAstNode) => {
     for (const block of tree.children ?? []) {
       if (block.type !== "paragraph" || !block.children) continue;
@@ -48,7 +57,7 @@ export function remarkStandaloneMediaLinks() {
         if (
           child.type !== "link" ||
           typeof child.url !== "string" ||
-          markdownLinkMediaKind(child.url) === null ||
+          !embeddable(child.url) ||
           !isLineBoundary(before, "before") ||
           !isLineBoundary(after, "after")
         ) {

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -111,6 +111,10 @@ provider supports it. Web and desktop also offer compaction from the context met
 
 ## Images and videos in messages
 
+Image links on a line of their own render inline. Web and desktop also embed
+standalone video links; mobile keeps those as links. Links within sentences, lists,
+quotes, or code keep their existing presentation.
+
 Select an image or video attachment or link to preview it. Playback support depends
 on your browser or device; save an unsupported video to open it in another app.
 

--- a/packages/client-runtime/src/markdownImages.test.ts
+++ b/packages/client-runtime/src/markdownImages.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { classifyMarkdownImageSource, markdownImageSourceFragment } from "./markdownImages.js";
+import {
+  classifyMarkdownImageSource,
+  markdownImageSourceFragment,
+  markdownLinkMediaKind,
+} from "./markdownImages.js";
+
+describe("markdownLinkMediaKind", () => {
+  it.each([
+    ["/tmp/shot.png", "image"],
+    ["images/shot.webp", "image"],
+    ["C:\\shots\\shot.png", "image"],
+    ["file:///tmp/recording.mp4", "video"],
+    ["https://cdn.example.com/clip.mov?sig=1", "video"],
+    ["<https://cdn.example.com/login page.png>", "image"],
+    ["//cdn.example.com/shot.png", "image"],
+  ])("classifies %s as %s", (target, kind) => {
+    expect(markdownLinkMediaKind(target)).toBe(kind);
+  });
+
+  it.each([
+    "/tmp/report.pdf",
+    "https://example.com/docs",
+    "vscode://file/tmp/shot.png",
+    "t3-citation://v1/env/thread/msg?quote=shot.png",
+    "mailto:someone@example.com/shot.png",
+  ])("rejects %s", (target) => {
+    expect(markdownLinkMediaKind(target)).toBeNull();
+  });
+});
 
 describe("classifyMarkdownImageSource", () => {
   it.each([

--- a/packages/client-runtime/src/markdownImages.ts
+++ b/packages/client-runtime/src/markdownImages.ts
@@ -1,3 +1,4 @@
+import { mediaKindFromPath } from "@t3tools/shared/filePreview";
 import { isWindowsAbsolutePath } from "@t3tools/shared/path";
 
 import {
@@ -10,6 +11,7 @@ import {
 
 const DIRECT_IMAGE_SOURCE_PATTERN = /^(?:https?:|data:|blob:|\/\/)/i;
 const URI_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const EMBEDDABLE_LINK_SCHEME_PATTERN = /^(?:https?|file):/i;
 
 export type MarkdownImageSource =
   | { readonly _tag: "Direct"; readonly uri: string }
@@ -69,4 +71,21 @@ export function classifyMarkdownImageSource(
   if (!workspaceRoot) return { _tag: "Blocked" };
 
   return { _tag: "WorkspaceFile", path: joinWorkspacePath(workspaceRoot, path) };
+}
+
+/**
+ * The media a link could be embedded as: an image or video reached over the web, through a
+ * `file:` URL, or by path. Any other scheme is not media even when it ends in an image
+ * extension; an editor or citation link is still a link.
+ */
+export function markdownLinkMediaKind(target: string): "image" | "video" | null {
+  const source = normalizeMarkdownLinkDestination(target);
+  if (
+    URI_SCHEME_PATTERN.test(source) &&
+    !EMBEDDABLE_LINK_SCHEME_PATTERN.test(source) &&
+    !isWindowsAbsolutePath(source)
+  ) {
+    return null;
+  }
+  return mediaKindFromPath(source);
 }


### PR DESCRIPTION
A markdown link that sits alone on a line and points at an image or video renders as a file chip, even though the agent clearly wanted to show the file. Agents write `[screenshot.png](/tmp/screenshot.png)` far more often than image syntax, so the reader clicks a chip to see a screenshot they just asked for. The pull request body view already embeds a bare upload link on its own line; chat did not.

A link that owns its line in a top-level paragraph and targets an image or video file now embeds the media, on web and mobile. Links inside a sentence, list items, quotes, code, and other URL schemes keep their current chip or link. On web this is a remark plugin that rewrites the link node into an image node and turns the soft breaks around it into hard breaks so the media keeps the line to itself. On mobile the same rule runs against the native markdown tree, next to the existing soft-break transform, and is passed to the nitro fallback renderer. Both share one predicate in client-runtime for what counts as embeddable media, which rejects schemes such as `vscode://` and citations even when the string ends in an image extension.

## Verification

Captured in the web client from a seeded thread. Each case is one section of a single assistant reply, plus one user message.

| Case | Result |
| --- | --- |
| User message, link alone on a line | <img width="640" alt="User message with the linked image rendered inline in the bubble" src="https://github.com/user-attachments/assets/25bb25da-098b-423e-8cbc-0959b6437c91" /> |
| 1. Absolute workspace path alone on a line | <img width="800" alt="Absolute path link rendered as an inline image" src="https://github.com/user-attachments/assets/e5d8badf-bc95-4814-a715-b4497118ec82" /> |
| 2. Relative path alone on a line | <img width="800" alt="Relative path link rendered as an inline image resolved from the workspace" src="https://github.com/user-attachments/assets/3da63bbc-93c8-4a90-955b-508e167d672c" /> |
| 3. Video file alone on a line | <img width="800" alt="Video link rendered as an inline player" src="https://github.com/user-attachments/assets/370a5070-3e52-4a24-bb80-120dc6fb5f96" /> |
| 4. Bare URL alone on a line | <img width="800" alt="Bare image URL rendered as an inline image" src="https://github.com/user-attachments/assets/20b5a906-9f2a-41e0-8262-980168342a62" /> |
| 5. Own line inside a paragraph | <img width="800" alt="Link on its own line inside a paragraph rendered as an image between the text lines" src="https://github.com/user-attachments/assets/6b07ffcd-86a6-4583-a97d-c55b393c1db9" /> |
| 6. Link inside a sentence | <img width="800" alt="Link inside a sentence still rendered as a file chip" src="https://github.com/user-attachments/assets/9839a8dd-2cb5-489c-853e-f3430557d95e" /> |
| 7. Two links on one line | <img width="800" alt="Two links on one line still rendered as chips" src="https://github.com/user-attachments/assets/4772725c-c29a-4398-a7d2-6f4723962975" /> |
| 8. List items | <img width="800" alt="Links in list items still rendered as chips" src="https://github.com/user-attachments/assets/420107c8-9db7-4e13-bf79-3e43601a5221" /> |
| 9. Non-media file | <img width="800" alt="Link to a markdown file still rendered as a chip" src="https://github.com/user-attachments/assets/30c28799-6451-4b53-b38c-5e9090c09803" /> |
| 10. Other URL scheme | <img width="800" alt="vscode scheme link still rendered as a plain link" src="https://github.com/user-attachments/assets/01ea3ef9-5f82-4752-a259-1d382439cf95" /> |
| 11. Inside a code block | <img width="800" alt="Link inside a code block left untouched" src="https://github.com/user-attachments/assets/0e7d3bde-f53b-418c-bce7-b2090906fa6e" /> |

<details>
<summary>Full thread</summary>

<img width="900" alt="The whole seeded thread" src="https://github.com/user-attachments/assets/12c93206-7ba5-4866-811c-a98c8152c091" />

</details>

Mobile is covered by unit tests on the native tree transform and a typecheck; no simulator pass was run.

## Testing

- `vp test run packages/client-runtime/src/markdownImages.test.ts`
- `vp test run apps/web/src/markdown-media-links.test.tsx apps/web/src/components/ChatMarkdown.test.tsx apps/web/src/components/ChatMarkdown.workspace-images.test.tsx`
- `vp test run apps/mobile/src/lib/nativeMarkdownText.test.ts`
- `vp run typecheck` in `apps/web`, `apps/mobile`, and `packages/client-runtime`
- `vp lint` and `vp fmt --check` on the touched files

Built with Claude Fable 5.1 using the Claude Code harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Markdown rendering behavior changes for a common agent pattern (standalone media links), with platform-specific rules for local paths and videos; mistakes in line-boundary or classification logic could embed or strip links incorrectly.
> 
> **Overview**
> **Standalone image/video links on their own line now render as embedded media** in chat on web and mobile, instead of file chips—matching how agents often write `[screenshot.png](/path)` rather than `![]()` syntax.
> 
> Web adds a **`remarkStandaloneMediaLinks`** remark plugin wired into `ChatMarkdown`; mobile adds **`nativeMarkdownWithStandaloneMediaLinks`** on the parsed AST (selectable iOS path and nitro `Markdown` fallback in `ThreadFeed`). Both use shared **`markdownLinkMediaKind`** in client-runtime to decide embeddability and reject non-http/file schemes (e.g. `vscode://`, citations). **Local/workspace paths embed only when the surface can resolve assets** (`threadRef` on web, `renderImage` on mobile); otherwise chips stay. Inline links, lists, quotes, and code are unchanged; **mobile still leaves video as links** (native image view limitation).
> 
> **`MediaActions`** accepts optional **`tooltipContent`** so link titles show on hover for embedded images. User docs in `composer.md` describe the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a08764c49dc17f36d556e393f1bcfe3571b2826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render standalone media links inline in chat markdown on web and mobile
> - Adds shared `markdownLinkMediaKind` classifier in [markdownImages.ts](https://github.com/pingdotgg/t3code/pull/9262/files#diff-a0e62b9b7ad618117ab7a7e9cc3c2f7e211811ac4cf8b19c864b6714f6bc4b1f) to detect image/video link targets, rejecting non-embeddable schemes like mailto or docs.
> - Adds `remarkStandaloneMediaLinks` plugin for web in [markdown-media-links.ts](https://github.com/pingdotgg/t3code/pull/9262/files#diff-cfd2e1c0009d4ff0f21f7b7e85e469d02d0d5a27aaf87133796f166bc815fbf6) and `nativeMarkdownWithStandaloneMediaLinks` transform for mobile in [nativeMarkdownText.ts](https://github.com/pingdotgg/t3code/pull/9262/files#diff-6ca1a8722a1053a74dedf7789620201e8345f0d095c5b9f9307c754fa0a4147a); both convert whole-line links to media nodes while preserving inline, nested, code-block, and unsupported links.
> - Propagates a workspace-root property through `ThreadFeed`, `FileMarkdownPreview`, and `ChatMarkdown` so relative media paths resolve against the containing directory.
> - Preserves authored markdown titles as media tooltips in `MediaActions`, `MediaVideoPlayer`, and asset image components.
> - Risk: fallback transform calls in [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/9262/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) (`AssistantMarkdownContent` and `UserMessageContent`) omit the required `embedLocalPaths` option declared by the imported web transform, causing a compile-time options type mismatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c67509.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standalone image links now render as inline images across web, desktop, and supported mobile Markdown views.
  - Standalone video links render as media on web and desktop; mobile continues displaying them as links.
  - Workspace-local image links can render as images when relevant thread context is available.
  - Image titles and meaningful labels are preserved in media tooltips and accessibility text.
  - Links within sentences, lists, quotes, and code blocks retain their existing presentation.
  - Without thread context, local media links remain file-link chips.

- **Documentation**
  - Updated composer documentation to describe standalone image and video link rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->