### PR TITLE
fix(server): bound provider command output

### DIFF
--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -93,7 +93,12 @@ exec ${mockAgentCommand} "$@"
   return wrapperPath;
 });
 
-const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")(function* () {
+const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")(function* (
+  aboutCommand = [
+    "printf 'CLI Version         2026.04.09-f2b0fcd\\n'",
+    "printf 'User Email          cursor@example.com\\n'",
+  ].join("\n"),
+) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const mockAgentPath = yield* resolveMockAgentPath();
@@ -105,8 +110,7 @@ const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")
   const mockAgentCommand = ["node", mockAgentPath].map((arg) => JSON.stringify(arg)).join(" ");
   const script = `#!/bin/sh
 if [ "$1" = "about" ]; then
-  printf 'CLI Version         2026.04.09-f2b0fcd\\n'
-  printf 'User Email          cursor@example.com\\n'
+  ${aboutCommand}
   exit 0
 fi
 exec ${mockAgentCommand} "$@"
@@ -569,6 +573,30 @@ describe("checkCursorProviderStatus", () => {
       "claude-opus-4-6",
     ]);
     await expect(runNode(waitForFileContent(requestLogPath))).resolves.toContain("initialize");
+  });
+
+  it("rejects truncated about output instead of parsing it", async () => {
+    const overflowBytes = 8 * 1024 * 1024 + 1;
+    const wrapperPath = await runNode(
+      makeMockAgentWithAboutWrapper(
+        `exec node -e 'process.stdout.write("x".repeat(${overflowBytes}))'`,
+      ),
+    );
+
+    const provider = await runNode(
+      checkCursorProviderStatus({
+        enabled: true,
+        binaryPath: wrapperPath,
+        apiEndpoint: "",
+        customModels: [],
+      }),
+    );
+
+    expect(provider).toMatchObject({
+      installed: true,
+      status: "error",
+      message: "Failed to execute Cursor Agent CLI health check.",
+    });
   });
 });
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -34,7 +34,7 @@ import {
   buildBooleanOptionDescriptor,
   buildSelectOptionDescriptor,
   buildServerProvider,
-  collectStreamAsString,
+  collectProviderCommandOutput,
   isCommandMissingCause,
   providerModelsFromSettings,
   type CommandResult,
@@ -959,16 +959,15 @@ const runCursorCommand = (
     });
 
     const child = yield* spawner.spawn(command);
-    const [stdout, stderr, exitCode] = yield* Effect.all(
+    const [output, exitCode] = yield* Effect.all(
       [
-        collectStreamAsString(child.stdout),
-        collectStreamAsString(child.stderr),
+        collectProviderCommandOutput({ stdout: child.stdout, stderr: child.stderr }),
         child.exitCode.pipe(Effect.map(Number)),
       ],
       { concurrency: "unbounded" },
     );
 
-    return { stdout, stderr, code: exitCode } satisfies CommandResult;
+    return { ...output, code: exitCode } satisfies CommandResult;
   }).pipe(Effect.scoped);
 
 const runCursorAboutCommand = (cursorSettings: CursorSettings, environment?: NodeJS.ProcessEnv) =>

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -116,7 +116,7 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
     }),
   );
 
-  it.effect("drops oversized CLI skill output without losing the model inventory", () =>
+  it.effect("does not retry oversized CLI skill output or lose the model inventory", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -127,11 +127,14 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
       const isWindows = hostPlatform === "win32";
       const binaryPath = path.join(tempDir, isWindows ? "opencode.cmd" : "opencode");
       const scriptPath = path.join(tempDir, "opencode.mjs");
+      const invocationLogPath = path.join(tempDir, "invocations.log");
       const oversizedContentBytes = 8 * 1024 * 1024 + 1;
 
       yield* fs.writeFileString(
         scriptPath,
         [
+          'import { appendFileSync } from "node:fs";',
+          "appendFileSync(process.env.T3_TEST_OPENCODE_INVOCATION_LOG, `${process.argv[2]}\\n`);",
           'if (process.argv[2] === "models") {',
           '  process.stdout.write(`openai/gpt-test\\n{"id":"gpt-test","providerID":"openai","name":"GPT Test"}\\n`);',
           '} else if (process.argv[2] === "debug") {',
@@ -163,31 +166,35 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
           ...hostEnvironment,
           T3_TEST_NODE_BINARY: executablePath,
           T3_TEST_OPENCODE_SCRIPT: scriptPath,
+          T3_TEST_OPENCODE_INVOCATION_LOG: invocationLogPath,
         },
       });
 
       NodeAssert.deepEqual(inventory.providerList.connected, ["openai"]);
       NodeAssert.equal(inventory.skills.length, 0);
+      const invocations = (yield* fs.readFileString(invocationLogPath)).trim().split("\n");
+      NodeAssert.equal(invocations.filter((command) => command === "debug").length, 1);
     }),
   );
 
-  it.effect("caps and drains command stdout and stderr when requested", () =>
+  it.effect("fails after draining command stdout and stderr that exceed the limit", () =>
     Effect.gen(function* () {
       const runtime = yield* OpenCodeRuntime;
       const executablePath = yield* HostProcessExecutablePath;
       const outputBytes = 2 * 1024 * 1024;
-      const result = yield* runtime.runOpenCodeCommand({
-        binaryPath: executablePath,
-        args: [
-          "-e",
-          `process.stdout.write("o".repeat(${outputBytes})); process.stderr.write("e".repeat(${outputBytes}));`,
-        ],
-        maxOutputBytes: 64,
-      });
+      const error = yield* runtime
+        .runOpenCodeCommand({
+          binaryPath: executablePath,
+          args: [
+            "-e",
+            `process.stdout.write("o".repeat(${outputBytes})); process.stderr.write("e".repeat(${outputBytes}));`,
+          ],
+          maxOutputBytes: 64,
+        })
+        .pipe(Effect.flip);
 
-      NodeAssert.equal(result.stdout, "o".repeat(64));
-      NodeAssert.equal(result.stderr, "e".repeat(64));
-      NodeAssert.equal(result.code, 0);
+      NodeAssert.equal(error._tag, "OpenCodeRuntimeError");
+      NodeAssert.match(error.detail, /output exceeded the 64 byte limit/);
     }),
   );
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -30,7 +30,10 @@ import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { isWindowsCommandNotFound } from "../processRunner.ts";
-import { collectStreamAsString } from "./providerSnapshot.ts";
+import {
+  collectProviderCommandOutput,
+  ProviderCommandOutputLimitError,
+} from "./providerSnapshot.ts";
 import * as NetService from "@t3tools/shared/Net";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { compareSemverVersions, parseSemver } from "@t3tools/shared/semver";
@@ -551,6 +554,16 @@ function ensureRuntimeError(
     : new OpenCodeRuntimeError({ operation, detail, cause });
 }
 
+const isProviderCommandOutputLimitError = Schema.is(ProviderCommandOutputLimitError);
+
+function shouldRetryInventoryCommand(
+  result: Exit.Exit<OpenCodeCommandResult, OpenCodeRuntimeError>,
+) {
+  if (Exit.isSuccess(result)) return result.value.code !== 0;
+  const error = Cause.squash(result.cause);
+  return !(OpenCodeRuntimeError.is(error) && isProviderCommandOutputLimitError(error.cause));
+}
+
 const makeOpenCodeRuntime = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const netService = yield* NetService.NetService;
@@ -580,26 +593,26 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
               }
             });
       yield* Effect.addFinalizer(() => terminateCommandGroup.pipe(Effect.ignore));
-      const collectOptions =
-        input.maxOutputBytes === undefined ? undefined : { maxBytes: input.maxOutputBytes };
-      const [stdout, stderr, code] = yield* Effect.all(
+      const [output, code] = yield* Effect.all(
         [
-          collectStreamAsString(child.stdout, collectOptions),
-          collectStreamAsString(child.stderr, collectOptions),
+          collectProviderCommandOutput({
+            stdout: child.stdout,
+            stderr: child.stderr,
+            ...(input.maxOutputBytes === undefined ? {} : { maxBytes: input.maxOutputBytes }),
+          }),
           child.exitCode,
         ],
         { concurrency: "unbounded" },
       );
       const exitCode = Number(code);
-      if (yield* isWindowsCommandNotFound(exitCode, stderr)) {
+      if (yield* isWindowsCommandNotFound(exitCode, output.stderr)) {
         return yield* new OpenCodeRuntimeError({
           operation: "runOpenCodeCommand",
           detail: `spawn ${input.binaryPath} ENOENT`,
         });
       }
       return {
-        stdout,
-        stderr,
+        ...output,
         code: exitCode,
       } satisfies OpenCodeCommandResult;
     }).pipe(
@@ -928,9 +941,9 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       let skillsResult = initialSkillsResult;
 
       // Retry once after 1s on transient failures (e.g. SQLite "database is locked")
-      const needsModelsRetry = modelsResult._tag === "Failure" || modelsResult.value.code !== 0;
-      const needsAgentsRetry = agentsResult._tag === "Failure" || agentsResult.value.code !== 0;
-      const needsSkillsRetry = skillsResult._tag === "Failure" || skillsResult.value.code !== 0;
+      const needsModelsRetry = shouldRetryInventoryCommand(modelsResult);
+      const needsAgentsRetry = shouldRetryInventoryCommand(agentsResult);
+      const needsSkillsRetry = shouldRetryInventoryCommand(skillsResult);
       if (needsModelsRetry || needsAgentsRetry || needsSkillsRetry) {
         yield* Effect.sleep("1 second");
         const [m2, a2, s2] = yield* Effect.all(

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -73,8 +73,9 @@ describe("providerModelsFromSettings", () => {
 });
 
 describe("provider command collection", () => {
-  it.effect("bounds provider command output by default", () => {
+  it.effect("fails after draining provider command output that exceeds the default limit", () => {
     const maxOutputBytes = 8 * 1024 * 1024;
+    let stdoutChunksRead = 0;
     const spawner = ChildProcessSpawner.make(() =>
       Effect.succeed(
         ChildProcessSpawner.makeHandle({
@@ -84,7 +85,11 @@ describe("provider command collection", () => {
           kill: () => Effect.void,
           unref: Effect.succeed(Effect.void),
           stdin: Sink.drain,
-          stdout: Stream.make(new Uint8Array(maxOutputBytes + 1).fill(120)),
+          stdout: Stream.fromIterable([
+            new Uint8Array(maxOutputBytes).fill(120),
+            Uint8Array.of(120),
+            Uint8Array.of(120),
+          ]).pipe(Stream.tap(() => Effect.sync(() => stdoutChunksRead++))),
           stderr: Stream.empty,
           all: Stream.empty,
           getInputFd: () => Sink.drain,
@@ -94,15 +99,26 @@ describe("provider command collection", () => {
     );
 
     return Effect.gen(function* () {
-      const result = yield* spawnAndCollect(
+      const error = yield* spawnAndCollect(
         "provider",
         ChildProcess.make("provider", ["--version"]),
       ).pipe(
         Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)),
         Effect.provideService(HostProcessPlatform, "linux"),
+        Effect.match({
+          onFailure: (error) => error,
+          onSuccess: () => null,
+        }),
       );
 
-      expect(Buffer.byteLength(result.stdout)).toBe(maxOutputBytes);
+      if (error === null) {
+        return expect.fail("Expected provider command collection to fail on output overflow");
+      }
+      expect(error).toMatchObject({
+        _tag: "ProviderCommandOutputLimitError",
+        maxBytes: maxOutputBytes,
+      });
+      expect(stdoutChunksRead).toBe(3);
     });
   });
 });

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -72,6 +72,41 @@ describe("providerModelsFromSettings", () => {
   });
 });
 
+describe("provider command collection", () => {
+  it.effect("bounds provider command output by default", () => {
+    const maxOutputBytes = 8 * 1024 * 1024;
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(
+        ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          unref: Effect.succeed(Effect.void),
+          stdin: Sink.drain,
+          stdout: Stream.make(new Uint8Array(maxOutputBytes + 1).fill(120)),
+          stderr: Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const result = yield* spawnAndCollect(
+        "provider",
+        ChildProcess.make("provider", ["--version"]),
+      ).pipe(
+        Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+        Effect.provideService(HostProcessPlatform, "linux"),
+      );
+
+      expect(Buffer.byteLength(result.stdout)).toBe(maxOutputBytes);
+    });
+  });
+});
+
 describe("ProviderCommandNotFoundError", () => {
   it("classifies normalized platform failures without parsing messages", () => {
     expect(

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -43,6 +43,17 @@ export class ProviderCommandNotFoundError extends Schema.TaggedErrorClass<Provid
   }
 }
 
+export class ProviderCommandOutputLimitError extends Schema.TaggedErrorClass<ProviderCommandOutputLimitError>()(
+  "ProviderCommandOutputLimitError",
+  {
+    maxBytes: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Provider command output exceeded the ${this.maxBytes} byte limit.`;
+  }
+}
+
 const isProviderCommandNotFoundError = Schema.is(ProviderCommandNotFoundError);
 
 export interface ProviderProbeResult {
@@ -77,22 +88,21 @@ export const spawnAndCollect = (binaryPath: string, command: ChildProcess.Comman
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const child = yield* spawner.spawn(command);
-    const [stdout, stderr, exitCode] = yield* Effect.all(
+    const [output, exitCode] = yield* Effect.all(
       [
-        collectStreamAsString(child.stdout),
-        collectStreamAsString(child.stderr),
+        collectProviderCommandOutput({ stdout: child.stdout, stderr: child.stderr }),
         child.exitCode.pipe(Effect.map(Number)),
       ],
       { concurrency: "unbounded" },
     );
 
-    const result: CommandResult = { stdout, stderr, code: exitCode };
-    if (yield* isWindowsCommandNotFound(exitCode, stderr)) {
+    const result: CommandResult = { ...output, code: exitCode };
+    if (yield* isWindowsCommandNotFound(exitCode, output.stderr)) {
       return yield* new ProviderCommandNotFoundError({
         binaryPath,
         exitCode,
-        stdoutLength: stdout.length,
-        stderrLength: stderr.length,
+        stdoutLength: output.stdout.length,
+        stderrLength: output.stderr.length,
       });
     }
     return result;
@@ -254,11 +264,23 @@ export function buildServerProvider(input: {
   };
 }
 
-export const collectStreamAsString = <E>(
-  stream: Stream.Stream<Uint8Array, E>,
-  options?: { readonly maxBytes?: number | undefined },
-): Effect.Effect<string, E> =>
-  collectUint8StreamText({
-    stream,
-    maxBytes: options?.maxBytes ?? DEFAULT_PROVIDER_COMMAND_MAX_OUTPUT_BYTES,
-  }).pipe(Effect.map((collected) => collected.text));
+export const collectProviderCommandOutput = Effect.fn(
+  "providerSnapshot.collectProviderCommandOutput",
+)(function* <StdoutError, StderrError>(input: {
+  readonly stdout: Stream.Stream<Uint8Array, StdoutError>;
+  readonly stderr: Stream.Stream<Uint8Array, StderrError>;
+  readonly maxBytes?: number | undefined;
+}) {
+  const maxBytes = input.maxBytes ?? DEFAULT_PROVIDER_COMMAND_MAX_OUTPUT_BYTES;
+  const [stdout, stderr] = yield* Effect.all(
+    [
+      collectUint8StreamText({ stream: input.stdout, maxBytes }),
+      collectUint8StreamText({ stream: input.stderr, maxBytes }),
+    ],
+    { concurrency: "unbounded" },
+  );
+  if (stdout.truncated || stderr.truncated) {
+    return yield* new ProviderCommandOutputLimitError({ maxBytes });
+  }
+  return { stdout: stdout.text, stderr: stderr.text };
+});

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -19,6 +19,7 @@ import { createProviderVersionAdvisory } from "./providerMaintenance.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 
 export const DEFAULT_TIMEOUT_MS = 4_000;
+const DEFAULT_PROVIDER_COMMAND_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 // Auth status checks involve disk/network lookups and can be slow on first run (especially Windows)
 export const AUTH_PROBE_TIMEOUT_MS = 10_000;
 
@@ -257,4 +258,7 @@ export const collectStreamAsString = <E>(
   stream: Stream.Stream<Uint8Array, E>,
   options?: { readonly maxBytes?: number | undefined },
 ): Effect.Effect<string, E> =>
-  collectUint8StreamText({ stream, ...options }).pipe(Effect.map((collected) => collected.text));
+  collectUint8StreamText({
+    stream,
+    maxBytes: options?.maxBytes ?? DEFAULT_PROVIDER_COMMAND_MAX_OUTPUT_BYTES,
+  }).pipe(Effect.map((collected) => collected.text));


### PR DESCRIPTION
## What changed

- Cap provider CLI stdout and stderr collection at 8 MiB each by default.
- Fail provider commands explicitly when either stream exceeds its limit.
- Preserve explicit smaller `maxBytes` overrides and avoid retrying deterministic overflow failures.

## Why

Provider probes shared a collector with no default output limit. A misbehaving CLI could therefore retain arbitrary stdout or stderr in the server process.

The provider collector now uses the same 8 MiB per-stream default as `ProcessRunner`. It drains both streams before reporting overflow so child processes can exit normally, including on Windows. Parsers never receive truncated JSON, version, or model output as a successful command result.

## Verification

- 62 focused provider tests pass.
- Server typecheck passes.
- Targeted lint and formatting checks pass.
- The regression test exceeds the default limit across three chunks, verifies all chunks were drained, and receives `ProviderCommandOutputLimitError`.
- The OpenCode process test writes 2 MiB to both stdout and stderr with a 64-byte limit and exits with an explicit overflow error.

## Checklist

- [x] This PR is focused on one reliability issue
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because this PR has no UI changes
- [x] A video is not applicable because this PR has no animation or interaction changes

Model: gpt-5.6-sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared provider probing and OpenCode inventory retry behavior; mis-sized limits could break legitimate large CLI output, but the change hardens memory use on a security-sensitive server path.
> 
> **Overview**
> Caps provider CLI **stdout/stderr** collection at **8 MiB** by default (with optional smaller `maxBytes`), replacing unbounded `collectStreamAsString` with `collectProviderCommandOutput` and a **`ProviderCommandOutputLimitError`** when either stream exceeds the budget. The collector still **drains** child output after the limit so processes can exit cleanly.
> 
> **Cursor** and **OpenCode** command paths now use the shared helper. Oversized `agent about` output surfaces as a health-check error instead of being parsed. OpenCode **fails** on limit breaches (no silent truncation), skips **retries** for output-limit failures during CLI inventory, while keeping model inventory when skill discovery alone overflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1fd2ce303220fc5ee6ec688ffa486a21b33fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider health checks now report a clear error when command output exceeds the supported 8 MiB limit.
  * Oversized command responses are handled consistently across providers, preventing incomplete output from being parsed as valid data.
  * Inventory checks no longer repeatedly retry commands that fail because their output exceeds the limit.
  * Command execution continues draining output before reporting size-limit failures, improving process cleanup and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->