### PR TITLE
fix(web): align provider panel controls

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -629,7 +629,11 @@ export function ProviderInstanceCard({
               ) : null}
               {versionCodeNode}
               {versionAdvisory ? (
-                <span role="img" aria-label="Update available" className="inline-flex shrink-0">
+                <span
+                  role="img"
+                  aria-label="Update available"
+                  className="ml-auto inline-flex shrink-0"
+                >
                   <ArrowUpCircleIcon className="size-3.5 text-muted-foreground" />
                 </span>
               ) : null}

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -252,7 +252,11 @@ function ProviderSettingsPanelContent() {
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
     !onlyPrimaryDevice && options.length > 0 ? (
-      <ScrollArea hideScrollbars scrollFade className="mx-3 h-11 min-w-0 rounded-none sm:mx-4">
+      <ScrollArea
+        hideScrollbars
+        scrollFade
+        className="mx-3 h-11 w-auto min-w-0 rounded-none sm:mx-4"
+      >
         <div
           role="group"
           aria-label="Devices"


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-5.6 Sol on behalf of Oliver**

## Problem

Provider update indicators sit immediately after version text, so their horizontal position changes between providers and environments. The device tab divider also inherits the scroll area's full width after horizontal margins, which makes it extend past the provider panel.

## Fix

Push update indicators to the trailing edge of each provider title row. Let the device tab scroll area calculate its width from its horizontal margins so its divider ends at the provider panel edge.

## UI changes

### Before

<!-- Add before video here -->

https://github.com/user-attachments/assets/c93dc9f4-6130-4607-bc79-6e2ee41edeb4

<img width="936" height="262" alt="SCR-20260902-scnn" src="https://github.com/user-attachments/assets/4fc85b1a-2775-486d-b019-f23b486e5c8c" />



### After

<!-- Add after video here -->

https://github.com/user-attachments/assets/bd903a4a-f813-42ee-b5a3-1bdc3c899abb

<img width="907" height="215" alt="SCR-20260902-scfv" src="https://github.com/user-attachments/assets/4f6cb319-35ea-40b7-9014-c081f1395690" />



## Verification

- `vp test run src/components/settings/ProviderSettingsPanel.environment.test.tsx --project unit` from `apps/web` — 6 tests passed
- `vp lint apps/web/src/components/settings/ProviderSettingsPanel.tsx apps/web/src/components/settings/ProviderInstanceCard.tsx --report-unused-disable-directives`
- `vp fmt --check apps/web/src/components/settings/ProviderSettingsPanel.tsx apps/web/src/components/settings/ProviderInstanceCard.tsx`
- `vp run --filter @t3tools/web typecheck`
- Browser layout probe across primary and remote environments — update indicator gap and divider overrun both measured `0px`
- `git diff --check origin/main...HEAD`

Changes prepared by GPT-5.6 Sol through Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix alignment of `ProviderInstanceCard` and `ProviderSettingsPanel` controls
> - Updates the update-available indicator in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/9336/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9) to use automatic left margin, positioning it at the far right of the name row.
> - Changes the device-tab `ScrollArea` in [ProviderSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/9336/files#diff-f12e4babdd78afe45c2a0146ab2c0ef5a097d301ebed3350f53de81fc57349d3) to use automatic width sizing instead of relying solely on minimum width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5f8d43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->