### PR TITLE
fix(web): collapse PR header actions to icons when narrow

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1464,24 +1464,28 @@ export function PullRequestDetailPanel({
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Button
-                        size="xs"
-                        variant="warning-outline"
-                        disabled={actionPending}
-                        onClick={() => setConfirmation({ open: true, action: "approve-workflows" })}
-                        aria-label={
-                          pendingAction === "approve-workflows"
-                            ? "Approving..."
-                            : "Approve workflows to run"
-                        }
-                      >
-                        <PlayIcon aria-hidden className="size-3.5" />
-                        <span className="@max-[40rem]/pr-header:hidden">
-                          {pendingAction === "approve-workflows"
-                            ? "Approving..."
-                            : "Approve workflows to run"}
-                        </span>
-                      </Button>
+                      <span className="inline-flex shrink-0">
+                        <Button
+                          size="xs"
+                          variant="warning-outline"
+                          disabled={actionPending}
+                          onClick={() =>
+                            setConfirmation({ open: true, action: "approve-workflows" })
+                          }
+                          aria-label={
+                            pendingAction === "approve-workflows"
+                              ? "Approving..."
+                              : "Approve workflows to run"
+                          }
+                        >
+                          <PlayIcon aria-hidden className="size-3.5" />
+                          <span className="@max-[40rem]/pr-header:hidden">
+                            {pendingAction === "approve-workflows"
+                              ? "Approving..."
+                              : "Approve workflows to run"}
+                          </span>
+                        </Button>
+                      </span>
                     }
                   />
                   <TooltipPopup side="top">
@@ -1497,14 +1501,20 @@ export function PullRequestDetailPanel({
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Badge size="control" variant="info">
+                      <Badge
+                        size="control"
+                        variant="info"
+                        role="img"
+                        aria-label={armedAutoMergeLabel}
+                      >
                         <GitMergeIcon aria-hidden className="size-3.5" />
                         <span className="@max-[30rem]/pr-header:hidden">{armedAutoMergeLabel}</span>
                       </Badge>
                     }
                   />
                   <TooltipPopup side="top">
-                    The host will merge this on its own once its requirements are met
+                    {armedAutoMergeLabel}: the host will merge this on its own once its requirements
+                    are met
                   </TooltipPopup>
                 </Tooltip>
               ) : null}
@@ -1512,18 +1522,22 @@ export function PullRequestDetailPanel({
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Button
-                        size="xs"
-                        variant="destructive-outline"
-                        disabled={handoff !== null}
-                        onClick={startResolveConflicts}
-                        aria-label={handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
-                      >
-                        <TriangleAlertIcon aria-hidden className="size-3.5" />
-                        <span className="@max-[30rem]/pr-header:hidden">
-                          {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
-                        </span>
-                      </Button>
+                      <span className="inline-flex shrink-0">
+                        <Button
+                          size="xs"
+                          variant="destructive-outline"
+                          disabled={handoff !== null}
+                          onClick={startResolveConflicts}
+                          aria-label={
+                            handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"
+                          }
+                        >
+                          <TriangleAlertIcon aria-hidden className="size-3.5" />
+                          <span className="@max-[30rem]/pr-header:hidden">
+                            {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
+                          </span>
+                        </Button>
+                      </span>
                     }
                   />
                   <TooltipPopup side="top">
@@ -1534,18 +1548,20 @@ export function PullRequestDetailPanel({
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Button
-                        size="xs"
-                        disabled={actionPending}
-                        onClick={() => void perform("ready")}
-                        aria-label="Ready for review"
-                      >
-                        <GitPullRequestIcon
-                          aria-hidden
-                          className="hidden size-3.5 @max-[30rem]/pr-header:inline"
-                        />
-                        <span className="@max-[30rem]/pr-header:hidden">Ready for review</span>
-                      </Button>
+                      <span className="inline-flex shrink-0">
+                        <Button
+                          size="xs"
+                          disabled={actionPending}
+                          onClick={() => void perform("ready")}
+                          aria-label="Ready for review"
+                        >
+                          <GitPullRequestIcon
+                            aria-hidden
+                            className="hidden size-3.5 @max-[30rem]/pr-header:inline"
+                          />
+                          <span className="@max-[30rem]/pr-header:hidden">Ready for review</span>
+                        </Button>
+                      </span>
                     }
                   />
                   <TooltipPopup side="top">Ready for review</TooltipPopup>
@@ -1554,23 +1570,27 @@ export function PullRequestDetailPanel({
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Button
-                        size="xs"
-                        disabled={actionPending}
-                        onClick={() => setConfirmation({ open: true, action: "enable-auto-merge" })}
-                        aria-label={
-                          pendingAction === "enable-auto-merge"
-                            ? "Enabling..."
-                            : pendingAutoMergeLabel
-                        }
-                      >
-                        <GitMergeIcon aria-hidden className="size-3.5" />
-                        <span className="@max-[30rem]/pr-header:hidden">
-                          {pendingAction === "enable-auto-merge"
-                            ? "Enabling..."
-                            : pendingAutoMergeLabel}
-                        </span>
-                      </Button>
+                      <span className="inline-flex shrink-0">
+                        <Button
+                          size="xs"
+                          disabled={actionPending}
+                          onClick={() =>
+                            setConfirmation({ open: true, action: "enable-auto-merge" })
+                          }
+                          aria-label={
+                            pendingAction === "enable-auto-merge"
+                              ? "Enabling..."
+                              : pendingAutoMergeLabel
+                          }
+                        >
+                          <GitMergeIcon aria-hidden className="size-3.5" />
+                          <span className="@max-[30rem]/pr-header:hidden">
+                            {pendingAction === "enable-auto-merge"
+                              ? "Enabling..."
+                              : pendingAutoMergeLabel}
+                          </span>
+                        </Button>
+                      </span>
                     }
                   />
                   <TooltipPopup side="top">
@@ -1581,36 +1601,44 @@ export function PullRequestDetailPanel({
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Badge size="control" variant="info">
+                      <Badge
+                        size="control"
+                        variant="info"
+                        role="img"
+                        aria-label={armedAutoMergeLabel}
+                      >
                         <GitMergeIcon aria-hidden className="size-3.5" />
                         <span className="@max-[30rem]/pr-header:hidden">{armedAutoMergeLabel}</span>
                       </Badge>
                     }
                   />
                   <TooltipPopup side="top">
-                    The host will merge this on its own once its requirements are met
+                    {armedAutoMergeLabel}: the host will merge this on its own once its requirements
+                    are met
                   </TooltipPopup>
                 </Tooltip>
               ) : primaryAction === "merge" ? (
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Button
-                        size="xs"
-                        disabled={actionPending}
-                        onClick={() => setConfirmation({ open: true, action: "merge" })}
-                        aria-label={
-                          pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel
-                        }
-                      >
-                        <GitMergeIcon
-                          aria-hidden
-                          className="hidden size-3.5 @max-[30rem]/pr-header:inline"
-                        />
-                        <span className="@max-[30rem]/pr-header:hidden">
-                          {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
-                        </span>
-                      </Button>
+                      <span className="inline-flex shrink-0">
+                        <Button
+                          size="xs"
+                          disabled={actionPending}
+                          onClick={() => setConfirmation({ open: true, action: "merge" })}
+                          aria-label={
+                            pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel
+                          }
+                        >
+                          <GitMergeIcon
+                            aria-hidden
+                            className="hidden size-3.5 @max-[30rem]/pr-header:inline"
+                          />
+                          <span className="@max-[30rem]/pr-header:hidden">
+                            {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
+                          </span>
+                        </Button>
+                      </span>
                     }
                   />
                   <TooltipPopup side="top">

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1296,8 +1296,8 @@ export function PullRequestDetailPanel({
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-background">
-      <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 border-b border-border/60">
-        <div className="ml-4 grid h-7 min-w-0 items-center">
+      <div className="@container/pr-header grid min-w-0 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 border-b border-border/60">
+        <div className="ml-4 grid h-7 min-w-0 items-center overflow-hidden">
           <div
             aria-hidden={condensed}
             inert={condensed}
@@ -1402,7 +1402,7 @@ export function PullRequestDetailPanel({
             ) : null}
           </div>
         </div>
-        <div className="mr-4 flex h-7 min-w-0 flex-nowrap items-center justify-end gap-1">
+        <div className="mr-4 flex h-7 shrink-0 items-center justify-end gap-1">
           {detail ? (
             <>
               {/* Checking a pull request out is the reason to open one here at all, so it is a
@@ -1415,9 +1415,17 @@ export function PullRequestDetailPanel({
                   <MenuTrigger
                     disabled={handoff !== null}
                     render={
-                      <Button size="xs" variant="outline">
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        aria-label={
+                          handoff?.startsWith("checkout") ? "Checking out..." : "Check out"
+                        }
+                      >
                         <GitBranchIcon aria-hidden className="size-3.5" />
-                        {handoff?.startsWith("checkout") ? "Checking out..." : "Check out"}
+                        <span className="@max-[35rem]/pr-header:hidden">
+                          {handoff?.startsWith("checkout") ? "Checking out..." : "Check out"}
+                        </span>
                         <ChevronDownIcon aria-hidden className="size-3.5 text-muted-foreground" />
                       </Button>
                     }
@@ -1453,17 +1461,35 @@ export function PullRequestDetailPanel({
                 </Menu>
               ) : null}
               {workflowApprovalsRequired > 0 && can("approve-workflows") ? (
-                <Button
-                  size="xs"
-                  variant="warning-outline"
-                  disabled={actionPending}
-                  onClick={() => setConfirmation({ open: true, action: "approve-workflows" })}
-                >
-                  <PlayIcon className="size-3.5" />
-                  {pendingAction === "approve-workflows"
-                    ? "Approving..."
-                    : "Approve workflows to run"}
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="xs"
+                        variant="warning-outline"
+                        disabled={actionPending}
+                        onClick={() => setConfirmation({ open: true, action: "approve-workflows" })}
+                        aria-label={
+                          pendingAction === "approve-workflows"
+                            ? "Approving..."
+                            : "Approve workflows to run"
+                        }
+                      >
+                        <PlayIcon aria-hidden className="size-3.5" />
+                        <span className="@max-[40rem]/pr-header:hidden">
+                          {pendingAction === "approve-workflows"
+                            ? "Approving..."
+                            : "Approve workflows to run"}
+                        </span>
+                      </Button>
+                    }
+                  />
+                  <TooltipPopup side="top">
+                    {pendingAction === "approve-workflows"
+                      ? "Approving..."
+                      : "Approve workflows to run"}
+                  </TooltipPopup>
+                </Tooltip>
               ) : null}
               {/* Said where the Merge button is, because it is the answer to why nobody has
                   pressed it: the merge is already asked for, and the host is holding it. */}
@@ -1473,7 +1499,9 @@ export function PullRequestDetailPanel({
                     render={
                       <Badge size="control" variant="info">
                         <GitMergeIcon aria-hidden className="size-3.5" />
-                        {armedAutoMergeLabel}
+                        <span className="@max-[30rem]/pr-header:hidden">
+                          {armedAutoMergeLabel}
+                        </span>
                       </Badge>
                     }
                   />
@@ -1483,35 +1511,85 @@ export function PullRequestDetailPanel({
                 </Tooltip>
               ) : null}
               {primaryAction === "resolve" ? (
-                <Button
-                  size="xs"
-                  variant="destructive-outline"
-                  disabled={handoff !== null}
-                  onClick={startResolveConflicts}
-                >
-                  <TriangleAlertIcon className="size-3.5" />
-                  {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="xs"
+                        variant="destructive-outline"
+                        disabled={handoff !== null}
+                        onClick={startResolveConflicts}
+                        aria-label={
+                          handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"
+                        }
+                      >
+                        <TriangleAlertIcon aria-hidden className="size-3.5" />
+                        <span className="@max-[30rem]/pr-header:hidden">
+                          {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
+                        </span>
+                      </Button>
+                    }
+                  />
+                  <TooltipPopup side="top">
+                    {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
+                  </TooltipPopup>
+                </Tooltip>
               ) : primaryAction === "ready" ? (
-                <Button size="xs" disabled={actionPending} onClick={() => void perform("ready")}>
-                  Ready for review
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="xs"
+                        disabled={actionPending}
+                        onClick={() => void perform("ready")}
+                        aria-label="Ready for review"
+                      >
+                        <GitPullRequestIcon
+                          aria-hidden
+                          className="hidden size-3.5 @max-[30rem]/pr-header:inline"
+                        />
+                        <span className="@max-[30rem]/pr-header:hidden">Ready for review</span>
+                      </Button>
+                    }
+                  />
+                  <TooltipPopup side="top">Ready for review</TooltipPopup>
+                </Tooltip>
               ) : primaryAction === "enable-auto-merge" ? (
-                <Button
-                  size="xs"
-                  disabled={actionPending}
-                  onClick={() => setConfirmation({ open: true, action: "enable-auto-merge" })}
-                >
-                  <GitMergeIcon className="size-3.5" />
-                  {pendingAction === "enable-auto-merge" ? "Enabling..." : pendingAutoMergeLabel}
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="xs"
+                        disabled={actionPending}
+                        onClick={() => setConfirmation({ open: true, action: "enable-auto-merge" })}
+                        aria-label={
+                          pendingAction === "enable-auto-merge"
+                            ? "Enabling..."
+                            : pendingAutoMergeLabel
+                        }
+                      >
+                        <GitMergeIcon aria-hidden className="size-3.5" />
+                        <span className="@max-[30rem]/pr-header:hidden">
+                          {pendingAction === "enable-auto-merge"
+                            ? "Enabling..."
+                            : pendingAutoMergeLabel}
+                        </span>
+                      </Button>
+                    }
+                  />
+                  <TooltipPopup side="top">
+                    {pendingAction === "enable-auto-merge" ? "Enabling..." : pendingAutoMergeLabel}
+                  </TooltipPopup>
+                </Tooltip>
               ) : primaryAction === "auto-merge-armed" ? (
                 <Tooltip>
                   <TooltipTrigger
                     render={
                       <Badge size="control" variant="info">
-                        <GitMergeIcon className="size-3.5" />
-                        {armedAutoMergeLabel}
+                        <GitMergeIcon aria-hidden className="size-3.5" />
+                        <span className="@max-[30rem]/pr-header:hidden">
+                          {armedAutoMergeLabel}
+                        </span>
                       </Badge>
                     }
                   />
@@ -1520,13 +1598,31 @@ export function PullRequestDetailPanel({
                   </TooltipPopup>
                 </Tooltip>
               ) : primaryAction === "merge" ? (
-                <Button
-                  size="xs"
-                  disabled={actionPending}
-                  onClick={() => setConfirmation({ open: true, action: "merge" })}
-                >
-                  {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="xs"
+                        disabled={actionPending}
+                        onClick={() => setConfirmation({ open: true, action: "merge" })}
+                        aria-label={
+                          pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel
+                        }
+                      >
+                        <GitMergeIcon
+                          aria-hidden
+                          className="hidden size-3.5 @max-[30rem]/pr-header:inline"
+                        />
+                        <span className="@max-[30rem]/pr-header:hidden">
+                          {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
+                        </span>
+                      </Button>
+                    }
+                  />
+                  <TooltipPopup side="top">
+                    {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
+                  </TooltipPopup>
+                </Tooltip>
               ) : (primaryAction === "merged" || primaryAction === "closed") &&
                 statePresentation !== null ? (
                 <Badge size="control" variant="outline" className={statePresentation.toneClassName}>
@@ -1857,10 +1953,17 @@ export function PullRequestDetailPanel({
             {detail ? (
               <div className="col-span-2 mt-1 min-w-0 px-4 pb-4">
                 {titleDraft === null ? (
-                  <div className="group flex min-w-0 items-start gap-1">
-                    <h1 className="min-w-0 flex-1 text-base font-semibold leading-snug">
-                      {detail.title}
-                    </h1>
+                  <div className="group flex min-w-0 items-center gap-1">
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <h1 className="min-w-0 flex-1 truncate text-base font-semibold leading-snug">
+                            {detail.title}
+                          </h1>
+                        }
+                      />
+                      <TooltipPopup side="top">{detail.title}</TooltipPopup>
+                    </Tooltip>
                     {canEditPullRequestChangeRequest(detail) ? (
                       <Button
                         size="icon-xs"

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1499,9 +1499,7 @@ export function PullRequestDetailPanel({
                     render={
                       <Badge size="control" variant="info">
                         <GitMergeIcon aria-hidden className="size-3.5" />
-                        <span className="@max-[30rem]/pr-header:hidden">
-                          {armedAutoMergeLabel}
-                        </span>
+                        <span className="@max-[30rem]/pr-header:hidden">{armedAutoMergeLabel}</span>
                       </Badge>
                     }
                   />
@@ -1519,9 +1517,7 @@ export function PullRequestDetailPanel({
                         variant="destructive-outline"
                         disabled={handoff !== null}
                         onClick={startResolveConflicts}
-                        aria-label={
-                          handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"
-                        }
+                        aria-label={handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
                       >
                         <TriangleAlertIcon aria-hidden className="size-3.5" />
                         <span className="@max-[30rem]/pr-header:hidden">
@@ -1587,9 +1583,7 @@ export function PullRequestDetailPanel({
                     render={
                       <Badge size="control" variant="info">
                         <GitMergeIcon aria-hidden className="size-3.5" />
-                        <span className="@max-[30rem]/pr-header:hidden">
-                          {armedAutoMergeLabel}
-                        </span>
+                        <span className="@max-[30rem]/pr-header:hidden">{armedAutoMergeLabel}</span>
                       </Badge>
                     }
                   />


### PR DESCRIPTION
Narrow PR detail headers let the action buttons overflow and paint over the title, and long titles wrapped to two lines. The header row is now a named container: approve/checkout labels collapse to icons below 640/560px, the remaining action labels below 480px (ready and merge swap text for an icon), and the title truncates to one line with an ellipsis. Collapsed controls keep an aria-label and tooltip.

Verified with web typecheck plus same-fixture base/branch captures of PR #9255 at a 1040px viewport.

![before: full button labels and two-line title](https://uploads-production-47e4.up.railway.app/files/fac23653-36ef-44db-a659-8e1e4f9fcd44/pr-before-header.png)

![after: icon-only checkout and single-line truncated title](https://uploads-production-47e4.up.railway.app/files/29a86249-1f89-4eee-bf6e-d52a42de4ef9/pr-after-header.png)

Built with opencode/muse-spark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in the PR detail header; click handlers and merge/checkout behavior are unchanged.
> 
> **Overview**
> Fixes narrow PR detail headers where action buttons overlapped the title and long titles wrapped to two lines.
> 
> The header row is now a named container (`@container/pr-header`) so layout responds to **panel width**, not just the viewport. The title column gets **overflow hidden**; the main **h1 truncates** to one line with a tooltip for the full title. The action cluster is **`shrink-0`** so it no longer squeezes the title.
> 
> **Checkout** hides its label below **35rem**; **approve workflows** below **40rem**; and merge/ready/conflict/auto-merge controls (plus armed auto-merge badges) hide labels below **30rem**, leaving icons. **Ready** and **merge** show a PR/merge icon only in the narrowest band. Collapsed controls keep **`aria-label`s**, tooltips repeat the full label, and decorative icons are **`aria-hidden`**. Auto-merge badge tooltips now prefix the badge text before the existing explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b514807afeee3a51f47d0ece1c8e5c9be1fb0acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse PR header action buttons to icons at narrow widths
> - In `PullRequestDetailPanel`, the header now uses a named container query and marks the action area as non-shrinking so overflowing content is hidden.
> - At narrow widths, action button labels are removed and only icons remain; tooltips and `aria-label` expose the action names.
> - The PR title heading truncates to a single line, with a tooltip showing the full title; the title edit control remains available.
> - Auto-merge status tooltips now include the current action label.
> - Behavioral Change: at narrow container widths, several header action buttons display icons only; confirm that `aria-label` values in [PullRequestDetailPanel.tsx](https://github.com/pingdotgg/t3code/pull/9334/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a) still expose the action names to assistive tech.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b514807.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->