### PR TITLE
fix(chat): show single tool calls without summaries

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -870,6 +870,7 @@ describe("buildThreadFeed", () => {
       status: undefined,
       displayName: "Click in the preview browser",
       liveDisplayName: "Clicking in the preview browser",
+      settledDisplayName: "Clicked in the preview browser",
       icon: "browser",
     },
     {
@@ -880,11 +881,12 @@ describe("buildThreadFeed", () => {
       status: undefined,
       displayName: "Get delegated task status",
       liveDisplayName: "Getting delegated task status",
+      settledDisplayName: "Got delegated task status",
       icon: "t3-code",
     },
   ])(
     "uses friendly row and running labels from $source",
-    ({ label, title, item, status, displayName, liveDisplayName, icon }) => {
+    ({ label, title, item, status, displayName, liveDisplayName, settledDisplayName, icon }) => {
       const turnId = TurnId.make("turn-friendly-mcp");
       const rawCommand = "node mcp-call.js";
       const rawDetail = '{"provider":"raw MCP output"}';
@@ -949,6 +951,22 @@ describe("buildThreadFeed", () => {
           live: true,
         },
       ]);
+      if (settledDisplayName) {
+        const settledRows = deriveThreadFeedPresentation(
+          feed,
+          {
+            ...thread.latestTurn!,
+            state: "completed",
+            completedAt: "2026-04-01T00:00:03.000Z",
+          },
+          new Set([turnId]),
+          new Set(),
+        );
+        expect(settledRows.find((entry) => entry.type === "work-toggle")).toMatchObject({
+          summary: settledDisplayName,
+          live: false,
+        });
+      }
     },
   );
 

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -964,6 +964,7 @@ describe("buildThreadFeed", () => {
         );
         expect(settledRows.find((entry) => entry.type === "work-toggle")).toMatchObject({
           summary: settledDisplayName,
+          summaryToolIcon: icon,
           live: false,
         });
       }

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1762,7 +1762,11 @@ describe("buildThreadFeed", () => {
       const stoppedRows = deriveThreadFeedPresentation(feed, latestTurn, new Set());
       expect(stoppedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
         { live: false, shimmer: false },
-        { live: false, shimmer: false },
+        {
+          live: false,
+          shimmer: false,
+          summary: lifecycleStatus === "inProgress" ? "printf done" : command,
+        },
       ]);
 
       const completedRows = deriveThreadFeedPresentation(

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1041,7 +1041,7 @@ describe("buildThreadFeed", () => {
       hasFailure: true,
     },
   ])(
-    "keeps a browser group expanded as its action changes from active to $status",
+    "renders a direct browser row once its action settles as $status",
     ({ status, displayName, detail, hasFailure }) => {
       const turnId = TurnId.make("turn-preview-lifecycle");
       const toolCallId = "preview-click";
@@ -1172,18 +1172,10 @@ describe("buildThreadFeed", () => {
           completedAt: "2026-04-01T00:00:04.000Z",
         },
       });
-      expect(settledRows.find((entry) => entry.type === "work-toggle")).toMatchObject({
-        groupId,
-        hiddenCount: 1,
-        expanded: true,
-        summary: "Used browser 1 time",
-        summaryKind: "browser",
-        hasFailure,
-        live: false,
-      });
+      expect(settledRows.some((entry) => entry.type === "work-toggle")).toBe(false);
       expect(settledRows.find((entry) => entry.type === "activity-group")).toMatchObject({
-        id: `work-details:${groupId}`,
-        activities: [{ id: "preview-click-started", summary: displayName, live: false }],
+        id: "preview-click-started",
+        activities: [{ id: "preview-click-started", summary: displayName }],
       });
     },
   );
@@ -1358,7 +1350,7 @@ describe("buildThreadFeed", () => {
     expect(expanded.map((entry) => entry.id)).toEqual([
       "assistant-first",
       "turn-fold:turn-1",
-      "work-toggle:work-group:tool-completed",
+      "tool-completed",
       "assistant-final",
     ]);
   });
@@ -1742,7 +1734,7 @@ describe("buildThreadFeed", () => {
         latestTurn.startedAt,
       );
       expect(rows.slice(0, 3).map((entry) => [entry.id, entry.type])).toEqual([
-        ["work-toggle:work-group:activity-1", "work-toggle"],
+        ["activity-1", "activity-group"],
         ["activity-2", "activity-group"],
         ["work-live:work-group:activity-3", "work-toggle"],
       ]);
@@ -1757,13 +1749,10 @@ describe("buildThreadFeed", () => {
         live: true,
         shimmer,
       });
-      expect(rows[0]).toMatchObject({ live: false, shimmer: false });
+      expect(rows[0]).toMatchObject({ type: "activity-group" });
 
       const stoppedRows = deriveThreadFeedPresentation(feed, latestTurn, new Set());
-      expect(stoppedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
-        { live: false, shimmer: false },
-        { live: false, shimmer: false },
-      ]);
+      expect(stoppedRows.every((entry) => entry.type === "activity-group")).toBe(true);
 
       const completedRows = deriveThreadFeedPresentation(
         feed,
@@ -1772,10 +1761,11 @@ describe("buildThreadFeed", () => {
         new Set(),
         latestTurn.startedAt,
       );
-      expect(completedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
-        { live: false, shimmer: false },
-        { live: false, shimmer: false },
-      ]);
+      expect(
+        completedRows
+          .filter((entry) => entry.type !== "turn-fold")
+          .every((entry) => entry.type === "activity-group"),
+      ).toBe(true);
     },
   );
 

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1041,7 +1041,7 @@ describe("buildThreadFeed", () => {
       hasFailure: true,
     },
   ])(
-    "renders a direct browser row once its action settles as $status",
+    "uses the browser call label once its action settles as $status",
     ({ status, displayName, detail, hasFailure }) => {
       const turnId = TurnId.make("turn-preview-lifecycle");
       const toolCallId = "preview-click";
@@ -1172,10 +1172,18 @@ describe("buildThreadFeed", () => {
           completedAt: "2026-04-01T00:00:04.000Z",
         },
       });
-      expect(settledRows.some((entry) => entry.type === "work-toggle")).toBe(false);
+      expect(settledRows.find((entry) => entry.type === "work-toggle")).toMatchObject({
+        groupId,
+        hiddenCount: 1,
+        expanded: true,
+        summary: displayName,
+        summaryKind: "browser",
+        hasFailure,
+        live: false,
+      });
       expect(settledRows.find((entry) => entry.type === "activity-group")).toMatchObject({
-        id: "preview-click-started",
-        activities: [{ id: "preview-click-started", summary: displayName }],
+        id: `work-details:${groupId}`,
+        activities: [{ id: "preview-click-started", summary: displayName, live: false }],
       });
     },
   );
@@ -1350,7 +1358,7 @@ describe("buildThreadFeed", () => {
     expect(expanded.map((entry) => entry.id)).toEqual([
       "assistant-first",
       "turn-fold:turn-1",
-      "tool-completed",
+      "work-toggle:work-group:tool-completed",
       "assistant-final",
     ]);
   });
@@ -1734,7 +1742,7 @@ describe("buildThreadFeed", () => {
         latestTurn.startedAt,
       );
       expect(rows.slice(0, 3).map((entry) => [entry.id, entry.type])).toEqual([
-        ["activity-1", "activity-group"],
+        ["work-toggle:work-group:activity-1", "work-toggle"],
         ["activity-2", "activity-group"],
         ["work-live:work-group:activity-3", "work-toggle"],
       ]);
@@ -1749,10 +1757,13 @@ describe("buildThreadFeed", () => {
         live: true,
         shimmer,
       });
-      expect(rows[0]).toMatchObject({ type: "activity-group" });
+      expect(rows[0]).toMatchObject({ live: false, shimmer: false });
 
       const stoppedRows = deriveThreadFeedPresentation(feed, latestTurn, new Set());
-      expect(stoppedRows.every((entry) => entry.type === "activity-group")).toBe(true);
+      expect(stoppedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
+        { live: false, shimmer: false },
+        { live: false, shimmer: false },
+      ]);
 
       const completedRows = deriveThreadFeedPresentation(
         feed,
@@ -1761,11 +1772,10 @@ describe("buildThreadFeed", () => {
         new Set(),
         latestTurn.startedAt,
       );
-      expect(
-        completedRows
-          .filter((entry) => entry.type !== "turn-fold")
-          .every((entry) => entry.type === "activity-group"),
-      ).toBe(true);
+      expect(completedRows.filter((entry) => entry.type === "work-toggle")).toMatchObject([
+        { live: false, shimmer: false },
+        { live: false, shimmer: false },
+      ]);
     },
   );
 

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1519,26 +1519,16 @@ function appendToolGroupRows(
   const active = latestActiveActivity !== undefined;
   const live = activeTail || active;
   const latestActivity = latestActiveActivity ?? activities.at(-1)!;
-  if (
-    !live &&
-    activities.length === 1 &&
-    latestActivity.toolLike &&
-    toolGroupAction(latestActivity.workEntry) !== "edit"
-  ) {
-    result.push({
-      type: "activity-group",
-      id: latestActivity.id,
-      createdAt: latestActivity.createdAt,
-      turnId: latestActivity.turnId,
-      activities,
-    });
-    return;
-  }
+  const singleActivity = activities.length === 1 ? latestActivity : null;
   const summary = live
     ? liveToolActivitySummary(latestActivity, active)
-    : activities.length === 1 && !activities[0]!.toolLike
-      ? activities[0]!.workEntry.label
-      : summarizeToolGroup(activities.map((activity) => activity.workEntry));
+    : singleActivity !== null &&
+        singleActivity.toolLike &&
+        toolGroupAction(singleActivity.workEntry) !== "edit"
+      ? singleActivity.summary
+      : singleActivity !== null && !singleActivity.toolLike
+        ? singleActivity.workEntry.label
+        : summarizeToolGroup(activities.map((activity) => activity.workEntry));
   const summaryToolIcon = live
     ? resolveWorkEntryToolPresentation(latestActivity.workEntry)?.icon
     : undefined;

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -839,7 +839,7 @@ function workEntryHeading(workEntry: WorkLogEntry): string {
 }
 
 function singleToolCallLabel(activity: ThreadFeedActivity): string {
-  const presentation = resolveWorkEntryToolPresentation(activity.workEntry);
+  const presentation = resolveWorkEntryToolPresentation(activity.workEntry, "completed");
   if (presentation) return presentation.displayName;
   const command = activity.workEntry.command?.trim();
   return command || activity.summary;

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -21,6 +21,7 @@ import {
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
   summarizeToolGroup,
+  toolGroupAction,
   toolGroupSummaryKind,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
@@ -1518,6 +1519,21 @@ function appendToolGroupRows(
   const active = latestActiveActivity !== undefined;
   const live = activeTail || active;
   const latestActivity = latestActiveActivity ?? activities.at(-1)!;
+  if (
+    !live &&
+    activities.length === 1 &&
+    latestActivity.toolLike &&
+    toolGroupAction(latestActivity.workEntry) !== "edit"
+  ) {
+    result.push({
+      type: "activity-group",
+      id: latestActivity.id,
+      createdAt: latestActivity.createdAt,
+      turnId: latestActivity.turnId,
+      activities,
+    });
+    return;
+  }
   const summary = live
     ? liveToolActivitySummary(latestActivity, active)
     : activities.length === 1 && !activities[0]!.toolLike

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -838,6 +838,13 @@ function workEntryHeading(workEntry: WorkLogEntry): string {
   return capitalizePhrase(normalizeCompactToolLabel(workEntry.toolTitle));
 }
 
+function singleToolCallLabel(activity: ThreadFeedActivity): string {
+  const presentation = resolveWorkEntryToolPresentation(activity.workEntry);
+  if (presentation) return presentation.displayName;
+  const command = activity.workEntry.command?.trim();
+  return command || activity.summary;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
 }
@@ -1525,7 +1532,7 @@ function appendToolGroupRows(
     : singleActivity !== null &&
         singleActivity.toolLike &&
         toolGroupAction(singleActivity.workEntry) !== "edit"
-      ? singleActivity.summary
+      ? singleToolCallLabel(singleActivity)
       : singleActivity !== null && !singleActivity.toolLike
         ? singleActivity.workEntry.label
         : summarizeToolGroup(activities.map((activity) => activity.workEntry));

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1538,7 +1538,11 @@ function appendToolGroupRows(
         : summarizeToolGroup(activities.map((activity) => activity.workEntry));
   const summaryToolIcon = live
     ? resolveWorkEntryToolPresentation(latestActivity.workEntry)?.icon
-    : undefined;
+    : singleActivity !== null &&
+        singleActivity.toolLike &&
+        toolGroupAction(singleActivity.workEntry) !== "edit"
+      ? resolveWorkEntryToolPresentation(singleActivity.workEntry, "completed")?.icon
+      : undefined;
   result.push({
     type: "work-toggle",
     id: `${live ? "work-live" : "work-toggle"}:${groupId}`,

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -152,7 +152,7 @@ describe("work entry labels", () => {
     },
   );
 
-  it("renders one completed browser call without a group summary", () => {
+  it("uses the completed browser call label instead of a group summary", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [
         {
@@ -173,11 +173,7 @@ describe("work entry labels", () => {
       revertTurnCountByUserMessageId: new Map(),
     });
     expect(rows).toMatchObject([
-      {
-        kind: "work",
-        groupedEntries: [{ id: "tool-1" }],
-        isExpandedToolGroup: false,
-      },
+      { kind: "work-toggle", hiddenCount: 1, summary: "Clicked in the preview browser" },
     ]);
   });
 });
@@ -736,7 +732,7 @@ describe("deriveMessagesTimelineRows", () => {
       "user-entry",
       "turn-fold:turn-1",
       "assistant-first-entry",
-      "work-entry-1",
+      "work-toggle:work-entry-1",
       "assistant-final-entry",
     ]);
     expect(
@@ -1130,7 +1126,7 @@ describe("deriveMessagesTimelineRows", () => {
     });
   });
 
-  it("renders a single completed tool call without summarizing it", () => {
+  it("labels a single completed tool call without summarizing it", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [
         {
@@ -1190,10 +1186,10 @@ describe("deriveMessagesTimelineRows", () => {
       revertTurnCountByUserMessageId: new Map(),
     });
 
-    expect(rows.map((row) => row.kind)).toEqual(["working", "work", "message", "work-live"]);
-    expect(rows.find((row) => row.kind === "work")).toMatchObject({
-      groupedEntries: [{ id: "completed-command" }],
-      isExpandedToolGroup: false,
+    expect(rows.map((row) => row.kind)).toEqual(["working", "work-toggle", "message", "work-live"]);
+    expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
+      hiddenCount: 1,
+      summary: "rg toolCall",
     });
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -152,29 +152,35 @@ describe("work entry labels", () => {
     },
   );
 
-  it("uses the completed browser call label for a settled legacy tool", () => {
-    const rows = deriveMessagesTimelineRows({
-      timelineEntries: [
-        {
-          id: "browser-entry",
-          kind: "work",
-          createdAt: entry.createdAt,
-          entry: {
-            ...entry,
-            itemType: "mcp_tool_call",
-            toolData: { server: "t3-code", tool: "preview_click" },
+  it.each([
+    ["preview_click", "Clicked in the preview browser", "browser"],
+    ["task_status", "Got delegated task status", "t3-code"],
+  ] as const)(
+    "uses the completed %s call presentation for a settled legacy tool",
+    (tool, summary, summaryToolIcon) => {
+      const rows = deriveMessagesTimelineRows({
+        timelineEntries: [
+          {
+            id: "browser-entry",
+            kind: "work",
+            createdAt: entry.createdAt,
+            entry: {
+              ...entry,
+              itemType: "mcp_tool_call",
+              toolData: { server: "t3-code", tool },
+            },
           },
-        },
-      ],
-      isWorking: false,
-      activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
-    });
-    expect(rows).toMatchObject([
-      { kind: "work-toggle", hiddenCount: 1, summary: "Clicked in the preview browser" },
-    ]);
-  });
+        ],
+        isWorking: false,
+        activeTurnStartedAt: null,
+        turnDiffSummaryByAssistantMessageId: new Map(),
+        revertTurnCountByUserMessageId: new Map(),
+      });
+      expect(rows).toMatchObject([
+        { kind: "work-toggle", hiddenCount: 1, summary, summaryToolIcon },
+      ]);
+    },
+  );
 });
 
 describe("shouldPreserveAssistantLineBreaks", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -152,7 +152,7 @@ describe("work entry labels", () => {
     },
   );
 
-  it("gives a completed browser group its own count and summary icon category", () => {
+  it("renders one completed browser call without a group summary", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [
         {
@@ -173,7 +173,11 @@ describe("work entry labels", () => {
       revertTurnCountByUserMessageId: new Map(),
     });
     expect(rows).toMatchObject([
-      { kind: "work-toggle", summary: "Used browser 1 time", summaryKind: "browser" },
+      {
+        kind: "work",
+        groupedEntries: [{ id: "tool-1" }],
+        isExpandedToolGroup: false,
+      },
     ]);
   });
 });
@@ -732,7 +736,7 @@ describe("deriveMessagesTimelineRows", () => {
       "user-entry",
       "turn-fold:turn-1",
       "assistant-first-entry",
-      "work-toggle:work-entry-1",
+      "work-entry-1",
       "assistant-final-entry",
     ]);
     expect(
@@ -1126,7 +1130,7 @@ describe("deriveMessagesTimelineRows", () => {
     });
   });
 
-  it("summarizes a tool run after commentary starts a new run", () => {
+  it("renders a single completed tool call without summarizing it", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [
         {
@@ -1186,10 +1190,10 @@ describe("deriveMessagesTimelineRows", () => {
       revertTurnCountByUserMessageId: new Map(),
     });
 
-    expect(rows.map((row) => row.kind)).toEqual(["working", "work-toggle", "message", "work-live"]);
-    expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
-      hiddenCount: 1,
-      summary: "Ran 1 command",
+    expect(rows.map((row) => row.kind)).toEqual(["working", "work", "message", "work-live"]);
+    expect(rows.find((row) => row.kind === "work")).toMatchObject({
+      groupedEntries: [{ id: "completed-command" }],
+      isExpandedToolGroup: false,
     });
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -152,7 +152,7 @@ describe("work entry labels", () => {
     },
   );
 
-  it("uses the completed browser call label instead of a group summary", () => {
+  it("uses the completed browser call label for a settled legacy tool", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [
         {
@@ -162,7 +162,6 @@ describe("work entry labels", () => {
           entry: {
             ...entry,
             itemType: "mcp_tool_call",
-            toolLifecycleStatus: "completed",
             toolData: { server: "t3-code", tool: "preview_click" },
           },
         },

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -36,7 +36,7 @@ export const TIMELINE_CONTENT_MAX_WIDTH = 768;
 export const TIMELINE_MINIMAP_PERSISTENT_GUTTER = 48;
 
 function singleToolCallLabel(entry: WorkLogEntry): string {
-  const toolPresentation = resolveWorkEntryToolPresentation(entry);
+  const toolPresentation = resolveWorkEntryToolPresentation(entry, "completed");
   if (toolPresentation) return toolPresentation.displayName;
   const command = entry.command?.trim();
   if (command) return command;

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -836,23 +836,13 @@ export function deriveMessagesTimelineRows(input: {
               expandedWorkGroupRow(groupId, timelineEntry.createdAt, visibleGroupedEntries),
             );
           }
-        } else if (
-          visibleGroupedEntries.length === 1 &&
-          workLogEntryIsToolLike(visibleGroupedEntries[0]!) &&
-          toolGroupAction(visibleGroupedEntries[0]!) !== "edit"
-        ) {
-          nextRows.push({
-            kind: "work",
-            id: timelineEntry.id,
-            createdAt: timelineEntry.createdAt,
-            groupedEntries: visibleGroupedEntries,
-            isExpandedToolGroup: false,
-          });
         } else {
           const groupId = workGroupId(timelineEntry.id, timelineEntry.entry);
           const expanded = input.expandedWorkGroupIds?.has(groupId) ?? false;
           const summaryKind = toolGroupSummaryKind(visibleGroupedEntries);
           const latestToolEntry = visibleGroupedEntries.findLast(workLogEntryIsToolLike);
+          const singleEntry =
+            visibleGroupedEntries.length === 1 ? (visibleGroupedEntries[0] ?? null) : null;
           nextRows.push({
             kind: "work-toggle",
             id: `work-toggle:${timelineEntry.id}`,
@@ -861,10 +851,13 @@ export function deriveMessagesTimelineRows(input: {
             hiddenCount: visibleGroupedEntries.length,
             expanded,
             summary:
-              visibleGroupedEntries.length === 1 &&
-              !workLogEntryIsToolLike(visibleGroupedEntries[0]!)
-                ? visibleGroupedEntries[0]!.label
-                : summarizeToolGroup(visibleGroupedEntries),
+              singleEntry !== null &&
+              workLogEntryIsToolLike(singleEntry) &&
+              toolGroupAction(singleEntry) !== "edit"
+                ? workEntryDisplayLabel(singleEntry, undefined)
+                : singleEntry !== null && !workLogEntryIsToolLike(singleEntry)
+                  ? singleEntry.label
+                  : summarizeToolGroup(visibleGroupedEntries),
             summaryKind,
             hasFailure:
               latestToolEntry !== undefined &&

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -6,6 +6,7 @@ import {
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
   summarizeToolGroup,
+  toolGroupAction,
   toolGroupSummaryKind,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
@@ -835,6 +836,18 @@ export function deriveMessagesTimelineRows(input: {
               expandedWorkGroupRow(groupId, timelineEntry.createdAt, visibleGroupedEntries),
             );
           }
+        } else if (
+          visibleGroupedEntries.length === 1 &&
+          workLogEntryIsToolLike(visibleGroupedEntries[0]!) &&
+          toolGroupAction(visibleGroupedEntries[0]!) !== "edit"
+        ) {
+          nextRows.push({
+            kind: "work",
+            id: timelineEntry.id,
+            createdAt: timelineEntry.createdAt,
+            groupedEntries: visibleGroupedEntries,
+            isExpandedToolGroup: false,
+          });
         } else {
           const groupId = workGroupId(timelineEntry.id, timelineEntry.entry);
           const expanded = input.expandedWorkGroupIds?.has(groupId) ?? false;

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -35,6 +35,15 @@ export const TIMELINE_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
 export const TIMELINE_CONTENT_MAX_WIDTH = 768;
 export const TIMELINE_MINIMAP_PERSISTENT_GUTTER = 48;
 
+function singleToolCallLabel(entry: WorkLogEntry): string {
+  const toolPresentation = resolveWorkEntryToolPresentation(entry);
+  if (toolPresentation) return toolPresentation.displayName;
+  const command = entry.command?.trim();
+  if (command) return command;
+  const heading = normalizeCompactToolLabel(entry.toolTitle || entry.label);
+  return `${heading.charAt(0).toUpperCase()}${heading.slice(1)}`;
+}
+
 export function workEntryDisplayLabel(entry: WorkLogEntry, workspaceRoot: string | undefined) {
   const toolPresentation = resolveWorkEntryToolPresentation(entry);
   if (toolPresentation) return toolPresentation.displayName;
@@ -854,7 +863,7 @@ export function deriveMessagesTimelineRows(input: {
               singleEntry !== null &&
               workLogEntryIsToolLike(singleEntry) &&
               toolGroupAction(singleEntry) !== "edit"
-                ? workEntryDisplayLabel(singleEntry, undefined)
+                ? singleToolCallLabel(singleEntry)
                 : singleEntry !== null && !workLogEntryIsToolLike(singleEntry)
                   ? singleEntry.label
                   : summarizeToolGroup(visibleGroupedEntries),

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -305,6 +305,7 @@ export type MessagesTimelineRow =
       expanded: boolean;
       summary: string;
       summaryKind: ToolGroupSummaryKind;
+      summaryToolIcon?: "browser" | "t3-code";
       hasFailure: boolean;
     }
   | {
@@ -852,6 +853,13 @@ export function deriveMessagesTimelineRows(input: {
           const latestToolEntry = visibleGroupedEntries.findLast(workLogEntryIsToolLike);
           const singleEntry =
             visibleGroupedEntries.length === 1 ? (visibleGroupedEntries[0] ?? null) : null;
+          const usesSingleToolCallLabel =
+            singleEntry !== null &&
+            workLogEntryIsToolLike(singleEntry) &&
+            toolGroupAction(singleEntry) !== "edit";
+          const summaryToolIcon = usesSingleToolCallLabel
+            ? resolveWorkEntryToolPresentation(singleEntry, "completed")?.icon
+            : undefined;
           nextRows.push({
             kind: "work-toggle",
             id: `work-toggle:${timelineEntry.id}`,
@@ -859,15 +867,13 @@ export function deriveMessagesTimelineRows(input: {
             groupId,
             hiddenCount: visibleGroupedEntries.length,
             expanded,
-            summary:
-              singleEntry !== null &&
-              workLogEntryIsToolLike(singleEntry) &&
-              toolGroupAction(singleEntry) !== "edit"
-                ? singleToolCallLabel(singleEntry)
-                : singleEntry !== null && !workLogEntryIsToolLike(singleEntry)
-                  ? singleEntry.label
-                  : summarizeToolGroup(visibleGroupedEntries),
+            summary: usesSingleToolCallLabel
+              ? singleToolCallLabel(singleEntry)
+              : singleEntry !== null && !workLogEntryIsToolLike(singleEntry)
+                ? singleEntry.label
+                : summarizeToolGroup(visibleGroupedEntries),
             summaryKind,
+            ...(summaryToolIcon ? { summaryToolIcon } : {}),
             hasFailure:
               latestToolEntry !== undefined &&
               workEntryDisplayIndicatesToolFailure(latestToolEntry),

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1851,7 +1851,7 @@ function WorkGroupToggleTimelineRow({
     >
       <span className="flex size-6 shrink-0 items-center justify-center text-icon-muted">
         <WorkEntryIcon
-          name={toolGroupSummaryIconName(row.summaryKind)}
+          name={row.summaryToolIcon ?? toolGroupSummaryIconName(row.summaryKind)}
           className="size-4 shrink-0 stroke-[1.8] opacity-70"
         />
       </span>


### PR DESCRIPTION
single completed tool calls were displayed as one-item group summaries such as "Ran 1 command". this uses each settled call's own label in the existing expandable activity row on web, desktop, and mobile while preserving summaries for multi-call groups and file changes.

verified with the focused web and mobile presentation suites, targeted lint and formatting, both client typechecks, and the same seeded browser fixture before and after.

| before | after |
| --- | --- |
| ![before: one call summarized as Ran 1 command](https://uploads-production-47e4.up.railway.app/files/2888e46e-ca97-4ac6-a28b-9e70def1eb1b/t3-single-call-before.png) | ![after: the command shown directly as git status --short](https://uploads-production-47e4.up.railway.app/files/f43632d9-b84a-4a9f-ac3a-c36e329162fa/t3-single-call-after.png) |

built with `gpt-5.6-sol` in the codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only labeling in chat timeline presentation logic; behavior is covered by updated web and mobile tests with no auth or data-path changes.
> 
> **Overview**
> Settled **work-toggle** rows for a single non-edit tool call now show that call’s own completed label (for example `rg toolCall` or **Clicked in the preview browser**) instead of one-item aggregate text like “Ran 1 command” or “Used browser 1 time”. Multi-entry groups and file edits still use `summarizeToolGroup`.
> 
> **Web and mobile** share the same rule via a `singleToolCallLabel` helper that resolves friendly names with `resolveWorkEntryToolPresentation(..., "completed")`, then falls back to command text or the activity summary. When that path applies, rows can also carry **`summaryToolIcon`** so the timeline prefers the tool’s icon over the generic group-kind icon.
> 
> Presentation tests on both clients were updated for settled MCP/browser calls and for mixed live vs settled command rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71cb61e768a07f3b57e16ab07eeac601cccc70f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show single completed tool calls with their own label and icon instead of a group summary
> - Adds `singleToolCallLabel` helper in both [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/9267/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5) and [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/9267/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) to resolve the completed tool presentation label, falling back to command text then activity summary
> - Settled work groups containing exactly one non-edit tool-like entry now use that label and the completed presentation icon (browser or T3-code) rather than a generic tool-group summary
> - Web `WorkGroupToggleTimelineRow` prefers the new optional `summaryToolIcon` on the row, falling back to the existing summary-kind icon
> - Edit actions, non-tool entries, multi-entry groups, and live groups keep their existing summary paths
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71cb61e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->