### PR TITLE
fix(server): validate external favicon targets

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -2,7 +2,11 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeHttpPlatform from "@effect/platform-node/NodeHttpPlatform";
 import * as NodeFSP from "node:fs/promises";
-import { AssetPreviewTypeValidationError, ThreadId } from "@t3tools/contracts";
+import {
+  AssetPreviewTypeValidationError,
+  AssetProjectFaviconInspectionError,
+  ThreadId,
+} from "@t3tools/contracts";
 import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import { describe, expect, it } from "@effect/vitest";
 import * as Crypto from "effect/Crypto";
@@ -11,11 +15,13 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
 import { HttpServerResponse } from "effect/unstable/http";
 import { vi } from "vite-plus/test";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import { base64UrlEncode, signPayload } from "../auth/utils.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "../project/T3ProjectFileLoader.ts";
@@ -42,6 +48,16 @@ const testLayer = Layer.mergeAll(
   ),
   ServerSecretStore.layer.pipe(Layer.provide(configLayer)),
 ).pipe(Layer.provideMerge(NodeServices.layer));
+
+const LegacyExternalProjectFaviconClaims = Schema.Struct({
+  version: Schema.Literal(1),
+  kind: Schema.Literal("project-favicon-external"),
+  filePath: Schema.String,
+  expiresAt: Schema.Number,
+});
+const encodeLegacyExternalProjectFaviconClaims = Schema.encodeEffect(
+  Schema.fromJsonString(LegacyExternalProjectFaviconClaims),
+);
 
 describe("AssetAccess", () => {
   it.effect("issues exact URLs for media and browser documents outside the workspace", () =>
@@ -744,13 +760,157 @@ describe("AssetAccess", () => {
       expect(result.relativeUrl).toMatch(/\/v[0-9a-f]{64}-custom\.png$/);
       expect(
         yield* resolveAsset(suffix.slice(0, separatorIndex), suffix.slice(separatorIndex + 1)),
-      ).toEqual({ kind: "file", path: canonicalPath });
+      ).toMatchObject({ kind: "file", path: canonicalPath });
       const tamperedSuffixResult = yield* resolveAsset(
         suffix.slice(0, separatorIndex),
         "sibling.png",
       );
-      expect(tamperedSuffixResult).toEqual({ kind: "file", path: canonicalPath });
-      expect(tamperedSuffixResult).not.toEqual({ kind: "file", path: canonicalSiblingPath });
+      expect(tamperedSuffixResult).toMatchObject({ kind: "file", path: canonicalPath });
+      expect(tamperedSuffixResult?.path).not.toBe(canonicalSiblingPath);
+
+      const dotfilePath = path.join(pictures, ".png");
+      yield* fileSystem.writeFile(dotfilePath, new Uint8Array([7, 8, 9]));
+      const dotfileResult = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root },
+        projectFaviconPath: dotfilePath,
+      });
+      expect(dotfileResult.relativeUrl).toMatch(/\/v[0-9a-f]{64}-\.png$/);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("keeps external favicon responses bound to the resolved file", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-response-workspace-",
+      });
+      const pictures = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-response-pictures-",
+      });
+      const faviconPath = path.join(pictures, "custom.png");
+      const savedPath = path.join(pictures, "saved.png");
+      const secretPath = path.join(pictures, "secret.txt");
+      yield* fileSystem.writeFileString(faviconPath, "favicon");
+      yield* fileSystem.writeFileString(secretPath, "private");
+
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root },
+        projectFaviconPath: faviconPath,
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const asset = yield* resolveAsset(
+        suffix.slice(0, separatorIndex),
+        suffix.slice(separatorIndex + 1),
+      );
+      if (!asset) throw new Error("Expected a resolved project favicon");
+
+      yield* fileSystem.rename(faviconPath, savedPath);
+      yield* fileSystem.symlink(secretPath, faviconPath);
+      const response = HttpServerResponse.toWeb(yield* assetFileResponse(asset));
+      expect(yield* Effect.promise(() => response.text())).toBe("favicon");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("keeps file context when reading an external favicon fails", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-read-workspace-",
+      });
+      const pictures = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-read-pictures-",
+      });
+      const faviconPath = path.join(pictures, "custom.png");
+      yield* fileSystem.writeFileString(faviconPath, "favicon");
+      const canonicalPath = yield* fileSystem.realPath(faviconPath);
+      const readFailure = new Error("read failed");
+      const originalOpen = (yield* Effect.promise(() =>
+        vi.importActual<typeof NodeFSP>("node:fs/promises"),
+      )).open;
+      let opened: NodeFSP.FileHandle | undefined;
+      const openSpy = vi.mocked(NodeFSP.open).mockImplementation(async (target, flags, mode) => {
+        const handle = await originalOpen(target, flags, mode);
+        if (target === canonicalPath) {
+          opened = handle;
+          vi.spyOn(handle, "readFile").mockRejectedValue(readFailure);
+        }
+        return handle;
+      });
+      yield* Effect.addFinalizer(() => Effect.sync(() => openSpy.mockImplementation(originalOpen)));
+
+      const error = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root },
+        projectFaviconPath: faviconPath,
+      }).pipe(Effect.flip);
+
+      const isInspectionError = Schema.is(AssetProjectFaviconInspectionError);
+      expect(isInspectionError(error)).toBe(true);
+      if (!isInspectionError(error)) return;
+      expect(error.cause).toMatchObject({
+        _tag: "MediaFileReadError",
+        path: canonicalPath,
+        cause: readFailure,
+      });
+      expect(opened?.fd).toBe(-1);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects external favicon paths with non-image source or target names", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-symlink-workspace-",
+      });
+      const outside = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-symlink-outside-",
+      });
+      for (const { sourceName, targetName } of [
+        { sourceName: "leak.png", targetName: "secret.txt" },
+        { sourceName: "fragment-target.png", targetName: "secret.png#private.txt" },
+        { sourceName: "fragment-source.png#ignored", targetName: "target.png" },
+      ]) {
+        const secretPath = path.join(outside, targetName);
+        const faviconPath = path.join(root, sourceName);
+        yield* fileSystem.writeFileString(secretPath, "private");
+        yield* fileSystem.symlink(secretPath, faviconPath);
+
+        const error = yield* issueAssetUrl({
+          resource: { _tag: "project-favicon", cwd: root },
+          projectFaviconPath: faviconPath,
+        }).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(AssetPreviewTypeValidationError);
+      }
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects existing external favicon tokens for non-image files", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const outside = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-existing-token-",
+      });
+      const secretPath = path.join(outside, "secret.txt");
+      yield* fileSystem.writeFileString(secretPath, "private");
+
+      const secretStore = yield* ServerSecretStore.ServerSecretStore;
+      const secret = yield* secretStore.getOrCreateRandom("asset-access-signing-key", 32);
+      const encodedPayload = base64UrlEncode(
+        yield* encodeLegacyExternalProjectFaviconClaims({
+          version: 1,
+          kind: "project-favicon-external",
+          filePath: yield* fileSystem.realPath(secretPath),
+          expiresAt: 60 * 60 * 1000,
+        }),
+      );
+      const token = `${encodedPayload}.${signPayload(encodedPayload, secret)}`;
+
+      expect(yield* resolveAsset(token, "leak.png")).toBeNull();
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -42,7 +42,7 @@ import { parseAttachmentFileExtension, resolveAttachmentPathById } from "../atta
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
-import { openMediaFile, type OpenMediaFile } from "./MediaFile.ts";
+import { openMediaFile, readMediaFile, type OpenMediaFile } from "./MediaFile.ts";
 
 export const ASSET_ROUTE_PREFIX = "/api/assets";
 
@@ -152,6 +152,11 @@ function decodeRelativePath(value: string): string | null {
   }
 }
 
+function hasImageFileExtension(path: Path.Path, filePath: string): boolean {
+  const fileName = path.basename(filePath).toLowerCase();
+  return WORKSPACE_IMAGE_PREVIEW_EXTENSIONS.some((extension) => fileName.endsWith(extension));
+}
+
 const optionOnNotFound = <A, R>(
   effect: Effect.Effect<A, PlatformError.PlatformError, R>,
 ): Effect.Effect<Option.Option<A>, PlatformError.PlatformError, R> =>
@@ -172,6 +177,13 @@ const resolveCanonicalFile = Effect.fn("AssetAccess.resolveCanonicalFile")(funct
 
   const info = yield* optionOnNotFound(fileSystem.stat(canonicalFile.value));
   return Option.isSome(info) && info.value.type === "File" ? canonicalFile.value : null;
+});
+
+const readCanonicalFileBytes = Effect.fn("AssetAccess.readCanonicalFileBytes")(function* (
+  filePath: string,
+) {
+  const file = yield* openMediaFile(filePath);
+  return file ? yield* readMediaFile(filePath, file) : null;
 });
 
 const resolveCanonicalWorkspaceFile = Effect.fn("AssetAccess.resolveCanonicalWorkspaceFile")(
@@ -430,7 +442,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       const relativePath =
         faviconPath && !isExternalOverride ? path.relative(workspaceRoot, faviconPath) : null;
       const sourceFaviconPath = isExternalOverride ? faviconPath : relativePath;
-      if (sourceFaviconPath && !isWorkspaceImagePreviewPath(sourceFaviconPath)) {
+      if (sourceFaviconPath && !hasImageFileExtension(path, sourceFaviconPath)) {
         return yield* new AssetPreviewTypeValidationError({ resource: input.resource });
       }
       sourcePath = sourceFaviconPath ?? undefined;
@@ -453,6 +465,13 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         return yield* new AssetProjectFaviconNotFoundError({
           resource: input.resource,
         });
+      }
+      if (
+        isExternalOverride &&
+        canonicalFaviconPath &&
+        !hasImageFileExtension(path, canonicalFaviconPath)
+      ) {
+        return yield* new AssetPreviewTypeValidationError({ resource: input.resource });
       }
       claims =
         isExternalOverride && canonicalFaviconPath
@@ -479,15 +498,29 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             };
       if (sourceFaviconPath && canonicalFaviconPath) {
         const crypto = yield* Crypto.Crypto;
-        const faviconBytes = yield* fileSystem.readFile(canonicalFaviconPath).pipe(
-          Effect.mapError(
-            (cause) =>
-              new AssetProjectFaviconInspectionError({
-                resource: input.resource,
-                cause,
-              }),
-          ),
-        );
+        const faviconBytes = isExternalOverride
+          ? yield* readCanonicalFileBytes(canonicalFaviconPath).pipe(
+              Effect.scoped,
+              Effect.mapError(
+                (cause) =>
+                  new AssetProjectFaviconInspectionError({
+                    resource: input.resource,
+                    cause,
+                  }),
+              ),
+            )
+          : yield* fileSystem.readFile(canonicalFaviconPath).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new AssetProjectFaviconInspectionError({
+                    resource: input.resource,
+                    cause,
+                  }),
+              ),
+            );
+        if (!faviconBytes) {
+          return yield* new AssetProjectFaviconNotFoundError({ resource: input.resource });
+        }
         const revision = yield* crypto.digest("SHA-256", faviconBytes).pipe(
           Effect.map(Encoding.encodeHex),
           Effect.mapError(
@@ -589,18 +622,18 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
   }
 
   if (claims.kind === "project-favicon-external") {
-    const faviconPath = yield* resolveCanonicalFile(claims.filePath).pipe(
+    const path = yield* Path.Path;
+    if (!hasImageFileExtension(path, claims.filePath)) return null;
+    const file = yield* openMediaFile(claims.filePath).pipe(
       Effect.tapError((cause) =>
-        Effect.logError("Failed to resolve canonical asset path.", {
+        Effect.logError("Failed to open canonical asset path.", {
           filePath: claims.filePath,
           cause,
         }),
       ),
       Effect.orElseSucceed(() => null),
     );
-    return faviconPath === claims.filePath
-      ? ({ kind: "file", path: faviconPath } satisfies ResolvedAsset)
-      : null;
+    return file ? ({ kind: "file", path: claims.filePath, file } satisfies ResolvedAsset) : null;
   }
 
   const decodedPath = decodeRelativePath(relativePath);

--- a/apps/server/src/assets/MediaFile.ts
+++ b/apps/server/src/assets/MediaFile.ts
@@ -31,6 +31,18 @@ class MediaFileStatError extends Schema.TaggedErrorClass<MediaFileStatError>()(
   }
 }
 
+class MediaFileReadError extends Schema.TaggedErrorClass<MediaFileReadError>()(
+  "MediaFileReadError",
+  {
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read media file '${this.path}'.`;
+  }
+}
+
 /** Holds the file identity and descriptor for one HTTP request, never a copy of its bytes. */
 export interface OpenMediaFile {
   readonly handle: NodeFSP.FileHandle;
@@ -93,6 +105,16 @@ export const statMediaFile = Effect.fn("statMediaFile")(function* (
   return yield* Effect.tryPromise({
     try: () => file.handle.stat({ bigint: true }),
     catch: (cause) => new MediaFileStatError({ path: filePath, cause }),
+  });
+});
+
+export const readMediaFile = Effect.fn("readMediaFile")(function* (
+  filePath: string,
+  file: OpenMediaFile,
+) {
+  return yield* Effect.tryPromise({
+    try: () => file.handle.readFile(),
+    catch: (cause) => new MediaFileReadError({ path: filePath, cause }),
   });
 });
 


### PR DESCRIPTION
## What Changed

- Require both a saved external favicon path and its canonical target to use a supported image suffix.
- Keep external favicon hashing and HTTP responses bound to the validated file descriptor.
- Reject existing signed external favicon tokens when their stored target is not an image path.
- Add regressions for symlink escapes, literal filenames, existing tokens, and path replacement after resolution.

## Why

An external favicon path such as `leak.png` could resolve through a symlink to a non-image host file. The signed asset token stored that canonical target, allowing the asset route to return it.

Validating the canonical filename closes the label-versus-target mismatch. Descriptor-backed reads also prevent the file at that path from being replaced between validation and the HTTP response.

## Verification

- `NO_COLOR=1 ./node_modules/.bin/vitest run apps/server/src/assets/AssetAccess.test.ts apps/server/src/project/ProjectFaviconResolver.test.ts apps/server/src/http.test.ts --reporter=dot`
- `./node_modules/.bin/vp run --filter t3 typecheck`
- Targeted lint and formatting checks for both changed files
- Fallow audit and security gates against `upstream/main`
- Daybreak Blue security review

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes signed asset access for external favicons and close a symlink/content-disclosure class of bugs; behavior changes for existing tokens targeting non-image paths.
> 
> **Overview**
> Closes a path where an external project favicon could look like an image (e.g. `leak.png`) while `realpath` pointed at a non-image file, and signed `project-favicon-external` tokens could still serve that target.
> 
> **External favicon validation** now uses basename image-suffix checks on both the configured path and the canonical resolved path, so symlink and fragment tricks are rejected at `issueAssetUrl`. `resolveAsset` returns `null` for legacy tokens whose stored path is not an image.
> 
> **Descriptor-backed I/O** for external favicons mirrors media assets: revision hashing at issue time reads through `openMediaFile` / new `readMediaFile` (with `MediaFileReadError`), and resolution attaches an opened handle on the resolved asset so HTTP responses keep the bytes from the file opened at resolve time even if the path is swapped afterward.
> 
> Tests add regressions for dotfile names, tampered URL suffixes, symlink escapes, post-resolve replacement, read failures, and forged tokens pointing at `.txt` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219bcd8b238d60b81751220bfd9347c4c6ca57c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate external favicon filenames and read bytes via open file handles
> - External project-favicon URL issuance and resolution now validate both the source and canonical target filenames using `hasImageFileExtension` in [AssetAccess.ts](https://github.com/pingdotgg/t3code/pull/9333/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1).
> - Resolution opens the claimed path with `openMediaFile` and reads bytes through the resulting handle. This prevents serving a different file if the path is replaced by a symlink after resolution.
> - Added `MediaFileReadError` and `readMediaFile` in [MediaFile.ts](https://github.com/pingdotgg/t3code/pull/9333/files#diff-424574dcf5b519a9f9ae105181dae2a327bd986f50472319fa6a5c0d64462ed2) to wrap read failures and ensure descriptors are closed.
> - Behavioral Change: Unopenable or unreadable external favicons now return `AssetProjectFaviconNotFoundError` or `AssetProjectFaviconInspectionError`. Legacy tokens for non-image files resolve to `null`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 219bcd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for project favicon assets, including dotfile names, symlinks, tampered filenames, and legacy tokens.
  * Ensured favicon responses remain bound to the validated file, including after the underlying file is replaced.
  * Rejected non-image files when used as project favicons.
  * Improved handling of missing, inaccessible, or unreadable favicon files by returning appropriate errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->