### PR TITLE
fix(cursor): honor auto and full access modes

### DIFF
--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -820,6 +820,9 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         );
         assert.isDefined(permissionResponse);
 
+        const argvRuns = yield* Effect.promise(() => readArgvLog(argvLogPath));
+        assert.deepStrictEqual(argvRuns, [["--force", "acp"]]);
+
         yield* adapter.stopSession(threadId);
       }),
   );
@@ -1260,7 +1263,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
 
       const argvRuns = yield* Effect.promise(() => readArgvLog(argvLogPath));
       assert.lengthOf(argvRuns, 1, "session should not restart — only one spawn");
-      assert.deepStrictEqual(argvRuns[0], ["acp"]);
+      assert.deepStrictEqual(argvRuns[0], ["--force", "acp"]);
 
       const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
       const setConfigRequests = requests.filter(

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -537,6 +537,7 @@ export function makeCursorAdapter(
             ...(options?.environment ? { environment: options.environment } : {}),
             childProcessSpawner,
             cwd,
+            runtimeMode: input.runtimeMode,
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientInfo: { name: "t3-code", version: "0.0.0" },
             ...(mcpSession

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -83,8 +83,16 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it.each(["approval-required", "auto-accept-edits", "auto"] as const)(
-    "does not force approval in %s mode",
+  it("uses Cursor auto-review in auto mode", () => {
+    expect(buildCursorAcpSpawnInput(undefined, "/tmp/project", undefined, "auto")).toEqual({
+      command: "cursor-agent",
+      args: ["--auto-review", "acp"],
+      cwd: "/tmp/project",
+    });
+  });
+
+  it.each(["approval-required", "auto-accept-edits"] as const)(
+    "does not relax approval in %s mode",
     (runtimeMode) => {
       expect(buildCursorAcpSpawnInput(undefined, "/tmp/project", undefined, runtimeMode)).toEqual({
         command: "cursor-agent",

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -74,6 +74,25 @@ describe("buildCursorAcpSpawnInput", () => {
       cwd: "/tmp/project",
     });
   });
+
+  it("forces approval in full-access mode", () => {
+    expect(buildCursorAcpSpawnInput(undefined, "/tmp/project", undefined, "full-access")).toEqual({
+      command: "cursor-agent",
+      args: ["--force", "acp"],
+      cwd: "/tmp/project",
+    });
+  });
+
+  it.each(["approval-required", "auto-accept-edits", "auto"] as const)(
+    "does not force approval in %s mode",
+    (runtimeMode) => {
+      expect(buildCursorAcpSpawnInput(undefined, "/tmp/project", undefined, runtimeMode)).toEqual({
+        command: "cursor-agent",
+        args: ["acp"],
+        cwd: "/tmp/project",
+      });
+    },
+  );
 });
 
 describe("applyCursorAcpModelSelection", () => {

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -19,6 +19,17 @@ import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
 type CursorAcpRuntimeCursorSettings = Pick<CursorSettings, "apiEndpoint" | "binaryPath">;
 
+function cursorAcpPermissionArgs(runtimeMode?: RuntimeMode): ReadonlyArray<string> {
+  switch (runtimeMode) {
+    case "auto":
+      return ["--auto-review"];
+    case "full-access":
+      return ["--force"];
+    default:
+      return [];
+  }
+}
+
 export interface CursorAcpRuntimeInput extends Omit<
   AcpSessionRuntime.AcpSessionRuntimeOptions,
   "authMethodId" | "clientCapabilities" | "spawn"
@@ -45,7 +56,7 @@ export function buildCursorAcpSpawnInput(
     command: cursorSettings?.binaryPath || "cursor-agent",
     args: [
       ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
-      ...(runtimeMode === "full-access" ? (["--force"] as const) : []),
+      ...cursorAcpPermissionArgs(runtimeMode),
       "acp",
     ],
     cwd,

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -1,4 +1,8 @@
-import { type CursorSettings, type ProviderOptionSelection } from "@t3tools/contracts";
+import {
+  type CursorSettings,
+  type ProviderOptionSelection,
+  type RuntimeMode,
+} from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -22,6 +26,7 @@ export interface CursorAcpRuntimeInput extends Omit<
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   readonly cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined;
   readonly environment?: NodeJS.ProcessEnv;
+  readonly runtimeMode?: RuntimeMode;
 }
 
 export interface CursorAcpModelSelectionErrorContext {
@@ -34,11 +39,13 @@ export function buildCursorAcpSpawnInput(
   cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined,
   cwd: string,
   environment?: NodeJS.ProcessEnv,
+  runtimeMode?: RuntimeMode,
 ): AcpSessionRuntime.AcpSpawnInput {
   return {
     command: cursorSettings?.binaryPath || "cursor-agent",
     args: [
       ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
+      ...(runtimeMode === "full-access" ? (["--force"] as const) : []),
       "acp",
     ],
     cwd,
@@ -57,7 +64,12 @@ export const makeCursorAcpRuntime = (
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
         ...input,
-        spawn: buildCursorAcpSpawnInput(input.cursorSettings, input.cwd, input.environment),
+        spawn: buildCursorAcpSpawnInput(
+          input.cursorSettings,
+          input.cwd,
+          input.environment,
+          input.runtimeMode,
+        ),
         authMethodId: "cursor_login",
         clientCapabilities: CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
       }).pipe(

--- a/docs/user/permission-modes.md
+++ b/docs/user/permission-modes.md
@@ -17,8 +17,8 @@ without prompting; commands and anything else still stop for approval.
 
 **Auto**: routine actions proceed without you; risky ones still ask. How this is enforced depends
 on the provider: Codex delegates routine approvals to an AI reviewer, Claude uses its own auto
-permission mode, and providers without an equivalent (such as OpenCode) fall back to asking, like
-Supervised.
+permission mode, Cursor uses Smart Auto review, and providers without an equivalent (such as
+OpenCode) fall back to asking, like Supervised.
 
 **Full access**: allow commands and edits without prompts. The default. The agent runs
 unattended until it finishes or asks a question of its own.


### PR DESCRIPTION
> [!NOTE]
> Written by `gpt-5.6-sol` on behalf of Maria

Cursor's Full access and Auto runtime modes were launched like restrictive modes, leaving approval behavior dependent on reactive permission replies.
Full access now starts Cursor with `--force`, while Auto starts it with native Smart Auto review through `--auto-review`; supervised modes stay unchanged.
Verified with 26 targeted tests, server typecheck and lint, plus a real T3 Code Auto/Auto thread against an authenticated Cursor CLI that ran `git status --short` without an approval prompt and spawned `cursor-agent --auto-review acp`.
Fixes #6533; built by `gpt-5.6-sol` in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Cursor CLI is spawned for permission-sensitive modes; incorrect mapping could over-approve or under-approve tool actions at session start.
> 
> **Overview**
> Cursor ACP sessions now map the thread **runtime mode** to `cursor-agent` startup flags instead of always launching plain `acp`.
> 
> **Full access** adds `--force` so approvals are relaxed at process start (not only via reactive permission replies). **Auto** adds `--auto-review`; supervised-style modes keep unchanged args. `CursorAdapter` forwards `input.runtimeMode` into `makeCursorAcpRuntime` / `buildCursorAcpSpawnInput`, with unit and adapter tests asserting the argv log. User docs note that **Auto** on Cursor uses Smart Auto review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84baae0866d2f73e7b2fcc7750a5cc3a21ec90fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CursorAdapter` to honor auto and full-access permission modes
> - Adds `cursorAcpPermissionArgs` in [CursorAcpSupport.ts](https://github.com/pingdotgg/t3code/pull/9283/files#diff-b1d00612dffa089ec6b38ee66ba6c910fe9c5240bc928acb859177510a99f4a4) to map runtime modes to Cursor ACP launch arguments: `auto` selects Cursor automatic review, `full-access` selects forced approval, other modes get no extra argument
> - Threads the runtime mode from `CursorAdapter.startSession` through `makeCursorAcpRuntime` into `buildCursorAcpSpawnInput`, which inserts the selected permission args before the ACP subcommand
> - Updates [permission-modes.md](https://github.com/pingdotgg/t3code/pull/9283/files#diff-b0382a5d0d5541b3ad51c034e0ca7174f4481834d6b5547430d14f8d89c9778e) to list Cursor Smart Auto review under Auto-mode providers
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84baae0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->