### PR TITLE
fix(server): accept Bitbucket permission endpoint 404

### DIFF
--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -873,17 +873,17 @@ layer("BitbucketPullRequestApi.layer", (it) => {
     }),
   );
 
-  it.effect(
-    "reads a removed permissions endpoint as granted rather than failing the merge on it",
-    () =>
+  it.effect.each([404, 410])(
+    "reads a removed permissions endpoint returning %s as granted",
+    (status) =>
       Effect.gen(function* () {
         // Bitbucket retired /user/permissions/repositories under CHANGE-2770: every account now
-        // gets HTTP 410 here, whatever it may do.
+        // gets an endpoint-level error here, whatever it may do.
         mockedRequest.mockReturnValue(
           Effect.fail(
             new BitbucketApi.BitbucketResponseError({
               operation: "request",
-              status: 410,
+              status,
               responseBodyLength: 0,
             }),
           ),

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -110,12 +110,12 @@ export type BitbucketPullRequestApiError =
 
 /**
  * `/user/permissions/repositories` answering CHANGE-2770's removal notice rather than a
- * permission — Bitbucket sends this for every account now, not only ones it would have refused.
+ * permission — production has returned both 404 and 410 for the retired endpoint.
  */
 function isRepositoryPermissionRemovedError(
   error: BitbucketPullRequestApiError,
 ): error is BitbucketApi.BitbucketResponseError {
-  return error._tag === "BitbucketResponseError" && error.status === 410;
+  return error._tag === "BitbucketResponseError" && (error.status === 404 || error.status === 410);
 }
 
 /**


### PR DESCRIPTION
## Problem

Bitbucket Cloud removed `/2.0/user/permissions/repositories`, but production returns HTTP 404 while T3 only recognized HTTP 410 as the removal response. The permission preflight therefore blocks merges and other write actions before their real API calls run.

Closes #8328.

## Fix

Treat both 404 and 410 from that retired endpoint as an unavailable permission signal, preserving the existing non-blocking fallback. Other response failures still propagate. The focused test now covers both statuses.

## Testing

- `node_modules/.bin/vp test run apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts` (44 passed)
- targeted lint and formatting checks

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Bitbucket permission preflight error handling with parameterized tests; other HTTP failures still fail as before.
> 
> **Overview**
> Bitbucket’s retired `/user/permissions/repositories` check was only treated as “endpoint gone” on **HTTP 410**, while production often returns **404**, so the permission preflight failed and blocked merges and other writes before the real API ran.
> 
> **`isRepositoryPermissionRemovedError`** now matches **404 or 410**, and **`getRepositoryPermission`** still falls through to **granted** (`true`) for those cases only; other errors still propagate. Tests use **`it.effect.each([404, 410])`** so both removal responses are covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1329e1201ff2cd42bf6c4749810f4c431389e6ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->