### PR TITLE
fix(chat): keep live tool labels in present tense

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -868,7 +868,7 @@ describe("buildThreadFeed", () => {
       title: "Call MCP tool",
       item: { server: "t3-code", tool: "preview_click" },
       status: undefined,
-      displayName: "Click in the preview browser",
+      displayName: "Clicking in the preview browser",
       liveDisplayName: "Clicking in the preview browser",
       settledDisplayName: "Clicked in the preview browser",
       icon: "browser",
@@ -879,7 +879,7 @@ describe("buildThreadFeed", () => {
       title: "Call MCP tool",
       item: { server: "t3-code", tool: "task_status" },
       status: undefined,
-      displayName: "Get delegated task status",
+      displayName: "Getting delegated task status",
       liveDisplayName: "Getting delegated task status",
       settledDisplayName: "Got delegated task status",
       icon: "t3-code",
@@ -1039,7 +1039,7 @@ describe("buildThreadFeed", () => {
     ).toMatchObject([
       {
         type: "work-toggle",
-        summary: "Clicked in the preview browser",
+        summary: "Clicking in the preview browser",
         summaryToolIcon: "browser",
         live: true,
       },
@@ -1050,18 +1050,20 @@ describe("buildThreadFeed", () => {
     {
       status: "completed",
       displayName: "Clicked in the preview browser",
+      liveDisplayName: "Clicking in the preview browser",
       detail: "Clicked Continue",
       hasFailure: false,
     },
     {
       status: "failed",
       displayName: "Failed to click in the preview browser",
+      liveDisplayName: "Failed to click in the preview browser",
       detail: "Timed out waiting for Continue",
       hasFailure: true,
     },
   ])(
     "uses the browser call label once its action settles as $status",
-    ({ status, displayName, detail, hasFailure }) => {
+    ({ status, displayName, liveDisplayName, detail, hasFailure }) => {
       const turnId = TurnId.make("turn-preview-lifecycle");
       const toolCallId = "preview-click";
       const groupId = `work-group:tool:${turnId}:${toolCallId}`;
@@ -1156,7 +1158,7 @@ describe("buildThreadFeed", () => {
           groupId,
           hiddenCount: 1,
           expanded: true,
-          summary: displayName,
+          summary: liveDisplayName,
           summaryToolIcon: "browser",
           hasFailure,
           live: true,
@@ -1677,7 +1679,7 @@ describe("buildThreadFeed", () => {
       (
         [
           { lifecycleStatus: "inProgress", summary: "Running pnpm", shimmer: true },
-          { lifecycleStatus: "completed", summary: "Ran pnpm", shimmer: false },
+          { lifecycleStatus: "completed", summary: "Running pnpm", shimmer: false },
           { lifecycleStatus: "failed", summary: "Failed pnpm", shimmer: false },
           { lifecycleStatus: "declined", summary: "Declined pnpm", shimmer: false },
           { lifecycleStatus: "stopped", summary: "Stopped pnpm", shimmer: false },

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -17,6 +17,7 @@ import {
   commandDetailRepeatsCommand,
   extractCommandOutputText,
   isWorktreeSetupActivity,
+  liveActivityToolStatus,
   normalizeCompactToolLabel,
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
@@ -1528,7 +1529,7 @@ function appendToolGroupRows(
   const latestActivity = latestActiveActivity ?? activities.at(-1)!;
   const singleActivity = activities.length === 1 ? latestActivity : null;
   const summary = live
-    ? liveToolActivitySummary(latestActivity, active)
+    ? liveToolActivitySummary(latestActivity, live)
     : singleActivity !== null &&
         singleActivity.toolLike &&
         toolGroupAction(singleActivity.workEntry) !== "edit"
@@ -1580,16 +1581,16 @@ function appendToolGroupRows(
   });
 }
 
-function liveToolActivitySummary(activity: ThreadFeedActivity, active: boolean): string {
-  const presentation = resolveWorkEntryToolPresentation(
-    activity.workEntry,
-    active ? "inProgress" : "completed",
-  );
+function liveToolActivitySummary(activity: ThreadFeedActivity, presentTense: boolean): string {
+  const status = liveActivityToolStatus(activity.lifecycleStatus, presentTense);
+  const presentation = resolveWorkEntryToolPresentation({
+    ...activity.workEntry,
+    toolLifecycleStatus: status,
+  });
   if (presentation) return presentation.displayName;
   const command = activity.workEntry.command?.trim();
   if (command) {
     const program = commandProgramName(command);
-    const status = activity.lifecycleStatus ?? (active ? "inProgress" : "completed");
     const verb =
       status === "inProgress"
         ? "Running"

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -99,13 +99,16 @@ describe("work entry labels", () => {
     );
   });
 
-  it("does not describe a finished call as still running while the turn continues", () => {
+  it("keeps the latest live activity in the present tense after the call completes", () => {
     const browserEntry = {
       ...entry,
       toolTitle: "T3-code.preview_click",
       toolLifecycleStatus: "completed" as const,
     };
     expect(liveWorkEntryLabel(browserEntry, undefined, true)).toBe(
+      "Clicking in the preview browser",
+    );
+    expect(liveWorkEntryLabel(browserEntry, undefined, false)).toBe(
       "Clicked in the preview browser",
     );
   });
@@ -134,21 +137,21 @@ describe("work entry labels", () => {
   });
 
   it.each([
-    ["inProgress", "Running vp"],
-    ["completed", "Ran vp"],
-    ["failed", "Failed vp"],
-    ["declined", "Declined vp"],
-    ["stopped", "Stopped vp"],
+    ["inProgress", "Running vp", "Running vp"],
+    ["completed", "Running vp", "Ran vp"],
+    ["failed", "Failed vp", "Failed vp"],
+    ["declined", "Declined vp", "Declined vp"],
+    ["stopped", "Stopped vp", "Stopped vp"],
   ] as const)(
-    "uses the command's %s outcome even while the turn continues",
-    (toolLifecycleStatus, label) => {
+    "uses present tense for a live %s command and the outcome once it is no longer live",
+    (toolLifecycleStatus, liveLabel, settledLabel) => {
       const commandEntry = {
         ...entry,
         command: "/bin/bash -lc 'vp test run'",
         toolLifecycleStatus,
       };
-      expect(liveWorkEntryLabel(commandEntry, undefined, true)).toBe(label);
-      expect(liveWorkEntryLabel(commandEntry, undefined, false)).toBe(label);
+      expect(liveWorkEntryLabel(commandEntry, undefined, true)).toBe(liveLabel);
+      expect(liveWorkEntryLabel(commandEntry, undefined, false)).toBe(settledLabel);
     },
   );
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -2,6 +2,7 @@ import * as Equal from "effect/Equal";
 import { renderCodexDirectivesForCopy } from "@t3tools/client-runtime/codex-markdown-directives";
 import { commandProgramName } from "@t3tools/client-runtime/work-log/command-label";
 import {
+  liveActivityToolStatus,
   normalizeCompactToolLabel,
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
@@ -65,14 +66,14 @@ export function liveWorkEntryLabel(
   workspaceRoot: string | undefined,
   active: boolean,
 ) {
-  const toolPresentation = resolveWorkEntryToolPresentation(
-    entry,
-    active ? "inProgress" : "completed",
-  );
+  const status = liveActivityToolStatus(entry.toolLifecycleStatus, active);
+  const toolPresentation = resolveWorkEntryToolPresentation({
+    ...entry,
+    toolLifecycleStatus: status,
+  });
   if (toolPresentation) return toolPresentation.displayName;
   const command = entry.command?.trim();
   if (command) {
-    const status = entry.toolLifecycleStatus ?? (active ? "inProgress" : "completed");
     const verb =
       status === "inProgress"
         ? "Running"

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1209,7 +1209,7 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('data-timeline-row-id="live-activity-row"');
   });
 
-  it("keeps the completed command in the shared activity row with a past-tense label", () => {
+  it("keeps the completed command in the shared activity row with a present-tense label", () => {
     const turnId = TurnId.make("turn-live");
     const markup = renderToStaticMarkup(
       <MessagesTimeline
@@ -1244,10 +1244,10 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain("Ran pnpm");
+    expect(markup).toContain("Running pnpm");
     expect(markup).toContain("lucide-terminal");
     expect(markup).toContain("live-activity-focus");
-    expect(markup).not.toContain("Running pnpm");
+    expect(markup).not.toContain("Ran pnpm");
     expect(markup).not.toContain("Thinking");
     expect(markup).not.toContain('data-timeline-row-kind="thinking"');
   });

--- a/docs/user/tool-activity.md
+++ b/docs/user/tool-activity.md
@@ -8,7 +8,10 @@ indicate more calls above or below. Short groups use only the space they need.
 Collapsing and reopening a group preserves your reading position and any open call details.
 
 Recognized T3 tools use descriptive labels in both the running summary and individual rows.
-Labels follow the call's state, such as "Clicking" while running and "Clicked" after success.
+The latest live activity stays in the present tense while the turn continues, such as
+"Running vp" or "Clicking in the preview browser", even after that call has completed.
+Expanded rows follow the call's own state, such as "Clicked" after success.
+When a call has not reported a state yet, the label stays in the present tense.
 Failed, declined, and stopped calls say what happened without implying success.
 Preview browser actions use a globe icon. Other T3 tools keep the T3 mark.
 Group summaries count browser actions separately, such as "Used browser 18 times" or

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -25,7 +25,7 @@ describe("resolveWorkEntryToolPresentation", () => {
     "preview_click",
   ])("recognizes browser tool names across providers: %s", (label) => {
     expect(resolveWorkEntryToolPresentation({ label })).toEqual({
-      displayName: "Click in the preview browser",
+      displayName: "Clicking in the preview browser",
       icon: "browser",
     });
   });
@@ -37,7 +37,7 @@ describe("resolveWorkEntryToolPresentation", () => {
         toolTitle: "Inspect the current page",
         toolData: { server: "t3-code", tool: "preview_snapshot", result: { title: "Example" } },
       }),
-    ).toEqual({ displayName: "Take a snapshot of the preview page", icon: "browser" });
+    ).toEqual({ displayName: "Taking a snapshot of the preview page", icon: "browser" });
   });
 
   it.each([
@@ -46,7 +46,7 @@ describe("resolveWorkEntryToolPresentation", () => {
     ["failed", "Failed to click in the preview browser"],
     ["declined", "Declined to click in the preview browser"],
     ["stopped", "Stopped clicking in the preview browser"],
-    ["unknown", "Click in the preview browser"],
+    ["unknown", "Clicking in the preview browser"],
   ])("describes the tool's own %s state", (toolLifecycleStatus, displayName) => {
     expect(
       resolveWorkEntryToolPresentation({
@@ -115,7 +115,7 @@ describe("resolveWorkEntryToolPresentation", () => {
         label: "mcp__t3_code__task_status",
         toolTitle: "Check the child task",
       }),
-    ).toEqual({ displayName: "Get delegated task status", icon: "t3-code" });
+    ).toEqual({ displayName: "Getting delegated task status", icon: "t3-code" });
   });
 
   it("does not brand unknown tools or another server's matching tool name", () => {

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -115,12 +115,19 @@ function resolveT3McpToolPresentation(value: string | undefined, status: string 
             ? `Declined to ${action.toLowerCase()}`
             : status === "stopped"
               ? `Stopped ${running.toLowerCase()}`
-              : action;
+              : running;
 
   return {
     displayName: `${verb} ${detail}`,
     icon: name.startsWith("preview_") ? ("browser" as const) : ("t3-code" as const),
   };
+}
+
+/** Latest live activity stays present-tense unless the call itself failed, declined, or stopped. */
+export function liveActivityToolStatus(status: string | undefined, presentTense: boolean) {
+  if (status === "failed" || status === "declined" || status === "stopped") return status;
+  if (presentTense || status === "inProgress") return "inProgress";
+  return "completed";
 }
 
 /** Resolves tool identity before choosing labels or icons in either client. */


### PR DESCRIPTION
> [!NOTE]
> Written by `gpt-5.6-sol` on behalf of Maria

the nightly tool-group ui switches the latest completed call to past tense while its turn is still running. this keeps the latest live summary in present tense across web and mobile while preserving failed, declined, stopped, and expanded-row outcomes.

verified with 217 focused tests, targeted typechecks, lint, formatting, and the live web interaction.

before

![nightly showing ran pwd while the turn remains active](https://uploads-production-47e4.up.railway.app/files/62bf1ad4-2675-4d81-9d7d-c973da71ccc2/t3-tool-status-before.png)

after

![patched build showing running pwd while the turn remains active](https://uploads-production-47e4.up.railway.app/files/b34b42ea-5b3e-4391-ab9c-abc7f87811fb/t3-tool-status-after.png)

built with `gpt-5.6-sol` in the codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix live tool labels to keep present tense for completed live activities
> - Live tool group summaries now use present-tense wording whenever the group is in the live tail, even if the latest tool call has completed; failed, declined, and stopped outcomes remain terminal.
> - Adds shared `liveActivityToolStatus` normalizer in [presentation.ts](https://github.com/pingdotgg/t3code/pull/9316/files#diff-b6852793cd3916fd7bb7704e9bfe1391f7ca44403063a0502eb92d59f5060972) that maps live or unstated activity to in-progress, preserves terminal failure states, and maps non-live remaining states to completed.
> - T3 MCP tools without a handled lifecycle status now return running-form labels instead of base-action labels.
> - Updates mobile ([threadActivity.ts](https://github.com/pingdotgg/t3code/pull/9316/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5)) and web ([MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/9316/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe)) label formatters to use the shared normalizer, and expands tests and [tool-activity.md](https://github.com/pingdotgg/t3code/pull/9316/files#diff-5ea6b41330e70fafc5b57ca858ef4ce643327e008ac0d16960465b4d8ecb62ba) docs accordingly.
> - Behavioral Change: `resolveT3McpToolPresentation` fallback changes from base action form to running form when status is absent or unhandled; callers expecting imperative labels for unrecognized tools will see present-tense wording instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fc0db8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->