### PR TITLE
Revert "feat(providers): add context compaction across harnesses"

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -127,8 +127,8 @@ export function useComposerCommandMenu({
         // Codex feedback uploads an existing thread's session and logs.
         if (
           !hasThread &&
-          (command.name === "compact" ||
-            (selectedProviderStatus?.driver === "codex" && command.name === "feedback"))
+          selectedProviderStatus?.driver === "codex" &&
+          command.name === "feedback"
         ) {
           continue;
         }

--- a/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
+++ b/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
@@ -110,7 +110,6 @@ const startupDependencies = Layer.mergeAll(
   Layer.succeed(ProviderService.ProviderService, {
     startSession: () => Effect.die("unused"),
     sendTurn: () => Effect.die("unused"),
-    compactThread: () => Effect.die("unused"),
     interruptTurn: () => Effect.die("unused"),
     respondToRequest: () => Effect.die("unused"),
     respondToUserInput: () => Effect.die("unused"),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -107,7 +107,6 @@ function createProviderServiceHarness(
   const service: ProviderServiceShape = {
     startSession: () => unsupported(),
     sendTurn: () => unsupported(),
-    compactThread: () => unsupported(),
     interruptTurn: () => unsupported(),
     respondToRequest: () => unsupported(),
     respondToUserInput: () => unsupported(),

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1275,21 +1275,6 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
-        case "thread.activity-appended":
-          if (event.payload.activity.kind !== "provider.turn.start.failed") return;
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId(
-            event.payload,
-          );
-          if (
-            Option.isNone(pendingTurnStart) ||
-            String(pendingTurnStart.value.messageId) !==
-              extractActivityRequestId(event.payload.activity.payload)
-          ) {
-            return;
-          }
-          yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
-          return;
-
         case "thread.session-set": {
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -254,7 +254,6 @@ describe("ProviderCommandReactor", () => {
         turnId: asTurnId("turn-1"),
       }),
     );
-    const compactThread = vi.fn((_: ThreadId) => Effect.void);
     const interruptTurn = vi.fn((_: unknown) => input?.interruptTurnEffect?.() ?? Effect.void);
     const respondToRequest = vi.fn<ProviderServiceShape["respondToRequest"]>(() => Effect.void);
     const respondToUserInput = vi.fn<ProviderServiceShape["respondToUserInput"]>(() => Effect.void);
@@ -340,7 +339,6 @@ describe("ProviderCommandReactor", () => {
     const service: ProviderServiceShape = {
       startSession: startSession as ProviderServiceShape["startSession"],
       sendTurn: sendTurn as ProviderServiceShape["sendTurn"],
-      compactThread,
       interruptTurn: interruptTurn as ProviderServiceShape["interruptTurn"],
       respondToRequest: respondToRequest as ProviderServiceShape["respondToRequest"],
       respondToUserInput: respondToUserInput as ProviderServiceShape["respondToUserInput"],
@@ -535,7 +533,6 @@ describe("ProviderCommandReactor", () => {
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       startSession,
       sendTurn,
-      compactThread,
       interruptTurn,
       respondToRequest,
       respondToUserInput,
@@ -635,27 +632,6 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
-  effectIt.effect("rejects /compact without conversation context", () =>
-    Effect.gen(function* () {
-      const harness = yield* Effect.promise(() => createHarness());
-      yield* harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-empty-compact"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-empty-compact"),
-          role: "user",
-          text: "/compact",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: "2026-01-01T00:00:00.000Z",
-      });
-      yield* Effect.promise(() => harness.drain());
-      expect(harness.compactThread).not.toHaveBeenCalled();
-    }),
-  );
   effectIt.effect("projects starting before a slow provider session finishes", () =>
     Effect.gen(function* () {
       const releaseStart = yield* Deferred.make<void>();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -30,10 +30,7 @@ import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
-import {
-  ProviderAdapterRequestError,
-  ProviderAdapterValidationError,
-} from "../../provider/Errors.ts";
+import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
@@ -53,7 +50,6 @@ import {
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
-const isProviderAdapterValidationError = Schema.is(ProviderAdapterValidationError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 
 type ProviderIntentEvent = Extract<
@@ -76,10 +72,6 @@ function toNonEmptyProviderInput(value: string | undefined): string | undefined 
   return normalized && normalized.length > 0 ? normalized : undefined;
 }
 
-const isCompactCommandMessage = (message: ThreadTitleMessage): boolean =>
-  message.role === "user" &&
-  (message.attachments?.length ?? 0) === 0 &&
-  message.text.trim().toLowerCase() === "/compact";
 function mapProviderSessionStatusToOrchestrationStatus(
   status: "connecting" | "ready" | "running" | "error" | "closed",
 ): OrchestrationSession["status"] {
@@ -340,7 +332,6 @@ const make = Effect.gen(function* () {
     );
 
   const threadModelSelections = new Map<string, ModelSelection>();
-  const compactingThreadIds = new Set<ThreadId>();
 
   const appendProviderFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -384,11 +375,11 @@ const make = Effect.gen(function* () {
 
   const formatFailureDetail = (cause: Cause.Cause<unknown>): string => {
     const failReason = cause.reasons.find(Cause.isFailReason);
-    if (isProviderAdapterRequestError(failReason?.error)) {
-      return failReason.error.detail;
-    }
-    if (isProviderAdapterValidationError(failReason?.error)) {
-      return failReason.error.issue;
+    const providerError = isProviderAdapterRequestError(failReason?.error)
+      ? failReason.error
+      : undefined;
+    if (providerError) {
+      return providerError.detail;
     }
     return Cause.pretty(cause);
   };
@@ -1146,6 +1137,7 @@ const make = Effect.gen(function* () {
     if (!thread) {
       return;
     }
+
     const message = thread.messages.find((entry) => entry.id === event.payload.messageId);
     if (!message || message.role !== "user") {
       yield* appendProviderFailureActivity({
@@ -1155,28 +1147,15 @@ const make = Effect.gen(function* () {
         detail: `User message '${event.payload.messageId}' was not found for turn start request.`,
         turnId: null,
         createdAt: event.payload.createdAt,
-        requestId: event.payload.messageId,
       });
       return;
     }
-    const appendTurnStartFailure = (summary: string, detail: string) =>
-      appendProviderFailureActivity({
-        threadId: event.payload.threadId,
-        kind: "provider.turn.start.failed",
-        summary,
-        detail,
-        turnId: null,
-        createdAt: event.payload.createdAt,
-        requestId: event.payload.messageId,
-      });
 
     yield* ensureThreadWorktree(thread);
 
-    const isCompactCommand = isCompactCommandMessage(message);
-    const nonCompactUserMessageCount = thread.messages.filter(
-      (entry) => entry.role === "user" && !isCompactCommandMessage(entry),
-    ).length;
-    if (nonCompactUserMessageCount === 1 && !isCompactCommand) {
+    const isFirstUserMessageTurn =
+      thread.messages.filter((entry) => entry.role === "user").length === 1;
+    if (isFirstUserMessageTurn) {
       const project = yield* resolveProject(thread.projectId);
       const generationCwd =
         resolveThreadWorkspaceCwd({
@@ -1215,7 +1194,16 @@ const make = Effect.gen(function* () {
         detail,
         createdAt: event.payload.createdAt,
       }).pipe(
-        Effect.flatMap(() => appendTurnStartFailure("Provider turn start failed", detail)),
+        Effect.flatMap(() =>
+          appendProviderFailureActivity({
+            threadId: event.payload.threadId,
+            kind: "provider.turn.start.failed",
+            summary: "Provider turn start failed",
+            detail,
+            turnId: null,
+            createdAt: event.payload.createdAt,
+          }),
+        ),
         Effect.asVoid,
       );
     };
@@ -1232,69 +1220,6 @@ const make = Effect.gen(function* () {
         ),
       );
 
-    const handleCompactionFailure = (cause: Cause.Cause<unknown>) => {
-      if (Cause.hasInterruptsOnly(cause)) {
-        return Effect.void;
-      }
-      const detail = formatFailureDetail(cause);
-      return appendTurnStartFailure("Context compaction failed", detail).pipe(Effect.asVoid);
-    };
-    const recoverCompactionFailure = (cause: Cause.Cause<unknown>) =>
-      handleCompactionFailure(cause).pipe(
-        Effect.catchCause((recoveryCause) =>
-          Effect.logWarning("provider command reactor failed to recover compaction failure", {
-            eventType: event.type,
-            threadId: event.payload.threadId,
-            cause: Cause.pretty(recoveryCause),
-            originalCause: Cause.pretty(cause),
-          }),
-        ),
-      );
-    if (isCompactCommand) {
-      if (nonCompactUserMessageCount === 0) {
-        return yield* appendTurnStartFailure(
-          "Context compaction failed",
-          "Context compaction requires an existing conversation.",
-        );
-      }
-      const latestThread = yield* resolveThread(event.payload.threadId);
-      if (
-        compactingThreadIds.has(event.payload.threadId) ||
-        latestThread?.session?.status === "starting" ||
-        latestThread?.session?.status === "running"
-      ) {
-        yield* appendTurnStartFailure(
-          "Context compaction failed",
-          "Context compaction is unavailable while a provider turn is running.",
-        );
-        return;
-      }
-      compactingThreadIds.add(event.payload.threadId);
-      yield* Effect.gen(function* () {
-        yield* ensureSessionForThread(
-          event.payload.threadId,
-          event.payload.createdAt,
-          event.payload.modelSelection !== undefined
-            ? { modelSelection: event.payload.modelSelection }
-            : undefined,
-        );
-        if (event.payload.modelSelection !== undefined) {
-          threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
-        }
-        yield* providerService.compactThread(event.payload.threadId, event.payload.modelSelection);
-      }).pipe(
-        Effect.catchCause(recoverCompactionFailure),
-        Effect.ensuring(Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId))),
-        Effect.forkScoped,
-      );
-      return;
-    }
-    if (compactingThreadIds.has(event.payload.threadId)) {
-      return yield* appendTurnStartFailure(
-        "Provider turn start failed",
-        "Wait for context compaction to finish before sending another message.",
-      );
-    }
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
       messageText: message.text,
@@ -1315,7 +1240,7 @@ const make = Effect.gen(function* () {
 
     yield* providerService
       .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
+      .pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -105,7 +105,6 @@ function createProviderServiceHarness() {
   const service: ProviderServiceShape = {
     startSession: () => unsupported(),
     sendTurn: () => unsupported(),
-    compactThread: () => unsupported(),
     interruptTurn: () => unsupported(),
     respondToRequest: () => unsupported(),
     respondToUserInput: () => unsupported(),
@@ -3222,8 +3221,6 @@ describe("ProviderRuntimeIngestion", () => {
       turnId: asTurnId("turn-1"),
       payload: {
         state: "compacted",
-        beforeTokens: 899_000,
-        afterTokens: 19_000,
         detail: { source: "provider" },
       },
     });
@@ -3237,7 +3234,7 @@ describe("ProviderRuntimeIngestion", () => {
     const activity = thread.activities.find(
       (candidate: ProviderRuntimeTestActivity) => candidate.kind === "context-compaction",
     );
-    expect(activity?.summary).toBe("Compacted context 899K → 19K tokens");
+    expect(activity?.summary).toBe("Context compacted");
     expect(activity?.tone).toBe("info");
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -28,7 +28,6 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
-import { formatTokens } from "@t3tools/shared/usageFormat";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
@@ -754,23 +753,15 @@ export function runtimeEventToActivities(
         return [];
       }
 
-      const beforeTokens = event.payload.beforeTokens;
-      const afterTokens = event.payload.afterTokens;
-      const summary =
-        beforeTokens !== undefined && afterTokens !== undefined
-          ? `Compacted context ${formatTokens(beforeTokens)} → ${formatTokens(afterTokens)} tokens`
-          : "Context compacted";
       return [
         {
           id: event.eventId,
           createdAt: event.createdAt,
           tone: "info",
           kind: "context-compaction",
-          summary,
+          summary: "Context compacted",
           payload: {
             state: event.payload.state,
-            ...(beforeTokens !== undefined ? { beforeTokens } : {}),
-            ...(afterTokens !== undefined ? { afterTokens } : {}),
             ...(event.payload.detail !== undefined ? { detail: event.payload.detail } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -729,7 +729,12 @@ describe("ClaudeAdapterLive", () => {
         runtimeMode: "full-access",
       });
 
-      yield* adapter.compactThread!(session.threadId, modelSelection);
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "/compact",
+        attachments: [],
+        modelSelection,
+      });
 
       const promptText = yield* Effect.promise(() =>
         readFirstPromptText(harness.getLastCreateQueryInput()),
@@ -2227,12 +2232,6 @@ describe("ClaudeAdapterLive", () => {
       } as unknown as SDKMessage);
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      const compactionEvent = runtimeEvents.find(
-        (event) => event.type === "thread.state.changed" && event.payload.state === "compacted",
-      );
-      assert.ok(compactionEvent?.type === "thread.state.changed");
-      assert.equal(compactionEvent.payload.beforeTokens, 200);
-      assert.equal(compactionEvent.payload.afterTokens, 40);
       const finalUsageEvent = runtimeEvents.findLast(
         (event) => event.type === "thread.token-usage.updated",
       );

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3198,36 +3198,32 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           },
         });
         return;
-      case "compact_boundary": {
+      case "compact_boundary":
         if (context.turnState) {
           context.turnState.latestAssistantUsage = undefined;
           context.turnState.compactedSinceLatestAssistantUsage = true;
         }
-        const compactedUsage = compactBoundaryTokenUsageSnapshot(
-          message as unknown as Record<string, unknown>,
-          context.lastKnownContextWindow,
-          context.lastKnownTotalProcessedTokens,
+        yield* emitThreadTokenUsage(
+          context,
+          compactBoundaryTokenUsageSnapshot(
+            message as unknown as Record<string, unknown>,
+            context.lastKnownContextWindow,
+            context.lastKnownTotalProcessedTokens,
+          ),
+          {
+            rawMethod: "claude/system/compact_boundary",
+            rawPayload: message,
+          },
         );
-        yield* emitThreadTokenUsage(context, compactedUsage, {
-          rawMethod: "claude/system/compact_boundary",
-          rawPayload: message,
-        });
         yield* offerRuntimeEvent({
           ...base,
           type: "thread.state.changed",
           payload: {
             state: "compacted",
-            ...(compactedUsage?.lastUsedTokens !== undefined
-              ? { beforeTokens: compactedUsage.lastUsedTokens }
-              : {}),
-            ...(compactedUsage?.usedTokens !== undefined
-              ? { afterTokens: compactedUsage.usedTokens }
-              : {}),
             detail: message,
           },
         });
         return;
-      }
       case "hook_started":
         yield* offerRuntimeEvent({
           ...base,
@@ -3786,7 +3782,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     // Same reason as the approvals above: a request nobody can answer any more
     // must not stay open, or the thread can never be settled.
-    for (const pending of context.pendingUserInputs.values()) {
+    for (const pending of [...context.pendingUserInputs.values()]) {
       yield* pending.cancel;
     }
 
@@ -4694,16 +4690,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     };
   });
 
-  const compactThread: NonNullable<ClaudeAdapterShape["compactThread"]> = (
-    threadId,
-    modelSelection,
-  ) =>
-    sendTurn({
-      threadId,
-      input: "/compact",
-      ...(modelSelection !== undefined ? { modelSelection } : {}),
-    }).pipe(Effect.asVoid);
-
   const interruptTurn: ClaudeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
     function* (threadId, _turnId) {
       const context = yield* requireSession(threadId);
@@ -4818,7 +4804,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
     startSession,
     sendTurn,
-    compactThread,
     interruptTurn,
     readThread,
     rollbackThread,

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -22,7 +22,6 @@ import {
 
 import {
   buildServerProvider,
-  COMPACT_SLASH_COMMAND,
   DEFAULT_TIMEOUT_MS,
   isCommandMissingCause,
   parseGenericCliVersion,
@@ -504,7 +503,13 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
   const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
-  const slashCommands = [COMPACT_SLASH_COMMAND, ...(capabilities?.slashCommands ?? [])];
+  const slashCommands = [
+    {
+      name: "compact",
+      description: "Summarize the conversation and reduce context usage",
+    },
+    ...(capabilities?.slashCommands ?? []),
+  ];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 
   if (!capabilities) {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -84,8 +84,6 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
       }),
   );
 
-  public readonly compactThread = Effect.void;
-
   public readonly interruptTurnImpl = vi.fn(
     (_turnId?: TurnId): Promise<void> => Promise.resolve(undefined),
   );
@@ -335,47 +333,6 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
       NodeAssert.equal(result.failure._tag, "ProviderAdapterSessionNotFoundError");
       NodeAssert.equal(result.failure.provider, "codex");
       NodeAssert.equal(result.failure.threadId, "sess-missing");
-    }),
-  );
-
-  it.effect("compacts the active Codex thread and emits compacted state", () =>
-    Effect.gen(function* () {
-      const adapter = yield* CodexAdapter;
-      const threadId = asThreadId("thread-compact");
-      yield* adapter.startSession({
-        provider: ProviderDriverKind.make("codex"),
-        threadId,
-        runtimeMode: "full-access",
-      });
-      const runtime = sessionRuntimeFactory.lastRuntime;
-      NodeAssert.ok(runtime);
-      const compactedEventFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter((event) => event.type === "thread.state.changed"),
-        Stream.runHead,
-        Effect.forkChild,
-      );
-      yield* adapter.compactThread!(threadId);
-      yield* runtime.emit({
-        id: asEventId("evt-compaction-item-completed"),
-        kind: "notification",
-        provider: ProviderDriverKind.make("codex"),
-        createdAt: "2026-01-01T00:00:00.000Z",
-        method: "item/completed",
-        threadId,
-        payload: {
-          completedAtMs: 1_778_000_000_000,
-          threadId: "provider-thread-1",
-          turnId: "provider-compact-turn",
-          item: {
-            id: "provider-compact-item",
-            type: "contextCompaction",
-          },
-        },
-      });
-      const event = Option.getOrThrow(yield* Fiber.join(compactedEventFiber));
-      NodeAssert.ok(event.type === "thread.state.changed");
-      NodeAssert.equal(event.payload.state, "compacted");
-      yield* adapter.stopSession(threadId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -11,7 +11,6 @@ import {
   type CanonicalItemType,
   type CanonicalRequestType,
   type CodexSettings,
-  EventId,
   ProviderDriverKind,
   type ProviderEvent,
   ProviderInstanceId,
@@ -1152,18 +1151,7 @@ function mapToRuntimeEvents(
       ];
     }
     const completed = mapItemLifecycle(event, canonicalThreadId, "item.completed");
-    if (!completed || itemType !== "context_compaction") {
-      return completed ? [completed] : [];
-    }
-    return [
-      completed,
-      {
-        ...runtimeEventBase(event, canonicalThreadId),
-        eventId: EventId.make(`${event.id}:thread-compacted`),
-        type: "thread.state.changed",
-        payload: { state: "compacted" },
-      },
-    ];
+    return completed ? [completed] : [];
   }
 
   if (
@@ -1891,15 +1879,6 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       ),
     );
 
-  const compactThread: NonNullable<CodexAdapterShape["compactThread"]> = Effect.fn("compactThread")(
-    function* (threadId) {
-      const session = yield* requireSession(threadId);
-      yield* session.runtime.compactThread.pipe(
-        Effect.mapError((cause) => mapCodexRuntimeError(threadId, "thread/compact/start", cause)),
-      );
-    },
-  );
-
   const readThread: CodexAdapterShape["readThread"] = (threadId) =>
     requireSession(threadId).pipe(
       Effect.flatMap((session) => session.runtime.readThread),
@@ -2035,7 +2014,6 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     },
     startSession,
     sendTurn,
-    compactThread,
     interruptTurn,
     readThread,
     rollbackThread,

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -30,7 +30,6 @@ import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts
 import {
   AUTH_PROBE_TIMEOUT_MS,
   buildServerProvider,
-  COMPACT_SLASH_COMMAND,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
@@ -649,7 +648,6 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     models: snapshot.models,
     skills: snapshot.skills,
     slashCommands: [
-      COMPACT_SLASH_COMMAND,
       {
         name: "feedback",
         description: "Send this thread and Codex logs to OpenAI",

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -196,7 +196,6 @@ export interface CodexSessionRuntimeShape {
   readonly sendTurn: (
     input: CodexSessionRuntimeSendTurnInput,
   ) => Effect.Effect<ProviderTurnStartResult, CodexSessionRuntimeError>;
-  readonly compactThread: Effect.Effect<void, CodexSessionRuntimeError>;
   readonly interruptTurn: (turnId?: TurnId) => Effect.Effect<void, CodexSessionRuntimeError>;
   readonly readThread: Effect.Effect<CodexThreadSnapshot, CodexSessionRuntimeError>;
   readonly rollbackThread: (
@@ -2294,10 +2293,6 @@ export const makeCodexSessionRuntime = (
     return {
       start,
       getSession: Ref.get(sessionRef),
-      compactThread: Effect.gen(function* () {
-        const providerThreadId = yield* readProviderThreadId;
-        yield* client.request("thread/compact/start", { threadId: providerThreadId });
-      }),
       sendTurn: (input) =>
         Effect.gen(function* () {
           const providerThreadId = yield* readProviderThreadId;

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -34,7 +34,6 @@ import {
   buildBooleanOptionDescriptor,
   buildSelectOptionDescriptor,
   buildServerProvider,
-  COMPACT_SLASH_COMMAND,
   collectStreamAsString,
   isCommandMissingCause,
   providerModelsFromSettings,
@@ -640,7 +639,6 @@ export function buildCursorProviderSnapshot(input: {
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
     ),
-    slashCommands: [COMPACT_SLASH_COMMAND],
     probe: {
       installed: true,
       version: input.parsed.version,

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -21,7 +21,6 @@ import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import {
   AUTH_PROBE_TIMEOUT_MS,
   buildServerProvider,
-  COMPACT_SLASH_COMMAND,
   isCommandMissingCause,
   parseGenericCliVersion,
   providerModelsFromSettings,
@@ -497,7 +496,6 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     checkedAt,
     models,
     skills,
-    slashCommands: [COMPACT_SLASH_COMMAND],
     probe: {
       installed: true,
       version,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -79,7 +79,6 @@ const runtimeMock = {
     messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
     messageFailures: 0,
     promptCalls: [] as Array<unknown>,
-    summarizeCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
     promptAsyncImplementation: null as (() => Promise<void>) | null,
     autoPromptEcho: true,
@@ -130,7 +129,6 @@ const runtimeMock = {
     this.state.messageCalls.length = 0;
     this.state.messageFailures = 0;
     this.state.promptCalls.length = 0;
-    this.state.summarizeCalls.length = 0;
     this.state.promptAsyncError = null;
     this.state.promptAsyncImplementation = null;
     this.state.autoPromptEcho = true;
@@ -314,10 +312,6 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
               },
             });
           }
-        },
-        summarize: async (input: unknown) => {
-          runtimeMock.state.summarizeCalls.push(input);
-          return { data: true };
         },
         messages: async () => ({ data: runtimeMock.state.messages }),
         message: async ({ sessionID, messageID }: { sessionID: string; messageID: string }) => {
@@ -955,39 +949,6 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("compacts through the native OpenCode session API", () =>
-    Effect.gen(function* () {
-      const adapter = yield* OpenCodeAdapter;
-      const threadId = asThreadId("thread-opencode-compact");
-      runtimeMock.state.subscribedEvents.push({
-        type: "session.compacted",
-        properties: { sessionID: "http://127.0.0.1:9999/session" },
-      });
-      const eventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter((event) => event.threadId === threadId),
-        Stream.take(3),
-        Stream.runCollect,
-        Effect.forkChild,
-      );
-      yield* adapter.startSession({
-        provider: ProviderDriverKind.make("opencode"),
-        threadId,
-        runtimeMode: "full-access",
-      });
-      yield* adapter.compactThread!(
-        threadId,
-        createModelSelection(ProviderInstanceId.make("opencode"), "openai/gpt-5"),
-      );
-      const summarizeCall = runtimeMock.state.summarizeCalls[0] as Record<string, unknown>;
-      NodeAssert.equal(summarizeCall.modelID, "gpt-5");
-      const events = Array.from(yield* Fiber.join(eventsFiber));
-      yield* adapter.stopSession(threadId);
-      const compacted = events.some(
-        (event) => event.type === "thread.state.changed" && event.payload.state === "compacted",
-      );
-      NodeAssert.equal(compacted, true);
-    }),
-  );
   it.effect("falls back to a fresh session when the persisted session is gone", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2014,21 +2014,6 @@ export function makeOpenCodeAdapter(
           }
           break;
         }
-        case "session.compacted": {
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              raw: event,
-            })),
-            type: "thread.state.changed",
-            payload: {
-              state: "compacted",
-              detail: event,
-            },
-          });
-          break;
-        }
 
         case "message.updated": {
           const promptAdmission = context.promptAdmission;
@@ -2999,71 +2984,6 @@ export function makeOpenCodeAdapter(
       );
     });
 
-    const compactThread: NonNullable<OpenCodeAdapterShape["compactThread"]> = Effect.fn(
-      "compactThread",
-    )(function* (threadId, requestedModelSelection) {
-      const context = yield* ensureSessionContext(sessions, threadId);
-      yield* awaitOpenCodeContextReady(context);
-      const modelSelection =
-        requestedModelSelection ??
-        (context.session.model
-          ? { instanceId: boundInstanceId, model: context.session.model }
-          : undefined);
-      if (modelSelection !== undefined && modelSelection.instanceId !== boundInstanceId) {
-        return yield* new ProviderAdapterValidationError({
-          provider: PROVIDER,
-          operation: "compactThread",
-          issue: `OpenCode model selection is bound to instance '${modelSelection.instanceId}', expected '${boundInstanceId}'.`,
-        });
-      }
-      const parsedModel = parseOpenCodeModelSlug(modelSelection?.model);
-      if (!parsedModel) {
-        return yield* new ProviderAdapterValidationError({
-          provider: PROVIDER,
-          operation: "compactThread",
-          issue: "OpenCode compaction requires an active 'provider/model' selection.",
-        });
-      }
-      yield* context.promptSemaphore.withPermit(
-        Effect.gen(function* () {
-          if (sessions.get(threadId) !== context || (yield* Ref.get(context.stopped))) {
-            return yield* Effect.interrupt;
-          }
-          if (context.activeTurnId !== undefined) {
-            return yield* new ProviderAdapterValidationError({
-              provider: PROVIDER,
-              operation: "compactThread",
-              issue: "OpenCode cannot compact while a turn is running.",
-            });
-          }
-          yield* runOpenCodeSdk("session.summarize", (signal) =>
-            context.client.session.summarize(
-              {
-                sessionID: context.openCodeSessionId,
-                ...parsedModel,
-                auto: false,
-              },
-              { signal },
-            ),
-          ).pipe(
-            Effect.timeout("10 minutes"),
-            Effect.catchTags({
-              OpenCodeRuntimeError: (cause) => Effect.fail(toRequestError(cause)),
-              TimeoutError: (cause) =>
-                Effect.fail(
-                  new ProviderAdapterRequestError({
-                    provider: PROVIDER,
-                    method: "session.summarize",
-                    detail: "OpenCode session compaction did not complete within 10 minutes.",
-                    cause,
-                  }),
-                ),
-            }),
-            Effect.asVoid,
-          );
-        }),
-      );
-    });
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
@@ -3348,7 +3268,6 @@ export function makeOpenCodeAdapter(
       },
       startSession,
       sendTurn,
-      compactThread,
       interruptTurn,
       respondToRequest,
       respondToUserInput,

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -13,7 +13,6 @@ import { createModelCapabilities } from "@t3tools/shared/model";
 import { compareSemverVersions } from "@t3tools/shared/semver";
 import {
   buildServerProvider,
-  COMPACT_SLASH_COMMAND,
   nonEmptyTrimmed,
   parseGenericCliVersion,
   providerModelsFromSettings,
@@ -496,7 +495,6 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     checkedAt,
     models,
     skills,
-    slashCommands: [COMPACT_SLASH_COMMAND],
     probe: {
       installed: true,
       version,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -48,7 +48,6 @@ import {
 import * as ServerConfig from "../../config.ts";
 import * as ServerSettingsModule from "../../serverSettings.ts";
 import { readProviderStatusCache, resolveProviderStatusCachePath } from "../providerStatusCache.ts";
-import { COMPACT_SLASH_COMMAND } from "../providerSnapshot.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import * as ProviderInstanceRegistry from "../Services/ProviderInstanceRegistry.ts";
 import * as ProviderRegistry from "../Services/ProviderRegistry.ts";
@@ -385,7 +384,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               shortDescription: "Debug failing GitHub Actions checks",
             },
           ]);
-          assert.deepStrictEqual(status.slashCommands.slice(1), [
+          assert.deepStrictEqual(status.slashCommands, [
             {
               name: "feedback",
               description: "Send this thread and Codex logs to OpenAI",
@@ -2440,7 +2439,11 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             }),
           );
 
-          assert.deepStrictEqual(status.slashCommands.slice(1), [
+          assert.deepStrictEqual(status.slashCommands, [
+            {
+              name: "compact",
+              description: "Summarize the conversation and reduce context usage",
+            },
             {
               name: "review",
               description: "Review a pull request",
@@ -2484,7 +2487,10 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           );
 
           assert.deepStrictEqual(status.slashCommands, [
-            COMPACT_SLASH_COMMAND,
+            {
+              name: "compact",
+              description: "Summarize the conversation and reduce context usage",
+            },
             {
               name: "ui",
               description: "Explore and refine UI",

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -172,18 +172,6 @@ function makeFakeCodexAdapter(provider: ProviderDriverKind = CODEX_DRIVER) {
       Effect.void,
   );
 
-  const compactThread = vi.fn((threadId: ThreadId) =>
-    Effect.sync(() =>
-      emit({
-        type: "thread.state.changed",
-        eventId: asEventId("evt-native-compact"),
-        provider,
-        createdAt: "2026-01-01T00:00:00.000Z",
-        threadId,
-        payload: { state: "compacted" },
-      }),
-    ),
-  );
   const respondToRequest = vi.fn(
     (
       _threadId: ThreadId,
@@ -262,7 +250,6 @@ function makeFakeCodexAdapter(provider: ProviderDriverKind = CODEX_DRIVER) {
     },
     startSession,
     sendTurn,
-    ...(provider === CODEX_DRIVER ? { compactThread } : {}),
     interruptTurn,
     respondToRequest,
     respondToUserInput,
@@ -299,7 +286,6 @@ function makeFakeCodexAdapter(provider: ProviderDriverKind = CODEX_DRIVER) {
     updateSession,
     startSession,
     sendTurn,
-    compactThread,
     interruptTurn,
     respondToRequest,
     respondToUserInput,
@@ -1048,10 +1034,6 @@ routing.layer("ProviderServiceLive routing", (it) => {
       });
       assert.equal(routing.codex.sendTurn.mock.calls.length, 1);
 
-      yield* advanceTestClock(10);
-      yield* provider.compactThread(session.threadId);
-      assert.deepEqual(routing.codex.compactThread.mock.calls, [[session.threadId, undefined]]);
-
       yield* provider.interruptTurn({ threadId: session.threadId });
       assert.deepEqual(routing.codex.interruptTurn.mock.calls, [[session.threadId, undefined]]);
 
@@ -1112,40 +1094,6 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(startPayload.threadId, session.threadId);
       }
       assert.equal(routing.codex.sendTurn.mock.calls.length, 1);
-    }),
-  );
-
-  it.effect("marks a successful fallback compaction as compacted", () =>
-    Effect.gen(function* () {
-      const provider = yield* ProviderService.ProviderService;
-      const threadId = asThreadId("thread-compact-cursor");
-      yield* provider.startSession(threadId, {
-        provider: CURSOR_DRIVER,
-        providerInstanceId: ProviderInstanceId.make("cursor"),
-        threadId,
-        runtimeMode: "full-access",
-      });
-      const compactedEventFiber = yield* provider.streamEvents.pipe(
-        Stream.filter((event) => event.type === "thread.state.changed"),
-        Stream.runHead,
-        Effect.forkChild,
-      );
-      const compactFiber = yield* provider.compactThread(threadId).pipe(Effect.forkChild);
-      yield* advanceTestClock(50);
-      routing.cursor.emit({
-        type: "turn.completed",
-        eventId: asEventId("evt-cursor-compact-completed"),
-        provider: CURSOR_DRIVER,
-        createdAt: "2026-01-01T00:00:01.000Z",
-        threadId,
-        turnId: asTurnId(`turn-${threadId}`),
-        payload: { state: "completed" },
-      });
-      yield* Fiber.join(compactFiber);
-
-      const compacted = yield* Fiber.join(compactedEventFiber);
-      assert.equal(compacted._tag, "Some");
-      yield* provider.stopSession({ threadId });
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -10,7 +10,6 @@
  * @module ProviderServiceLive
  */
 import {
-  EventId,
   ModelSelection,
   NonNegativeInt,
   ThreadId,
@@ -29,7 +28,6 @@ import {
 import { expandAssistantCitationsForProvider } from "@t3tools/shared/assistantCitations";
 import { causeErrorTag } from "@t3tools/shared/observability";
 import * as DateTime from "effect/DateTime";
-import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -51,7 +49,6 @@ import {
   providerTurnMetricAttributes,
   withMetrics,
 } from "../../observability/Metrics.ts";
-import { ProviderAdapterRequestError } from "../Errors.ts";
 import { type ProviderAdapterError, ProviderValidationError } from "../Errors.ts";
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts";
@@ -236,17 +233,6 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const revokeMcpCredential =
     options?.revokeMcpCredential ?? McpSessionRegistry.revokeActiveMcpThread;
   const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
-  const pendingCompactions = new Map<
-    ThreadId,
-    { readonly completion: Deferred.Deferred<string>; readonly synthesizeCompactedEvent: boolean }
-  >();
-  const settleCompaction = (threadId: ThreadId, terminal: string) => {
-    const pending = pendingCompactions.get(threadId);
-    pendingCompactions.delete(threadId);
-    return pending
-      ? Deferred.succeed(pending.completion, terminal).pipe(Effect.as(pending))
-      : Effect.succeed(undefined);
-  };
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
   /**
    * Attach the `t3-code` MCP server to the session that is about to start.
@@ -359,58 +345,14 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     },
     event: ProviderRuntimeEvent,
   ): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      const canonicalEvent = yield* Effect.sync(() =>
-        correlateRuntimeEventWithInstance(source, event),
-      );
-      yield* increment(providerRuntimeEventsTotal, {
-        provider: canonicalEvent.provider,
-        eventType: canonicalEvent.type,
-      });
-      yield* publishRuntimeEvent(canonicalEvent);
-      const pendingCompaction = pendingCompactions.get(canonicalEvent.threadId);
-      if (!pendingCompaction) return;
-      if (
-        !pendingCompaction.synthesizeCompactedEvent &&
-        canonicalEvent.type === "thread.state.changed" &&
-        canonicalEvent.payload.state === "compacted"
-      ) {
-        yield* settleCompaction(canonicalEvent.threadId, "completed");
-        return;
-      }
-      const compactionTerminal =
-        canonicalEvent.type === "turn.completed"
-          ? canonicalEvent.payload.state
-          : canonicalEvent.type === "session.exited" ||
-              canonicalEvent.type === "runtime.error" ||
-              canonicalEvent.type === "turn.aborted"
-            ? canonicalEvent.type
-            : null;
-      const settledCompaction =
-        compactionTerminal !== null &&
-        (yield* settleCompaction(canonicalEvent.threadId, compactionTerminal));
-      if (
-        !settledCompaction ||
-        compactionTerminal !== "completed" ||
-        !settledCompaction.synthesizeCompactedEvent
-      ) {
-        return;
-      }
-      const compactedEvent = {
-        ...canonicalEvent,
-        eventId: EventId.make(`${canonicalEvent.eventId}:context-compaction`),
-        type: "thread.state.changed",
-        payload: {
-          state: "compacted",
-          detail: { source: "provider-native-command" },
-        },
-      } satisfies ProviderRuntimeEvent;
-      yield* increment(providerRuntimeEventsTotal, {
-        provider: compactedEvent.provider,
-        eventType: compactedEvent.type,
-      });
-      yield* publishRuntimeEvent(compactedEvent);
-    });
+    Effect.sync(() => correlateRuntimeEventWithInstance(source, event)).pipe(
+      Effect.flatMap((canonicalEvent) =>
+        increment(providerRuntimeEventsTotal, {
+          provider: canonicalEvent.provider,
+          eventType: canonicalEvent.type,
+        }).pipe(Effect.andThen(publishRuntimeEvent(canonicalEvent))),
+      ),
+    );
 
   // `subscribedAdapters` is our source-of-truth for "which instance adapters
   // are currently wired into the runtime event bus". It both tracks the set
@@ -912,50 +854,6 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     );
   });
 
-  const compactThread: ProviderServiceMethod<"compactThread"> = Effect.fn("compactThread")(
-    function* (threadId, modelSelection) {
-      const routed = yield* resolveRoutableSession({
-        threadId,
-        operation: "ProviderService.compactThread",
-        allowRecovery: true,
-      });
-      yield* Effect.annotateCurrentSpan({
-        "provider.operation": "compact-thread",
-        "provider.kind": routed.adapter.provider,
-        "provider.thread_id": threadId,
-      });
-      yield* McpSessionRegistry.touchActiveMcpThread(threadId);
-      const nativeCompaction = routed.adapter.compactThread;
-      const completion = yield* Deferred.make<string>();
-      pendingCompactions.set(threadId, {
-        completion,
-        synthesizeCompactedEvent: nativeCompaction === undefined,
-      });
-      const terminal = yield* (
-        nativeCompaction
-          ? nativeCompaction(routed.threadId, modelSelection)
-          : sendTurn({
-              threadId,
-              input: routed.adapter.provider === "cursor" ? "/compress" : "/compact",
-              ...(modelSelection !== undefined ? { modelSelection } : {}),
-            })
-      ).pipe(
-        Effect.andThen(Deferred.await(completion)),
-        Effect.ensuring(Effect.sync(() => void pendingCompactions.delete(threadId))),
-      );
-      if (terminal !== "completed") {
-        return yield* new ProviderAdapterRequestError({
-          provider: routed.adapter.provider,
-          method: "turn/start",
-          detail: `Context compaction ended with ${terminal}.`,
-        });
-      }
-      yield* analytics.record("provider.thread.compacted", {
-        provider: routed.adapter.provider,
-      });
-    },
-  );
-
   const interruptTurn: ProviderServiceMethod<"interruptTurn"> = Effect.fn("interruptTurn")(
     function* (rawInput) {
       const input = yield* decodeInputOrValidationError({
@@ -1351,7 +1249,6 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   return {
     startSession,
     sendTurn,
-    compactThread,
     interruptTurn,
     respondToRequest,
     respondToUserInput,

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -164,7 +164,6 @@ describe("ProviderSessionReaper", () => {
     const providerService: ProviderServiceShape = {
       startSession: () => unsupported(),
       sendTurn: () => unsupported(),
-      compactThread: () => unsupported(),
       interruptTurn: () => unsupported(),
       respondToRequest: () => unsupported(),
       respondToUserInput: () => unsupported(),

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -68,11 +68,6 @@ export interface ProviderAdapterShape<TError> {
     input: ProviderSendTurnInput,
   ) => Effect.Effect<ProviderTurnStartResult, TError>;
 
-  readonly compactThread?: (
-    threadId: ThreadId,
-    modelSelection?: ProviderSendTurnInput["modelSelection"],
-  ) => Effect.Effect<void, TError>;
-
   /**
    * Interrupt an active turn.
    */

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -53,11 +53,6 @@ export interface ProviderServiceShape {
     input: ProviderSendTurnInput,
   ) => Effect.Effect<ProviderTurnStartResult, ProviderServiceError>;
 
-  readonly compactThread: (
-    threadId: ThreadId,
-    modelSelection?: ProviderSendTurnInput["modelSelection"],
-  ) => Effect.Effect<void, ProviderServiceError>;
-
   /**
    * Interrupt a running provider turn.
    */

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -22,11 +22,6 @@ export const DEFAULT_TIMEOUT_MS = 4_000;
 // Auth status checks involve disk/network lookups and can be slow on first run (especially Windows)
 export const AUTH_PROBE_TIMEOUT_MS = 10_000;
 
-export const COMPACT_SLASH_COMMAND = {
-  name: "compact",
-  description: "Summarize the conversation and reduce context usage",
-} satisfies ServerProviderSlashCommand;
-
 export interface CommandResult {
   readonly stdout: string;
   readonly stderr: string;

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -51,7 +51,6 @@ const makeProviderService = (liveThreadIds: ReadonlyArray<ThreadId> = []) =>
   ({
     startSession: () => Effect.die("unused"),
     sendTurn: () => Effect.die("unused"),
-    compactThread: () => Effect.die("unused"),
     interruptTurn: () => Effect.die("unused"),
     respondToRequest: () => Effect.die("unused"),
     respondToUserInput: () => Effect.die("unused"),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -328,7 +328,7 @@ import {
 import type { ComposerBannerStackItem } from "./chat/ComposerBannerStack";
 import { ComposerSurface } from "./chat/ComposerSurface";
 import {
-  hasAvailableCompactionProvider,
+  hasAvailableClaudeCompactionProvider,
   hasDismissedResumeCompaction,
   shouldOfferResumeCompaction,
 } from "./chat/ContextWindowMeter.logic";
@@ -2947,23 +2947,13 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread?.modelSelection.instanceId ??
     activeProject?.defaultModelSelection?.instanceId ??
     null;
-  const activeProviderStatus = useMemo(() => {
-    if (activeProviderInstanceId) {
-      return (
-        providerStatuses.find((status) => status.instanceId === activeProviderInstanceId) ?? null
-      );
-    }
-    const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
-    return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
-  }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
-  const manualCompactionProviderAvailable = useMemo(
+  const compactionProviderAvailable = useMemo(
     () =>
-      hasAvailableCompactionProvider({
+      hasAvailableClaudeCompactionProvider({
         providers: applyProviderInstanceSettings(
           deriveProviderInstanceEntries(providerStatuses),
           settings,
         ),
-        driverKind: selectedProvider,
         instanceId: activeProviderInstanceId,
         lockedInstanceId: lockedProvider
           ? (activeThread?.session?.providerInstanceId ??
@@ -2977,10 +2967,18 @@ function ChatViewContent(props: ChatViewProps) {
       activeThread?.session?.providerInstanceId,
       lockedProvider,
       providerStatuses,
-      selectedProvider,
       settings,
     ],
   );
+  const activeProviderStatus = useMemo(() => {
+    if (activeProviderInstanceId) {
+      return (
+        providerStatuses.find((status) => status.instanceId === activeProviderInstanceId) ?? null
+      );
+    }
+    const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
+    return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
+  }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
   const [resumeCompactionPermanentlyDismissed, setResumeCompactionPermanentlyDismissed] =
     useLocalStorage(
       `t3code:resume-compaction-dismissed:${environmentId}:${activeProviderInstanceId ?? "claudeAgent"}`,
@@ -5246,11 +5244,12 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread && activeContextWindow
       ? `${activeThread.id}:${activeContextWindow.updatedAt}`
       : null;
-  const compactThreadUnavailable =
+  const compactDisabled =
     !activeThread ||
     !activeProject ||
     !isServerThread ||
-    !manualCompactionProviderAvailable ||
+    selectedProvider !== "claudeAgent" ||
+    !compactionProviderAvailable ||
     isWorking ||
     threadDetailLoading ||
     isPreparingWorktree ||
@@ -5258,15 +5257,15 @@ function ChatViewContent(props: ChatViewProps) {
     feedbackUploading ||
     pendingApprovals.length > 0 ||
     pendingUserInputs.length > 0 ||
-    showPlanFollowUpPrompt;
-  const compactDisabled = compactThreadUnavailable || composerHasUnsentContent;
+    showPlanFollowUpPrompt ||
+    composerHasUnsentContent;
   const compactDisabledReason = compactDisabled
     ? composerHasUnsentContent
       ? "Send or clear your draft before compacting"
       : !activeProject
         ? "Choose a project before compacting"
-        : !manualCompactionProviderAvailable
-          ? "Compaction is unavailable for this provider"
+        : !compactionProviderAvailable
+          ? "Enable a Claude provider before compacting"
           : "Compacting is unavailable right now"
     : null;
   const resumeCompactionBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
@@ -7650,7 +7649,6 @@ function ChatViewContent(props: ChatViewProps) {
                             }
                             activeThreadModelSelection={activeThread?.modelSelection}
                             activeContextWindow={activeContextWindow}
-                            compactThreadUnavailable={compactThreadUnavailable}
                             compactDisabled={compactDisabled}
                             compactDisabledReason={compactDisabledReason}
                             resolvedTheme={resolvedTheme}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -163,10 +163,7 @@ import {
   renderProviderTraitsPicker,
 } from "./composerProviderState";
 import { ContextWindowMeter } from "./ContextWindowMeter";
-import {
-  providerSupportsManualCompaction,
-  resolveContextWindowModelDisplayName,
-} from "./ContextWindowMeter.logic";
+import { resolveContextWindowModelDisplayName } from "./ContextWindowMeter.logic";
 import {
   attachVideoThumbnail,
   buildExpandedImagePreview,
@@ -694,7 +691,6 @@ export interface ChatComposerProps {
 
   // Context window
   activeContextWindow: ContextWindowSnapshot | null;
-  compactThreadUnavailable: boolean;
   compactDisabled: boolean;
   compactDisabledReason: string | null;
 
@@ -791,7 +787,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeProjectDefaultModelSelection,
     activeThreadModelSelection,
     activeContextWindow,
-    compactThreadUnavailable,
     compactDisabled,
     compactDisabledReason,
     resolvedTheme,
@@ -1125,7 +1120,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => selectedProviderEntry?.snapshot ?? null,
     [selectedProviderEntry],
   );
-  const compactCommandAvailable = providerSupportsManualCompaction(selectedProviderEntry);
   const selectedProviderSkills = selectedProviderStatus
     ? resolveProviderSkillsForCwd(selectedProviderStatus, gitCwd)
     : [];
@@ -1354,6 +1348,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       prompt,
     ],
   );
+
   // ------------------------------------------------------------------
   // Derived: composer trigger / menu
   // ------------------------------------------------------------------
@@ -1365,16 +1360,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     cwd: isPathTrigger ? gitCwd : null,
     query: isPathTrigger ? pathTriggerQuery : null,
   });
-  const compactSlashCommandAvailable =
-    composerTrigger?.kind === "slash-command" &&
-    !compactThreadUnavailable &&
-    prompt.slice(composerTrigger.rangeEnd).trim() === "" &&
-    composerImages.length + composerFiles.length === 0 &&
-    composerDraft.persistedAttachments.length === 0 &&
-    composerTerminalContexts.length === 0 &&
-    composerElementContexts.length === 0 &&
-    composerPreviewAnnotations.length === 0 &&
-    composerReviewComments.length === 0;
 
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];
@@ -1443,11 +1428,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           skill.description ??
           (skill.scope ? `${skill.scope} skill` : ""),
       }));
-      const visibleProviderSlashCommandItems = providerSlashCommandItems.filter(
-        (item) => item.command.name !== "compact" || compactSlashCommandAvailable,
-      );
       const slashCommandItems = slashCommandItemsForPromptPosition(
-        [...builtInSlashCommandItems, ...visibleProviderSlashCommandItems, ...skillItems],
+        [...builtInSlashCommandItems, ...providerSlashCommandItems, ...skillItems],
         composerTrigger.rangeStart === 0,
       );
       return searchSlashCommandItems(slashCommandItems, query);
@@ -1467,7 +1449,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
     return [];
   }, [
-    compactSlashCommandAvailable,
     composerTrigger,
     planModeUiEnabled,
     selectedProvider,
@@ -2317,6 +2298,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (
       compactDisabled ||
       noProviderAvailable ||
+      composerSendState.hasSendableContent ||
       activePendingApproval !== null ||
       pendingUserInputs.length > 0 ||
       phase === "running" ||
@@ -2354,6 +2336,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeThreadId,
     compactDisabled,
     composerDraftTarget,
+    composerSendState.hasSendableContent,
     isConnecting,
     isSendBusy,
     noProviderAvailable,
@@ -4419,7 +4402,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       compactDisabled || noProviderAvailable || isSendBusy || isConnecting
                     }
                     compactDisabledReason={resolvedCompactDisabledReason}
-                    {...(compactCommandAvailable ? { onCompactContext: compactThreadContext } : {})}
+                    {...(selectedProvider === "claudeAgent"
+                      ? { onCompactContext: compactThreadContext }
+                      : {})}
                   />
                 </div>
               </div>

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { deriveProviderInstanceEntries } from "../../providerInstances";
 import {
   formatContextWindowCompactionMessage,
-  hasAvailableCompactionProvider,
+  hasAvailableClaudeCompactionProvider,
   hasDismissedResumeCompaction,
   resolveContextWindowModelDisplayName,
   shouldOfferResumeCompaction,
@@ -25,12 +25,12 @@ function claudeProvider(input: {
     auth: { status: "authenticated" },
     checkedAt: "2026-08-24T12:00:00.000Z",
     models: [],
-    slashCommands: [{ name: "compact", description: "" }],
+    slashCommands: [],
     skills: [],
   };
 }
 
-describe("hasAvailableCompactionProvider", () => {
+describe("hasAvailableClaudeCompactionProvider", () => {
   const originalInstanceId = ProviderInstanceId.make("claude_original");
 
   it("rejects a fallback in a different locked continuation group", () => {
@@ -47,9 +47,8 @@ describe("hasAvailableCompactionProvider", () => {
     ]);
 
     expect(
-      hasAvailableCompactionProvider({
+      hasAvailableClaudeCompactionProvider({
         providers,
-        driverKind: ProviderDriverKind.make("claudeAgent"),
         instanceId: originalInstanceId,
         lockedInstanceId: originalInstanceId,
       }),
@@ -70,9 +69,8 @@ describe("hasAvailableCompactionProvider", () => {
     ]);
 
     expect(
-      hasAvailableCompactionProvider({
+      hasAvailableClaudeCompactionProvider({
         providers,
-        driverKind: ProviderDriverKind.make("claudeAgent"),
         instanceId: originalInstanceId,
         lockedInstanceId: originalInstanceId,
       }),

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.ts
@@ -1,4 +1,4 @@
-import type { ModelSelection, ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+import type { ModelSelection, ProviderInstanceId } from "@t3tools/contracts";
 import {
   CLAUDE_RESUME_COMPACTION_NEVER_ANSWER,
   isClaudeResumeCompactionQuestion,
@@ -12,33 +12,27 @@ import { getTriggerDisplayModelName, type ModelEsque } from "./providerIconUtils
 export const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
 export const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
 
-export function providerSupportsManualCompaction(
-  provider: ProviderInstanceEntry | null | undefined,
-): boolean {
-  return provider?.snapshot.slashCommands.some((command) => command.name === "compact") ?? false;
-}
-
-export function hasAvailableCompactionProvider(input: {
+export function hasAvailableClaudeCompactionProvider(input: {
   readonly providers: ReadonlyArray<ProviderInstanceEntry>;
-  readonly driverKind: ProviderDriverKind;
   readonly instanceId: ProviderInstanceId | null;
   readonly lockedInstanceId: ProviderInstanceId | null;
 }): boolean {
-  const driverProviders = input.providers.filter(
-    (provider) => provider.driverKind === input.driverKind,
+  const claudeProviders = input.providers.filter(
+    (provider) => provider.driverKind === "claudeAgent",
   );
   const lockedContinuationGroupKey = input.lockedInstanceId
-    ? driverProviders.find((provider) => provider.instanceId === input.lockedInstanceId)
+    ? claudeProviders.find((provider) => provider.instanceId === input.lockedInstanceId)
         ?.continuationGroupKey
     : undefined;
   const compatibleProviders = lockedContinuationGroupKey
-    ? driverProviders.filter(
+    ? claudeProviders.filter(
         (provider) => provider.continuationGroupKey === lockedContinuationGroupKey,
       )
-    : driverProviders;
+    : claudeProviders;
 
-  return providerSupportsManualCompaction(
-    resolveSelectableProviderInstanceEntry(compatibleProviders, input.instanceId ?? undefined),
+  return (
+    resolveSelectableProviderInstanceEntry(compatibleProviders, input.instanceId ?? undefined) !==
+    undefined
   );
 }
 

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -919,7 +919,7 @@ describe("MessagesTimeline", () => {
             entry: {
               id: "work-1",
               createdAt: "2026-03-17T19:12:28.000Z",
-              label: "Compacted context 899K → 19K tokens",
+              label: "Context compacted",
               tone: "info",
             },
           },
@@ -927,7 +927,7 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain("Compacted context 899K → 19K tokens");
+    expect(markup).toContain("Context compacted");
   });
 
   it("summarizes changed files in one line", () => {

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -196,8 +196,6 @@ such as System, Personal, Project, or App.
 On mobile, these menus are available on the **New task** screen before you start a thread. They
 use the skills and commands from the selected environment and provider.
 
-In an existing thread, send `/compact` to reduce context usage. Web and desktop also offer this action from the context meter, and the work log records token counts when the provider reports them.
-
 By default, the `/` menu includes skills. To keep this menu command-only, turn off **Show skills in
 slash menu** in **Settings → General**. Skill results use the `/skill:Skill Name` label and add the
 same `$name` skill token to your message. The original skill name remains searchable. If the provider

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -298,8 +298,6 @@ export type ThreadStartedPayload = typeof ThreadStartedPayload.Type;
 
 const ThreadStateChangedPayload = Schema.Struct({
   state: RuntimeThreadState,
-  beforeTokens: Schema.optional(NonNegativeInt),
-  afterTokens: Schema.optional(NonNegativeInt),
   detail: Schema.optional(Schema.Unknown),
 });
 export type ThreadStateChangedPayload = typeof ThreadStateChangedPayload.Type;


### PR DESCRIPTION
Reverts pingdotgg/t3code#8808

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large surface-area revert across orchestration, provider contracts, and UI turn-start paths; risk is mainly regression in turn failures, Claude `/compact`, and context-meter behavior rather than auth or data loss.
> 
> **Overview**
> Reverts the cross-provider **context compaction** feature: the shared `compactThread` path through `ProviderService` and provider adapters is removed, along with orchestration that treated `/compact` as a special turn, pending-compaction tracking, and synthesized `thread.state.changed` compaction events.
> 
> **Compaction is no longer advertised or driven for Codex, Cursor, Grok, or OpenCode** (slash commands, native APIs, and Codex `contextCompaction` → compacted mapping are dropped). Work-log compaction lines are simplified to **"Context compacted"** without token before/after counts, and `ThreadStateChangedPayload` no longer carries those fields.
> 
> **Web and mobile** gate the context-meter compact action to **Claude** (`claudeAgent`) and submit **`/compact` as a normal message** rather than calling a compaction API; composer menus no longer special-case hiding or gating `/compact` for non-Claude providers. Claude still lists `/compact` in provider slash commands; resume-compaction banners remain Claude-oriented.
> 
> Tests and docs are updated to match the slimmer behavior; Claude adapter tests use `sendTurn` with `/compact` instead of `compactThread`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f08670787253c78bf4cbe3ba591117fe293987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert context compaction across provider harnesses
> - Removes the `compactThread` operation from `ProviderService` and all provider adapters (Claude, Codex, OpenCode) and session runtimes, along with native compaction routing and fallback compaction logic
> - Removes compact-command handling from the `ProviderCommandReactor` turn-start handler, including in-progress state, empty-conversation rejection, and blocking of subsequent turns; messages containing the compact command now follow the ordinary turn-send path
> - Removes `beforeTokens` and `afterTokens` fields from the `ThreadStateChangedPayload` schema in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/9284/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7); compacted thread-state events and context-compaction activities no longer carry token counts
> - Frontend `ChatComposer` and `ChatViewContent` now gate the compact-context action on the selected provider being `claudeAgent` rather than an advertised slash command, and show "Enable a Claude provider before compacting" when unavailable
> - Removes the `/compact` command from provider snapshots for Codex, Cursor, Grok, and OpenCode; Claude retains an inline compact descriptor
> - Behavioral Change: provider snapshots no longer advertise a compact slash command (except Claude); `ThreadStateChangedPayload` drops `beforeTokens`/`afterTokens`; `ProviderCommandReactor` no longer rejects turns during compaction or attaches request identifiers to turn-start failure activities; `formatFailureDetail` now formats `ProviderAdapterValidationError` via `Cause.pretty` instead of returning issue text directly; the `applyProjectsProjection` projector no longer deletes pending turn-start records on `provider.turn.start.failed` activities
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57f0867.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->