### PR TITLE
fix(sidebar): collapse settled and snoozed shelves by default

### DIFF
--- a/apps/mobile/src/features/threads/use-thread-list-v2-shelf-preferences.ts
+++ b/apps/mobile/src/features/threads/use-thread-list-v2-shelf-preferences.ts
@@ -14,9 +14,9 @@ export function useThreadListV2ShelfPreferences() {
   const savePreferences = useAtomSet(updateMobilePreferencesAtom);
   const loaded = AsyncResult.isSuccess(preferencesResult);
   const snoozedShelfExpanded =
-    loaded && preferencesResult.value.threadListV2SnoozedShelfExpanded === true;
+    loaded && preferencesResult.value.threadListSnoozedShelfExpanded === true;
   const settledShelfExpanded =
-    !loaded || preferencesResult.value.threadListV2SettledShelfExpanded !== false;
+    loaded && preferencesResult.value.threadListSettledShelfExpanded === true;
   const snoozedShelfExpandedRef = useRef(snoozedShelfExpanded);
   const settledShelfExpandedRef = useRef(settledShelfExpanded);
   snoozedShelfExpandedRef.current = snoozedShelfExpanded;
@@ -26,13 +26,13 @@ export function useThreadListV2ShelfPreferences() {
     if (!loaded) return;
     const expanded = !snoozedShelfExpandedRef.current;
     snoozedShelfExpandedRef.current = expanded;
-    savePreferences({ threadListV2SnoozedShelfExpanded: expanded });
+    savePreferences({ threadListSnoozedShelfExpanded: expanded });
   }, [loaded, savePreferences]);
   const toggleSettledShelf = useCallback(() => {
     if (!loaded) return;
     const expanded = !settledShelfExpandedRef.current;
     settledShelfExpandedRef.current = expanded;
-    savePreferences({ threadListV2SettledShelfExpanded: expanded });
+    savePreferences({ threadListSettledShelfExpanded: expanded });
   }, [loaded, savePreferences]);
 
   return {

--- a/apps/mobile/src/lib/storage.test.ts
+++ b/apps/mobile/src/lib/storage.test.ts
@@ -213,33 +213,35 @@ describe("mobile connection storage", () => {
     expect(fallback.updatedAt).toEqual(expect.any(Number));
   });
 
-  it("persists Thread List v2 shelf expansion preferences", async () => {
+  it("persists thread list shelf expansion preferences", async () => {
     await expect(
       savePreferencesPatch({
-        threadListV2SettledShelfExpanded: false,
-        threadListV2SnoozedShelfExpanded: true,
+        threadListSettledShelfExpanded: false,
+        threadListSnoozedShelfExpanded: true,
       }),
     ).resolves.toEqual({
-      threadListV2SettledShelfExpanded: false,
-      threadListV2SnoozedShelfExpanded: true,
+      threadListSettledShelfExpanded: false,
+      threadListSnoozedShelfExpanded: true,
     });
 
     await expect(loadPreferences()).resolves.toEqual({
-      threadListV2SettledShelfExpanded: false,
-      threadListV2SnoozedShelfExpanded: true,
+      threadListSettledShelfExpanded: false,
+      threadListSnoozedShelfExpanded: true,
     });
     expect(JSON.parse(mocks.getPreferencesJson() ?? "")).toEqual({
-      threadListV2SettledShelfExpanded: false,
-      threadListV2SnoozedShelfExpanded: true,
+      threadListSettledShelfExpanded: false,
+      threadListSnoozedShelfExpanded: true,
     });
   });
 
-  it("ignores invalid Thread List v2 shelf expansion preference types", async () => {
+  it("drops legacy and invalid thread list shelf expansion preferences", async () => {
     mocks.setPreferencesJson(
       JSON.stringify({
         baseFontSize: 17,
-        threadListV2SettledShelfExpanded: "false",
-        threadListV2SnoozedShelfExpanded: 1,
+        threadListV2SettledShelfExpanded: true,
+        threadListV2SnoozedShelfExpanded: true,
+        threadListSettledShelfExpanded: "false",
+        threadListSnoozedShelfExpanded: 1,
       }),
       10,
     );

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -41,10 +41,9 @@ export interface Preferences {
   readonly legacyThreadListEnabled?: boolean;
   /** Device-local counterpart of desktop's `planModeEnabled` legacy flag. */
   readonly planModeEnabled?: boolean;
-  /** Undefined preserves the default expanded Settled shelf. */
-  readonly threadListV2SettledShelfExpanded?: boolean;
-  /** Undefined preserves the default collapsed Snoozed shelf. */
-  readonly threadListV2SnoozedShelfExpanded?: boolean;
+  /** Fresh keys reset both shelves to collapsed when users update. */
+  readonly threadListSettledShelfExpanded?: boolean;
+  readonly threadListSnoozedShelfExpanded?: boolean;
 }
 
 export class MobilePreferencesLoadError extends Schema.TaggedErrorClass<MobilePreferencesLoadError>()(
@@ -102,8 +101,8 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     projectGroupingMode?: SidebarProjectGroupingMode;
     legacyThreadListEnabled?: boolean;
     planModeEnabled?: boolean;
-    threadListV2SettledShelfExpanded?: boolean;
-    threadListV2SnoozedShelfExpanded?: boolean;
+    threadListSettledShelfExpanded?: boolean;
+    threadListSnoozedShelfExpanded?: boolean;
   } = {};
 
   if (typeof parsed.liveActivitiesEnabled === "boolean") {
@@ -171,11 +170,11 @@ function sanitizePreferences(parsed: Preferences): Preferences {
   if (typeof parsed.planModeEnabled === "boolean") {
     preferences.planModeEnabled = parsed.planModeEnabled;
   }
-  if (typeof parsed.threadListV2SettledShelfExpanded === "boolean") {
-    preferences.threadListV2SettledShelfExpanded = parsed.threadListV2SettledShelfExpanded;
+  if (typeof parsed.threadListSettledShelfExpanded === "boolean") {
+    preferences.threadListSettledShelfExpanded = parsed.threadListSettledShelfExpanded;
   }
-  if (typeof parsed.threadListV2SnoozedShelfExpanded === "boolean") {
-    preferences.threadListV2SnoozedShelfExpanded = parsed.threadListV2SnoozedShelfExpanded;
+  if (typeof parsed.threadListSnoozedShelfExpanded === "boolean") {
+    preferences.threadListSnoozedShelfExpanded = parsed.threadListSnoozedShelfExpanded;
   }
   return preferences;
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -206,9 +206,9 @@ import {
 // stays behind an explicit Show more.
 const SETTLED_TAIL_INITIAL_COUNT = 10;
 const SETTLED_TAIL_PAGE_COUNT = 25;
-// Keep the v2 key so existing preferences survive the v2-to-default rename.
-const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:settled-expanded";
-const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:snoozed-expanded";
+// Fresh keys deliberately reset both shelves to collapsed for existing users.
+const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar:settled-expanded";
+const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar:snoozed-expanded";
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -2240,7 +2240,7 @@ export default function Sidebar() {
   );
   const [settledShelfExpanded, setSettledShelfExpanded] = useLocalStorage(
     SETTLED_SHELF_EXPANDED_KEY,
-    true,
+    false,
     Schema.Boolean,
   );
   const toggleSettledShelf = useCallback(


### PR DESCRIPTION
Settled and snoozed shelves now initialize collapsed across web, desktop, and mobile. Fresh persistence keys discard pre-update expanded state once while preserving later user toggles. Verified in an isolated web app, plus focused lint and web/mobile typechecks; the focused mobile storage test is blocked before collection by the current Vite+ runner's undefined config error.

![Settled and snoozed shelves collapsed by default](https://uploads-production-47e4.up.railway.app/files/2aa379c1-b51a-4553-9390-53763ebee71e/t3-shelves-collapsed.png)

![Both shelves expanded through their existing toggles](https://uploads-production-47e4.up.railway.app/files/3c207ab0-4e51-49ac-ad85-26ff97805c6e/t3-shelves-expanded.png)

Implemented by `gpt-5.6-sol` through the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse settled and snoozed sidebar shelves by default
> - Renames persisted shelf-preference fields from legacy V2 names to new thread-list names on both web and mobile, and drops legacy values during preference sanitization
> - Changes the settled shelf default from expanded to collapsed on both platforms when the new storage entry is absent or still loading
> - Updates tests to verify the new field names are persisted, loaded, and serialized, and that legacy and non-boolean shelf values are discarded
> - Behavioral Change: existing users with stored shelf expansion under the old V2 field names will see both shelves reset to collapsed, since [mobile-preferences.ts](https://github.com/pingdotgg/t3code/pull/9314/files#diff-3aa27c7cc6d8de9ee5cea2957f2ae3f02d47323310fab6293827508e890b7be7) no longer copies legacy fields and [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9314/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) uses new local-storage keys
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2647c58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->