### PR TITLE
fix(opencode): show Reasoning selector for OpenCode models

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -171,7 +171,30 @@ function inferDefaultAgent(agents: ReadonlyArray<Agent>): string | undefined {
 }
 
 const DEFAULT_OPENCODE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
-  optionDescriptors: [],
+  optionDescriptors: [
+    {
+      id: "variant",
+      label: "Reasoning",
+      type: "select",
+      options: [
+        { id: "low", label: "Low" },
+        { id: "medium", label: "Medium", isDefault: true },
+        { id: "high", label: "High" },
+        { id: "xhigh", label: "Extra High" },
+      ],
+      currentValue: "medium",
+    },
+    {
+      id: "agent",
+      label: "Agent",
+      type: "select",
+      options: [
+        { id: "build", label: "Build", isDefault: true },
+        { id: "plan", label: "Plan" },
+      ],
+      currentValue: "build",
+    },
+  ],
 });
 
 function openCodeCapabilitiesForModel(input: {
@@ -179,7 +202,16 @@ function openCodeCapabilitiesForModel(input: {
   readonly model: ProviderListResponse["all"][number]["models"][string];
   readonly agents: ReadonlyArray<Agent>;
 }): ModelCapabilities {
-  const variantValues = Object.keys(input.model.variants ?? {});
+  const rawVariantValues = Object.keys(input.model.variants ?? {});
+  // When a model advertises no variants, synthesize the standard reasoning
+  // levels so the composer still offers a Reasoning selector (mirrors the
+  // Codex/Grok experience where reasoning is always configurable). The set
+  // covers the common OpenCode variant spectrum; `inferDefaultVariant`
+  // picks the provider-appropriate default (e.g. medium for openai/opencode).
+  const variantValues =
+    rawVariantValues.length > 0
+      ? rawVariantValues
+      : ["low", "medium", "high", "xhigh"];
   const defaultVariant = inferDefaultVariant(input.providerID, variantValues);
   const variantOptions = variantValues.map((value) =>
     defaultVariant === value
@@ -201,7 +233,7 @@ function openCodeCapabilitiesForModel(input: {
         ? [
             {
               id: "variant",
-              label: "Variant",
+              label: "Reasoning",
               type: "select" as const,
               options: variantOptions,
               ...(defaultVariant ? { currentValue: defaultVariant } : {}),

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -209,9 +209,7 @@ function openCodeCapabilitiesForModel(input: {
   // covers the common OpenCode variant spectrum; `inferDefaultVariant`
   // picks the provider-appropriate default (e.g. medium for openai/opencode).
   const variantValues =
-    rawVariantValues.length > 0
-      ? rawVariantValues
-      : ["low", "medium", "high", "xhigh"];
+    rawVariantValues.length > 0 ? rawVariantValues : ["low", "medium", "high", "xhigh"];
   const defaultVariant = inferDefaultVariant(input.providerID, variantValues);
   const variantOptions = variantValues.map((value) =>
     defaultVariant === value

--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -167,7 +167,7 @@ describe("buildUnavailableModelOptionDescriptors", () => {
     ).toEqual([
       {
         id: "variant",
-        label: "Variant",
+        label: "Reasoning",
         type: "select",
         options: [{ id: "max", label: "max" }],
         currentValue: "max",

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -40,7 +40,7 @@ const SAVED_OPTION_LABELS: Readonly<Record<string, string>> = {
   agent: "Agent",
   effort: "Effort",
   reasoningEffort: "Reasoning effort",
-  variant: "Variant",
+  variant: "Reasoning",
 };
 
 function savedOptionLabel(id: string): string {


### PR DESCRIPTION
> [!NOTE]
> Written by `muse-spark-1.2-contributor` on behalf of Maria

OpenCode showed only the Agent chip (e.g. Build) while Codex/Grok/Cursor all expose a Reasoning control. Variant was labeled "Variant" and hidden when a model advertised no variants, leaving the composer with no effort selector.

Label the variant descriptor as "Reasoning" and synthesize standard levels (low/medium/high/xhigh, default medium) when a model reports no variants. Provide the same fallback for custom models and update the saved-option label for unavailable models. The composer now shows the reasoning effort next to the agent (e.g. "Medium · Build").

Before | After
---|---
![before](https://uploads-production-47e4.up.railway.app/files/f7265a52-bbd7-41e5-a8f6-587cd1e7db23/before-opencode.png) | ![after](https://uploads-production-47e4.up.railway.app/files/46305afa-0d32-4df9-b5bd-6c8636f8461d/after-opencode-reasoning.png)
![menu](https://uploads-production-47e4.up.railway.app/files/465169ff-819a-4ceb-ac12-b0015d0d15b6/reasoning-menu.png) | Reasoning menu (Reasoning / Agent groups)

Verified by inspecting provider capabilities and TraitsPicker logic; reasoning selector now renders for OpenCode models with and without advertised variants.

*Model: `muse-spark-1.2-contributor` via `opencode`*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Synthesized reasoning levels may be sent for models that never advertised variants; behavior depends on OpenCode accepting those values at request time.
> 
> **Overview**
> OpenCode’s composer now aligns with Codex/Grok by exposing a **Reasoning** control (renamed from “Variant”) alongside **Agent**.
> 
> **Server (`OpenCodeProvider`):** When a model reports no `variants`, capabilities now **synthesize** `low` / `medium` / `high` / `xhigh` (default still via `inferDefaultVariant`). The dynamic descriptor label is **Reasoning**. **Custom / fallback** `DEFAULT_OPENCODE_MODEL_CAPABILITIES` includes the same Reasoning and Agent selectors instead of an empty options list.
> 
> **Web (`TraitsPicker`):** Saved-option display maps `variant` → **Reasoning** when model metadata is unavailable.
> 
> Users should see effort in the traits chip (e.g. **Medium · Build**) and in the traits menu for models with or without advertised variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe6ced3ee59a3a32ef6dee12d4233b2fefd87e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->