### PR TITLE
fix(desktop): preserve WSL path whitespace

### DIFF
--- a/apps/desktop/src/wsl/wslPathParsing.test.ts
+++ b/apps/desktop/src/wsl/wslPathParsing.test.ts
@@ -105,6 +105,12 @@ describe("wslUncPathToLinuxPath", () => {
     );
   });
 
+  it("preserves trailing spaces in Linux path segments", () => {
+    expect(wslUncPathToLinuxPath("\\\\wsl.localhost\\Ubuntu\\home\\project ")).toBe(
+      "/home/project ",
+    );
+  });
+
   it("maps a distro UNC root to Linux root", () => {
     expect(wslUncPathToLinuxPath("\\\\wsl$\\Debian")).toBe("/");
     expect(wslUncPathToLinuxPath("\\\\wsl.localhost\\Debian\\")).toBe("/");
@@ -155,6 +161,18 @@ describe("resolveWslPickFolderDefaultPath", () => {
     ).toBe("\\\\wsl.localhost\\Debian\\home\\josh\\project");
   });
 
+  it("preserves trailing spaces in Linux initial paths", () => {
+    expect(
+      resolveWslPickFolderDefaultPath({ initialPath: "/home/josh/project " }, config, distros),
+    ).toBe("\\\\wsl.localhost\\Debian\\home\\josh\\project ");
+  });
+
+  it("uses WSL home for whitespace-only initial paths", () => {
+    expect(resolveWslPickFolderDefaultPath({ initialPath: "   " }, config, distros)).toBe(
+      "\\\\wsl.localhost\\Debian\\home",
+    );
+  });
+
   it("expands ~/path against the user's home dir when known", () => {
     expect(
       resolveWslPickFolderDefaultPath({ initialPath: "~/project" }, config, distros, "/home/josh"),
@@ -173,14 +191,13 @@ describe("resolveWslPickFolderDefaultPath", () => {
     );
   });
 
-  it("preserves existing UNC initial paths", () => {
-    expect(
-      resolveWslPickFolderDefaultPath(
-        { initialPath: "\\\\wsl.localhost\\Ubuntu\\home\\josh" },
-        config,
-        distros,
-      ),
-    ).toBe("\\\\wsl.localhost\\Ubuntu\\home\\josh");
+  it("preserves existing UNC initial paths, including trailing spaces", () => {
+    for (const initialPath of [
+      "\\\\wsl.localhost\\Ubuntu\\home\\josh",
+      "\\\\wsl.localhost\\Ubuntu\\home\\project ",
+    ]) {
+      expect(resolveWslPickFolderDefaultPath({ initialPath }, config, distros)).toBe(initialPath);
+    }
   });
 });
 

--- a/apps/desktop/src/wsl/wslPathParsing.ts
+++ b/apps/desktop/src/wsl/wslPathParsing.ts
@@ -49,7 +49,7 @@ export function extractDistroFromUncPath(windowsPath: string): string | null {
 }
 
 export function wslUncPathToLinuxPath(windowsPath: string): string | null {
-  const match = /^\\\\(?:wsl\.localhost|wsl\$)\\([^\\]+)(?:\\(.*))?$/i.exec(windowsPath.trim());
+  const match = /^\\\\(?:wsl\.localhost|wsl\$)\\([^\\]+)(?:\\(.*))?$/i.exec(windowsPath);
   if (!match) return null;
 
   const distro = match[1]!;
@@ -89,12 +89,11 @@ export function resolveWslPickFolderDefaultPath(
     return homePath;
   }
 
-  const trimmedPath = initialPath.trim();
-  if (trimmedPath.length === 0) {
+  if (initialPath.trim().length === 0) {
     return homePath;
   }
-  if (trimmedPath.startsWith("\\\\")) {
-    return trimmedPath;
+  if (initialPath.startsWith("\\\\")) {
+    return initialPath;
   }
 
   const distroName = config.distro ?? distros.find((distro) => distro.isDefault)?.name ?? null;
@@ -107,18 +106,18 @@ export function resolveWslPickFolderDefaultPath(
 
   const normalizedUserHome = userHome && userHome.startsWith("/") ? userHome : null;
 
-  if (trimmedPath === "~") {
+  if (initialPath === "~") {
     return normalizedUserHome ? toUncPath(normalizedUserHome) : homePath;
   }
-  if (trimmedPath.startsWith("~/")) {
-    const remainder = trimmedPath.slice(2);
+  if (initialPath.startsWith("~/")) {
+    const remainder = initialPath.slice(2);
     if (normalizedUserHome) {
       return toUncPath(`${normalizedUserHome}/${remainder}`);
     }
     return homePath ? `${homePath}\\${remainder.replaceAll("/", "\\")}` : null;
   }
-  if (trimmedPath.startsWith("/")) {
-    return toUncPath(trimmedPath);
+  if (initialPath.startsWith("/")) {
+    return toUncPath(initialPath);
   }
 
   return homePath;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5586,12 +5586,12 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
-  it.effect("creates a missing workspace root during websocket project.create dispatch", () =>
+  it.effect("preserves workspace root whitespace during websocket project.create dispatch", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const parentDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ws-project-create-" });
-      const missingWorkspaceRoot = path.join(parentDir, "nested", "new-project");
+      const missingWorkspaceRoot = path.join(parentDir, "nested", "new-project ");
 
       yield* buildAppUnderTest();
 

--- a/apps/server/src/workspace/WorkspacePaths.ts
+++ b/apps/server/src/workspace/WorkspacePaths.ts
@@ -152,7 +152,10 @@ export const make = Effect.gen(function* () {
   const normalizeWorkspaceRoot: WorkspacePaths["Service"]["normalizeWorkspaceRoot"] = Effect.fn(
     "WorkspacePaths.normalizeWorkspaceRoot",
   )(function* (workspaceRoot, options) {
-    const normalizedWorkspaceRoot = path.resolve(expandHomePathWith(workspaceRoot.trim(), path));
+    const workspaceRootInput = path.isAbsolute(workspaceRoot)
+      ? workspaceRoot
+      : workspaceRoot.trim();
+    const normalizedWorkspaceRoot = path.resolve(expandHomePathWith(workspaceRootInput, path));
     let workspaceStat = yield* statWorkspaceRoot(
       workspaceRoot,
       normalizedWorkspaceRoot,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
   getCloneDirectoryName,
   getDefaultCloneUrl,
   normalizePastedCloneUrl,
+  resolveAddProjectPath,
 } from "@t3tools/client-runtime/operations/projects";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
@@ -1804,32 +1805,23 @@ function OpenCommandPaletteDialog(props: {
         );
         return;
       }
-      const rawCwd = input.rawCwd;
-
-      if (isUnsupportedWindowsProjectPath(rawCwd.trim(), input.platform)) {
+      const resolved = resolveAddProjectPath({
+        rawPath: input.rawCwd,
+        currentProjectCwd: input.currentProjectCwd,
+        platform: input.platform,
+      });
+      if (!resolved.ok) {
         toastManager.add(
           stackedThreadToast({
             type: "error",
             title: "Failed to add project",
-            description: "Windows-style paths are only supported on Windows.",
+            description: resolved.error,
           }),
         );
         return;
       }
 
-      if (isExplicitRelativeProjectPath(rawCwd.trim()) && !input.currentProjectCwd) {
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Failed to add project",
-            description: "Relative paths require an active project.",
-          }),
-        );
-        return;
-      }
-
-      const cwd = resolveProjectPathForDispatch(rawCwd, input.currentProjectCwd);
-      if (cwd.length === 0) return;
+      const cwd = resolved.path;
 
       const existing = findProjectByPath(
         projects.filter((project) => project.environmentId === input.environmentId),

--- a/apps/web/src/lib/projectPaths.test.ts
+++ b/apps/web/src/lib/projectPaths.test.ts
@@ -23,6 +23,13 @@ describe("projectPaths", () => {
     expect(normalizeProjectPathForComparison("/repo/app/")).toBe("/repo/app");
   });
 
+  it("preserves trailing spaces in project paths", () => {
+    expect(resolveProjectPathForDispatch("/home/project ")).toBe("/home/project ");
+    expect(
+      findProjectByPath([{ id: "project-1", cwd: "/home/project" }], "/home/project "),
+    ).toBeUndefined();
+  });
+
   it("normalizes windows-style paths for comparison", () => {
     expect(normalizeProjectPathForComparison("C:/Work/Repo/")).toBe("c:\\work\\repo");
     expect(normalizeProjectPathForComparison("C:\\Work\\Repo\\")).toBe("c:\\work\\repo");

--- a/apps/web/src/wslPaths.test.ts
+++ b/apps/web/src/wslPaths.test.ts
@@ -22,6 +22,13 @@ describe("parseWslUncPath", () => {
     });
   });
 
+  it("preserves trailing spaces in the Linux path", () => {
+    expect(parseWslUncPath("\\\\wsl.localhost\\Ubuntu\\home\\josh\\repo ")).toEqual({
+      distro: "Ubuntu",
+      linuxPath: "/home/josh/repo ",
+    });
+  });
+
   it("rejects non-WSL paths and invalid distro names", () => {
     expect(parseWslUncPath("C:\\Users\\Josh\\repo")).toBeNull();
     expect(parseWslUncPath("\\\\wsl.localhost\\bad!name\\home")).toBeNull();
@@ -39,6 +46,18 @@ describe("resolveWslProjectSelection", () => {
       distro: "Ubuntu",
       environmentId: "env-ubuntu",
       linuxPath: "/home/theo/repo",
+    });
+  });
+
+  it("preserves trailing spaces while routing a UNC path", () => {
+    expect(
+      resolveWslProjectSelection("\\\\wsl.localhost\\Ubuntu\\home\\theo\\repo ", [
+        { environmentId: "env-ubuntu", backendId: "wsl:Ubuntu", runningDistro: null },
+      ]),
+    ).toEqual({
+      distro: "Ubuntu",
+      environmentId: "env-ubuntu",
+      linuxPath: "/home/theo/repo ",
     });
   });
 

--- a/apps/web/src/wslPaths.ts
+++ b/apps/web/src/wslPaths.ts
@@ -28,7 +28,7 @@ const WSL_DISTRO_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 const WSL_DEFAULT_BACKEND_ID = "wsl:default";
 
 export function parseWslUncPath(input: string): WslUncPath | null {
-  const normalized = input.trim().replaceAll("/", "\\");
+  const normalized = input.replaceAll("/", "\\");
   const prefix = WSL_UNC_PREFIXES.find((candidate) =>
     normalized.toLowerCase().startsWith(candidate.toLowerCase()),
   );

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -79,6 +79,9 @@ successful launch, T3 Code keeps the current runtime and one previous runtime fo
 removes older caches automatically. If a cached runtime stops working, T3 Code launches from the
 application files under `/mnt/c` instead and reinstalls the runtime on the next launch.
 
+When the desktop folder picker opens or returns a WSL path, it preserves trailing spaces in
+directory names.
+
 ## Providers
 
 T3 Code drives provider CLIs; it does not ship them. Install the CLI for each provider you want

--- a/packages/client-runtime/src/operations/commands.test.ts
+++ b/packages/client-runtime/src/operations/commands.test.ts
@@ -74,7 +74,7 @@ const makeSupervisor = Effect.fn("TestEnvironmentCommands.makeSupervisor")(funct
 });
 
 describe("environment commands", () => {
-  it.effect("adds generated command metadata", () =>
+  it.effect("adds generated command metadata without changing the workspace root", () =>
     Effect.gen(function* () {
       const dispatched: ClientOrchestrationCommand[] = [];
       const supervisor = yield* makeSupervisor(dispatched);
@@ -82,7 +82,7 @@ describe("environment commands", () => {
       const result = yield* createProject({
         projectId: ProjectId.make("project-1"),
         title: "Project",
-        workspaceRoot: "/workspace/project",
+        workspaceRoot: "/workspace/project ",
         createdAt: "2026-06-06T00:00:00.000Z",
       }).pipe(Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor));
 
@@ -93,7 +93,7 @@ describe("environment commands", () => {
           commandId: "00000000-0000-4000-8000-000000000000",
           projectId: "project-1",
           title: "Project",
-          workspaceRoot: "/workspace/project",
+          workspaceRoot: "/workspace/project ",
           createdAt: "2026-06-06T00:00:00.000Z",
         },
       ]);

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -165,6 +165,29 @@ describe("add project shared logic", () => {
     });
   });
 
+  it("classifies padded paths before dispatch", () => {
+    expect(
+      resolveAddProjectPath({
+        rawPath: " C:\\repo ",
+        platform: "Linux",
+        currentProjectCwd: null,
+      }),
+    ).toEqual({
+      ok: false,
+      error: "Windows-style paths are only supported on Windows environments.",
+    });
+    expect(
+      resolveAddProjectPath({
+        rawPath: " ../repo ",
+        platform: "Linux",
+        currentProjectCwd: null,
+      }),
+    ).toEqual({
+      ok: false,
+      error: "Relative paths require an active project in this environment.",
+    });
+  });
+
   it("resolves relative paths from the active project cwd", () => {
     expect(
       resolveAddProjectPath({

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -175,6 +175,16 @@ describe("add project shared logic", () => {
     ).toEqual({ ok: true, path: "/work/next" });
   });
 
+  it("preserves trailing spaces in absolute project paths", () => {
+    expect(
+      resolveAddProjectPath({
+        rawPath: "/home/project ",
+        platform: "Linux",
+        currentProjectCwd: null,
+      }),
+    ).toEqual({ ok: true, path: "/home/project " });
+  });
+
   it("marks authenticated source control providers as ready", () => {
     const discovery: SourceControlDiscoveryResult = {
       versionControlSystems: [],

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -271,13 +271,14 @@ export function resolveAddProjectPath(input: {
   readonly platform: string;
 }): { readonly ok: true; readonly path: string } | { readonly ok: false; readonly error: string } {
   const rawPath = input.rawPath;
-  if (rawPath.trim().length === 0) {
+  const classifiedPath = rawPath.trim();
+  if (classifiedPath.length === 0) {
     return { ok: false, error: "Enter a project path." };
   }
-  if (isUnsupportedWindowsProjectPath(rawPath, input.platform)) {
+  if (isUnsupportedWindowsProjectPath(classifiedPath, input.platform)) {
     return { ok: false, error: "Windows-style paths are only supported on Windows environments." };
   }
-  if (isExplicitRelativeProjectPath(rawPath) && !input.currentProjectCwd) {
+  if (isExplicitRelativeProjectPath(classifiedPath) && !input.currentProjectCwd) {
     return { ok: false, error: "Relative paths require an active project in this environment." };
   }
   const path = resolveProjectPathForDispatch(rawPath, input.currentProjectCwd);

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -270,8 +270,8 @@ export function resolveAddProjectPath(input: {
   readonly currentProjectCwd?: string | null;
   readonly platform: string;
 }): { readonly ok: true; readonly path: string } | { readonly ok: false; readonly error: string } {
-  const rawPath = input.rawPath.trim();
-  if (rawPath.length === 0) {
+  const rawPath = input.rawPath;
+  if (rawPath.trim().length === 0) {
     return { ok: false, error: "Enter a project path." };
   }
   if (isUnsupportedWindowsProjectPath(rawPath, input.platform)) {

--- a/packages/client-runtime/src/state/projects.ts
+++ b/packages/client-runtime/src/state/projects.ts
@@ -95,18 +95,18 @@ export function isUnsupportedWindowsProjectPath(value: string, platform: string)
 }
 
 export function resolveProjectPathForDispatch(value: string, cwd?: string | null): string {
-  const trimmedValue = value.trim();
-  if (!isExplicitRelativePath(trimmedValue) || !cwd) {
-    return normalizeProjectPathForDispatch(trimmedValue);
+  const normalizedValue = normalizeProjectPathForDispatch(value);
+  if (!isExplicitRelativePath(normalizedValue) || !cwd) {
+    return normalizedValue;
   }
 
   const absoluteBase = splitAbsolutePath(normalizeProjectPathForDispatch(cwd));
   if (!absoluteBase) {
-    return normalizeProjectPathForDispatch(trimmedValue);
+    return normalizedValue;
   }
 
   const nextSegments = [...absoluteBase.segments];
-  for (const segment of trimmedValue.split(/[\\/]+/)) {
+  for (const segment of normalizedValue.split(/[\\/]+/)) {
     if (segment.length === 0 || segment === ".") continue;
     if (segment === "..") {
       nextSegments.pop();

--- a/packages/contracts/src/baseSchemas.ts
+++ b/packages/contracts/src/baseSchemas.ts
@@ -14,6 +14,9 @@ export const TrimmedString = Schema.String.pipe(
 );
 export const TrimmedNonEmptyString = TrimmedString.check(Schema.isNonEmpty());
 
+/** Reject blank workspace roots without changing valid path whitespace. */
+export const WorkspaceRootPath = Schema.String.check(Schema.isPattern(/\S/));
+
 export const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0));
 export const PositiveInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1));
 export const PortSchema = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }));

--- a/packages/contracts/src/desktopAppActivation.ts
+++ b/packages/contracts/src/desktopAppActivation.ts
@@ -1,6 +1,6 @@
 import * as Schema from "effect/Schema";
 
-import { ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { ProjectId, ThreadId, TrimmedNonEmptyString, WorkspaceRootPath } from "./baseSchemas.ts";
 
 export const DESKTOP_APP_ACTIVATION_PROTOCOL_VERSION = 1 as const;
 
@@ -11,7 +11,7 @@ export const DesktopAppActivationRequest = Schema.Struct({
   version: Schema.Literal(DESKTOP_APP_ACTIVATION_PROTOCOL_VERSION),
   requestId: TrimmedNonEmptyString,
   type: Schema.Literal("open-workspace"),
-  workspaceRoot: TrimmedNonEmptyString,
+  workspaceRoot: WorkspaceRootPath,
   platform: DesktopAppActivationPlatform,
 });
 export type DesktopAppActivationRequest = typeof DesktopAppActivationRequest.Type;

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -139,14 +139,14 @@ it.effect("rejects thread turn diff when fromTurnCount > toTurnCount", () =>
   }),
 );
 
-it.effect("trims branded ids and command string fields at decode boundaries", () =>
+it.effect("trims identifiers and labels but preserves workspace root whitespace", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeProjectCreateCommand({
       type: "project.create",
       commandId: " cmd-1 ",
       projectId: " project-1 ",
       title: " Project Title ",
-      workspaceRoot: " /tmp/workspace ",
+      workspaceRoot: "/tmp/workspace ",
       defaultModelSelection: {
         provider: "codex",
         model: " gpt-5.2 ",
@@ -156,12 +156,29 @@ it.effect("trims branded ids and command string fields at decode boundaries", ()
     assert.strictEqual(parsed.commandId, "cmd-1");
     assert.strictEqual(parsed.projectId, "project-1");
     assert.strictEqual(parsed.title, "Project Title");
-    assert.strictEqual(parsed.workspaceRoot, "/tmp/workspace");
+    assert.strictEqual(parsed.workspaceRoot, "/tmp/workspace ");
     assert.strictEqual(parsed.createWorkspaceRootIfMissing, undefined);
     assert.deepStrictEqual(parsed.defaultModelSelection, {
       instanceId: ProviderInstanceId.make("codex"),
       model: "gpt-5.2",
     });
+  }),
+);
+
+it.effect("rejects blank workspace roots", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.exit(
+      decodeProjectCreateCommand({
+        type: "project.create",
+        commandId: "cmd-1",
+        projectId: "project-1",
+        title: "Project Title",
+        workspaceRoot: "   ",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    assert.strictEqual(result._tag, "Failure");
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -21,6 +21,7 @@ import {
   TrimmedNonEmptyString,
   TrimmedString,
   TurnId,
+  WorkspaceRootPath,
 } from "./baseSchemas.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
 
@@ -285,7 +286,7 @@ export type ProjectFaviconPath = typeof ProjectFaviconPath.Type;
 export const OrchestrationProject = Schema.Struct({
   id: ProjectId,
   title: TrimmedNonEmptyString,
-  workspaceRoot: TrimmedNonEmptyString,
+  workspaceRoot: WorkspaceRootPath,
   repositoryIdentity: Schema.optional(Schema.NullOr(RepositoryIdentity)),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   // Per-project override for where new threads start. Null/absent means
@@ -501,7 +502,7 @@ export type OrchestrationReadModel = typeof OrchestrationReadModel.Type;
 export const OrchestrationProjectShell = Schema.Struct({
   id: ProjectId,
   title: TrimmedNonEmptyString,
-  workspaceRoot: TrimmedNonEmptyString,
+  workspaceRoot: WorkspaceRootPath,
   repositoryIdentity: Schema.optional(Schema.NullOr(RepositoryIdentity)),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   defaultThreadEnvMode: Schema.optional(Schema.NullOr(ThreadEnvMode)),
@@ -710,7 +711,7 @@ export const ProjectCreateCommand = Schema.Struct({
   commandId: CommandId,
   projectId: ProjectId,
   title: TrimmedNonEmptyString,
-  workspaceRoot: TrimmedNonEmptyString,
+  workspaceRoot: WorkspaceRootPath,
   createWorkspaceRootIfMissing: Schema.optional(Schema.Boolean),
   // Retained for older clients that sent an automatic create-time seed. The
   // server ignores it; explicit project defaults use project.meta.update.
@@ -723,7 +724,7 @@ const ProjectMetaUpdateCommand = Schema.Struct({
   commandId: CommandId,
   projectId: ProjectId,
   title: Schema.optional(TrimmedNonEmptyString),
-  workspaceRoot: Schema.optional(TrimmedNonEmptyString),
+  workspaceRoot: Schema.optional(WorkspaceRootPath),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   // Absent = leave unchanged; null = clear the override.
   defaultThreadEnvMode: Schema.optional(Schema.NullOr(ThreadEnvMode)),
@@ -1180,7 +1181,7 @@ export const OrchestrationActorKind = Schema.Literals(["client", "server", "prov
 export const ProjectCreatedPayload = Schema.Struct({
   projectId: ProjectId,
   title: TrimmedNonEmptyString,
-  workspaceRoot: TrimmedNonEmptyString,
+  workspaceRoot: WorkspaceRootPath,
   repositoryIdentity: Schema.optional(Schema.NullOr(RepositoryIdentity)),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   // Optional so persisted events from older servers still decode.
@@ -1193,7 +1194,7 @@ export const ProjectCreatedPayload = Schema.Struct({
 export const ProjectMetaUpdatedPayload = Schema.Struct({
   projectId: ProjectId,
   title: Schema.optional(TrimmedNonEmptyString),
-  workspaceRoot: Schema.optional(TrimmedNonEmptyString),
+  workspaceRoot: Schema.optional(WorkspaceRootPath),
   repositoryIdentity: Schema.optional(Schema.NullOr(RepositoryIdentity)),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   defaultThreadEnvMode: Schema.optional(Schema.NullOr(ThreadEnvMode)),

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -8,6 +8,7 @@ import {
   PositiveInt,
   ProjectId,
   TrimmedNonEmptyString,
+  WorkspaceRootPath,
 } from "./baseSchemas.ts";
 import { SourceControlProviderKind } from "./sourceControl.ts";
 
@@ -669,7 +670,7 @@ export const PullRequestDetail = Schema.Struct({
   viewerPermissions: PullRequestViewerPermissions,
   projectId: ProjectId,
   projectTitle: TrimmedNonEmptyString,
-  workspaceRoot: TrimmedNonEmptyString,
+  workspaceRoot: WorkspaceRootPath,
   repository: TrimmedNonEmptyString,
   number: PositiveInt,
   title: TrimmedNonEmptyString,

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -43,7 +43,8 @@ function trimTrailingPathSeparators(value: string): string {
 }
 
 export function normalizeProjectPathForDispatch(value: string): string {
-  return trimTrailingPathSeparators(value.trim());
+  const normalized = value.startsWith("/") || isWindowsAbsolutePath(value) ? value : value.trim();
+  return trimTrailingPathSeparators(normalized);
 }
 
 export function normalizeProjectPathForComparison(value: string): string {


### PR DESCRIPTION
## What Changed

- Preserve WSL UNC path whitespace in the desktop parser and folder-picker default.
- Carry absolute project paths unchanged through the shared Command Palette resolver, `project.create` contracts, and server workspace normalization.
- Reject whitespace-only workspace roots without rewriting valid Linux path whitespace.
- Add regression coverage at the parser, client dispatch, contract, lookup, and WebSocket integration boundaries.

## Why

Linux directory names may end with spaces. Trimming a selected WSL path at any later boundary could silently redirect the desktop app to a different directory.

## Proof

Before the fix, focused regression tests showed the whitespace being lost:

```text
Expected: "/home/project "
Received: "/home/project"

Expected: "/tmp/workspace "
Received: "/tmp/workspace"
```

The WebSocket integration also failed with `NotFound` when it checked the exact `new-project ` directory, proving that the server had created the trimmed sibling instead.

After the fix:

```text
$ pnpm exec vp test run packages/client-runtime/src/operations/projects.test.ts packages/client-runtime/src/operations/commands.test.ts apps/web/src/lib/projectPaths.test.ts
Test Files  3 passed (3)
Tests       34 passed (34)

$ pnpm exec vp test run apps/desktop/src/wsl/wslPathParsing.test.ts packages/contracts/src/orchestration.test.ts packages/shared/src/path.test.ts apps/server/src/workspace/WorkspacePaths.test.ts
Test Files  4 passed (4)
Tests       91 passed (91)

$ pnpm exec vp test run apps/server/src/server.test.ts -t "preserves workspace root whitespace during websocket project.create dispatch"
Tests       1 passed | 147 skipped
```

Focused formatting, lint, and typechecks for the changed desktop, web, client-runtime, contracts, shared, and server scopes pass.

Fallow new-only audit:

```text
$ npx --yes fallow audit --base upstream/main --gate new-only --format json --quiet
verdict: warn
new dead code: 0
new complexity findings: 0
new duplication fingerprints: 1
```

The duplication warning points to the existing parallel `OrchestrationProject` and `OrchestrationProjectShell` schema shapes. Both fingerprints changed because their `workspaceRoot` fields now use the same path-preserving schema; this PR does not introduce a new duplicated implementation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable because this changes path handling only
- [x] Animation or interaction video is not applicable

Implemented with GPT-5.6 Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes path normalization and project identity across desktop, web, server, and contracts; incorrect handling could open the wrong directory or break dedup, though behavior is heavily regression-tested.
> 
> **Overview**
> **Trailing spaces in directory names are no longer stripped** when adding projects or opening workspaces through WSL UNC paths, the desktop folder picker, Command Palette, client dispatch, or server workspace normalization. Whitespace-only inputs still fall back or fail validation instead of being treated as real paths.
> 
> A new **`WorkspaceRootPath`** contract replaces trimmed workspace-root fields on orchestration and desktop activation payloads: blank roots are rejected, but valid paths like `/tmp/workspace ` stay intact on the wire. **`normalizeWorkspaceRoot`** on the server trims only non-absolute roots before `path.resolve`, so a created directory matches the exact name the client sent.
> 
> Path classification (Windows vs relative vs empty) still uses trimmed input for errors; absolute paths keep internal whitespace and trailing spaces, so two projects that differ only by trailing space are not deduplicated as the same repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109d07d9dd438212cc3811881f47a3f50d4d1b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved leading and trailing spaces in valid project and workspace paths across desktop, web, WSL, and server workflows.
  * Continued rejecting blank or whitespace-only workspace paths.
  * Improved add-project path validation and error handling.
  * Prevented paths that differ only by trailing spaces from being treated as the same project.

* **Documentation**
  * Clarified that WSL folder-picker interactions preserve trailing spaces in directory names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->