### PR TITLE
feat(environments): draw each environment as the machine it runs on

### DIFF
--- a/apps/mobile/src/components/AppSymbol.tsx
+++ b/apps/mobile/src/components/AppSymbol.tsx
@@ -22,6 +22,7 @@ import IconBox from "@tabler/icons-react-native/IconBox";
 import IconCamera from "@tabler/icons-react-native/IconCamera";
 import IconChartBar from "@tabler/icons-react-native/IconChartBar";
 import IconCheck from "@tabler/icons-react-native/IconCheck";
+import IconCloud from "@tabler/icons-react-native/IconCloud";
 import IconChevronDown from "@tabler/icons-react-native/IconChevronDown";
 import IconChevronLeft from "@tabler/icons-react-native/IconChevronLeft";
 import IconChevronRight from "@tabler/icons-react-native/IconChevronRight";
@@ -32,6 +33,7 @@ import IconClock from "@tabler/icons-react-native/IconClock";
 import IconCode from "@tabler/icons-react-native/IconCode";
 import IconCopy from "@tabler/icons-react-native/IconCopy";
 import IconDeviceDesktop from "@tabler/icons-react-native/IconDeviceDesktop";
+import IconDeviceLaptop from "@tabler/icons-react-native/IconDeviceLaptop";
 import IconDots from "@tabler/icons-react-native/IconDots";
 import IconDotsCircleHorizontal from "@tabler/icons-react-native/IconDotsCircleHorizontal";
 import IconEdit from "@tabler/icons-react-native/IconEdit";
@@ -110,6 +112,7 @@ const ANDROID_ICON_BY_SF_SYMBOL: Partial<Record<SFSymbol, Icon>> = {
   checkmark: IconCheck,
   "checkmark.circle": IconCircleCheck,
   clock: IconClock,
+  cloud: IconCloud,
   cube: IconBox,
   "chevron.down": IconChevronDown,
   "chevron.left": IconChevronLeft,
@@ -129,9 +132,13 @@ const ANDROID_ICON_BY_SF_SYMBOL: Partial<Record<SFSymbol, Icon>> = {
   "folder.fill": IconFolder,
   gearshape: IconSettings,
   "info.circle": IconInfoCircle,
+  laptopcomputer: IconDeviceLaptop,
   link: IconLink,
   "line.3.horizontal.decrease.circle": IconFilter,
   "line.3.horizontal.decrease.circle.fill": IconFilterFilled,
+  // Tabler has no Apple desktops; the closest silhouettes stand in on Android.
+  macmini: IconServer,
+  macstudio: IconDeviceDesktop,
   magnifyingglass: IconSearch,
   paintbrush: IconPalette,
   "person.crop.circle": IconUserCircle,

--- a/apps/mobile/src/components/EnvironmentMachineSymbol.tsx
+++ b/apps/mobile/src/components/EnvironmentMachineSymbol.tsx
@@ -1,0 +1,39 @@
+import type { EnvironmentMachineKind } from "@t3tools/contracts";
+import type { SFSymbol } from "expo-symbols";
+
+import { SymbolView } from "./AppSymbol";
+
+const SYMBOL_BY_KIND: Record<EnvironmentMachineKind, SFSymbol> = {
+  server: "server.rack",
+  cloud: "cloud",
+  desktop: "desktopcomputer",
+  laptop: "laptopcomputer",
+  "mac-mini": "macmini",
+  "mac-studio": "macstudio",
+};
+
+export const ENVIRONMENT_MACHINE_KIND_LABELS: Record<EnvironmentMachineKind, string> = {
+  server: "Server",
+  cloud: "Cloud VM",
+  desktop: "Desktop",
+  laptop: "Laptop",
+  "mac-mini": "Mac mini",
+  "mac-studio": "Mac Studio",
+};
+
+/** The glyph an environment wears in lists; SF Symbols on iOS, Tabler on Android. */
+export function EnvironmentMachineSymbol(props: {
+  readonly kind: EnvironmentMachineKind;
+  readonly size: number;
+  readonly tintColorClassName: string;
+}) {
+  return (
+    <SymbolView
+      accessibilityLabel={ENVIRONMENT_MACHINE_KIND_LABELS[props.kind]}
+      name={SYMBOL_BY_KIND[props.kind]}
+      size={props.size}
+      tintColorClassName={props.tintColorClassName}
+      type="monochrome"
+    />
+  );
+}

--- a/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
+++ b/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
@@ -4,7 +4,12 @@ import {
   connectionStatusText,
   type EnvironmentConnectionPhase,
 } from "@t3tools/client-runtime/connection";
-import type { EnvironmentId } from "@t3tools/contracts";
+import {
+  type EnvironmentId,
+  type EnvironmentMachineKind,
+  resolveEnvironmentMachineKind,
+} from "@t3tools/contracts";
+import { useAtomValue } from "@effect/atom-react";
 import { useCallback, useState } from "react";
 import {
   ActivityIndicator,
@@ -15,10 +20,12 @@ import {
 } from "react-native";
 
 import { AppText as Text } from "../../components/AppText";
+import { EnvironmentMachineSymbol } from "../../components/EnvironmentMachineSymbol";
 import { ThemedSwitch } from "../../components/ThemedSwitch";
 import { cn } from "../../lib/cn";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-types";
+import { serverEnvironment } from "../../state/server";
 import { availableCloudEnvironmentPresentation } from "../cloud/cloudEnvironmentPresentation";
 import { hasCloudPublicConfig } from "../cloud/publicConfig";
 import { ConnectionStatusDot } from "./ConnectionStatusDot";
@@ -205,6 +212,9 @@ function ConnectedCloudEnvironmentRow(props: {
   readonly onDisconnect: () => void;
   readonly onToggleError: () => void;
 }) {
+  const serverConfig = useAtomValue(
+    serverEnvironment.configValueAtom(props.environment.environmentId),
+  );
   return (
     <CloudEnvironmentRowShell
       borderTop={props.borderTop}
@@ -213,6 +223,7 @@ function ConnectedCloudEnvironmentRow(props: {
       connectionState={props.environment.connectionState}
       errorExpanded={props.errorExpanded}
       label={props.environment.environmentLabel}
+      machine={resolveEnvironmentMachineKind(serverConfig)}
       onValueChange={(enabled) => {
         if (enabled) {
           props.onConnect();
@@ -268,6 +279,8 @@ function CloudEnvironmentRowShell(props: {
   readonly disabled?: boolean;
   readonly errorExpanded: boolean;
   readonly label: string;
+  /** Absent for environments the relay lists but this device has not connected to. */
+  readonly machine?: EnvironmentMachineKind;
   readonly onToggleError: () => void;
   readonly onValueChange: (enabled: boolean) => void;
   readonly statusText?: string;
@@ -323,6 +336,13 @@ function CloudEnvironmentRowShell(props: {
       <View className="min-w-0 flex-1 gap-0.5">
         <View className="min-w-0 flex-row items-center gap-2">
           <ConnectionStatusDot state={props.connectionState} pulse={shouldPulse} size={7} />
+          {props.machine ? (
+            <EnvironmentMachineSymbol
+              kind={props.machine}
+              size={14}
+              tintColorClassName="accent-foreground-muted"
+            />
+          ) : null}
           <Text
             className="min-w-0 flex-shrink text-base font-t3-bold leading-snug text-foreground"
             numberOfLines={1}

--- a/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
+++ b/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
@@ -1,7 +1,8 @@
 import { SymbolView } from "../../components/AppSymbol";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
-import type { EnvironmentId } from "@t3tools/contracts";
+import { type EnvironmentId, resolveEnvironmentMachineKind } from "@t3tools/contracts";
+import { useAtomValue } from "@effect/atom-react";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useState } from "react";
@@ -9,9 +10,11 @@ import { Alert, Pressable, View } from "react-native";
 import Animated, { FadeIn, FadeOut, LinearTransition } from "react-native-reanimated";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
+import { EnvironmentMachineSymbol } from "../../components/EnvironmentMachineSymbol";
 import { cn } from "../../lib/cn";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-types";
+import { serverEnvironment } from "../../state/server";
 import { ConnectionStatusDot } from "./ConnectionStatusDot";
 
 function connectionStatusLabel(environment: ConnectedEnvironmentSummary): string | null {
@@ -35,6 +38,9 @@ export function ConnectionEnvironmentRow(props: {
 }) {
   const [label, setLabel] = useState(props.environment.environmentLabel);
   const [url, setUrl] = useState(props.environment.displayUrl);
+  const serverConfig = useAtomValue(
+    serverEnvironment.configValueAtom(props.environment.environmentId),
+  );
   const statusLabel = connectionStatusLabel(props.environment);
   const statusTraceId = props.environment.connectionErrorTraceId;
   const hasConnectionFailure = props.environment.connectionError !== null;
@@ -70,9 +76,19 @@ export function ConnectionEnvironmentRow(props: {
         />
 
         <View className="flex-1 gap-0.5">
-          <Text className="text-base font-t3-bold leading-snug text-foreground" numberOfLines={1}>
-            {props.environment.environmentLabel}
-          </Text>
+          <View className="flex-row items-center gap-1.5">
+            <EnvironmentMachineSymbol
+              kind={resolveEnvironmentMachineKind(serverConfig)}
+              size={14}
+              tintColorClassName="accent-foreground-muted"
+            />
+            <Text
+              className="min-w-0 flex-shrink text-base font-t3-bold leading-snug text-foreground"
+              numberOfLines={1}
+            >
+              {props.environment.environmentLabel}
+            </Text>
+          </View>
           <Text className="text-xs text-foreground-muted" numberOfLines={1}>
             {props.environment.displayUrl}
           </Text>

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -12,10 +12,11 @@ import {
   type EnvironmentThreadSearchMatch,
 } from "@t3tools/client-runtime/state/thread-search";
 import { sortPinnedThreadsByOrderKey } from "@t3tools/client-runtime/state/thread-sort";
-import type {
-  EnvironmentId,
-  SidebarProjectGroupingMode,
-  SidebarThreadSortOrder,
+import {
+  type EnvironmentId,
+  resolveEnvironmentMachineKind,
+  type SidebarProjectGroupingMode,
+  type SidebarThreadSortOrder,
 } from "@t3tools/contracts";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
@@ -612,6 +613,16 @@ export function HomeScreen(props: HomeScreenProps) {
     }
     return supported;
   }, [serverConfigs]);
+  const machineByEnvironmentId = useMemo(
+    () =>
+      new Map(
+        [...serverConfigs].map(
+          ([environmentId, config]) =>
+            [environmentId, resolveEnvironmentMachineKind(config)] as const,
+        ),
+      ),
+    [serverConfigs],
+  );
   // Canonical arranged pinned order (reorder-capable threads only) for the
   // Move up/down position flags. Computed from all shells, not the rendered
   // list, so search/scope filtering never disables or misdirects a move.
@@ -740,6 +751,7 @@ export function HomeScreen(props: HomeScreenProps) {
                     ?.environmentLabel ?? null)
                 : null
             }
+            environmentMachine={machineByEnvironmentId.get(item.pendingTask.message.environmentId)}
             showPendingDivider={item.showPendingDivider}
             showTrailingDivider={showTrailingDivider}
             onSelectPendingTask={props.onSelectPendingTask}
@@ -797,6 +809,7 @@ export function HomeScreen(props: HomeScreenProps) {
               ? (props.savedConnectionsById[thread.environmentId]?.environmentLabel ?? null)
               : null
           }
+          environmentMachine={machineByEnvironmentId.get(thread.environmentId)}
           searchMatch={threadSearchMatchByKey.get(
             threadSearchMatchKey({
               environmentId: thread.environmentId,
@@ -847,6 +860,7 @@ export function HomeScreen(props: HomeScreenProps) {
       handleSwipeableWillOpen,
       handleUnsettleThread,
       pinningEnvironmentIds,
+      machineByEnvironmentId,
       pinReorderEnvironmentIds,
       projectByKey,
       projectCwdByKey,
@@ -938,6 +952,9 @@ export function HomeScreen(props: HomeScreenProps) {
                 props.savedConnectionsById[item.pendingTask.message.environmentId]
                   ?.environmentLabel ?? null
               }
+              environmentMachine={machineByEnvironmentId.get(
+                item.pendingTask.message.environmentId,
+              )}
               isLast={item.isLast}
               onSelectPendingTask={props.onSelectPendingTask}
               onDeletePendingTask={props.onDeletePendingTask}
@@ -952,6 +969,7 @@ export function HomeScreen(props: HomeScreenProps) {
               environmentLabel={
                 props.savedConnectionsById[thread.environmentId]?.environmentLabel ?? null
               }
+              environmentMachine={machineByEnvironmentId.get(thread.environmentId)}
               projectCwd={
                 projectCwdByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ??
                 null
@@ -990,6 +1008,7 @@ export function HomeScreen(props: HomeScreenProps) {
       handleSwipeableClose,
       handleSwipeableWillOpen,
       handleRegenerateThreadTitle,
+      machineByEnvironmentId,
       projectCwdByKey,
       props.onArchiveThread,
       props.onDeletePendingTask,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { LegendList } from "@legendapp/list/react-native";
 import type { MenuAction } from "@react-native-menu/menu";
 import { useAtomValue } from "@effect/atom-react";
-import type { EnvironmentId } from "@t3tools/contracts";
+import { type EnvironmentId, resolveEnvironmentMachineKind } from "@t3tools/contracts";
 import { sortPinnedThreadsByOrderKey } from "@t3tools/client-runtime/state/thread-sort";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
@@ -441,6 +441,16 @@ function ThreadNavigationSidebarPane(
     }
     return supported;
   }, [serverConfigs]);
+  const machineByEnvironmentId = useMemo(
+    () =>
+      new Map(
+        [...serverConfigs].map(
+          ([environmentId, config]) =>
+            [environmentId, resolveEnvironmentMachineKind(config)] as const,
+        ),
+      ),
+    [serverConfigs],
+  );
   // Canonical arranged pinned order for Move up/down flags — computed from
   // all shells so search/scope filtering never disables a valid move.
   const arrangedPinnedKeys = useMemo(() => {
@@ -819,6 +829,9 @@ function ThreadNavigationSidebarPane(
                       ?.environmentLabel ?? null)
                   : null
               }
+              environmentMachine={machineByEnvironmentId.get(
+                item.pendingTask.message.environmentId,
+              )}
               pane="sidebar"
               showPendingDivider={item.showPendingDivider}
               onSelectPendingTask={openPendingTask}
@@ -853,6 +866,7 @@ function ThreadNavigationSidebarPane(
                   ? (savedConnectionsById[thread.environmentId]?.environmentLabel ?? null)
                   : null
               }
+              environmentMachine={machineByEnvironmentId.get(thread.environmentId)}
               searchMatch={threadSearchMatchByKey.get(
                 threadSearchMatchKey({
                   environmentId: thread.environmentId,
@@ -956,6 +970,9 @@ function ThreadNavigationSidebarPane(
                 savedConnectionsById[item.pendingTask.message.environmentId]?.environmentLabel ??
                 null
               }
+              environmentMachine={machineByEnvironmentId.get(
+                item.pendingTask.message.environmentId,
+              )}
               isLast={item.isLast}
               onSelectPendingTask={openPendingTask}
               onDeletePendingTask={confirmDeletePendingTask}
@@ -970,6 +987,7 @@ function ThreadNavigationSidebarPane(
               environmentLabel={
                 savedConnectionsById[thread.environmentId]?.environmentLabel ?? null
               }
+              environmentMachine={machineByEnvironmentId.get(thread.environmentId)}
               projectCwd={
                 projectCwdByKey.get(scopedProjectKey(thread.environmentId, thread.projectId)) ??
                 null
@@ -1017,6 +1035,7 @@ function ThreadNavigationSidebarPane(
       handleSelectThread,
       handleSwipeableClose,
       handleSwipeableWillOpen,
+      machineByEnvironmentId,
       movePinnedThread,
       openPendingTask,
       pinReorderEnvironmentIds,

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -4,6 +4,7 @@ import type {
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentThreadSearchMatch } from "@t3tools/client-runtime/state/thread-search";
+import type { EnvironmentMachineKind } from "@t3tools/contracts";
 import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "../../components/AppSymbol";
 import { memo, useCallback, useMemo, type ComponentProps } from "react";
@@ -14,6 +15,7 @@ import Svg, { Circle, Path } from "react-native-svg";
 
 import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
+import { EnvironmentMachineSymbol } from "../../components/EnvironmentMachineSymbol";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { cn } from "../../lib/cn";
 import { HOME_HORIZONTAL_INSET } from "../../lib/layoutMetrics";
@@ -268,6 +270,7 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
   readonly variant: ThreadListVariant;
   readonly pendingTask: PendingNewTask;
   readonly environmentLabel: string | null;
+  readonly environmentMachine?: EnvironmentMachineKind;
   readonly isLast: boolean;
   readonly onSelectPendingTask: (pendingTask: PendingNewTask) => void;
   readonly onDeletePendingTask: (pendingTask: PendingNewTask) => void;
@@ -305,6 +308,13 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
           tintColorClassName={compact ? "accent-icon-subtle" : "accent-foreground-muted"}
           type="monochrome"
         />
+        {props.environmentLabel && props.environmentMachine ? (
+          <EnvironmentMachineSymbol
+            kind={props.environmentMachine}
+            size={compact ? 12 : 10}
+            tintColorClassName={compact ? "accent-icon-subtle" : "accent-foreground-muted"}
+          />
+        ) : null}
         <Text
           className={
             compact
@@ -416,6 +426,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   readonly variant: ThreadListVariant;
   readonly thread: EnvironmentThreadShell;
   readonly environmentLabel: string | null;
+  readonly environmentMachine?: EnvironmentMachineKind;
   readonly projectCwd: string | null;
   readonly searchMatch?: EnvironmentThreadSearchMatch;
   readonly searchQuery?: string;
@@ -524,6 +535,19 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
       <View className="mt-px flex-row items-center gap-1.5">
         {subtitleParts.length > 0 ? (
           <>
+            {props.environmentLabel && props.environmentMachine ? (
+              <EnvironmentMachineSymbol
+                kind={props.environmentMachine}
+                size={compact ? 12 : 10}
+                tintColorClassName={
+                  compact
+                    ? "accent-icon-subtle"
+                    : selected
+                      ? "accent-user-bubble-foreground-muted"
+                      : "accent-foreground-muted"
+                }
+              />
+            ) : null}
             <Text
               className={cn(
                 "shrink",

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -3,6 +3,7 @@ import type {
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentThreadSearchMatch } from "@t3tools/client-runtime/state/thread-search";
+import type { EnvironmentMachineKind } from "@t3tools/contracts";
 import { canSnooze, resolveSnoozePresets } from "@t3tools/client-runtime/state/thread-settled";
 import type { MenuAction } from "@react-native-menu/menu";
 import { memo, useCallback, useEffect, useMemo, useState, type ComponentProps } from "react";
@@ -12,6 +13,7 @@ import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSw
 import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
+import { EnvironmentMachineSymbol } from "../../components/EnvironmentMachineSymbol";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import { cn } from "../../lib/cn";
@@ -200,6 +202,8 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
   readonly project: EnvironmentProject | null;
   readonly projectTitle?: string;
   readonly environmentLabel: string | null;
+  /** Drawn beside the label; ignored while the label is null. */
+  readonly environmentMachine?: EnvironmentMachineKind;
   readonly pane?: "screen" | "sidebar";
   /** Draws the "Pending" divider above the first queued row. */
   readonly showPendingDivider: boolean;
@@ -248,17 +252,26 @@ export const ThreadListV2PendingRow = memo(function ThreadListV2PendingRow(props
         {pendingTask.title}
       </Text>
       {branch || props.environmentLabel ? (
-        <Text className="mt-1 text-xs text-foreground-muted" numberOfLines={1}>
-          {branch ? (
-            <Text className="text-xs text-foreground-muted" style={{ fontFamily: MONO_FONT }}>
-              {branch}
-            </Text>
+        <View className="mt-1 flex-row items-center gap-1">
+          <Text className="shrink text-xs text-foreground-muted" numberOfLines={1}>
+            {branch ? (
+              <Text className="text-xs text-foreground-muted" style={{ fontFamily: MONO_FONT }}>
+                {branch}
+              </Text>
+            ) : null}
+            {branch && props.environmentLabel ? "  ·  " : null}
+            {props.environmentLabel ? (
+              <Text className="text-xs text-foreground-tertiary">{props.environmentLabel}</Text>
+            ) : null}
+          </Text>
+          {props.environmentLabel && props.environmentMachine ? (
+            <EnvironmentMachineSymbol
+              kind={props.environmentMachine}
+              size={11}
+              tintColorClassName="accent-foreground-tertiary"
+            />
           ) : null}
-          {branch && props.environmentLabel ? "  ·  " : null}
-          {props.environmentLabel ? (
-            <Text className="text-xs text-foreground-tertiary">{props.environmentLabel}</Text>
-          ) : null}
-        </Text>
+        </View>
       ) : null}
     </>
   );
@@ -326,6 +339,9 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       the web sidebar's remote-environment cloud icon, but as text since
       phones have no hover tooltips. */
   readonly environmentLabel: string | null;
+  /** Drawn after the label so the machine reads at a glance; ignored while
+      the label is null. */
+  readonly environmentMachine?: EnvironmentMachineKind;
   /** Hosting surface. "screen" (default) renders the compact Home idiom:
       flat edge-to-edge rows on the screen background with inset hairlines.
       "sidebar" renders the iPad split-view idiom: rounded rows blending
@@ -760,6 +776,15 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         ) : (
           <View className="flex-1" />
         )}
+        {status !== "failed" && props.environmentLabel && props.environmentMachine ? (
+          <EnvironmentMachineSymbol
+            kind={props.environmentMachine}
+            size={11}
+            tintColorClassName={
+              selected ? "accent-user-bubble-foreground-muted" : "accent-foreground-tertiary"
+            }
+          />
+        ) : null}
         {pr ? (
           <Text
             accessibilityLabel={pr.accessibilityLabel}

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -20,6 +20,7 @@ import { resolveServiceLauncherMode } from "../cloud/serviceLauncherClient.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
 import { resolveServerEnvironmentLabel } from "./ServerEnvironmentLabel.ts";
+import { detectServerEnvironmentMachineKind } from "./ServerEnvironmentMachine.ts";
 
 export class ServerEnvironmentIdPersistenceError extends Schema.TaggedErrorClass<ServerEnvironmentIdPersistenceError>()(
   "ServerEnvironmentIdPersistenceError",
@@ -188,6 +189,7 @@ export const make = Effect.gen(function* () {
   const environmentId = yield* identity.getEnvironmentId;
   const cwdBaseName = path.basename(serverConfig.cwd).trim();
   const label = yield* resolveServerEnvironmentLabel({ cwdBaseName });
+  const machine = yield* detectServerEnvironmentMachineKind();
   const launcher = yield* resolveServiceLauncherMode();
   const serverSelfUpdate = resolveServerSelfUpdateCapability({
     desktopManaged: serverConfig.mode === "desktop",
@@ -206,6 +208,7 @@ export const make = Effect.gen(function* () {
     platform: {
       os: platformOs(hostPlatform),
       arch: platformArch(hostArchitecture),
+      ...(machine === null ? {} : { machine }),
     },
     serverVersion: packageJson.version,
     capabilities: {

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -225,6 +225,7 @@ export const make = Effect.gen(function* () {
       threadPinReorder: true,
       threadTitleRegeneration: true,
       threadPullRequestLinking: true,
+      environmentIcon: true,
       ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
       ...(serverSelfUpdate === "boot-service" || desktopAppUpdate
         ? {

--- a/apps/server/src/environment/ServerEnvironmentMachine.test.ts
+++ b/apps/server/src/environment/ServerEnvironmentMachine.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { vi } from "vite-plus/test";
+
+import * as ProcessRunner from "../processRunner.ts";
+import {
+  detectServerEnvironmentMachineKind,
+  machineKindFromAppleProductName,
+  machineKindFromDmi,
+} from "./ServerEnvironmentMachine.ts";
+
+const runMock = vi.fn<ProcessRunner.ProcessRunner["Service"]["run"]>();
+
+const ProcessRunnerTest = Layer.succeed(
+  ProcessRunner.ProcessRunner,
+  ProcessRunner.ProcessRunner.of({ run: (input) => runMock(input) }),
+);
+
+const processOutput = (stdout: string, code = 0) =>
+  Effect.succeed({
+    stdout,
+    stderr: "",
+    code: ChildProcessSpawner.ExitCode(code),
+    timedOut: false,
+    stdoutTruncated: false,
+    stderrTruncated: false,
+    stdoutInvalidUtf8: false,
+    stderrInvalidUtf8: false,
+  });
+
+const dmiFileSystem = (files: Readonly<Record<string, string>>) =>
+  FileSystem.layerNoop({
+    readFileString: (path) => {
+      const name = path.slice(path.lastIndexOf("/") + 1);
+      return name in files
+        ? Effect.succeed(files[name]!)
+        : Effect.fail(
+            PlatformError.systemError({
+              _tag: "NotFound",
+              module: "FileSystem",
+              method: "readFileString",
+              pathOrDescriptor: path,
+              cause: new Error("ENOENT"),
+            }),
+          );
+    },
+  });
+
+const withPlatform = (platform: NodeJS.Platform, fileSystem = FileSystem.layerNoop({})) =>
+  Layer.mergeAll(ProcessRunnerTest, fileSystem, Layer.succeed(HostProcessPlatform, platform));
+
+afterEach(() => {
+  runMock.mockReset();
+});
+
+describe("machineKindFromAppleProductName", () => {
+  it("maps marketing names and model identifiers", () => {
+    expect(machineKindFromAppleProductName("Mac mini (2024)")).toBe("mac-mini");
+    expect(machineKindFromAppleProductName("Macmini8,1")).toBe("mac-mini");
+    expect(machineKindFromAppleProductName("Mac Studio (2023)")).toBe("mac-studio");
+    expect(machineKindFromAppleProductName("MacBook Pro (14-inch, 2024)")).toBe("laptop");
+    expect(machineKindFromAppleProductName("MacBookAir10,1")).toBe("laptop");
+    expect(machineKindFromAppleProductName("iMac (24-inch, 2024)")).toBe("desktop");
+    expect(machineKindFromAppleProductName("Mac Pro (2023)")).toBe("desktop");
+  });
+
+  it("returns null for Apple silicon model identifiers, which carry no product family", () => {
+    expect(machineKindFromAppleProductName("Mac16,10")).toBeNull();
+  });
+});
+
+describe("machineKindFromDmi", () => {
+  it("prefers virtualization markers over chassis type", () => {
+    expect(
+      machineKindFromDmi({ chassisType: "1", sysVendor: "QEMU", productName: "Standard PC" }),
+    ).toBe("cloud");
+    expect(
+      machineKindFromDmi({
+        chassisType: "3",
+        sysVendor: "Microsoft Corporation",
+        productName: "Virtual Machine",
+      }),
+    ).toBe("cloud");
+    expect(
+      machineKindFromDmi({ chassisType: "1", sysVendor: "Amazon EC2", productName: "t3.large" }),
+    ).toBe("cloud");
+  });
+
+  it("does not treat Microsoft hardware as a VM", () => {
+    expect(
+      machineKindFromDmi({
+        chassisType: "9",
+        sysVendor: "Microsoft Corporation",
+        productName: "Surface Laptop 5",
+      }),
+    ).toBe("laptop");
+  });
+
+  it("maps SMBIOS chassis codes", () => {
+    expect(
+      machineKindFromDmi({ chassisType: "3", sysVendor: "GMKtec", productName: "NucBox K8 Plus" }),
+    ).toBe("desktop");
+    expect(
+      machineKindFromDmi({ chassisType: "10", sysVendor: "LENOVO", productName: "ThinkPad X1" }),
+    ).toBe("laptop");
+    expect(
+      machineKindFromDmi({ chassisType: "23", sysVendor: "Supermicro", productName: "X11" }),
+    ).toBe("server");
+    expect(machineKindFromDmi({ chassisType: "1", sysVendor: null, productName: null })).toBeNull();
+    expect(
+      machineKindFromDmi({ chassisType: null, sysVendor: null, productName: null }),
+    ).toBeNull();
+  });
+
+  it("recognizes Apple hardware running Linux", () => {
+    expect(
+      machineKindFromDmi({ chassisType: "3", sysVendor: "Apple", productName: "Mac Studio" }),
+    ).toBe("mac-studio");
+  });
+});
+
+describe("detectServerEnvironmentMachineKind", () => {
+  it.effect("reads the IOKit product name on macOS", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(
+        processOutput(
+          '+-o product  <class IOPlatformDevice>\n    {\n      "product-name" = <"Mac mini (2024)">\n    }\n',
+        ),
+      );
+
+      const result = yield* detectServerEnvironmentMachineKind().pipe(
+        Effect.provide(withPlatform("darwin")),
+      );
+
+      expect(result).toBe("mac-mini");
+      expect(runMock).toHaveBeenCalledTimes(1);
+      expect(runMock).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "ioreg", args: ["-rd1", "-n", "product"] }),
+      );
+    }),
+  );
+
+  it.effect("falls back to hw.model when IOKit has no product node", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(processOutput("", 1));
+      runMock.mockReturnValueOnce(processOutput("MacBookPro16,1\n"));
+
+      const result = yield* detectServerEnvironmentMachineKind().pipe(
+        Effect.provide(withPlatform("darwin")),
+      );
+
+      expect(result).toBe("laptop");
+      expect(runMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ command: "sysctl", args: ["-n", "hw.model"] }),
+      );
+    }),
+  );
+
+  it.effect("returns null when both macOS probes fail", () =>
+    Effect.gen(function* () {
+      runMock.mockImplementation((input) =>
+        Effect.fail(
+          new ProcessRunner.ProcessSpawnError({
+            command: input.command,
+            argumentCount: input.args.length,
+            cause: new Error("ENOENT"),
+          }),
+        ),
+      );
+
+      const result = yield* detectServerEnvironmentMachineKind().pipe(
+        Effect.provide(withPlatform("darwin")),
+      );
+
+      expect(result).toBeNull();
+      expect(runMock).toHaveBeenCalledTimes(2);
+    }),
+  );
+
+  it.effect("reads DMI on Linux", () =>
+    Effect.gen(function* () {
+      const result = yield* detectServerEnvironmentMachineKind().pipe(
+        Effect.provide(
+          withPlatform(
+            "linux",
+            dmiFileSystem({
+              chassis_type: "3\n",
+              sys_vendor: "GMKtec\n",
+              product_name: "NucBox K8 Plus\n",
+            }),
+          ),
+        ),
+      );
+
+      expect(result).toBe("desktop");
+      expect(runMock).not.toHaveBeenCalled();
+    }),
+  );
+
+  it.effect("returns null on Linux without DMI (containers, ARM boards)", () =>
+    Effect.gen(function* () {
+      const result = yield* detectServerEnvironmentMachineKind().pipe(
+        Effect.provide(withPlatform("linux", dmiFileSystem({}))),
+      );
+
+      expect(result).toBeNull();
+    }),
+  );
+
+  it.effect("skips detection on other platforms", () =>
+    Effect.gen(function* () {
+      const result = yield* detectServerEnvironmentMachineKind().pipe(
+        Effect.provide(withPlatform("win32")),
+      );
+
+      expect(result).toBeNull();
+      expect(runMock).not.toHaveBeenCalled();
+    }),
+  );
+});

--- a/apps/server/src/environment/ServerEnvironmentMachine.ts
+++ b/apps/server/src/environment/ServerEnvironmentMachine.ts
@@ -1,0 +1,167 @@
+import type { EnvironmentMachineKind } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+
+import * as ProcessRunner from "../processRunner.ts";
+
+/**
+ * Best-effort hardware detection for the environment icon. Every probe is
+ * allowed to fail: a null result means "no signal", and the client draws a
+ * generic server until the user picks something in Settings → Connections.
+ */
+
+const DMI_ROOT = "/sys/class/dmi/id";
+
+// SMBIOS 3.x System Enclosure types (table 17). Codes that describe a shape
+// rather than a machine (docking stations, blades enclosures, IoT gateways)
+// fall through to null on purpose.
+const DMI_CHASSIS_KINDS: Readonly<Record<string, EnvironmentMachineKind>> = {
+  "3": "desktop", // Desktop
+  "4": "desktop", // Low Profile Desktop
+  "5": "desktop", // Pizza Box
+  "6": "desktop", // Mini Tower
+  "7": "desktop", // Tower
+  "8": "laptop", // Portable
+  "9": "laptop", // Laptop
+  "10": "laptop", // Notebook
+  "13": "desktop", // All in One
+  "14": "laptop", // Sub Notebook
+  "15": "desktop", // Space-saving
+  "16": "desktop", // Lunch Box
+  "17": "server", // Main Server Chassis
+  "18": "server", // Expansion Chassis
+  "19": "server", // SubChassis
+  "20": "server", // Bus Expansion Chassis
+  "21": "server", // Peripheral Chassis
+  "22": "server", // RAID Chassis
+  "23": "server", // Rack Mount Chassis
+  "24": "server", // Sealed-case PC
+  "28": "server", // Blade
+  "31": "laptop", // Convertible
+  "32": "laptop", // Detachable
+  "35": "desktop", // Mini PC
+};
+
+// Hypervisors and cloud providers write themselves into the DMI vendor or
+// product strings; any hit means the box is a VM, and a VM reads as "cloud"
+// regardless of the chassis type the hypervisor fakes. Hyper-V is matched on
+// its "Virtual Machine" product, not the "Microsoft Corporation" vendor that
+// physical Surface devices share.
+const VIRTUALIZATION_MARKERS = [
+  "qemu",
+  "kvm",
+  "bochs",
+  "vmware",
+  "virtualbox",
+  "innotek",
+  "xen",
+  "parallels",
+  "amazon ec2",
+  "google compute engine",
+  "digitalocean",
+  "hetzner",
+  "linode",
+  "vultr",
+  "scaleway",
+  "openstack",
+  "cloud",
+  "virtual machine",
+];
+
+function normalize(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+/** Marketing names and Intel-era model identifiers share these prefixes. */
+export function machineKindFromAppleProductName(name: string): EnvironmentMachineKind | null {
+  const normalized = name.trim().toLowerCase().replaceAll(/\s+/g, "");
+  if (normalized.startsWith("macmini")) return "mac-mini";
+  if (normalized.startsWith("macstudio")) return "mac-studio";
+  if (normalized.startsWith("macbook")) return "laptop";
+  if (normalized.startsWith("imac") || normalized.startsWith("macpro")) return "desktop";
+  return null;
+}
+
+export function machineKindFromDmi(input: {
+  readonly chassisType: string | null;
+  readonly sysVendor: string | null;
+  readonly productName: string | null;
+}): EnvironmentMachineKind | null {
+  const productName = input.productName ?? "";
+  const vendorAndProduct = `${input.sysVendor ?? ""} ${productName}`.toLowerCase();
+  if (VIRTUALIZATION_MARKERS.some((marker) => vendorAndProduct.includes(marker))) {
+    return "cloud";
+  }
+  // Apple hardware booting Linux (Asahi) still reports the Apple product name.
+  const appleKind = machineKindFromAppleProductName(productName);
+  if (appleKind !== null) {
+    return appleKind;
+  }
+  return input.chassisType === null ? null : (DMI_CHASSIS_KINDS[input.chassisType] ?? null);
+}
+
+const readOptionalFile = Effect.fn("readOptionalFile")(function* (path: string) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  return yield* fileSystem.readFileString(path).pipe(
+    Effect.map(normalize),
+    Effect.catch(() => Effect.succeed(null)),
+  );
+});
+
+const runProbe = Effect.fn("runMachineProbe")(function* (input: {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+}) {
+  const processRunner = yield* ProcessRunner.ProcessRunner;
+  return yield* processRunner
+    .run({
+      command: input.command,
+      args: input.args,
+      timeout: "5 seconds",
+      timeoutBehavior: "timedOutResult",
+    })
+    .pipe(
+      Effect.map((result) => (result.code === 0 ? normalize(result.stdout) : null)),
+      Effect.catch(() => Effect.succeed(null)),
+    );
+});
+
+// IOKit's `product` node carries the marketing name ("Mac mini (2024)") on
+// Apple silicon; Intel Macs lack it, so `hw.model` ("Macmini8,1") is the
+// fallback. Both are single-digit-millisecond calls.
+const detectDarwinMachineKind = Effect.fn("detectDarwinMachineKind")(function* () {
+  const ioreg = yield* runProbe({ command: "ioreg", args: ["-rd1", "-n", "product"] });
+  const productName = ioreg?.match(/"product-name"\s*=\s*<"([^"]+)">/)?.[1] ?? null;
+  const fromProductName =
+    productName === null ? null : machineKindFromAppleProductName(productName);
+  if (fromProductName !== null) {
+    return fromProductName;
+  }
+  const model = yield* runProbe({ command: "sysctl", args: ["-n", "hw.model"] });
+  return model === null ? null : machineKindFromAppleProductName(model);
+});
+
+const detectLinuxMachineKind = Effect.fn("detectLinuxMachineKind")(function* () {
+  const [chassisType, sysVendor, productName] = yield* Effect.all([
+    readOptionalFile(`${DMI_ROOT}/chassis_type`),
+    readOptionalFile(`${DMI_ROOT}/sys_vendor`),
+    readOptionalFile(`${DMI_ROOT}/product_name`),
+  ]);
+  return machineKindFromDmi({ chassisType, sysVendor, productName });
+});
+
+export const detectServerEnvironmentMachineKind = Effect.fn("detectServerEnvironmentMachineKind")(
+  function* () {
+    const platform = yield* HostProcessPlatform;
+    switch (platform) {
+      case "darwin":
+        return yield* detectDarwinMachineKind();
+      case "linux":
+        return yield* detectLinuxMachineKind();
+      default:
+        return null;
+    }
+  },
+);

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentId, VcsRef, ProjectId } from "@t3tools/contracts";
+import type { EnvironmentId, EnvironmentMachineKind, VcsRef, ProjectId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 import { toSortableTimestamp } from "../lib/threadSort";
 export {
@@ -11,6 +11,7 @@ export interface EnvironmentOption {
   projectId: ProjectId;
   label: string;
   isPrimary: boolean;
+  machine: EnvironmentMachineKind;
 }
 
 export const EnvMode = Schema.Literals(["local", "worktree"]);

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -2,16 +2,15 @@ import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environ
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import {
   ChevronDownIcon,
-  CloudIcon,
   FolderGit2Icon,
   FolderGitIcon,
   FolderIcon,
   HistoryIcon,
-  MonitorIcon,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
+import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
 import { useProject, useThread, useThreadShellsForProjectRefs } from "../state/entities";
 import { useIsMobile } from "../hooks/useMediaQuery";
 import {
@@ -105,12 +104,14 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
       ? resolveEnvModeLabel("worktree")
       : resolveCurrentWorkspaceLabel(activeWorktreePath);
   const isLocked = envLocked || envModeLocked;
-  const EnvironmentIcon = activeEnvironment?.isPrimary ? MonitorIcon : CloudIcon;
   const icon = showEnvironmentIndicator ? (
     // Button's base styles apply `-mx-0.5` to descendant SVGs, which eats 4px
     // out of whatever gap we set. mx-0! cancels that so gap-0.5 reads as 2px.
     <span className="inline-flex shrink-0 items-center gap-0.5">
-      <EnvironmentIcon className="size-3 shrink-0 mx-0!" />
+      <EnvironmentMachineIcon
+        kind={activeEnvironment?.machine ?? "server"}
+        className="size-3 shrink-0 mx-0!"
+      />
       <WorkspaceIcon className="size-3 shrink-0 mx-0!" />
     </span>
   ) : (
@@ -151,21 +152,18 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
                 value={environmentId}
                 onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
               >
-                {availableEnvironments.map((env) => {
-                  const Icon = env.isPrimary ? MonitorIcon : CloudIcon;
-                  return (
-                    <MenuRadioItem
-                      key={env.environmentId}
-                      disabled={envLocked}
-                      value={env.environmentId}
-                    >
-                      <span className="flex min-w-0 items-center gap-1.5">
-                        <Icon className="size-3" />
-                        <span className="min-w-0 truncate">{env.label}</span>
-                      </span>
-                    </MenuRadioItem>
-                  );
-                })}
+                {availableEnvironments.map((env) => (
+                  <MenuRadioItem
+                    key={env.environmentId}
+                    disabled={envLocked}
+                    value={env.environmentId}
+                  >
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <EnvironmentMachineIcon kind={env.machine} className="size-3" />
+                      <span className="min-w-0 truncate">{env.label}</span>
+                    </span>
+                  </MenuRadioItem>
+                ))}
               </MenuRadioGroup>
             </MenuGroup>
             <MenuSeparator />

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -22,6 +22,7 @@ import {
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   ProviderInteractionMode,
   ProviderDriverKind,
+  resolveEnvironmentMachineKind,
   RuntimeMode,
   TerminalOpenInput,
 } from "@t3tools/contracts";
@@ -302,6 +303,7 @@ import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
 import { WorkspacePageHeader } from "./WorkspacePageHeader";
 import {
+  type EnvironmentOption,
   resolveEffectiveEnvMode,
   resolveLocalCheckoutBranchMismatch,
   shouldShowComposerContextStrip,
@@ -2060,22 +2062,18 @@ function ChatViewContent(props: ChatViewProps) {
       (p) => deriveLogicalProjectKeyFromSettings(p, projectGroupingSettings) === logicalKey,
     );
     const seen = new Set<string>();
-    const envs: Array<{
-      environmentId: EnvironmentId;
-      projectId: ProjectId;
-      label: string;
-      isPrimary: boolean;
-    }> = [];
+    const envs: EnvironmentOption[] = [];
     for (const p of memberProjects) {
       if (seen.has(p.environmentId)) continue;
       seen.add(p.environmentId);
       const isPrimary = p.environmentId === primaryEnvironmentId;
-      const label = environmentById.get(p.environmentId)?.label ?? p.environmentId;
+      const environment = environmentById.get(p.environmentId) ?? null;
       envs.push({
         environmentId: p.environmentId,
         projectId: p.id,
-        label,
+        label: environment?.label ?? p.environmentId,
         isPrimary,
+        machine: resolveEnvironmentMachineKind(environment?.serverConfig ?? null),
       });
     }
     // Sort: primary first, then alphabetical

--- a/apps/web/src/components/EnvironmentMachineIcon.tsx
+++ b/apps/web/src/components/EnvironmentMachineIcon.tsx
@@ -1,0 +1,75 @@
+import type { EnvironmentMachineKind } from "@t3tools/contracts";
+import { CloudIcon, LaptopIcon, MonitorIcon, ServerIcon, type LucideProps } from "lucide-react";
+import type { FunctionComponent, SVGProps } from "react";
+
+// Lucide has no Apple desktops, so these two are drawn to its grammar (24
+// unit grid, 2 unit stroke, round joins) and share its prop surface so callers
+// can swap freely.
+function LucideLike(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    />
+  );
+}
+
+/** A Mac mini: squat rounded slab with a front-edge LED. */
+export function MacMiniIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <LucideLike {...props}>
+      <rect width="20" height="8" x="2" y="8" rx="2" />
+      <path d="M6 12h.01" />
+    </LucideLike>
+  );
+}
+
+/** A Mac Studio: the same slab twice as tall, ports along the front foot. */
+export function MacStudioIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <LucideLike {...props}>
+      <rect width="18" height="14" x="3" y="5" rx="2" />
+      <path d="M7 15h.01M11 15h.01M15 15h.01" />
+    </LucideLike>
+  );
+}
+
+const ICON_BY_KIND: Record<EnvironmentMachineKind, FunctionComponent<LucideProps>> = {
+  server: ServerIcon,
+  cloud: CloudIcon,
+  desktop: MonitorIcon,
+  laptop: LaptopIcon,
+  "mac-mini": MacMiniIcon,
+  "mac-studio": MacStudioIcon,
+};
+
+export const ENVIRONMENT_MACHINE_KIND_LABELS: Record<EnvironmentMachineKind, string> = {
+  server: "Server",
+  cloud: "Cloud VM",
+  desktop: "Desktop",
+  laptop: "Laptop",
+  "mac-mini": "Mac mini",
+  "mac-studio": "Mac Studio",
+};
+
+export function environmentMachineIcon(
+  kind: EnvironmentMachineKind,
+): FunctionComponent<LucideProps> {
+  return ICON_BY_KIND[kind];
+}
+
+export function EnvironmentMachineIcon({
+  kind,
+  ...props
+}: LucideProps & { readonly kind: EnvironmentMachineKind }) {
+  const Icon = ICON_BY_KIND[kind];
+  return <Icon {...props} />;
+}

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -22,6 +22,7 @@ import {
   ThreadWorktreeIndicator,
   useLinkedThreadPullRequest,
 } from "./ThreadStatusIndicators";
+import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { useAtomValue } from "@effect/atom-react";
 import { autoAnimate } from "@formkit/auto-animate";
@@ -48,6 +49,7 @@ import {
   type ScopedThreadRef,
   type ResolvedKeybindingsConfig,
   type SidebarProjectGroupingMode,
+  resolveEnvironmentMachineKind,
   ThreadId,
 } from "@t3tools/contracts";
 import {
@@ -395,9 +397,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   });
   const environment = useEnvironment(thread.environmentId);
   const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const isRemoteThread =
-    primaryEnvironmentId !== null && thread.environmentId !== primaryEnvironmentId;
+  // No primary (the hosted app) means every thread is remote, and the machine
+  // glyph is what tells the environments apart.
+  const isRemoteThread = thread.environmentId !== primaryEnvironmentId;
   const remoteEnvLabel = environment?.label ?? null;
+  const remoteMachine = resolveEnvironmentMachineKind(environment?.serverConfig ?? null);
   // A desktop-local secondary backend (e.g. the WSL backend) shows up as a
   // bearer environment whose connection id is prefixed "local:". It runs on the
   // user's own machine, so the cloud icon is misleading — label it "Local" and
@@ -876,7 +880,10 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                         />
                       }
                     >
-                      <CloudIcon className="size-3 text-muted-foreground/40" />
+                      <EnvironmentMachineIcon
+                        kind={remoteMachine}
+                        className="size-3 text-muted-foreground/40"
+                      />
                     </TooltipTrigger>
                     <TooltipPopup side="top">{threadEnvironmentLabel}</TooltipPopup>
                   </Tooltip>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -28,7 +28,12 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import {
+  resolveEnvironmentMachineKind,
+  type EnvironmentMachineKind,
+  type ScopedThreadRef,
+  type ThreadId,
+} from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
@@ -46,7 +51,6 @@ import {
   PinIcon,
   PlusIcon,
   SearchIcon,
-  ServerIcon,
   SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
@@ -120,6 +124,7 @@ import {
 import { formatRelativeTimeLabel, parseTimestampDate } from "../timestampFormat";
 import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
+import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
 import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
 import {
   animatePinnedLayoutChanges,
@@ -274,6 +279,7 @@ function SidebarThreadTooltip({
   projectCwd,
   projectFaviconPath,
   environmentLabel,
+  environmentMachine,
   providerEntry,
   showInstanceBadge,
   modelInstanceId,
@@ -287,6 +293,7 @@ function SidebarThreadTooltip({
   projectCwd: string | null;
   projectFaviconPath: string | null;
   environmentLabel: string | null;
+  environmentMachine: EnvironmentMachineKind;
   providerEntry: ProviderInstanceEntry | null;
   showInstanceBadge: boolean;
   modelInstanceId: string;
@@ -325,7 +332,10 @@ function SidebarThreadTooltip({
           ) : null}
           {environmentLabel ? (
             <div className="flex min-w-0 items-center gap-2">
-              <ServerIcon className="size-3 shrink-0 stroke-muted-foreground" />
+              <EnvironmentMachineIcon
+                kind={environmentMachine}
+                className="size-3 shrink-0 stroke-muted-foreground"
+              />
               <div className="min-w-0 truncate text-foreground/75">{environmentLabel}</div>
             </div>
           ) : null}
@@ -735,6 +745,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   jumpLabel: string | null;
   currentEnvironmentId: string | null;
   environmentLabel: string | null;
+  environmentMachine: EnvironmentMachineKind;
   projectCwd: string | null;
   projectFaviconPath: string | null;
   projectTitle: string | null;
@@ -963,8 +974,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
 
-  const isRemote =
-    props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
+  // The local environment is "this machine" and needs no marker; every other
+  // one gets its machine glyph. With no local environment (the hosted app)
+  // that is every thread, which is the point: the glyph is what tells rows on
+  // different machines apart.
+  const isRemote = thread.environmentId !== props.currentEnvironmentId;
 
   const detailsTooltip = (
     <SidebarThreadTooltip
@@ -973,6 +987,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       projectCwd={props.projectCwd}
       projectFaviconPath={props.projectFaviconPath}
       environmentLabel={props.environmentLabel}
+      environmentMachine={props.environmentMachine}
       providerEntry={providerEntry}
       showInstanceBadge={showInstanceBadge}
       modelInstanceId={modelInstanceId}
@@ -1590,7 +1605,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               >
                 {isRemote ? (
                   <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                    <ServerIcon aria-hidden className="size-3.5" />
+                    <EnvironmentMachineIcon
+                      aria-hidden
+                      kind={props.environmentMachine}
+                      className="size-3.5"
+                    />
                   </span>
                 ) : null}
                 {driverKind ? (
@@ -1636,6 +1655,7 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   projectFaviconPath: string | null;
   projectTitle: string | null;
   environmentLabel: string | null;
+  environmentMachine: EnvironmentMachineKind;
   providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
   isHighlighted: boolean;
   isRouteActive: boolean;
@@ -1731,6 +1751,7 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
           projectCwd={props.projectCwd}
           projectFaviconPath={props.projectFaviconPath}
           environmentLabel={props.environmentLabel}
+          environmentMachine={props.environmentMachine}
           providerEntry={providerEntry}
           showInstanceBadge={showInstanceBadge}
           modelInstanceId={modelInstanceId}
@@ -1868,6 +1889,19 @@ export default function Sidebar() {
     () =>
       new Map(
         environments.map((environment) => [environment.environmentId, environment.label] as const),
+      ),
+    [environments],
+  );
+  const environmentMachineById = useMemo(
+    () =>
+      new Map(
+        environments.map(
+          (environment) =>
+            [
+              environment.environmentId,
+              resolveEnvironmentMachineKind(environment.serverConfig),
+            ] as const,
+        ),
       ),
     [environments],
   );
@@ -3717,6 +3751,9 @@ export default function Sidebar() {
                           ) ?? null
                         }
                         environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
+                        environmentMachine={
+                          environmentMachineById.get(thread.environmentId) ?? "server"
+                        }
                         providerEntryByInstanceId={
                           providerEntriesByEnvironment.get(thread.environmentId) ??
                           EMPTY_PROVIDER_ENTRIES
@@ -3815,6 +3852,9 @@ export default function Sidebar() {
                         }
                         currentEnvironmentId={primaryEnvironmentId}
                         environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
+                        environmentMachine={
+                          environmentMachineById.get(thread.environmentId) ?? "server"
+                        }
                         projectCwd={
                           projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null
                         }

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1,13 +1,14 @@
 import { scopedThreadKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
-import type {
-  EnvironmentId,
-  PullRequestAction,
-  PullRequestMergeMethod,
-  PullRequestUpdateMethod,
-  PullRequestRef,
-  PullRequestState,
-  ScopedThreadRef,
+import {
+  type EnvironmentId,
+  type PullRequestAction,
+  type PullRequestMergeMethod,
+  type PullRequestUpdateMethod,
+  type PullRequestRef,
+  type PullRequestState,
+  resolveEnvironmentMachineKind,
+  type ScopedThreadRef,
 } from "@t3tools/contracts";
 import {
   ArrowDownUpIcon,
@@ -36,7 +37,6 @@ import {
   PlayIcon,
   RefreshCwIcon,
   RotateCcwIcon,
-  ServerIcon,
   TriangleAlertIcon,
 } from "lucide-react";
 import {
@@ -77,6 +77,7 @@ import {
   AlertDialogPopup,
   AlertDialogTitle,
 } from "../ui/alert-dialog";
+import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -269,7 +270,10 @@ function ActOnEnvironmentPicker({
             {/* The radio item lays its children out as one block, so the icon and the label
                 need their own row to share a line. */}
             <span className="flex min-w-0 items-center gap-2">
-              <ServerIcon className="size-3.5 shrink-0" />
+              <EnvironmentMachineIcon
+                kind={environment.machine ?? "server"}
+                className="size-3.5 shrink-0"
+              />
               <span className="truncate">{environment.label}</span>
             </span>
           </MenuRadioItem>
@@ -689,7 +693,11 @@ export function PullRequestDetailPanel({
         ? resolvePickableEnvironments(
             { environmentId, projectId: reference.projectId },
             projects,
-            environments,
+            environments.map((environment) => ({
+              environmentId: environment.environmentId,
+              label: environment.label,
+              machine: resolveEnvironmentMachineKind(environment.serverConfig),
+            })),
           )
         : [],
     [context, environmentId, environments, projects, reference.projectId],

--- a/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import type { EnvironmentId, EnvironmentMachineKind, ProjectId } from "@t3tools/contracts";
 
 /** The little of a project this needs: who holds it, and which repository it is a copy of. */
 export interface AssignableProject {
@@ -69,6 +69,7 @@ export interface PickableEnvironment {
   readonly projectId: ProjectId;
   readonly workspaceRoot: string;
   readonly label: string;
+  readonly machine?: EnvironmentMachineKind;
 }
 
 /**
@@ -85,17 +86,21 @@ export interface PickableEnvironment {
 export function resolvePickableEnvironments(
   current: { readonly environmentId: EnvironmentId; readonly projectId: ProjectId },
   projects: ReadonlyArray<AssignableProject & { readonly workspaceRoot: string }>,
-  environments: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>,
+  environments: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly label: string;
+    readonly machine?: EnvironmentMachineKind;
+  }>,
 ): ReadonlyArray<PickableEnvironment> {
   const own = projects.find(
     (project) =>
       project.environmentId === current.environmentId && project.id === current.projectId,
   );
   const key = own === undefined ? undefined : repositoryKey(own);
-  const ownLabel = environments.find(
+  const ownEnvironment = environments.find(
     (environment) => environment.environmentId === current.environmentId,
-  )?.label;
-  if (own === undefined || !key || ownLabel === undefined) return [];
+  );
+  if (own === undefined || !key || ownEnvironment === undefined) return [];
   const others = environments.flatMap((environment) => {
     if (environment.environmentId === current.environmentId) return [];
     // One entry per server, whichever copy comes first: a server holding two worktrees of the
@@ -112,6 +117,7 @@ export function resolvePickableEnvironments(
             projectId: copy.id,
             workspaceRoot: copy.workspaceRoot,
             label: environment.label,
+            ...(environment.machine === undefined ? {} : { machine: environment.machine }),
           },
         ];
   });
@@ -123,7 +129,8 @@ export function resolvePickableEnvironments(
       environmentId: current.environmentId,
       projectId: own.id,
       workspaceRoot: own.workspaceRoot,
-      label: ownLabel,
+      label: ownEnvironment.label,
+      ...(ownEnvironment.machine === undefined ? {} : { machine: ownEnvironment.machine }),
     },
     ...others,
   ];

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -27,6 +27,7 @@ import {
   type DesktopServerExposureState,
   type DesktopWslState,
   type EnvironmentId,
+  resolveEnvironmentMachineKind,
 } from "@t3tools/contracts";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import {
@@ -53,6 +54,7 @@ import {
   useRelativeTimeTick,
 } from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
+import { EnvironmentIconPicker } from "./EnvironmentIconPicker";
 import { Input } from "../ui/input";
 import { Checkbox } from "../ui/checkbox";
 import {
@@ -86,6 +88,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { Button } from "../ui/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
 import { AnimatedHeight } from "../AnimatedHeight";
+import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { Textarea } from "../ui/textarea";
 import { getPairingTokenFromUrl, setPairingTokenOnUrl } from "../../pairingUrl";
 import { readHostedPairingRequest } from "../../hostedPairing";
@@ -1438,12 +1441,26 @@ function SavedBackendListRow({
                   : null
               }
             />
+            <EnvironmentMachineIcon
+              aria-hidden
+              kind={resolveEnvironmentMachineKind(environment.serverConfig)}
+              className="size-3.5 shrink-0 text-muted-foreground"
+            />
             <h3 className="min-w-0 truncate text-sm font-medium text-foreground">
               {environment.label}
             </h3>
           </div>
           {metadataBits.length > 0 ? (
             <p className="truncate text-xs text-muted-foreground">{metadataBits.join(" · ")}</p>
+          ) : null}
+          {isConnected ? (
+            <div className="pt-1">
+              <EnvironmentIconPicker
+                environmentId={environmentId}
+                serverConfig={environment.serverConfig}
+                size="xs"
+              />
+            </div>
           ) : null}
           {serverUpdateState.status !== "idle" ? (
             <div className="max-w-md">
@@ -3078,6 +3095,18 @@ export function ConnectionsSettings() {
                       label={primaryServerUpdateState.status === "failed" ? "Retry" : "Update"}
                     />
                   ) : undefined
+                }
+              />
+            ) : null}
+            {primaryEnvironmentId !== null ? (
+              <SettingsRow
+                {...searchableSetting("environment-icon")}
+                description="The machine other devices see this environment as. Automatic uses what the server detected."
+                control={
+                  <EnvironmentIconPicker
+                    environmentId={primaryEnvironmentId}
+                    serverConfig={primaryServerConfig}
+                  />
                 }
               />
             ) : null}

--- a/apps/web/src/components/settings/EnvironmentIconPicker.test.ts
+++ b/apps/web/src/components/settings/EnvironmentIconPicker.test.ts
@@ -1,0 +1,41 @@
+import type { ServerConfig } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveEnvironmentIconPickerLock } from "./EnvironmentIconPicker";
+
+const config = (environmentIcon: boolean | undefined) =>
+  ({
+    environment: { capabilities: environmentIcon === undefined ? {} : { environmentIcon } },
+  }) as unknown as ServerConfig;
+
+describe("resolveEnvironmentIconPickerLock", () => {
+  it("locks until the environment is connected", () => {
+    expect(
+      resolveEnvironmentIconPickerLock({ serverConfig: null, operateAccess: "granted" }),
+    ).toMatch(/Connect/);
+  });
+
+  it("locks on servers that predate the setting, before looking at permissions", () => {
+    expect(
+      resolveEnvironmentIconPickerLock({
+        serverConfig: config(undefined),
+        operateAccess: "denied",
+      }),
+    ).toMatch(/too old/);
+  });
+
+  it("locks when the session cannot operate the environment", () => {
+    expect(
+      resolveEnvironmentIconPickerLock({ serverConfig: config(true), operateAccess: "denied" }),
+    ).toMatch(/cannot change/);
+  });
+
+  it("stays open while access is still resolving so a slow session does not flicker", () => {
+    expect(
+      resolveEnvironmentIconPickerLock({ serverConfig: config(true), operateAccess: "pending" }),
+    ).toBeNull();
+    expect(
+      resolveEnvironmentIconPickerLock({ serverConfig: config(true), operateAccess: "granted" }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/settings/EnvironmentIconPicker.tsx
+++ b/apps/web/src/components/settings/EnvironmentIconPicker.tsx
@@ -1,0 +1,81 @@
+import {
+  ENVIRONMENT_MACHINE_KINDS,
+  isEnvironmentMachineKind,
+  resolveEnvironmentMachineKind,
+  type EnvironmentId,
+  type ServerConfig,
+} from "@t3tools/contracts";
+import { useCallback } from "react";
+
+import { useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { ENVIRONMENT_MACHINE_KIND_LABELS, EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+
+const AUTOMATIC_VALUE = "automatic";
+
+/**
+ * Picks the machine glyph an environment wears everywhere it is listed.
+ * "Automatic" clears the override so the server's own detection shows
+ * through; the label says what that currently resolves to so the user can
+ * tell whether detection got it right before overriding.
+ */
+export function EnvironmentIconPicker({
+  environmentId,
+  serverConfig,
+  size = "sm",
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly serverConfig: ServerConfig | null;
+  readonly size?: "xs" | "sm";
+}) {
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const override = serverConfig?.settings.environmentIcon ?? null;
+  const detected = serverConfig?.environment.platform.machine ?? null;
+  const resolved = resolveEnvironmentMachineKind(serverConfig);
+  const value = override ?? AUTOMATIC_VALUE;
+  const automaticLabel =
+    detected === null ? "Automatic" : `Automatic (${ENVIRONMENT_MACHINE_KIND_LABELS[detected]})`;
+
+  const handleValueChange = useCallback(
+    (next: string | null) => {
+      if (next === null) return;
+      if (next === AUTOMATIC_VALUE) {
+        updateSettings({ environmentIcon: null });
+      } else if (isEnvironmentMachineKind(next)) {
+        updateSettings({ environmentIcon: next });
+      }
+    },
+    [updateSettings],
+  );
+
+  return (
+    <Select value={value} onValueChange={handleValueChange} disabled={serverConfig === null}>
+      <SelectTrigger size={size} className="w-full sm:w-52" aria-label="Environment icon">
+        <SelectValue>
+          <span className="flex min-w-0 items-center gap-2">
+            <EnvironmentMachineIcon kind={resolved} className="size-3.5 shrink-0" />
+            <span className="truncate">
+              {override === null ? automaticLabel : ENVIRONMENT_MACHINE_KIND_LABELS[override]}
+            </span>
+          </span>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectItem hideIndicator value={AUTOMATIC_VALUE}>
+          <span className="flex min-w-0 items-center gap-2">
+            <EnvironmentMachineIcon kind={detected ?? "server"} className="size-3.5 shrink-0" />
+            <span className="truncate">{automaticLabel}</span>
+          </span>
+        </SelectItem>
+        {ENVIRONMENT_MACHINE_KINDS.map((kind) => (
+          <SelectItem hideIndicator key={kind} value={kind}>
+            <span className="flex min-w-0 items-center gap-2">
+              <EnvironmentMachineIcon kind={kind} className="size-3.5 shrink-0" />
+              <span className="truncate">{ENVIRONMENT_MACHINE_KIND_LABELS[kind]}</span>
+            </span>
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </Select>
+  );
+}

--- a/apps/web/src/components/settings/EnvironmentIconPicker.tsx
+++ b/apps/web/src/components/settings/EnvironmentIconPicker.tsx
@@ -7,17 +7,73 @@ import {
 } from "@t3tools/contracts";
 import { useCallback } from "react";
 
+import { isElectron } from "../../env";
+import { usePrimarySessionState } from "../../environments/primary";
 import { useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { usePrimaryEnvironmentId } from "../../state/environments";
+import { useEnvironmentSessionState } from "../../state/session";
 import { ENVIRONMENT_MACHINE_KIND_LABELS, EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import {
+  resolvePrimaryOperateAccess,
+  resolveRemoteOperateAccess,
+} from "./ProviderSettingsPanel.logic";
 
 const AUTOMATIC_VALUE = "automatic";
+
+/**
+ * Why the picker is inert, in the order the user can do something about it.
+ * Null means it can be changed.
+ */
+export function resolveEnvironmentIconPickerLock(input: {
+  readonly serverConfig: ServerConfig | null;
+  readonly operateAccess: "granted" | "denied" | "pending";
+}): string | null {
+  if (input.serverConfig === null) {
+    return "Connect to this environment to change its icon.";
+  }
+  if (input.serverConfig.environment.capabilities.environmentIcon !== true) {
+    return "This environment's server is too old to keep an icon. Update it to choose one.";
+  }
+  if (input.operateAccess === "denied") {
+    return "Your session on this environment cannot change its settings.";
+  }
+  return null;
+}
+
+// Same split the provider settings use: the desktop app owns its primary
+// server outright, a browser session on the primary checks its cookie
+// session's scopes, and a remote checks the scopes its own server reports.
+function useEnvironmentOperateAccess(environmentId: EnvironmentId) {
+  const isPrimary = usePrimaryEnvironmentId() === environmentId;
+  const primarySession = usePrimarySessionState();
+  const remoteSession = useEnvironmentSessionState(environmentId);
+  if (isPrimary) {
+    return isElectron
+      ? "granted"
+      : resolvePrimaryOperateAccess({
+          isPrimary: true,
+          hasDesktopBridge: false,
+          session: primarySession.data,
+          isPending: primarySession.isPending,
+          hasError: primarySession.error !== null,
+        });
+  }
+  return resolveRemoteOperateAccess({
+    session: remoteSession.data,
+    isPending: remoteSession.isPending,
+    hasError: remoteSession.hasError,
+  });
+}
 
 /**
  * Picks the machine glyph an environment wears everywhere it is listed.
  * "Automatic" clears the override so the server's own detection shows
  * through; the label says what that currently resolves to so the user can
- * tell whether detection got it right before overriding.
+ * tell whether detection got it right before overriding. The control stays
+ * visible while locked so the current icon still reads, the same way
+ * server-scoped rows go inert instead of disappearing.
  */
 export function EnvironmentIconPicker({
   environmentId,
@@ -29,6 +85,8 @@ export function EnvironmentIconPicker({
   readonly size?: "xs" | "sm";
 }) {
   const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const operateAccess = useEnvironmentOperateAccess(environmentId);
+  const lock = resolveEnvironmentIconPickerLock({ serverConfig, operateAccess });
   const override = serverConfig?.settings.environmentIcon ?? null;
   const detected = serverConfig?.environment.platform.machine ?? null;
   const resolved = resolveEnvironmentMachineKind(serverConfig);
@@ -48,8 +106,8 @@ export function EnvironmentIconPicker({
     [updateSettings],
   );
 
-  return (
-    <Select value={value} onValueChange={handleValueChange} disabled={serverConfig === null}>
+  const select = (
+    <Select value={value} onValueChange={handleValueChange} disabled={lock !== null}>
       <SelectTrigger size={size} className="w-full sm:w-52" aria-label="Environment icon">
         <SelectValue>
           <span className="flex min-w-0 items-center gap-2">
@@ -77,5 +135,27 @@ export function EnvironmentIconPicker({
         ))}
       </SelectPopup>
     </Select>
+  );
+
+  if (lock === null) {
+    return select;
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          // Focusable so keyboard users can still reach the explanation.
+          <span
+            tabIndex={0}
+            className="flex w-full items-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-auto"
+          />
+        }
+      >
+        <span className="flex w-full items-center sm:w-auto">{select}</span>
+      </TooltipTrigger>
+      <TooltipPopup side="top" className="max-w-72">
+        {lock}
+      </TooltipPopup>
+    </Tooltip>
   );
 }

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -407,6 +407,14 @@ export const SETTINGS_SEARCH_ITEMS = [
     primaryOnly: true,
   },
   {
+    id: "environment-icon",
+    title: "Environment icon",
+    to: "/settings/connections",
+    targetId: "connections-environment",
+    searchTerms: ["machine glyph sidebar mac mini studio laptop desktop server cloud vm"],
+    localBackendManagementOnly: true,
+  },
+  {
     id: "network-access",
     title: "Network access",
     to: "/settings/connections",

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1,5 +1,5 @@
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
-import { pullRequestHostOf, ThreadId } from "@t3tools/contracts";
+import { pullRequestHostOf, resolveEnvironmentMachineKind, ThreadId } from "@t3tools/contracts";
 import type {
   EnvironmentId,
   ProjectId,
@@ -19,8 +19,6 @@ import {
   ChevronDownIcon,
   ClockIcon,
   EyeIcon,
-  MonitorIcon,
-  ServerIcon,
   GitMergeIcon,
   GitPullRequestClosedIcon,
   GitPullRequestIcon,
@@ -86,6 +84,7 @@ import {
   writePullRequestListPreferences,
 } from "../components/pullRequest/pullRequestListPreferences";
 import { assignProjectsToEnvironments } from "../components/pullRequest/pullRequestProjectAssignment.logic";
+import { environmentMachineIcon } from "../components/EnvironmentMachineIcon";
 import { PullRequestDetailPanel } from "../components/pullRequest/PullRequestDetailPanel";
 import {
   PullRequestFiltersMenu,
@@ -1736,14 +1735,14 @@ function PullRequestsRouteView() {
       };
     }),
   ];
-  // The same shape the host pills take, so the two groups read as one control. A local
-  // connection wears the screen it is on; every other server wears a server.
+  // The same shape the host pills take, so the two groups read as one control. Each server
+  // wears the machine it runs on.
   const serverMenuOptions: ReadonlyArray<PullRequestFilterOption<string>> = [
     { value: "", label: "All servers", Icon: LayersIcon },
     ...capableEnvironments.map((environment) => ({
       value: environment.environmentId,
       label: environment.label,
-      Icon: environment.displayUrl === null ? MonitorIcon : ServerIcon,
+      Icon: environmentMachineIcon(resolveEnvironmentMachineKind(environment.serverConfig)),
     })),
   ];
   const sortMenu = (

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -224,6 +224,22 @@ right action without making the transport responsible for process management. Th
 supervisor owns the resulting disconnect and reconnect like any other involuntary close. See
 [server-updates.md](./server-updates.md).
 
+## Machine identity
+
+Every environment is drawn with one of a fixed set of machine glyphs (`EnvironmentMachineKind` in
+contracts: server, cloud, desktop, laptop, mac-mini, mac-studio). Two inputs feed it, and the
+precedence lives in one helper, `resolveEnvironmentMachineKind`, so web and mobile cannot drift:
+
+1. `settings.environmentIcon`, a nullable server setting the user picks in Settings → Connections.
+   It is server state rather than client state so every device connecting to that server agrees.
+2. `environment.platform.machine`, detected once at startup by [ServerEnvironmentMachine.ts][machine]
+   (IOKit product name / `hw.model` on macOS, `/sys/class/dmi/id` on Linux with virtualization
+   markers mapped to "cloud"). Absent when there is no signal, so older servers, Windows hosts, and
+   containers decode without it.
+3. A generic server otherwise.
+
+Clients treat the field like any other capability: absent means "use the fallback", never "wait".
+
 ## Future work
 
 These remain unbuilt and are listed to keep the model honest:
@@ -237,3 +253,4 @@ These remain unbuilt and are listed to keep the model honest:
 [authremote]: ../../packages/client-runtime/src/authorization/remote.ts
 [sshenv]: ../../apps/desktop/src/ssh/DesktopSshEnvironment.ts
 [sshtunnel]: ../../packages/ssh/src/tunnel.ts
+[machine]: ../../apps/server/src/environment/ServerEnvironmentMachine.ts

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -49,6 +49,21 @@ The main sidebar, right panel, and terminal drawer open and close immediately by
 The duration can be set up to 400 ms. Clicking the preview replays all three panel transitions; at
 0 ms, it snaps between the same open and closed states.
 
+## Environment icons
+
+When you are connected to more than one environment, every thread that lives somewhere other than
+the machine you are on wears a small icon for that machine at the end of its row: a server, a cloud
+VM, a desktop, a laptop, a Mac mini, or a Mac Studio. In the hosted web app and the mobile app,
+where every environment is remote, each row wears its machine so you can tell them apart at a
+glance. The same icon appears in the thread tooltip, the "Run on" picker, the pull request server
+filter, and the environment lists under **Settings → Connections**.
+
+Servers pick the icon themselves from the hardware they run on. A Mac reports its model, a Linux
+machine reports its chassis type and whether it is a virtual machine, and anything without a usable
+signal shows a generic server. To override it, open **Settings → Connections** and choose an icon
+for that environment; **Automatic** goes back to what the server detected. The choice is stored on
+that server, so every device that connects to it sees the same icon.
+
 ## Environment artwork
 
 Dev and Nightly environments can identify themselves with artwork at the top of the sidebar and in

--- a/packages/contracts/src/baseSchemas.ts
+++ b/packages/contracts/src/baseSchemas.ts
@@ -43,6 +43,27 @@ export type IsoDateTime = typeof IsoDateTime.Type;
  * rejecting the payload would take down the connection over data the client
  * couldn't act on anyway. Encoding is the plain array encoding.
  */
+/**
+ * Same idea for one optional value whose literal set grows over time: a
+ * member this build does not know decodes as absent rather than failing the
+ * enclosing struct. Encoding is the plain encoding.
+ */
+export const ForwardCompatibleOptional = <Value extends Schema.Top>(value: Value) => {
+  const decodeValue = Schema.decodeUnknownOption(value as never);
+  return Schema.optionalKey(
+    Schema.Unknown.pipe(
+      Schema.decodeTo(
+        Schema.UndefinedOr(value),
+        SchemaTransformation.transform<Value["Encoded"] | undefined, unknown>({
+          decode: (raw) =>
+            Option.isSome(decodeValue(raw)) ? (raw as Value["Encoded"]) : undefined,
+          encode: (raw) => raw,
+        }),
+      ),
+    ),
+  );
+};
+
 export const ForwardCompatibleArray = <Element extends Schema.Top>(element: Element) => {
   const decodeElement = Schema.decodeUnknownOption(element as never);
   return Schema.Array(Schema.Unknown).pipe(

--- a/packages/contracts/src/baseSchemas.ts
+++ b/packages/contracts/src/baseSchemas.ts
@@ -64,6 +64,24 @@ export const ForwardCompatibleOptional = <Value extends Schema.Top>(value: Value
   );
 };
 
+/**
+ * The nullable form, for a persisted setting whose literal set grows over
+ * time: a member this build does not know (or a missing key) decodes as null
+ * rather than failing the enclosing struct. Encoding is the plain encoding.
+ */
+export const ForwardCompatibleNullable = <Value extends Schema.Top>(value: Value) => {
+  const decodeValue = Schema.decodeUnknownOption(value as never);
+  return Schema.Unknown.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(value),
+      SchemaTransformation.transform<Value["Encoded"] | null, unknown>({
+        decode: (raw) => (Option.isSome(decodeValue(raw)) ? (raw as Value["Encoded"]) : null),
+        encode: (raw) => raw,
+      }),
+    ),
+  );
+};
+
 export const ForwardCompatibleArray = <Element extends Schema.Top>(element: Element) => {
   const decodeElement = Schema.decodeUnknownOption(element as never);
   return Schema.Array(Schema.Unknown).pipe(

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -129,6 +129,10 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
       this is false — no update would ever repaint it. Absent on older
       servers, which may still publish, so only an explicit false skips. */
   agentActivityPublishing: Schema.optionalKey(Schema.Boolean),
+  /** Server detects `platform.machine` and persists the `environmentIcon`
+      setting. Older servers drop the key on write, so clients show the
+      picker inert rather than offering a choice that would never stick. */
+  environmentIcon: Schema.optionalKey(Schema.Boolean),
   /** The desktop app supervising this server can be driven over RPC:
       server.updateServer runs its check -> download -> relaunch. Absent on
       desktop servers whose app predates the remote trigger, where clients

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -1,7 +1,13 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
-import { EnvironmentId, ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import {
+  EnvironmentId,
+  ForwardCompatibleOptional,
+  ProjectId,
+  ThreadId,
+  TrimmedNonEmptyString,
+} from "./baseSchemas.ts";
 
 export const ExecutionEnvironmentPlatformOs = Schema.Literals([
   "darwin",
@@ -14,9 +20,30 @@ export type ExecutionEnvironmentPlatformOs = typeof ExecutionEnvironmentPlatform
 export const ExecutionEnvironmentPlatformArch = Schema.Literals(["arm64", "x64", "other"]);
 export type ExecutionEnvironmentPlatformArch = typeof ExecutionEnvironmentPlatformArch.Type;
 
+/**
+ * The curated set of machine shapes an environment can wear as its icon.
+ * Servers detect one from the hardware they run on (`platform.machine`), and
+ * the `environmentIcon` server setting lets a user pick one instead.
+ */
+export const ENVIRONMENT_MACHINE_KINDS = [
+  "server",
+  "cloud",
+  "desktop",
+  "laptop",
+  "mac-mini",
+  "mac-studio",
+] as const;
+export const EnvironmentMachineKind = Schema.Literals(ENVIRONMENT_MACHINE_KINDS);
+export type EnvironmentMachineKind = typeof EnvironmentMachineKind.Type;
+export const isEnvironmentMachineKind = Schema.is(EnvironmentMachineKind);
+
 export const ExecutionEnvironmentPlatform = Schema.Struct({
   os: ExecutionEnvironmentPlatformOs,
   arch: ExecutionEnvironmentPlatformArch,
+  /** Hardware shape detected at startup. Absent when the host gives no usable
+      signal (containers, Windows, unknown DMI), on servers that predate it, or
+      when a newer server names a kind this build cannot draw. */
+  machine: ForwardCompatibleOptional(EnvironmentMachineKind),
 });
 
 /**

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -1,12 +1,15 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
+import { ExecutionEnvironmentDescriptor } from "./environment.ts";
 import {
+  resolveEnvironmentMachineKind,
   ServerConfig,
   ServerProvider,
   ServerProviders,
   ServerUpsertKeybindingResult,
 } from "./server.ts";
+import { ServerSettings } from "./settings.ts";
 
 const decodeServerProvider = Schema.decodeUnknownSync(ServerProvider);
 const decodeServerProviders = Schema.decodeUnknownSync(ServerProviders);
@@ -153,5 +156,55 @@ describe("server config forward compatibility", () => {
     ]);
 
     expect(parsed).toEqual([decodedBase]);
+  });
+});
+
+describe("resolveEnvironmentMachineKind", () => {
+  const decodeDescriptor = Schema.decodeUnknownSync(ExecutionEnvironmentDescriptor);
+  const decodeSettings = Schema.decodeUnknownSync(ServerSettings);
+  const descriptor = (platform: Record<string, unknown>) =>
+    decodeDescriptor({
+      environmentId: "env-1",
+      label: "Box",
+      platform: { os: "linux", arch: "x64", ...platform },
+      serverVersion: "1.0.0",
+      capabilities: {},
+    });
+
+  it("prefers the user's pick over what the server detected", () => {
+    expect(
+      resolveEnvironmentMachineKind({
+        environment: descriptor({ machine: "mac-mini" }),
+        settings: decodeSettings({ environmentIcon: "laptop" }),
+      }),
+    ).toBe("laptop");
+  });
+
+  it("uses detection when nothing is picked", () => {
+    expect(
+      resolveEnvironmentMachineKind({
+        environment: descriptor({ machine: "mac-mini" }),
+        settings: decodeSettings({}),
+      }),
+    ).toBe("mac-mini");
+  });
+
+  it("falls back to a server for older servers and before connect", () => {
+    expect(
+      resolveEnvironmentMachineKind({
+        environment: descriptor({}),
+        settings: decodeSettings({}),
+      }),
+    ).toBe("server");
+    expect(resolveEnvironmentMachineKind(null)).toBe("server");
+  });
+
+  it("drops a machine kind this build does not know instead of failing the descriptor", () => {
+    const parsed = descriptor({ machine: "toaster" });
+
+    expect(parsed.platform.machine).toBeUndefined();
+    expect(
+      resolveEnvironmentMachineKind({ environment: parsed, settings: decodeSettings({}) }),
+    ).toBe("server");
   });
 });

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -1,6 +1,10 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
-import { ExecutionEnvironmentDescriptor, ServerSelfUpdateMethod } from "./environment.ts";
+import {
+  type EnvironmentMachineKind,
+  ExecutionEnvironmentDescriptor,
+  ServerSelfUpdateMethod,
+} from "./environment.ts";
 import { ServerAuthDescriptor } from "./auth.ts";
 import {
   ForwardCompatibleArray,
@@ -571,6 +575,18 @@ export const ServerConfig = Schema.Struct({
   environmentThemes: Schema.optional(Schema.Array(EnvironmentTheme)),
 });
 export type ServerConfig = typeof ServerConfig.Type;
+
+/**
+ * The machine an environment should be drawn as: the user's pick, else what
+ * the server detected, else a generic server. A null config (not connected
+ * yet, or an older server) resolves to the same generic so rows never
+ * flicker between glyphs.
+ */
+export function resolveEnvironmentMachineKind(
+  config: Pick<ServerConfig, "environment" | "settings"> | null,
+): EnvironmentMachineKind {
+  return config?.settings.environmentIcon ?? config?.environment.platform.machine ?? "server";
+}
 
 const ServerUpsertKeybindingReplaceTarget = Schema.Struct({
   key: KeybindingValue,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -505,3 +505,22 @@ describe("ServerSettingsPatch string normalization", () => {
     expect(encoded.providers?.codex?.launchArgs).toBe("--strict-config");
   });
 });
+
+describe("ServerSettings environment icon", () => {
+  it("defaults to null", () => {
+    expect(decodeServerSettings({}).environmentIcon).toBeNull();
+  });
+
+  it("keeps a kind this build knows", () => {
+    expect(decodeServerSettings({ environmentIcon: "mac-mini" }).environmentIcon).toBe("mac-mini");
+  });
+
+  it("decodes a kind from a newer server as null instead of failing the snapshot", () => {
+    expect(decodeServerSettings({ environmentIcon: "toaster" }).environmentIcon).toBeNull();
+  });
+
+  it("round-trips through encode", () => {
+    const settings = decodeServerSettings({ environmentIcon: "laptop" });
+    expect(encodeServerSettings(settings).environmentIcon).toBe("laptop");
+  });
+});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -2,7 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Duration from "effect/Duration";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
-import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
+import { ForwardCompatibleNullable, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 import { EnvironmentMachineKind, ThreadEnvMode } from "./environment.ts";
 import {
   DEFAULT_TEXT_GENERATION_MODEL,
@@ -738,9 +738,10 @@ export const ServerSettings = Schema.Struct({
    * The icon clients draw for this environment. Null means "use what the
    * server detected" (`environment.platform.machine`), falling back to a
    * generic server. Lives on the server, not the client, so every device
-   * sees the same machine.
+   * sees the same machine. A kind picked on a newer server decodes as null
+   * here rather than failing the whole settings snapshot for an older client.
    */
-  environmentIcon: Schema.NullOr(EnvironmentMachineKind).pipe(
+  environmentIcon: ForwardCompatibleNullable(EnvironmentMachineKind).pipe(
     Schema.withDecodingDefault(Effect.succeed(null)),
   ),
   defaultThreadEnvMode: ThreadEnvMode.pipe(

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -3,7 +3,7 @@ import * as Duration from "effect/Duration";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
-import { ThreadEnvMode } from "./environment.ts";
+import { EnvironmentMachineKind, ThreadEnvMode } from "./environment.ts";
 import {
   DEFAULT_TEXT_GENERATION_MODEL,
   DEFAULT_TEXT_GENERATION_REASONING_EFFORT,
@@ -734,6 +734,15 @@ export const ServerSettings = Schema.Struct({
   defaultThemeSetAt: Schema.String.check(Schema.isMaxLength(64)).pipe(
     Schema.withDecodingDefault(Effect.succeed("")),
   ),
+  /**
+   * The icon clients draw for this environment. Null means "use what the
+   * server detected" (`environment.platform.machine`), falling back to a
+   * generic server. Lives on the server, not the client, so every device
+   * sees the same machine.
+   */
+  environmentIcon: Schema.NullOr(EnvironmentMachineKind).pipe(
+    Schema.withDecodingDefault(Effect.succeed(null)),
+  ),
   defaultThreadEnvMode: ThreadEnvMode.pipe(
     Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
   ),
@@ -945,6 +954,7 @@ export const ServerSettingsPatch = Schema.Struct({
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
   providerHealthRefreshInterval: Schema.optionalKey(Schema.DurationFromMillis),
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
+  environmentIcon: Schema.optionalKey(Schema.NullOr(EnvironmentMachineKind)),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),


### PR DESCRIPTION
## Problem

Every remote environment wore the same glyph (a cloud in the sidebar, a server elsewhere), so a Mac mini, a MacBook, and a Hetzner VM were indistinguishable in the thread list, the "Run on" picker, the pull request server filter, and the mobile lists. In the hosted web app, where there is no local environment, thread rows carried no marker at all.

## Fix

Each environment is now drawn as the machine it runs on, from a fixed set: server, cloud VM, desktop, laptop, Mac mini, Mac Studio.

- **Detection.** At startup the server reads the IOKit product name (falling back to `hw.model` on Intel Macs) or, on Linux, the DMI chassis type plus vendor/product strings, with hypervisor and cloud markers mapping to "cloud". The result ships as `platform.machine` on the environment descriptor; absent when there is no signal (Windows, containers, unknown DMI).
- **Override.** A nullable `environmentIcon` server setting, picked in Settings → Connections. It lives on the server rather than the client so every device connecting to that environment sees the same icon. The picker reads "Automatic (Mac mini)" so you can tell whether detection got it right before overriding.
- **One resolver.** `resolveEnvironmentMachineKind` in contracts holds the precedence (override → detected → generic server) so web and mobile cannot drift. `platform.machine` decodes forward-compatibly: a kind from a newer server falls back to the generic glyph instead of failing the descriptor.
- **Surfaces.** Web sidebar (new and legacy) rows and tooltip, composer "Run on" picker, pull request server filter and act-on picker, Connections settings; mobile thread rows (v1 and v2), Environments and T3 Connect rows. The sidebar marker now shows whenever a thread's environment differs from the primary, which in the hosted app means every row, since the glyph is what tells them apart there.

Lucide has no Apple desktops, so Mac mini and Mac Studio are drawn in its grammar. On iOS the SF Symbols `macmini` and `macstudio` are used; Android falls back to the closest Tabler silhouettes.

## Icons

Server · Mac mini · Mac Studio · Desktop · Laptop (cloud is lucide's stock icon)

![environment machine icons](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/fd2a686dcf943112/environment-machine-icons.png)

## Verification

- 12 new server tests cover the Apple and DMI mappers and the mocked darwin / linux / win32 probe paths; 4 new contracts tests cover the resolver precedence and the forward-compat decode.
- Verified detection on real hardware: a 2024 Mac mini resolves `mac-mini`, a GMKtec NucBox on Linux resolves `desktop`.
- Typecheck passes for contracts, server, client-runtime, desktop, web, and mobile; existing sidebar, BranchToolbar, pull request assignment, and settings search suites pass.

Built with Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and optional server settings with best-effort hardware probes that fail safely to null; forward-compatible schema handling limits version-skew breakage.
> 
> **Overview**
> Environments are no longer shown as a generic cloud/server everywhere. Each one can display a **machine glyph** (server, cloud VM, desktop, laptop, Mac mini, Mac Studio) derived from hardware detection, an optional user override, or a generic server fallback.
> 
> **Server & contracts:** Startup detection fills `environment.platform.machine` (macOS IOKit/`hw.model`, Linux DMI with VM→cloud heuristics) and advertises an `environmentIcon` capability. A nullable `settings.environmentIcon` override is stored on the server so all clients agree. **`resolveEnvironmentMachineKind`** centralizes precedence (override → detected → `"server"`), with forward-compatible decoding for unknown kinds.
> 
> **Clients:** Web and mobile add shared icon components (`EnvironmentMachineIcon` / `EnvironmentMachineSymbol`) plus an **Environment icon** picker in Connections (gated on connect, server version, and operate access). Thread sidebars, connection rows, composer “Run on”, and pull-request server pickers/filters now use these glyphs instead of one-size-fits-all icons; remote-thread markers also apply when the primary environment differs (including hosted/mobile where every row is remote).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9f250f8ebeed264b3388906b9c361e6f6cb87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->