### PR TITLE
fix(web): offer browser profiles from the empty-panel launcher

### DIFF
--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -2,6 +2,7 @@ import type { ContextMenuItem, PreviewSessionSnapshot, PullRequestState } from "
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import {
   Bot,
+  ChevronDown,
   FileDiff,
   Files,
   GitPullRequest,
@@ -270,6 +271,8 @@ function SurfaceMenuItem(props: {
  */
 function RightPanelEmptyState(props: {
   onAddBrowser: () => void;
+  onAddBrowserInProfile: (profileId: string) => void;
+  browserProfiles: ReadonlyArray<{ readonly id: string; readonly name: string }>;
   onAddTerminal: () => void;
   onAddDiff: () => void;
   onAddFiles: () => void;
@@ -460,31 +463,70 @@ function RightPanelEmptyState(props: {
         <div className="grid grid-cols-2 gap-2">
           {actions.map((action) =>
             action.available ? (
-              <button
-                key={action.label}
-                type="button"
-                onClick={action.onClick}
-                onMouseEnter={() => setHighlight(availableActions.indexOf(action))}
-                onMouseLeave={() =>
-                  setHighlight((current) =>
-                    current === availableActions.indexOf(action) ? -1 : current,
-                  )
-                }
-                className={cn(
-                  "relative flex w-full cursor-pointer flex-col items-start p-4 text-left transition hover:border-border hover:bg-accent/60",
-                  cardShellClass,
-                  isHighlighted(action) && highlightedCardClass,
-                )}
-              >
-                <Kbd className="absolute top-3 right-3">{action.shortcut}</Kbd>
-                <span className="flex items-center gap-2 pe-8">
-                  {actionIcon(action)}
-                  <span className="font-medium text-sm">{action.label}</span>
-                </span>
-                <span className="mt-1.5 text-muted-foreground text-xs leading-relaxed">
-                  {action.description}
-                </span>
-              </button>
+              // The card is itself a button, so the profile chooser sits beside
+              // it in a wrapper rather than inside it.
+              <div key={action.label} className="relative">
+                <button
+                  type="button"
+                  onClick={action.onClick}
+                  onMouseEnter={() => setHighlight(availableActions.indexOf(action))}
+                  onMouseLeave={() =>
+                    setHighlight((current) =>
+                      current === availableActions.indexOf(action) ? -1 : current,
+                    )
+                  }
+                  className={cn(
+                    "relative flex w-full cursor-pointer flex-col items-start p-4 text-left transition hover:border-border hover:bg-accent/60",
+                    cardShellClass,
+                    isHighlighted(action) && highlightedCardClass,
+                  )}
+                >
+                  <Kbd className="absolute top-3 right-3">{action.shortcut}</Kbd>
+                  <span className="flex items-center gap-2 pe-8">
+                    {actionIcon(action)}
+                    <span className="font-medium text-sm">{action.label}</span>
+                  </span>
+                  <span className="mt-1.5 text-muted-foreground text-xs leading-relaxed">
+                    {action.description}
+                  </span>
+                </button>
+                {/*
+                  Same choice the tab bar's "+" menu offers: the card opens the
+                  default profile, the chevron picks another. Only worth showing
+                  once there is something to choose between.
+                */}
+                {action.label === "Browser" && props.browserProfiles.length > 1 ? (
+                  <Menu>
+                    <MenuTrigger
+                      render={
+                        <Button
+                          aria-label="Open browser in a profile"
+                          className="absolute right-3 bottom-3 text-muted-foreground hover:text-foreground"
+                          size="icon-xs"
+                          variant="ghost"
+                        />
+                      }
+                    >
+                      <ChevronDown className="size-3.5" />
+                    </MenuTrigger>
+                    <MenuPopup
+                      align="end"
+                      side="bottom"
+                      sideOffset={6}
+                      className="min-w-40 max-w-56"
+                    >
+                      {props.browserProfiles.map((profile) => (
+                        <MenuItem
+                          key={profile.id}
+                          onClick={() => props.onAddBrowserInProfile(profile.id)}
+                        >
+                          <span className="min-w-0 truncate">{profile.name}</span>
+                        </MenuItem>
+                      ))}
+                    </MenuPopup>
+                  </Menu>
+                ) : null}
+              </div>
             ) : (
               <div
                 key={action.label}
@@ -1009,6 +1051,8 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
         {props.activeSurfaceId === null ? (
           <RightPanelEmptyState
             onAddBrowser={props.onAddBrowser}
+            onAddBrowserInProfile={props.onAddBrowserInProfile}
+            browserProfiles={browserProfiles}
             onAddTerminal={props.onAddTerminal}
             onAddDiff={props.onAddDiff}
             onAddFiles={props.onAddFiles}

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -464,19 +464,27 @@ function RightPanelEmptyState(props: {
           {actions.map((action) =>
             action.available ? (
               // The card is itself a button, so the profile chooser sits beside
-              // it in a wrapper rather than inside it.
-              <div key={action.label} className="relative">
+              // it in a wrapper rather than inside it. Hover lives on the
+              // wrapper: the chooser overlays the card, and a pointer moving
+              // onto it must not read as leaving the card.
+              <div
+                key={action.label}
+                className="group relative"
+                onMouseEnter={() => setHighlight(availableActions.indexOf(action))}
+                onMouseLeave={() =>
+                  setHighlight((current) =>
+                    current === availableActions.indexOf(action) ? -1 : current,
+                  )
+                }
+              >
                 <button
                   type="button"
                   onClick={action.onClick}
-                  onMouseEnter={() => setHighlight(availableActions.indexOf(action))}
-                  onMouseLeave={() =>
-                    setHighlight((current) =>
-                      current === availableActions.indexOf(action) ? -1 : current,
-                    )
-                  }
                   className={cn(
-                    "relative flex w-full cursor-pointer flex-col items-start p-4 text-left transition hover:border-border hover:bg-accent/60",
+                    // Full height: the wrapper is the grid item that stretches
+                    // to the row, so the button must fill it to stay level with
+                    // its neighbour and keep the chooser anchored inside.
+                    "relative flex h-full w-full cursor-pointer flex-col items-start p-4 text-left transition group-hover:border-border group-hover:bg-accent/60",
                     cardShellClass,
                     isHighlighted(action) && highlightedCardClass,
                   )}
@@ -501,9 +509,9 @@ function RightPanelEmptyState(props: {
                       render={
                         <Button
                           aria-label="Open browser in a profile"
-                          className="absolute right-3 bottom-3 text-muted-foreground hover:text-foreground"
+                          className="absolute right-3 bottom-3 [--control-icon-color:currentColor]"
                           size="icon-xs"
-                          variant="ghost"
+                          variant="ghost-muted"
                         />
                       }
                     >


### PR DESCRIPTION
Follow-up to #7254. The profile submenu only existed on the tab bar's "+" menu, which is not mounted until a surface is open, so the first browser tab in a fresh thread could only ever use the default profile. Flagged in review on #7254 after it merged.

The Browser card in the empty-panel launcher now carries the same chooser: the card itself still opens the default profile in one click, and a chevron beside it lists the other profiles. The chevron only renders when there is more than one profile to choose from.

Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to the empty right-panel launcher; reuses existing profile callbacks and menu patterns from the tab bar.
> 
> **Overview**
> When the right panel has no surfaces, the **Browser** launcher card could only open the default profile because profile picking lived on the tab bar **+** menu, which is not shown until a surface exists.
> 
> The empty-state **Browser** card now matches that behavior: the card still opens the default profile in one click, and when more than one profile is configured a **chevron** menu lists each profile and calls `onAddBrowserInProfile` with the selected id. The card is wrapped in a `group` container so hover/highlight stays stable when moving the pointer onto the chevron control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a2d6d3f172c562a02be1d27423417cbbe432ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add browser profile chooser to `RightPanelEmptyState` launcher
> - Adds a `ChevronDown` menu next to the Browser card in [RightPanelTabs.tsx](https://github.com/pingdotgg/t3code/pull/9279/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91) when multiple browser profiles exist.
> - `RightPanelTabs` passes the profile list and a profile-specific open callback to `RightPanelEmptyState`.
> - Wraps each surface card in a container to prevent nesting interactive elements.
> - Behavioral Change: Hover highlighting moved from the card button to the wrapper `div`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7a2d6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->