### PR TITLE
feat(web): choose whether links open in the default browser or in T3 Code

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -18,6 +18,7 @@ const clientSettings: ClientSettings = {
   browserDefaultZoomFactor: 1.25,
   browserDefaultAppearance: "dark",
   browserRecordingFrameRate: 60,
+  browserLinkTarget: "app",
   browserAutoShowFloatingPreview: false,
   browserProfiles: [{ id: "work", name: "Work", kind: "persistent" }],
   browserDefaultProfileId: "work",

--- a/apps/web/src/browser/browserLinkTarget.test.ts
+++ b/apps/web/src/browser/browserLinkTarget.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveLinkTarget } from "./browserLinkTarget";
+
+const click = { metaKey: false, ctrlKey: false };
+
+describe("resolveLinkTarget", () => {
+  it("keeps the system browser unless the user asked for in-app", () => {
+    expect(
+      resolveLinkTarget({
+        url: "https://example.com/",
+        event: click,
+        preference: "system",
+        canOpenInApp: true,
+      }),
+    ).toBe("system");
+  });
+
+  it("opens in-app when asked and the runtime can", () => {
+    expect(
+      resolveLinkTarget({
+        url: "https://example.com/",
+        event: click,
+        preference: "app",
+        canOpenInApp: true,
+      }),
+    ).toBe("app");
+  });
+
+  it("falls back to the system browser where there is no in-app browser", () => {
+    // The hosted web app and mobile have nowhere to open a tab, so the
+    // preference cannot be honoured there and the link still has to open.
+    expect(
+      resolveLinkTarget({
+        url: "https://example.com/",
+        event: click,
+        preference: "app",
+        canOpenInApp: false,
+      }),
+    ).toBe("system");
+  });
+
+  it("treats a modifier click as the way out of the in-app default", () => {
+    expect(
+      resolveLinkTarget({
+        url: "https://example.com/",
+        event: { metaKey: true, ctrlKey: false },
+        preference: "app",
+        canOpenInApp: true,
+      }),
+    ).toBe("system");
+    expect(
+      resolveLinkTarget({
+        url: "https://example.com/",
+        event: { metaKey: false, ctrlKey: true },
+        preference: "app",
+        canOpenInApp: true,
+      }),
+    ).toBe("system");
+  });
+
+  it("leaves non-web schemes to the shell", () => {
+    for (const url of ["mailto:someone@example.com", "vscode://file/x", "not a url"]) {
+      expect(resolveLinkTarget({ url, event: click, preference: "app", canOpenInApp: true })).toBe(
+        "system",
+      );
+    }
+  });
+});

--- a/apps/web/src/browser/browserLinkTarget.ts
+++ b/apps/web/src/browser/browserLinkTarget.ts
@@ -1,0 +1,61 @@
+/**
+ * Where a link clicked inside a thread should open.
+ *
+ * Settings → Integrations → Browser lets the user choose between the OS
+ * default browser and a tab in the in-app browser. This module turns that
+ * preference plus the click itself into one answer, so chat markdown and the
+ * terminal drawer make the same decision and offer the same escape hatch.
+ *
+ * @module browserLinkTarget
+ */
+import type { BrowserLinkTarget } from "@t3tools/contracts";
+
+import { getClientSettings } from "~/hooks/useSettings";
+import { isPreviewSupportedInRuntime } from "~/previewStateStore";
+
+export interface ResolveLinkTargetInput {
+  readonly url: string;
+  /** Cmd/Ctrl-click always goes to the system browser, whatever the default. */
+  readonly event: { readonly metaKey: boolean; readonly ctrlKey: boolean };
+  readonly preference: BrowserLinkTarget;
+  /** Whether this client has an in-app browser and a thread to open it beside. */
+  readonly canOpenInApp: boolean;
+}
+
+/**
+ * The target a click resolves to. "app" only comes back when the preference
+ * asks for it, the runtime can honour it, the URL is one the in-app browser
+ * can load, and the click carried no modifier — the modifier is the one-gesture
+ * way out when the default is in-app, mirroring how change-request links
+ * already treat it.
+ */
+export function resolveLinkTarget(input: ResolveLinkTargetInput): BrowserLinkTarget {
+  if (input.event.metaKey || input.event.ctrlKey) return "system";
+  if (input.preference !== "app") return "system";
+  if (!input.canOpenInApp) return "system";
+  if (!isWebUrl(input.url)) return "system";
+  return "app";
+}
+
+/**
+ * Only http(s) can load in the in-app browser. Anything else — mailto:,
+ * vscode://, a bare fragment — belongs to the shell whatever the preference.
+ */
+export function isWebUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** Non-hook accessor for the configured default, for the imperative open paths. */
+export function getBrowserLinkTargetPreference(): BrowserLinkTarget {
+  return getClientSettings().browserLinkTarget;
+}
+
+/** Whether the in-app target is available at all in this client. */
+export function canOpenLinksInApp(hasThread: boolean): boolean {
+  return hasThread && isPreviewSupportedInRuntime();
+}

--- a/apps/web/src/browser/browserLinkTarget.ts
+++ b/apps/web/src/browser/browserLinkTarget.ts
@@ -10,7 +10,7 @@
  */
 import type { BrowserLinkTarget } from "@t3tools/contracts";
 
-import { getClientSettings } from "~/hooks/useSettings";
+import { ensureClientSettingsHydrated, getClientSettings } from "~/hooks/useSettings";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
 
 export interface ResolveLinkTargetInput {
@@ -50,8 +50,14 @@ export function isWebUrl(url: string): boolean {
   }
 }
 
-/** Non-hook accessor for the configured default, for the imperative open paths. */
-export function getBrowserLinkTargetPreference(): BrowserLinkTarget {
+/**
+ * The configured default, once client settings have actually loaded. Before
+ * hydration the snapshot is the schema default ("system"), so a link clicked
+ * in the first moments after launch would ignore a persisted "app" — opening
+ * is asynchronous anyway, so waiting costs nothing the user can see.
+ */
+export async function resolveBrowserLinkTargetPreference(): Promise<BrowserLinkTarget> {
+  await ensureClientSettingsHydrated();
   return getClientSettings().browserLinkTarget;
 }
 

--- a/apps/web/src/browser/useOpenLink.ts
+++ b/apps/web/src/browser/useOpenLink.ts
@@ -1,0 +1,54 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
+import { useCallback } from "react";
+
+import { readLocalApi } from "~/localApi";
+import { previewEnvironment } from "~/state/preview";
+import { useAtomCommand } from "~/state/use-atom-command";
+
+import {
+  canOpenLinksInApp,
+  getBrowserLinkTargetPreference,
+  resolveLinkTarget,
+} from "./browserLinkTarget";
+import { openUrlInPreview } from "./openFileInPreview";
+
+const NO_MODIFIER = { metaKey: false, ctrlKey: false } as const;
+
+/**
+ * Opens a URL where the "Open links in" setting says, for buttons that sit
+ * beside a thread but are not markdown anchors: CI check details, a pull
+ * request that has no project to open in the panel. Without a thread there is
+ * nowhere to put an in-app tab, so the link goes to the system browser.
+ *
+ * The in-app open falling over is reported through the returned promise, so
+ * the caller decides whether that deserves a toast; the system-browser path
+ * rejects the same way `shell.openExternal` does.
+ */
+export function useOpenLink(
+  threadRef: ScopedThreadRef | null | undefined,
+): (
+  url: string,
+  event?: { readonly metaKey: boolean; readonly ctrlKey: boolean },
+) => Promise<void> {
+  const openPreview = useAtomCommand(previewEnvironment.open, { reportFailure: false });
+  return useCallback(
+    async (url, event = NO_MODIFIER) => {
+      const target = resolveLinkTarget({
+        url,
+        event,
+        preference: getBrowserLinkTargetPreference(),
+        canOpenInApp: canOpenLinksInApp(Boolean(threadRef)),
+      });
+      if (target === "app" && threadRef) {
+        const result = await openUrlInPreview({ threadRef, url, openPreview });
+        if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+        throw new Error("Unable to open the link in T3 Code.", { cause: result.cause });
+      }
+      const api = readLocalApi();
+      if (!api) throw new Error("Link opening is unavailable.");
+      await api.shell.openExternal(url);
+    },
+    [openPreview, threadRef],
+  );
+}

--- a/apps/web/src/browser/useOpenLink.ts
+++ b/apps/web/src/browser/useOpenLink.ts
@@ -2,13 +2,14 @@ import type { ScopedThreadRef } from "@t3tools/contracts";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { useCallback } from "react";
 
+import { recordVisitForThread } from "~/browserHistoryStore";
 import { readLocalApi } from "~/localApi";
 import { previewEnvironment } from "~/state/preview";
 import { useAtomCommand } from "~/state/use-atom-command";
 
 import {
   canOpenLinksInApp,
-  getBrowserLinkTargetPreference,
+  resolveBrowserLinkTargetPreference,
   resolveLinkTarget,
 } from "./browserLinkTarget";
 import { openUrlInPreview } from "./openFileInPreview";
@@ -21,29 +22,37 @@ const NO_MODIFIER = { metaKey: false, ctrlKey: false } as const;
  * request that has no project to open in the panel. Without a thread there is
  * nowhere to put an in-app tab, so the link goes to the system browser.
  *
- * The in-app open falling over is reported through the returned promise, so
- * the caller decides whether that deserves a toast; the system-browser path
- * rejects the same way `shell.openExternal` does.
+ * An in-app open that fails falls back to the system browser rather than
+ * dropping the click: the user asked for the link, and the setting only says
+ * where it should go first. The returned promise rejects only when that
+ * fallback fails too, the same way `shell.openExternal` does.
  */
-export function useOpenLink(
-  threadRef: ScopedThreadRef | null | undefined,
-): (
+export function useOpenLink(threadRef: ScopedThreadRef | null | undefined): (
   url: string,
-  event?: { readonly metaKey: boolean; readonly ctrlKey: boolean },
+  options?: {
+    readonly event?: { readonly metaKey: boolean; readonly ctrlKey: boolean };
+    /** Thread to open beside when it is not the hook's own, e.g. a sidebar row's. */
+    readonly threadRef?: ScopedThreadRef | undefined;
+  },
 ) => Promise<void> {
   const openPreview = useAtomCommand(previewEnvironment.open, { reportFailure: false });
   return useCallback(
-    async (url, event = NO_MODIFIER) => {
+    async (url, options = {}) => {
+      const targetThreadRef = options.threadRef ?? threadRef;
       const target = resolveLinkTarget({
         url,
-        event,
-        preference: getBrowserLinkTargetPreference(),
-        canOpenInApp: canOpenLinksInApp(Boolean(threadRef)),
+        event: options.event ?? NO_MODIFIER,
+        preference: await resolveBrowserLinkTargetPreference(),
+        canOpenInApp: canOpenLinksInApp(Boolean(targetThreadRef)),
       });
-      if (target === "app" && threadRef) {
-        const result = await openUrlInPreview({ threadRef, url, openPreview });
-        if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
-        throw new Error("Unable to open the link in T3 Code.", { cause: result.cause });
+      if (target === "app" && targetThreadRef) {
+        const result = await openUrlInPreview({ threadRef: targetThreadRef, url, openPreview });
+        if (isAtomCommandInterrupted(result)) return;
+        if (result._tag === "Success") {
+          recordVisitForThread(targetThreadRef, url);
+          return;
+        }
+        console.error(result.cause);
       }
       const api = readLocalApi();
       if (!api) throw new Error("Link opening is unavailable.");

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -173,6 +173,7 @@ import {
   openUrlInPreview,
   BrowserPreviewUnavailableError,
 } from "../browser/openFileInPreview";
+import { getBrowserLinkTargetPreference, resolveLinkTarget } from "../browser/browserLinkTarget";
 
 interface ChatMarkdownProps {
   text: string;
@@ -2472,9 +2473,33 @@ function ChatMarkdown({
                 }
                 // A link to a change request in a workspace project opens beside the
                 // conversation instead of in a browser: it is the thing being talked about, and
-                // the panel it opens offers the browser as one of its actions. Anything else is
-                // an ordinary link and keeps the `_blank` the shell already handles.
-                if (href) openChangeRequestLink(event, href);
+                // the panel it opens offers the browser as one of its actions.
+                if (!href || openChangeRequestLink(event, href)) return;
+                // Anything else follows the "Open links in" setting. The system browser
+                // keeps the `_blank` the shell already handles; the in-app browser needs
+                // the click intercepted here. A modifier click is the way out of the
+                // in-app default, so it is left to the shell too.
+                if (
+                  event.defaultPrevented ||
+                  resolveLinkTarget({
+                    url: href,
+                    event,
+                    preference: getBrowserLinkTargetPreference(),
+                    canOpenInApp: canOpenInPreview,
+                  }) !== "app"
+                ) {
+                  return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                void openExternalLinkInPreview(href).then((result) => {
+                  if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+                    reportMarkdownActionFailure(
+                      { operation: "open-link-in-preview", target: href },
+                      result.cause,
+                    );
+                  }
+                });
               }}
               onContextMenu={(event) => {
                 if (!href || !faviconHost) return;

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -119,7 +119,7 @@ import { LRUCache } from "../lib/lruCache";
 import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
 import { RenderErrorBoundary } from "./RenderErrorBoundary";
 import { useTheme } from "../hooks/useTheme";
-import { getClientSettings } from "../hooks/useSettings";
+import { getClientSettings, useClientSettings } from "../hooks/useSettings";
 import {
   chatMarkdownClipboardPayload,
   serializeTableElementToCsv,
@@ -173,7 +173,7 @@ import {
   openUrlInPreview,
   BrowserPreviewUnavailableError,
 } from "../browser/openFileInPreview";
-import { getBrowserLinkTargetPreference, resolveLinkTarget } from "../browser/browserLinkTarget";
+import { resolveLinkTarget } from "../browser/browserLinkTarget";
 
 interface ChatMarkdownProps {
   text: string;
@@ -2121,6 +2121,10 @@ function ChatMarkdown({
     event.clipboardData.setData("text/html", payload.html);
   }, []);
   const openChangeRequestLink = useOpenChangeRequestLink(threadRef);
+  // Subscribed rather than read at click time: the anchor has to decide
+  // synchronously whether to intercept its `_blank`, and a subscription is what
+  // makes a persisted "app" apply once settings hydrate after launch.
+  const linkTargetPreference = useClientSettings((settings) => settings.browserLinkTarget);
   const resolveThreadPullRequest = useCallback(
     (href: string): ThreadLinkedPullRequest | null => {
       if (
@@ -2484,7 +2488,7 @@ function ChatMarkdown({
                   resolveLinkTarget({
                     url: href,
                     event,
-                    preference: getBrowserLinkTargetPreference(),
+                    preference: linkTargetPreference,
                     canOpenInApp: canOpenInPreview,
                   }) !== "app"
                 ) {
@@ -2492,13 +2496,15 @@ function ChatMarkdown({
                 }
                 event.preventDefault();
                 event.stopPropagation();
+                // The click was taken from the shell, so an in-app open that fails
+                // hands the link to the system browser instead of dropping it.
                 void openExternalLinkInPreview(href).then((result) => {
-                  if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-                    reportMarkdownActionFailure(
-                      { operation: "open-link-in-preview", target: href },
-                      result.cause,
-                    );
-                  }
+                  if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+                  reportMarkdownActionFailure(
+                    { operation: "open-link-in-preview", target: href },
+                    result.cause,
+                  );
+                  void readLocalApi()?.shell.openExternal(href);
                 });
               }}
               onContextMenu={(event) => {
@@ -2736,6 +2742,7 @@ function ChatMarkdown({
     inlineCodeFileLinkMetaByText,
     imageBaseDir,
     isStreaming,
+    linkTargetPreference,
     markdownFileLinkMetaByHref,
     onTaskListChange,
     onUseArtifactTemplate,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7289,6 +7289,7 @@ function ChatViewContent(props: ChatViewProps) {
       <PullRequestDetailPanel
         key={`${renderedRightPanelSurface.repository}#${renderedRightPanelSurface.number}`}
         environmentId={activeThread.environmentId}
+        threadRef={activeThreadRef}
         reference={{
           projectId: renderedRightPanelSurface.projectId as ProjectId,
           repository: renderedRightPanelSurface.repository,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -32,7 +32,6 @@ import {
   ChevronDownIcon,
   CloudDownloadIcon,
   CloudUploadIcon,
-  ExternalLinkIcon,
   GitBranchPlusIcon,
   GitCommitIcon,
   InfoIcon,
@@ -97,9 +96,9 @@ import { vcsEnvironment } from "~/state/vcs";
 import { randomUUID } from "~/lib/utils";
 import { resolvePathLinkTarget } from "~/terminal-links";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
-import { readLocalApi } from "~/localApi";
 import { getSourceControlPresentation } from "~/sourceControlPresentation";
-import { openPullRequestLink, useOpenPrLink } from "~/lib/openPullRequestLink";
+import { useOpenLink } from "~/browser/useOpenLink";
+import { useOpenPrLink } from "~/lib/openPullRequestLink";
 
 interface GitActionsControlProps {
   gitCwd: string | null;
@@ -384,10 +383,13 @@ interface PublishRepositoryDialogProps {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
   readonly environmentId: ScopedThreadRef["environmentId"] | null;
+  /** Thread the dialog was opened from, so the new repository can open beside it. */
+  readonly threadRef: ScopedThreadRef | null;
   readonly gitCwd: string;
 }
 
 function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
+  const openLink = useOpenLink(props.threadRef);
   const navigate = useNavigate();
   const sourceControlDiscovery = useEnvironmentQuery(
     props.environmentId === null
@@ -911,12 +913,9 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
                       size="sm"
                       className="w-full"
                       onClick={() => {
-                        const api = readLocalApi();
-                        if (!api) return;
-                        void api.shell.openExternal(publishResult.repository.url);
+                        void openLink(publishResult.repository.url).catch(() => undefined);
                       }}
                     >
-                      <ExternalLinkIcon className="size-3.5" aria-hidden />
                       Open on {publishProviderLabel}
                     </Button>
                   </>
@@ -1004,6 +1003,7 @@ export default function GitActionsControl({
     [activeThreadRef],
   );
   const openPrLink = useOpenPrLink(activeThreadRef ?? undefined);
+  const openLink = useOpenLink(activeThreadRef);
   const activeDraftThread = useComposerDraftStore((store) =>
     draftId
       ? store.getDraftSession(draftId)
@@ -1238,15 +1238,6 @@ export default function GitActionsControl({
       onOpenPullRequest(openPr.number);
       return;
     }
-    const api = readLocalApi();
-    if (!api) {
-      toastManager.add({
-        type: "error",
-        title: "Link opening is unavailable.",
-        data: threadToastData,
-      });
-      return;
-    }
     const prUrl = openPr?.url ?? null;
     if (!prUrl) {
       toastManager.add({
@@ -1256,7 +1247,7 @@ export default function GitActionsControl({
       });
       return;
     }
-    void openPullRequestLink(api.shell, prUrl).catch((err: unknown) => {
+    void openLink(prUrl).catch((err: unknown) => {
       console.error(err);
       toastManager.add(
         stackedThreadToast({
@@ -1267,7 +1258,7 @@ export default function GitActionsControl({
         }),
       );
     });
-  }, [gitStatusForActions, onOpenPullRequest, threadToastData]);
+  }, [gitStatusForActions, onOpenPullRequest, openLink, threadToastData]);
 
   runGitActionWithToast = useEffectEvent(
     async ({
@@ -2010,6 +2001,7 @@ export default function GitActionsControl({
         open={isPublishDialogOpen}
         onOpenChange={setIsPublishDialogOpen}
         environmentId={activeEnvironmentId}
+        threadRef={activeThreadRef}
         gitCwd={gitCwd}
       />
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -728,10 +728,8 @@ export function TerminalViewport({
           };
           void openTerminalLinkInPreview({
             url: text,
-            position: { x: event.clientX, y: event.clientY },
             threadRef,
             openPreview,
-            localApi,
             fallbackToBrowser,
           });
           return;

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
@@ -1,11 +1,10 @@
-import type { LocalApi, PreviewSessionSnapshot, ScopedThreadRef } from "@t3tools/contracts";
+import type { PreviewSessionSnapshot, ScopedThreadRef } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   openTerminalLinkInPreview,
-  TerminalLinkContextMenuShowError,
   TerminalLinkPreviewOpenError,
 } from "./openTerminalLinkInPreview";
 
@@ -30,6 +29,15 @@ vi.mock("~/browser/browserDefaults", () => ({
   browserDefaultOpenProfileId: (defaults: { profileId: string }) => defaults.profileId,
 }));
 
+const linkTargetMocks = vi.hoisted(() => ({
+  preference: vi.fn<() => "system" | "app">(),
+}));
+
+vi.mock("~/browser/browserLinkTarget", () => ({
+  getBrowserLinkTargetPreference: linkTargetMocks.preference,
+  isWebUrl: (url: string) => /^https?:/u.test(url),
+}));
+
 const hydratedDefaults = {
   viewport: { _tag: "fixed", width: 1280, height: 720 } as const,
   profileId: "work",
@@ -50,7 +58,9 @@ const snapshot: PreviewSessionSnapshot = {
 };
 
 beforeEach(() => {
+  browserDefaultsMocks.resolve.mockReset();
   browserDefaultsMocks.resolve.mockResolvedValue(hydratedDefaults);
+  linkTargetMocks.preference.mockReturnValue("app");
 });
 
 afterEach(() => {
@@ -58,6 +68,37 @@ afterEach(() => {
 });
 
 describe("openTerminalLinkInPreview", () => {
+  it("opens in the system browser while that is the configured target", async () => {
+    linkTargetMocks.preference.mockReturnValue("system");
+    const fallbackToBrowser = vi.fn();
+    const openPreview = vi.fn(async () => AsyncResult.success(snapshot));
+
+    await openTerminalLinkInPreview({
+      url: "http://localhost:3000/",
+      threadRef,
+      openPreview,
+      fallbackToBrowser,
+    });
+
+    expect(fallbackToBrowser).toHaveBeenCalledOnce();
+    expect(openPreview).not.toHaveBeenCalled();
+  });
+
+  it("opens public URLs in-app too, not only local servers", async () => {
+    const fallbackToBrowser = vi.fn();
+    const openPreview = vi.fn(async () => AsyncResult.success(snapshot));
+
+    await openTerminalLinkInPreview({
+      url: "https://example.com/docs",
+      threadRef,
+      openPreview,
+      fallbackToBrowser,
+    });
+
+    expect(openPreview).toHaveBeenCalledOnce();
+    expect(fallbackToBrowser).not.toHaveBeenCalled();
+  });
+
   it("waits for hydrated viewport and profile defaults before opening", async () => {
     let hydrate: ((defaults: typeof hydratedDefaults) => void) | undefined;
     browserDefaultsMocks.resolve.mockImplementationOnce(
@@ -70,14 +111,8 @@ describe("openTerminalLinkInPreview", () => {
 
     const opening = openTerminalLinkInPreview({
       url: "http://localhost:3000/",
-      position: { x: 12, y: 34 },
       threadRef,
       openPreview,
-      localApi: {
-        contextMenu: {
-          show: vi.fn(async () => "open-in-preview"),
-        },
-      } as unknown as LocalApi,
       fallbackToBrowser: vi.fn(),
     });
 
@@ -97,42 +132,6 @@ describe("openTerminalLinkInPreview", () => {
     });
   });
 
-  it("preserves context-menu failures with terminal link context before falling back", async () => {
-    const cause = new Error("menu unavailable");
-    const fallbackToBrowser = vi.fn();
-    const openPreview = vi.fn(async () => AsyncResult.success(snapshot));
-    const reportError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-    await openTerminalLinkInPreview({
-      url: "http://localhost:3000/path?token=secret",
-      position: { x: 12, y: 34 },
-      threadRef,
-      openPreview,
-      localApi: {
-        contextMenu: {
-          show: vi.fn(async () => {
-            throw cause;
-          }),
-        },
-      } as unknown as LocalApi,
-      fallbackToBrowser,
-    });
-
-    expect(fallbackToBrowser).toHaveBeenCalledOnce();
-    expect(openPreview).not.toHaveBeenCalled();
-    expect(reportError).toHaveBeenCalledOnce();
-    const error = reportError.mock.calls[0]?.[0];
-    expect(error).toBeInstanceOf(TerminalLinkContextMenuShowError);
-    expect(error).toMatchObject({
-      environmentId: "local",
-      threadId: "thread-1",
-      targetOrigin: "http://localhost:3000",
-      cause,
-    });
-    expect(error.message).not.toContain("menu unavailable");
-    expect(error.targetOrigin).not.toContain("secret");
-  });
-
   it("preserves the complete preview failure cause before falling back", async () => {
     const rpcError = new Error("preview unavailable");
     const cause = Cause.combine(Cause.fail(rpcError), Cause.die("preview defect"));
@@ -141,14 +140,8 @@ describe("openTerminalLinkInPreview", () => {
 
     await openTerminalLinkInPreview({
       url: "http://127.0.0.1:5173/",
-      position: { x: 12, y: 34 },
       threadRef,
       openPreview: async () => AsyncResult.failure(cause),
-      localApi: {
-        contextMenu: {
-          show: vi.fn(async () => "open-in-preview"),
-        },
-      } as unknown as LocalApi,
       fallbackToBrowser,
     });
 
@@ -171,14 +164,8 @@ describe("openTerminalLinkInPreview", () => {
 
     await openTerminalLinkInPreview({
       url: "http://localhost:5173/",
-      position: { x: 12, y: 34 },
       threadRef,
       openPreview: async () => AsyncResult.failure(Cause.interrupt()),
-      localApi: {
-        contextMenu: {
-          show: vi.fn(async () => "open-in-preview"),
-        },
-      } as unknown as LocalApi,
       fallbackToBrowser,
     });
 

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
@@ -34,7 +34,7 @@ const linkTargetMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("~/browser/browserLinkTarget", () => ({
-  getBrowserLinkTargetPreference: linkTargetMocks.preference,
+  resolveBrowserLinkTargetPreference: async () => linkTargetMocks.preference(),
   isWebUrl: (url: string) => /^https?:/u.test(url),
 }));
 

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -1,6 +1,5 @@
-import type { LocalApi, ScopedThreadRef } from "@t3tools/contracts";
+import type { ScopedThreadRef } from "@t3tools/contracts";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
-import { isPreviewableUrl } from "@t3tools/shared/preview";
 import * as Schema from "effect/Schema";
 
 import {
@@ -8,6 +7,7 @@ import {
   browserDefaultOpenViewport,
   resolveBrowserDefaults,
 } from "~/browser/browserDefaults";
+import { getBrowserLinkTargetPreference, isWebUrl } from "~/browser/browserLinkTarget";
 import type { OpenPreviewMutation } from "~/browser/openFileInPreview";
 import { recordVisitForThread } from "~/browserHistoryStore";
 import { applyPreviewServerSnapshot, isPreviewSupportedInRuntime } from "~/previewStateStore";
@@ -20,15 +20,6 @@ const terminalLinkErrorContext = {
   cause: Schema.Defect(),
 };
 
-export class TerminalLinkContextMenuShowError extends Schema.TaggedErrorClass<TerminalLinkContextMenuShowError>()(
-  "TerminalLinkContextMenuShowError",
-  terminalLinkErrorContext,
-) {
-  override get message(): string {
-    return `Failed to show the context menu for terminal link ${this.targetOrigin}.`;
-  }
-}
-
 export class TerminalLinkPreviewOpenError extends Schema.TaggedErrorClass<TerminalLinkPreviewOpenError>()(
   "TerminalLinkPreviewOpenError",
   terminalLinkErrorContext,
@@ -40,18 +31,24 @@ export class TerminalLinkPreviewOpenError extends Schema.TaggedErrorClass<Termin
 
 interface OpenTerminalLinkInPreviewInput<E> {
   readonly url: string;
-  readonly position: { x: number; y: number };
   readonly threadRef: ScopedThreadRef;
   readonly openPreview: OpenPreviewMutation<E>;
-  readonly localApi: LocalApi;
   readonly fallbackToBrowser: () => void;
 }
 
+/**
+ * Opens a terminal hyperlink where the "Open links in" setting says. Terminal
+ * links are activated with the platform modifier already held, so unlike chat
+ * links the modifier cannot double as the system-browser override; the setting
+ * alone decides, and the system browser is the fallback whenever the in-app
+ * one cannot take the URL.
+ */
 export async function openTerminalLinkInPreview<E>(
   input: OpenTerminalLinkInPreviewInput<E>,
 ): Promise<void> {
   const supportsPreview =
-    isPreviewableUrl(input.url) &&
+    getBrowserLinkTargetPreference() === "app" &&
+    isWebUrl(input.url) &&
     isPreviewSupportedInRuntime() &&
     input.threadRef.threadId.length > 0;
 
@@ -66,59 +63,32 @@ export async function openTerminalLinkInPreview<E>(
     targetOrigin: new URL(input.url).origin,
   };
 
-  let choice: "open-in-preview" | "open-in-browser" | null;
-  try {
-    choice = await input.localApi.contextMenu.show(
-      [
-        { id: "open-in-preview", label: "Open in preview" },
-        { id: "open-in-browser", label: "Open in browser" },
-      ],
-      input.position,
-    );
-  } catch (cause) {
+  const defaults = await resolveBrowserDefaults();
+  const result = await input.openPreview({
+    environmentId: input.threadRef.environmentId,
+    input: {
+      threadId: input.threadRef.threadId,
+      url: input.url,
+      // Same reason as `openUrlInPreview`: this path handles its own result
+      // mapping, so the configured defaults are applied explicitly.
+      viewport: browserDefaultOpenViewport(defaults),
+      profileId: browserDefaultOpenProfileId(defaults),
+    },
+  });
+  if (result._tag === "Failure") {
+    if (isAtomCommandInterrupted(result)) {
+      return;
+    }
     console.error(
-      new TerminalLinkContextMenuShowError({
+      new TerminalLinkPreviewOpenError({
         ...errorContext,
-        cause,
+        cause: result.cause,
       }),
     );
     input.fallbackToBrowser();
     return;
   }
-
-  if (choice === "open-in-preview") {
-    const defaults = await resolveBrowserDefaults();
-    const result = await input.openPreview({
-      environmentId: input.threadRef.environmentId,
-      input: {
-        threadId: input.threadRef.threadId,
-        url: input.url,
-        // Same reason as `openUrlInPreview`: this path handles its own result
-        // mapping, so the configured defaults are applied explicitly.
-        viewport: browserDefaultOpenViewport(defaults),
-        profileId: browserDefaultOpenProfileId(defaults),
-      },
-    });
-    if (result._tag === "Failure") {
-      if (isAtomCommandInterrupted(result)) {
-        return;
-      }
-      console.error(
-        new TerminalLinkPreviewOpenError({
-          ...errorContext,
-          cause: result.cause,
-        }),
-      );
-      input.fallbackToBrowser();
-      return;
-    }
-    recordVisitForThread(input.threadRef, input.url);
-    applyPreviewServerSnapshot(input.threadRef, result.value);
-    useRightPanelStore.getState().openBrowser(input.threadRef, result.value.tabId);
-    return;
-  }
-
-  if (choice === "open-in-browser") {
-    input.fallbackToBrowser();
-  }
+  recordVisitForThread(input.threadRef, input.url);
+  applyPreviewServerSnapshot(input.threadRef, result.value);
+  useRightPanelStore.getState().openBrowser(input.threadRef, result.value.tabId);
 }

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -7,7 +7,7 @@ import {
   browserDefaultOpenViewport,
   resolveBrowserDefaults,
 } from "~/browser/browserDefaults";
-import { getBrowserLinkTargetPreference, isWebUrl } from "~/browser/browserLinkTarget";
+import { isWebUrl, resolveBrowserLinkTargetPreference } from "~/browser/browserLinkTarget";
 import type { OpenPreviewMutation } from "~/browser/openFileInPreview";
 import { recordVisitForThread } from "~/browserHistoryStore";
 import { applyPreviewServerSnapshot, isPreviewSupportedInRuntime } from "~/previewStateStore";
@@ -47,10 +47,10 @@ export async function openTerminalLinkInPreview<E>(
   input: OpenTerminalLinkInPreviewInput<E>,
 ): Promise<void> {
   const supportsPreview =
-    getBrowserLinkTargetPreference() === "app" &&
     isWebUrl(input.url) &&
     isPreviewSupportedInRuntime() &&
-    input.threadRef.threadId.length > 0;
+    input.threadRef.threadId.length > 0 &&
+    (await resolveBrowserLinkTargetPreference()) === "app";
 
   if (!supportsPreview) {
     input.fallbackToBrowser();

--- a/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
@@ -3,9 +3,10 @@ import type {
   PullRequestCheck,
   PullRequestChecksState,
   PullRequestRef,
+  ScopedThreadRef,
 } from "@t3tools/contracts";
 
-import { readLocalApi } from "~/localApi";
+import { useOpenLink } from "~/browser/useOpenLink";
 import { cn } from "~/lib/utils";
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useEnvironmentQuery } from "~/state/query";
@@ -27,9 +28,11 @@ import {
 function LazyChecksBody({
   environmentId,
   reference,
+  threadRef,
 }: {
   environmentId: EnvironmentId;
   reference: PullRequestRef;
+  threadRef: ScopedThreadRef | null;
 }) {
   const detailQuery = useEnvironmentQuery(
     pullRequestEnvironment.detail({ environmentId, input: reference }),
@@ -44,10 +47,17 @@ function LazyChecksBody({
       </p>
     );
   }
-  return <ChecksBody checks={detailQuery.data.checks} />;
+  return <ChecksBody checks={detailQuery.data.checks} threadRef={threadRef} />;
 }
 
-function ChecksBody({ checks }: { checks: ReadonlyArray<PullRequestCheck> }) {
+function ChecksBody({
+  checks,
+  threadRef,
+}: {
+  checks: ReadonlyArray<PullRequestCheck>;
+  threadRef: ScopedThreadRef | null;
+}) {
+  const openLink = useOpenLink(threadRef);
   if (checks.length === 0) {
     return <p className="text-muted-foreground text-xs">No checks reported</p>;
   }
@@ -71,7 +81,9 @@ function ChecksBody({ checks }: { checks: ReadonlyArray<PullRequestCheck> }) {
             <button
               type="button"
               className="shrink-0 text-primary hover:underline"
-              onClick={() => void readLocalApi()?.shell.openExternal(check.url ?? "")}
+              onClick={() => {
+                if (check.url) void openLink(check.url).catch(() => undefined);
+              }}
             >
               Details
             </button>
@@ -94,6 +106,7 @@ export function PullRequestChecksPopover({
   checks,
   environmentId,
   reference,
+  threadRef = null,
   className,
 }: {
   checksState: PullRequestChecksState;
@@ -101,6 +114,8 @@ export function PullRequestChecksPopover({
   checks?: ReadonlyArray<PullRequestCheck>;
   environmentId?: EnvironmentId;
   reference?: PullRequestRef;
+  /** Thread the popover sits beside; a listing row has none. */
+  threadRef?: ScopedThreadRef | null;
   className?: string;
 }) {
   const presentation = pullRequestChecksStatePresentation(checksState);
@@ -129,9 +144,13 @@ export function PullRequestChecksPopover({
         <p className="mb-2 font-medium text-sm">{presentation.label}</p>
         {summary === null ? null : <p className="mb-2 text-muted-foreground text-xs">{summary}</p>}
         {checks !== undefined ? (
-          <ChecksBody checks={checks} />
+          <ChecksBody checks={checks} threadRef={threadRef} />
         ) : environmentId !== undefined && reference !== undefined ? (
-          <LazyChecksBody environmentId={environmentId} reference={reference} />
+          <LazyChecksBody
+            environmentId={environmentId}
+            reference={reference}
+            threadRef={threadRef}
+          />
         ) : null}
       </PopoverPopup>
     </Popover>

--- a/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
@@ -13,6 +13,7 @@ import { useEnvironmentQuery } from "~/state/query";
 
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { toastManager } from "../ui/toast";
 import {
   PullRequestCheckStatusIcon,
   pullRequestCheckStatusLabel,
@@ -82,7 +83,11 @@ function ChecksBody({
               type="button"
               className="shrink-0 text-primary hover:underline"
               onClick={() => {
-                if (check.url) void openLink(check.url).catch(() => undefined);
+                if (!check.url) return;
+                void openLink(check.url).catch((error: unknown) => {
+                  console.error(error);
+                  toastManager.add({ type: "error", title: "Unable to open check details" });
+                });
               }}
             >
               Details

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -445,6 +445,7 @@ function PullRequestBaseFreshnessWarning({
 
 export function PullRequestDetailPanel({
   environmentId,
+  threadRef = null,
   reference,
   refreshToken: forcedRefreshToken = 0,
   onActed,
@@ -454,6 +455,13 @@ export function PullRequestDetailPanel({
   composerDraftTarget,
 }: {
   environmentId: EnvironmentId;
+  /**
+   * The thread this panel sits beside, if any. Links that are not the pull
+   * request itself (check details, host permalinks) can open in that thread's
+   * in-app browser when the user has asked for it; the page has no thread, so
+   * there they always go to the system browser.
+   */
+  threadRef?: ScopedThreadRef | null;
   reference: PullRequestRef;
   /**
    * Bumped by whatever holds the panel when a reader asks for everything on screen to be read
@@ -2027,7 +2035,11 @@ export function PullRequestDetailPanel({
                 aria-label={checksSummary ? `Checks: ${checksSummary}` : "Checks"}
               >
                 {checksState !== null ? (
-                  <PullRequestChecksPopover checks={detail.checks} checksState={checksState} />
+                  <PullRequestChecksPopover
+                    checks={detail.checks}
+                    checksState={checksState}
+                    threadRef={threadRef}
+                  />
                 ) : (
                   <CircleDotIcon aria-hidden className="size-3.5" />
                 )}
@@ -2151,6 +2163,7 @@ export function PullRequestDetailPanel({
               <div className={cn("absolute inset-0", tab !== "summary" && "invisible")}>
                 <PullRequestSummaryTab
                   environmentId={environmentId}
+                  threadRef={threadRef}
                   reference={reference}
                   detail={detail}
                   activityPending={activityPending}

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -2191,6 +2191,7 @@ export function PullRequestDetailPanel({
                   <PullRequestTimelineTab
                     detail={detail}
                     environmentId={environmentId}
+                    threadRef={threadRef}
                     reference={reference}
                     order={timelineOrder}
                     onOpenCommit={openCommit}

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,5 +1,5 @@
 import { ExternalLinkIcon, PaperclipIcon, PlayIcon } from "lucide-react";
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
 import { createContext, useContext, useMemo } from "react";
 import type { Options as ReactMarkdownOptions } from "react-markdown";
 
@@ -21,11 +21,14 @@ export function PullRequestMarkdown({
   text,
   cwd,
   environmentId,
+  threadRef,
   className,
 }: {
   text: string;
   cwd: string;
   environmentId: EnvironmentId;
+  /** Thread the body is shown beside, so its links can open in that thread's in-app browser. */
+  threadRef?: ScopedThreadRef | null;
   className?: string;
 }) {
   const segments = splitPullRequestBody(text);
@@ -43,6 +46,7 @@ export function PullRequestMarkdown({
               key={segment.id}
               text={segment.text}
               cwd={cwd}
+              threadRef={threadRef ?? undefined}
               environmentId={environmentId}
               extraRemarkPlugins={extraRemarkPlugins}
             />

--- a/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
 
 import { cn } from "~/lib/utils";
 
@@ -19,6 +19,7 @@ export function PullRequestMarkdownEditor({
   value,
   cwd,
   environmentId,
+  threadRef = null,
   placeholder,
   label,
   saving,
@@ -30,6 +31,8 @@ export function PullRequestMarkdownEditor({
   readonly value: string;
   readonly cwd: string;
   readonly environmentId: EnvironmentId;
+  /** Thread the editor sits beside, so links in its preview follow the link target setting. */
+  readonly threadRef?: ScopedThreadRef | null;
   readonly placeholder?: string | undefined;
   readonly label: string;
   readonly saving: boolean;
@@ -84,7 +87,12 @@ export function PullRequestMarkdownEditor({
           {empty ? (
             <p className="text-xs text-muted-foreground">Nothing to preview.</p>
           ) : (
-            <PullRequestMarkdown text={draft} cwd={cwd} environmentId={environmentId} />
+            <PullRequestMarkdown
+              text={draft}
+              cwd={cwd}
+              environmentId={environmentId}
+              threadRef={threadRef}
+            />
           )}
         </div>
       ) : (

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -4,6 +4,7 @@ import type {
   PullRequestComment,
   PullRequestDetailView,
   PullRequestRef,
+  ScopedThreadRef,
 } from "@t3tools/contracts";
 import {
   ArrowDownUpIcon,
@@ -23,7 +24,7 @@ import { useRef, useState, type ReactNode } from "react";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { cn } from "~/lib/utils";
-import { readLocalApi } from "~/localApi";
+import { useOpenLink } from "~/browser/useOpenLink";
 import { formatRelativeTimeLabel } from "~/timestampFormat";
 
 import { Button } from "../ui/button";
@@ -423,6 +424,7 @@ const COMMENT_PAGE = 30;
 
 export function PullRequestSummaryTab({
   environmentId,
+  threadRef,
   reference,
   detail,
   activityPending,
@@ -436,6 +438,7 @@ export function PullRequestSummaryTab({
   onRefresh,
 }: {
   environmentId: EnvironmentId;
+  threadRef: ScopedThreadRef | null;
   reference: PullRequestRef;
   detail: PullRequestDetailView;
   activityPending: boolean;
@@ -508,8 +511,12 @@ export function PullRequestSummaryTab({
     ),
   );
 
+  const openLink = useOpenLink(threadRef);
   const openCheck = (url: string) => {
-    void readLocalApi()?.shell.openExternal(url);
+    void openLink(url).catch((error: unknown) => {
+      console.error(error);
+      toastManager.add({ type: "error", title: "Unable to open check details" });
+    });
   };
 
   const update = useAtomCommand(pullRequestEnvironment.update, { reportFailure: false });

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -94,6 +94,7 @@ function reviewStateLabel(state: string): string {
 interface CommentEditing {
   readonly cwd: string;
   readonly environmentId: EnvironmentId;
+  readonly threadRef: ScopedThreadRef | null;
   readonly canEdit: (comment: PullRequestComment) => boolean;
   readonly editingId: string | null;
   readonly saving: boolean;
@@ -135,6 +136,7 @@ function CommentBody({
         text={comment.body}
         cwd={editing.cwd}
         environmentId={editing.environmentId}
+        threadRef={editing.threadRef}
       />
       {editing.canEdit(comment) ? (
         <Button
@@ -554,6 +556,7 @@ export function PullRequestSummaryTab({
   const commentEditing: CommentEditing = {
     cwd: detail.workspaceRoot,
     environmentId,
+    threadRef,
     canEdit: (comment) => canEditPullRequestComment(detail, comment),
     editingId: editingCommentId,
     saving: commentSaving,
@@ -742,6 +745,7 @@ export function PullRequestSummaryTab({
                 text={detail.body.trim().length > 0 ? detail.body : "_No description provided._"}
                 cwd={detail.workspaceRoot}
                 environmentId={environmentId}
+                threadRef={threadRef}
               />
               {canEditPullRequestChangeRequest(detail) ? (
                 <Button

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -122,6 +122,7 @@ function CommentBody({
         value={comment.body}
         cwd={editing.cwd}
         environmentId={editing.environmentId}
+        threadRef={editing.threadRef}
         label="Edit comment"
         saving={editing.saving}
         onSave={(body) => editing.onSave(comment, body)}
@@ -732,6 +733,7 @@ export function PullRequestSummaryTab({
               value={detail.body}
               cwd={detail.workspaceRoot}
               environmentId={environmentId}
+              threadRef={threadRef}
               label="Pull request description"
               placeholder="Describe this pull request"
               saving={bodySaving}

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -4,6 +4,7 @@ import type {
   PullRequestComment,
   PullRequestDetailView,
   PullRequestRef,
+  ScopedThreadRef,
 } from "@t3tools/contracts";
 import {
   ChevronDownIcon,
@@ -55,6 +56,8 @@ import {
 interface ReactionSurface {
   readonly canReact: boolean;
   readonly environmentId: EnvironmentId;
+  /** Thread the timeline is shown beside, so body links can open in its in-app browser. */
+  readonly threadRef: ScopedThreadRef | null;
   readonly reference: PullRequestRef;
   readonly onRefresh: () => void;
 }
@@ -64,16 +67,23 @@ function TimelineBody({
   markdown,
   cwd,
   environmentId,
+  threadRef,
 }: {
   body: string;
   markdown: boolean;
   cwd: string;
   environmentId: EnvironmentId;
+  threadRef: ScopedThreadRef | null;
 }) {
   return (
     <div className="mt-3">
       {markdown ? (
-        <PullRequestMarkdown text={body} cwd={cwd} environmentId={environmentId} />
+        <PullRequestMarkdown
+          text={body}
+          cwd={cwd}
+          environmentId={environmentId}
+          threadRef={threadRef}
+        />
       ) : (
         <p className="whitespace-pre-wrap text-xs text-muted-foreground">{body}</p>
       )}
@@ -259,6 +269,7 @@ function ConversationCard({
             markdown={event.markdown}
             cwd={cwd}
             environmentId={reactions.environmentId}
+            threadRef={reactions.threadRef}
           />
         </div>
       ) : null}
@@ -526,6 +537,7 @@ function ReviewVerdictEvent({
               markdown={event.markdown}
               cwd={cwd}
               environmentId={reactions.environmentId}
+              threadRef={reactions.threadRef}
             />
           ) : null}
         </div>
@@ -538,6 +550,7 @@ function ReviewVerdictEvent({
 export function PullRequestTimelineTab({
   detail,
   environmentId,
+  threadRef = null,
   reference,
   order,
   onOpenCommit,
@@ -545,6 +558,7 @@ export function PullRequestTimelineTab({
 }: {
   detail: PullRequestDetailView;
   environmentId: EnvironmentId;
+  threadRef?: ScopedThreadRef | null;
   reference: PullRequestRef;
   order: "newest" | "oldest";
   onOpenCommit: (oid: string) => void;
@@ -555,6 +569,7 @@ export function PullRequestTimelineTab({
   const reactions: ReactionSurface = {
     canReact: detail.capabilities.reactions === true,
     environmentId,
+    threadRef,
     reference,
     onRefresh,
   };

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -256,6 +256,7 @@ function ConversationCard({
             value={editable.body}
             cwd={cwd}
             environmentId={reactions.environmentId}
+            threadRef={reactions.threadRef}
             label="Edit comment"
             saving={saving}
             onSave={(body) => void save(body)}

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -8,12 +8,14 @@
  */
 import {
   BROWSER_PROFILE_MAX_COUNT,
+  type BrowserLinkTarget,
   type BrowserProfile,
   type EnvironmentId,
   BROWSER_PROFILE_NAME_MAX_LENGTH,
   BROWSER_RECORDING_FRAME_RATES,
   DEFAULT_BROWSER_AUTO_SHOW_FLOATING_PREVIEW,
   DEFAULT_BROWSER_PROFILE_ID,
+  DEFAULT_BROWSER_LINK_TARGET,
   DEFAULT_BROWSER_RECORDING_FRAME_RATE,
   DEFAULT_BROWSER_VIEWPORT,
   DEFAULT_PREVIEW_APPEARANCE,
@@ -465,6 +467,53 @@ function BrowserRecordingFrameRateSetting({ disabled }: { readonly disabled: boo
   );
 }
 
+const LINK_TARGET_LABELS: Readonly<Record<BrowserLinkTarget, string>> = {
+  system: "Your default browser",
+  app: "T3 Code",
+};
+
+function BrowserLinkTargetSetting({ disabled }: { readonly disabled: boolean }) {
+  const linkTarget = useClientSettings((settings) => settings.browserLinkTarget);
+  const updateSettings = useUpdatePrimarySettings();
+
+  return (
+    <SettingsRow
+      {...searchableSetting("browser-link-target")}
+      description="Where links in the chat and terminal open. Hold ⌘ or Ctrl while clicking a chat link to open it in your default browser either way."
+      resetAction={
+        !disabled && linkTarget !== DEFAULT_BROWSER_LINK_TARGET ? (
+          <SettingResetButton
+            label="link target"
+            onClick={() => updateSettings({ browserLinkTarget: DEFAULT_BROWSER_LINK_TARGET })}
+          />
+        ) : null
+      }
+      control={
+        <Select
+          disabled={disabled}
+          value={linkTarget}
+          onValueChange={(value) => {
+            if (value === "system" || value === "app") {
+              updateSettings({ browserLinkTarget: value });
+            }
+          }}
+        >
+          <SelectTrigger size="sm" className="w-full sm:w-40" aria-label="Open links in">
+            <SelectValue>{LINK_TARGET_LABELS[linkTarget]}</SelectValue>
+          </SelectTrigger>
+          <SelectPopup align="end" alignItemWithTrigger={false}>
+            {(Object.keys(LINK_TARGET_LABELS) as ReadonlyArray<BrowserLinkTarget>).map((target) => (
+              <SelectItem hideIndicator key={target} value={target}>
+                {LINK_TARGET_LABELS[target]}
+              </SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+      }
+    />
+  );
+}
+
 function AgentBrowserAccessSetting() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
@@ -868,6 +917,7 @@ export function IntegrationsSettingsPanel() {
       <BrowserZoomSetting disabled={previewDefaultsDisabled} />
       <BrowserAppearanceSetting disabled={previewDefaultsDisabled} />
       <BrowserRecordingFrameRateSetting disabled={previewDefaultsDisabled} />
+      <BrowserLinkTargetSetting disabled={previewDefaultsDisabled} />
       <BrowserAutoShowFloatingPreviewSetting disabled={previewDefaultsDisabled} />
     </>
   );

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -269,6 +269,7 @@ describe("getChangedBrowserSettingLabels", () => {
         browserDefaultZoomFactor: 1.5,
         browserDefaultAppearance: "dark",
         browserRecordingFrameRate: 60,
+        browserLinkTarget: "app",
         browserAutoShowFloatingPreview: !DEFAULT_UNIFIED_SETTINGS.browserAutoShowFloatingPreview,
       }),
     ).toEqual([
@@ -276,6 +277,7 @@ describe("getChangedBrowserSettingLabels", () => {
       "Browser zoom",
       "Browser appearance",
       "Recording frame rate",
+      "Open links in",
       "Floating preview",
     ]);
   });

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -115,6 +115,7 @@ export type BrowserDefaultSettings = Pick<
   | "browserDefaultZoomFactor"
   | "browserDefaultAppearance"
   | "browserRecordingFrameRate"
+  | "browserLinkTarget"
   | "browserAutoShowFloatingPreview"
 >;
 
@@ -154,6 +155,9 @@ export function getChangedBrowserSettingLabels(settings: BrowserDefaultSettings)
       : []),
     ...(settings.browserRecordingFrameRate !== DEFAULT_UNIFIED_SETTINGS.browserRecordingFrameRate
       ? ["Recording frame rate"]
+      : []),
+    ...(settings.browserLinkTarget !== DEFAULT_UNIFIED_SETTINGS.browserLinkTarget
+      ? ["Open links in"]
       : []),
     ...(settings.browserAutoShowFloatingPreview !==
     DEFAULT_UNIFIED_SETTINGS.browserAutoShowFloatingPreview

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -589,6 +589,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.browserDefaultZoomFactor,
       settings.browserDefaultAppearance,
       settings.browserRecordingFrameRate,
+      settings.browserLinkTarget,
       settings.browserAutoShowFloatingPreview,
       settings.appearanceContrast,
       settings.enableAgentBrowserAccess,
@@ -735,6 +736,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       browserDefaultZoomFactor: DEFAULT_UNIFIED_SETTINGS.browserDefaultZoomFactor,
       browserDefaultAppearance: DEFAULT_UNIFIED_SETTINGS.browserDefaultAppearance,
       browserRecordingFrameRate: DEFAULT_UNIFIED_SETTINGS.browserRecordingFrameRate,
+      browserLinkTarget: DEFAULT_UNIFIED_SETTINGS.browserLinkTarget,
       browserAutoShowFloatingPreview: DEFAULT_UNIFIED_SETTINGS.browserAutoShowFloatingPreview,
       // Re-granted like any other default. The confirmation dialog lists it by
       // name, so a user restoring defaults is told the agent regains access

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -207,4 +207,12 @@ describe("searchSettings", () => {
     });
     expect(result).not.toHaveProperty("targetId");
   });
+
+  it("routes where links open to integrations", () => {
+    expect(searchSettings("open links in")[0]).toMatchObject({
+      id: "browser-link-target",
+      to: "/settings/integrations",
+    });
+    expect(searchSettings("external links")[0]).toMatchObject({ id: "browser-link-target" });
+  });
 });

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -365,6 +365,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/integrations",
   },
   {
+    id: "browser-link-target",
+    title: "Open links in",
+    to: "/settings/integrations",
+    searchTerms: ["links default browser in-app browser external open"],
+  },
+  {
     id: "browser-auto-show-floating-preview",
     title: "Auto-show floating preview",
     to: "/settings/integrations",

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -11,8 +11,8 @@ import { type MouseEvent, useCallback } from "react";
 
 import { pullRequestHostOf, type SourceControlProviderKind } from "@t3tools/contracts";
 
+import { useOpenLink } from "../browser/useOpenLink";
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
-import { readLocalApi } from "../localApi";
 import { useRightPanelStore } from "../rightPanelStore";
 import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 
@@ -328,6 +328,7 @@ export function useOpenChangeRequestLink(
 
 export function useOpenPrLink(threadRef?: ScopedThreadRef) {
   const openChangeRequest = useOpenChangeRequestLink(threadRef);
+  const openLink = useOpenLink(threadRef);
   return useCallback(
     (event: MouseEvent<HTMLElement>, prUrl: string, targetThreadRef?: ScopedThreadRef) => {
       event.stopPropagation();
@@ -342,16 +343,9 @@ export function useOpenPrLink(threadRef?: ScopedThreadRef) {
       event.preventDefault();
       if (!openInBrowser && openChangeRequest(event, prUrl, targetThreadRef)) return true;
 
-      const api = readLocalApi();
-      if (!api) {
-        toastManager.add({
-          type: "error",
-          title: "Link opening is unavailable.",
-        });
-        return false;
-      }
-
-      void openPullRequestLink(api.shell, prUrl).catch((error) => {
+      // No project to show it in, so it is an ordinary link and follows the
+      // "Open links in" setting; the modifier still forces the system browser.
+      void openLink(prUrl, event).catch((error: unknown) => {
         console.error(error);
         toastManager.add(
           stackedThreadToast({

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -345,7 +345,7 @@ export function useOpenPrLink(threadRef?: ScopedThreadRef) {
 
       // No project to show it in, so it is an ordinary link and follows the
       // "Open links in" setting; the modifier still forces the system browser.
-      void openLink(prUrl, event).catch((error: unknown) => {
+      void openLink(prUrl, { event, threadRef: targetThreadRef }).catch((error: unknown) => {
         console.error(error);
         toastManager.add(
           stackedThreadToast({
@@ -357,6 +357,6 @@ export function useOpenPrLink(threadRef?: ScopedThreadRef) {
       });
       return false;
     },
-    [openChangeRequest],
+    [openChangeRequest, openLink],
   );
 }

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -188,6 +188,14 @@ export const BROWSER_RECORDING_FRAME_RATES = [30, 60] as const;
 export const BrowserRecordingFrameRate = Schema.Literals(BROWSER_RECORDING_FRAME_RATES);
 export type BrowserRecordingFrameRate = typeof BrowserRecordingFrameRate.Type;
 export const DEFAULT_BROWSER_RECORDING_FRAME_RATE: BrowserRecordingFrameRate = 30;
+/**
+ * Where a clicked link goes: the OS default browser, or a tab in the in-app
+ * browser beside the thread. "system" is the default because that is what
+ * every link did before the setting existed.
+ */
+export const BrowserLinkTarget = Schema.Literals(["system", "app"]);
+export type BrowserLinkTarget = typeof BrowserLinkTarget.Type;
+export const DEFAULT_BROWSER_LINK_TARGET: BrowserLinkTarget = "system";
 
 export const ClientSettingsSchema = Schema.Struct({
   appearanceContrast: AppearanceContrast.pipe(
@@ -209,6 +217,13 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   browserRecordingFrameRate: BrowserRecordingFrameRate.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_BROWSER_RECORDING_FRAME_RATE)),
+  ),
+  /**
+   * Where links clicked in a thread (chat markdown, terminal output) open.
+   * Only the desktop app has an in-app browser, so other clients ignore "app".
+   */
+  browserLinkTarget: BrowserLinkTarget.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_BROWSER_LINK_TARGET)),
   ),
   /**
    * Whether an agent opening a preview pops the floating mini player into
@@ -1003,6 +1018,7 @@ export const ClientSettingsPatch = Schema.Struct({
   browserDefaultZoomFactor: Schema.optionalKey(PreviewZoomFactor),
   browserDefaultAppearance: Schema.optionalKey(PreviewAppearancePreference),
   browserRecordingFrameRate: Schema.optionalKey(BrowserRecordingFrameRate),
+  browserLinkTarget: Schema.optionalKey(BrowserLinkTarget),
   browserAutoShowFloatingPreview: Schema.optionalKey(Schema.Boolean),
   browserProfiles: Schema.optionalKey(Schema.Array(BrowserProfile)),
   browserDefaultProfileId: Schema.optionalKey(BrowserProfileId),


### PR DESCRIPTION
The in-app browser has become a general-purpose browser (profiles, cookie import), but every link a user clicks still went to the OS browser. The only way to get one into the in-app browser was the right-click menu on chat links, and terminal links forced a two-item menu on every click.

This adds a Browser setting, **Open links in**: *Your default browser* (the default, so nothing changes until it is switched) or *T3 Code*. With T3 Code selected, links clicked beside a thread open as a tab in the in-app browser. Cmd/Ctrl-click on a chat link still opens the default browser as the way out, mirroring how change-request links already treat the modifier; the right-click menu keeps offering both explicitly.

What follows the setting:
- Markdown links in the chat (and PR descriptions, which reuse the same renderer)
- Hyperlinks in the terminal — these no longer show a menu on every click; the setting decides
- CI check *Details* in the PR panel
- A PR link that has no checked-out project to open in the panel
- The repository a publish just created

What stays on the system browser, because the control names its destination: *Open on GitHub*, the external-link icons in the PR header, the in-app browser's own "open in system browser" escape hatch, release notes. Non-web schemes (`mailto:`, `vscode://`) always go to the shell. The hosted web app and mobile have no in-app browser, so the setting does not render there and links behave as before.

Implementation: one pure resolver (`browser/browserLinkTarget.ts`) turns preference + click into a target, and a `useOpenLink(threadRef)` hook wraps it for the non-markdown buttons so every entry point makes the same decision.

## Setting

![Open links in setting](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/10ed5567b8f4ce98/link-target-setting.png)

## Chat link with T3 Code selected

![Chat link opened in the in-app browser](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8ada375232c9fc23/link-target-chat-inapp.png)

## Terminal link with T3 Code selected (no menu)

![Terminal link opened in the in-app browser](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8629d61a65230563/link-target-terminal-inapp.png)

Verified in the desktop app: chat link plain-click → in-app tab; Cmd-click → default browser; terminal link → in-app tab, no menu; a foreign PR link → in-app tab; setting back to default → unchanged pre-feature behaviour.

Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide user-facing link routing change across chat, terminal, and PR surfaces, though default `system` preserves prior behavior until users opt in; in-app open paths add failure/fallback complexity beside threads.
> 
> **Overview**
> Adds a client setting **Open links in** (`browserLinkTarget`: `system` by default, or `app` on desktop) under Integrations → Browser, with search, dirty-state labels, and restore-defaults support.
> 
> **Central behavior:** `resolveLinkTarget` and `useOpenLink(threadRef)` decide whether http(s) links beside a thread open in the in-app preview or via `shell.openExternal`, with in-app failure falling back to the system browser. Cmd/Ctrl on chat links still forces the system browser; non-web schemes always go to the shell; clients without an in-app browser ignore `app`.
> 
> **Where it applies:** chat markdown (including PR bodies via `ChatMarkdown`), terminal hyperlinks (the per-click preview/browser context menu is removed—the setting drives the path), CI check details, publish-repo links, and PR URLs that cannot open in-panel. PR UI passes `threadRef` through markdown editors and panels so previews and inline links follow the preference. Explicit “open on host” controls in the timeline still use the shell.
> 
> **Contracts:** `BrowserLinkTarget` and `browserLinkTarget` added to client settings schema and patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ee98fe783331d693abe386d2fb6db845a50814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add setting to open links in default browser or in-app browser
> - Adds a `BrowserLinkTarget` client setting (`system` | `in-app`, default `system`) and an "Open links in" control in Integrations settings, with search and dirty-tracking support
> - Introduces `resolveLinkTarget` in [browserLinkTarget.ts](https://github.com/pingdotgg/t3code/pull/9339/files#diff-414fb044ad2939f6b1834715dc88e5a62a1d4d9a80fff22e9e207ff786e2d44a) and a shared `useOpenLink` hook that route link clicks based on the hydrated preference, falling back to the system browser for Cmd/Ctrl clicks, unsupported runtimes, and non-HTTP(S) URLs
> - Wires the active thread reference through chat markdown, terminal links, pull-request detail/timeline, and Git action controls so in-app preview opening has the context it needs
> - Removes the old terminal-link context menu; terminal links now open directly via the setting-aware path with system-browser fallback on failure
> - Risk: `openTerminalLinkInPreview` removes `TerminalLinkContextMenuShowError` and the per-click preview/browser choice; any out-of-tree callers of that error class or the context-menu flow will break. Non-desktop clients ignore the `in-app` choice and always use the system browser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69ee98f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->