### PR TITLE
fix(web): show scroll-to-end as soon as the last message slips under the composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4219,8 +4219,7 @@ function ChatViewContent(props: ChatViewProps) {
         // up, and a gesture landing in that window while still pinned would
         // otherwise break follow with no scroll event left to re-arm it.
         const viewportIsAwayFromEnd = () =>
-          resolveTimelineIsAtEnd(legendListRef.current?.getState(), composerOverlayHeight) ===
-          false;
+          resolveTimelineIsAtEnd(legendListRef.current?.getState()) === false;
         // Only an upward wheel is a navigation intent; wheeling down while
         // following either does nothing (at the end) or moves toward it.
         const handleWheel = (event: WheelEvent) => {
@@ -4299,7 +4298,7 @@ function ChatViewContent(props: ChatViewProps) {
       }
       removeListeners?.();
     };
-  }, [activeThread?.id, composerOverlayHeight, timelineRealContentOverflowsViewport]);
+  }, [activeThread?.id, timelineRealContentOverflowsViewport]);
 
   const onTimelineAnchorReady = useCallback((messageId: MessageId, anchorIndex: number) => {
     // Anchored-end space can be remeasured when the turn completes. Once the

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -135,23 +135,21 @@ export interface TimelineEndState {
  */
 export const TIMELINE_FOLLOW_REARM_THRESHOLD_PX = 40;
 
-export function resolveTimelineIsAtEnd(
-  state: TimelineEndState | undefined,
-  endInset = 0,
-): boolean | undefined {
+export function resolveTimelineIsAtEnd(state: TimelineEndState | undefined): boolean | undefined {
   if (!state) {
     return undefined;
-  }
-  if (state.isAtEnd) {
-    return true;
   }
   const { contentLength, scroll, scrollLength } = state;
   if (contentLength === undefined || scroll === undefined || scrollLength === undefined) {
     return state.isAtEnd;
   }
-  // contentLength includes the end inset (composer overlay), so subtract it to
-  // measure the distance to the real content bottom.
-  return contentLength - scroll - scrollLength - endInset <= TIMELINE_FOLLOW_REARM_THRESHOLD_PX;
+  // contentLength includes the composer inset spacer, but the composer hides
+  // the same amount of viewport, so the inset cancels: plain
+  // contentLength - scroll - scrollLength is the gap between the last real row
+  // and the visible edge above the composer. LegendList's own isAtEnd subtracts
+  // the inset and is true anywhere in the bottom composer-height band, so it is
+  // only a fallback here, never a short-circuit.
+  return contentLength - scroll - scrollLength <= TIMELINE_FOLLOW_REARM_THRESHOLD_PX;
 }
 
 export function shouldPreserveAssistantLineBreaks(text: string): boolean {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -378,14 +378,17 @@ describe("MessagesTimeline", () => {
         scrollLength: 800,
       }),
     ).toBe(false);
-    // The composer inset is part of contentLength and must not count as
-    // distance-to-end.
+    // LegendList's isAtEnd is true anywhere within the composer-height band
+    // (it subtracts the inset); the last row is still hidden under the
+    // composer there, so the flag must not short-circuit the geometry.
     expect(
-      resolveTimelineIsAtEnd(
-        { isAtEnd: false, contentLength: 2100, scroll: 1170, scrollLength: 800 },
-        100,
-      ),
-    ).toBe(true);
+      resolveTimelineIsAtEnd({
+        isAtEnd: true,
+        contentLength: 2000,
+        scroll: 1100,
+        scrollLength: 800,
+      }),
+    ).toBe(false);
     // Geometry missing (older state shape): fall back to the strict flag.
     expect(resolveTimelineIsAtEnd({ isAtEnd: false })).toBe(false);
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -555,7 +555,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   const handleScroll = useCallback(() => {
     const state = listRef.current?.getState?.();
-    const isAtEnd = resolveTimelineIsAtEnd(state, contentInsetEndAdjustment);
+    const isAtEnd = resolveTimelineIsAtEnd(state);
     if (isAtEnd !== undefined && !citationPositioning) {
       onIsAtEndChange(isAtEnd);
     }
@@ -581,14 +581,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
       strip.dataset.inView = inView ? "true" : "false";
     }
-  }, [
-    citationPositioning,
-    contentInsetEndAdjustment,
-    listRef,
-    minimapItems,
-    minimapStripMap,
-    onIsAtEndChange,
-  ]);
+  }, [citationPositioning, listRef, minimapItems, minimapStripMap, onIsAtEndChange]);
 
   useEffect(() => {
     const frame = requestAnimationFrame(handleScroll);


### PR DESCRIPTION
Scrolling up in a thread required travelling a whole composer height (~150px) before the scroll-to-end pill appeared, even though the last message was already hidden under the composer.

The end check subtracted the composer inset twice. LegendList's `contentLength` already includes the inset spacer, and the composer covers the same amount of viewport, so the two cancel out: plain `contentLength - scroll - scrollLength` is the real gap between the last row and the visible edge above the composer. On top of that, `resolveTimelineIsAtEnd` short-circuited on LegendList's own `isAtEnd`, which is true anywhere inside that composer-height band, so the pill stayed suppressed even once the geometry check would have fired.

This drops the inset parameter and the flag short-circuit; the flag is now only the fallback for state shapes without geometry. Follow re-arm uses the same predicate, so it now re-engages at the same point the pill hides.

Same thread, same viewport, both scrolled up exactly 120px from the end. Before: nothing. After: pill.

![before/after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f7293a38076b9d94/compare.png)

Claude Fable 5.1 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat timeline scroll UX logic with updated unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **scroll-to-end** visibility and **live-follow re-arm** so they trigger when the last message is hidden under the composer, instead of only after scrolling up by roughly a full composer height.
> 
> `resolveTimelineIsAtEnd` no longer takes a composer **end inset** (it was effectively subtracted twice against `contentLength` that already includes the spacer) and no longer treats LegendList’s **`isAtEnd`** as authoritative when scroll geometry exists—that flag stays true in the whole composer band even when the last row is still covered. End detection is now **`contentLength - scroll - scrollLength`** within the existing 40px follow band; **`isAtEnd`** is only used when geometry is missing. Call sites in **`ChatView`** and **`MessagesTimeline`** drop the inset argument and related effect dependencies; tests assert that **`isAtEnd: true`** with bad geometry still yields “not at end.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b9b042f30fcfae22347d63ea6368a0167b205f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scroll-to-end button to show when last message slips under composer
> The timeline end detection was subtracting the composer overlay height from the content gap, so positions where content sat under the composer were wrongly reported as "at the end." This removed the `endInset` parameter from `resolveTimelineIsAtEnd` and all callers across [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9280/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9280/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588).
> - The function now uses geometry first: when geometry is available, it reports `false` if the real gap exceeds 40 pixels, even when LegendList reports `isAtEnd` true. The `isAtEnd` flag is only used as a fallback when geometry is missing.
> - The scroll/follow listener in `ChatViewContent` and the `handleScroll` callback in `MessagesTimeline` no longer depend on composer overlay height, so they are not recreated when the composer resizes.
> - Risk: callers that previously relied on `resolveTimelineIsAtEnd` accepting an `endInset` argument will fail to compile; the in-tree callers are all updated but any out-of-tree usage would break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94b9b04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->