### PR TITLE
feat(mobile): add account switch shortcut

### DIFF
--- a/apps/mobile/modules/t3-native-controls/android/src/main/java/expo/modules/t3nativecontrols/T3KeyboardCommandsModule.kt
+++ b/apps/mobile/modules/t3-native-controls/android/src/main/java/expo/modules/t3nativecontrols/T3KeyboardCommandsModule.kt
@@ -29,6 +29,18 @@ class T3KeyboardCommandsView(
   var enabledCommands = emptySet<String>()
 
   override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+    val opensAccount =
+      event.action == KeyEvent.ACTION_DOWN &&
+        event.repeatCount == 0 &&
+        event.keyCode == KeyEvent.KEYCODE_A &&
+        event.isCtrlPressed &&
+        event.isShiftPressed &&
+        !event.isAltPressed &&
+        enabledCommands.contains("account")
+    if (opensAccount) {
+      onCommand(mapOf("command" to "account"))
+      return true
+    }
     val copiesThreadReference =
       event.action == KeyEvent.ACTION_DOWN &&
         event.repeatCount == 0 &&

--- a/apps/mobile/modules/t3-native-controls/ios/T3KeyboardCommandsModule.swift
+++ b/apps/mobile/modules/t3-native-controls/ios/T3KeyboardCommandsModule.swift
@@ -23,6 +23,13 @@ public final class T3KeyboardCommandsView: ExpoView {
   public override var keyCommands: [UIKeyCommand]? {
     [
       enabledCommand("newTask", input: "n", modifiers: .command, action: #selector(newTask), title: "New Task"),
+      enabledCommand(
+        "account",
+        input: "a",
+        modifiers: [.command, .shift],
+        action: #selector(openAccount),
+        title: "Switch Account"
+      ),
       enabledCommand("focusSearch", input: "f", modifiers: .command, action: #selector(focusSearch), title: "Find"),
       enabledCommand("focusSearch", input: "k", modifiers: .command, action: #selector(focusSearch), title: "Focus Search"),
       enabledCommand("back", input: "[", modifiers: .command, action: #selector(goBack), title: "Back"),
@@ -108,6 +115,7 @@ public final class T3KeyboardCommandsView: ExpoView {
   }
 
   @objc private func newTask() { emit("newTask") }
+  @objc private func openAccount() { emit("account") }
   @objc private func focusSearch() { emit("focusSearch") }
   @objc private func goBack() { emit("back") }
   @objc private func openFiles() { emit("files") }

--- a/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
+++ b/apps/mobile/src/features/keyboard/HardwareKeyboardCommandProvider.tsx
@@ -16,6 +16,7 @@ import { useProject, useThreadShell } from "../../state/entities";
 import { useEnvironmentQuery } from "../../state/query";
 import type { GitActionProgress } from "../../state/use-vcs-action-state";
 import { vcsEnvironment } from "../../state/vcs";
+import { hasCloudPublicConfig } from "../cloud/publicConfig";
 import { GitActionProgressOverlay } from "../threads/GitActionProgressOverlay";
 import {
   dispatchHardwareKeyboardCommand,
@@ -114,6 +115,7 @@ export function HardwareKeyboardCommandProvider({
   const enabledCommands = useMemo(() => {
     const commands = new Set<HardwareKeyboardCommand>(getRegisteredHardwareKeyboardCommands());
     commands.add("newTask");
+    if (hasCloudPublicConfig()) commands.add("account");
     if (pathname !== "/" || navigation.canGoBack()) commands.add("back");
     if (activeThreadRef !== null) {
       commands.add("files");
@@ -154,6 +156,10 @@ export function HardwareKeyboardCommandProvider({
 
       if (command === "newTask") {
         navigation.navigate("NewTaskSheet", { screen: "NewTask" });
+        return;
+      }
+      if (command === "account") {
+        navigation.navigate("SettingsSheet", { screen: "SettingsAuth" });
         return;
       }
       if (command === "back") {

--- a/apps/mobile/src/features/keyboard/hardwareKeyboardCommands.ts
+++ b/apps/mobile/src/features/keyboard/hardwareKeyboardCommands.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 export type HardwareKeyboardCommand =
   | "newTask"
+  | "account"
   | "focusSearch"
   | "back"
   | "files"

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -83,6 +83,12 @@ Background submission from a new thread is the exception. `mod+enter` starts tha
 another new thread with the same workspace mode and base branch. **New worktree** remains selected,
 but the new thread does not reuse the worktree created for the thread that just started.
 
+## Mobile hardware keyboards
+
+On iPhone and iPad, `Command+Shift+A` opens the T3 Connect account screen so you can add or switch
+accounts without navigating through Settings. On Android, use `Ctrl+Shift+A` with a hardware
+keyboard. The shortcut is available only in builds configured for T3 Connect.
+
 ## `when` Conditions
 
 A `when` expression is evaluated against context keys describing the current UI state. The keys


### PR DESCRIPTION
Opening the account surface on iPad currently requires navigating through Settings, which makes changing or adding a T3 Connect account awkward with a hardware keyboard.

This adds a discoverable account keyboard command that opens Settings directly on the existing Clerk account route. iOS/iPadOS uses Cmd+Shift+A and Android hardware keyboards use Ctrl+Shift+A. The command is only enabled when Connect is configured, and the user keybinding docs cover both platforms.

## Testing

- `vp run --filter @t3tools/mobile typecheck`
- `vp test run apps/mobile/src/features/keyboard/hardwareKeyboardCommands.test.ts`
- `vp run lint:mobile`
- `git diff --check`
- Local iPad Pro 11-inch (M5), iOS 26.5 simulator: atomic Cmd+Shift+A hardware event navigated from the workspace directly to the Clerk account/sign-in route

## Simulator evidence

Before/after captures are preserved in the task workspace for maintainer inspection; this environment could not attach them because its GitHub browser session is signed out.

Implemented with Codex (GPT-5.6 Sol); validated with the repository mobile harness and XcodeBuildMCP 2.6.2.
