### PR TITLE
fix(worktrees): remove t3code branch prefix

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1596,7 +1596,7 @@ describe("ProviderCommandReactor", () => {
         type: "thread.meta.update",
         commandId: CommandId.make("cmd-thread-branch"),
         threadId: ThreadId.make("thread-1"),
-        branch: "t3code/1234abcd",
+        branch: "1234abcd",
         worktreePath: "/tmp/provider-project-worktree",
       }),
     );
@@ -1640,6 +1640,11 @@ describe("ProviderCommandReactor", () => {
     );
     expect(harness.generateBranchName.mock.calls[0]?.[0].message).not.toContain("t3-citation://");
     expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+    expect(harness.renameBranch).toHaveBeenCalledWith({
+      cwd: "/tmp/provider-project-worktree",
+      oldBranch: "1234abcd",
+      newBranch: "feature/gpt-5-6-luna",
+    });
     const readModel = await harness.readModel();
     expect(
       readModel.threads

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -301,7 +301,7 @@ function buildGeneratedWorktreeBranchName(raw: string): string {
     .replace(/[./_-]+$/g, "");
 
   const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
+  return safeFragment;
 }
 
 const make = Effect.gen(function* () {

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -74,7 +74,13 @@ describe("isTemporaryWorktreeBranch", () => {
     ).toBe(true);
   });
 
-  it("matches generated temporary worktree refs", () => {
+  it("matches generated temporary worktree refs without a prefix", () => {
+    expect(isTemporaryWorktreeBranch("deadbeef")).toBe(true);
+    expect(isTemporaryWorktreeBranch(" deadbeef ")).toBe(true);
+    expect(isTemporaryWorktreeBranch("DEADBEEF")).toBe(true);
+  });
+
+  it("matches legacy prefixed temporary worktree refs", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef`)).toBe(true);
     expect(isTemporaryWorktreeBranch(` ${WORKTREE_BRANCH_PREFIX}/deadbeef `)).toBe(true);
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/DEADBEEF`)).toBe(true);
@@ -82,7 +88,7 @@ describe("isTemporaryWorktreeBranch", () => {
 
   it("normalizes a UUID-shaped random callback to the canonical 8-hex form", () => {
     expect(buildTemporaryWorktreeBranchName(() => "f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12")).toBe(
-      `${WORKTREE_BRANCH_PREFIX}/f4ae4e0e`,
+      "f4ae4e0e",
     );
   });
 
@@ -106,6 +112,7 @@ describe("isTemporaryWorktreeBranch", () => {
   it("rejects non-temporary refName names", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);
+    expect(isTemporaryWorktreeBranch("deadbeef-extra")).toBe(false);
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(false);
   });
 });

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -11,12 +11,12 @@ import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
 export const WORKTREE_BRANCH_PREFIX = "t3code";
-// Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
-// via Crypto.randomUUID() (always RFC 4122 v4), so the matcher also accepts exactly
-// that shape — version nibble `4`, variant nibble `[89ab]` — to keep those threads
-// eligible for branch regeneration without loosening beyond what was ever generated.
+// Canonical form is `<8 hex>`. Older clients generated `t3code/<8 hex>` and some
+// mobile builds generated `t3code/<uuid>` via Crypto.randomUUID() (always RFC 4122
+// v4), so the matcher accepts those exact legacy shapes to keep existing threads
+// eligible for branch regeneration.
 const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(
-  `^${WORKTREE_BRANCH_PREFIX}\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$`,
+  `^(?:[0-9a-f]{8}|${WORKTREE_BRANCH_PREFIX}\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}))$`,
 );
 
 /**
@@ -101,7 +101,7 @@ export function buildTemporaryWorktreeBranchName(
     .toLowerCase()
     .replace(/[^0-9a-f]/g, "")
     .slice(0, 8);
-  return `${WORKTREE_BRANCH_PREFIX}/${token}`;
+  return token;
 }
 
 export function isTemporaryWorktreeBranch(refName: string): boolean {


### PR DESCRIPTION
New worktrees start on branches such as `t3code/aa34ff6b`, and generated names keep the same product prefix. This exposes an unnecessary T3 Code namespace in user repositories.

Generate temporary branches as bare eight-character hashes and keep generated semantic names unprefixed. Legacy `t3code/<hash>` and UUID branch names remain recognized so existing threads can still rename their branches.

Tests:
- `vp test run packages/shared/src/git.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts` (65 passed)
- targeted format and lint checks
- `vp run --filter @t3tools/shared --filter t3 typecheck`

Implemented with gpt-5.6-sol in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `t3code` prefix from temporary worktree branch names
> - `buildTemporaryWorktreeBranchName` in [git.ts](https://github.com/pingdotgg/t3code/pull/9275/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) and `buildGeneratedWorktreeBranchName` in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/9275/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) now return the bare sanitized eight-hex token instead of prepending the legacy worktree branch prefix
> - `TEMP_WORKTREE_BRANCH_PATTERN` expanded to match bare eight-hex refs as the canonical form while still accepting legacy prefixed eight-hex and prefixed UUID forms
> - `isTemporaryWorktreeBranch` now classifies bare eight-hex branch refs as temporary; normalization and legacy matching behavior are otherwise unchanged
> - Behavioral Change: existing worktrees created with the old `t3code`-prefixed branch names are still recognized by `isTemporaryWorktreeBranch`, but all newly generated branches use the unprefixed form
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8a6b6e6. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how new git branches appear in customer repositories and relies on legacy regex matching for migration; misclassification could skip or mishandle branch rename on first turn.
> 
> **Overview**
> **New worktree and generated branch names no longer use the `t3code/` prefix** in user repos. Temporary branches are created as bare 8-character hex refs (e.g. `1234abcd`), and LLM-driven renames keep only the sanitized fragment (e.g. `feature/gpt-5-6-luna`) instead of nesting under `t3code/`.
> 
> Shared git helpers (`buildTemporaryWorktreeBranchName`, `isTemporaryWorktreeBranch`) treat unprefixed 8-hex as canonical while still recognizing legacy `t3code/<8-hex>` and `t3code/<uuid>` so existing threads can be detected and renamed on first turn. Tests were updated for unprefixed temps and explicit `renameBranch` expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6b6e664d8b3c259b47e6e805bc2c5caa9b7b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->