### PR TITLE
chore(ci): only run check-run agents on vouched contributors

### DIFF
--- a/.macroscope/check-run-agents/effect-service-conventions.md
+++ b/.macroscope/check-run-agents/effect-service-conventions.md
@@ -15,6 +15,11 @@ include:
   - "packages/**/*.tsx"
   - "infra/**/*.ts"
   - "infra/**/*.tsx"
+labels:
+  - vouch:trusted
+requires:
+  - Check
+maxBudgetPerPR: 25
 conclusion: failure
 showToolCalls: true
 ---

--- a/.macroscope/check-run-agents/ui-consistency.md
+++ b/.macroscope/check-run-agents/ui-consistency.md
@@ -11,6 +11,11 @@ include:
   - "apps/web/src/**/*.css"
 exclude:
   - "apps/web/src/**/*.test.tsx"
+labels:
+  - vouch:trusted
+requires:
+  - Check
+maxBudgetPerPR: 25
 conclusion: failure
 maxBudgetPerRun: 10
 ---


### PR DESCRIPTION
The Macroscope check-run agents ran on every pull request, so anyone could open a PR against the repo and consume our review budget. This gates both agents on the trust signal we already maintain.

`pr-vouch.yml` labels every PR with exactly one of `vouch:trusted`, `vouch:unvouched`, or `vouch:denounced` based on repo permissions and `.github/VOUCHED.td`. Each agent now sets `labels: [vouch:trusted]`, so it only runs for collaborators and vouched externals. Macroscope enforces this filter on every trigger including manual `@macroscope` mentions, and a filtered-out agent creates no check run and bills nothing. Promoting a contributor is the same as today: add them to `VOUCHED.td`.

Two further cost levers on both agents:

- `requires: [Check]` waits for the CI lint/typecheck job and skips the review if it failed, so we don't pay to review code that doesn't compile. A skipped CI job counts as passing, so conditional jobs won't block it.
- `maxBudgetPerPR: 25` caps each agent's cumulative spend on a single PR. Checked before dispatch, so it prevents runs rather than cutting them off mid-way.

One thing to watch: Macroscope evaluates label filters on open, push, or mention, and the vouch workflow labels the PR a few seconds after open. If Macroscope evaluates the filter before the `requires` wait rather than after, a trusted author's very first push may be skipped until the next push or an `@macroscope review`. Unvouched authors are correctly never reviewed either way. Asking Macroscope which order applies; if it's filter-first, the fix is a `waitsFor` on a statically named vouch job.

Stacks cleanly with #9297, which trims the UI agent's prompt.

Claude Fable 5 via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only changes to Macroscope agent metadata; no application runtime or security logic is modified.
> 
> **Overview**
> Both Macroscope check-run agents (**Effect Service Conventions** and **UI Consistency**) now only run when the PR has the `vouch:trusted` label, so unvouched contributors no longer trigger automated reviews or spend review budget.
> 
> Each agent also **waits for the `Check` CI job** (`requires: [Check]`) before running, skipping review when lint/typecheck failed, and sets **`maxBudgetPerPR: 25`** to cap cumulative spend per pull request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8807c05bbd90a1229cd17ea150e899d309c67715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->