### PR TITLE
chore: audit lint directives and move plugin allowlists into config

### DIFF
--- a/apps/desktop/src/preview-pip-preload.ts
+++ b/apps/desktop/src/preview-pip-preload.ts
@@ -1,4 +1,3 @@
-// @effect-diagnostics globalDate:off - This isolated Electron preload does not run inside an Effect runtime.
 import type { DesktopPreviewRecordingFrame } from "@t3tools/contracts";
 import { contextBridge, ipcRenderer } from "electron";
 

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -36,8 +36,7 @@ config.resolver = {
     new RegExp(`${escapedWorkspaceRoot}[/\\\\]\\.t3[/\\\\].*`),
   ],
   extraNodeModules: {
-    // oxlint-disable-next-line unicorn/no-useless-fallback-in-spread
-    ...(config.resolver?.extraNodeModules ?? {}),
+    ...config.resolver?.extraNodeModules,
     shiki: mobileShikiRoot,
     "@shikijs/core": resolveShikiDependencyRoot("@shikijs/core"),
     "@shikijs/engine-javascript": resolveShikiDependencyRoot("@shikijs/engine-javascript"),

--- a/apps/mobile/modules/t3-markdown-text/src/MarkdownTextPrimitive.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/MarkdownTextPrimitive.tsx
@@ -9,10 +9,10 @@ const TextAncestorContext = React.createContext<[boolean, ViewStyle]>([
   StyleSheet.create({}),
 ]);
 
-const textDefaults: TextProps = {
+const textDefaults = {
   allowFontScaling: true,
   selectable: true,
-};
+} satisfies TextProps;
 
 const useTextAncestorContext = () => React.useContext(TextAncestorContext);
 
@@ -28,7 +28,11 @@ export type ContextMenuActionEvent = {
   nativeEvent: { target: number; actionIdentifier: string };
 };
 
-export type MarkdownTextPrimitiveProps = TextProps & {
+/**
+ * `onTextLayout` is not offered: the native view reports plain line strings
+ * while the React Native Text fallback reports measured `TextLayoutLine`s.
+ */
+export type MarkdownTextPrimitiveProps = Omit<TextProps, "onTextLayout"> & {
   uiTextView?: boolean;
   contextMenuConfig?: string;
   onContextMenuAction?: (event: ContextMenuActionEvent) => void;
@@ -75,16 +79,14 @@ function MarkdownTextPrimitiveChild({ style, children, ...rest }: MarkdownTextPr
   });
 
   if (!isAncestor) {
+    // Press handlers are delivered by the text runs; the container never sees them.
+    const { onPress: _onPress, onLongPress: _onLongPress, ...containerProps } = rest;
     return (
       <TextAncestorContext.Provider value={contextValue}>
         <T3MarkdownTextNativeComponent
           {...textDefaults}
-          {...rest}
-          // ellipsizeMode={rest.ellipsizeMode ?? rest.lineBreakMode ?? 'tail'}
+          {...containerProps}
           style={[flattenedStyle]}
-          // @ts-expect-error Weirdness
-          onPress={undefined}
-          onLongPress={undefined}
         >
           {nativeChildren}
         </T3MarkdownTextNativeComponent>

--- a/apps/server/scripts/migrate-dev-db.ts
+++ b/apps/server/scripts/migrate-dev-db.ts
@@ -24,7 +24,6 @@
  * cursors never rewind.
  */
 
-// @effect-diagnostics nodeBuiltinImport:off - node:os resolves the shared T3 home guard.
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeOS from "node:os";

--- a/apps/server/scripts/t3-sqlite-state.ts
+++ b/apps/server/scripts/t3-sqlite-state.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-// @effect-diagnostics nodeBuiltinImport:off - node:os resolves the shared T3 home guard.
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeOS from "node:os";

--- a/apps/server/src/assets/AttachmentUpload.ts
+++ b/apps/server/src/assets/AttachmentUpload.ts
@@ -1,4 +1,3 @@
-// @effect-diagnostics nodeBuiltinImport:off
 import * as NodeCrypto from "node:crypto";
 
 import {

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -71,8 +71,7 @@ export function downloadContentDisposition(fileName?: string): string {
     return "attachment";
   }
   // toWellFormed: encodeURIComponent throws URIError on unpaired surrogates.
-  // eslint-disable-next-line no-control-regex -- Header filenames must strip ASCII controls.
-  const sanitized = fileName.toWellFormed().replace(/[\u0000-\u001f"\\]/g, "_");
+  const sanitized = fileName.toWellFormed().replace(/[\p{Cc}"\\]/gu, "_");
   const asciiFallback = sanitized.replace(/[^\u0020-\u007e]/g, "_");
   const needsExtended = asciiFallback !== sanitized;
   const extendedName = encodeURIComponent(sanitized).replace(

--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -358,58 +358,45 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
     ).toEqual([activeThreadId]);
   });
 
-  it("signs the activity publish JWT and rejects tampering", async () => {
-    const keyPair = NodeCrypto.generateKeyPairSync("ed25519", {
-      privateKeyEncoding: { format: "pem", type: "pkcs8" },
-      publicKeyEncoding: { format: "pem", type: "spki" },
-    });
-    const payload = {
-      iss: "t3-env:env",
-      aud: "https://relay.example.test",
-      sub: "env",
-      jti: "nonce-1",
-      iat: 100,
-      exp: 200,
-      environmentId: state.environmentId,
-      threadId: state.threadId,
-      state,
-    } satisfies RelayAgentActivityPublishProofPayload;
-    const proof = await Effect.runPromise(
-      AgentAwarenessRelay.signRelayAgentActivityPublishProof({
+  it.effect("signs the activity publish JWT and rejects tampering", () =>
+    Effect.gen(function* () {
+      const keyPair = NodeCrypto.generateKeyPairSync("ed25519", {
+        privateKeyEncoding: { format: "pem", type: "pkcs8" },
+        publicKeyEncoding: { format: "pem", type: "spki" },
+      });
+      const payload = {
+        iss: "t3-env:env",
+        aud: "https://relay.example.test",
+        sub: "env",
+        jti: "nonce-1",
+        iat: 100,
+        exp: 200,
+        environmentId: state.environmentId,
+        threadId: state.threadId,
+        state,
+      } satisfies RelayAgentActivityPublishProofPayload;
+      const proof = yield* AgentAwarenessRelay.signRelayAgentActivityPublishProof({
         privateKey: keyPair.privateKey,
         payload,
-      }),
-    );
+      });
+      const verify = (token: string) =>
+        verifyRelayJwt({
+          publicKey: keyPair.publicKey,
+          token,
+          typ: RELAY_ACTIVITY_PUBLISH_TYP,
+          issuer: "t3-env:env",
+          audience: "https://relay.example.test",
+          nowEpochSeconds: 150,
+        });
 
-    await expect(
-      Effect.runPromise(
-        verifyRelayJwt({
-          publicKey: keyPair.publicKey,
-          token: proof,
-          typ: RELAY_ACTIVITY_PUBLISH_TYP,
-          issuer: "t3-env:env",
-          audience: "https://relay.example.test",
-          nowEpochSeconds: 150,
-        }),
-      ),
-    ).resolves.toMatchObject({ jti: "nonce-1", state });
-    await expect(
-      Effect.runPromise(
-        verifyRelayJwt({
-          publicKey: keyPair.publicKey,
-          token: (() => {
-            const [header, body, signature = ""] = proof.split(".");
-            const corruptedSignature = `${signature.startsWith("a") ? "b" : "a"}${signature.slice(1)}`;
-            return `${header}.${body}.${corruptedSignature}`;
-          })(),
-          typ: RELAY_ACTIVITY_PUBLISH_TYP,
-          issuer: "t3-env:env",
-          audience: "https://relay.example.test",
-          nowEpochSeconds: 150,
-        }),
-      ),
-    ).rejects.toBeDefined();
-  });
+      expect(yield* verify(proof)).toMatchObject({ jti: "nonce-1", state });
+
+      const [header, body, signature = ""] = proof.split(".");
+      const corruptedSignature = `${signature.startsWith("a") ? "b" : "a"}${signature.slice(1)}`;
+      const rejection = yield* Effect.flip(verify(`${header}.${body}.${corruptedSignature}`));
+      expect(rejection).toBeDefined();
+    }),
+  );
 
   it.effect("keeps the orchestration listener armed until relay config is installed", () =>
     Effect.scoped(
@@ -557,10 +544,11 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
     Effect.scoped(
       Effect.gen(function* () {
         const originalFetch = globalThis.fetch;
-        const context = yield* Effect.context<never>();
-        const runFork = Effect.runForkWith(context);
         const events = yield* Queue.unbounded<OrchestrationEvent>();
-        const fetchSeen = yield* Deferred.make<URL>();
+        let resolveFetchSeen: (url: URL) => void = () => {};
+        const fetchSeen = new Promise<URL>((resolve) => {
+          resolveFetchSeen = resolve;
+        });
         const userSpans: Array<string> = [];
         const productSpans: Array<string> = [];
         const collectingTracer = (spans: Array<string>) =>
@@ -648,7 +636,7 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
               ? input
               : (input as unknown as { readonly url: string }).url,
           );
-          runFork(Deferred.succeed(fetchSeen, url));
+          resolveFetchSeen(url);
           return Promise.resolve(Response.json({ ok: true, deliveries: [] }));
         }) as unknown as typeof fetch;
         yield* Effect.addFinalizer(() =>
@@ -707,7 +695,7 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
             occurredAt: now,
           } as unknown as OrchestrationEvent);
 
-          const url = yield* Deferred.await(fetchSeen).pipe(Effect.timeout("2 seconds"));
+          const url = yield* Effect.promise(() => fetchSeen).pipe(Effect.timeout("2 seconds"));
           expect(url.origin).toBe("https://transport.example.test");
           expect(productSpans).toContain("makePublishProof");
           expect(userSpans).not.toContain("makePublishProof");

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -56,7 +56,6 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
-import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
@@ -398,7 +397,9 @@ const makeBrowserOtlpPayload = (spanName: string) =>
       ({ close }) => Effect.promise(close),
     );
 
-    const runtime = ManagedRuntime.make(
+    // The exporter's batch fiber is forked while the layer builds and ticks on
+    // a wall-clock interval, so the whole tracer runs on the live clock.
+    yield* Layer.build(
       OtlpTracer.layer({
         url: collector.url,
         exportInterval: "10 millis",
@@ -411,13 +412,12 @@ const makeBrowserOtlpPayload = (spanName: string) =>
           },
         },
       }).pipe(Layer.provide(browserOtlpTracingLayer)),
+    ).pipe(
+      Effect.flatMap((tracing) =>
+        Effect.void.pipe(Effect.withSpan(spanName), Effect.provideContext(tracing)),
+      ),
+      TestClock.withLive,
     );
-
-    try {
-      yield* Effect.promise(() => runtime.runPromise(Effect.void.pipe(Effect.withSpan(spanName))));
-    } finally {
-      yield* Effect.promise(() => runtime.dispose());
-    }
 
     const request = yield* Effect.raceFirst(
       Effect.promise(() => collector.firstRequest).pipe(Effect.orDie),

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -1,5 +1,4 @@
 // @effect-diagnostics nodeBuiltinImport:off
-// @effect-diagnostics globalDate:off
 // @effect-diagnostics globalTimers:off
 // This file is shipped as a standalone bundle and copied to a stable path by
 // `t3 service update`. Keep runtime imports limited to Node built-ins.

--- a/apps/web/src/components/settings/ThemeSearchSection.tsx
+++ b/apps/web/src/components/settings/ThemeSearchSection.tsx
@@ -204,13 +204,12 @@ export function ThemeSearchSection({
       return;
     }
     void runSearch(debouncedQuery);
-    // `installingId` and `sortBy` are deliberately not dependencies: the
-    // guards above read the current values from the fresh render closure. An
-    // install finishing reruns the search only when the query or sort changed
-    // while it was in flight (checked via lastSearchKeyRef, recorded only
-    // once a search succeeds), so the install error the user needs to see is
-    // preserved across that rerun.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // `sortBy` is deliberately not a direct dependency: the guards above read
+    // the current value from the fresh render closure. An install finishing
+    // reruns the search only when the query or sort changed while it was in
+    // flight (checked via lastSearchKeyRef, recorded only once a search
+    // succeeds), so the install error the user needs to see is preserved
+    // across that rerun.
   }, [open, query, debouncedQuery, installingId, runSearch]);
 
   const handleSortChange = useCallback((value: OpenVsxThemeSort | null) => {

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -356,8 +356,7 @@ function applyTheme(theme: Theme, { suppressTransitions = false, preservePreview
   syncDesktopTheme(theme, followSystem, appearanceMode);
   if (suppressTransitions) {
     // Force a reflow so the no-transitions class takes effect before removal
-    // oxlint-disable-next-line no-unused-expressions
-    document.documentElement.offsetHeight;
+    void document.documentElement.offsetHeight;
     requestAnimationFrame(() => {
       document.documentElement.classList.remove("no-transitions");
     });

--- a/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
+++ b/oxlint-plugin-t3code/rules/no-global-process-runtime.ts
@@ -4,22 +4,7 @@ import * as Option from "effect/Option";
 import { getPropertyName, isIdentifier, unwrapExpression } from "../utils.ts";
 
 const RUNTIME_PROPERTIES = new Set(["platform", "arch"]);
-const HOST_PROCESS_REFERENCE_FILE = "packages/shared/src/hostProcess.ts";
 const NODE_OS_MODULES = new Set(["node:os", "os"]);
-
-const normalizePath = (path: string) => path.replaceAll("\\", "/");
-
-const toRepoPath = (filename: string, cwd: string) => {
-  const normalizedFilename = normalizePath(filename);
-  const normalizedCwd = normalizePath(cwd).replace(/\/+$/u, "");
-  const prefix = `${normalizedCwd}/`;
-  return normalizedFilename.startsWith(prefix)
-    ? normalizedFilename.slice(prefix.length)
-    : normalizedFilename;
-};
-
-const isHostProcessReferenceFile = (filename: string, cwd: string) =>
-  toRepoPath(filename, cwd) === HOST_PROCESS_REFERENCE_FILE;
 
 const isGlobalProcessObject = (node: unknown): boolean => {
   const expression = unwrapExpression(node);
@@ -48,7 +33,7 @@ export default defineRule({
     type: "problem",
     docs: {
       description:
-        "Disallow direct host runtime platform/architecture reads outside the shared host process references.",
+        "Disallow direct host runtime platform/architecture reads; the shared host process references are exempted in the lint config.",
     },
   },
   createOnce(context) {
@@ -117,8 +102,6 @@ export default defineRule({
       before: resetBindings,
       ImportDeclaration: trackImportDeclaration,
       MemberExpression(node) {
-        if (isHostProcessReferenceFile(context.filename, context.cwd)) return;
-
         const property = getPropertyName(node.property);
         if (Option.isNone(property) || !RUNTIME_PROPERTIES.has(property.value)) return;
         if (!isGlobalProcessObject(node.object)) return;
@@ -129,8 +112,6 @@ export default defineRule({
         });
       },
       CallExpression(node) {
-        if (isHostProcessReferenceFile(context.filename, context.cwd)) return;
-
         const property = getNodeOsRuntimeCall(node.callee);
         if (Option.isNone(property)) return;
 

--- a/oxlint-plugin-t3code/rules/no-manual-effect-runtime-in-tests.test.ts
+++ b/oxlint-plugin-t3code/rules/no-manual-effect-runtime-in-tests.test.ts
@@ -71,3 +71,34 @@ productionRule.valid(
     export const main = () => Effect.runPromise(Effect.void);
   `,
 );
+
+const legacyRule = createOxlintRuleHarness("t3code/no-manual-effect-runtime-in-tests", {
+  filename: "legacy.test.ts",
+  ruleOptions: [{ maxOccurrences: 2 }],
+});
+
+describe("t3code/no-manual-effect-runtime-in-tests with maxOccurrences", () => {
+  legacyRule.valid(
+    "allows occurrences up to the ceiling",
+    `
+      import * as Effect from "effect/Effect";
+
+      test("first", () => Effect.runSync(Effect.void));
+      test("second", () => Effect.runSync(Effect.void));
+    `,
+  );
+
+  legacyRule.invalid(
+    "reports occurrences beyond the ceiling",
+    `
+      import * as Effect from "effect/Effect";
+
+      test("first", () => Effect.runSync(Effect.void));
+      test("second", () => Effect.runSync(Effect.void));
+      test("third", () => Effect.runSync(Effect.void));
+    `,
+    (output) => {
+      assert.equal(output.match(/no-manual-effect-runtime-in-tests/g)?.length, 1);
+    },
+  );
+});

--- a/oxlint-plugin-t3code/rules/no-manual-effect-runtime-in-tests.ts
+++ b/oxlint-plugin-t3code/rules/no-manual-effect-runtime-in-tests.ts
@@ -19,44 +19,17 @@ const EFFECT_RUNTIME_METHODS = new Set([
   "runSyncWith",
 ]);
 
-// Existing manual runners are tracked as debt. The rule permits no net-new
-// occurrences in these files, while unlisted test files must have zero.
-const LEGACY_BASELINE = new Map<string, number>([
-  ["apps/mobile/src/features/agent-awareness/liveActivityPreferences.test.ts", 1],
-  ["apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts", 2],
-  ["apps/mobile/src/state/use-remote-environment-registry.test.ts", 2],
-  ["apps/server/src/orchestration/commandInvariants.test.ts", 6],
-  ["apps/server/src/orchestration/Layers/CheckpointReactor.test.ts", 42],
-  ["apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts", 5],
-  ["apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts", 4],
-  ["apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts", 70],
-  ["apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts", 31],
-  ["apps/server/src/orchestration/Layers/ThreadDeletionReactor.test.ts", 2],
-  ["apps/server/src/orchestration/projector.test.ts", 20],
-  ["apps/server/src/project/Layers/ProjectSetupScriptRunner.test.ts", 4],
-  ["apps/server/src/provider/acp/CursorAcpSupport.test.ts", 1],
-  ["apps/server/src/provider/Layers/ClaudeAdapter.test.ts", 2],
-  ["apps/server/src/provider/Layers/CodexAdapter.test.ts", 1],
-  ["apps/server/src/provider/Layers/CodexSessionRuntime.test.ts", 5],
-  ["apps/server/src/provider/Layers/CursorAdapter.test.ts", 1],
-  ["apps/server/src/provider/Layers/CursorProvider.test.ts", 4],
-  ["apps/server/src/provider/Layers/ProviderService.test.ts", 2],
-  ["apps/server/src/provider/Layers/ProviderSessionReaper.test.ts", 21],
-  ["apps/server/src/relay/AgentAwarenessRelay.test.ts", 4],
-  ["apps/server/src/server.test.ts", 1],
-  ["apps/web/src/cloud/dpop.test.ts", 2],
-  ["apps/web/src/environments/runtime/service.addSavedEnvironment.test.ts", 1],
-  ["oxlint-plugin-t3code/rules/no-manual-effect-runtime-in-tests.test.ts", 7],
-  ["packages/client-runtime/src/relay/managedRelayState.test.ts", 1],
-  ["packages/client-runtime/src/wsTransport.test.ts", 2],
-]);
-
-const baselineFor = (filename: string): number => {
-  const normalized = filename.replaceAll("\\", "/");
-  for (const [suffix, count] of LEGACY_BASELINE) {
-    if (normalized.endsWith(suffix)) return count;
-  }
-  return 0;
+// Existing manual runners are tracked as debt through the `maxOccurrences`
+// option, set per file in the lint config. The rule permits no net-new
+// occurrences in those files, while every other test file must have zero.
+const readMaxOccurrences = (options: ReadonlyArray<unknown>): number => {
+  const [first] = options;
+  return typeof first === "object" &&
+    first !== null &&
+    "maxOccurrences" in first &&
+    typeof first.maxOccurrences === "number"
+    ? first.maxOccurrences
+    : 0;
 };
 
 const manualRunnerName = (callee: unknown): Option.Option<string> => {
@@ -87,11 +60,26 @@ export default defineRule({
       description:
         "Disallow manually creating or running Effect runtimes in tests; use @effect/vitest.",
     },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          maxOccurrences: {
+            type: "integer",
+            minimum: 0,
+            description:
+              "Legacy debt ceiling for this file: occurrences beyond this count are reported.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ maxOccurrences: 0 }],
   },
   create(context) {
     if (!TEST_FILE_PATTERN.test(context.filename)) return {};
 
-    const allowedCount = baselineFor(context.filename);
+    const allowedCount = readMaxOccurrences(context.options);
     let occurrenceCount = 0;
 
     return {

--- a/oxlint-plugin-t3code/rules/no-mobile-uniwind-theme-escape-hatches.test.ts
+++ b/oxlint-plugin-t3code/rules/no-mobile-uniwind-theme-escape-hatches.test.ts
@@ -7,15 +7,11 @@ const guardedMobileFile = createOxlintRuleHarness("t3code/no-mobile-uniwind-them
 });
 const reviewedInteropFile = createOxlintRuleHarness(
   "t3code/no-mobile-uniwind-theme-escape-hatches",
-  { filename: "apps/mobile/src/features/home/HomeHeader.tsx" },
+  {
+    filename: "apps/mobile/src/features/home/HomeHeader.tsx",
+    ruleOptions: [{ allowUniwindTheme: true }],
+  },
 );
-const gitOverlayInteropFile = createOxlintRuleHarness(
-  "t3code/no-mobile-uniwind-theme-escape-hatches",
-  { filename: "apps/mobile/src/features/threads/GitActionProgressOverlay.tsx" },
-);
-const webFile = createOxlintRuleHarness("t3code/no-mobile-uniwind-theme-escape-hatches", {
-  filename: "apps/web/src/ThemeSurface.tsx",
-});
 
 describe("t3code/no-mobile-uniwind-theme-escape-hatches", () => {
   guardedMobileFile.valid(
@@ -93,18 +89,9 @@ describe("t3code/no-mobile-uniwind-theme-escape-hatches", () => {
     `,
   );
 
-  gitOverlayInteropFile.valid(
-    "allows the native liquid-glass theme boundary",
-    `
-      import { useUniwindTheme } from "../../lib/useUniwindTheme";
-
-      export const tint = useUniwindTheme()["--color-glass-surface"];
-    `,
-  );
-
-  webFile.valid(
-    "does not impose the mobile custom-theme policy on web code",
-    `const surface = <div className="bg-white dark:bg-black" />;`,
+  reviewedInteropFile.invalid(
+    "still reports appearance variants in reviewed interop boundaries",
+    `const surface = <View className="bg-white dark:bg-black" />;`,
   );
 
   guardedMobileFile.invalid(

--- a/oxlint-plugin-t3code/rules/no-mobile-uniwind-theme-escape-hatches.ts
+++ b/oxlint-plugin-t3code/rules/no-mobile-uniwind-theme-escape-hatches.ts
@@ -3,44 +3,9 @@ import * as Option from "effect/Option";
 
 import { getPropertyName, unwrapExpression } from "../utils.ts";
 
-const MOBILE_SOURCE_MARKER = "/apps/mobile/src/";
 const APPEARANCE_VARIANT_PATTERN = /\b(?:dark|light):(?=\S)/u;
 const APPEARANCE_VARIANT_MESSAGE =
   "dark:/light: utilities do not follow registered custom themes; use an adaptive semantic token.";
-const THEME_INTEROP_ALLOWLIST = new Set([
-  "features/archive/ArchivedThreadsScreen.tsx",
-  "features/connection/ConnectionsNewRouteScreen.tsx",
-  "features/files/FileMarkdownPreview.tsx",
-  "features/files/SourceFileSurface.tsx",
-  "features/files/ThreadFilesRouteScreen.tsx",
-  "features/files/thread-file-navigator-pane.tsx",
-  "features/home/HomeHeader.tsx",
-  "features/review/ReviewSheet.tsx",
-  "features/review/useNativeReviewDiffBridge.ts",
-  "features/settings/SettingsEnvironmentsRouteScreen.tsx",
-  "features/settings/appearance/components/AppearancePreviews.tsx",
-  "features/settings/appearance/components/FontSizeSliderRow.tsx",
-  "features/threads/GitActionProgressOverlay.tsx",
-  "features/threads/NewTaskContextPickerScreens.tsx",
-  "features/threads/NewTaskDraftScreen.tsx",
-  "features/threads/ThreadComposer.tsx",
-  "features/threads/ThreadFeed.tsx",
-  "features/threads/ThreadSettingsSheet.tsx",
-  "features/threads/git/GitOverviewSheet.tsx",
-  "features/threads/thread-list-items.tsx",
-  "features/threads/thread-list-v2-items.tsx",
-  "lib/useMobileNavigationTheme.ts",
-  "native/T3ComposerEditor.ios.tsx",
-  "native/T3ComposerEditor.native.tsx",
-]);
-
-const mobileSourcePath = (filename: string): string | undefined => {
-  const normalized = `/${filename.replaceAll("\\", "/")}`;
-  const markerIndex = normalized.lastIndexOf(MOBILE_SOURCE_MARKER);
-  return markerIndex === -1
-    ? undefined
-    : normalized.slice(markerIndex + MOBILE_SOURCE_MARKER.length);
-};
 
 const literalStringValue = (node: unknown): Option.Option<string> => {
   if (typeof node !== "object" || node === null) return Option.none();
@@ -54,18 +19,40 @@ const reportsAppearanceVariant = (value: string) => APPEARANCE_VARIANT_PATTERN.t
 const importsModule = (source: string, modulePath: string): boolean =>
   source.replace(/\.[cm]?[jt]sx?$/u, "").endsWith(modulePath);
 
+const readAllowUniwindTheme = (options: ReadonlyArray<unknown>): boolean => {
+  const [first] = options;
+  return (
+    typeof first === "object" &&
+    first !== null &&
+    "allowUniwindTheme" in first &&
+    first.allowUniwindTheme === true
+  );
+};
+
 export default defineRule({
   meta: {
     type: "problem",
     docs: {
       description:
-        "Keep mobile theme styling on semantic Uniwind classes and reviewed native interop boundaries.",
+        "Keep mobile theme styling on semantic Uniwind classes. Scope the rule to mobile sources and exempt reviewed native interop boundaries in the lint config.",
     },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowUniwindTheme: {
+            type: "boolean",
+            description:
+              "Permit useUniwindTheme in a reviewed native/third-party interop boundary that cannot consume a className.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ allowUniwindTheme: false }],
   },
   create(context) {
-    const sourcePath = mobileSourcePath(context.filename);
-    if (sourcePath === undefined) return {};
-
+    const allowUniwindTheme = readAllowUniwindTheme(context.options);
     const uniwindNamespaces = new Set<Variable>();
 
     const resolveVariable = (node: unknown): Variable | undefined => {
@@ -131,13 +118,13 @@ export default defineRule({
 
           if (
             !isTypeOnly &&
-            importsModule(source.value, "/useUniwindTheme") &&
-            !THEME_INTEROP_ALLOWLIST.has(sourcePath)
+            !allowUniwindTheme &&
+            importsModule(source.value, "/useUniwindTheme")
           ) {
             context.report({
               node: specifier,
               message:
-                "Use className for theme styling, or review and add this native/third-party interop boundary to the lint allowlist.",
+                "Use className for theme styling, or review this native/third-party interop boundary and enable allowUniwindTheme for it in the lint config.",
             });
           }
         }

--- a/oxlint-plugin-t3code/test/utils.ts
+++ b/oxlint-plugin-t3code/test/utils.ts
@@ -61,6 +61,8 @@ interface RuleHarness {
 
 interface RuleHarnessOptions {
   readonly filename?: string;
+  /** Rule options, as they would appear after the severity in the lint config. */
+  readonly ruleOptions?: ReadonlyArray<unknown>;
 }
 
 const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
@@ -111,7 +113,7 @@ export const createOxlintRuleHarness = (
       configPath,
       yield* encodeOxlintConfig({
         jsPlugins: [{ name: "t3code", specifier: pluginPath }],
-        rules: { [ruleName]: "error" },
+        rules: { [ruleName]: ["error", ...(options.ruleOptions ?? [])] },
       }),
     );
     yield* fs.makeDirectory(path.dirname(sourcePath), { recursive: true });

--- a/packages/client-runtime/src/relay/managedRelayState.test.ts
+++ b/packages/client-runtime/src/relay/managedRelayState.test.ts
@@ -243,30 +243,38 @@ describe("createManagedRelayQueryManager", () => {
     }),
   );
 
-  it("emits credential changes only when the managed relay account changes", async () => {
-    setManagedRelaySession(registry, {
-      accountId: "account-1",
-      readClerkToken: () => Promise.resolve("first-token"),
-    });
-    const changes = Effect.runPromise(
-      managedRelayAccountChanges(registry).pipe(Stream.take(2), Stream.runCollect),
-    );
-    await vi.waitFor(() => {
-      expect(registry.getNodes().get(managedRelaySessionAtom)?.listeners.size).toBeGreaterThan(0);
-    });
+  it.effect("emits credential changes only when the managed relay account changes", () =>
+    Effect.gen(function* () {
+      setManagedRelaySession(registry, {
+        accountId: "account-1",
+        readClerkToken: () => Promise.resolve("first-token"),
+      });
+      const changes = yield* managedRelayAccountChanges(registry).pipe(
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* Effect.promise(() =>
+        vi.waitFor(() => {
+          expect(registry.getNodes().get(managedRelaySessionAtom)?.listeners.size).toBeGreaterThan(
+            0,
+          );
+        }),
+      );
 
-    setManagedRelaySession(registry, {
-      accountId: "account-1",
-      readClerkToken: () => Promise.resolve("refreshed-token"),
-    });
-    setManagedRelaySession(registry, {
-      accountId: "account-2",
-      readClerkToken: () => Promise.resolve("second-token"),
-    });
-    setManagedRelaySession(registry, null);
+      setManagedRelaySession(registry, {
+        accountId: "account-1",
+        readClerkToken: () => Promise.resolve("refreshed-token"),
+      });
+      setManagedRelaySession(registry, {
+        accountId: "account-2",
+        readClerkToken: () => Promise.resolve("second-token"),
+      });
+      setManagedRelaySession(registry, null);
 
-    expect(Array.from(await changes)).toEqual(["account-2", null]);
-  });
+      expect(Array.from(yield* Fiber.join(changes))).toEqual(["account-2", null]);
+    }),
+  );
 
   it("shares one Clerk token read across concurrent relay list and status queries", async () => {
     const secondEnvironment = {

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -1,4 +1,3 @@
-// @effect-diagnostics nodeBuiltinImport:off - packaged-archive fixtures compute the sidecar digest with the same Node primitive as the builder.
 import * as NodeCrypto from "node:crypto";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -180,13 +180,10 @@ export default defineConfig({
         "apps/server/src/provider/Layers/ProviderService.test.ts": 2,
         "apps/server/src/provider/Layers/ProviderSessionReaper.test.ts": 12,
         "apps/server/src/provider/acp/CursorAcpSupport.test.ts": 1,
-        "apps/server/src/relay/AgentAwarenessRelay.test.ts": 4,
-        "apps/server/src/server.test.ts": 1,
-        "packages/client-runtime/src/relay/managedRelayState.test.ts": 1,
-      }).map(([file, maxOccurrences]) => ({
-        files: [file],
-        rules: { "t3code/no-manual-effect-runtime-in-tests": ["error", { maxOccurrences }] },
-      })),
+      }).map(([file, maxOccurrences]) => {
+        const rule: ["error", { maxOccurrences: number }] = ["error", { maxOccurrences }];
+        return { files: [file], rules: { "t3code/no-manual-effect-runtime-in-tests": rule } };
+      }),
     ],
     options: {
       reportUnusedDisableDirectives: "error",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
   },
   fmt: {
     ignorePatterns: [
-      ".reference",
       ".repos/**",
       ".alchemy",
       "dist",
@@ -37,7 +36,6 @@ export default defineConfig({
       "**/routeTree.gen.ts",
       "apps/mobile/android/**",
       "apps/mobile/ios/**",
-      "apps/web/src/lib/vendor/qrcodegen.ts",
       "apps/mobile/uniwind-types.d.ts",
       "*.icon/**",
     ],
@@ -119,11 +117,79 @@ export default defineConfig({
       "t3code/no-global-process-runtime": "error",
       "t3code/no-inline-schema-compile": "warn",
       "t3code/no-manual-effect-runtime-in-tests": "error",
-      "t3code/no-mobile-uniwind-theme-escape-hatches": "error",
       "t3code/no-native-title-tooltip": "error",
       "t3code/namespace-node-imports": "error",
     },
+    overrides: [
+      {
+        // The one place that reads the host platform to seed the injected references.
+        files: ["packages/shared/src/hostProcess.ts"],
+        rules: { "t3code/no-global-process-runtime": "off" },
+      },
+      {
+        files: ["apps/mobile/src/**"],
+        rules: { "t3code/no-mobile-uniwind-theme-escape-hatches": "error" },
+      },
+      {
+        // Reviewed native and third-party interop boundaries that cannot consume a className.
+        files: [
+          "apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx",
+          "apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx",
+          "apps/mobile/src/features/files/FileMarkdownPreview.tsx",
+          "apps/mobile/src/features/files/SourceFileSurface.tsx",
+          "apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx",
+          "apps/mobile/src/features/files/thread-file-navigator-pane.tsx",
+          "apps/mobile/src/features/home/HomeHeader.tsx",
+          "apps/mobile/src/features/review/ReviewSheet.tsx",
+          "apps/mobile/src/features/review/useNativeReviewDiffBridge.ts",
+          "apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx",
+          "apps/mobile/src/features/settings/appearance/components/AppearancePreviews.tsx",
+          "apps/mobile/src/features/settings/appearance/components/FontSizeSliderRow.tsx",
+          "apps/mobile/src/features/threads/GitActionProgressOverlay.tsx",
+          "apps/mobile/src/features/threads/NewTaskContextPickerScreens.tsx",
+          "apps/mobile/src/features/threads/NewTaskDraftScreen.tsx",
+          "apps/mobile/src/features/threads/ThreadComposer.tsx",
+          "apps/mobile/src/features/threads/ThreadFeed.tsx",
+          "apps/mobile/src/features/threads/ThreadSettingsSheet.tsx",
+          "apps/mobile/src/features/threads/git/GitOverviewSheet.tsx",
+          "apps/mobile/src/features/threads/thread-list-items.tsx",
+          "apps/mobile/src/features/threads/thread-list-v2-items.tsx",
+          "apps/mobile/src/lib/useMobileNavigationTheme.ts",
+          "apps/mobile/src/native/T3ComposerEditor.ios.tsx",
+          "apps/mobile/src/native/T3ComposerEditor.native.tsx",
+        ],
+        rules: {
+          "t3code/no-mobile-uniwind-theme-escape-hatches": ["error", { allowUniwindTheme: true }],
+        },
+      },
+      // Legacy manual Effect runners tracked as debt: no net-new occurrences.
+      // Lower a ceiling when you migrate a file, and delete its entry at zero.
+      ...Object.entries({
+        "apps/server/src/orchestration/Layers/CheckpointReactor.test.ts": 42,
+        "apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts": 5,
+        "apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts": 4,
+        "apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts": 66,
+        "apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts": 29,
+        "apps/server/src/orchestration/Layers/ThreadDeletionReactor.test.ts": 2,
+        "apps/server/src/orchestration/commandInvariants.test.ts": 5,
+        "apps/server/src/orchestration/projector.test.ts": 20,
+        "apps/server/src/provider/Layers/CodexAdapter.test.ts": 1,
+        "apps/server/src/provider/Layers/CodexSessionRuntime.test.ts": 5,
+        "apps/server/src/provider/Layers/CursorAdapter.test.ts": 1,
+        "apps/server/src/provider/Layers/CursorProvider.test.ts": 1,
+        "apps/server/src/provider/Layers/ProviderService.test.ts": 2,
+        "apps/server/src/provider/Layers/ProviderSessionReaper.test.ts": 12,
+        "apps/server/src/provider/acp/CursorAcpSupport.test.ts": 1,
+        "apps/server/src/relay/AgentAwarenessRelay.test.ts": 4,
+        "apps/server/src/server.test.ts": 1,
+        "packages/client-runtime/src/relay/managedRelayState.test.ts": 1,
+      }).map(([file, maxOccurrences]) => ({
+        files: [file],
+        rules: { "t3code/no-manual-effect-runtime-in-tests": ["error", { maxOccurrences }] },
+      })),
+    ],
     options: {
+      reportUnusedDisableDirectives: "error",
       // Revisit once Oxlint's tsgolint path can integrate with @effect/tsgo diagnostics.
       typeAware: false,
       typeCheck: false,


### PR DESCRIPTION
## Problem

A pass over every lint suppression in the repo (22 oxlint/eslint directives, 2 `@ts-expect-error`, 338 `@effect-diagnostics`) found three kinds of rot:

- Directives whose underlying code could be written so the rule simply passes (`no-unused-expressions`, `no-useless-fallback-in-spread`, `no-control-regex`, two `@ts-expect-error`s in the markdown primitive, one of which was annotated "Weirdness").
- `@effect-diagnostics` comments that never fired: `nodeBuiltinImport:off` on files importing only `node:crypto`/`node:os` (the rule only flags fs, path, child_process, http, https) and `globalDate:off` on files with no `Date` usage. tsgo has no unused-directive reporting, so these rot silently.
- The oxlint plugin hardcoded file paths in rule source. The manual-runtime baseline had drifted badly: 5 listed files no longer exist, 4 had dropped to zero, and 6 counts were stale (`ProviderSessionReaper.test.ts` allowed 21 but has 12, so 9 regressions could have slipped in unnoticed).

## Fix

- Refactor the code under the removable directives instead of keeping the suppression. `MarkdownTextPrimitive` now omits `onTextLayout` from its props (native emits `string[]` lines, RN Text emits `TextLayoutLine[]`; the two are incompatible and nothing consumed it) and stops spreading press handlers onto the container native component, which never accepted them.
- Delete the six `@effect-diagnostics` directives that never fired, verified by removing them and typechecking with tsgo.
- Move the plugin's per-file policy into `vite.config.ts` as oxlint `overrides` and rule options: `hostProcess.ts` exemption becomes an override; the mobile theme rule is scoped to `apps/mobile/src/**` with reviewed interop files opting in via `allowUniwindTheme`; the manual-runtime debt becomes a per-file `maxOccurrences` ceiling set to today's exact counts.
- Enable `reportUnusedDisableDirectives: "error"` in the lint config so `vp check` (what CI runs) fails on the next stale directive. Previously only the `lint` script passed the flag.
- Drop two `fmt.ignorePatterns` entries for paths that no longer exist.

Left alone, on purpose: the ~83 remaining `nodeBuiltinImport:off` directives all cover modules the rule genuinely flags and mostly need APIs Effect's `FileSystem` doesn't expose; `ChatMarkdown`'s nested-components block (12 real warnings without it); `CursorProvider`'s `no-control-regex` (the `\u{1b}` form is still flagged by oxlint); `ClaudeProvider`'s `require-yield` (never yielding is the point).

## Verification

- `vp check --no-fmt` fails on a planted unused directive and passes clean; the 23 remaining warnings are pre-existing and unchanged.
- Each override probed end to end: unlisted mobile file reports, over-ceiling runner reports, `hostProcess.ts` is exempt.
- Plugin tests: 72 pass, including 3 new cases for the rule options.
- tsgo typecheck clean for server, desktop, scripts, web, plugin; `tsc` clean for mobile.
- Targeted tests for http, CursorProvider, and web settings/hooks pass.

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly lint and test harness changes; the markdown props and download filename sanitization are small, localized behavior tweaks with no auth or data-path impact.
> 
> **Overview**
> Cleans up stale lint and `@effect-diagnostics` suppressions by fixing the underlying code where possible, and moves per-file policy out of custom oxlint rules into **`vite.config.ts` overrides** with rule options (`maxOccurrences` for manual Effect runners, `allowUniwindTheme` for reviewed mobile interop files, `hostProcess.ts` exempt from `no-global-process-runtime`). Enables **`reportUnusedDisableDirectives: "error"`** so unused disables fail `vp check`.
> 
> **Product-adjacent tweaks:** mobile **`MarkdownTextPrimitive`** drops incompatible `onTextLayout`, strips press handlers from the container native view, and types defaults with `satisfies`; **`downloadContentDisposition`** uses `\p{Cc}` instead of an eslint disable; several tests switch to **`@effect/vitest` `it.effect`** (including relay JWT and managed relay state); OTLP tracing test builds the layer with live clock instead of `ManagedRuntime`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b7ea6de5220c15084f3178b0a7ee25ffa3aa43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move lint rule allowlists from hardcoded paths into `vite.config.ts` overrides and add configurable options
> - Removes hardcoded filename/path exemption maps from three custom oxlint rules (`no-global-process-runtime`, `no-manual-effect-runtime-in-tests`, `no-mobile-uniwind-theme-escape-hatches`) and replaces them with configuration-driven options (`maxOccurrences`, `allowUniwindTheme`) read from lint overrides in [vite.config.ts](https://github.com/pingdotgg/t3code/pull/9300/files#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890dd)
> - Adds `ruleOptions` support to the shared lint rule test harness in [test/utils.ts](https://github.com/pingdotgg/t3code/pull/9300/files#diff-b6fa71d7a844ebce1d41f98cf5a8f3c1cb861f346b3491ec68e78011cd3ded97) and updates rule tests to cover the new option-driven behavior
> - Cleans up unnecessary `eslint-disable` / Effect diagnostic suppressions across server, desktop, and web modules; replaces the bare `offsetHeight` forced-layout read with `void offsetHeight` in [useTheme.ts](https://github.com/pingdotgg/t3code/pull/9300/files#diff-57ecb397fe0e1618fa00c5e68da8f87d74b28fa80bbe3278328f195bc91505c4)
> - Fixes `downloadContentDisposition` in [http.ts](https://github.com/pingdotgg/t3code/pull/9300/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d) to strip all Unicode control-category characters from filenames, not just the ASCII control range
> - Converts several relay and OTLP tests to the native Effect test runner instead of manually managing `ManagedRuntime` instances
> - Behavioral Change: lint now reports unused disable directives as errors; the `no-manual-effect-runtime-in-tests` rule defaults to a ceiling of zero manual runner calls; `downloadContentDisposition` strips a broader set of control characters from `Content-Disposition` filenames
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93b7ea6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->