### PR TITLE
fix(server): report missing thread workspaces

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -177,6 +177,9 @@ describe("ProviderCommandReactor", () => {
     const baseDir =
       input?.baseDir ?? NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3code-reactor-"));
     createdBaseDirs.add(baseDir);
+    const workspaceRoot = NodePath.join(baseDir, "provider-project");
+    const worktreeRoot = NodePath.join(baseDir, "provider-project-worktree");
+    NodeFS.mkdirSync(workspaceRoot, { recursive: true });
     const { stateDir } = deriveServerPathsSync(baseDir, undefined);
     createdStateDirs.add(stateDir);
     const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
@@ -290,7 +293,10 @@ describe("ProviderCommandReactor", () => {
     const pruneWorktrees = vi.fn((_: { readonly cwd: string }) => Effect.void);
     const createWorktree = vi.fn(
       (input: { readonly refName: string; readonly path: string | null }) =>
-        Effect.succeed({ worktree: { path: input.path ?? "", refName: input.refName } }),
+        Effect.sync(() => {
+          if (input.path) NodeFS.mkdirSync(input.path, { recursive: true });
+          return { worktree: { path: input.path ?? "", refName: input.refName } };
+        }),
     );
     const refreshStatus = vi.fn((_: string) =>
       Effect.succeed({
@@ -461,7 +467,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.make("cmd-project-create"),
         projectId: asProjectId("project-1"),
         title: "Provider Project",
-        workspaceRoot: "/tmp/provider-project",
+        workspaceRoot,
         defaultModelSelection: modelSelection,
         createdAt: now,
       }),
@@ -544,6 +550,8 @@ describe("ProviderCommandReactor", () => {
       generateBranchName,
       generateThreadTitle,
       runtimeSessions,
+      workspaceRoot,
+      worktreeRoot,
       stateDir,
       drain,
       runEffect,
@@ -578,7 +586,7 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     expect(harness.startSession.mock.calls[0]?.[0]).toEqual(ThreadId.make("thread-1"));
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: harness.workspaceRoot,
       modelSelection: {
         instanceId: ProviderInstanceId.make("codex"),
         model: "gpt-5-codex",
@@ -591,6 +599,50 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("reports a missing workspace before starting the provider", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    NodeFS.rmSync(harness.workspaceRoot, { recursive: true });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-missing-workspace"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-missing-workspace"),
+          role: "user",
+          text: "continue in moved workspace",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await harness.readModel();
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      return thread?.session?.status === "error";
+    });
+
+    expect(harness.startSession).not.toHaveBeenCalled();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.lastError).toBe(
+      `This thread's workspace folder no longer exists: '${harness.workspaceRoot}'. Restore the folder before retrying.`,
+    );
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toMatchObject({
+      payload: {
+        detail: expect.stringContaining(harness.workspaceRoot),
+      },
+    });
   });
 
   effectIt.effect("retains a turn dispatched immediately after start until activation", () =>
@@ -869,7 +921,7 @@ describe("ProviderCommandReactor", () => {
 
     expect(harness.generateThreadTitle).toHaveBeenCalledTimes(1);
     expect(harness.generateThreadTitle.mock.calls[0]?.[0]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: harness.workspaceRoot,
       previousTitle: "Investigate reconnect regressions",
       message: [
         "USER:",
@@ -1597,7 +1649,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.make("cmd-thread-branch"),
         threadId: ThreadId.make("thread-1"),
         branch: "t3code/1234abcd",
-        worktreePath: "/tmp/provider-project-worktree",
+        worktreePath: harness.worktreeRoot,
       }),
     );
 
@@ -1639,7 +1691,7 @@ describe("ProviderCommandReactor", () => {
       `Add a safer reconnect backoff. ${assistantQuoteText}`,
     );
     expect(harness.generateBranchName.mock.calls[0]?.[0].message).not.toContain("t3-citation://");
-    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe(harness.worktreeRoot);
     const readModel = await harness.readModel();
     expect(
       readModel.threads
@@ -1681,9 +1733,9 @@ describe("ProviderCommandReactor", () => {
     );
 
     await waitFor(() => harness.startSession.mock.calls.length === 1);
-    expect(harness.pruneWorktrees).toHaveBeenCalledWith({ cwd: "/tmp/provider-project" });
+    expect(harness.pruneWorktrees).toHaveBeenCalledWith({ cwd: harness.workspaceRoot });
     expect(harness.createWorktree).toHaveBeenCalledWith({
-      cwd: "/tmp/provider-project",
+      cwd: harness.workspaceRoot,
       refName: "feature/restore",
       path: worktreePath,
     });
@@ -2182,15 +2234,16 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: harness.workspaceRoot,
     });
+    NodeFS.mkdirSync(harness.worktreeRoot, { recursive: true });
 
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.meta.update",
         commandId: CommandId.make("cmd-thread-worktree-change"),
         threadId: ThreadId.make("thread-1"),
-        worktreePath: "/tmp/provider-project-worktree",
+        worktreePath: harness.worktreeRoot,
       }),
     );
 
@@ -2216,7 +2269,7 @@ describe("ProviderCommandReactor", () => {
     expect(harness.stopSession.mock.calls.length).toBe(0);
     expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
-      cwd: "/tmp/provider-project-worktree",
+      cwd: harness.worktreeRoot,
       resumeCursor: { opaque: "resume-1" },
       modelSelection: {
         instanceId: ProviderInstanceId.make("claudeAgent"),
@@ -2961,7 +3014,7 @@ describe("ProviderCommandReactor", () => {
       status: "ready",
       runtimeMode: "approval-required",
       threadId: ThreadId.make("thread-1"),
-      cwd: "/tmp/provider-project",
+      cwd: harness.workspaceRoot,
       resumeCursor: { opaque: "resume-without-instance" },
       createdAt: now,
       updatedAt: now,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -657,6 +657,13 @@ const make = Effect.gen(function* () {
       thread,
       projects: project ? [project] : [],
     });
+    if (effectiveCwd && !(yield* fileSystem.exists(effectiveCwd))) {
+      return yield* new ProviderAdapterRequestError({
+        provider: preferredProvider,
+        method: "thread.turn.start",
+        detail: `This thread's workspace folder no longer exists: '${effectiveCwd}'. Restore the folder before retrying.`,
+      });
+    }
     const refreshWorkspaceSnapshot = effectiveCwd
       ? providerRegistry
           .refreshWorkspaceSnapshot({ instanceId: desiredInstanceId, cwd: effectiveCwd })


### PR DESCRIPTION
## Problem

When a project folder moves or a thread points at a deleted worktree, provider startup wraps the missing-directory error as a provider process failure. Users are told that Codex or Claude failed even though the configured workspace path is the real problem.

Closes #4940.

## Fix

Validate the resolved thread workspace in the shared provider reactor before starting a session. A missing folder now records an actionable turn-start failure with the exact path, consistently across every provider, and no provider process is launched.

The test harness now creates real temporary workspace directories so its provider-start fixtures continue to model valid workspaces.

## Test

- `vp test run apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts` (52 passed)
- targeted lint and formatting checks for the two changed files

Generated with GPT-5.6-sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small pre-flight guard on the shared turn-start path; fails closed without launching providers and is covered by a targeted reactor test.
> 
> **Overview**
> Turn starts now **fail fast with a clear workspace error** when the thread’s resolved cwd (project root or worktree) is missing, instead of starting Codex/Claude and surfacing a misleading provider failure.
> 
> In `ProviderCommandReactor`, `ensureSessionForThread` checks `fileSystem.exists(effectiveCwd)` after resolving the workspace and returns a `ProviderAdapterRequestError` with the path and “restore the folder” guidance. That flows through the existing turn-start failure handling (session `error`, `lastError`, `provider.turn.start.failed` activity) **without** calling `startSession` or `sendTurn`.
> 
> Tests use **real temp workspace/worktree dirs** in the harness (replacing hardcoded `/tmp/...` paths), and a new case deletes the workspace and asserts the missing-folder behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3333b9acbe44bc1bec7bd9ec53ab16f0c411165c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->