### PR TITLE
fix(dev): share dev servers on the loopback Vite actually binds

### DIFF
--- a/scripts/lib/dev-share.test.ts
+++ b/scripts/lib/dev-share.test.ts
@@ -27,11 +27,16 @@ const encode = (value: string) => Stream.make(new TextEncoder().encode(value));
  * test set the outcome of the `off` (pre-clear) and `serve` calls separately —
  * they are the same subcommand and are told apart by the trailing `off`.
  */
-const spawnerLayer = (input: { readonly off?: CallResult; readonly serve?: CallResult }) =>
+const spawnerLayer = (input: {
+  readonly off?: CallResult;
+  readonly serve?: CallResult;
+  readonly calls?: Array<ReadonlyArray<string>>;
+}) =>
   Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
     ChildProcessSpawner.make((command) => {
       const args = "args" in command ? (command.args as ReadonlyArray<string>) : [];
+      input.calls?.push(args);
       const result: CallResult = args.includes("status")
         ? { exitCode: 0 }
         : args.includes("off")
@@ -99,6 +104,20 @@ describe("shareDevServer", () => {
 
       assert.equal(shared.host, "host.example.ts.net");
       assert.equal(shared.url, "https://host.example.ts.net:5788/");
+    }),
+  );
+
+  // Vite binds `localhost`, which modern Node resolves to `::1` first, so a
+  // 127.0.0.1 target would proxy to a loopback nothing listens on.
+  it.effect("proxies to the localhost name Vite binds, not 127.0.0.1", () =>
+    Effect.gen(function* () {
+      const calls: Array<ReadonlyArray<string>> = [];
+      yield* shareDevServer({ webPort: 5788 }).pipe(
+        Effect.provide(spawnerLayer({ off: { exitCode: 0 }, calls })),
+      );
+
+      const serveCall = calls.find((args) => args.includes("--bg"));
+      assert.deepEqual(serveCall, ["serve", "--bg", "--https=5788", "http://localhost:5788"]);
     }),
   );
 

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -195,7 +195,17 @@ export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (in
     });
   }
 
-  yield* ensureTailscaleServe({ localPort: input.webPort, servePort: input.webPort }).pipe(
+  // Proxy to the hostname Vite binds rather than the package default of
+  // 127.0.0.1. Vite listens on `localhost`, which Node 17+ resolves to `::1`
+  // first, so it only binds the IPv6 loopback and a 127.0.0.1 target has
+  // nothing behind it (tailscale answers 502). Passing `localhost` lets the
+  // tailscale proxy resolve it the same way Node did. Not a literal `[::1]`:
+  // tailscale rejects that form.
+  yield* ensureTailscaleServe({
+    localPort: input.webPort,
+    servePort: input.webPort,
+    localHost: "localhost",
+  }).pipe(
     Effect.mapError((error) => {
       const explanation = explainCommandFailure(error);
       return new DevServeFailedError({


### PR DESCRIPTION
## Problem

`vp run dev --share` registers a `tailscale serve` rule that proxies `https://<node>.ts.net:<webPort>` to `http://127.0.0.1:<webPort>`. But Vite is configured with `server.host: "localhost"`, and on Node 17+ `localhost` resolves to `::1` first (verbatim DNS order), so Vite binds only `[::1]:<webPort>`. Nothing listens on the IPv4 loopback, and the tailnet URL returns a 502 from Tailscale.

Reproduced on macOS with Node 24: `lsof -iTCP:6561 -sTCP:LISTEN` showed only `[::1]:6561`; `curl http://127.0.0.1:6561/` was refused while `curl http://[::1]:6561/` returned 200.

A secondary symptom you may notice while sharing: the dev runner logs "Port 6561 is in use on a wildcard address, but localhost:6561 is available". That wildcard holder is Tailscale's own serve listener on the tailnet IP, so the warning is misleading but harmless. Not addressed here.

## Fix

`scripts/lib/dev-share.ts` now passes `localHost: "localhost"` to `ensureTailscaleServe`, so the Tailscale proxy resolves the same name Vite bound. A literal `[::1]` target is not an option: Tailscale rejects that form with a 500.

The `@t3tools/tailscale` default of `127.0.0.1` is unchanged. The server's own `--tailscale-serve` path passes `127.0.0.1` explicitly and binds it explicitly, and `t3 pair --tailscale` resolves its target from the recorded dev URL, so neither is affected.

## Verification

- Manual repro before the change: 502 on the tailnet URL; re-running `tailscale serve --bg --https=6561 http://localhost:6561` by hand fixed it immediately, which is exactly what this change makes the runner do.
- `vp test run scripts/lib/dev-share.test.ts`: 8 passed, including a new test asserting the serve call targets `http://localhost:<port>`.
- `npx tsgo -p scripts/tsconfig.json --noEmit`: clean.
- `vp lint --report-unused-disable-directives scripts/lib/dev-share.ts scripts/lib/dev-share.test.ts`: clean.

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to dev-share Tailscale proxy targeting; server `--tailscale-serve` and other explicit `127.0.0.1` paths are unchanged.
> 
> **Overview**
> **`vp run dev --share`** was registering Tailscale to forward to `http://127.0.0.1:<port>` while Vite listens on `localhost`, which on Node 17+ often resolves to IPv6 (`::1`) only—so the tailnet URL returned **502**.
> 
> `shareDevServer` now passes **`localHost: "localhost"`** into `ensureTailscaleServe` so the proxy target matches how Vite binds. Tests record spawned `tailscale` argv and assert the serve invocation uses `http://localhost:<webPort>` instead of `127.0.0.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a68fea798c1ec37f1366cc64b07be026041c94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `shareDevServer` to proxy through `localhost` instead of `127.0.0.1`
> Updates the Tailscale serve command in [dev-share.ts](https://github.com/pingdotgg/t3code/pull/9324/files#diff-fd5b0e9907d754def0ec9a0942bd952f2df50d8cf55618a633b96352d0b134e3) to pass `localhost` as the local host while keeping the requested web port. The returned tailnet HTTPS URL and all status/cleanup logic remain unchanged.
> - Extends the spawner test helper in [dev-share.test.ts](https://github.com/pingdotgg/t3code/pull/9324/files#diff-70703c0ffcc72de25f163a2fe84000b48ae916f0fd46120122d24d714558d8b7) to record spawned command arguments, and adds a test asserting the serve command targets `localhost` on the requested port.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a68fea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->