### PR TITLE
fix(mobile): stop indented code overflowing Android chat bubbles

### DIFF
--- a/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
@@ -21,10 +21,14 @@ describe("hasWideMarkdownBlock", () => {
     const prompt = 'before\n\n    def search(x):\n        return x\n\n"""\n\nafter';
     expect(hasWideMarkdownBlock(prompt)).toBe(true);
     expect(hasWideMarkdownBlock("before\n\n\treturn x\n\nafter")).toBe(true);
+    expect(hasWideMarkdownBlock("before\n\n \treturn x\n\nafter")).toBe(true);
+    expect(hasWideMarkdownBlock(">     return x")).toBe(true);
+    expect(hasWideMarkdownBlock("> >  \treturn x")).toBe(true);
     expect(hasWideMarkdownBlock("    1. indented code")).toBe(true);
     expect(hasWideMarkdownBlock("    - code-like bullet")).toBe(true);
     expect(hasWideMarkdownBlock("before\n   not code\nafter")).toBe(false);
     expect(hasWideMarkdownBlock("before\n    \nafter")).toBe(false);
+    expect(hasWideMarkdownBlock("before\n \t\nafter")).toBe(false);
   });
 
   it("detects top-level and blockquoted ordered-list markers", () => {

--- a/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.test.ts
@@ -17,6 +17,16 @@ describe("hasWideMarkdownBlock", () => {
     expect(hasWideMarkdownBlock("   ```\ncode\n```")).toBe(true);
   });
 
+  it("detects indented code blocks", () => {
+    const prompt = 'before\n\n    def search(x):\n        return x\n\n"""\n\nafter';
+    expect(hasWideMarkdownBlock(prompt)).toBe(true);
+    expect(hasWideMarkdownBlock("before\n\n\treturn x\n\nafter")).toBe(true);
+    expect(hasWideMarkdownBlock("    1. indented code")).toBe(true);
+    expect(hasWideMarkdownBlock("    - code-like bullet")).toBe(true);
+    expect(hasWideMarkdownBlock("before\n   not code\nafter")).toBe(false);
+    expect(hasWideMarkdownBlock("before\n    \nafter")).toBe(false);
+  });
+
   it("detects top-level and blockquoted ordered-list markers", () => {
     expect(hasWideMarkdownBlock("1. One\n2. Two\n3. Three\n4. Four\n5. Five")).toBe(true);
     expect(hasWideMarkdownBlock("before\n3) Three")).toBe(true);
@@ -24,11 +34,9 @@ describe("hasWideMarkdownBlock", () => {
     expect(hasWideMarkdownBlock("> > 3) Three")).toBe(true);
   });
 
-  it("detects nested ordered lists without treating indented code as a list", () => {
+  it("detects nested ordered lists", () => {
     expect(hasWideMarkdownBlock("- Parent\n    1. Child\n    2. Child")).toBe(true);
     expect(hasWideMarkdownBlock("> - Parent\n>     1. Child")).toBe(true);
-    expect(hasWideMarkdownBlock("    1. indented code")).toBe(false);
-    expect(hasWideMarkdownBlock("    - code-like bullet\n    1. indented code")).toBe(false);
   });
 
   it("can limit ordered-list width pinning to Android", () => {
@@ -46,7 +54,7 @@ describe("hasWideMarkdownBlock", () => {
     expect(hasWideMarkdownBlock("  > quoted", { includeBlockquotes: true })).toBe(true);
     expect(hasWideMarkdownBlock("> quoted")).toBe(false);
     expect(hasWideMarkdownBlock("prose > quoted", { includeBlockquotes: true })).toBe(false);
-    expect(hasWideMarkdownBlock("    > indented code", { includeBlockquotes: true })).toBe(false);
+    expect(hasWideMarkdownBlock("    > indented code", { includeBlockquotes: true })).toBe(true);
   });
 
   it("detects GFM tables", () => {

--- a/apps/mobile/src/lib/wideMarkdownBlocks.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.ts
@@ -1,7 +1,7 @@
 /**
  * Detects markdown that the renderer draws as a block requiring a definite
- * user-bubble width: fenced code blocks, GFM tables, ordered lists, and
- * blockquotes when requested by the caller.
+ * user-bubble width: fenced and indented code blocks, GFM tables, ordered
+ * lists, and blockquotes when requested by the caller.
  *
  * Fenced code blocks and tables report an intrinsic width equal to their
  * widest line, which is effectively unbounded. A user bubble sizes itself
@@ -23,6 +23,7 @@
  */
 
 const FENCED_CODE_BLOCK = /^ {0,3}(?:```|~~~)/m;
+const INDENTED_CODE_BLOCK = /^(?: {4,}|\t+)\S/m;
 // Trades some precision for a simple check, favoring false positives over false
 // negatives: list-shaped paragraph may get a wider bubble
 const ORDERED_LIST_ITEM = /^ {0,3}\d{1,9}[.)](?:[ \t]+|$)/;
@@ -87,6 +88,9 @@ export function hasWideMarkdownBlock(
     return true;
   }
   if (options.includeBlockquotes === true && hasBlockquote(text)) {
+    return true;
+  }
+  if (INDENTED_CODE_BLOCK.test(text)) {
     return true;
   }
   if (options.includeOrderedLists !== false && hasOrderedListItem(text)) {

--- a/apps/mobile/src/lib/wideMarkdownBlocks.ts
+++ b/apps/mobile/src/lib/wideMarkdownBlocks.ts
@@ -23,7 +23,6 @@
  */
 
 const FENCED_CODE_BLOCK = /^ {0,3}(?:```|~~~)/m;
-const INDENTED_CODE_BLOCK = /^(?: {4,}|\t+)\S/m;
 // Trades some precision for a simple check, favoring false positives over false
 // negatives: list-shaped paragraph may get a wider bubble
 const ORDERED_LIST_ITEM = /^ {0,3}\d{1,9}[.)](?:[ \t]+|$)/;
@@ -42,6 +41,28 @@ function stripBlockquotePrefixes(line: string): string {
     content = content.replace(BLOCKQUOTE_PREFIX, "");
   }
   return content;
+}
+
+function hasIndentedCodeBlock(text: string): boolean {
+  return text.split("\n").some((rawLine) => {
+    const line = stripBlockquotePrefixes(rawLine);
+    let column = 0;
+    let index = 0;
+
+    // Markdown tabs advance to the next four-column stop.
+    while (index < line.length) {
+      if (line[index] === " ") {
+        column += 1;
+      } else if (line[index] === "\t") {
+        column += 4 - (column % 4);
+      } else {
+        break;
+      }
+      index += 1;
+    }
+
+    return column >= 4 && index < line.length && line[index] !== "\r";
+  });
 }
 
 function hasBlockquote(text: string): boolean {
@@ -90,7 +111,7 @@ export function hasWideMarkdownBlock(
   if (options.includeBlockquotes === true && hasBlockquote(text)) {
     return true;
   }
-  if (INDENTED_CODE_BLOCK.test(text)) {
+  if (hasIndentedCodeBlock(text)) {
     return true;
   }
   if (options.includeOrderedLists !== false && hasOrderedListItem(text)) {


### PR DESCRIPTION
## Summary

On Android, a user message with space/tab-indented Python (not a fenced code block) overflowed its chat bubble and painted over later assistant messages. The server stored each message correctly and only once; this is purely a mobile layout bug, not corrupted thread data or a sync problem.

## What changed

- `hasWideMarkdownBlock` now recognizes four-space/tab indented code blocks (including inside blockquotes) as wide Markdown, routing those messages through the fixed-width bubble layout that already handles fenced code, tables, and lists.
- Regression coverage shaped like the reported prompt; the two old assertions that classified indented code as non-wide now assert the fixed behavior.

## Validation

- `vp test run apps/mobile/src/lib/wideMarkdownBlocks.test.ts`: 8/8 pass
- Clean worktree, focused two-file diff (two commits on this branch)
##Issue:
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/84093953-ddb2-46a1-9565-8df3548436ab" />

Implemented in a T3 Code worktree; PR filed via OpenCode (Muse Spark).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix indented code overflowing Android chat bubbles by detecting it in `hasWideMarkdownBlock`
> Adds an `hasIndentedCodeBlock` helper that strips blockquote prefixes, computes indentation with four-column tab stops, and flags non-empty lines reaching at least four columns. `hasWideMarkdownBlock` now runs this check before ordered-list and table handling, so indented code blocks get a full-width bubble.
> - Indented list-shaped text is now also classified as wide, since it is indistinguishable from indented code.
> - Risk: `hasWideMarkdownBlock` in [wideMarkdownBlocks.ts](https://github.com/pingdotgg/t3code/pull/9347/files#diff-9aff26e3a6e595c30414365d8b3df55c671704b0aa46f2d105b41a0a249143e3) now returns `true` for indented list-shaped content, which may widen bubbles for lists that previously rendered narrow.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a4aa085. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/mobile/src/lib/wideMarkdownBlocks.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 64](https://github.com/pingdotgg/t3code/blob/a4aa085edf56ef6df9dea0e92534876817920c90/apps/mobile/src/lib/wideMarkdownBlocks.ts#L64): `hasIndentedCodeBlock` treats every nonblank line reaching column four as a code block, even when it continues an existing paragraph. For example, `"Summary:\n    continued explanation"` returns `true`, although indented code cannot interrupt a paragraph (the line renders as ordinary paragraph text). This unnecessarily forces normal user messages into the fixed 85%-width bubble rather than their content-sized layout; require a preceding blank/block boundary before classifying the first indented line. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->