### PR TITLE
fix(server): authenticate Azure DevOps comment reads

### DIFF
--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -543,10 +543,18 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
       });
 
       assert.strictEqual(comments.length, 1);
-      expect(argsOfCall(0)).toContain("rest");
-      expect(argsOfCall(0)).toContain(
+      expect(argsOfCall(0)).toEqual([
+        "rest",
+        "--method",
+        "get",
+        "--url",
         "https://dev.azure.com/acme/platform/_apis/git/r/web/pullRequests/42/threads?api-version=7.1",
-      );
+        "--resource",
+        "499b84ac-1321-427f-aa17-267ca6975798",
+        "--only-show-errors",
+        "--output",
+        "json",
+      ]);
     }),
   );
 

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -111,6 +111,7 @@ export type AzureDevOpsPullRequestCliError =
 
 /** The version every REST call below is pinned to, so a new default cannot reshape a response. */
 const REST_API_VERSION = "7.1";
+const AZURE_DEVOPS_RESOURCE_ID = "499b84ac-1321-427f-aa17-267ca6975798";
 const PULL_REQUEST_LIST_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 
 export class AzureDevOpsPullRequestCli extends Context.Service<
@@ -455,6 +456,8 @@ export const make = Effect.gen(function* () {
           "get",
           "--url",
           `${input.threadsUrl}?api-version=${REST_API_VERSION}`,
+          "--resource",
+          AZURE_DEVOPS_RESOURCE_ID,
         ],
       }).pipe(
         Effect.flatMap((result) => {


### PR DESCRIPTION
Azure DevOps comment-thread reads use `az rest` without identifying the Azure DevOps token resource. This fix passes the documented resource ID to the existing request and verifies the complete command arguments.

Addresses the comment-authentication portion of [#8078](https://github.com/pingdotgg/t3code/issues/8078). Microsoft's [Azure DevOps CLI guidance](https://learn.microsoft.com/en-us/azure/devops/cli/azure-devops-cli-in-yaml?view=azure-devops) uses this resource for `az rest` requests.

Verification on current main [a5bbad910](https://github.com/pingdotgg/t3code/commit/a5bbad910f78cc14eef8baa94fe6f46676f78d5a):

- The regression fails against the unchanged production implementation. The captured arguments lack `--resource 499b84ac-1321-427f-aa17-267ca6975798`.
- The revised request retains its URL, API version, HTTP method, and JSON-output flags. No request destination or provider data model changes.
- `vp test run apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts apps/server/src/pullRequest/azureDevOpsPullRequestJson.test.ts apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts --maxWorkers=2`: 59 tests pass. Targeted lint, formatting, and the server typecheck pass.

Human authentication review and a live authenticated Azure DevOps check are still required. The local fixture proves command construction, not the reporter's HTML sign-in response or a successful live token exchange. [#8364](https://github.com/pingdotgg/t3code/pull/8364) proposes a different, broader authentication route; choose the intended path before landing either. This PR must not auto-merge.

All CI jobs that ran pass on [a7c458fe](https://github.com/pingdotgg/t3code/commit/a7c458fe1784706ad1201a30854db02d9cf5b719), including Bugbot. No unresolved inline review threads. These checks do not clear the authentication review or live-account evidence gates above.

Original implementation by Michel Liao. Updated verification and preparation by GPT 6 Astra via Codex in T3 Code.
