### PR TITLE
feat(usage): show provider subscription limits on the usage page

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
+import type { UsageProviderKind } from "@t3tools/contracts";
 import type { DailyTotals, MergedUsage } from "@t3tools/shared/usageMerge";
 import {
   enumerateDays,
@@ -6,6 +7,9 @@ import {
   formatCount,
   formatDayShort,
   formatHourShort,
+  formatLimitReset,
+  formatLimitWindowLabel,
+  formatObservedAgo,
   formatPercent,
   formatTokens,
   formatUsd,
@@ -22,7 +26,7 @@ import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import { SettingsSection } from "../settings/components/SettingsSection";
 import { UsageDailyChart } from "./UsageDailyChart";
 import type { UsageChartMetric } from "./usageChartData";
-import { PROVIDER_LABEL, useProviderColors } from "./usageProviders";
+import { PROVIDER_LABEL, PROVIDER_ORDER, useProviderColors } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
   { days: 1, label: "Past 24h" },
@@ -68,6 +72,9 @@ export function UsageRouteScreen() {
         : merged.daily,
     [isPast24Hours, merged.daily, merged.hourly],
   );
+
+  // Limits are read relative to when the answers landed, not to every render.
+  const limitsReadAt = useMemo(() => new Date(), [merged]);
 
   // The pull spinner tracks re-scans of environments that have answered
   // before. The initial scan renders its own placeholder, and an unreachable
@@ -139,6 +146,7 @@ export function UsageRouteScreen() {
               timeZone={window.timeZone}
             />
             <ProviderSection merged={merged} metric={metric} />
+            <LimitsSection merged={merged} now={limitsReadAt} timeZone={window.timeZone} />
             <TotalsSection merged={merged} isPast24Hours={isPast24Hours} />
             <ModelsSection merged={merged} />
           </>
@@ -341,6 +349,118 @@ function ProviderSection(props: {
                 ? `${formatPercent(share)} of cost · ${formatTokens(provider.totalTokens)} tokens`
                 : `${formatPercent(share)} of tokens · ${formatUsd(provider.costUsd)}`}
             </Text>
+          </View>
+        );
+      })}
+    </SettingsSection>
+  );
+}
+
+/** Why a provider has no limit figure to show. */
+const LIMITS_UNAVAILABLE: Record<UsageProviderKind, string> = {
+  codex: "Sign in to the Codex CLI to see its limits here.",
+  claude: "Reported once a Claude Code turn runs through T3 Code.",
+  grok: "Grok Build does not report subscription limits.",
+};
+
+/**
+ * Rolling subscription windows per provider. Every provider with activity in
+ * the window gets a row, so a provider that cannot report says so instead of
+ * silently missing.
+ */
+function LimitsSection(props: {
+  readonly merged: MergedUsage;
+  readonly now: Date;
+  readonly timeZone: string;
+}) {
+  const { merged, now } = props;
+  const colors = useProviderColors();
+  const active = new Set(
+    merged.providers
+      .filter((entry) => entry.totalTokens > 0 || entry.costUsd > 0)
+      .map((entry) => entry.provider),
+  );
+  const rows = PROVIDER_ORDER.flatMap((provider) => {
+    const entry = merged.limits.find((candidate) => candidate.provider === provider);
+    if (entry === undefined && !active.has(provider)) return [];
+    return [{ provider, entry }];
+  });
+  if (rows.length === 0) return null;
+
+  return (
+    <SettingsSection title="Subscription limits" card>
+      {rows.map(({ provider, entry }, index) => {
+        const observedAt = entry?.windows.reduce(
+          (latest, window) => (window.observedAt > latest ? window.observedAt : latest),
+          "",
+        );
+        return (
+          <View
+            key={provider}
+            className={index === 0 ? "gap-3 p-4" : "gap-3 border-t border-border-subtle p-4"}
+          >
+            <View className="flex-row items-baseline justify-between gap-3">
+              <View className="flex-row items-center gap-2">
+                <View
+                  className="size-2.5 rounded-full"
+                  style={{ backgroundColor: colors[provider] }}
+                />
+                <Text className="text-lg text-foreground">{PROVIDER_LABEL[provider]}</Text>
+                {entry?.plan ? (
+                  <Text className="text-sm text-foreground-muted">{entry.plan}</Text>
+                ) : null}
+              </View>
+              {observedAt ? (
+                <Text className="text-xs text-foreground-tertiary">
+                  Updated {formatObservedAgo(observedAt, now)}
+                </Text>
+              ) : null}
+            </View>
+            {entry === undefined || entry.windows.length === 0 ? (
+              <Text className="text-sm text-foreground-muted">{LIMITS_UNAVAILABLE[provider]}</Text>
+            ) : (
+              entry.windows.map((window) => {
+                const used = Math.min(100, Math.max(0, window.usedPercent));
+                const reset = formatLimitReset(window.resetsAt, now, props.timeZone);
+                return (
+                  <View key={window.id} className="gap-1.5">
+                    <View className="flex-row items-baseline justify-between gap-3">
+                      <Text className="text-sm text-foreground-muted">
+                        {formatLimitWindowLabel(window)}
+                      </Text>
+                      <View className="flex-row items-baseline gap-2">
+                        <Text
+                          className={
+                            used >= 90
+                              ? "text-sm font-t3-medium tabular-nums text-danger-foreground"
+                              : "text-sm font-t3-medium tabular-nums text-foreground"
+                          }
+                        >
+                          {Math.round(used)}%
+                        </Text>
+                        {reset ? (
+                          <Text className="text-xs text-foreground-tertiary">{reset}</Text>
+                        ) : null}
+                      </View>
+                    </View>
+                    <View className="h-1 flex-row overflow-hidden rounded-full bg-subtle">
+                      <View
+                        className={
+                          used >= 90
+                            ? "h-full rounded-full bg-danger-foreground"
+                            : "h-full rounded-full"
+                        }
+                        style={{
+                          flex: used / 100,
+                          ...(used >= 90 ? {} : { backgroundColor: colors[provider] }),
+                        }}
+                      />
+                      <View style={{ flex: 1 - used / 100 }} />
+                    </View>
+                  </View>
+                );
+              })
+            )}
           </View>
         );
       })}

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -10,6 +10,7 @@ import {
   formatLimitReset,
   formatLimitWindowLabel,
   formatObservedAgo,
+  latestObservedAt,
   formatPercent,
   formatTokens,
   formatUsd,
@@ -390,10 +391,7 @@ function LimitsSection(props: {
   return (
     <SettingsSection title="Subscription limits" card>
       {rows.map(({ provider, entry }, index) => {
-        const observedAt = entry?.windows.reduce(
-          (latest, window) => (window.observedAt > latest ? window.observedAt : latest),
-          "",
-        );
+        const observedAt = entry === undefined ? null : latestObservedAt(entry.windows);
         return (
           <View
             key={provider}

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -414,13 +414,21 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   } satisfies CodexAppServerProviderSnapshot;
 });
 
-export const probeCodexSkillsForCwd = Effect.fn("probeCodexSkillsForCwd")(function* (input: {
+export interface CodexAppServerLaunch {
   readonly binaryPath: string;
   readonly homePath?: string;
   readonly launchArgs?: string;
   readonly cwd: string;
   readonly environment?: NodeJS.ProcessEnv;
-}) {
+}
+
+/**
+ * Spawns a short-lived `codex app-server`, completes the handshake, and hands
+ * back the client. The process lives for the caller's scope.
+ */
+const connectCodexAppServer = Effect.fn("connectCodexAppServer")(function* (
+  input: CodexAppServerLaunch,
+) {
   const resolvedHomePath = input.homePath ? expandHomePath(input.homePath) : undefined;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const environment = {
@@ -457,8 +465,23 @@ export const probeCodexSkillsForCwd = Effect.fn("probeCodexSkillsForCwd")(functi
   );
   yield* client.request("initialize", buildCodexInitializeParams());
   yield* client.notify("initialized", undefined);
+  return client;
+});
+
+export const probeCodexSkillsForCwd = Effect.fn("probeCodexSkillsForCwd")(function* (
+  input: CodexAppServerLaunch,
+) {
+  const client = yield* connectCodexAppServer(input);
   const skillsResponse = yield* client.request("skills/list", { cwds: [input.cwd] });
   return parseCodexSkillsListResponse(skillsResponse, input.cwd);
+});
+
+/** Live subscription limits for the account the Codex CLI is signed into. */
+export const readCodexRateLimits = Effect.fn("readCodexRateLimits")(function* (
+  input: CodexAppServerLaunch,
+) {
+  const client = yield* connectCodexAppServer(input);
+  return yield* client.request("account/rateLimits/read", undefined);
 });
 
 const emptyCodexModelsFromSettings = (codexSettings: CodexSettings): ServerProvider["models"] => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -118,6 +118,7 @@ import * as NativeTelemetryClient from "./resourceTelemetry/NativeTelemetryClien
 import * as ResourceAttribution from "./resourceTelemetry/ResourceAttribution.ts";
 import * as ResourceMonitorBinary from "./resourceTelemetry/ResourceMonitorBinary.ts";
 import * as ResourceTelemetry from "./resourceTelemetry/ResourceTelemetry.ts";
+import * as UsageLimits from "./usage/usageLimits.ts";
 import * as UsageService from "./usage/UsageService.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import {
@@ -186,12 +187,15 @@ const DesktopAppUpdateLayerLive = DesktopAppUpdate.layer.pipe(
   Layer.provide(DesktopTelemetryReceiverLayerLive),
 );
 
+const UsageLayerLive = UsageService.layer.pipe(
+  Layer.provide(ServerSettingsLayerLive),
+  Layer.provide(UsageLimits.layer.pipe(Layer.provide(ServerSettingsLayerLive))),
+);
+
 const BackgroundLayerLive = BackgroundPolicy.layer.pipe(
   Layer.provide(HostPowerMonitorLayerLive),
   Layer.provideMerge(ServerSettingsLayerLive),
 );
-
-const UsageLayerLive = UsageService.layer.pipe(Layer.provide(ServerSettingsLayerLive));
 
 const ResourceDiagnosticsLayerLive = Layer.mergeAll(
   ResourceTelemetryLayerLive,
@@ -441,8 +445,9 @@ const AntigravityInstallationRefreshLive = Layer.effectDiscard(
 const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(AntigravityInstallationRefreshLive),
   Layer.provideMerge(ProviderAuthServiceLive),
-  // Core Services
-  Layer.provideMerge(ServerSettingsLayerLive),
+  // Core Services. Subscription limits listen on the provider event stream,
+  // so usage sits ahead of the provider runtime that satisfies it.
+  Layer.provideMerge(Layer.mergeAll(ServerSettingsLayerLive, UsageLayerLive)),
   Layer.provideMerge(CheckpointingLayerLive),
   Layer.provideMerge(
     Layer.mergeAll(SourceControlProviderRegistryLayerLive, PullRequestServiceLive),
@@ -500,7 +505,6 @@ const RuntimeDependenciesLive = RuntimeCoreDependenciesLive.pipe(
   // Misc.
   Layer.provideMerge(BackgroundLayerLive),
   Layer.provideMerge(ResourceDiagnosticsLayerLive),
-  Layer.provideMerge(UsageLayerLive),
   Layer.provideMerge(TraceDiagnostics.layer),
   Layer.provideMerge(AnalyticsService.layer),
   Layer.provideMerge(ExternalLauncher.layer),

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -19,6 +19,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
+import * as UsageLimits from "./usageLimits.ts";
 import * as UsageService from "./UsageService.ts";
 
 function claudeLine(id: number, outputTokens: number): string {
@@ -73,6 +74,7 @@ const serviceLayers = (input: {
   ServerConfig.layerTest(process.cwd(), { prefix: input.prefix }).pipe(
     Layer.provideMerge(NodeServices.layer),
     Layer.provideMerge(ServerSettings.layerTest(input.settings)),
+    Layer.provideMerge(UsageLimits.layerTest),
     Layer.provideMerge(
       Layer.succeed(
         HttpClient.HttpClient,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -44,6 +44,7 @@ import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
+import { UsageLimitsStore } from "./usageLimits.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
   listTranscriptFiles,
@@ -126,6 +127,7 @@ export const layerTest = Layer.succeed(
         sources: [],
         pricing: EMPTY_PRICING,
         scanDurationMs: 0,
+        limits: [],
       }),
     refreshRates: Effect.succeed(EMPTY_PRICING),
   }),
@@ -138,6 +140,7 @@ export const make = Effect.gen(function* () {
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
   const hostEnvironment = yield* HostProcessEnvironment;
+  const limits = yield* UsageLimitsStore;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -455,9 +458,11 @@ export const make = Effect.gen(function* () {
     // Pricing only matters once records are aggregated, so the rate table
     // loads while transcripts stream instead of gating them: a cold rates
     // fetch on a slow network no longer delays the scan by its own timeout.
-    const [, scannedDirs] = yield* Effect.all([ensureRates(false), collectDirs(windowStartMs)], {
-      concurrency: 2,
-    });
+    // The live Codex limit read rides alongside for the same reason.
+    const [, scannedDirs] = yield* Effect.all(
+      [ensureRates(false), collectDirs(windowStartMs), limits.refresh],
+      { concurrency: 3 },
+    );
 
     const aggregator = new UsageAggregator({
       timeZone: input.timeZone,
@@ -530,6 +535,7 @@ export const make = Effect.gen(function* () {
     yield* persistScanCache();
 
     const aggregated = aggregator.finish();
+    const knownLimits = yield* limits.read;
     const readAt = yield* DateTime.now;
     const finishedAtMs = yield* Clock.currentTimeMillis;
 
@@ -543,6 +549,7 @@ export const make = Effect.gen(function* () {
       sources,
       pricing: pricing(),
       scanDurationMs: Math.max(0, finishedAtMs - startedAtMs),
+      limits: knownLimits,
     } satisfies UsageSummary;
   });
 

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -30,6 +30,7 @@ import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -78,6 +79,14 @@ const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /** Longest window the UI offers, plus slack. Older entries are pruned. */
 const CACHE_RETENTION_DAYS = 90;
+
+/**
+ * How long a response waits for the live limits read after the scan is
+ * done. A healthy Codex handshake is well inside this; a stalled one keeps
+ * running detached and lands for the next request instead of holding this
+ * one.
+ */
+const LIMITS_REFRESH_GRACE_MS = 3_000;
 
 /** On-disk shape of the rate snapshot. */
 const RatesCacheFile = Schema.Struct({
@@ -455,14 +464,16 @@ export const make = Effect.gen(function* () {
     const windowStartMs =
       (hourlyWindow?.sinceTimeMs ?? DateTime.toEpochMillis(windowStart.value)) - MTIME_SLACK_MS;
 
+    // The live limits read runs detached from the start so it overlaps the
+    // scan; the response waits for it only briefly once the scan is done.
+    const refreshFiber = yield* Effect.forkDetach(limits.refresh);
+
     // Pricing only matters once records are aggregated, so the rate table
     // loads while transcripts stream instead of gating them: a cold rates
     // fetch on a slow network no longer delays the scan by its own timeout.
-    // The live Codex limit read rides alongside for the same reason.
-    const [, scannedDirs] = yield* Effect.all(
-      [ensureRates(false), collectDirs(windowStartMs), limits.refresh],
-      { concurrency: 3 },
-    );
+    const [, scannedDirs] = yield* Effect.all([ensureRates(false), collectDirs(windowStartMs)], {
+      concurrency: 2,
+    });
 
     const aggregator = new UsageAggregator({
       timeZone: input.timeZone,
@@ -535,6 +546,7 @@ export const make = Effect.gen(function* () {
     yield* persistScanCache();
 
     const aggregated = aggregator.finish();
+    yield* Fiber.join(refreshFiber).pipe(Effect.timeoutOption(LIMITS_REFRESH_GRACE_MS));
     const knownLimits = yield* limits.read;
     const readAt = yield* DateTime.now;
     const finishedAtMs = yield* Clock.currentTimeMillis;

--- a/apps/server/src/usage/usageLimits.test.ts
+++ b/apps/server/src/usage/usageLimits.test.ts
@@ -1,0 +1,367 @@
+// @effect-diagnostics nodeBuiltinImport:off - the suite removes the temp state
+// directory it persisted into, outside the store's Effect FileSystem.
+import * as NodeFSP from "node:fs/promises";
+
+import { assert, describe, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  EventId,
+  ProviderDriverKind,
+  ThreadId,
+  type ProviderRuntimeAccountRateLimitsUpdatedEvent,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
+import {
+  limitsFromRuntimeEvent,
+  makeStore,
+  mergeProviderLimits,
+  parseClaudeRateLimitEvent,
+  parseCodexRateLimits,
+  parseCodexRateLimitsRead,
+} from "./usageLimits.ts";
+
+const OBSERVED_AT = "2026-08-10T12:00:00.000Z";
+const LATER = "2026-08-10T13:00:00.000Z";
+
+function rateLimitEvent(
+  provider: string,
+  rateLimits: unknown,
+): ProviderRuntimeAccountRateLimitsUpdatedEvent {
+  return {
+    type: "account.rate-limits.updated",
+    eventId: EventId.make("evt-1"),
+    provider: ProviderDriverKind.make(provider),
+    threadId: ThreadId.make("thread-1"),
+    createdAt: OBSERVED_AT,
+    payload: { rateLimits },
+  };
+}
+
+describe("parseCodexRateLimits", () => {
+  it("names Codex's unnamed windows by their length", () => {
+    const limits = parseCodexRateLimits(
+      {
+        planType: "pro",
+        primary: { usedPercent: 42, windowDurationMins: 300, resetsAt: 1_786_200_000 },
+        secondary: { usedPercent: 18, windowDurationMins: 10_080, resetsAt: null },
+      },
+      OBSERVED_AT,
+    );
+
+    assert.deepStrictEqual(limits, {
+      provider: "codex",
+      plan: "Pro",
+      windows: [
+        {
+          id: "five_hour",
+          scope: null,
+          durationMinutes: 300,
+          usedPercent: 42,
+          resetsAt: "2026-08-08T14:40:00.000Z",
+          observedAt: OBSERVED_AT,
+        },
+        {
+          id: "seven_day",
+          scope: null,
+          durationMinutes: 10_080,
+          usedPercent: 18,
+          resetsAt: null,
+          observedAt: OBSERVED_AT,
+        },
+      ],
+    });
+  });
+
+  it("keeps Codex's own key for a window of unfamiliar length", () => {
+    const limits = parseCodexRateLimits(
+      { primary: { usedPercent: 5, windowDurationMins: 60 } },
+      OBSERVED_AT,
+    );
+    assert.strictEqual(limits?.windows[0]?.id, "primary");
+    assert.strictEqual(limits?.plan, null);
+  });
+
+  it("keeps separately metered buckets apart from the plan's own windows", () => {
+    const limits = parseCodexRateLimitsRead(
+      {
+        rateLimits: {
+          limitId: "codex",
+          planType: "pro",
+          primary: { usedPercent: 16, windowDurationMins: 10_080, resetsAt: null },
+          secondary: null,
+        },
+        rateLimitsByLimitId: {
+          codex: {
+            limitId: "codex",
+            primary: { usedPercent: 16, windowDurationMins: 10_080, resetsAt: null },
+          },
+          codex_spark: {
+            limitId: "codex_spark",
+            limitName: "GPT-5.3-Codex-Spark",
+            primary: { usedPercent: 3, windowDurationMins: 300, resetsAt: null },
+            secondary: { usedPercent: 1, windowDurationMins: 10_080, resetsAt: null },
+          },
+        },
+      },
+      OBSERVED_AT,
+    );
+
+    assert.deepStrictEqual(
+      limits?.windows.map((window) => [window.id, window.scope, window.usedPercent]),
+      [
+        ["seven_day", null, 16],
+        ["codex_spark:five_hour", "GPT-5.3-Codex-Spark", 3],
+        ["codex_spark:seven_day", "GPT-5.3-Codex-Spark", 1],
+      ],
+    );
+  });
+
+  it("reports nothing for a snapshot without windows", () => {
+    assert.strictEqual(parseCodexRateLimits({ planType: "pro" }, OBSERVED_AT), null);
+    assert.strictEqual(parseCodexRateLimits("nonsense", OBSERVED_AT), null);
+  });
+});
+
+describe("parseClaudeRateLimitEvent", () => {
+  it("reads every window when the CLI attaches the per-window breakdown", () => {
+    const limits = parseClaudeRateLimitEvent(
+      {
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "allowed",
+          rateLimitType: "five_hour",
+          utilization: 0.2,
+          resetsAt: 1_786_200_000,
+          unifiedWindows: {
+            five_hour: { utilization: 0.2, resetsAt: 1_786_200_000 },
+            seven_day: { utilization: 0.615, resetsAt: 1_786_500_000 },
+            seven_day_overage_included: null,
+          },
+        },
+      },
+      OBSERVED_AT,
+    );
+
+    assert.deepStrictEqual(
+      limits?.windows.map((window) => [window.id, window.usedPercent, window.resetsAt]),
+      [
+        ["five_hour", 20, "2026-08-08T14:40:00.000Z"],
+        ["seven_day", 61.5, "2026-08-12T02:00:00.000Z"],
+      ],
+    );
+  });
+
+  it("falls back to the one representative window older CLIs report", () => {
+    const limits = parseClaudeRateLimitEvent(
+      {
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "allowed_warning",
+          rateLimitType: "seven_day",
+          utilization: 0.81,
+          resetsAt: 1_786_500_000,
+        },
+      },
+      OBSERVED_AT,
+    );
+
+    assert.deepStrictEqual(limits, {
+      provider: "claude",
+      plan: null,
+      windows: [
+        {
+          id: "seven_day",
+          scope: null,
+          durationMinutes: 10_080,
+          usedPercent: 81,
+          resetsAt: "2026-08-12T02:00:00.000Z",
+          observedAt: OBSERVED_AT,
+        },
+      ],
+    });
+  });
+
+  it("ignores overage and events without a utilization figure", () => {
+    assert.strictEqual(
+      parseClaudeRateLimitEvent(
+        { rate_limit_info: { status: "allowed", rateLimitType: "overage", utilization: 0.03 } },
+        OBSERVED_AT,
+      ),
+      null,
+    );
+    assert.strictEqual(
+      parseClaudeRateLimitEvent(
+        { rate_limit_info: { status: "allowed", rateLimitType: "five_hour" } },
+        OBSERVED_AT,
+      ),
+      null,
+    );
+  });
+});
+
+describe("limitsFromRuntimeEvent", () => {
+  it("unwraps the Codex notification envelope", () => {
+    const limits = limitsFromRuntimeEvent(
+      rateLimitEvent("codex", {
+        rateLimits: { primary: { usedPercent: 7, windowDurationMins: 300 } },
+      }),
+    );
+    assert.strictEqual(limits?.provider, "codex");
+    assert.strictEqual(limits?.windows[0]?.usedPercent, 7);
+  });
+
+  it("routes Claude events by driver kind and ignores other drivers", () => {
+    const claude = limitsFromRuntimeEvent(
+      rateLimitEvent("claudeAgent", {
+        rate_limit_info: { status: "allowed", rateLimitType: "five_hour", utilization: 0.12 },
+      }),
+    );
+    assert.strictEqual(claude?.provider, "claude");
+    assert.strictEqual(claude?.windows[0]?.usedPercent, 12);
+    assert.strictEqual(
+      limitsFromRuntimeEvent(
+        rateLimitEvent("opencode", {
+          rate_limit_info: { status: "allowed", rateLimitType: "five_hour", utilization: 0.12 },
+        }),
+      ),
+      null,
+    );
+  });
+});
+
+describe("mergeProviderLimits", () => {
+  it("keeps windows the update did not mention and orders by length", () => {
+    const merged = mergeProviderLimits(
+      {
+        provider: "claude",
+        plan: null,
+        windows: [
+          {
+            id: "seven_day",
+            scope: null,
+            durationMinutes: 10_080,
+            usedPercent: 60,
+            resetsAt: null,
+            observedAt: OBSERVED_AT,
+          },
+        ],
+      },
+      {
+        provider: "claude",
+        plan: null,
+        windows: [
+          {
+            id: "five_hour",
+            scope: null,
+            durationMinutes: 300,
+            usedPercent: 20,
+            resetsAt: null,
+            observedAt: LATER,
+          },
+        ],
+      },
+    );
+
+    assert.deepStrictEqual(
+      merged.windows.map((window) => [window.id, window.usedPercent]),
+      [
+        ["five_hour", 20],
+        ["seven_day", 60],
+      ],
+    );
+  });
+
+  it("never replaces a reading with an older one", () => {
+    const merged = mergeProviderLimits(
+      {
+        provider: "codex",
+        plan: "Pro",
+        windows: [
+          {
+            id: "five_hour",
+            scope: null,
+            durationMinutes: 300,
+            usedPercent: 50,
+            resetsAt: null,
+            observedAt: LATER,
+          },
+        ],
+      },
+      {
+        provider: "codex",
+        plan: null,
+        windows: [
+          {
+            id: "five_hour",
+            scope: null,
+            durationMinutes: 300,
+            usedPercent: 10,
+            resetsAt: null,
+            observedAt: OBSERVED_AT,
+          },
+        ],
+      },
+    );
+
+    assert.strictEqual(merged.windows[0]?.usedPercent, 50);
+    assert.strictEqual(merged.plan, "Pro");
+  });
+});
+
+describe("UsageLimitsStore", () => {
+  const storeLayers = (prefix: string) =>
+    ServerConfig.layerTest(process.cwd(), { prefix }).pipe(
+      Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(ServerSettings.layerTest({ providers: { codex: { enabled: false } } })),
+    );
+
+  it.live("persists readings so a restarted store starts from the last figure", () =>
+    Effect.gen(function* () {
+      // Built once: each build of the config layer is a fresh temp directory.
+      const services = yield* Layer.build(storeLayers("usage-limits-test"));
+      const first = yield* makeStore.pipe(Effect.provide(services));
+      const config = yield* ServerConfig.ServerConfig.pipe(Effect.provide(services));
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => NodeFSP.rm(config.stateDir, { recursive: true, force: true })),
+      );
+
+      yield* first.record({
+        provider: "claude",
+        plan: null,
+        windows: [
+          {
+            id: "five_hour",
+            scope: null,
+            durationMinutes: 300,
+            usedPercent: 33,
+            resetsAt: null,
+            observedAt: OBSERVED_AT,
+          },
+        ],
+      });
+
+      const second = yield* makeStore.pipe(Effect.provide(services));
+      const limits = yield* second.read;
+      assert.strictEqual(limits.length, 1);
+      assert.strictEqual(limits[0]?.windows[0]?.usedPercent, 33);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("refresh leaves the store untouched while Codex is disabled", () =>
+    Effect.gen(function* () {
+      const services = yield* Layer.build(storeLayers("usage-limits-disabled-test"));
+      const store = yield* makeStore.pipe(Effect.provide(services));
+      const config = yield* ServerConfig.ServerConfig.pipe(Effect.provide(services));
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => NodeFSP.rm(config.stateDir, { recursive: true, force: true })),
+      );
+
+      yield* store.refresh;
+      assert.deepStrictEqual(yield* store.read, []);
+    }).pipe(Effect.scoped),
+  );
+});

--- a/apps/server/src/usage/usageLimits.test.ts
+++ b/apps/server/src/usage/usageLimits.test.ts
@@ -277,6 +277,36 @@ describe("mergeProviderLimits", () => {
     );
   });
 
+  it("lets a complete reading drop a bucket the account no longer reports", () => {
+    const spark = {
+      id: "codex_spark:five_hour",
+      scope: "Spark",
+      durationMinutes: 300,
+      usedPercent: 3,
+      resetsAt: null,
+      observedAt: OBSERVED_AT,
+    };
+    const weekly = {
+      id: "seven_day",
+      scope: null,
+      durationMinutes: 10_080,
+      usedPercent: 16,
+      resetsAt: null,
+      observedAt: LATER,
+    };
+    const previous = { provider: "codex" as const, plan: "Pro", windows: [weekly, spark] };
+    const next = { provider: "codex" as const, plan: "Pro", windows: [weekly] };
+
+    assert.deepStrictEqual(
+      mergeProviderLimits(previous, next).windows.map((window) => window.id),
+      ["seven_day", "codex_spark:five_hour"],
+    );
+    assert.deepStrictEqual(
+      mergeProviderLimits(previous, next, { complete: true }).windows.map((window) => window.id),
+      ["seven_day"],
+    );
+  });
+
   it("never replaces a reading with an older one", () => {
     const merged = mergeProviderLimits(
       {
@@ -310,6 +340,22 @@ describe("mergeProviderLimits", () => {
     );
 
     assert.strictEqual(merged.windows[0]?.usedPercent, 50);
+    assert.strictEqual(merged.plan, "Pro");
+  });
+
+  it("keeps the current plan label when an older observation carries a different one", () => {
+    const window = {
+      id: "five_hour",
+      scope: null,
+      durationMinutes: 300,
+      usedPercent: 50,
+      resetsAt: null,
+    };
+    const merged = mergeProviderLimits(
+      { provider: "codex", plan: "Pro", windows: [{ ...window, observedAt: LATER }] },
+      { provider: "codex", plan: "Plus", windows: [{ ...window, observedAt: OBSERVED_AT }] },
+    );
+
     assert.strictEqual(merged.plan, "Pro");
   });
 });

--- a/apps/server/src/usage/usageLimits.test.ts
+++ b/apps/server/src/usage/usageLimits.test.ts
@@ -7,6 +7,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   EventId,
   ProviderDriverKind,
+  ProviderInstanceId,
   ThreadId,
   type ProviderRuntimeAccountRateLimitsUpdatedEvent,
 } from "@t3tools/contracts";
@@ -22,6 +23,7 @@ import {
   parseClaudeRateLimitEvent,
   parseCodexRateLimits,
   parseCodexRateLimitsRead,
+  resolveCodexRefreshSettings,
 } from "./usageLimits.ts";
 
 const OBSERVED_AT = "2026-08-10T12:00:00.000Z";
@@ -310,6 +312,42 @@ describe("mergeProviderLimits", () => {
     assert.strictEqual(merged.windows[0]?.usedPercent, 50);
     assert.strictEqual(merged.plan, "Pro");
   });
+});
+
+describe("resolveCodexRefreshSettings", () => {
+  it.live("prefers an explicit Codex instance over the legacy provider block", () =>
+    Effect.gen(function* () {
+      const settingsService = yield* ServerSettings.ServerSettingsService.pipe(
+        Effect.provide(
+          ServerSettings.layerTest({
+            providers: { codex: { binaryPath: "legacy-codex" } },
+            providerInstances: {
+              [ProviderInstanceId.make("codex")]: {
+                driver: ProviderDriverKind.make("codex"),
+                config: { binaryPath: "instance-codex" },
+              },
+            },
+          }).pipe(Layer.provideMerge(NodeServices.layer)),
+        ),
+      );
+      const settings = yield* settingsService.getSettings;
+      assert.strictEqual(resolveCodexRefreshSettings(settings).binaryPath, "instance-codex");
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("falls back to the legacy provider block without an explicit instance", () =>
+    Effect.gen(function* () {
+      const settingsService = yield* ServerSettings.ServerSettingsService.pipe(
+        Effect.provide(
+          ServerSettings.layerTest({ providers: { codex: { binaryPath: "legacy-codex" } } }).pipe(
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      );
+      const settings = yield* settingsService.getSettings;
+      assert.strictEqual(resolveCodexRefreshSettings(settings).binaryPath, "legacy-codex");
+    }).pipe(Effect.scoped),
+  );
 });
 
 describe("UsageLimitsStore", () => {

--- a/apps/server/src/usage/usageLimits.test.ts
+++ b/apps/server/src/usage/usageLimits.test.ts
@@ -17,7 +17,7 @@ import * as ServerConfig from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import {
   limitsFromRuntimeEvent,
-  makeStore,
+  make,
   mergeProviderLimits,
   parseClaudeRateLimitEvent,
   parseCodexRateLimits,
@@ -323,7 +323,7 @@ describe("UsageLimitsStore", () => {
     Effect.gen(function* () {
       // Built once: each build of the config layer is a fresh temp directory.
       const services = yield* Layer.build(storeLayers("usage-limits-test"));
-      const first = yield* makeStore.pipe(Effect.provide(services));
+      const first = yield* make.pipe(Effect.provide(services));
       const config = yield* ServerConfig.ServerConfig.pipe(Effect.provide(services));
       yield* Effect.addFinalizer(() =>
         Effect.promise(() => NodeFSP.rm(config.stateDir, { recursive: true, force: true })),
@@ -344,7 +344,7 @@ describe("UsageLimitsStore", () => {
         ],
       });
 
-      const second = yield* makeStore.pipe(Effect.provide(services));
+      const second = yield* make.pipe(Effect.provide(services));
       const limits = yield* second.read;
       assert.strictEqual(limits.length, 1);
       assert.strictEqual(limits[0]?.windows[0]?.usedPercent, 33);
@@ -354,7 +354,7 @@ describe("UsageLimitsStore", () => {
   it.live("refresh leaves the store untouched while Codex is disabled", () =>
     Effect.gen(function* () {
       const services = yield* Layer.build(storeLayers("usage-limits-disabled-test"));
-      const store = yield* makeStore.pipe(Effect.provide(services));
+      const store = yield* make.pipe(Effect.provide(services));
       const config = yield* ServerConfig.ServerConfig.pipe(Effect.provide(services));
       yield* Effect.addFinalizer(() =>
         Effect.promise(() => NodeFSP.rm(config.stateDir, { recursive: true, force: true })),

--- a/apps/server/src/usage/usageLimits.ts
+++ b/apps/server/src/usage/usageLimits.ts
@@ -1,0 +1,435 @@
+/**
+ * Subscription limits per provider, as the provider CLIs report them.
+ *
+ * Codex answers `account/rateLimits/read` on demand and pushes
+ * `account/rateLimits/updated` during turns. Claude Code only pushes a
+ * `rate_limit_event` inside a running turn, carrying the single window closest
+ * to exhaustion. Both reach the store as `account.rate-limits.updated` runtime
+ * events; the latest figure per window is kept and persisted so the usage page
+ * has something to show before the next turn runs.
+ *
+ * @module usageLimits
+ */
+import {
+  type ProviderRuntimeAccountRateLimitsUpdatedEvent,
+  type UsageLimitWindow,
+  type UsageProviderKind,
+  UsageProviderLimits,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import { ServerConfig } from "../config.ts";
+import { ProviderService } from "../provider/Services/ProviderService.ts";
+import { readCodexRateLimits } from "../provider/Layers/CodexProvider.ts";
+import { resolveCodexLaunchArgs } from "../provider/Layers/codexLaunchArgs.ts";
+import { forkParked } from "../serverActivation.ts";
+import * as ServerSettings from "../serverSettings.ts";
+
+/** A cold app-server handshake is well under a second; anything longer is a stuck CLI. */
+const CODEX_READ_TIMEOUT = Duration.seconds(8);
+
+const FIVE_HOURS_MINUTES = 5 * 60;
+const SEVEN_DAYS_MINUTES = 7 * 24 * 60;
+
+const OptionalNumber = Schema.optionalKey(Schema.NullOr(Schema.Number));
+const OptionalString = Schema.optionalKey(Schema.NullOr(Schema.String));
+
+/** The subset of Codex's `RateLimitSnapshot` the page shows. */
+const CodexRateLimitWindow = Schema.Struct({
+  usedPercent: Schema.Number,
+  windowDurationMins: OptionalNumber,
+  resetsAt: OptionalNumber,
+});
+const CodexRateLimitSnapshot = Schema.Struct({
+  limitId: OptionalString,
+  limitName: OptionalString,
+  planType: OptionalString,
+  primary: Schema.optionalKey(Schema.NullOr(CodexRateLimitWindow)),
+  secondary: Schema.optionalKey(Schema.NullOr(CodexRateLimitWindow)),
+});
+type CodexRateLimitSnapshot = typeof CodexRateLimitSnapshot.Type;
+const decodeCodexSnapshot = Schema.decodeUnknownOption(CodexRateLimitSnapshot);
+/** `account/rateLimits/read`: the plan's bucket plus any separately metered ones. */
+const CodexRateLimitsRead = Schema.Struct({
+  rateLimits: CodexRateLimitSnapshot,
+  rateLimitsByLimitId: Schema.optionalKey(
+    Schema.NullOr(Schema.Record(Schema.String, CodexRateLimitSnapshot)),
+  ),
+});
+const decodeCodexRead = Schema.decodeUnknownOption(CodexRateLimitsRead);
+
+/** Codex's default bucket; other ids are separately metered model families. */
+const CODEX_MAIN_LIMIT_ID = "codex";
+
+/**
+ * The subset of the Claude Agent SDK's `rate_limit_event` the page shows.
+ *
+ * `utilization` is a 0-1 fraction and `resetsAt` unix seconds. Recent CLIs
+ * also attach `unifiedWindows`, every window at once; older ones only carry
+ * the single representative window at the top level.
+ */
+const ClaudeRateLimitWindow = Schema.Struct({
+  utilization: Schema.Number,
+  resetsAt: OptionalNumber,
+});
+const ClaudeRateLimitEvent = Schema.Struct({
+  rate_limit_info: Schema.Struct({
+    rateLimitType: OptionalString,
+    utilization: OptionalNumber,
+    resetsAt: OptionalNumber,
+    unifiedWindows: Schema.optionalKey(
+      Schema.NullOr(Schema.Record(Schema.String, Schema.NullOr(ClaudeRateLimitWindow))),
+    ),
+  }),
+});
+const decodeClaudeEvent = Schema.decodeUnknownOption(ClaudeRateLimitEvent);
+
+const CODEX_PLAN_LABELS: Record<string, string> = {
+  free: "Free",
+  go: "Go",
+  plus: "Plus",
+  pro: "Pro",
+  prolite: "Pro 5x",
+  team: "Team",
+  self_serve_business_prolite: "Business",
+  self_serve_business_usage_based: "Business",
+  business: "Business",
+  ent26: "Enterprise",
+  enterprise_cbp_automation: "Enterprise",
+  enterprise_cbp_usage_based: "Enterprise",
+  enterprise: "Enterprise",
+  edu: "Edu",
+  edu_plus: "Edu",
+  edu_pro: "Edu",
+};
+
+/** Providers with a `rate_limit`-shaped payload, keyed by driver kind. */
+const PROVIDER_BY_DRIVER: Partial<Record<string, UsageProviderKind>> = {
+  codex: "codex",
+  claudeAgent: "claude",
+};
+
+function isoFromUnixSeconds(seconds: number | null | undefined): string | null {
+  if (seconds === null || seconds === undefined || !Number.isFinite(seconds)) return null;
+  return DateTime.formatIso(DateTime.makeUnsafe(seconds * 1000));
+}
+
+/**
+ * Codex's primary/secondary windows have no name of their own, so they are
+ * mapped onto Claude's ids by duration and both providers label alike.
+ */
+function codexWindowId(key: "primary" | "secondary", durationMinutes: number | null): string {
+  if (durationMinutes === FIVE_HOURS_MINUTES) return "five_hour";
+  if (durationMinutes === SEVEN_DAYS_MINUTES) return "seven_day";
+  return key;
+}
+
+/**
+ * One snapshot's windows. A separately metered bucket keeps its id in the
+ * window id so a rolling update for it replaces its own windows, not the
+ * plan's.
+ */
+function codexSnapshotWindows(
+  snapshot: CodexRateLimitSnapshot,
+  observedAt: string,
+): UsageLimitWindow[] {
+  const limitId = snapshot.limitId ?? CODEX_MAIN_LIMIT_ID;
+  const isMain = limitId === CODEX_MAIN_LIMIT_ID;
+  const scope = isMain ? null : (snapshot.limitName ?? limitId);
+  const windows: UsageLimitWindow[] = [];
+  for (const key of ["primary", "secondary"] as const) {
+    const window = snapshot[key];
+    if (!window) continue;
+    const durationMinutes =
+      window.windowDurationMins === null || window.windowDurationMins === undefined
+        ? null
+        : Math.max(0, Math.round(window.windowDurationMins));
+    const base = codexWindowId(key, durationMinutes);
+    windows.push({
+      id: isMain ? base : `${limitId}:${base}`,
+      scope,
+      durationMinutes,
+      usedPercent: window.usedPercent,
+      resetsAt: isoFromUnixSeconds(window.resetsAt),
+      observedAt,
+    });
+  }
+  return windows;
+}
+
+function codexLimits(
+  planType: string | null | undefined,
+  windows: UsageLimitWindow[],
+): UsageProviderLimits | null {
+  if (windows.length === 0) return null;
+  return {
+    provider: "codex",
+    plan: planType ? (CODEX_PLAN_LABELS[planType] ?? null) : null,
+    windows,
+  };
+}
+
+/** Reads one `RateLimitSnapshot`, the shape `account/rateLimits/updated` pushes. */
+export function parseCodexRateLimits(
+  snapshot: unknown,
+  observedAt: string,
+): UsageProviderLimits | null {
+  const decoded = decodeCodexSnapshot(snapshot);
+  if (decoded._tag === "None") return null;
+  return codexLimits(decoded.value.planType, codexSnapshotWindows(decoded.value, observedAt));
+}
+
+/** Reads an `account/rateLimits/read` response, including separately metered buckets. */
+export function parseCodexRateLimitsRead(
+  response: unknown,
+  observedAt: string,
+): UsageProviderLimits | null {
+  const decoded = decodeCodexRead(response);
+  if (decoded._tag === "None") return null;
+  const main = decoded.value.rateLimits;
+  const windows = codexSnapshotWindows(main, observedAt);
+  const mainId = main.limitId ?? CODEX_MAIN_LIMIT_ID;
+  for (const [limitId, snapshot] of Object.entries(decoded.value.rateLimitsByLimitId ?? {})) {
+    if (limitId === mainId) continue;
+    windows.push(...codexSnapshotWindows({ ...snapshot, limitId }, observedAt));
+  }
+  return codexLimits(main.planType, windows);
+}
+
+/** Overage is a billing mode, not a rolling window; anything else is 5h or 7d. */
+function claudeWindowDuration(id: string): number | null {
+  if (id === "five_hour") return FIVE_HOURS_MINUTES;
+  if (id.startsWith("seven_day")) return SEVEN_DAYS_MINUTES;
+  return null;
+}
+
+/**
+ * Reads one Claude Agent SDK `rate_limit_event`. With `unifiedWindows` the
+ * event yields every window; without it only the representative one, and the
+ * store merges successive events into the full picture.
+ */
+export function parseClaudeRateLimitEvent(
+  message: unknown,
+  observedAt: string,
+): UsageProviderLimits | null {
+  const decoded = decodeClaudeEvent(message);
+  if (decoded._tag === "None") return null;
+  const info = decoded.value.rate_limit_info;
+  const windows: UsageLimitWindow[] = [];
+  const push = (id: string, utilization: number, resetsAt: number | null | undefined) => {
+    const durationMinutes = claudeWindowDuration(id);
+    if (durationMinutes === null || !Number.isFinite(utilization)) return;
+    windows.push({
+      id,
+      scope: null,
+      durationMinutes,
+      usedPercent: utilization * 100,
+      resetsAt: isoFromUnixSeconds(resetsAt),
+      observedAt,
+    });
+  };
+  for (const [id, window] of Object.entries(info.unifiedWindows ?? {})) {
+    if (window) push(id, window.utilization, window.resetsAt);
+  }
+  if (
+    windows.length === 0 &&
+    info.rateLimitType &&
+    info.utilization !== null &&
+    info.utilization !== undefined
+  ) {
+    push(info.rateLimitType, info.utilization, info.resetsAt);
+  }
+  if (windows.length === 0) return null;
+  return { provider: "claude", plan: null, windows };
+}
+
+/** Translates a runtime event from either adapter into limits, or null when it carries none. */
+export function limitsFromRuntimeEvent(
+  event: ProviderRuntimeAccountRateLimitsUpdatedEvent,
+): UsageProviderLimits | null {
+  const provider = PROVIDER_BY_DRIVER[event.provider];
+  if (provider === "codex") {
+    const payload = event.payload.rateLimits;
+    const snapshot =
+      typeof payload === "object" && payload !== null && "rateLimits" in payload
+        ? payload.rateLimits
+        : payload;
+    return parseCodexRateLimits(snapshot, event.createdAt);
+  }
+  if (provider === "claude") {
+    return parseClaudeRateLimitEvent(event.payload.rateLimits, event.createdAt);
+  }
+  return null;
+}
+
+/**
+ * Folds a new observation into what is already known for the provider. Each
+ * window is replaced by its newer reading; windows the update did not mention
+ * are kept, which is what turns Claude's one-window events into a full set.
+ */
+export function mergeProviderLimits(
+  previous: UsageProviderLimits | undefined,
+  next: UsageProviderLimits,
+): UsageProviderLimits {
+  const byId = new Map<string, UsageLimitWindow>();
+  for (const window of previous?.windows ?? []) byId.set(window.id, window);
+  for (const window of next.windows) {
+    const existing = byId.get(window.id);
+    if (existing === undefined || existing.observedAt <= window.observedAt) {
+      byId.set(window.id, window);
+    }
+  }
+  // The plan's own windows first, then each named bucket, shortest window first.
+  const windows = [...byId.values()].sort(
+    (left, right) =>
+      (left.scope ?? "").localeCompare(right.scope ?? "") ||
+      (left.durationMinutes ?? Number.MAX_SAFE_INTEGER) -
+        (right.durationMinutes ?? Number.MAX_SAFE_INTEGER) ||
+      left.id.localeCompare(right.id),
+  );
+  return { provider: next.provider, plan: next.plan ?? previous?.plan ?? null, windows };
+}
+
+function sameWindow(left: UsageLimitWindow, right: UsageLimitWindow): boolean {
+  return (
+    left.id === right.id &&
+    left.scope === right.scope &&
+    left.durationMinutes === right.durationMinutes &&
+    left.usedPercent === right.usedPercent &&
+    left.resetsAt === right.resetsAt &&
+    left.observedAt === right.observedAt
+  );
+}
+
+function sameLimits(left: UsageProviderLimits, right: UsageProviderLimits): boolean {
+  return (
+    left.plan === right.plan &&
+    left.windows.length === right.windows.length &&
+    left.windows.every((window, index) => {
+      const other = right.windows[index];
+      return other !== undefined && sameWindow(window, other);
+    })
+  );
+}
+
+export class UsageLimitsStore extends Context.Service<
+  UsageLimitsStore,
+  {
+    /** Folds one observation into the store. */
+    readonly record: (limits: UsageProviderLimits) => Effect.Effect<void>;
+    /**
+     * Asks providers that can answer on demand (Codex) for a live reading.
+     * Never fails: a provider that cannot answer leaves its last reading in
+     * place.
+     */
+    readonly refresh: Effect.Effect<void>;
+    readonly read: Effect.Effect<readonly UsageProviderLimits[]>;
+  }
+>()("t3/usage/usageLimits/UsageLimitsStore") {}
+
+/** Empty, inert store for suites that only need the usage surface to resolve. */
+export const layerTest = Layer.succeed(
+  UsageLimitsStore,
+  UsageLimitsStore.of({
+    record: () => Effect.void,
+    refresh: Effect.void,
+    read: Effect.succeed([]),
+  }),
+);
+
+const LimitsFile = Schema.Struct({ limits: Schema.Array(UsageProviderLimits) });
+const LimitsFileJson = Schema.fromJsonString(
+  LimitsFile as unknown as Schema.Codec<typeof LimitsFile.Type>,
+);
+const decodeLimitsFile = Schema.decodeUnknownEffect(LimitsFileJson);
+const encodeLimitsFile = Schema.encodeEffect(LimitsFileJson);
+
+/** The in-memory fold and its on-disk mirror; the provider subscription is wired separately. */
+export const makeStore = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const config = yield* ServerConfig;
+  const settingsService = yield* ServerSettings.ServerSettingsService;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  const filePath = path.join(config.stateDir, "usage-limits.json");
+  const byProvider = new Map<UsageProviderKind, UsageProviderLimits>();
+
+  const loaded = yield* fileSystem.readFileString(filePath).pipe(
+    Effect.flatMap((raw) => decodeLimitsFile(raw)),
+    Effect.catchCause(() => Effect.succeed(null)),
+  );
+  for (const limits of loaded?.limits ?? []) byProvider.set(limits.provider, limits);
+
+  const persist = Effect.suspend(() => encodeLimitsFile({ limits: [...byProvider.values()] })).pipe(
+    Effect.flatMap((serialized) => fileSystem.writeFileString(filePath, serialized)),
+    // A file we cannot write is a blank page after the next restart, not a failed turn.
+    Effect.catchCause(() => Effect.void),
+  );
+
+  const record: UsageLimitsStore["Service"]["record"] = (limits) =>
+    Effect.suspend(() => {
+      const previous = byProvider.get(limits.provider);
+      const merged = mergeProviderLimits(previous, limits);
+      // Claude repeats the same reading on every request inside a turn; only
+      // a changed figure is worth a write.
+      if (previous !== undefined && sameLimits(previous, merged)) return Effect.void;
+      byProvider.set(limits.provider, merged);
+      return persist;
+    });
+
+  const refresh: UsageLimitsStore["Service"]["refresh"] = Effect.gen(function* () {
+    const settings = yield* settingsService.getSettings.pipe(
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    const codex = settings?.providers.codex;
+    if (!codex || !codex.enabled) return;
+    const observedAt = DateTime.formatIso(yield* DateTime.now);
+    const response = yield* readCodexRateLimits({
+      binaryPath: codex.binaryPath,
+      homePath: codex.homePath,
+      launchArgs: resolveCodexLaunchArgs(codex.launchArgs, process.env),
+      cwd: process.cwd(),
+      environment: process.env,
+    }).pipe(
+      Effect.scoped,
+      Effect.timeout(CODEX_READ_TIMEOUT),
+      Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      // A missing or signed-out CLI is a normal state, not a failed page.
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    if (response === null) return;
+    const limits = parseCodexRateLimitsRead(response, observedAt);
+    if (limits !== null) yield* record(limits);
+  });
+
+  const read: UsageLimitsStore["Service"]["read"] = Effect.sync(() => [...byProvider.values()]);
+
+  return UsageLimitsStore.of({ record, refresh, read });
+});
+
+/** Production store: persisted, fed by every adapter's rate-limit events. */
+export const layer = Layer.effect(
+  UsageLimitsStore,
+  Effect.gen(function* () {
+    const store = yield* makeStore;
+    const providerService = yield* ProviderService;
+    yield* forkParked(
+      Stream.runForEach(providerService.streamEvents, (event) => {
+        if (event.type !== "account.rate-limits.updated") return Effect.void;
+        const limits = limitsFromRuntimeEvent(event);
+        return limits === null ? Effect.void : store.record(limits);
+      }),
+    );
+    return store;
+  }),
+);

--- a/apps/server/src/usage/usageLimits.ts
+++ b/apps/server/src/usage/usageLimits.ts
@@ -11,7 +11,11 @@
  * @module usageLimits
  */
 import {
+  CodexSettings,
+  defaultInstanceIdForDriver,
+  ProviderDriverKind,
   type ProviderRuntimeAccountRateLimitsUpdatedEvent,
+  type ServerSettings as ServerSettingsSnapshot,
   type UsageLimitWindow,
   type UsageProviderKind,
   UsageProviderLimits,
@@ -24,6 +28,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
@@ -69,6 +74,25 @@ const decodeCodexRead = Schema.decodeUnknownOption(CodexRateLimitsRead);
 
 /** Codex's default bucket; other ids are separately metered model families. */
 const CODEX_MAIN_LIMIT_ID = "codex";
+
+const CODEX_DRIVER = ProviderDriverKind.make("codex");
+const decodeCodexSettings = Schema.decodeUnknownOption(CodexSettings);
+
+/**
+ * The Codex configuration the runtime actually launches: an explicit
+ * `providerInstances` entry for the default Codex slot wins over the legacy
+ * `providers.codex` mirror, matching `deriveProviderInstanceConfigMap`.
+ */
+export function resolveCodexRefreshSettings(settings: ServerSettingsSnapshot): CodexSettings {
+  const instance = settings.providerInstances[defaultInstanceIdForDriver(CODEX_DRIVER)];
+  if (instance !== undefined && instance.driver === CODEX_DRIVER) {
+    const decoded = decodeCodexSettings(instance.config ?? {});
+    if (decoded._tag === "Some") {
+      return instance.enabled === false ? { ...decoded.value, enabled: false } : decoded.value;
+    }
+  }
+  return settings.providers.codex;
+}
 
 /**
  * The subset of the Claude Agent SDK's `rate_limit_event` the page shows.
@@ -271,6 +295,12 @@ export function limitsFromRuntimeEvent(
   return null;
 }
 
+/** Unparseable instants sort oldest so a well-formed reading always replaces them. */
+function observedAtMs(window: UsageLimitWindow): number {
+  const ms = Date.parse(window.observedAt);
+  return Number.isNaN(ms) ? Number.NEGATIVE_INFINITY : ms;
+}
+
 /**
  * Folds a new observation into what is already known for the provider. Each
  * window is replaced by its newer reading; windows the update did not mention
@@ -284,7 +314,7 @@ export function mergeProviderLimits(
   for (const window of previous?.windows ?? []) byId.set(window.id, window);
   for (const window of next.windows) {
     const existing = byId.get(window.id);
-    if (existing === undefined || existing.observedAt <= window.observedAt) {
+    if (existing === undefined || observedAtMs(existing) <= observedAtMs(window)) {
       byId.set(window.id, window);
     }
   }
@@ -363,6 +393,10 @@ export const make = Effect.gen(function* () {
 
   const filePath = path.join(config.stateDir, "usage-limits.json");
   const byProvider = new Map<UsageProviderKind, UsageProviderLimits>();
+  // The event subscription and a page-load refresh can record at the same
+  // time; one permit keeps each fold and its write in order so the file never
+  // ends up holding an older snapshot than memory.
+  const recordSemaphore = yield* Semaphore.make(1);
 
   const loaded = yield* fileSystem.readFileString(filePath).pipe(
     Effect.flatMap((raw) => decodeLimitsFile(raw)),
@@ -377,22 +411,25 @@ export const make = Effect.gen(function* () {
   );
 
   const record: UsageLimitsStore["Service"]["record"] = (limits) =>
-    Effect.suspend(() => {
-      const previous = byProvider.get(limits.provider);
-      const merged = mergeProviderLimits(previous, limits);
-      // Claude repeats the same reading on every request inside a turn; only
-      // a changed figure is worth a write.
-      if (previous !== undefined && sameLimits(previous, merged)) return Effect.void;
-      byProvider.set(limits.provider, merged);
-      return persist;
-    });
+    recordSemaphore.withPermits(1)(
+      Effect.suspend(() => {
+        const previous = byProvider.get(limits.provider);
+        const merged = mergeProviderLimits(previous, limits);
+        // Claude repeats the same reading on every request inside a turn; only
+        // a changed figure is worth a write.
+        if (previous !== undefined && sameLimits(previous, merged)) return Effect.void;
+        byProvider.set(limits.provider, merged);
+        return persist;
+      }),
+    );
 
   const refresh: UsageLimitsStore["Service"]["refresh"] = Effect.gen(function* () {
     const settings = yield* settingsService.getSettings.pipe(
       Effect.catchCause(() => Effect.succeed(null)),
     );
-    const codex = settings?.providers.codex;
-    if (!codex || !codex.enabled) return;
+    if (settings === null) return;
+    const codex = resolveCodexRefreshSettings(settings);
+    if (!codex.enabled) return;
     const observedAt = DateTime.formatIso(yield* DateTime.now);
     const response = yield* readCodexRateLimits({
       binaryPath: codex.binaryPath,

--- a/apps/server/src/usage/usageLimits.ts
+++ b/apps/server/src/usage/usageLimits.ts
@@ -354,7 +354,7 @@ const decodeLimitsFile = Schema.decodeUnknownEffect(LimitsFileJson);
 const encodeLimitsFile = Schema.encodeEffect(LimitsFileJson);
 
 /** The in-memory fold and its on-disk mirror; the provider subscription is wired separately. */
-export const makeStore = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const config = yield* ServerConfig;
@@ -421,7 +421,7 @@ export const makeStore = Effect.gen(function* () {
 export const layer = Layer.effect(
   UsageLimitsStore,
   Effect.gen(function* () {
-    const store = yield* makeStore;
+    const store = yield* make;
     const providerService = yield* ProviderService;
     yield* forkParked(
       Stream.runForEach(providerService.streamEvents, (event) => {

--- a/apps/server/src/usage/usageLimits.ts
+++ b/apps/server/src/usage/usageLimits.ts
@@ -22,6 +22,7 @@ import {
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -301,17 +302,30 @@ function observedAtMs(window: UsageLimitWindow): number {
   return Number.isNaN(ms) ? Number.NEGATIVE_INFINITY : ms;
 }
 
+/** The newest instant among a reading's windows; oldest possible when it has none. */
+function latestObservedMs(limits: UsageProviderLimits | undefined): number {
+  let latest = Number.NEGATIVE_INFINITY;
+  for (const window of limits?.windows ?? []) latest = Math.max(latest, observedAtMs(window));
+  return latest;
+}
+
 /**
  * Folds a new observation into what is already known for the provider. Each
- * window is replaced by its newer reading; windows the update did not mention
- * are kept, which is what turns Claude's one-window events into a full set.
+ * window is replaced by its newer reading. A partial update keeps the windows
+ * it did not mention, which is what turns Claude's one-window events into a
+ * full set; a complete reading (Codex's on-demand read) replaces the set, so a
+ * bucket the account stopped reporting disappears.
  */
 export function mergeProviderLimits(
   previous: UsageProviderLimits | undefined,
   next: UsageProviderLimits,
+  options: { readonly complete?: boolean } = {},
 ): UsageProviderLimits {
   const byId = new Map<string, UsageLimitWindow>();
-  for (const window of previous?.windows ?? []) byId.set(window.id, window);
+  if (!options.complete) {
+    for (const window of previous?.windows ?? []) byId.set(window.id, window);
+  }
+  const nextIsNewest = latestObservedMs(next) >= latestObservedMs(previous);
   for (const window of next.windows) {
     const existing = byId.get(window.id);
     if (existing === undefined || observedAtMs(existing) <= observedAtMs(window)) {
@@ -326,7 +340,9 @@ export function mergeProviderLimits(
         (right.durationMinutes ?? Number.MAX_SAFE_INTEGER) ||
       left.id.localeCompare(right.id),
   );
-  return { provider: next.provider, plan: next.plan ?? previous?.plan ?? null, windows };
+  // A delayed older observation must not relabel the plan either.
+  const plan = next.plan !== null && nextIsNewest ? next.plan : (previous?.plan ?? null);
+  return { provider: next.provider, plan, windows };
 }
 
 function sameWindow(left: UsageLimitWindow, right: UsageLimitWindow): boolean {
@@ -354,12 +370,19 @@ function sameLimits(left: UsageProviderLimits, right: UsageProviderLimits): bool
 export class UsageLimitsStore extends Context.Service<
   UsageLimitsStore,
   {
-    /** Folds one observation into the store. */
-    readonly record: (limits: UsageProviderLimits) => Effect.Effect<void>;
+    /**
+     * Folds one observation into the store. A `complete` reading replaces the
+     * provider's window set instead of merging into it.
+     */
+    readonly record: (
+      limits: UsageProviderLimits,
+      options?: { readonly complete?: boolean },
+    ) => Effect.Effect<void>;
     /**
      * Asks providers that can answer on demand (Codex) for a live reading.
      * Never fails: a provider that cannot answer leaves its last reading in
-     * place.
+     * place. Concurrent callers share one in-flight read rather than each
+     * launching a CLI.
      */
     readonly refresh: Effect.Effect<void>;
     readonly read: Effect.Effect<readonly UsageProviderLimits[]>;
@@ -410,11 +433,11 @@ export const make = Effect.gen(function* () {
     Effect.catchCause(() => Effect.void),
   );
 
-  const record: UsageLimitsStore["Service"]["record"] = (limits) =>
+  const record: UsageLimitsStore["Service"]["record"] = (limits, options) =>
     recordSemaphore.withPermits(1)(
       Effect.suspend(() => {
         const previous = byProvider.get(limits.provider);
-        const merged = mergeProviderLimits(previous, limits);
+        const merged = mergeProviderLimits(previous, limits, options);
         // Claude repeats the same reading on every request inside a turn; only
         // a changed figure is worth a write.
         if (previous !== undefined && sameLimits(previous, merged)) return Effect.void;
@@ -423,7 +446,7 @@ export const make = Effect.gen(function* () {
       }),
     );
 
-  const refresh: UsageLimitsStore["Service"]["refresh"] = Effect.gen(function* () {
+  const refreshOnce = Effect.gen(function* () {
     const settings = yield* settingsService.getSettings.pipe(
       Effect.catchCause(() => Effect.succeed(null)),
     );
@@ -446,7 +469,24 @@ export const make = Effect.gen(function* () {
     );
     if (response === null) return;
     const limits = parseCodexRateLimitsRead(response, observedAt);
-    if (limits !== null) yield* record(limits);
+    if (limits !== null) yield* record(limits, { complete: true });
+  });
+
+  // Single-flight: every usage request asks for a refresh, and each one is a
+  // CLI process. Callers that arrive while one is running wait for it.
+  let inflightRefresh: Deferred.Deferred<void> | null = null;
+  const refresh: UsageLimitsStore["Service"]["refresh"] = Effect.suspend(() => {
+    const existing = inflightRefresh;
+    if (existing !== null) return Deferred.await(existing);
+    const created = Deferred.makeUnsafe<void>();
+    inflightRefresh = created;
+    return refreshOnce.pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          inflightRefresh = null;
+        }).pipe(Effect.andThen(Deferred.succeed(created, undefined))),
+      ),
+    );
   });
 
   const read: UsageLimitsStore["Service"]["read"] = Effect.sync(() => [...byProvider.values()]);

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,4 +1,4 @@
-import type { UsageProviderKind } from "@t3tools/contracts";
+import type { UsageProviderKind, UsageProviderLimits } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -14,6 +14,9 @@ import {
   formatDateTimeShort,
   formatDayShort,
   formatHourShort,
+  formatLimitReset,
+  formatLimitWindowLabel,
+  formatObservedAgo,
   formatPercent,
   formatTokens,
   formatUsd,
@@ -85,6 +88,8 @@ export function UsagePage() {
   );
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
+  // Limits are read relative to when the answers landed, not to every render.
+  const limitsReadAt = useMemo(() => new Date(), [merged]);
 
   const selectWindow = (days: number) => {
     setWindowSelection({
@@ -300,6 +305,13 @@ export function UsagePage() {
                   </div>
                 </section>
 
+                <UsageLimitsSection
+                  limits={merged.limits}
+                  providers={activeProviders}
+                  now={limitsReadAt}
+                  timeZone={window.timeZone}
+                />
+
                 <section className="flex flex-col gap-2">
                   <h2 className="text-sm font-medium text-foreground">Totals</h2>
                   <div className="grid grid-cols-2 gap-x-6 gap-y-4 py-1 md:grid-cols-5">
@@ -476,6 +488,118 @@ function ProviderMark({
   return <Mark className={cn("shrink-0", className)} aria-hidden />;
 }
 
+/** Why a provider has no limit figure to show. */
+const LIMITS_UNAVAILABLE: Record<UsageProviderKind, string> = {
+  codex: "Sign in to the Codex CLI to see its limits here.",
+  claude: "Reported once a Claude Code turn runs through T3 Code.",
+  grok: "Grok Build does not report subscription limits.",
+};
+
+/**
+ * Rolling subscription windows per provider. Every provider with activity in
+ * the window gets a row, so a provider that cannot report says so instead of
+ * silently missing.
+ */
+function UsageLimitsSection({
+  limits,
+  providers,
+  now,
+  timeZone,
+}: {
+  readonly limits: readonly UsageProviderLimits[];
+  readonly providers: readonly UsageProviderKind[];
+  readonly now: Date;
+  readonly timeZone: string;
+}) {
+  const rows = PROVIDER_ORDER.flatMap((provider) => {
+    const entry = limits.find((candidate) => candidate.provider === provider);
+    if (entry === undefined && !providers.includes(provider)) return [];
+    return [{ provider, entry }];
+  });
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-sm font-medium text-foreground">Subscription limits</h2>
+      <div className="grid gap-x-8 gap-y-5 md:grid-cols-2">
+        {rows.map(({ provider, entry }) => {
+          const observedAt = entry?.windows.reduce(
+            (latest, window) => (window.observedAt > latest ? window.observedAt : latest),
+            "",
+          );
+          return (
+            <div key={provider} className="flex min-w-0 flex-col gap-3">
+              <div className="flex items-baseline justify-between gap-4">
+                <span className="flex min-w-0 items-center gap-2 text-sm text-foreground">
+                  <ProviderMark provider={provider} className="size-4" />
+                  <span className="truncate">{PROVIDER_PRESENTATION[provider].label}</span>
+                  {entry?.plan ? (
+                    <span className="shrink-0 text-[11px] text-muted-foreground">{entry.plan}</span>
+                  ) : null}
+                </span>
+                {observedAt ? (
+                  <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+                    Updated {formatObservedAgo(observedAt, now)}
+                  </span>
+                ) : null}
+              </div>
+              {entry === undefined || entry.windows.length === 0 ? (
+                <span className="text-xs text-muted-foreground">
+                  {LIMITS_UNAVAILABLE[provider]}
+                </span>
+              ) : (
+                entry.windows.map((window) => {
+                  const used = Math.min(100, Math.max(0, window.usedPercent));
+                  const reset = formatLimitReset(window.resetsAt, now, timeZone);
+                  return (
+                    <div key={window.id} className="flex flex-col gap-1.5">
+                      <div className="flex items-baseline justify-between gap-4 text-xs">
+                        <span className="text-muted-foreground">
+                          {formatLimitWindowLabel(window)}
+                        </span>
+                        <span className="flex shrink-0 items-baseline gap-2 tabular-nums">
+                          <span
+                            className={cn(
+                              "font-medium text-foreground",
+                              used >= 90 && "text-destructive",
+                            )}
+                          >
+                            {Math.round(used)}%
+                          </span>
+                          {reset ? <span className="text-muted-foreground">{reset}</span> : null}
+                        </span>
+                      </div>
+                      <div
+                        role="progressbar"
+                        aria-label={`${PROVIDER_PRESENTATION[provider].label} ${formatLimitWindowLabel(window)}`}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={Math.round(used)}
+                        className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+                      >
+                        <div
+                          className="h-full rounded-full"
+                          style={{
+                            width: `${used}%`,
+                            backgroundColor:
+                              used >= 90
+                                ? "var(--destructive)"
+                                : PROVIDER_PRESENTATION[provider].color,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 function Metric({ label, value }: { readonly label: string; readonly value: string }) {
   return (
     <div className="flex min-w-0 flex-col gap-0.5">
@@ -618,6 +742,32 @@ function UsageSkeleton() {
             <div className="ml-16 h-56 rounded-sm bg-muted/35" />
             <div className="ml-16 h-4 rounded-sm bg-muted/35" />
           </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-medium text-foreground">Subscription limits</h2>
+        <div className="grid gap-x-8 gap-y-5 md:grid-cols-2">
+          {PROVIDER_ORDER.slice(0, 2).map((provider) => (
+            <div key={provider} className="flex flex-col gap-3">
+              <div className="flex min-h-5 items-center justify-between gap-4">
+                <span className="flex items-center gap-2">
+                  <span className="size-4 shrink-0 rounded-full bg-muted" />
+                  <div className="h-3.5 w-20 rounded-sm bg-muted" />
+                </span>
+                <div className="h-3 w-20 rounded-sm bg-muted" />
+              </div>
+              {[0, 1].map((row) => (
+                <div key={row} className="flex flex-col gap-1.5">
+                  <div className="flex justify-between gap-4">
+                    <div className="h-3 w-20 rounded-sm bg-muted" />
+                    <div className="h-3 w-28 rounded-sm bg-muted" />
+                  </div>
+                  <div className="h-1.5 w-full rounded-full bg-muted/35" />
+                </div>
+              ))}
+            </div>
+          ))}
         </div>
       </section>
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -17,6 +17,7 @@ import {
   formatLimitReset,
   formatLimitWindowLabel,
   formatObservedAgo,
+  latestObservedAt,
   formatPercent,
   formatTokens,
   formatUsd,
@@ -523,10 +524,7 @@ function UsageLimitsSection({
       <h2 className="text-sm font-medium text-foreground">Subscription limits</h2>
       <div className="grid gap-x-8 gap-y-5 md:grid-cols-2">
         {rows.map(({ provider, entry }) => {
-          const observedAt = entry?.windows.reduce(
-            (latest, window) => (window.observedAt > latest ? window.observedAt : latest),
-            "",
-          );
+          const observedAt = entry === undefined ? null : latestObservedAt(entry.windows);
           return (
             <div key={provider} className="flex min-w-0 flex-col gap-3">
               <div className="flex items-baseline justify-between gap-4">

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -13,3 +13,12 @@ Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. 
 headline and chart. Refreshing rescans every connected environment and refetches model pricing on
 each of them, so a newly released model that showed $0.00 gets a price without waiting for the daily
 pricing update.
+
+## Subscription limits
+
+Below the chart, **Subscription limits** shows how much of each provider's rolling windows you have
+used, such as the 5-hour and weekly limits, with the reset time for each. Codex reports its limits
+live whenever the page loads, including any model family it meters separately. Claude Code only reports limits while a turn is running, so its
+figures are as of the most recent Claude Code turn in T3 Code and the row says when it was updated.
+Grok Build does not report limits. When several environments share one account, the freshest
+reading is shown.

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -12,6 +12,7 @@
  *
  * @module usage
  */
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
@@ -21,14 +22,15 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 6 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5 only adds `grok` to {@link UsageProviderKind} and v6 only adds the
+ * optional `limits` list; v4 Claude/Codex buckets remain valid, so
+ * mixed-version environments keep those totals instead of treating every
+ * older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 
@@ -169,6 +171,46 @@ export const UsagePricing = Schema.Struct({
 });
 export type UsagePricing = typeof UsagePricing.Type;
 
+/**
+ * One rolling subscription window, as the provider's CLI reported it.
+ *
+ * `id` is the provider's own name for the window (`five_hour`, `seven_day`,
+ * `seven_day_opus`, ...); Codex's unnamed primary/secondary windows are mapped
+ * onto the same ids by duration so both providers label alike. `usedPercent`
+ * runs 0-100 as both CLIs report it.
+ */
+export const UsageLimitWindow = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  /**
+   * The named bucket a window belongs to when a provider meters some models
+   * separately (Codex `limitName`, e.g. a Spark bucket). Null for the plan's
+   * main limit.
+   */
+  scope: Schema.NullOr(TrimmedNonEmptyString),
+  durationMinutes: Schema.NullOr(NonNegativeInt),
+  usedPercent: Schema.Number,
+  /** ISO instant the window resets, when the provider reports one. */
+  resetsAt: Schema.NullOr(Schema.String),
+  /** ISO instant this figure was last observed. */
+  observedAt: Schema.String,
+});
+export type UsageLimitWindow = typeof UsageLimitWindow.Type;
+
+/**
+ * A provider's subscription limits as last seen by this environment.
+ *
+ * Codex answers `account/rateLimits/read` on demand, so its figures are live.
+ * Claude Code only reports limits inside a running turn, and only the window
+ * closest to exhaustion, so its figures are whatever the latest turn carried.
+ */
+export const UsageProviderLimits = Schema.Struct({
+  provider: UsageProviderKind,
+  /** Provider's plan name when it reports one (Codex `planType`). */
+  plan: Schema.NullOr(TrimmedNonEmptyString),
+  windows: Schema.Array(UsageLimitWindow),
+});
+export type UsageProviderLimits = typeof UsageProviderLimits.Type;
+
 export const UsageSummaryInput = Schema.Struct({
   /** Inclusive first day of the window, in `timeZone`. */
   sinceDay: UsageDay,
@@ -199,6 +241,8 @@ export const UsageSummary = Schema.Struct({
   pricing: UsagePricing,
   /** Wall-clock cost of the scan, surfaced in diagnostics. */
   scanDurationMs: NonNegativeInt,
+  /** Absent from pre-v6 environments, which read as "no limits known". */
+  limits: Schema.Array(UsageProviderLimits).pipe(Schema.withDecodingDefaultKey(Effect.succeed([]))),
 });
 export type UsageSummary = typeof UsageSummary.Type;
 

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -5,6 +5,9 @@ import {
   enumerateHourStarts,
   formatDateTimeShort,
   formatHourShort,
+  formatLimitReset,
+  formatLimitWindowLabel,
+  formatObservedAgo,
   formatRelativeHourShort,
   makeWindow,
 } from "./usageFormat.ts";
@@ -69,5 +72,42 @@ describe("hourly usage formatting", () => {
     } finally {
       resolvedOptions.mockRestore();
     }
+  });
+});
+
+describe("limit formatting", () => {
+  it("labels known windows by name and unknown ones by length", () => {
+    expect(formatLimitWindowLabel({ id: "five_hour", durationMinutes: 300 })).toBe("5-hour limit");
+    expect(formatLimitWindowLabel({ id: "seven_day_opus", durationMinutes: 10_080 })).toBe(
+      "Weekly Opus limit",
+    );
+    expect(formatLimitWindowLabel({ id: "primary", durationMinutes: 10_080 })).toBe("Weekly limit");
+    expect(formatLimitWindowLabel({ id: "primary", durationMinutes: 180 })).toBe("3-hour limit");
+    expect(formatLimitWindowLabel({ id: "primary", durationMinutes: 2880 })).toBe("2-day limit");
+    expect(formatLimitWindowLabel({ id: "primary", durationMinutes: null })).toBe("Usage limit");
+    expect(
+      formatLimitWindowLabel({ id: "codex_spark:five_hour", scope: "Spark", durationMinutes: 300 }),
+    ).toBe("Spark · 5-hour limit");
+  });
+
+  it("describes a reset as a countdown inside a day and a weekday beyond it", () => {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+
+    expect(formatLimitReset("2026-08-11T14:10:00.000Z", now)).toBe("Resets in 2h 10m");
+    expect(formatLimitReset("2026-08-11T12:00:30.000Z", now)).toBe("Resets in 1m");
+    expect(formatLimitReset("2026-08-11T15:00:00.000Z", now)).toBe("Resets in 3h");
+    expect(formatLimitReset("2026-08-11T11:00:00.000Z", now)).toBe("Resets now");
+    expect(formatLimitReset("2026-08-14T15:00:00.000Z", now, "UTC")).toBe("Resets Fri 3 PM");
+    expect(formatLimitReset(null, now)).toBeNull();
+    expect(formatLimitReset("not a date", now)).toBeNull();
+  });
+
+  it("describes how old a reading is", () => {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+
+    expect(formatObservedAgo("2026-08-11T11:59:30.000Z", now)).toBe("just now");
+    expect(formatObservedAgo("2026-08-11T11:35:00.000Z", now)).toBe("25m ago");
+    expect(formatObservedAgo("2026-08-11T08:00:00.000Z", now)).toBe("4h ago");
+    expect(formatObservedAgo("2026-08-08T08:00:00.000Z", now)).toBe("3d ago");
   });
 });

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -230,3 +230,79 @@ export function makeWindow(
     resolution,
   };
 }
+
+const LIMIT_WINDOW_LABELS: Record<string, string> = {
+  five_hour: "5-hour limit",
+  seven_day: "Weekly limit",
+  seven_day_opus: "Weekly Opus limit",
+  seven_day_sonnet: "Weekly Sonnet limit",
+  seven_day_overage_included: "Weekly limit incl. overage",
+};
+
+/**
+ * `five_hour` to `5-hour limit`; a window with no known name is labelled by
+ * its length, and a separately metered bucket carries its name in front.
+ */
+export function formatLimitWindowLabel(window: {
+  readonly id: string;
+  readonly scope?: string | null;
+  readonly durationMinutes: number | null;
+}): string {
+  const base = window.id.includes(":")
+    ? window.id.slice(window.id.lastIndexOf(":") + 1)
+    : window.id;
+  const label = LIMIT_WINDOW_LABELS[base] ?? labelByDuration(window.durationMinutes);
+  return window.scope ? `${window.scope} · ${label}` : label;
+}
+
+function labelByDuration(minutes: number | null): string {
+  if (minutes === null || minutes <= 0) return "Usage limit";
+  if (minutes % (24 * 60) === 0) {
+    const days = minutes / (24 * 60);
+    return days === 7 ? "Weekly limit" : `${days}-day limit`;
+  }
+  if (minutes % 60 === 0) return `${minutes / 60}-hour limit`;
+  return `${minutes}-minute limit`;
+}
+
+/**
+ * When a window resets, relative to `now` while it is less than a day out and
+ * as a weekday and hour beyond that. Null when the provider gave no reset.
+ */
+export function formatLimitReset(
+  resetsAt: string | null,
+  now: Date,
+  timeZone?: string,
+): string | null {
+  if (resetsAt === null) return null;
+  const instant = new Date(resetsAt);
+  if (Number.isNaN(instant.getTime())) return null;
+  const remainingMs = instant.getTime() - now.getTime();
+  if (remainingMs <= 0) return "Resets now";
+  if (remainingMs < 24 * HOUR_MS) {
+    const totalMinutes = Math.ceil(remainingMs / 60_000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours === 0) return `Resets in ${minutes}m`;
+    return minutes === 0 ? `Resets in ${hours}h` : `Resets in ${hours}h ${minutes}m`;
+  }
+  const label = new Intl.DateTimeFormat("en-US", {
+    ...(timeZone === undefined ? {} : { timeZone }),
+    weekday: "short",
+    hour: "numeric",
+  }).format(instant);
+  return `Resets ${label}`;
+}
+
+/** How old a reading is: `just now`, `5m ago`, `3h ago`, `2d ago`. */
+export function formatObservedAgo(observedAt: string, now: Date): string {
+  const instant = new Date(observedAt);
+  if (Number.isNaN(instant.getTime())) return "";
+  const elapsedMs = Math.max(0, now.getTime() - instant.getTime());
+  if (elapsedMs < 60_000) return "just now";
+  const minutes = Math.floor(elapsedMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -294,6 +294,24 @@ export function formatLimitReset(
   return `Resets ${label}`;
 }
 
+/**
+ * The most recently observed window's instant, compared as time rather than
+ * text so readings with different offsets or precision still order correctly.
+ */
+export function latestObservedAt(
+  windows: readonly { readonly observedAt: string }[],
+): string | null {
+  let latest: string | null = null;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const window of windows) {
+    const ms = Date.parse(window.observedAt);
+    if (Number.isNaN(ms) || ms <= latestMs) continue;
+    latest = window.observedAt;
+    latestMs = ms;
+  }
+  return latest;
+}
+
 /** How old a reading is: `just now`, `5m ago`, `3h ago`, `2d ago`. */
 export function formatObservedAgo(observedAt: string, now: Date): string {
   const instant = new Date(observedAt);

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -386,6 +386,22 @@ describe("mergeLimits", () => {
     ]);
   });
 
+  it("orders observations as instants, not text", () => {
+    const limits = mergeLimits([
+      environment("env-a", {
+        ...summary([], []),
+        limits: [reading("claude", 1, "2026-08-07T12:00:00.000Z")],
+      }),
+      environment("env-b", {
+        ...summary([], []),
+        // Later instant, but sorts first as a string because of the offset.
+        limits: [reading("claude", 2, "2026-08-07T15:00:00+02:00")],
+      }),
+    ]);
+
+    expect(limits[0]?.windows[0]?.usedPercent).toBe(2);
+  });
+
   it("breaks an observation tie by environment id so the winner is stable", () => {
     const limits = mergeLimits([
       environment("env-b", {

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,5 +1,6 @@
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -8,7 +9,7 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
+import { mergeLimits, mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
 
 function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
   return {
@@ -66,6 +67,7 @@ function summary(
     })),
     pricing: { status: "fresh", source: "litellm", fetchedAt: null, knownModels: 10 },
     scanDurationMs: 1,
+    limits: [],
   };
 }
 
@@ -158,7 +160,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket()],
             [{ provider: "claude", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 2,
+            USAGE_MERGE_COMPATIBLE_SINCE - 1,
           ),
         ),
       ],
@@ -337,5 +339,80 @@ describe("mergeUsage", () => {
     ]);
     expect(merged.daily).toHaveLength(1);
     expect(merged.daily[0]?.costUsd).toBe(10);
+  });
+});
+
+describe("mergeLimits", () => {
+  const reading = (
+    provider: UsageProviderKind,
+    usedPercent: number,
+    observedAt: string,
+    plan: string | null = null,
+  ) => ({
+    provider,
+    plan,
+    windows: [
+      {
+        id: "five_hour",
+        scope: null,
+        durationMinutes: 300,
+        usedPercent,
+        resetsAt: null,
+        observedAt,
+      },
+    ],
+  });
+
+  it("keeps the freshest reading per provider rather than mixing environments", () => {
+    const limits = mergeLimits([
+      environment("env-b", {
+        ...summary([], []),
+        limits: [reading("codex", 40, "2026-08-07T10:00:00.000Z", "Pro")],
+      }),
+      environment("env-a", {
+        ...summary([], []),
+        limits: [
+          reading("codex", 10, "2026-08-07T09:00:00.000Z", "Plus"),
+          reading("claude", 55, "2026-08-07T09:30:00.000Z"),
+        ],
+      }),
+    ]);
+
+    expect(
+      limits.map((entry) => [entry.provider, entry.plan, entry.windows[0]?.usedPercent]),
+    ).toEqual([
+      ["codex", "Pro", 40],
+      ["claude", null, 55],
+    ]);
+  });
+
+  it("breaks an observation tie by environment id so the winner is stable", () => {
+    const limits = mergeLimits([
+      environment("env-b", {
+        ...summary([], []),
+        limits: [reading("claude", 2, "2026-08-07T10:00:00.000Z")],
+      }),
+      environment("env-a", {
+        ...summary([], []),
+        limits: [reading("claude", 1, "2026-08-07T10:00:00.000Z")],
+      }),
+    ]);
+
+    expect(limits[0]?.windows[0]?.usedPercent).toBe(1);
+  });
+
+  it("excludes environments on an incompatible contract from limits too", () => {
+    const merged = mergeUsage(
+      [
+        environment("env-old", {
+          ...summary([], [], 1),
+          limits: [reading("claude", 99, "2026-08-07T10:00:00.000Z")],
+        }),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.limits).toEqual([]);
+    expect(merged.staleEnvironments).toEqual(["env-old"]);
   });
 });

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -11,6 +11,7 @@ import {
   type EnvironmentId,
   type UsageBucket,
   type UsageProviderKind,
+  type UsageProviderLimits,
   type UsageSourceFingerprint,
   type UsageSummary,
 } from "@t3tools/contracts";
@@ -77,6 +78,13 @@ export interface MergedUsage {
   readonly daily: readonly DailyTotals[];
   readonly hourly: readonly HourlyTotals[];
   readonly costQuality: CostQuality;
+  /**
+   * One entry per provider with a known subscription limit, in provider order
+   * of first appearance. Where several environments report the same provider,
+   * the one with the freshest reading wins outright: limits belong to an
+   * account, not a machine, so two readings of one account must not be mixed.
+   */
+  readonly limits: readonly UsageProviderLimits[];
   /** Environments whose data was dropped as a duplicate of another's. */
   readonly duplicateSources: readonly string[];
   readonly contributingEnvironments: readonly EnvironmentId[];
@@ -197,10 +205,57 @@ const EMPTY_MERGED: MergedUsage = {
     unpricedShare: 0,
     cacheSavingsUsd: 0,
   },
+  limits: [],
   duplicateSources: [],
   contributingEnvironments: [],
   staleEnvironments: [],
 };
+
+/** The most recent instant any window of a reading was observed. */
+function latestObservation(limits: UsageProviderLimits): string {
+  let latest = "";
+  for (const window of limits.windows) {
+    if (window.observedAt > latest) latest = window.observedAt;
+  }
+  return latest;
+}
+
+/**
+ * Picks one reading per provider across environments: the freshest one, with
+ * environment id as the tiebreak so the winner is stable between renders.
+ */
+export function mergeLimits(
+  environments: readonly EnvironmentUsage[],
+): readonly UsageProviderLimits[] {
+  const chosen = new Map<
+    UsageProviderKind,
+    {
+      readonly limits: UsageProviderLimits;
+      readonly observedAt: string;
+      readonly environmentId: EnvironmentId;
+    }
+  >();
+  for (const environment of environments) {
+    for (const limits of environment.summary.limits) {
+      if (limits.windows.length === 0) continue;
+      const observedAt = latestObservation(limits);
+      const current = chosen.get(limits.provider);
+      if (
+        current === undefined ||
+        observedAt > current.observedAt ||
+        (observedAt === current.observedAt &&
+          environment.environmentId.localeCompare(current.environmentId) < 0)
+      ) {
+        chosen.set(limits.provider, {
+          limits,
+          observedAt,
+          environmentId: environment.environmentId,
+        });
+      }
+    }
+  }
+  return [...chosen.values()].map((entry) => entry.limits);
+}
 
 /**
  * Merges every connected environment's summary.
@@ -417,6 +472,7 @@ export function mergeUsage(
         records === 0 ? 0 : (records - providerReportedRecords - unpricedRecords) / records,
       cacheSavingsUsd,
     },
+    limits: mergeLimits(current),
     duplicateSources: duplicates,
     contributingEnvironments,
     staleEnvironments,

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -16,6 +16,8 @@ import {
   type UsageSummary,
 } from "@t3tools/contracts";
 
+import { latestObservedAt } from "./usageFormat.ts";
+
 export interface EnvironmentUsage {
   readonly environmentId: EnvironmentId;
   readonly label: string;
@@ -211,15 +213,6 @@ const EMPTY_MERGED: MergedUsage = {
   staleEnvironments: [],
 };
 
-/** The most recent instant any window of a reading was observed. */
-function latestObservation(limits: UsageProviderLimits): string {
-  let latest = "";
-  for (const window of limits.windows) {
-    if (window.observedAt > latest) latest = window.observedAt;
-  }
-  return latest;
-}
-
 /**
  * Picks one reading per provider across environments: the freshest one, with
  * environment id as the tiebreak so the winner is stable between renders.
@@ -231,24 +224,25 @@ export function mergeLimits(
     UsageProviderKind,
     {
       readonly limits: UsageProviderLimits;
-      readonly observedAt: string;
+      readonly observedAtMs: number;
       readonly environmentId: EnvironmentId;
     }
   >();
   for (const environment of environments) {
     for (const limits of environment.summary.limits) {
-      if (limits.windows.length === 0) continue;
-      const observedAt = latestObservation(limits);
+      const latest = latestObservedAt(limits.windows);
+      if (latest === null) continue;
+      const observedAtMs = Date.parse(latest);
       const current = chosen.get(limits.provider);
       if (
         current === undefined ||
-        observedAt > current.observedAt ||
-        (observedAt === current.observedAt &&
+        observedAtMs > current.observedAtMs ||
+        (observedAtMs === current.observedAtMs &&
           environment.environmentId.localeCompare(current.environmentId) < 0)
       ) {
         chosen.set(limits.provider, {
           limits,
-          observedAt,
+          observedAtMs,
           environmentId: environment.environmentId,
         });
       }


### PR DESCRIPTION
## What changed

- The usage page gets a **Subscription limits** section on web and mobile: one row per provider with its plan, and one bar per rolling window showing percent used, reset time, and how old the reading is.
- `UsageSummary` (contract v6) carries `limits`: a list of per-provider windows. Older environments decode as "no limits known" and still merge; the client keeps the freshest reading per provider across environments so two servers on one account don't mix.
- New `UsageLimitsStore` on the server folds `account.rate-limits.updated` runtime events from every adapter into a per-window map and persists it to `usage-limits.json` so readings survive restarts. Codex additionally gets a live `account/rateLimits/read` on each page load, including separately metered model buckets (the Spark bucket below), through a shared app-server connect helper split out of the skills probe.
- Claude Code's `rate_limit_event` is parsed from its `unifiedWindows` breakdown when present and from the single representative window on older CLIs; utilization is normalised from the 0-1 fraction the CLI sends. Grok Build reports nothing, and its row says so.

## Why

Users on subscriptions care about "how much of my week is left" more than API-equivalent dollars, and had to leave T3 Code to find out. Each provider CLI already exposes this; the page just never showed it.

Model-scoped Claude windows (e.g. a per-model weekly meter) are deliberately not shown: Claude Code only serves those from its OAuth usage endpoint, which would mean reading its stored credential. Turn-reported windows are what the SDK hands to hosts, so that is what this uses.

## UI changes

<table>
  <tr>
    <th>Before</th>
    <th>After: light</th>
    <th>After: dark</th>
  </tr>
  <tr>
    <td>No limit information anywhere on the usage page.</td>
    <td><img width="420" src="https://github.com/jakeleventhal/t3code/releases/download/pr-assets-usage-subscription-limits/usage-limits-light.png" /></td>
    <td><img width="420" src="https://github.com/jakeleventhal/t3code/releases/download/pr-assets-usage-subscription-limits/usage-limits-dark.png" /></td>
  </tr>
</table>

Full page, light and dark. Codex figures are live from the signed-in CLI; Claude figures came from a real turn run through the dev server.

<table>
  <tr>
    <td><img width="420" src="https://github.com/jakeleventhal/t3code/releases/download/pr-assets-usage-subscription-limits/usage-page-light.png" /></td>
    <td><img width="420" src="https://github.com/jakeleventhal/t3code/releases/download/pr-assets-usage-subscription-limits/usage-page-dark.png" /></td>
  </tr>
</table>

## Testing

- `usageLimits.test.ts` (13 tests): Codex and Claude payload parsing, per-bucket ids, runtime event routing, window merging, persistence across a store restart, no-op refresh while Codex is disabled
- `usageMerge.test.ts` (+3) and `usageFormat.test.ts` (+3): freshest-environment selection, stale-version exclusion, window labels, reset countdowns, reading age
- Typecheck for contracts, shared, server, web, and mobile; lint and format on changed files
- Browser pass on the web app against seeded real data. Mobile is typechecked only: no simulator on this host.

Created with Claude Fable 5.1 using the Claude Code harness in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Usage scans can spawn a short-lived Codex app-server and block up to 3s for limits; layer ordering ties limits to the provider event stream. Additive contract v6 is backward-compatible for merge, but changes server behavior on every usage read.
> 
> **Overview**
> Adds **subscription limits** to the usage experience on web and mobile: rolling windows with % used, reset timing, plan name, and “updated … ago,” plus copy when a provider cannot report (Codex sign-in, Claude after a turn, Grok unsupported).
> 
> **Contract & merge:** `UsageSummary` bumps to **v6** with a `limits` array (`UsageProviderLimits` / `UsageLimitWindow`). Older servers decode as empty limits. `mergeUsage` picks the **freshest reading per provider** across environments so one account is not blended.
> 
> **Server:** New `UsageLimitsStore` merges `account.rate-limits.updated` events (Codex + Claude), persists to `usage-limits.json`, and on each usage scan triggers a **single-flight** Codex `account/rateLimits/read` via a shared `connectCodexAppServer` helper (also used by the skills probe). `UsageService.readSummary` starts that refresh in parallel with the transcript scan and waits up to **3s** before returning `limits`. Runtime wiring moves usage/limits **ahead of** provider runtime so the store can subscribe to provider events.
> 
> **Shared UI helpers:** `formatLimitWindowLabel`, `formatLimitReset`, `formatObservedAgo`, `latestObservedAt` power labels and progress bars (danger styling at ≥90%).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea798e730c39ba45d8ecf92d0990359d76d528b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider subscription limits to usage page across web and mobile
> - Adds `UsageLimitWindow` and `UsageProviderLimits` contract schemas, bumps usage contract to version 6 (additive, compatible with v4+), and includes a `limits` array in `UsageSummary` defaulting to empty for legacy summaries
> - Server parses Codex and Claude rate-limit events into normalized windows, persists them in `UsageLimitsStore`, refreshes enabled Codex limits on-demand via the app-server protocol with an 8-second timeout, and shares concurrent refreshes via single-flight
> - `UsageService.make readSummary` now triggers a detached limits refresh before scanning and waits up to 3 seconds for it after aggregation, returning known limits in the summary
> - `usageMerge` selects the freshest complete provider reading across environments, and shared formatters render window labels, reset countdowns, observation age, and progress bars with danger styling at ≥90%
> - Web and mobile usage screens render a new limits section between the chart and totals, with loading skeletons on web
> - Risk: `UsageService.make` now resolves `UsageLimitsStore` and blocks up to 3 seconds on the first refresh; existing usage scans that previously returned no limits now include an empty (or populated) `limits` array, which clients decoding with the v6 contract handle via the default empty list
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cea798e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->