### PR TITLE
fix(web): stop remounting markdown on every activity delta

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -626,7 +626,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       listRef,
       timestampFormat,
       routeThreadKey,
-      threadRef: parseScopedThreadKey(routeThreadKey),
+      // Must be referentially stable: ChatMarkdown keys its react-markdown
+      // component map on threadRef, and a fresh object here remounts every
+      // rendered markdown node whenever this memo recomputes (e.g. on each
+      // activity delta while the thread is working).
+      threadRef: citationThreadRef,
       markdownCwd,
       resolvedTheme,
       workspaceRoot,
@@ -650,6 +654,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       listRef,
       timestampFormat,
       routeThreadKey,
+      citationThreadRef,
       markdownCwd,
       resolvedTheme,
       workspaceRoot,


### PR DESCRIPTION
## Problem

Selecting assistant text on a **working** thread and clicking "Cite" was flaky: the selection would walk up one block at a time every ~250ms and the toolbar vanished within about a second. Idle threads were fine.

The selection endpoints were being destroyed. `MessagesTimeline`'s `sharedState` memo built a fresh `threadRef` via `parseScopedThreadKey(routeThreadKey)` on every recompute, and it recomputes on every activity delta (`agentPanelModel` derives from `threadActivities`). `ChatMarkdown` keys its react-markdown `components` map on `threadRef`, and react-markdown uses those functions as React element *types*, so a new identity remounted every `<p>`/`<pre>`/`<code>` in every visible assistant message. Chrome repairs a selection whose nodes were removed to the nearest boundary, hence the one-block-per-tick walk.

This predates the cite feature; it was already re-creating shiki blocks and chips on every delta.

## Fix

Reuse the already-memoized `citationThreadRef` so `ChatMarkdown`'s props stay referentially stable and its `memo` bails out on activity ticks.

Verified with `vp lint`, `apps/web` typecheck, and the `MessagesTimeline` tests (114 passing).

---

Claude Fable 5 via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix reusing an existing memoized value; no API or security changes, with tests already noted as passing.
> 
> **Overview**
> Fixes flaky assistant text selection and **Cite** on **working** threads by keeping `threadRef` referentially stable in timeline row shared context.
> 
> **`MessagesTimeline`** no longer calls `parseScopedThreadKey(routeThreadKey)` inside the `sharedState` memo (which recomputes on each activity tick via `agentPanelModel`). It now passes the existing memoized **`citationThreadRef`** into context so **`ChatMarkdown`** props stay stable, react-markdown does not treat new component types on every delta, and assistant markdown blocks are not remounted while the agent is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3883a3febac37996dc36510ddf2e49239c6b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop remounting markdown in `MessagesTimeline` on activity delta
> The shared timeline state now uses the existing `citationThreadRef` instead of building a new object from `parseScopedThreadKey(routeThreadKey)`. `citationThreadRef` is added to the `useMemo` dependency list so its stable reference carries across activity-driven recomputations. This keeps `ChatMarkdown`'s component map from being recreated on every update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff3883a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->