### PR TITLE
fix(web): fall back to local mode for empty repos

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -824,9 +824,21 @@ describe("getStartedThreadModelChangeBlockReason", () => {
 });
 
 describe("resolveSendEnvMode", () => {
-  it("keeps worktree mode only for git repositories", () => {
+  it("keeps worktree mode only for repositories with a commit", () => {
+    expect(
+      resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true, branch: "main" }),
+    ).toBe("worktree");
+    expect(
+      resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true, branch: null }),
+    ).toBe("local");
+    expect(
+      resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: false, branch: null }),
+    ).toBe("local");
+  });
+
+  it("does not override the requested mode while git status is loading", () => {
+    expect(resolveSendEnvMode({ requestedEnvMode: "local", isGitRepo: true })).toBe("local");
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
-    expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: false })).toBe("local");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -458,8 +458,12 @@ export function readFileAsDataUrl(file: File): Promise<string> {
 export function resolveSendEnvMode(input: {
   requestedEnvMode: DraftThreadEnvMode;
   isGitRepo: boolean;
+  branch?: string | null;
 }): DraftThreadEnvMode {
-  return input.isGitRepo ? input.requestedEnvMode : "local";
+  if (!input.isGitRepo || (input.requestedEnvMode === "worktree" && input.branch === null)) {
+    return "local";
+  }
+  return input.requestedEnvMode;
 }
 
 export function resolveBackgroundDraftWorkspaceOptions(input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4730,6 +4730,7 @@ function ChatViewContent(props: ChatViewProps) {
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
     isGitRepo,
+    branch: gitStatusQuery.data?.refName,
   });
   const localCheckoutBranchMismatch = useMemo(
     () =>


### PR DESCRIPTION
## Problem

Empty Git repositories report as repositories but have no branch to seed a worktree. Draft submission still selected worktree mode, so the server failed creation, deleted the promoted thread, and left the user on an empty route.

Closes #2148.

## Fix

Pass the resolved Git ref into the environment-mode decision and fall back to local mode only when status has resolved with no branch. While status is still loading, the user’s requested mode is preserved.

## Test

- `vp test run apps/web/src/components/ChatView.logic.test.ts` (79 passed)
- targeted lint and formatting checks for the three changed files

Generated with GPT-5.6-sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to draft send env resolution with explicit tests; no auth or server contract changes.
> 
> **Overview**
> Fixes draft sends in **empty Git repos** (initialized but no commits): worktree mode is no longer used when git status has resolved with **no branch**, so thread creation does not fail and leave users on a broken route.
> 
> `resolveSendEnvMode` now takes an optional `branch` and forces **local** when worktree is requested but `branch === null`, in addition to non-git folders. **ChatView** passes `gitStatusQuery.data?.refName`. While status is still loading (`branch` omitted), the user’s requested env mode is left unchanged.
> 
> Tests cover repos with a branch, empty repos, non-git paths, and the loading case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd8ff2181da276e9fb26b8d2a1242b8c97e769e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->