### PR TITLE
fix(pull-requests): keep cached PR chrome on reopen

### DIFF
--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1,4 +1,5 @@
 import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as TestClock from "effect/testing/TestClock";
@@ -74,6 +75,27 @@ function changeRequest(number: number, updatedAt: string): ProviderChangeRequest
     updatedAt,
     reviewRequestLogins: [],
     labels: [],
+  };
+}
+
+function hostedChangeRequest(body: string, additions = 1) {
+  return {
+    ...changeRequest(1, "2026-07-02T00:00:00Z"),
+    body,
+    additions,
+    changedFiles: 2,
+    mergedAt: null,
+    closedAt: null,
+    reviewers: [],
+    checks: [],
+    mergeCapabilities: { merge: true, squash: true, rebase: true },
+    viewerPermissions: {
+      actions: ["merge"] as const,
+      comment: true,
+      resolve: true,
+      verdicts: ["comment", "approve", "request-changes"] as const,
+      requestReviewers: true,
+    },
   };
 }
 
@@ -2934,7 +2956,7 @@ it.effect(
     }),
 );
 
-it.effect("shares linked summaries and only recovers transient failures for display reads", () =>
+it.effect("shares linked summaries and reuses them for display without asking the host again", () =>
   Effect.gen(function* () {
     let calls = 0;
     let failing = false;
@@ -2984,11 +3006,70 @@ it.effect("shares linked summaries and only recovers transient failures for disp
 
     const stale = yield* service.summary(reference);
     assert.strictEqual(stale.updatedAt, "2026-07-02T00:00:00Z");
-    assert.strictEqual(calls, 3);
+    // Display reads keep the last title and state rather than asking the host again.
+    assert.strictEqual(calls, 2);
 
     yield* service.invalidate({ reference });
     const invalidated = yield* Effect.flip(service.summary(reference));
     assert.strictEqual(invalidated._tag, "PullRequestOperationError");
+  }),
+);
+
+it.effect("answers a known pull request immediately while the host refreshes", () =>
+  Effect.gen(function* () {
+    const gate = yield* Deferred.make<void>();
+    let calls = 0;
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequest: () =>
+            Effect.gen(function* () {
+              calls += 1;
+              if (calls > 1) yield* Deferred.await(gate);
+              return hostedChangeRequest("cached body", 4);
+            }),
+        }),
+      ],
+    });
+
+    const first = yield* service.detail(reference);
+    assert.strictEqual(first.body, "cached body");
+    assert.strictEqual(first.additions, 4);
+
+    yield* TestClock.adjust("16 seconds");
+    const second = yield* service.detail(reference);
+    assert.strictEqual(second.body, "cached body");
+    assert.strictEqual(second.additions, 4);
+    yield* Effect.yieldNow;
+    assert.strictEqual(calls, 2);
+  }),
+);
+
+it.effect("does not ask the host again for a linked summary it already holds", () =>
+  Effect.gen(function* () {
+    let calls = 0;
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequestSummary: () =>
+            Effect.sync(() => {
+              calls += 1;
+              return changeRequest(1, "2026-07-02T00:00:00Z");
+            }),
+        }),
+      ],
+    });
+
+    const first = yield* service.summary(reference);
+    assert.strictEqual(first.title, "Change request 1");
+    yield* TestClock.adjust("61 seconds");
+    const second = yield* service.summary(reference);
+    assert.strictEqual(second.title, "Change request 1");
+    assert.strictEqual(calls, 1);
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3073,6 +3073,55 @@ it.effect("does not ask the host again for a linked summary it already holds", (
   }),
 );
 
+it.effect("does not let a stale detail reopen overwrite a fresher linked summary", () =>
+  Effect.gen(function* () {
+    const gate = yield* Deferred.make<void>();
+    let detailCalls = 0;
+    let summaryTitle = "old title";
+    let summaryState: "open" | "merged" = "open";
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequest: () =>
+            Effect.gen(function* () {
+              detailCalls += 1;
+              if (detailCalls > 1) yield* Deferred.await(gate);
+              return hostedChangeRequest("old body", 4);
+            }),
+          getChangeRequestSummary: () =>
+            Effect.succeed({
+              ...changeRequest(1, "2026-07-02T00:00:00Z"),
+              title: summaryTitle,
+              state: summaryState,
+            }),
+        }),
+      ],
+    });
+
+    const first = yield* service.detail(reference);
+    assert.strictEqual(first.title, "Change request 1");
+
+    summaryTitle = "merged title";
+    summaryState = "merged";
+    yield* TestClock.adjust("61 seconds");
+    const settled = yield* service.summary(reference, { recoverTransientFailure: false });
+    assert.strictEqual(settled.title, "merged title");
+    assert.strictEqual(settled.state, "merged");
+
+    yield* TestClock.adjust("16 seconds");
+    const stale = yield* service.detail(reference);
+    assert.strictEqual(stale.title, "Change request 1");
+    yield* Effect.yieldNow;
+
+    const display = yield* service.summary(reference);
+    assert.strictEqual(display.title, "merged title");
+    assert.strictEqual(display.state, "merged");
+    assert.strictEqual(detailCalls, 2);
+  }),
+);
+
 it.effect("keeps recent detail on a transient refresh failure but not after invalidation", () =>
   Effect.gen(function* () {
     let failing = false;

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3122,6 +3122,44 @@ it.effect("does not let a stale detail reopen overwrite a fresher linked summary
   }),
 );
 
+it.effect("does not let a still-cached detail overwrite a fresher linked summary", () =>
+  Effect.gen(function* () {
+    let summaryTitle = "old title";
+    let summaryState: "open" | "merged" = "open";
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequest: () => Effect.succeed(hostedChangeRequest("old body", 4)),
+          getChangeRequestSummary: () =>
+            Effect.succeed({
+              ...changeRequest(1, "2026-07-02T00:00:00Z"),
+              title: summaryTitle,
+              state: summaryState,
+            }),
+        }),
+      ],
+    });
+
+    const first = yield* service.detail(reference);
+    assert.strictEqual(first.title, "Change request 1");
+
+    summaryTitle = "merged title";
+    summaryState = "merged";
+    const settled = yield* service.summary(reference, { recoverTransientFailure: false });
+    assert.strictEqual(settled.state, "merged");
+
+    const cached = yield* service.detail(reference);
+    assert.strictEqual(cached.title, "Change request 1");
+    yield* Effect.yieldNow;
+
+    const display = yield* service.summary(reference);
+    assert.strictEqual(display.title, "merged title");
+    assert.strictEqual(display.state, "merged");
+  }),
+);
+
 it.effect("keeps recent detail on a transient refresh failure but not after invalidation", () =>
   Effect.gen(function* () {
     let failing = false;

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2181,9 +2181,16 @@ export const make = Effect.gen(function* () {
   });
   const detail: PullRequestService["Service"]["detail"] = (input) => {
     const key = refCacheKey(input);
-    return lastGoodDetail
-      .serveHeld(key, Cache.get(detailCache, key), "revalidate")
-      .pipe(Effect.tap((value) => lastGoodSummary.record(key, summaryFromDetail(value))));
+    // Record the summary from a host (or cache) read, not from the stale value
+    // `serveHeld` returns immediately — that snapshot can be older than a later
+    // strict summary, and display reuse would then never ask the host again.
+    return lastGoodDetail.serveHeld(
+      key,
+      Cache.get(detailCache, key).pipe(
+        Effect.tap((value) => lastGoodSummary.record(key, summaryFromDetail(value))),
+      ),
+      "revalidate",
+    );
   };
 
   const activityCache = yield* Cache.makeWith(

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2001,7 +2001,25 @@ export const make = Effect.gen(function* () {
           },
         }),
       );
-    return { read, record };
+    /**
+     * A change request already read does not wait on the host again. `reuse` answers from
+     * what we hold and spends nothing — title, author, and state barely move, and a linked
+     * thread already names the change request. `revalidate` answers the same way and
+     * refreshes behind it, so line counts and the rest can change in place.
+     */
+    const serveHeld = (
+      key: string,
+      effect: Effect.Effect<A, PullRequestError>,
+      mode: "reuse" | "revalidate",
+    ) => {
+      const snapshot = held.get(key);
+      if (snapshot === undefined) return read(key, effect);
+      if (mode === "reuse") return Effect.succeed(snapshot.value);
+      return Effect.sync(() => runFork(Effect.ignore(read(key, effect)))).pipe(
+        Effect.as(snapshot.value),
+      );
+    };
+    return { read, record, serveHeld };
   };
   const lastGoodSummary = makeLastGoodRead<PullRequestSummary>(DETAIL_CACHE_CAPACITY);
   const lastGoodDetail = makeLastGoodRead<PullRequestDetail>(DETAIL_CACHE_CAPACITY);
@@ -2059,7 +2077,7 @@ export const make = Effect.gen(function* () {
     const cached = Cache.get(summaryCache, key);
     return options?.recoverTransientFailure === false
       ? cached.pipe(Effect.tap((value) => lastGoodSummary.record(key, value)))
-      : lastGoodSummary.read(key, cached);
+      : lastGoodSummary.serveHeld(key, cached, "reuse");
   };
 
   // Keys serialize positionally and parse back in the lookup, so the cache is the only holder
@@ -2149,9 +2167,23 @@ export const make = Effect.gen(function* () {
       timeToLive: (exit) => (Exit.isSuccess(exit) ? DETAIL_CACHE_TTL : Duration.zero),
     },
   );
+  const summaryFromDetail = (detail: PullRequestDetail): PullRequestSummary => ({
+    provider: detail.provider,
+    projectId: detail.projectId,
+    repository: detail.repository,
+    number: detail.number,
+    title: detail.title,
+    url: detail.url,
+    state: detail.state,
+    headBranch: detail.headBranch,
+    baseBranch: detail.baseBranch,
+    updatedAt: detail.updatedAt,
+  });
   const detail: PullRequestService["Service"]["detail"] = (input) => {
     const key = refCacheKey(input);
-    return lastGoodDetail.read(key, Cache.get(detailCache, key));
+    return lastGoodDetail
+      .serveHeld(key, Cache.get(detailCache, key), "revalidate")
+      .pipe(Effect.tap((value) => lastGoodSummary.record(key, summaryFromDetail(value))));
   };
 
   const activityCache = yield* Cache.makeWith(

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2019,7 +2019,7 @@ export const make = Effect.gen(function* () {
         Effect.as(snapshot.value),
       );
     };
-    return { read, record, serveHeld };
+    return { peek: (key: string) => held.get(key)?.value, read, record, serveHeld };
   };
   const lastGoodSummary = makeLastGoodRead<PullRequestSummary>(DETAIL_CACHE_CAPACITY);
   const lastGoodDetail = makeLastGoodRead<PullRequestDetail>(DETAIL_CACHE_CAPACITY);
@@ -2179,15 +2179,27 @@ export const make = Effect.gen(function* () {
     baseBranch: detail.baseBranch,
     updatedAt: detail.updatedAt,
   });
+  const shouldReplaceHeldSummary = (key: string, next: PullRequestSummary) => {
+    const current = lastGoodSummary.peek(key);
+    if (current === undefined) return true;
+    if (current.state === "merged" && next.state !== "merged") return false;
+    return next.updatedAt >= current.updatedAt;
+  };
   const detail: PullRequestService["Service"]["detail"] = (input) => {
     const key = refCacheKey(input);
-    // Record the summary from a host (or cache) read, not from the stale value
-    // `serveHeld` returns immediately — that snapshot can be older than a later
-    // strict summary, and display reuse would then never ask the host again.
+    // Record the summary from a host or cache read, not the stale value
+    // `serveHeld` returns immediately. Skip the write when that read is older
+    // than a later strict summary — display reuse would otherwise keep the
+    // regression and never ask the host again.
     return lastGoodDetail.serveHeld(
       key,
       Cache.get(detailCache, key).pipe(
-        Effect.tap((value) => lastGoodSummary.record(key, summaryFromDetail(value))),
+        Effect.tap((value) => {
+          const summary = summaryFromDetail(value);
+          return shouldReplaceHeldSummary(key, summary)
+            ? lastGoodSummary.record(key, summary)
+            : Effect.void;
+        }),
       ),
       "revalidate",
     );

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -120,10 +120,13 @@ import {
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   readableFailure,
+  readPullRequestDetailSnapshot,
+  resolveDisplayedPullRequestDetail,
   resolvePullRequestPrimaryControl,
   resolveBaseFreshness,
   type PullRequestFinding,
   shouldRefreshPullRequestActivity,
+  writePullRequestDetailSnapshot,
 } from "./pullRequestDetail.logic";
 import { canEditPullRequestChangeRequest } from "./pullRequestEditing.logic";
 import {
@@ -558,7 +561,37 @@ export function PullRequestDetailPanel({
   const activityQuery = useEnvironmentQuery(
     pullRequestEnvironment.activity({ environmentId, input: reference }),
   );
-  const coreDetail = detailQuery.data;
+  const [cachedDetail, setCachedDetail] = useState(() =>
+    readPullRequestDetailSnapshot(
+      typeof window === "undefined" ? undefined : window.localStorage,
+      environmentId,
+      reference,
+    ),
+  );
+  useEffect(() => {
+    setCachedDetail(
+      readPullRequestDetailSnapshot(
+        typeof window === "undefined" ? undefined : window.localStorage,
+        environmentId,
+        reference,
+      ),
+    );
+  }, [environmentId, pullRequestKey, reference]);
+  useEffect(() => {
+    if (detailQuery.data === null) return;
+    writePullRequestDetailSnapshot(
+      typeof window === "undefined" ? undefined : window.localStorage,
+      environmentId,
+      reference,
+      detailQuery.data,
+    );
+    setCachedDetail(detailQuery.data);
+  }, [detailQuery.data, environmentId, pullRequestKey, reference]);
+  const coreDetail = resolveDisplayedPullRequestDetail({
+    live: detailQuery.data,
+    cached: cachedDetail,
+    reference,
+  });
   const activity = activityQuery.data;
   const detail = useMemo(
     () =>
@@ -1240,6 +1273,8 @@ export function PullRequestDetailPanel({
         ).length
       : 0;
 
+  // A reopen already has last time's title, author, and counts. Keep them on screen
+  // and let the live read replace fields — especially the diff counts — in place.
   if (detailQuery.isPending && !detail) {
     return <PullRequestDetailGhost />;
   }

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -576,7 +576,7 @@ export function PullRequestDetailPanel({
         reference,
       ),
     );
-  }, [environmentId, pullRequestKey, reference]);
+  }, [environmentId, pullRequestKey, reference.projectId, reference.repository, reference.number]);
   useEffect(() => {
     if (detailQuery.data === null) return;
     writePullRequestDetailSnapshot(
@@ -586,7 +586,14 @@ export function PullRequestDetailPanel({
       detailQuery.data,
     );
     setCachedDetail(detailQuery.data);
-  }, [detailQuery.data, environmentId, pullRequestKey, reference]);
+  }, [
+    detailQuery.data,
+    environmentId,
+    pullRequestKey,
+    reference.projectId,
+    reference.repository,
+    reference.number,
+  ]);
   const coreDetail = resolveDisplayedPullRequestDetail({
     live: detailQuery.data,
     cached: cachedDetail,

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -2,6 +2,7 @@ import {
   PullRequestAction,
   type PullRequestCheck,
   type PullRequestComment,
+  type PullRequestDetail,
   type PullRequestDetailView,
   type PullRequestReviewThread,
 } from "@t3tools/contracts";
@@ -31,12 +32,15 @@ import {
   pullRequestHandoffLabels,
   pullRequestReviewOutcome,
   readableFailure,
+  readPullRequestDetailSnapshot,
+  resolveDisplayedPullRequestDetail,
   resolvePullRequestPrimaryControl,
   shouldRefreshPullRequestActivity,
   resolveBaseFreshness,
   buildPullRequestTimeline,
   describePullRequestState,
   editPullRequestThreadComment,
+  writePullRequestDetailSnapshot,
 } from "./pullRequestDetail.logic";
 import type { ReviewCommentContext } from "~/reviewCommentContext";
 
@@ -1315,5 +1319,105 @@ describe("which actions need the host read again after they run", () => {
     ] as const) {
       expect(pullRequestActionNeedsHostRefresh(action)).toBe(false);
     }
+  });
+});
+
+describe("cached pull request detail", () => {
+  const reference = { projectId: "project-1", repository: "acme/web", number: 7 };
+  const detail = (overrides: Partial<PullRequestDetail> = {}): PullRequestDetail =>
+    ({
+      provider: "github",
+      capabilities: {
+        diff: true,
+        comment: true,
+        actions: ["merge"],
+        mergeMethods: ["merge"],
+        search: true,
+        review: {
+          inlineComment: true,
+          reply: true,
+          resolve: true,
+          verdicts: ["comment", "approve", "request-changes"],
+        },
+        reviewers: { request: true, listCandidates: true },
+      },
+      viewerPermissions: {
+        actions: ["merge"],
+        comment: true,
+        resolve: true,
+        verdicts: ["comment", "approve", "request-changes"],
+        requestReviewers: true,
+      },
+      projectId: "project-1",
+      projectTitle: "web",
+      workspaceRoot: "/repo",
+      repository: "acme/web",
+      number: 7,
+      title: "Cache the title",
+      body: "who made it",
+      url: "https://github.com/acme/web/pull/7",
+      author: { login: "octocat", name: null, avatarUrl: "https://avatars.example/octocat" },
+      state: "open",
+      isDraft: false,
+      mergeability: "mergeable",
+      additions: 12,
+      deletions: 3,
+      changedFiles: 2,
+      headBranch: "feat/cache",
+      baseBranch: "main",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-02T00:00:00.000Z",
+      mergedAt: null,
+      closedAt: null,
+      reviewers: [],
+      labels: [],
+      checks: [],
+      mergeCapabilities: { merge: true, squash: true, rebase: true },
+      ...overrides,
+    }) as PullRequestDetail;
+
+  const makeStorage = () => {
+    const held = new Map<string, string>();
+    return {
+      getItem: (key: string) => held.get(key) ?? null,
+      setItem: (key: string, value: string) => void held.set(key, value),
+    };
+  };
+
+  it("hydrates the last title, author, and counts so a reopen does not ghost the tab", () => {
+    const storage = makeStorage();
+    writePullRequestDetailSnapshot(storage, "env-1", reference, detail());
+    const snapshot = readPullRequestDetailSnapshot(storage, "env-1", reference);
+    expect(snapshot?.title).toBe("Cache the title");
+    expect(snapshot?.author?.login).toBe("octocat");
+    expect(snapshot?.additions).toBe(12);
+    expect(snapshot?.deletions).toBe(3);
+  });
+
+  it("keeps a cached tab painted while the live read replaces the counts", () => {
+    const cached = detail();
+    const live = detail({ additions: 40, deletions: 9, title: "Cache the title" });
+    expect(resolveDisplayedPullRequestDetail({ live, cached, reference })?.additions).toBe(40);
+    expect(resolveDisplayedPullRequestDetail({ live: null, cached, reference })?.additions).toBe(
+      12,
+    );
+  });
+
+  it("does not paint another change request's snapshot", () => {
+    expect(
+      resolveDisplayedPullRequestDetail({
+        live: null,
+        cached: detail({ number: 8 }),
+        reference,
+      }),
+    ).toBeNull();
+    expect(readPullRequestDetailSnapshot(makeStorage(), "env-2", reference)).toBeNull();
+  });
+
+  it("shrugs off corrupt storage and no storage at all", () => {
+    const storage = makeStorage();
+    storage.setItem("t3.pullRequests.detail:env-1:project-1:acme/web#7", "{not json");
+    expect(readPullRequestDetailSnapshot(storage, "env-1", reference)).toBeNull();
+    expect(readPullRequestDetailSnapshot(undefined, "env-1", reference)).toBeNull();
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -1,19 +1,22 @@
-import type {
-  PullRequestAction,
-  PullRequestActor,
-  PullRequestBaseComparison,
-  PullRequestCheck,
-  PullRequestChecksState,
-  PullRequestComment,
-  PullRequestCommit,
-  PullRequestDetailView,
-  PullRequestMergeability,
-  PullRequestReaction,
-  PullRequestReviewThread,
-  PullRequestState,
-  PullRequestUpdateMethod,
-  SourceControlProviderKind,
-  VcsRef,
+import * as Schema from "effect/Schema";
+
+import {
+  PullRequestDetail,
+  type PullRequestAction,
+  type PullRequestActor,
+  type PullRequestBaseComparison,
+  type PullRequestCheck,
+  type PullRequestChecksState,
+  type PullRequestComment,
+  type PullRequestCommit,
+  type PullRequestDetailView,
+  type PullRequestMergeability,
+  type PullRequestReaction,
+  type PullRequestReviewThread,
+  type PullRequestState,
+  type PullRequestUpdateMethod,
+  type SourceControlProviderKind,
+  type VcsRef,
 } from "@t3tools/contracts";
 
 import { inferReviewCommentFenceLanguage, type ReviewCommentContext } from "~/reviewCommentContext";
@@ -1008,4 +1011,76 @@ const ACTION_NEEDS_HOST_REFRESH: Record<PullRequestAction, boolean> = {
 
 export function pullRequestActionNeedsHostRefresh(action: PullRequestAction): boolean {
   return ACTION_NEEDS_HOST_REFRESH[action];
+}
+
+type SnapshotStorage = Pick<Storage, "getItem" | "setItem">;
+
+export interface PullRequestDetailSnapshotRef {
+  readonly projectId: string;
+  readonly repository: string;
+  readonly number: number;
+}
+
+const pullRequestDetailSnapshotKey = (
+  environmentId: string,
+  reference: PullRequestDetailSnapshotRef,
+) =>
+  `t3.pullRequests.detail:${environmentId}:${reference.projectId}:${reference.repository}#${reference.number}`;
+
+const decodeDetailSnapshot = Schema.decodeUnknownOption(PullRequestDetail);
+
+/**
+ * The last detail answered for this change request, brought back across a reload. The registry
+ * the queries live in is recreated with the renderer, so without this a reopen cold-starts
+ * into a full-tab ghost even though the title, author, and the rest barely moved. Hydrated,
+ * the chrome stays and the live read replaces fields in place — line counts included.
+ */
+export function readPullRequestDetailSnapshot(
+  storage: SnapshotStorage | undefined,
+  environmentId: string,
+  reference: PullRequestDetailSnapshotRef,
+): PullRequestDetail | null {
+  try {
+    const raw = storage?.getItem(pullRequestDetailSnapshotKey(environmentId, reference));
+    if (!raw) return null;
+    const decoded = decodeDetailSnapshot(JSON.parse(raw));
+    return decoded._tag === "Some" ? decoded.value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writePullRequestDetailSnapshot(
+  storage: SnapshotStorage | undefined,
+  environmentId: string,
+  reference: PullRequestDetailSnapshotRef,
+  detail: PullRequestDetail,
+): void {
+  try {
+    storage?.setItem(
+      pullRequestDetailSnapshotKey(environmentId, reference),
+      JSON.stringify(detail),
+    );
+  } catch {
+    // Quota or a private-mode store: the next open waits on the live read, which is the
+    // cold start this snapshot exists to avoid, not a failure of its own.
+  }
+}
+
+/** Live host state wins; a snapshot is only the same change request, never a neighbour's. */
+export function resolveDisplayedPullRequestDetail(input: {
+  readonly live: PullRequestDetail | null;
+  readonly cached: PullRequestDetail | null;
+  readonly reference: PullRequestDetailSnapshotRef;
+}): PullRequestDetail | null {
+  if (input.live !== null) return input.live;
+  if (
+    input.cached !== null &&
+    input.cached.projectId === input.reference.projectId &&
+    input.cached.repository.toLowerCase() === input.reference.repository.toLowerCase() &&
+    input.cached.number === input.reference.number
+  ) {
+    return input.cached;
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
Reopening a thread's linked pull request was painting a full-tab skeleton and asking GitHub again for title, author, and the rest. Last-known metadata now stays on screen, and a refresh only replaces fields that actually moved — especially diff counts.

A later strict summary (including auto-settle) is no longer overwritten by the stale detail snapshot served on reopen. Snapshot IO keys off the pull request identity, not the inline reference object.

Verified with focused server and web unit tests for reuse, stale-while-revalidate detail, settlement-over-stale-reopen, and snapshot hydration.

## Evidence
![Reopen the PR panel: title, author, branches, and counts stay painted instead of a full-tab skeleton](https://uploads-production-47e4.up.railway.app/files/4d5788ae-f162-4a3f-bf80-31bfa76d7fa6/pr-cache-reopen.webm)

![First open of PR 9294 with chrome and +412/-22 already on screen](https://uploads-production-47e4.up.railway.app/files/297a0314-a293-47b2-a445-86285d2a8cd9/04-first-open.png)

![Panel closed back to the pull request list](https://uploads-production-47e4.up.railway.app/files/33d37091-56f2-40ba-a762-6a4886d83d5a/05-closed.png)

![Same PR reopened with title, author, and counts still painted](https://uploads-production-47e4.up.railway.app/files/7301dd42-ea21-4e7d-93a8-e4921e03e136/06-reopen.png)

## Test plan
- [ ] Open a thread whose branch already has a linked PR, wait for the PR tab to load, switch away, then reopen it — chrome (title, author, icon, counts) should stay, not a full-tab skeleton
- [ ] After a later refresh, only changed fields such as `+`/`-` counts update in place
- [ ] First-ever open of an unseen PR can still show the loading ghost
- [ ] Sidebar linked-PR status does not re-hit GitHub for title/state on every remount

Cursor Grok 4.6 via T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caching changes what clients see and when host APIs are called; incorrect staleness rules could show outdated title/state, though merged-state and updatedAt guards mitigate regression.
> 
> **Overview**
> Reopening a linked pull request no longer flashes a full-tab skeleton or re-fetches title/state from the host when nothing meaningful changed.
> 
> **Server (`PullRequestService`)** adds **`serveHeld`** on the last-good cache: display **summaries** reuse held data without another host call; **detail** returns the held snapshot immediately and **revalidates in the background**. Detail refreshes only update the linked summary when **`shouldReplaceHeldSummary`** allows it (respects **merged** state and **`updatedAt`**) so a stale detail reopen cannot regress a fresher strict summary.
> 
> **Web** persists the last **`PullRequestDetail`** in **`localStorage`** (schema-validated, keyed by environment + PR identity) and **`resolveDisplayedPullRequestDetail`** prefers live data but paints the snapshot while the query is pending—ghost UI only when there is no cached or live detail.
> 
> Tests cover reuse counts, stale-while-revalidate detail, summary settlement vs stale reopen, and snapshot hydration edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89359f30f573c9ecc77a81b26c6227e1ce2cdcf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->