### PR TITLE
fix(codex): use trusted app approval labels

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -269,7 +269,7 @@ describe("Codex MCP elicitation approvals", () => {
           oneOf: [
             { const: "once", title: "Allow once" },
             { const: "session", title: "Allow for this session" },
-            { const: "always", title: "Always allow Safari" },
+            { const: "always", title: "Allow once" },
           ],
         },
       },
@@ -277,14 +277,14 @@ describe("Codex MCP elicitation approvals", () => {
     },
   } satisfies EffectCodexSchema.McpServerElicitationRequestParams;
 
-  it("preserves the app name and advertised persistence choices", () => {
+  it("uses trusted labels for advertised persistence choices", () => {
     NodeAssert.deepStrictEqual(describeMcpElicitation(request), {
       appName: "Safari",
       options: [
         { decision: "cancel", label: "Cancel" },
         { decision: "decline", label: "Decline" },
-        { decision: "acceptForSession", label: "Allow for this session" },
-        { decision: "acceptAlways", label: "Always allow Safari" },
+        { decision: "acceptForSession", label: "Always allow this session" },
+        { decision: "acceptAlways", label: "Always allow" },
         { decision: "accept", label: "Approve" },
       ],
     });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -318,14 +318,11 @@ function mcpElicitationFormFields(payload: EffectCodexSchema.McpServerElicitatio
   return payload.requestedSchema;
 }
 
-function mcpElicitationFieldOptions(field: typeof McpElicitationFormField.Type) {
+function mcpElicitationFieldValues(field: typeof McpElicitationFormField.Type) {
   if (field.oneOf) {
-    return field.oneOf.map((option) => ({ value: option.const, label: option.title }));
+    return field.oneOf.map((option) => option.const);
   }
-  return (field.enum ?? []).map((value, index) => ({
-    value,
-    label: field.enumNames?.[index],
-  }));
+  return field.enum ?? [];
 }
 
 function isMcpElicitationPersistenceField(
@@ -340,7 +337,7 @@ function isMcpElicitationPersistenceField(
   );
 }
 
-/** Returns the app and approval choices advertised by an MCP elicitation. */
+/** Returns the app and supported approval decisions for an MCP elicitation. */
 export function describeMcpElicitation(
   payload: EffectCodexSchema.McpServerElicitationRequestParams,
 ): { readonly appName: string; readonly options: ReadonlyArray<ProviderApprovalOption> } {
@@ -357,24 +354,24 @@ export function describeMcpElicitation(
     metadata?.connector_name ??
     metadata?.connectorName ??
     payload.serverName;
-  const persistenceOptions = new Map<McpElicitationPersistenceDecision, string>();
+  const persistenceDecisions = new Set<McpElicitationPersistenceDecision>();
   const persist = metadata?.persist;
   for (const value of typeof persist === "string" ? [persist] : (persist ?? [])) {
     const decision = mcpElicitationPersistenceDecision(value);
-    if (decision) persistenceOptions.set(decision, "");
+    if (decision) persistenceDecisions.add(decision);
   }
   if (metadata?.allowPersistentApproval) {
-    persistenceOptions.set("acceptAlways", "");
+    persistenceDecisions.add("acceptAlways");
   }
 
   const form = mcpElicitationFormFields(payload);
   for (const [key, field] of Object.entries(form?.properties ?? {})) {
-    for (const option of mcpElicitationFieldOptions(field)) {
-      const decision = mcpElicitationPersistenceDecision(option.value);
-      if (decision) persistenceOptions.set(decision, option.label ?? "");
+    for (const value of mcpElicitationFieldValues(field)) {
+      const decision = mcpElicitationPersistenceDecision(value);
+      if (decision) persistenceDecisions.add(decision);
     }
     if (field.type === "boolean" && isMcpElicitationPersistenceField(key, field)) {
-      persistenceOptions.set("acceptAlways", field.title ?? "");
+      persistenceDecisions.add("acceptAlways");
     }
   }
 
@@ -383,21 +380,21 @@ export function describeMcpElicitation(
     options: [
       { decision: "cancel", label: "Cancel" },
       { decision: "decline", label: "Decline" },
-      ...(persistenceOptions.has("acceptForSession") &&
+      ...(persistenceDecisions.has("acceptForSession") &&
       toMcpElicitationResponse(payload, "acceptForSession").action === "accept"
         ? [
             {
               decision: "acceptForSession" as const,
-              label: persistenceOptions.get("acceptForSession") || "Always allow this session",
+              label: "Always allow this session",
             },
           ]
         : []),
-      ...(persistenceOptions.has("acceptAlways") &&
+      ...(persistenceDecisions.has("acceptAlways") &&
       toMcpElicitationResponse(payload, "acceptAlways").action === "accept"
         ? [
             {
               decision: "acceptAlways" as const,
-              label: persistenceOptions.get("acceptAlways") || "Always allow",
+              label: "Always allow",
             },
           ]
         : []),
@@ -429,15 +426,14 @@ export function toMcpElicitationResponse(
   const content: Record<string, unknown> = {};
 
   for (const [key, field] of Object.entries(form?.properties ?? {})) {
-    const options = mcpElicitationFieldOptions(field);
-    const chosenOption = options.find((option) =>
+    const chosenValue = mcpElicitationFieldValues(field).find((value) =>
       persist
-        ? mcpElicitationPersistenceDecision(option.value) === decision
-        : /once|accept|approve|allow/i.test(option.value) &&
-          mcpElicitationPersistenceDecision(option.value) === null,
+        ? mcpElicitationPersistenceDecision(value) === decision
+        : /once|accept|approve|allow/i.test(value) &&
+          mcpElicitationPersistenceDecision(value) === null,
     );
-    if (chosenOption) {
-      content[key] = chosenOption.value;
+    if (chosenValue) {
+      content[key] = chosenValue;
     } else if (field.type === "boolean" && isMcpElicitationPersistenceField(key, field)) {
       content[key] = decision === "acceptAlways";
     } else if (field.default !== undefined && field.default !== null) {


### PR DESCRIPTION
## What Changed

- Ignore MCP-provided titles when building session and permanent approval options.
- Keep only the supported persistence decisions, then attach fixed T3 Code labels.
- Cover a persistent option whose MCP title says `Allow once`.

## Why

MCP option titles are provider-controlled. A title could describe a safer choice than the decision T3 Code sends after a click, including showing `Allow once` for permanent access.

T3 Code now owns the labels for `acceptForSession` and `acceptAlways`. MCP values still decide which choices are available and still produce the same MCP response.

Before, an `always` option could display its provider title. After, the same option displays `Always allow`.

## Verification

- `./node_modules/.bin/vitest run apps/server/src/provider/Layers/CodexSessionRuntime.test.ts apps/server/src/provider/Layers/CodexAdapter.test.ts`
- `./node_modules/.bin/vp run --filter t3 typecheck`
- Targeted lint and formatting checks for both changed files
- Fallow audit and security gates against `upstream/main`
- Daybreak Blue security review

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-facing approval UX and security-sensitive consent wording; behavior for which options appear and wire responses should stay the same aside from labels.
> 
> **Overview**
> Stops showing MCP-controlled option titles on Codex MCP elicitation approval prompts for session and permanent access. **`describeMcpElicitation`** now only infers which persistence decisions are supported from metadata and form field **values**, then attaches fixed T3 labels (`Always allow this session`, `Always allow`) instead of `oneOf`/`enumNames` titles that could misstate the outcome (e.g. permanent access labeled as “Allow once”).
> 
> Form submission via **`toMcpElicitationResponse`** is unchanged in intent: it still selects the correct `const`/enum value for each decision; helpers were refactored from value+label pairs to values only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fde0f3ba85bacc4deb91ec82bfdc430c9500d69e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CodexSessionRuntime` elicitation approvals to use trusted fixed labels
> - Replaces schema-advertised option titles and enum names with fixed trusted labels (`Always allow this session`, `Always allow`) in `describeMcpElicitation`, so persistence options shown to the user cannot be spoofed by the request schema
> - Reworks the field-option helper (renamed to `mcpElicitationFieldValues`) to return only raw `oneOf`/enum values, and updates `toMcpElicitationResponse` to select matching values directly from those raw values
> - Risk: callers that relied on `describeMcpElicitation` propagating schema-provided option titles will now always receive the fixed labels; the in-tree test in [CodexSessionRuntime.test.ts](https://github.com/pingdotgg/t3code/pull/9320/files#diff-257184c06ee4660c33558427b4981e1cda8e1476bfc12d0880f2343ccf853435) is updated to match
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fde0f3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized MCP elicitation approval labels for clearer choices:
    * “Allow once”
    * “Always allow this session”
    * “Always allow”
  * Improved handling of approval selections so the chosen persistence option is accurately reflected when responding to requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->