### PR TITLE
fix(web): send cited messages with Cmd+Enter

### DIFF
--- a/apps/web/src/components/ComposerCitationNode.tsx
+++ b/apps/web/src/components/ComposerCitationNode.tsx
@@ -47,7 +47,8 @@ export type ComposerCitationCommentTarget = {
 export const ComposerCitationCommentContext = createContext<{
   openComment: ComposerCitationCommentTarget | null;
   onOpenChange: (nodeKey: NodeKey, open: boolean) => void;
-}>({ openComment: null, onOpenChange: () => {} });
+  onSubmitAndSend: () => void;
+}>({ openComment: null, onOpenChange: () => {}, onSubmitAndSend: () => {} });
 
 /** Consume a cite action once its controlled prompt has been committed to the editor. */
 export function $consumeComposerCitationCommentRequest(requestRef: {
@@ -127,6 +128,11 @@ function ComposerCitationDecorator(props: { citation: AssistantCitation; nodeKey
             commentContext.onOpenChange(props.nodeKey, open);
           },
           onSave: onSaveComment,
+          onSaveAndSend: (comment) => {
+            if (!onSaveComment(comment)) return false;
+            commentContext.onSubmitAndSend();
+            return true;
+          },
         }}
         onRemove={onRemove}
       />

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -924,6 +924,7 @@ interface ComposerPromptEditorProps {
   onPageScrollKeyDown?: (key: "PageUp" | "PageDown") => void;
   onPageScrollKeyUp?: (key: string) => void;
   onPageScrollRelease?: () => void;
+  onCitationSubmitAndSend?: () => void;
   onPaste: React.ClipboardEventHandler<HTMLElement>;
   editorRef: React.RefObject<ComposerPromptEditorHandle | null>;
 }
@@ -1571,6 +1572,7 @@ function ComposerPromptEditorInner({
   onPageScrollKeyDown,
   onPageScrollKeyUp,
   onPageScrollRelease,
+  onCitationSubmitAndSend,
   onPaste,
   editorRef,
 }: ComposerPromptEditorProps) {
@@ -1603,8 +1605,9 @@ function ComposerPromptEditorInner({
           open ? { nodeKey } : current?.nodeKey === nodeKey ? null : current,
         );
       },
+      onSubmitAndSend: onCitationSubmitAndSend ?? (() => {}),
     }),
-    [openCitationComment],
+    [onCitationSubmitAndSend, openCitationComment],
   );
   const terminalContextActions = useMemo(
     () => ({ onRemoveTerminalContext }),
@@ -1969,6 +1972,7 @@ export function ComposerPromptEditor({
   onPageScrollKeyDown,
   onPageScrollKeyUp,
   onPageScrollRelease,
+  onCitationSubmitAndSend,
   onPaste,
   editorRef,
 }: ComposerPromptEditorProps) {
@@ -2013,6 +2017,7 @@ export function ComposerPromptEditor({
         onChange={onChange}
         {...(onVisibleSelectionChange ? { onVisibleSelectionChange } : {})}
         onPaste={onPaste}
+        {...(onCitationSubmitAndSend ? { onCitationSubmitAndSend } : {})}
         editorRef={editorRef}
         {...(onCommandKeyDown ? { onCommandKeyDown } : {})}
         {...(onPageScrollKeyDown ? { onPageScrollKeyDown } : {})}

--- a/apps/web/src/components/chat/AssistantCitationChip.tsx
+++ b/apps/web/src/components/chat/AssistantCitationChip.tsx
@@ -42,6 +42,7 @@ export function AssistantCitationChip({
     sourceAnchor?: AssistantCitationSourceAnchor | undefined;
     onOpenChange: (open: boolean) => void;
     onSave: (comment: string) => boolean;
+    onSaveAndSend?: (comment: string) => boolean;
   };
 }) {
   const navigate = useNavigate();
@@ -158,6 +159,15 @@ export function AssistantCitationChip({
                   commentEditor.onOpenChange(false);
                   return true;
                 }}
+                {...(commentEditor.onSaveAndSend
+                  ? {
+                      onSubmitAndSend: (comment: string) => {
+                        if (!commentEditor.onSaveAndSend?.(comment)) return false;
+                        commentEditor.onOpenChange(false);
+                        return true;
+                      },
+                    }
+                  : {})}
                 onCancel={() => commentEditor.onOpenChange(false)}
               />
             </PopoverPopup>

--- a/apps/web/src/components/chat/AssistantCitationCommentEditor.tsx
+++ b/apps/web/src/components/chat/AssistantCitationCommentEditor.tsx
@@ -7,17 +7,27 @@ export function AssistantCitationCommentEditor({
   citation,
   inputRef,
   onSubmit,
+  onSubmitAndSend,
   onCancel,
 }: {
   citation: AssistantCitation;
   inputRef?: Ref<HTMLTextAreaElement>;
   onSubmit: (comment: string) => boolean;
+  onSubmitAndSend?: (comment: string) => boolean;
   onCancel: () => void;
 }) {
   const [comment, setComment] = useState(citation.comment ?? "");
   const commentTooLong = comment.length > ASSISTANT_CITATION_MAX_COMMENT_LENGTH;
   const submit = () => {
     if (!commentTooLong) onSubmit(comment);
+  };
+  const submitAndSend = () => {
+    if (commentTooLong) return;
+    if (onSubmitAndSend) {
+      onSubmitAndSend(comment);
+    } else {
+      onSubmit(comment);
+    }
   };
 
   return (
@@ -35,7 +45,7 @@ export function AssistantCitationCommentEditor({
       <textarea
         ref={inputRef}
         aria-label="Comment on selected text"
-        aria-description="Enter to save the citation comment; Shift+Enter for a new line."
+        aria-description="Enter to save the citation comment; Command/Ctrl+Enter to save and send; Shift+Enter for a new line."
         aria-invalid={commentTooLong || undefined}
         placeholder="Add an optional comment..."
         rows={2}
@@ -50,7 +60,11 @@ export function AssistantCitationCommentEditor({
             event.keyCode !== 229
           ) {
             event.preventDefault();
-            submit();
+            if (event.metaKey || event.ctrlKey) {
+              submitAndSend();
+            } else {
+              submit();
+            }
           }
         }}
       />

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2824,6 +2824,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       shouldBlurMobileComposerOnSubmit,
     ],
   );
+  const submitCitationAndSend = useCallback(() => {
+    const intent = composerSubmissionIntentForEnter({
+      isMobileViewport,
+      shiftKey: false,
+      modifierKey: true,
+      isDraftThread: routeKind === "draft",
+    });
+    submitComposer(undefined, intent ?? "foreground");
+  }, [isMobileViewport, routeKind, submitComposer]);
   const compactThreadContext = useCallback(() => {
     if (
       compactDisabled ||
@@ -5246,6 +5255,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   onPageScrollKeyDown={onPageScrollKeyDown}
                   onPageScrollKeyUp={onPageScrollKeyUp}
                   onPageScrollRelease={onPageScrollRelease}
+                  onCitationSubmitAndSend={submitCitationAndSend}
                   onPaste={onComposerPaste}
                   placeholder={
                     isComposerApprovalState


### PR DESCRIPTION
## Summary
The citation comment box could save a citation into the composer, but could not submit the resulting message. Cmd/Ctrl+Enter now saves the citation and sends the full composer message.

## Verification
- Web typecheck
- Targeted lint and formatting
- 65 targeted composer tests
- Actual interaction test through the browser

No visual changes; this is keyboard behavior only.

Generated with GPT-5.6 in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard-only composer UX change that delegates sending to the existing `submitComposer` path; no auth, API, or data-model changes.
> 
> **Overview**
> Citation comment popovers in the composer could persist a comment on the chip but had no way to send the message afterward. **Cmd/Ctrl+Enter** now saves the comment and submits the full composer; plain **Enter** still saves without sending, and **Shift+Enter** still inserts a newline.
> 
> The flow adds optional `onSubmitAndSend` / `onSaveAndSend` hooks from `AssistantCitationCommentEditor` through `AssistantCitationChip`, `ComposerCitationCommentContext`, and `ComposerPromptEditor` into `ChatComposer`, where `submitCitationAndSend` reuses `composerSubmissionIntentForEnter` (modifier + non-draft rules) and calls `submitComposer`. The chip popover only closes when save or save-and-send callbacks return success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914daffdeab5a3d752b33265e760e2e41a20e2aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Cmd+Enter` send action to citation comments in web composer
> - Adds an `onSubmitAndSend` callback to `AssistantCitationCommentEditor` triggered by `Cmd/Ctrl+Enter` (without Shift); plain `Enter` still saves the comment without sending.
> - Threads the callback through `ComposerPromptEditor` and the citation node context so citation editors inside the composer receive the send action.
> - Implements `submitCitationAndSend` in `ChatComposer` to compute the submission intent and invoke `submitComposer`.
> - Behavioral Change: `AssistantCitationChip` popover now stays open if the `onSaveAndSend` callback reports failure, instead of closing immediately after save.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 914daff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->