### PR TITLE
fix(web): let the pull request list use wide screens

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -16,19 +16,46 @@ import {
   PullRequestStateGlyph,
 } from "./pullRequestPresentation";
 
+/**
+ * Each slot past the first only appears once the meta line is wide enough to hold it, so a
+ * narrow row shows one label and a "+N" while a wide one spreads out up to three. The "+N"
+ * rides on whichever pill is the last visible one, and is hidden as soon as the next slot shows.
+ */
+const LABEL_SLOTS = [
+  { pill: "", overflow: "@xl/pr-row-meta:hidden" },
+  { pill: "hidden @xl/pr-row-meta:inline-flex", overflow: "@3xl/pr-row-meta:hidden" },
+  { pill: "hidden @3xl/pr-row-meta:inline-flex", overflow: "" },
+] as const;
+
 function PullRequestRowLabels({ labels }: { labels: EnvironmentPullRequestEntry["labels"] }) {
-  const label = labels[0];
-  if (!label) return null;
-  const dot = pullRequestLabelColor(label.color);
+  if (labels.length === 0) return null;
   return (
-    <span className="inline-flex max-w-40 min-w-0 items-center gap-1 rounded-full border border-border/70 bg-muted/40 py-0 pl-1 pr-1.5 text-[10px] leading-3.5 text-muted-foreground">
-      <span
-        aria-hidden
-        className="size-2 shrink-0 rounded-full bg-muted-foreground"
-        {...(dot ? { style: { backgroundColor: dot } } : {})}
-      />
-      <span className="truncate">{label.name}</span>
-      {labels.length > 1 ? <span className="shrink-0">+{labels.length - 1}</span> : null}
+    <span className="flex min-w-0 items-center gap-1">
+      {LABEL_SLOTS.map((slot, index) => {
+        const label = labels[index];
+        if (!label) return null;
+        const dot = pullRequestLabelColor(label.color);
+        const remaining = labels.length - index - 1;
+        return (
+          <span
+            key={label.name}
+            className={cn(
+              "inline-flex max-w-40 min-w-0 items-center gap-1 rounded-full border border-border/70 bg-muted/40 py-0 pl-1 pr-1.5 text-[10px] leading-3.5 text-muted-foreground",
+              slot.pill,
+            )}
+          >
+            <span
+              aria-hidden
+              className="size-2 shrink-0 rounded-full bg-muted-foreground"
+              {...(dot ? { style: { backgroundColor: dot } } : {})}
+            />
+            <span className="truncate">{label.name}</span>
+            {remaining > 0 ? (
+              <span className={cn("shrink-0", slot.overflow)}>+{remaining}</span>
+            ) : null}
+          </span>
+        );
+      })}
     </span>
   );
 }

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -2228,7 +2228,7 @@ function PullRequestsColumn({
         {/* The top padding is the shared fade band's height, the same pairing the
             settings page makes: at rest the controls sit fully below the mask, and only
             content actually passing under the chrome fades. */}
-        <WorkspacePageContainer className="gap-4">
+        <WorkspacePageContainer width="expanded" className="gap-4">
           <div className="flex flex-col gap-3">
             <div ref={inFlowSearchRef} className="flex items-center gap-2">
               {searchInput}


### PR DESCRIPTION
The pull request list sat on the readable page width (896px), so on a large monitor it stayed narrow with empty space either side, and labels collapsed to one pill plus a `+N` count long before the row ran out of room.

The page now uses the expanded width (1152px), and rows spread labels out with the space they have: one pill below `@xl`, two from `@xl`, three from `@3xl` of the row's meta line, using the container query already on it. The `+N` count rides on the last visible pill and hides once the next slot appears, so a narrow split pane still gets the old compact form.

Both shots: 1920×1100, same state, same rows, `main` vs this branch.

**Before**

![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4655743bc4bd9d68/pr-before.png)

**After**

![after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9580e35acae9a1a3/pr-after.png)

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)