### PR TITLE
fix(web): key ChatMarkdown renderers on thread ids, not object identity

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1977,7 +1977,7 @@ function areMarkdownFileLinkPropsEqual(
 function ChatMarkdown({
   text,
   cwd,
-  threadRef,
+  threadRef: threadRefProp,
   environmentId: explicitEnvironmentId,
   onTaskListChange,
   isStreaming = false,
@@ -1990,6 +1990,14 @@ function ChatMarkdown({
   onImageExpand,
   extraRemarkPlugins = EMPTY_REMARK_PLUGINS,
 }: ChatMarkdownProps) {
+  // Key threadRef on its ids, not its identity. The react-markdown component
+  // map below depends on it, and react-markdown uses those renderers as
+  // element types, so a fresh-but-equal object from a caller would remount
+  // every rendered node (and destroy any native text selection inside).
+  const threadRef = useMemo(
+    () => threadRefProp,
+    [threadRefProp?.environmentId, threadRefProp?.threadId],
+  );
   const { resolvedTheme } = useTheme();
   const [localMediaPreview, setLocalMediaPreview] = useState<ExpandedImagePreview | null>(null);
   const expandMedia = onImageExpand ?? setLocalMediaPreview;


### PR DESCRIPTION
## Problem

Follow-up to #9306. `ChatMarkdown`'s `markdownComponents` memo depends on `threadRef`, and react-markdown uses those renderer functions as React element *types*. Any caller that passes a fresh-but-equal `threadRef` object therefore remounts every rendered `<p>`/`<pre>`/`<code>` in the message — which is what was destroying native text selections and dropping the cite toolbar on working threads. #9306 fixed the one caller doing that, but the component stayed one careless `parseScopedThreadKey(...)` away from regressing.

## Fix

Memoize `threadRef` on `environmentId` + `threadId` at the top of `ChatMarkdown`, before anything downstream depends on it. Every existing use (`markdownComponents`, the PR-link callbacks, the media effect, the child memo comparators) now sees a stable object as long as the ids are unchanged, regardless of what the caller passes.

Verified with `vp lint`, `apps/web` typecheck, and the `ChatMarkdown` tests (69 passing).

---

Claude Fable 5 via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized React memoization in chat markdown rendering with no auth, data, or API changes.
> 
> **Overview**
> **Stabilizes `threadRef` inside `ChatMarkdown`** so react-markdown does not treat every new object reference as a renderer change and remount the whole message tree (which was clearing native text selection and breaking the cite toolbar).
> 
> The prop is renamed to `threadRefProp` and wrapped in `useMemo` keyed on `environmentId` and `threadId`. Downstream logic (`markdownComponents`, PR-link handlers, media preview, effects) keeps the same API but sees a stable reference while the scoped thread is unchanged, even if parents pass a freshly allocated `ScopedThreadRef` each render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834f8072827322f0264717e79223d5c11120c5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ChatMarkdown` to key renderers on thread IDs, not object identity
> Memoizes the thread reference inside `ChatMarkdown` using environment and thread IDs so an equivalent-but-new thread object does not create a new renderer identity. This preserves native text selections inside rendered markdown nodes across re-renders when the IDs are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 834f807.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->