### PR TITLE
fix(desktop): detect installed Spectre libs for Windows builds

### DIFF
--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1707,23 +1707,21 @@ export const preflightMacDesktopBuild = Effect.fn("preflightMacDesktopBuild")(fu
 });
 
 function windowsVswherePrerequisiteScript(arch: typeof BuildArch.Type): string {
-  const components =
+  const toolComponents =
     arch === "arm64"
-      ? [
-          "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
-          "Microsoft.VisualStudio.Component.VC.Tools.ARM64.Spectre",
-        ]
-      : [
-          "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-          "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre",
-        ];
+      ? ["Microsoft.VisualStudio.Component.VC.Tools.ARM64"]
+      : ["Microsoft.VisualStudio.Component.VC.Tools.x86.x64"];
+  const spectreArch = arch === "arm64" ? "arm64" : "x64";
   return [
     "$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\\Installer\\vswhere.exe'",
     "if (!(Test-Path $vswhere)) { exit 1 }",
-    `$install = & $vswhere -latest -products * -requires ${components.join(" ")} -property installationPath`,
+    `$install = & $vswhere -latest -products * -requires ${toolComponents.join(" ")} -property installationPath`,
     "if (!$install) { exit 1 }",
     "$kitsRoot = Get-ItemPropertyValue 'HKLM:\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots' -Name KitsRoot10 -ErrorAction SilentlyContinue",
     "if (!$kitsRoot -or !(Test-Path (Join-Path $kitsRoot 'Lib'))) { exit 1 }",
+    "$msvcToolset = Get-ChildItem (Join-Path $install 'VC\\Tools\\MSVC') -Directory | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1",
+    "if (!$msvcToolset) { exit 1 }",
+    `if (!(Test-Path (Join-Path $msvcToolset.FullName 'lib\\spectre\\${spectreArch}'))) { exit 1 }`,
   ].join("; ");
 }
 


### PR DESCRIPTION
Windows desktop artifact builds rejected current Visual Studio Build Tools installs because the preflight required the stale generic Spectre component id. Current VS 2022 Build Tools exposes the selected Spectre libraries under versioned toolset components while still placing the actual libraries under the MSVC toolset directory.

This keeps the C++ tool and Windows SDK checks through vswhere, then validates the Spectre libraries by checking the installed MSVC toolset directory for lib\\spectre\\<arch>. That matches the real installed layout for current Build Tools without weakening the prerequisite guard.

Verified:
- vp run --filter @t3tools/scripts typecheck
- vpr dist:desktop:win --skip-build --keep-stage

Model: GPT-5 Codex
Harness: Codex CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time prerequisite detection only; no runtime or packaging behavior changes, and Spectre libs are still required via a more accurate filesystem check.
> 
> **Overview**
> Fixes **Windows desktop build preflight** falsely failing on current Visual Studio 2022 Build Tools installs that no longer register the old Spectre workload component IDs in `vswhere`.
> 
> The PowerShell probe in `windowsVswherePrerequisiteScript` still requires **VC toolset** and **Windows SDK** via `vswhere`, but **Spectre** is now verified by checking the latest installed MSVC toolset folder for `lib\spectre\arm64` or `lib\spectre\x64` instead of `-requires` on deprecated `*.Spectre` components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a07bee0b6b9786f30d76b6a00c23b407f4952ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->