### PR TITLE
fix(server): fetch worktree base branch's own remote during bootstrap

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -8675,6 +8675,125 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect.each([
+    {
+      caseName: "a non-origin remote base",
+      baseBranch: "upstream/main",
+      fetchRemoteName: "upstream",
+      lookupRefName: "main",
+      remoteRefName: "upstream/main",
+    },
+    {
+      caseName: "an origin-prefixed base",
+      baseBranch: "origin/main",
+      fetchRemoteName: "origin",
+      lookupRefName: "main",
+      remoteRefName: "origin/main",
+    },
+  ])(
+    "fetches the base branch's own remote for $caseName",
+    ({ baseBranch, fetchRemoteName, lookupRefName, remoteRefName }) =>
+      Effect.gen(function* () {
+        const fetchedCommit = "abcdef0123456789abcdef0123456789abcdef01";
+        const remoteExists = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteExists"]>[0]) =>
+            Effect.succeed(true),
+        );
+        const fetchRemote = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"]>[0]) => Effect.void,
+        );
+        const remoteBranchExists = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteBranchExists"]>[0]) =>
+            Effect.succeed(true),
+        );
+        const resolveRemoteTrackingCommit = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["resolveRemoteTrackingCommit"]>[0]) =>
+            Effect.succeed({
+              commitSha: fetchedCommit,
+              remoteRefName,
+            }),
+        );
+        const createWorktree = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+            Effect.succeed({
+              worktree: {
+                refName: "t3code/bootstrap-refName",
+                path: "/tmp/bootstrap-worktree",
+              },
+            }),
+        );
+
+        yield* buildAppUnderTest({
+          layers: {
+            gitVcsDriver: {
+              remoteExists,
+              fetchRemote,
+              remoteBranchExists,
+              resolveRemoteTrackingCommit,
+              createWorktree,
+            },
+            orchestrationEngine: {
+              dispatch: (command: OrchestrationCommand) =>
+                Effect.sync(() => ({ sequence: 1 })),
+              readEvents: () => Stream.empty,
+            },
+          },
+        });
+
+        const createdAt = "2026-01-01T00:00:00.000Z";
+        const wsUrl = yield* getWsServerUrl("/ws");
+        yield* Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+              type: "thread.turn.start",
+              commandId: CommandId.make("cmd-bootstrap-turn-start-remote-base"),
+              threadId: ThreadId.make("thread-bootstrap-remote-base"),
+              message: {
+                messageId: MessageId.make("msg-bootstrap-remote-base"),
+                role: "user",
+                text: "hello",
+                attachments: [],
+              },
+              modelSelection: defaultModelSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              bootstrap: {
+                prepareWorktree: {
+                  projectCwd: "/tmp/project",
+                  baseBranch,
+                  branch: "t3code/bootstrap-refName",
+                  startFromOrigin: true,
+                },
+              },
+              createdAt,
+            }),
+          ),
+        );
+
+        assert.deepEqual(fetchRemote.mock.calls[0]?.[0], {
+          cwd: "/tmp/project",
+          remoteName: fetchRemoteName,
+        });
+        assert.deepEqual(remoteBranchExists.mock.calls[0]?.[0], {
+          cwd: "/tmp/project",
+          remoteName: fetchRemoteName,
+          refName: lookupRefName,
+        });
+        assert.deepEqual(resolveRemoteTrackingCommit.mock.calls[0]?.[0], {
+          cwd: "/tmp/project",
+          refName: baseBranch,
+          fallbackRemoteName: fetchRemoteName,
+        });
+        assert.deepEqual(createWorktree.mock.calls[0]?.[0], {
+          cwd: "/tmp/project",
+          refName: fetchedCommit,
+          newRefName: "t3code/bootstrap-refName",
+          baseRefName: baseBranch,
+          path: null,
+        });
+      }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("records setup-script failures without aborting bootstrap turn start", () =>
     Effect.gen(function* () {
       const dispatchedCommands: Array<OrchestrationCommand> = [];

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1091,30 +1091,57 @@ const makeWsRpcLayer = (
             }
 
             if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
+              const baseBranch = bootstrap.prepareWorktree.baseBranch;
+              let worktreeBaseRef = baseBranch;
               // "Start from origin" is a stored default; repos without the
               // requested remote branch fall back to the local base branch.
-              const startFromOrigin =
-                bootstrap.prepareWorktree.startFromOrigin === true &&
-                (yield* gitWorkflow.remoteExists({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
-                }));
-              if (startFromOrigin) {
+              // The base may track a remote other than `origin` (e.g. `upstream/main`),
+              // so resolve the fetch target from the base ref instead of assuming `origin`.
+              // Otherwise we pay for a useless `fetch origin` and base the worktree
+              // on a stale ref while the real remote is never fetched.
+              const remotePrefix = baseBranch.includes("/")
+                ? baseBranch.slice(0, baseBranch.indexOf("/"))
+                : null;
+              let fetchRemoteName: string | null = null;
+              if (bootstrap.prepareWorktree.startFromOrigin === true) {
+                if (
+                  remotePrefix !== null &&
+                  (yield* gitWorkflow.remoteExists({
+                    cwd: bootstrap.prepareWorktree.projectCwd,
+                    remoteName: remotePrefix,
+                  }))
+                ) {
+                  fetchRemoteName = remotePrefix;
+                } else if (
+                  yield* gitWorkflow.remoteExists({
+                    cwd: bootstrap.prepareWorktree.projectCwd,
+                    remoteName: "origin",
+                  })
+                ) {
+                  fetchRemoteName = "origin";
+                }
+              }
+              if (fetchRemoteName !== null) {
                 yield* gitWorkflow.fetchRemote({
                   cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
+                  remoteName: fetchRemoteName,
                 });
+                // remoteBranchExists concatenates refs/remotes/<remote>/<refName>,
+                // so strip the remote prefix when the base already carries it
+                // (`upstream/main` on `upstream` must look up `main`, not `upstream/main`).
+                const remoteRefName = baseBranch.startsWith(`${fetchRemoteName}/`)
+                  ? baseBranch.slice(fetchRemoteName.length + 1)
+                  : baseBranch;
                 const remoteBaseExists = yield* gitWorkflow.remoteBranchExists({
                   cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  remoteName: "origin",
+                  refName: remoteRefName,
+                  remoteName: fetchRemoteName,
                 });
                 if (remoteBaseExists) {
                   const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
                     cwd: bootstrap.prepareWorktree.projectCwd,
-                    refName: bootstrap.prepareWorktree.baseBranch,
-                    fallbackRemoteName: "origin",
+                    refName: baseBranch,
+                    fallbackRemoteName: fetchRemoteName,
                   });
                   worktreeBaseRef = resolvedRemoteBase.commitSha;
                 }


### PR DESCRIPTION
New worktree threads based on `upstream/main` (or any non-`origin` remote base) sit with no useful progress for ~1min on remote servers. Fixes #9340 (server half; step-level progress UI tracked there).

The problem: `dispatchBootstrapTurnStart` hardcoded `remoteName: "origin"`. With base `upstream/main` it paid for a slow, irrelevant `git fetch origin`, then checked `remoteBranchExists({ refName: "upstream/main", remoteName: "origin" })` — i.e. `refs/remotes/origin/upstream/main`, a ref that can never exist — so it always fell back to the unfetched local ref. The `upstream` remote was never fetched, so the worktree could also be based on a stale commit.

How fixed: resolve the fetch target from the base ref. If the segment before the first `/` names a configured remote, fetch that remote; otherwise keep the existing `origin` behavior. The existence lookup strips the remote prefix (`upstream/main` on `upstream` looks up `main`), which also repairs literal `origin/main` bases that previously looked up `origin/origin/main`. Local-only branches still fall back to the local ref exactly as before.

Verified: new `it.effect.each` cases in `server.test.ts` (`upstream/main`, `origin/main`) assert fetch/check/resolve/createWorktree args; existing bootstrap tests (including the local-fallback cases) pass unchanged; server typecheck clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread bootstrap git workflow on the server; incorrect remote resolution could still mis-base worktrees, but behavior is narrowed with tests and preserves local-only fallback paths.
> 
> **Overview**
> Fixes bootstrap worktree preparation when **start from remote** is enabled but the base branch is not on `origin` (e.g. `upstream/main`). Previously the server always fetched `origin` and probed the wrong remote-tracking ref, so the real remote was never updated and worktrees could hang on stale local SHAs.
> 
> **`ws.ts`** now derives `fetchRemoteName` from the prefix before the first `/` when that remote exists, otherwise keeps the `origin` fallback. Remote branch checks strip that prefix so lookups hit `refs/remotes/upstream/main` instead of `refs/remotes/origin/upstream/main` (and the same fix applies to literal `origin/main` bases). **`server.test.ts`** adds parameterized coverage for `upstream/main` and `origin/main`, asserting fetch, branch existence, commit resolution, and worktree creation arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a81f93aa05159523a9ab0b3214b1e75723045643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worktree bootstrap to fetch base branch's own remote
> Adds a parameterized integration test in [server.test.ts](https://github.com/pingdotgg/t3code/pull/9341/files#diff-311d34bc81e1c9cdae991c24771a5c0b8f02084dc94251982be7466403965b9f) that verifies the server router bootstrap seam fetches and checks the correct remote for the worktree base branch. The test covers both upstream-qualified and origin-qualified bases, confirming that fetch, remote branch lookup, tracking-commit resolution, and worktree creation receive the expected remote-specific arguments using the unqualified branch name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a81f93a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->