### PR TITLE
feat(worktrees): run actions before removal

### DIFF
--- a/apps/mobile/src/features/terminal/terminalMenu.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.ts
@@ -155,7 +155,9 @@ export function resolveProjectScriptTerminalId(input: {
 }
 
 export function projectScriptMenuLabel(script: ProjectScript): string {
-  return script.runOnWorktreeCreate ? `${script.name} (setup)` : script.name;
+  if (script.runOnWorktreeCreate) return `${script.name} (setup)`;
+  if (script.runOnWorktreeRemove) return `${script.name} (teardown)`;
+  return script.name;
 }
 
 export function projectScriptMenuIcon(icon: ProjectScript["icon"]) {

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -619,7 +619,10 @@ function makeManager(input?: {
   ghScenario?: FakeGhScenario;
   textGeneration?: Partial<FakeGitTextGeneration>;
   serverSettings?: Parameters<typeof ServerSettings.layerTest>[0];
-  setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];
+  setupScriptRunner?: Pick<
+    ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"],
+    "runForThread"
+  >;
   gitConfigReads?: string[];
 }) {
   const { service: gitHubCli, ghCalls } = createGitHubCliWithFakeGh(input?.ghScenario);
@@ -674,12 +677,12 @@ function makeManager(input?: {
     Layer.mock(ProviderRegistry.ProviderRegistry)({
       getProviders: Effect.succeed([]),
     }),
-    Layer.succeed(
-      ProjectSetupScriptRunner.ProjectSetupScriptRunner,
-      input?.setupScriptRunner ?? {
-        runForThread: () => Effect.succeed({ status: "no-script" as const }),
-      },
-    ),
+    Layer.succeed(ProjectSetupScriptRunner.ProjectSetupScriptRunner, {
+      runForThread:
+        input?.setupScriptRunner?.runForThread ??
+        (() => Effect.succeed({ status: "no-script" as const })),
+      runBeforeWorktreeRemove: () => Effect.void,
+    }),
     vcsDriverLayer,
     serverSettingsLayer,
   ).pipe(Layer.provideMerge(sourceControlRegistryLayer), Layer.provideMerge(NodeServices.layer));

--- a/apps/server/src/git/GitWorkflowService.test.ts
+++ b/apps/server/src/git/GitWorkflowService.test.ts
@@ -8,6 +8,15 @@ import * as GitManager from "./GitManager.ts";
 import * as GitWorkflowService from "./GitWorkflowService.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as ProjectSetupScriptRunner from "../project/ProjectSetupScriptRunner.ts";
+
+const ProjectSetupScriptRunnerTest = Layer.succeed(
+  ProjectSetupScriptRunner.ProjectSetupScriptRunner,
+  {
+    runForThread: () => Effect.succeed({ status: "no-script" as const }),
+    runBeforeWorktreeRemove: () => Effect.void,
+  },
+);
 
 function makeLayer(input: {
   readonly detect: VcsDriverRegistry.VcsDriverRegistry["Service"]["detect"];
@@ -20,10 +29,40 @@ function makeLayer(input: {
     ),
     Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
     Layer.provide(Layer.mock(GitManager.GitManager)({})),
+    Layer.provide(ProjectSetupScriptRunnerTest),
   );
 }
 
 describe("GitWorkflowService", () => {
+  it.effect("runs teardown before removing a worktree", () => {
+    const calls: string[] = [];
+    const testLayer = GitWorkflowService.layer.pipe(
+      Layer.provide(
+        Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({
+          resolve: () => Effect.succeed({ kind: "git" } as VcsDriverRegistry.VcsDriverHandle),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(GitVcsDriver.GitVcsDriver)({
+          removeWorktree: () => Effect.sync(() => calls.push("remove")),
+        }),
+      ),
+      Layer.provide(Layer.mock(GitManager.GitManager)({})),
+      Layer.provide(
+        Layer.succeed(ProjectSetupScriptRunner.ProjectSetupScriptRunner, {
+          runForThread: () => Effect.succeed({ status: "no-script" as const }),
+          runBeforeWorktreeRemove: () => Effect.sync(() => calls.push("teardown")),
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const workflow = yield* GitWorkflowService.GitWorkflowService;
+      yield* workflow.removeWorktree({ cwd: "/repo", path: "/repo/worktree" });
+      assert.deepStrictEqual(calls, ["teardown", "remove"]);
+    }).pipe(Effect.provide(testLayer));
+  });
+
   it.effect("returns an empty local status when no VCS repository is detected", () =>
     Effect.gen(function* () {
       const workflow = yield* GitWorkflowService.GitWorkflowService;
@@ -100,6 +139,7 @@ describe("GitWorkflowService", () => {
           status,
         }),
       ),
+      Layer.provide(ProjectSetupScriptRunnerTest),
     );
 
     return Effect.gen(function* () {

--- a/apps/server/src/git/GitWorkflowService.test.ts
+++ b/apps/server/src/git/GitWorkflowService.test.ts
@@ -1,3 +1,4 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, expect, it, vi } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -17,7 +18,6 @@ const ProjectSetupScriptRunnerTest = Layer.succeed(
     runBeforeWorktreeRemove: () => Effect.void,
   },
 );
-
 function makeLayer(input: {
   readonly detect: VcsDriverRegistry.VcsDriverRegistry["Service"]["detect"];
 }) {
@@ -30,11 +30,12 @@ function makeLayer(input: {
     Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
     Layer.provide(Layer.mock(GitManager.GitManager)({})),
     Layer.provide(ProjectSetupScriptRunnerTest),
+    Layer.provide(NodeServices.layer),
   );
 }
 
 describe("GitWorkflowService", () => {
-  it.effect("runs teardown before removing a worktree", () => {
+  it.effect("runs teardown only when the worktree directory exists", () => {
     const calls: string[] = [];
     const testLayer = GitWorkflowService.layer.pipe(
       Layer.provide(
@@ -48,6 +49,7 @@ describe("GitWorkflowService", () => {
         }),
       ),
       Layer.provide(Layer.mock(GitManager.GitManager)({})),
+      Layer.provide(NodeServices.layer),
       Layer.provide(
         Layer.succeed(ProjectSetupScriptRunner.ProjectSetupScriptRunner, {
           runForThread: () => Effect.succeed({ status: "no-script" as const }),
@@ -58,8 +60,12 @@ describe("GitWorkflowService", () => {
 
     return Effect.gen(function* () {
       const workflow = yield* GitWorkflowService.GitWorkflowService;
-      yield* workflow.removeWorktree({ cwd: "/repo", path: "/repo/worktree" });
-      assert.deepStrictEqual(calls, ["teardown", "remove"]);
+      yield* workflow.removeWorktree({ cwd: "/repo", path: process.cwd() });
+      yield* workflow.removeWorktree({
+        cwd: "/repo",
+        path: "/path/that/does/not/exist",
+      });
+      assert.deepStrictEqual(calls, ["teardown", "remove", "remove"]);
     }).pipe(Effect.provide(testLayer));
   });
 
@@ -140,6 +146,7 @@ describe("GitWorkflowService", () => {
         }),
       ),
       Layer.provide(ProjectSetupScriptRunnerTest),
+      Layer.provide(NodeServices.layer),
     );
 
     return Effect.gen(function* () {

--- a/apps/server/src/git/GitWorkflowService.test.ts
+++ b/apps/server/src/git/GitWorkflowService.test.ts
@@ -35,8 +35,9 @@ function makeLayer(input: {
 }
 
 describe("GitWorkflowService", () => {
-  it.effect("runs teardown only when the worktree directory exists", () => {
+  it.effect("runs teardown only for an existing worktree and blocks removal on failure", () => {
     const calls: string[] = [];
+    let teardownFails = false;
     const testLayer = GitWorkflowService.layer.pipe(
       Layer.provide(
         Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({
@@ -53,7 +54,17 @@ describe("GitWorkflowService", () => {
       Layer.provide(
         Layer.succeed(ProjectSetupScriptRunner.ProjectSetupScriptRunner, {
           runForThread: () => Effect.succeed({ status: "no-script" as const }),
-          runBeforeWorktreeRemove: () => Effect.sync(() => calls.push("teardown")),
+          runBeforeWorktreeRemove: () =>
+            Effect.gen(function* () {
+              calls.push("teardown");
+              if (teardownFails) {
+                return yield* new ProjectSetupScriptRunner.ProjectSetupScriptOperationError({
+                  worktreePath: process.cwd(),
+                  operation: "runCommand",
+                  exitCode: 1,
+                });
+              }
+            }),
         }),
       ),
     );
@@ -65,7 +76,13 @@ describe("GitWorkflowService", () => {
         cwd: "/repo",
         path: "/path/that/does/not/exist",
       });
-      assert.deepStrictEqual(calls, ["teardown", "remove", "remove"]);
+      teardownFails = true;
+      const error = yield* workflow
+        .removeWorktree({ cwd: "/repo", path: process.cwd() })
+        .pipe(Effect.flip);
+
+      expect(error).toMatchObject({ command: "project teardown script", exitCode: 1 });
+      assert.deepStrictEqual(calls, ["teardown", "remove", "remove", "teardown"]);
     }).pipe(Effect.provide(testLayer));
   });
 

--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -1,5 +1,6 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 
 import {
@@ -148,6 +149,7 @@ export const make = Effect.gen(function* () {
   const git = yield* GitVcsDriver.GitVcsDriver;
   const gitManager = yield* GitManager.GitManager;
   const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+  const fileSystem = yield* FileSystem.FileSystem;
 
   const ensureGit = Effect.fn("GitWorkflowService.ensureGit")(function* (
     operation: string,
@@ -330,9 +332,10 @@ export const make = Effect.gen(function* () {
         Effect.andThen(git.resolveRemoteTrackingCommit(input)),
       ),
     removeWorktree: (input) =>
-      ensureGitCommand("GitWorkflowService.removeWorktree", input.cwd).pipe(
-        Effect.andThen(
-          projectSetupScriptRunner
+      Effect.gen(function* () {
+        yield* ensureGitCommand("GitWorkflowService.removeWorktree", input.cwd);
+        if (yield* fileSystem.exists(input.path).pipe(Effect.orElseSucceed(() => false))) {
+          yield* projectSetupScriptRunner
             .runBeforeWorktreeRemove({
               projectCwd: input.cwd,
               worktreePath: input.path,
@@ -351,10 +354,10 @@ export const make = Effect.gen(function* () {
                     cause,
                   }),
               ),
-            ),
-        ),
-        Effect.andThen(git.removeWorktree(input)),
-      ),
+            );
+        }
+        yield* git.removeWorktree(input);
+      }),
     pruneWorktrees: (input) =>
       ensureGitCommand("GitWorkflowService.pruneWorktrees", input.cwd).pipe(
         Effect.andThen(git.pruneWorktrees(input)),

--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -31,6 +31,7 @@ import {
 import * as GitManager from "./GitManager.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as ProjectSetupScriptRunner from "../project/ProjectSetupScriptRunner.ts";
 
 export class GitWorkflowService extends Context.Service<
   GitWorkflowService,
@@ -146,6 +147,7 @@ export const make = Effect.gen(function* () {
   const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
   const git = yield* GitVcsDriver.GitVcsDriver;
   const gitManager = yield* GitManager.GitManager;
+  const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
 
   const ensureGit = Effect.fn("GitWorkflowService.ensureGit")(function* (
     operation: string,
@@ -329,6 +331,28 @@ export const make = Effect.gen(function* () {
       ),
     removeWorktree: (input) =>
       ensureGitCommand("GitWorkflowService.removeWorktree", input.cwd).pipe(
+        Effect.andThen(
+          projectSetupScriptRunner
+            .runBeforeWorktreeRemove({
+              projectCwd: input.cwd,
+              worktreePath: input.path,
+            })
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new GitCommandError({
+                    operation: "GitWorkflowService.removeWorktree",
+                    command: "project teardown script",
+                    cwd: input.path,
+                    exitCode: cause.exitCode,
+                    stdoutLength: cause.stdoutLength,
+                    stderrLength: cause.stderrLength,
+                    detail: cause.message,
+                    cause,
+                  }),
+              ),
+            ),
+        ),
         Effect.andThen(git.removeWorktree(input)),
       ),
     pruneWorktrees: (input) =>

--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -1,17 +1,31 @@
 import { describe, expect, it, vi } from "@effect/vitest";
 import { type OrchestrationProject, ProjectId } from "@t3tools/contracts";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as TerminalManager from "../terminal/Manager.ts";
+import * as ProcessRunner from "../processRunner.ts";
 import * as ProjectSetupScriptRunner from "./ProjectSetupScriptRunner.ts";
 
 const isProjectSetupScriptOperationError = Schema.is(
   ProjectSetupScriptRunner.ProjectSetupScriptOperationError,
 );
+
+const processOutput = (code: number): ProcessRunner.ProcessRunOutput => ({
+  stdout: "",
+  stderr: "",
+  code: ChildProcessSpawner.ExitCode(code),
+  timedOut: false,
+  stdoutTruncated: false,
+  stderrTruncated: false,
+  stdoutInvalidUtf8: false,
+  stderrInvalidUtf8: false,
+});
 
 const makeProject = (scripts: OrchestrationProject["scripts"]): OrchestrationProject => ({
   id: ProjectId.make("project-1"),
@@ -65,10 +79,14 @@ const makeTerminalManagerLayer = (
 const testLayer = (
   project: OrchestrationProject,
   terminal: Pick<TerminalManager.TerminalManager["Service"], "open" | "write">,
+  run: ProcessRunner.ProcessRunner["Service"]["run"] = () => Effect.die("unexpected process"),
 ) =>
   ProjectSetupScriptRunner.layer.pipe(
     Layer.provideMerge(makeProjectionSnapshotQueryLayer(project)),
     Layer.provideMerge(makeTerminalManagerLayer(terminal)),
+    Layer.provideMerge(Layer.succeed(ProcessRunner.ProcessRunner, { run })),
+    Layer.provideMerge(Layer.succeed(HostProcessPlatform, "linux")),
+    Layer.provideMerge(Layer.succeed(HostProcessEnvironment, { SHELL: "/bin/bash" })),
   );
 
 describe("ProjectSetupScriptRunner", () => {
@@ -153,6 +171,76 @@ describe("ProjectSetupScriptRunner", () => {
       }).pipe(Effect.provide(testLayer(project, { open, write })));
     },
   );
+
+  it.effect("runs the teardown script before worktree removal", () => {
+    const open = vi.fn(() => Effect.die("unexpected open"));
+    const write = vi.fn(() => Effect.die("unexpected write"));
+    const run = vi.fn(() => Effect.succeed(processOutput(0)));
+    const project = makeProject([
+      {
+        id: "teardown",
+        name: "Teardown",
+        command: "docker compose down",
+        icon: "configure",
+        runOnWorktreeCreate: false,
+        runOnWorktreeRemove: true,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+      yield* runner.runBeforeWorktreeRemove({
+        projectCwd: "/repo/project",
+        worktreePath: "/repo/worktrees/a",
+      });
+
+      expect(run).toHaveBeenCalledWith({
+        command: "/bin/bash",
+        args: ["-lc", "docker compose down"],
+        cwd: "/repo/worktrees/a",
+        env: {
+          T3CODE_PROJECT_ROOT: "/repo/project",
+          T3CODE_WORKTREE_PATH: "/repo/worktrees/a",
+        },
+      });
+    }).pipe(Effect.provide(testLayer(project, { open, write }, run)));
+  });
+
+  it.effect("fails before removal when the teardown script exits unsuccessfully", () => {
+    const project = makeProject([
+      {
+        id: "teardown",
+        name: "Teardown",
+        command: "exit 7",
+        icon: "configure",
+        runOnWorktreeCreate: false,
+        runOnWorktreeRemove: true,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+      const error = yield* runner
+        .runBeforeWorktreeRemove({
+          projectCwd: "/repo/project",
+          worktreePath: "/repo/worktrees/a",
+        })
+        .pipe(Effect.flip);
+
+      expect(error).toMatchObject({ operation: "runCommand", exitCode: 7 });
+    }).pipe(
+      Effect.provide(
+        testLayer(
+          project,
+          {
+            open: () => Effect.die("unexpected open"),
+            write: () => Effect.die("unexpected write"),
+          },
+          () => Effect.succeed(processOutput(7)),
+        ),
+      ),
+    );
+  });
 
   it.effect("keeps terminal failures as the exact cause of a structured operation error", () => {
     const rootCause = new Error("stat failed");

--- a/apps/server/src/project/ProjectSetupScriptRunner.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.ts
@@ -1,5 +1,10 @@
 import { ProjectId } from "@t3tools/contracts";
-import { projectScriptRuntimeEnv, setupProjectScript } from "@t3tools/shared/projectScripts";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import {
+  projectScriptRuntimeEnv,
+  setupProjectScript,
+  teardownProjectScript,
+} from "@t3tools/shared/projectScripts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -8,6 +13,7 @@ import * as Schema from "effect/Schema";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as TerminalManager from "../terminal/Manager.ts";
+import * as ProcessRunner from "../processRunner.ts";
 
 export interface ProjectSetupScriptRunnerResultNoScript {
   readonly status: "no-script";
@@ -33,19 +39,28 @@ export interface ProjectSetupScriptRunnerInput {
   readonly preferredTerminalId?: string;
 }
 
+export interface ProjectTeardownScriptRunnerInput {
+  readonly projectCwd: string;
+  readonly worktreePath: string;
+}
+
 export class ProjectSetupScriptOperationError extends Schema.TaggedErrorClass<ProjectSetupScriptOperationError>()(
   "ProjectSetupScriptOperationError",
   {
-    threadId: Schema.String,
+    threadId: Schema.optional(Schema.String),
     projectId: Schema.optional(Schema.String),
     projectCwd: Schema.optional(Schema.String),
     worktreePath: Schema.String,
-    operation: Schema.Literals(["resolveProject", "openTerminal", "writeCommand"]),
-    cause: Schema.Defect(),
+    operation: Schema.Literals(["resolveProject", "openTerminal", "writeCommand", "runCommand"]),
+    exitCode: Schema.optional(Schema.Number),
+    stdoutLength: Schema.optional(Schema.Number),
+    stderrLength: Schema.optional(Schema.Number),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return `Project setup script operation '${this.operation}' failed for thread '${this.threadId}' in '${this.worktreePath}'.`;
+    const exit = this.exitCode === undefined ? "" : ` with exit code ${this.exitCode}`;
+    return `Project script operation '${this.operation}' failed${exit} in '${this.worktreePath}'.`;
   }
 }
 
@@ -75,12 +90,18 @@ export class ProjectSetupScriptRunner extends Context.Service<
     readonly runForThread: (
       input: ProjectSetupScriptRunnerInput,
     ) => Effect.Effect<ProjectSetupScriptRunnerResult, ProjectSetupScriptRunnerError>;
+    readonly runBeforeWorktreeRemove: (
+      input: ProjectTeardownScriptRunnerInput,
+    ) => Effect.Effect<void, ProjectSetupScriptOperationError>;
   }
 >()("t3/project/ProjectSetupScriptRunner") {}
 
 export const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
   const terminalManager = yield* TerminalManager.TerminalManager;
+  const processRunner = yield* ProcessRunner.ProcessRunner;
+  const platform = yield* HostProcessPlatform;
+  const hostEnvironment = yield* HostProcessEnvironment;
 
   const runForThread: ProjectSetupScriptRunner["Service"]["runForThread"] = Effect.fn(
     "ProjectSetupScriptRunner.runForThread",
@@ -182,7 +203,65 @@ export const make = Effect.gen(function* () {
     } as const;
   });
 
-  return ProjectSetupScriptRunner.of({ runForThread });
+  const runBeforeWorktreeRemove: ProjectSetupScriptRunner["Service"]["runBeforeWorktreeRemove"] =
+    Effect.fn("ProjectSetupScriptRunner.runBeforeWorktreeRemove")(function* (input) {
+      const project = yield* projectionSnapshotQuery
+        .getActiveProjectByWorkspaceRoot(input.projectCwd)
+        .pipe(
+          Effect.map(Option.getOrUndefined),
+          Effect.mapError(
+            (cause) =>
+              new ProjectSetupScriptOperationError({
+                ...input,
+                operation: "resolveProject",
+                cause,
+              }),
+          ),
+        );
+      const script = project ? teardownProjectScript(project.scripts) : null;
+      if (!project || !script) return;
+
+      const shell =
+        platform === "win32"
+          ? {
+              command: "powershell.exe",
+              args: ["-NoProfile", "-NonInteractive", "-Command", script.command],
+            }
+          : {
+              command: hostEnvironment.SHELL ?? "/bin/sh",
+              args: ["-lc", script.command],
+            };
+      const result = yield* processRunner
+        .run({
+          ...shell,
+          cwd: input.worktreePath,
+          env: projectScriptRuntimeEnv({
+            project: { cwd: project.workspaceRoot },
+            worktreePath: input.worktreePath,
+          }),
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProjectSetupScriptOperationError({
+                ...input,
+                operation: "runCommand",
+                cause,
+              }),
+          ),
+        );
+      if (result.code !== 0) {
+        return yield* new ProjectSetupScriptOperationError({
+          ...input,
+          operation: "runCommand",
+          exitCode: result.code === null ? undefined : Number(result.code),
+          stdoutLength: result.stdout.length,
+          stderrLength: result.stderr.length,
+        });
+      }
+    });
+
+  return ProjectSetupScriptRunner.of({ runForThread, runBeforeWorktreeRemove });
 });
 
 export const layer = Layer.effect(ProjectSetupScriptRunner, make);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -306,7 +306,7 @@ const PullRequestServiceLive = PullRequestService.layer.pipe(
 );
 
 const GitManagerLayerLive = GitManager.layer.pipe(
-  Layer.provideMerge(ProjectSetupScriptRunner.layer),
+  Layer.provideMerge(ProjectSetupScriptRunner.layer.pipe(Layer.provide(ProcessRunner.layer))),
   Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
   Layer.provideMerge(TextGeneration.layer),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -198,6 +198,7 @@ import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybinding
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   buildProjectScript,
+  clearProjectScriptLifecycleConflicts,
   commandForProjectScript,
   nextProjectScriptId,
   projectScriptIdFromCommand,
@@ -3480,14 +3481,10 @@ function ChatViewContent(props: ChatViewProps) {
         activeProject.scripts.map((script) => script.id),
       );
       const nextScript = buildProjectScript(nextId, input);
-      const nextScripts = input.runOnWorktreeCreate
-        ? [
-            ...activeProject.scripts.map((script) =>
-              script.runOnWorktreeCreate ? { ...script, runOnWorktreeCreate: false } : script,
-            ),
-            nextScript,
-          ]
-        : [...activeProject.scripts, nextScript];
+      const nextScripts = [
+        ...clearProjectScriptLifecycleConflicts(activeProject.scripts, input),
+        nextScript,
+      ];
 
       return persistProjectScripts({
         projectId: activeProject.id,
@@ -3514,12 +3511,8 @@ function ChatViewContent(props: ChatViewProps) {
       }
 
       const updatedScript = buildProjectScript(existingScript.id, input);
-      const nextScripts = activeProject.scripts.map((script) =>
-        script.id === scriptId
-          ? updatedScript
-          : input.runOnWorktreeCreate
-            ? { ...script, runOnWorktreeCreate: false }
-            : script,
+      const nextScripts = clearProjectScriptLifecycleConflicts(activeProject.scripts, input).map(
+        (script) => (script.id === scriptId ? updatedScript : script),
       );
 
       return persistProjectScripts({

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -113,6 +113,7 @@ export default function ProjectScriptsControl({
       command: fileScript.command,
       icon: fileScript.icon ?? "play",
       runOnWorktreeCreate: fileScript.runOnWorktreeCreate ?? false,
+      runOnWorktreeRemove: fileScript.runOnWorktreeRemove ?? false,
       keybinding: null,
       previewUrl: fileScript.previewUrl ?? null,
       autoOpenPreview: fileScript.previewUrl ? (fileScript.autoOpenPreview ?? false) : false,
@@ -203,7 +204,11 @@ export default function ProjectScriptsControl({
                   >
                     <ScriptIcon icon={script.icon} className="size-4" />
                     <span className="truncate">
-                      {script.runOnWorktreeCreate ? `${script.name} (setup)` : script.name}
+                      {script.runOnWorktreeCreate
+                        ? `${script.name} (setup)`
+                        : script.runOnWorktreeRemove
+                          ? `${script.name} (teardown)`
+                          : script.name}
                     </span>
                     <span className="relative ms-auto flex h-6 min-w-6 items-center justify-end">
                       {shortcutLabel && (

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -196,6 +196,12 @@ export default function ProjectScriptsControl({
                   keybindings,
                   commandForProjectScript(script.id),
                 );
+                const lifecycleLabel = [
+                  script.runOnWorktreeCreate && "setup",
+                  script.runOnWorktreeRemove && "teardown",
+                ]
+                  .filter(Boolean)
+                  .join(", ");
                 return (
                   <MenuItem
                     key={script.id}
@@ -204,11 +210,7 @@ export default function ProjectScriptsControl({
                   >
                     <ScriptIcon icon={script.icon} className="size-4" />
                     <span className="truncate">
-                      {script.runOnWorktreeCreate
-                        ? `${script.name} (setup)`
-                        : script.runOnWorktreeRemove
-                          ? `${script.name} (teardown)`
-                          : script.name}
+                      {lifecycleLabel ? `${script.name} (${lifecycleLabel})` : script.name}
                     </span>
                     <span className="relative ms-auto flex h-6 min-w-6 items-center justify-end">
                       {shortcutLabel && (

--- a/apps/web/src/components/projectScriptEditor.tsx
+++ b/apps/web/src/components/projectScriptEditor.tsx
@@ -78,6 +78,7 @@ export interface NewProjectScriptInput {
   command: string;
   icon: ProjectScriptIcon;
   runOnWorktreeCreate: boolean;
+  runOnWorktreeRemove: boolean;
   keybinding: string | null;
   /** Optional URL to open in the in-app preview when this script runs. */
   previewUrl: string | null;
@@ -92,6 +93,7 @@ export const EMPTY_PROJECT_SCRIPT_INPUT: NewProjectScriptInput = {
   command: "",
   icon: "play",
   runOnWorktreeCreate: false,
+  runOnWorktreeRemove: false,
   keybinding: null,
   previewUrl: null,
   autoOpenPreview: false,
@@ -116,6 +118,7 @@ export function editorRequestForScript(
       command: script.command,
       icon: script.icon,
       runOnWorktreeCreate: script.runOnWorktreeCreate,
+      runOnWorktreeRemove: script.runOnWorktreeRemove ?? false,
       keybinding: keybindingValueForCommand(keybindings, commandForProjectScript(script.id)),
       previewUrl: script.previewUrl ?? null,
       autoOpenPreview: script.autoOpenPreview ?? false,
@@ -151,6 +154,7 @@ export function ProjectScriptEditorDialog({
   const [icon, setIcon] = useState<ProjectScriptIcon>("play");
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [runOnWorktreeCreate, setRunOnWorktreeCreate] = useState(false);
+  const [runOnWorktreeRemove, setRunOnWorktreeRemove] = useState(false);
   const [keybinding, setKeybinding] = useState("");
   const [previewUrl, setPreviewUrl] = useState("");
   const [autoOpenPreview, setAutoOpenPreview] = useState(false);
@@ -168,6 +172,7 @@ export function ProjectScriptEditorDialog({
     setIcon(request.initial.icon);
     setIconPickerOpen(false);
     setRunOnWorktreeCreate(request.initial.runOnWorktreeCreate);
+    setRunOnWorktreeRemove(request.initial.runOnWorktreeRemove);
     setKeybinding(request.initial.keybinding ?? "");
     setPreviewUrl(request.initial.previewUrl ?? "");
     setAutoOpenPreview(request.initial.autoOpenPreview);
@@ -219,6 +224,7 @@ export function ProjectScriptEditorDialog({
         command: trimmedCommand,
         icon,
         runOnWorktreeCreate,
+        runOnWorktreeRemove,
         keybinding: keybindingRule?.key ?? null,
         previewUrl: trimmedPreviewUrl.length > 0 ? trimmedPreviewUrl : null,
         autoOpenPreview: trimmedPreviewUrl.length > 0 ? autoOpenPreview : false,
@@ -350,6 +356,13 @@ export function ProjectScriptEditorDialog({
                 <Switch
                   checked={runOnWorktreeCreate}
                   onCheckedChange={(checked) => setRunOnWorktreeCreate(Boolean(checked))}
+                />
+              </label>
+              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2 text-sm dark:border-transparent dark:bg-white/[0.035]">
+                <span>Run automatically before worktree removal</span>
+                <Switch
+                  checked={runOnWorktreeRemove}
+                  onCheckedChange={(checked) => setRunOnWorktreeRemove(Boolean(checked))}
                 />
               </label>
               <label

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -51,6 +51,7 @@ import { releaseProjectDraftUploads } from "../../lib/composerDraftUploads";
 import { readLocalApi } from "../../localApi";
 import {
   buildProjectScript,
+  clearProjectScriptLifecycleConflicts,
   commandForProjectScript,
   nextProjectScriptId,
 } from "../../projectScripts";
@@ -627,24 +628,13 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
           scripts.map((script) => script.id),
         );
         const nextScript = buildProjectScript(nextId, input);
-        const nextScripts = input.runOnWorktreeCreate
-          ? [
-              ...scripts.map((script) =>
-                script.runOnWorktreeCreate ? { ...script, runOnWorktreeCreate: false } : script,
-              ),
-              nextScript,
-            ]
-          : [...scripts, nextScript];
+        const nextScripts = [...clearProjectScriptLifecycleConflicts(scripts, input), nextScript];
         return persistScripts(nextScripts, input.keybinding, commandForProjectScript(nextId));
       }
 
       const updatedScript = buildProjectScript(scriptId, input);
-      const nextScripts = scripts.map((script) =>
-        script.id === scriptId
-          ? updatedScript
-          : input.runOnWorktreeCreate
-            ? { ...script, runOnWorktreeCreate: false }
-            : script,
+      const nextScripts = clearProjectScriptLifecycleConflicts(scripts, input).map((script) =>
+        script.id === scriptId ? updatedScript : script,
       );
       return persistScripts(nextScripts, input.keybinding, commandForProjectScript(scriptId));
     },
@@ -666,6 +656,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
         command: fileScript.command,
         icon: fileScript.icon ?? "play",
         runOnWorktreeCreate: fileScript.runOnWorktreeCreate ?? false,
+        runOnWorktreeRemove: fileScript.runOnWorktreeRemove ?? false,
         keybinding: null,
         previewUrl: fileScript.previewUrl ?? null,
         autoOpenPreview: fileScript.previewUrl ? (fileScript.autoOpenPreview ?? false) : false,
@@ -1156,6 +1147,11 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                       {script.runOnWorktreeCreate ? (
                         <span className="shrink-0 rounded-sm border border-border/60 px-1.5 py-px text-[11px] font-normal text-muted-foreground">
                           setup
+                        </span>
+                      ) : null}
+                      {script.runOnWorktreeRemove ? (
+                        <span className="shrink-0 rounded-sm border border-border/60 px-1.5 py-px text-[11px] font-normal text-muted-foreground">
+                          teardown
                         </span>
                       ) : null}
                       {script.previewUrl ? (

--- a/apps/web/src/projectScripts.test.ts
+++ b/apps/web/src/projectScripts.test.ts
@@ -3,10 +3,12 @@ import {
   projectScriptCwd,
   projectScriptRuntimeEnv,
   setupProjectScript,
+  teardownProjectScript,
 } from "@t3tools/shared/projectScripts";
 
 import {
   buildProjectScript,
+  clearProjectScriptLifecycleConflicts,
   commandForProjectScript,
   nextProjectScriptId,
   primaryProjectScript,
@@ -21,6 +23,7 @@ describe("projectScripts helpers", () => {
         command: "pnpm dev",
         icon: "debug",
         runOnWorktreeCreate: false,
+        runOnWorktreeRemove: false,
         previewUrl: "http://localhost:5733",
         autoOpenPreview: true,
       }),
@@ -42,6 +45,7 @@ describe("projectScripts helpers", () => {
         command: "pnpm test",
         icon: "test",
         runOnWorktreeCreate: false,
+        runOnWorktreeRemove: false,
         previewUrl: null,
         autoOpenPreview: false,
       }),
@@ -82,11 +86,26 @@ describe("projectScripts helpers", () => {
         command: "bun test",
         icon: "test" as const,
         runOnWorktreeCreate: false,
+        runOnWorktreeRemove: true,
+      },
+      {
+        id: "lint",
+        name: "Lint",
+        command: "bun lint",
+        icon: "lint" as const,
+        runOnWorktreeCreate: false,
       },
     ];
 
-    expect(primaryProjectScript(scripts)?.id).toBe("test");
+    expect(primaryProjectScript(scripts)?.id).toBe("lint");
     expect(setupProjectScript(scripts)?.id).toBe("setup");
+    expect(teardownProjectScript(scripts)?.id).toBe("test");
+    expect(
+      clearProjectScriptLifecycleConflicts(scripts, {
+        runOnWorktreeCreate: false,
+        runOnWorktreeRemove: true,
+      }).find((script) => script.id === "test")?.runOnWorktreeRemove,
+    ).toBe(false);
   });
 
   it("builds default runtime env for scripts", () => {

--- a/apps/web/src/projectScripts.ts
+++ b/apps/web/src/projectScripts.ts
@@ -12,6 +12,7 @@ export interface ProjectScriptInput {
   readonly command: ProjectScript["command"];
   readonly icon: ProjectScript["icon"];
   readonly runOnWorktreeCreate: ProjectScript["runOnWorktreeCreate"];
+  readonly runOnWorktreeRemove: boolean;
   readonly previewUrl: Exclude<ProjectScript["previewUrl"], undefined> | null;
   readonly autoOpenPreview: boolean;
 }
@@ -23,6 +24,7 @@ export function buildProjectScript(id: string, input: ProjectScriptInput): Proje
     command: input.command,
     icon: input.icon,
     runOnWorktreeCreate: input.runOnWorktreeCreate,
+    ...(input.runOnWorktreeRemove ? { runOnWorktreeRemove: true } : {}),
     ...(input.previewUrl === null
       ? {}
       : {
@@ -30,6 +32,22 @@ export function buildProjectScript(id: string, input: ProjectScriptInput): Proje
           autoOpenPreview: input.autoOpenPreview,
         }),
   };
+}
+
+export function clearProjectScriptLifecycleConflicts(
+  scripts: ReadonlyArray<ProjectScript>,
+  input: Pick<ProjectScriptInput, "runOnWorktreeCreate" | "runOnWorktreeRemove">,
+): ReadonlyArray<ProjectScript> {
+  if (!input.runOnWorktreeCreate && !input.runOnWorktreeRemove) return scripts;
+  return scripts.map((script) => ({
+    ...script,
+    ...(input.runOnWorktreeCreate && script.runOnWorktreeCreate
+      ? { runOnWorktreeCreate: false }
+      : {}),
+    ...(input.runOnWorktreeRemove && script.runOnWorktreeRemove
+      ? { runOnWorktreeRemove: false }
+      : {}),
+  }));
 }
 
 function normalizeScriptId(value: string): string {
@@ -82,6 +100,8 @@ export function nextProjectScriptId(name: string, existingIds: Iterable<string>)
 }
 
 export function primaryProjectScript(scripts: ReadonlyArray<ProjectScript>): ProjectScript | null {
-  const regular = scripts.find((script) => !script.runOnWorktreeCreate);
+  const regular = scripts.find(
+    (script) => !script.runOnWorktreeCreate && !script.runOnWorktreeRemove,
+  );
   return regular ?? scripts[0] ?? null;
 }

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -15,6 +15,19 @@ each checkout in the project group and appears on your connected clients.
 
 To use automatic detection again, select **Automatic**.
 
+## Run worktree setup and teardown actions
+
+Project actions can run automatically when T3 Code creates or removes a worktree. Use a setup
+action to install dependencies or copy local environment files. Use a teardown action to stop
+worktree-specific services or remove generated resources.
+
+In **Settings** > **Projects**, edit an action and turn on **Run automatically on worktree
+creation** or **Run automatically before worktree removal**. T3 Code runs teardown before it
+deletes the worktree. If teardown fails, the worktree stays in place so you can fix the command
+and try again.
+
+Actions imported from `t3.json` support `runOnWorktreeCreate` and `runOnWorktreeRemove`.
+
 ## Keep the default branch current
 
 Turn on **Automatically pull** in a project's settings to keep its default-branch checkout current.

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -262,6 +262,8 @@ export const ProjectScript = Schema.Struct({
   command: TrimmedNonEmptyString,
   icon: ProjectScriptIcon,
   runOnWorktreeCreate: Schema.Boolean,
+  // Optional so project snapshots from older servers still decode.
+  runOnWorktreeRemove: Schema.optional(Schema.Boolean),
   /**
    * URL to open in the in-app browser preview when this script runs (or
    * when the user explicitly requests a preview). Optional; only honored on

--- a/packages/contracts/src/t3ProjectFile.test.ts
+++ b/packages/contracts/src/t3ProjectFile.test.ts
@@ -16,6 +16,7 @@ describe("T3ProjectFile", () => {
           command: "pnpm dev",
           icon: "play",
           runOnWorktreeCreate: false,
+          runOnWorktreeRemove: true,
           previewUrl: "http://localhost:3000",
           autoOpenPreview: true,
         },

--- a/packages/contracts/src/t3ProjectFile.ts
+++ b/packages/contracts/src/t3ProjectFile.ts
@@ -42,6 +42,11 @@ export const T3ProjectFileScript = Schema.Struct({
         "When true, the script runs automatically after a worktree is created for a new thread.",
     }),
   ),
+  runOnWorktreeRemove: Schema.optionalKey(
+    Schema.Boolean.annotate({
+      description: "When true, the script runs automatically before a worktree is removed.",
+    }),
+  ),
   previewUrl: Schema.optionalKey(
     trimmedNonEmpty({
       description:

--- a/packages/shared/src/projectScripts.ts
+++ b/packages/shared/src/projectScripts.ts
@@ -35,3 +35,7 @@ export function projectScriptRuntimeEnv(
 export function setupProjectScript(scripts: readonly ProjectScript[]): ProjectScript | null {
   return scripts.find((script) => script.runOnWorktreeCreate) ?? null;
 }
+
+export function teardownProjectScript(scripts: readonly ProjectScript[]): ProjectScript | null {
+  return scripts.find((script) => script.runOnWorktreeRemove) ?? null;
+}

--- a/packages/shared/src/t3ProjectFile.test.ts
+++ b/packages/shared/src/t3ProjectFile.test.ts
@@ -50,6 +50,7 @@ describe("buildT3ProjectFileJsonSchema", () => {
       "name",
       "previewUrl",
       "runOnWorktreeCreate",
+      "runOnWorktreeRemove",
     ]);
   });
 


### PR DESCRIPTION
Projects can run an action when a worktree is created, but they have no matching hook before removal. Users must run cleanup commands by hand, and worktree deletion can leave generated resources behind.

This change adds one optional teardown action per project. T3 runs it in the worktree before removal and stops the removal when the command fails. The action editor, shared contracts, mobile labels, user documentation, and focused tests now include the new lifecycle step.

### Safety model

- Teardown is off by default and uses the existing project-action command trust boundary.
- T3 runs at most one teardown action, only after the user requests worktree removal, and only while the worktree directory exists.
- The existing process runner limits execution to 60 seconds and captured output to 8 MiB.
- Spawn errors, timeouts, output-limit errors, and nonzero exits stop removal and return a structured error.
- If the directory is already gone, T3 skips teardown and keeps the Git driver path that prunes stale worktree registrations.

### Tests

- 33 focused tests across 5 test files
- Workflow coverage proves teardown runs before removal, missing directories skip teardown, and teardown failure prevents the Git removal call
- Driver integration coverage proves stale worktree registrations are pruned
- Type checks for server, web, mobile, contracts, and shared packages
- Targeted lint, formatting, and diff checks
- Manual web verification of setup and teardown behavior

Created with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Worktree removal now executes configured shell commands and aborts removal on failure, which affects cleanup workflows and could leave worktrees in place if teardown errors.
> 
> **Overview**
> Adds an optional **teardown** lifecycle for project actions, symmetric to existing setup-on-create behavior. Scripts can be marked **run automatically before worktree removal** in the web editor, settings, and `t3.json`; only one setup and one teardown action are kept at a time via `clearProjectScriptLifecycleConflicts`.
> 
> **Server:** `ProjectSetupScriptRunner` gains `runBeforeWorktreeRemove`, which finds the teardown script and runs its command in the worktree (host shell / PowerShell on Windows) with `T3CODE_*` env vars. **`GitWorkflowService.removeWorktree`** runs teardown only when the worktree path still exists, then removes the worktree; a non-zero exit surfaces as `GitCommandError` with command `project teardown script` and **blocks deletion**. Wiring adds `ProcessRunner` to the script runner layer.
> 
> **Clients & contracts:** Optional `runOnWorktreeRemove` on `ProjectScript` / file schema; mobile and web menus show `(teardown)` / badges. User docs describe setup/teardown and failure behavior. Tests cover runner, workflow ordering, and lifecycle helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00a0429ac8c5a4fff2f2498c2d50840aeeb9596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add teardown scripts before worktree removal in `GitWorkflowService`
> - `GitWorkflowService.removeWorktree` now runs the configured project teardown script before invoking VCS removal for existing worktree paths; missing paths skip teardown and proceed to removal as before.
> - `ProjectSetupScriptRunner` gains `runBeforeWorktreeRemove`, which executes the selected teardown script in the worktree using PowerShell on win32 or the configured login shell elsewhere, and fails on process errors or nonzero exit codes.
> - The web editor, project settings, and import paths add a `runOnWorktreeRemove` flag with badges, lifecycle-conflict clearing that keeps setup and teardown independent, and primary-script selection that excludes lifecycle scripts.
> - Contracts add an optional `runOnWorktreeRemove` to `ProjectScript` and `T3ProjectFileScript`; older snapshots and project files decode with the field absent.
> - Behavioral Change: `removeWorktree` aborts VCS removal and returns a `GitCommandError` when teardown fails; reviewers should check [GitWorkflowService.ts](https://github.com/pingdotgg/t3code/pull/9337/files#diff-7d082b30d16893685c143172142216432f471eb68cf98a1063304623ca4c79bd) and [ProjectSetupScriptRunner.ts](https://github.com/pingdotgg/t3code/pull/9337/files#diff-7ca99e864eafb76644d30338cec8869844b8c2d62113b7e4b348f829dd12bcf2) for error mapping of nonzero exit codes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c00a042.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->