### PR TITLE
fix(server): heal skipped 045 and warn on migration slot collisions

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -10,6 +10,7 @@
 
 import * as Migrator from "effect/unstable/sql/Migrator";
 import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 // Import all migrations statically
 import Migration0001 from "./Migrations/001_OrchestrationEvents.ts";
@@ -58,6 +59,7 @@ import Migration0043 from "./Migrations/043_ProjectionThreadsUnsettledAt.ts";
 import Migration0044 from "./Migrations/044_ClearAutomaticProjectModelDefaults.ts";
 import Migration0045 from "./Migrations/045_ProjectionProjectsAutoPull.ts";
 import Migration0046 from "./Migrations/046_RepairAutomaticSettlementTimestamps.ts";
+import Migration0047 from "./Migrations/047_EnsureProjectionProjectsAutoPull.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -116,6 +118,7 @@ export const migrationEntries = [
   [44, "ClearAutomaticProjectModelDefaults", Migration0044],
   [45, "ProjectionProjectsAutoPull", Migration0045],
   [46, "RepairAutomaticSettlementTimestamps", Migration0046],
+  [47, "EnsureProjectionProjectsAutoPull", Migration0047],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);
@@ -140,6 +143,40 @@ export interface RunMigrationsOptions {
 }
 
 /**
+ * Warn about migration slots the journal recorded under a different name.
+ *
+ * effect's Migrator skips every migration at or below the highest recorded ID
+ * without comparing names, so a slot claimed by another line (fork, nightly,
+ * renumbered branch) silently disables this checkout's migration and leaves
+ * the schema behind the code (#8896). This is the production counterpart of
+ * the hard failure in scripts/migrate-dev-db.ts: loud, but non-fatal, because
+ * refusing to start would brick databases that are otherwise healed (e.g. by
+ * repair migrations like 047).
+ */
+const warnOnMigrationSlotCollisions = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const applied = yield* sql<{ readonly migration_id: number; readonly name: string }>`
+    SELECT migration_id, name FROM effect_sql_migrations
+  `;
+  const appliedById = new Map(applied.map((row) => [Number(row.migration_id), row.name]));
+  const collisions = migrationManifest
+    .filter(([slot, codeName]) => {
+      const appliedName = appliedById.get(slot);
+      return appliedName !== undefined && appliedName !== codeName;
+    })
+    .map(
+      ([slot, codeName]) => `${slot} (journal: '${appliedById.get(slot)}', code: '${codeName}')`,
+    );
+  if (collisions.length > 0) {
+    yield* Effect.logWarning(
+      `Migration slot collision: this database recorded different migrations under ${collisions.join(
+        ", ",
+      )}. The affected migrations were skipped; the schema may be behind the code. See https://github.com/pingdotgg/t3code/issues/8896`,
+    );
+  }
+});
+
+/**
  * Run all pending migrations.
  *
  * Creates the migrations tracking table (effect_sql_migrations) if it doesn't exist,
@@ -153,6 +190,7 @@ export const runMigrations = Effect.fn("runMigrations")(function* ({
   toMigrationInclusive,
 }: RunMigrationsOptions = {}) {
   const executedMigrations = yield* run({ loader: makeMigrationLoader(toMigrationInclusive) });
+  yield* warnOnMigrationSlotCollisions;
   const migrations = executedMigrations.map(([id, name]) => `${id}_${name}`);
   yield* migrations.length === 0
     ? Effect.logDebug("Database schema is current")

--- a/apps/server/src/persistence/Migrations/047_EnsureProjectionProjectsAutoPull.test.ts
+++ b/apps/server/src/persistence/Migrations/047_EnsureProjectionProjectsAutoPull.test.ts
@@ -1,0 +1,60 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "@t3tools/shared/nodeSqliteClient";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("047_EnsureProjectionProjectsAutoPull", (it) => {
+  it.effect("heals databases whose 045 was skipped by a slot collision", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      // Migrate to just before 045, then simulate a foreign line that claimed
+      // ID 45 first: the journal row exists, the column does not. The
+      // Migrator's max-ID logic then skips the real 045 forever (#8896).
+      yield* runMigrations({ toMigrationInclusive: 44 });
+      yield* sql`INSERT INTO effect_sql_migrations (migration_id, name) VALUES (45, 'SomethingElse')`;
+
+      yield* runMigrations();
+
+      const columns = yield* sql<{ readonly name: string; readonly notnull: number }>`
+        PRAGMA table_info(projection_projects)
+      `;
+      const autoPull = columns.find((column) => column.name === "auto_pull");
+      assert.equal(autoPull?.name, "auto_pull");
+      assert.equal(autoPull?.notnull, 1);
+
+      // Healing is recorded and repeat runs stay green.
+      const journal = yield* sql<{ readonly migration_id: number; readonly name: string }>`
+        SELECT migration_id, name FROM effect_sql_migrations WHERE migration_id = 47
+      `;
+      assert.deepStrictEqual(journal, [
+        { migration_id: 47, name: "EnsureProjectionProjectsAutoPull" },
+      ]);
+
+      yield* runMigrations();
+      const rerun = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(projection_projects)
+      `;
+      assert.isTrue(rerun.some((column) => column.name === "auto_pull"));
+    }),
+  );
+
+  it.effect("is a no-op when auto_pull already exists", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 46 });
+      yield* runMigrations();
+
+      const columns = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(projection_projects)
+      `;
+      assert.equal(columns.filter((column) => column.name === "auto_pull").length, 1);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/047_EnsureProjectionProjectsAutoPull.ts
+++ b/apps/server/src/persistence/Migrations/047_EnsureProjectionProjectsAutoPull.ts
@@ -1,0 +1,26 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+// Repair migration for databases whose 045 was silently skipped.
+//
+// effect's Migrator only runs migrations with an ID above the highest recorded
+// one and never compares names, so any line that occupied ID 45 first (a fork,
+// a nightly, a renumbered branch) marks 045_ProjectionProjectsAutoPull as done
+// without running it. Every project query then fails with
+// "no such column: auto_pull" and the backend crash-loops at startup (#8896).
+//
+// Idempotent: adds the column only when absent, so it is a no-op on healthy
+// databases. Safe to keep forever.
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_projects)
+  `;
+
+  if (!columns.some((column) => column.name === "auto_pull")) {
+    yield* sql`
+      ALTER TABLE projection_projects
+      ADD COLUMN auto_pull INTEGER NOT NULL DEFAULT 0
+    `;
+  }
+});


### PR DESCRIPTION
Fix #8896

Databases whose journal already occupied ID 45 (forks, nightlies, renumbered branches) silently skip 045_ProjectionProjectsAutoPull: effect's Migrator only runs IDs above the highest recorded one and never compares names. Every project query then fails with `no such column: auto_pull` and the backend crash-loops at startup without opening a window — the migrator half of #8896, reproduced again by nightly 0.0.39 after #9277.

This adds idempotent repair migration 047 (`047_EnsureProjectionProjectsAutoPull`) that adds the column only when absent, so it heals affected databases and is a no-op everywhere else. It also logs a loud non-fatal warning naming collided slots on every `runMigrations` — the production counterpart of the hard failure in `scripts/migrate-dev-db.ts`. Deliberately non-fatal: refusing to start would brick databases that are otherwise healed (e.g. by this repair migration).

Tests: new `047_EnsureProjectionProjectsAutoPull.test.ts` encodes the collision (journal claims 45 under another name, column absent) plus the healthy no-op case; neighboring migration tests (027, 040–042, 046) still pass, typecheck and lint/fmt clean.

Built and verified with OpenCode + Muse Spark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQLite schema repair at startup and migration journal behavior; low blast radius (one column, idempotent) but affects every database boot and could mask other slot collisions via warnings only.
> 
> **Overview**
> Addresses startup crash-loops when `projection_projects.auto_pull` is missing because migration **045** was never applied: Effect’s migrator treats any journal row at ID 45 as “done,” so a fork/nightly that claimed slot 45 under another name permanently skips the real `ProjectionProjectsAutoPull` migration (#8896).
> 
> Adds **047_EnsureProjectionProjectsAutoPull**, an idempotent repair that adds `auto_pull` only when absent (no-op on healthy DBs). Registers it in the migration manifest and wires **`warnOnMigrationSlotCollisions`** into `runMigrations` so production logs a non-fatal warning listing slots where the journal name disagrees with this checkout—loud visibility without refusing startup, since repair migrations can still heal the schema.
> 
> New tests simulate the collision (fake journal row at 45, column missing) and confirm healing plus repeat-run safety, plus the healthy no-op path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7464886e7021bc04d4493b76ecae1bb8f269d283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration 047 to heal skipped 045 and warn on slot collisions
> - Adds migration 047 to idempotently add the `auto_pull` column with `NOT NULL DEFAULT 0` to `projection_projects` if it is absent, repairing databases that skipped migration 045.
> - Introduces `warnOnMigrationSlotCollisions` which compares journal entries in `effect_sql_migrations` against the current manifest and emits a non-fatal warning if slot names differ.
> - Behavioral Change: `runMigrations` now logs a warning when existing migration journal rows use different names for the same numeric slot.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7464886. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->