### PR TITLE
fix(mobile): pressed and disabled styles no longer apply unconditionally

### DIFF
--- a/patches/uniwind@1.11.0.patch
+++ b/patches/uniwind@1.11.0.patch
@@ -1,5 +1,161 @@
+diff --git a/dist/common/bundler/css-processor/processor.js b/dist/common/bundler/css-processor/processor.js
+index 7dd369fa3197dbd622832c89ac3854c401e55c3e..ab3ea1a9520907321f9c21c2a3a859262fe5075b 100644
+--- a/dist/common/bundler/css-processor/processor.js
++++ b/dist/common/bundler/css-processor/processor.js
+@@ -105,6 +105,64 @@ class ProcessorBuilder {
+       style.importantProperties.push(declaration.property);
+     }
+   }
++  readSelectorVariants(tokens) {
++    const variants = {
++      rtl: null,
++      theme: null,
++      active: null,
++      focus: null,
++      disabled: null,
++      dataAttributes: null
++    };
++    tokens.forEach((token) => {
++      if (token.type === "pseudo-class" && token.kind === "where") {
++        token.selectors.forEach((compound) => {
++          compound.forEach((inner) => {
++            if (inner.type === "class" && this.bundlerConfig.themes.includes(inner.name)) {
++              variants.theme = inner.name;
++            }
++            if (inner.type === "pseudo-class" && inner.kind === "dir") {
++              variants.rtl = inner.direction === "rtl";
++            }
++          });
++        });
++      }
++      if (token.type === "pseudo-class" && token.kind === "active") {
++        variants.active = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "focus") {
++        variants.focus = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "disabled") {
++        variants.disabled = true;
++      }
++      if (token.type === "attribute" && token.operation === null && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"true"`;
++      }
++      if (token.type === "attribute" && token.operation?.operator === "equal" && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"${token.operation.value}"`;
++      }
++    });
++    const hasVariants = Object.values(variants).some(_utils.isDefined);
++    return { variants, hasVariants };
++  }
++  withSelectorVariants(variants, run) {
++    this.declarationConfig.rtl ??= variants.rtl;
++    this.declarationConfig.theme ??= variants.theme;
++    this.declarationConfig.active ??= variants.active;
++    this.declarationConfig.focus ??= variants.focus;
++    this.declarationConfig.disabled ??= variants.disabled;
++    this.declarationConfig.dataAttributes ??= variants.dataAttributes;
++    run();
++    this.declarationConfig.rtl = null;
++    this.declarationConfig.theme = null;
++    this.declarationConfig.active = null;
++    this.declarationConfig.focus = null;
++    this.declarationConfig.disabled = null;
++    this.declarationConfig.dataAttributes = null;
++  }
+   parseRuleRec(rule) {
+     if (this.declarationConfig.className !== null) {
+       const lastStyle = this.stylesheets[this.declarationConfig.className]?.at(-1);
+@@ -120,64 +178,30 @@ class ProcessorBuilder {
+           this.declarationConfig.className = newClassName;
+           this.stylesheets[newClassName] ??= [];
+           this.stylesheets[newClassName].push({});
+-          rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach(rule2 => this.parseRuleRec(rule2));
+-          return;
+-        }
+-        let rtl = null;
+-        let theme = null;
+-        let active = null;
+-        let focus = null;
+-        let disabled = null;
+-        let dataAttributes = null;
+-        selector.forEach(selector2 => {
+-          if (selector2.type === "pseudo-class" && selector2.kind === "where") {
+-            selector2.selectors.forEach(selector3 => {
+-              selector3.forEach(selector4 => {
+-                if (selector4.type === "class" && this.bundlerConfig.themes.includes(selector4.name)) {
+-                  theme = selector4.name;
+-                }
+-                if (selector4.type === "pseudo-class" && selector4.kind === "dir") {
+-                  rtl = selector4.direction === "rtl";
+-                }
+-              });
+-            });
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "active") {
+-            active = true;
++          const trailing = selector.slice(1);
++          const { variants, hasVariants } = this.readSelectorVariants(trailing);
++          if (trailing.length > 0 && !hasVariants) {
++            return;
+           }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "focus") {
+-            focus = true;
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "disabled") {
+-            disabled = true;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation === null && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"true"`;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation?.operator === "equal" && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"${selector2.operation.value}"`;
++          const parseClassRule = () => {
++            rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach(rule2 => this.parseRuleRec(rule2));
++          };
++          if (hasVariants) {
++            this.withSelectorVariants(variants, parseClassRule);
++          } else {
++            parseClassRule();
+           }
+-        });
+-        if ([rtl, theme, active, focus, disabled, dataAttributes].some(_utils.isDefined)) {
+-          this.declarationConfig.rtl ??= rtl;
+-          this.declarationConfig.theme ??= theme;
+-          this.declarationConfig.active ??= active;
+-          this.declarationConfig.focus ??= focus;
+-          this.declarationConfig.disabled ??= disabled;
+-          this.declarationConfig.dataAttributes ??= dataAttributes;
+-          rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach(rule2 => this.parseRuleRec(rule2));
+-          this.declarationConfig.rtl = null;
+-          this.declarationConfig.theme = null;
+-          this.declarationConfig.active = null;
+-          this.declarationConfig.focus = null;
+-          this.declarationConfig.disabled = null;
+-          this.declarationConfig.dataAttributes = null;
++          return;
++        }
++        const { variants, hasVariants } = this.readSelectorVariants(selector);
++        if (hasVariants) {
++          this.withSelectorVariants(variants, () => {
++            rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach(rule2 => this.parseRuleRec(rule2));
++          });
+           return;
+         }
+         selector.forEach(selectorToken => {
 diff --git a/dist/metro/transformer.cjs b/dist/metro/transformer.cjs
-index d57ca81..fd8693c 100644
+index d57ca8161f411f0dc7df827132586e428cafdf1b..3650a353b0db269ad4fc51b70a7158885c992e36 100644
 --- a/dist/metro/transformer.cjs
 +++ b/dist/metro/transformer.cjs
 @@ -7,6 +7,7 @@ const culori = require('culori');
@@ -10,7 +166,159 @@ index d57ca81..fd8693c 100644
  
  function _interopDefaultCompat (e) { return e && typeof e === 'object' && 'default' in e ? e.default : e; }
  
-@@ -1753,10 +1754,11 @@ const transform = async (config$1, projectRoot, filePath, data, options) => {
+@@ -1537,6 +1538,64 @@ class ProcessorBuilder {
+       style.importantProperties.push(declaration.property);
+     }
+   }
++  readSelectorVariants(tokens) {
++    const variants = {
++      rtl: null,
++      theme: null,
++      active: null,
++      focus: null,
++      disabled: null,
++      dataAttributes: null
++    };
++    tokens.forEach((token) => {
++      if (token.type === "pseudo-class" && token.kind === "where") {
++        token.selectors.forEach((compound) => {
++          compound.forEach((inner) => {
++            if (inner.type === "class" && this.bundlerConfig.themes.includes(inner.name)) {
++              variants.theme = inner.name;
++            }
++            if (inner.type === "pseudo-class" && inner.kind === "dir") {
++              variants.rtl = inner.direction === "rtl";
++            }
++          });
++        });
++      }
++      if (token.type === "pseudo-class" && token.kind === "active") {
++        variants.active = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "focus") {
++        variants.focus = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "disabled") {
++        variants.disabled = true;
++      }
++      if (token.type === "attribute" && token.operation === null && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"true"`;
++      }
++      if (token.type === "attribute" && token.operation?.operator === "equal" && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"${token.operation.value}"`;
++      }
++    });
++    const hasVariants = Object.values(variants).some(config.isDefined);
++    return { variants, hasVariants };
++  }
++  withSelectorVariants(variants, run) {
++    this.declarationConfig.rtl ??= variants.rtl;
++    this.declarationConfig.theme ??= variants.theme;
++    this.declarationConfig.active ??= variants.active;
++    this.declarationConfig.focus ??= variants.focus;
++    this.declarationConfig.disabled ??= variants.disabled;
++    this.declarationConfig.dataAttributes ??= variants.dataAttributes;
++    run();
++    this.declarationConfig.rtl = null;
++    this.declarationConfig.theme = null;
++    this.declarationConfig.active = null;
++    this.declarationConfig.focus = null;
++    this.declarationConfig.disabled = null;
++    this.declarationConfig.dataAttributes = null;
++  }
+   parseRuleRec(rule) {
+     if (this.declarationConfig.className !== null) {
+       const lastStyle = this.stylesheets[this.declarationConfig.className]?.at(-1);
+@@ -1552,64 +1611,30 @@ class ProcessorBuilder {
+           this.declarationConfig.className = newClassName;
+           this.stylesheets[newClassName] ??= [];
+           this.stylesheets[newClassName].push({});
+-          rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
+-          return;
+-        }
+-        let rtl = null;
+-        let theme = null;
+-        let active = null;
+-        let focus = null;
+-        let disabled = null;
+-        let dataAttributes = null;
+-        selector.forEach((selector2) => {
+-          if (selector2.type === "pseudo-class" && selector2.kind === "where") {
+-            selector2.selectors.forEach((selector3) => {
+-              selector3.forEach((selector4) => {
+-                if (selector4.type === "class" && this.bundlerConfig.themes.includes(selector4.name)) {
+-                  theme = selector4.name;
+-                }
+-                if (selector4.type === "pseudo-class" && selector4.kind === "dir") {
+-                  rtl = selector4.direction === "rtl";
+-                }
+-              });
+-            });
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "active") {
+-            active = true;
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "focus") {
+-            focus = true;
++          const trailing = selector.slice(1);
++          const { variants, hasVariants } = this.readSelectorVariants(trailing);
++          if (trailing.length > 0 && !hasVariants) {
++            return;
+           }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "disabled") {
+-            disabled = true;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation === null && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"true"`;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation?.operator === "equal" && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"${selector2.operation.value}"`;
++          const parseClassRule = () => {
++            rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
++          };
++          if (hasVariants) {
++            this.withSelectorVariants(variants, parseClassRule);
++          } else {
++            parseClassRule();
+           }
+-        });
+-        if ([rtl, theme, active, focus, disabled, dataAttributes].some(config.isDefined)) {
+-          this.declarationConfig.rtl ??= rtl;
+-          this.declarationConfig.theme ??= theme;
+-          this.declarationConfig.active ??= active;
+-          this.declarationConfig.focus ??= focus;
+-          this.declarationConfig.disabled ??= disabled;
+-          this.declarationConfig.dataAttributes ??= dataAttributes;
+-          rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
+-          this.declarationConfig.rtl = null;
+-          this.declarationConfig.theme = null;
+-          this.declarationConfig.active = null;
+-          this.declarationConfig.focus = null;
+-          this.declarationConfig.disabled = null;
+-          this.declarationConfig.dataAttributes = null;
++          return;
++        }
++        const { variants, hasVariants } = this.readSelectorVariants(selector);
++        if (hasVariants) {
++          this.withSelectorVariants(variants, () => {
++            rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
++          });
+           return;
+         }
+         selector.forEach((selectorToken) => {
+@@ -1753,10 +1778,11 @@ const transform = async (config$1, projectRoot, filePath, data, options) => {
    await bundlerConfig.generateArtifacts(cssArtifactPath);
    const virtualCode = await compileCSS(bundlerConfig);
    const isWeb = bundlerConfig.platform === config.Platform.Web;
@@ -24,7 +332,7 @@ index d57ca81..fd8693c 100644
      "utf-8"
    );
 diff --git a/dist/metro/transformer.mjs b/dist/metro/transformer.mjs
-index d3e7475..bf63587 100644
+index d3e7475f8f0aaba510b318657dc8374e6c6097cb..6ff8cffc4bb703521b6d86f0ac14be054ba5b9ce 100644
 --- a/dist/metro/transformer.mjs
 +++ b/dist/metro/transformer.mjs
 @@ -5,6 +5,7 @@ import { converter, parse, formatHex, formatHex8 } from 'culori';
@@ -35,7 +343,159 @@ index d3e7475..bf63587 100644
  
  const toCamelCase = (str) => str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
  const pipe = (data) => ((...fns) => fns.reduce((acc, fn) => fn(acc), data));
-@@ -1746,10 +1747,11 @@ const transform = async (config, projectRoot, filePath, data, options) => {
+@@ -1530,6 +1531,64 @@ class ProcessorBuilder {
+       style.importantProperties.push(declaration.property);
+     }
+   }
++  readSelectorVariants(tokens) {
++    const variants = {
++      rtl: null,
++      theme: null,
++      active: null,
++      focus: null,
++      disabled: null,
++      dataAttributes: null
++    };
++    tokens.forEach((token) => {
++      if (token.type === "pseudo-class" && token.kind === "where") {
++        token.selectors.forEach((compound) => {
++          compound.forEach((inner) => {
++            if (inner.type === "class" && this.bundlerConfig.themes.includes(inner.name)) {
++              variants.theme = inner.name;
++            }
++            if (inner.type === "pseudo-class" && inner.kind === "dir") {
++              variants.rtl = inner.direction === "rtl";
++            }
++          });
++        });
++      }
++      if (token.type === "pseudo-class" && token.kind === "active") {
++        variants.active = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "focus") {
++        variants.focus = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "disabled") {
++        variants.disabled = true;
++      }
++      if (token.type === "attribute" && token.operation === null && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"true"`;
++      }
++      if (token.type === "attribute" && token.operation?.operator === "equal" && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"${token.operation.value}"`;
++      }
++    });
++    const hasVariants = Object.values(variants).some(isDefined);
++    return { variants, hasVariants };
++  }
++  withSelectorVariants(variants, run) {
++    this.declarationConfig.rtl ??= variants.rtl;
++    this.declarationConfig.theme ??= variants.theme;
++    this.declarationConfig.active ??= variants.active;
++    this.declarationConfig.focus ??= variants.focus;
++    this.declarationConfig.disabled ??= variants.disabled;
++    this.declarationConfig.dataAttributes ??= variants.dataAttributes;
++    run();
++    this.declarationConfig.rtl = null;
++    this.declarationConfig.theme = null;
++    this.declarationConfig.active = null;
++    this.declarationConfig.focus = null;
++    this.declarationConfig.disabled = null;
++    this.declarationConfig.dataAttributes = null;
++  }
+   parseRuleRec(rule) {
+     if (this.declarationConfig.className !== null) {
+       const lastStyle = this.stylesheets[this.declarationConfig.className]?.at(-1);
+@@ -1545,64 +1604,30 @@ class ProcessorBuilder {
+           this.declarationConfig.className = newClassName;
+           this.stylesheets[newClassName] ??= [];
+           this.stylesheets[newClassName].push({});
+-          rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
+-          return;
+-        }
+-        let rtl = null;
+-        let theme = null;
+-        let active = null;
+-        let focus = null;
+-        let disabled = null;
+-        let dataAttributes = null;
+-        selector.forEach((selector2) => {
+-          if (selector2.type === "pseudo-class" && selector2.kind === "where") {
+-            selector2.selectors.forEach((selector3) => {
+-              selector3.forEach((selector4) => {
+-                if (selector4.type === "class" && this.bundlerConfig.themes.includes(selector4.name)) {
+-                  theme = selector4.name;
+-                }
+-                if (selector4.type === "pseudo-class" && selector4.kind === "dir") {
+-                  rtl = selector4.direction === "rtl";
+-                }
+-              });
+-            });
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "active") {
+-            active = true;
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "focus") {
+-            focus = true;
++          const trailing = selector.slice(1);
++          const { variants, hasVariants } = this.readSelectorVariants(trailing);
++          if (trailing.length > 0 && !hasVariants) {
++            return;
+           }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "disabled") {
+-            disabled = true;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation === null && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"true"`;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation?.operator === "equal" && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"${selector2.operation.value}"`;
++          const parseClassRule = () => {
++            rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
++          };
++          if (hasVariants) {
++            this.withSelectorVariants(variants, parseClassRule);
++          } else {
++            parseClassRule();
+           }
+-        });
+-        if ([rtl, theme, active, focus, disabled, dataAttributes].some(isDefined)) {
+-          this.declarationConfig.rtl ??= rtl;
+-          this.declarationConfig.theme ??= theme;
+-          this.declarationConfig.active ??= active;
+-          this.declarationConfig.focus ??= focus;
+-          this.declarationConfig.disabled ??= disabled;
+-          this.declarationConfig.dataAttributes ??= dataAttributes;
+-          rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
+-          this.declarationConfig.rtl = null;
+-          this.declarationConfig.theme = null;
+-          this.declarationConfig.active = null;
+-          this.declarationConfig.focus = null;
+-          this.declarationConfig.disabled = null;
+-          this.declarationConfig.dataAttributes = null;
++          return;
++        }
++        const { variants, hasVariants } = this.readSelectorVariants(selector);
++        if (hasVariants) {
++          this.withSelectorVariants(variants, () => {
++            rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
++          });
+           return;
+         }
+         selector.forEach((selectorToken) => {
+@@ -1746,10 +1771,11 @@ const transform = async (config, projectRoot, filePath, data, options) => {
    await bundlerConfig.generateArtifacts(cssArtifactPath);
    const virtualCode = await compileCSS(bundlerConfig);
    const isWeb = bundlerConfig.platform === Platform.Web;
@@ -48,8 +508,164 @@ index d3e7475..bf63587 100644
      ].join(""),
      "utf-8"
    );
+diff --git a/dist/module/bundler/css-processor/processor.js b/dist/module/bundler/css-processor/processor.js
+index 58c96b6ab642c2b724d1868d0d48b77bad33be6f..70b759b04913a0e9028c936827b4578d628b4728 100644
+--- a/dist/module/bundler/css-processor/processor.js
++++ b/dist/module/bundler/css-processor/processor.js
+@@ -99,6 +99,64 @@ export class ProcessorBuilder {
+       style.importantProperties.push(declaration.property);
+     }
+   }
++  readSelectorVariants(tokens) {
++    const variants = {
++      rtl: null,
++      theme: null,
++      active: null,
++      focus: null,
++      disabled: null,
++      dataAttributes: null
++    };
++    tokens.forEach((token) => {
++      if (token.type === "pseudo-class" && token.kind === "where") {
++        token.selectors.forEach((compound) => {
++          compound.forEach((inner) => {
++            if (inner.type === "class" && this.bundlerConfig.themes.includes(inner.name)) {
++              variants.theme = inner.name;
++            }
++            if (inner.type === "pseudo-class" && inner.kind === "dir") {
++              variants.rtl = inner.direction === "rtl";
++            }
++          });
++        });
++      }
++      if (token.type === "pseudo-class" && token.kind === "active") {
++        variants.active = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "focus") {
++        variants.focus = true;
++      }
++      if (token.type === "pseudo-class" && token.kind === "disabled") {
++        variants.disabled = true;
++      }
++      if (token.type === "attribute" && token.operation === null && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"true"`;
++      }
++      if (token.type === "attribute" && token.operation?.operator === "equal" && token.name.startsWith("data-")) {
++        variants.dataAttributes ??= {};
++        variants.dataAttributes[token.name] = `"${token.operation.value}"`;
++      }
++    });
++    const hasVariants = Object.values(variants).some(isDefined);
++    return { variants, hasVariants };
++  }
++  withSelectorVariants(variants, run) {
++    this.declarationConfig.rtl ??= variants.rtl;
++    this.declarationConfig.theme ??= variants.theme;
++    this.declarationConfig.active ??= variants.active;
++    this.declarationConfig.focus ??= variants.focus;
++    this.declarationConfig.disabled ??= variants.disabled;
++    this.declarationConfig.dataAttributes ??= variants.dataAttributes;
++    run();
++    this.declarationConfig.rtl = null;
++    this.declarationConfig.theme = null;
++    this.declarationConfig.active = null;
++    this.declarationConfig.focus = null;
++    this.declarationConfig.disabled = null;
++    this.declarationConfig.dataAttributes = null;
++  }
+   parseRuleRec(rule) {
+     if (this.declarationConfig.className !== null) {
+       const lastStyle = this.stylesheets[this.declarationConfig.className]?.at(-1);
+@@ -114,64 +172,30 @@ export class ProcessorBuilder {
+           this.declarationConfig.className = newClassName;
+           this.stylesheets[newClassName] ??= [];
+           this.stylesheets[newClassName].push({});
+-          rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
+-          return;
+-        }
+-        let rtl = null;
+-        let theme = null;
+-        let active = null;
+-        let focus = null;
+-        let disabled = null;
+-        let dataAttributes = null;
+-        selector.forEach((selector2) => {
+-          if (selector2.type === "pseudo-class" && selector2.kind === "where") {
+-            selector2.selectors.forEach((selector3) => {
+-              selector3.forEach((selector4) => {
+-                if (selector4.type === "class" && this.bundlerConfig.themes.includes(selector4.name)) {
+-                  theme = selector4.name;
+-                }
+-                if (selector4.type === "pseudo-class" && selector4.kind === "dir") {
+-                  rtl = selector4.direction === "rtl";
+-                }
+-              });
+-            });
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "active") {
+-            active = true;
++          const trailing = selector.slice(1);
++          const { variants, hasVariants } = this.readSelectorVariants(trailing);
++          if (trailing.length > 0 && !hasVariants) {
++            return;
+           }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "focus") {
+-            focus = true;
+-          }
+-          if (selector2.type === "pseudo-class" && selector2.kind === "disabled") {
+-            disabled = true;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation === null && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"true"`;
+-          }
+-          if (selector2.type === "attribute" && selector2.operation?.operator === "equal" && selector2.name.startsWith("data-")) {
+-            dataAttributes ??= {};
+-            dataAttributes[selector2.name] = `"${selector2.operation.value}"`;
++          const parseClassRule = () => {
++            rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
++          };
++          if (hasVariants) {
++            this.withSelectorVariants(variants, parseClassRule);
++          } else {
++            parseClassRule();
+           }
+-        });
+-        if ([rtl, theme, active, focus, disabled, dataAttributes].some(isDefined)) {
+-          this.declarationConfig.rtl ??= rtl;
+-          this.declarationConfig.theme ??= theme;
+-          this.declarationConfig.active ??= active;
+-          this.declarationConfig.focus ??= focus;
+-          this.declarationConfig.disabled ??= disabled;
+-          this.declarationConfig.dataAttributes ??= dataAttributes;
+-          rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
+-          rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
+-          rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
+-          this.declarationConfig.rtl = null;
+-          this.declarationConfig.theme = null;
+-          this.declarationConfig.active = null;
+-          this.declarationConfig.focus = null;
+-          this.declarationConfig.disabled = null;
+-          this.declarationConfig.dataAttributes = null;
++          return;
++        }
++        const { variants, hasVariants } = this.readSelectorVariants(selector);
++        if (hasVariants) {
++          this.withSelectorVariants(variants, () => {
++            rule.value.declarations?.declarations?.forEach((declaration) => this.addDeclaration(declaration));
++            rule.value.declarations?.importantDeclarations?.forEach((declaration) => this.addDeclaration(declaration, true));
++            rule.value.rules?.forEach((rule2) => this.parseRuleRec(rule2));
++          });
+           return;
+         }
+         selector.forEach((selectorToken) => {
 diff --git a/src/bundler/adapters/metro/transformer.ts b/src/bundler/adapters/metro/transformer.ts
-index 08059b0..05c0515 100644
+index 08059b0fb2394effd2553086216d8933a53fad84..05c051595bfffd313f1d731fcedc1e991af720e1 100644
 --- a/src/bundler/adapters/metro/transformer.ts
 +++ b/src/bundler/adapters/metro/transformer.ts
 @@ -5,6 +5,7 @@ import { Platform } from '@/common/consts'
@@ -82,8 +698,195 @@ index 08059b0..05c0515 100644
              ].join(''),
          'utf-8',
      )
+diff --git a/src/bundler/css-processor/processor.ts b/src/bundler/css-processor/processor.ts
+index c8b3bb86e2a50c16ebc3f0404f4d9ac050aba61d..b5e185469733aca4289b7b07bc76dbfcd8fd5788 100644
+--- a/src/bundler/css-processor/processor.ts
++++ b/src/bundler/css-processor/processor.ts
+@@ -123,6 +123,77 @@ export class ProcessorBuilder {
+         }
+     }
+ 
++    private readSelectorVariants(tokens: ReadonlyArray<any>) {
++        const variants = {
++            rtl: null as boolean | null,
++            theme: null as string | null,
++            active: null as boolean | null,
++            focus: null as boolean | null,
++            disabled: null as boolean | null,
++            dataAttributes: null as Record<string, string> | null,
++        }
++
++        tokens.forEach(token => {
++            if (token.type === 'pseudo-class' && token.kind === 'where') {
++                token.selectors.forEach((compound: Array<any>) => {
++                    compound.forEach(inner => {
++                        if (inner.type === 'class' && this.bundlerConfig.themes.includes(inner.name)) {
++                            variants.theme = inner.name
++                        }
++
++                        if (inner.type === 'pseudo-class' && inner.kind === 'dir') {
++                            variants.rtl = inner.direction === 'rtl'
++                        }
++                    })
++                })
++            }
++
++            if (token.type === 'pseudo-class' && token.kind === 'active') {
++                variants.active = true
++            }
++
++            if (token.type === 'pseudo-class' && token.kind === 'focus') {
++                variants.focus = true
++            }
++
++            if (token.type === 'pseudo-class' && token.kind === 'disabled') {
++                variants.disabled = true
++            }
++
++            // data-x
++            if (token.type === 'attribute' && token.operation === null && token.name.startsWith('data-')) {
++                variants.dataAttributes ??= {}
++                variants.dataAttributes[token.name] = `"true"`
++            }
++
++            // data-x=
++            if (token.type === 'attribute' && token.operation?.operator === 'equal' && token.name.startsWith('data-')) {
++                variants.dataAttributes ??= {}
++                variants.dataAttributes[token.name] = `"${token.operation.value}"`
++            }
++        })
++
++        return { variants, hasVariants: Object.values(variants).some(isDefined) }
++    }
++
++    private withSelectorVariants(variants: ReturnType<ProcessorBuilder['readSelectorVariants']>['variants'], run: () => void) {
++        this.declarationConfig.rtl ??= variants.rtl
++        this.declarationConfig.theme ??= variants.theme
++        this.declarationConfig.active ??= variants.active
++        this.declarationConfig.focus ??= variants.focus
++        this.declarationConfig.disabled ??= variants.disabled
++        this.declarationConfig.dataAttributes ??= variants.dataAttributes
++
++        run()
++
++        this.declarationConfig.rtl = null
++        this.declarationConfig.theme = null
++        this.declarationConfig.active = null
++        this.declarationConfig.focus = null
++        this.declarationConfig.disabled = null
++        this.declarationConfig.dataAttributes = null
++    }
++
+     private parseRuleRec(rule: Rule<Declaration, MediaQuery>) {
+         if (this.declarationConfig.className !== null) {
+             const lastStyle = this.stylesheets[this.declarationConfig.className]?.at(-1)
+@@ -142,78 +213,41 @@ export class ProcessorBuilder {
+                     this.stylesheets[newClassName] ??= []
+                     this.stylesheets[newClassName].push({})
+ 
+-                    rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration))
+-                    rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true))
+-                    rule.value.rules?.forEach(rule => this.parseRuleRec(rule))
++                    // Tailwind >= 4.3.3 emits `.active\:x:active {}` instead of
++                    // nesting `&:active` under the class, so the variant tokens
++                    // sit right after the class token. A compound the runtime
++                    // cannot express (e.g. `[aria-disabled="true"]`) used to be
++                    // an empty nested rule and must not become unconditional.
++                    const trailing = selector.slice(1)
++                    const { variants, hasVariants } = this.readSelectorVariants(trailing)
+ 
+-                    return
+-                }
+-
+-                let rtl = null as boolean | null
+-                let theme = null as string | null
+-                let active = null as boolean | null
+-                let focus = null as boolean | null
+-                let disabled = null as boolean | null
+-                let dataAttributes = null as Record<string, string> | null
+-
+-                selector.forEach(selector => {
+-                    if (selector.type === 'pseudo-class' && selector.kind === 'where') {
+-                        selector.selectors.forEach(selector => {
+-                            selector.forEach(selector => {
+-                                if (selector.type === 'class' && this.bundlerConfig.themes.includes(selector.name)) {
+-                                    theme = selector.name
+-                                }
+-
+-                                if (selector.type === 'pseudo-class' && selector.kind === 'dir') {
+-                                    rtl = selector.direction === 'rtl'
+-                                }
+-                            })
+-                        })
++                    if (trailing.length > 0 && !hasVariants) {
++                        return
+                     }
+ 
+-                    if (selector.type === 'pseudo-class' && selector.kind === 'active') {
+-                        active = true
+-                    }
+-
+-                    if (selector.type === 'pseudo-class' && selector.kind === 'focus') {
+-                        focus = true
++                    const parseClassRule = () => {
++                        rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration))
++                        rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true))
++                        rule.value.rules?.forEach(rule => this.parseRuleRec(rule))
+                     }
+ 
+-                    if (selector.type === 'pseudo-class' && selector.kind === 'disabled') {
+-                        disabled = true
++                    if (hasVariants) {
++                        this.withSelectorVariants(variants, parseClassRule)
++                    } else {
++                        parseClassRule()
+                     }
+ 
+-                    // data-x
+-                    if (selector.type === 'attribute' && selector.operation === null && selector.name.startsWith('data-')) {
+-                        dataAttributes ??= {}
+-                        dataAttributes[selector.name] = `"true"`
+-                    }
++                    return
++                }
+ 
+-                    // data-x=
+-                    if (selector.type === 'attribute' && selector.operation?.operator === 'equal' && selector.name.startsWith('data-')) {
+-                        dataAttributes ??= {}
+-                        dataAttributes[selector.name] = `"${selector.operation.value}"`
+-                    }
+-                })
++                const { variants, hasVariants } = this.readSelectorVariants(selector)
+ 
+-                if ([rtl, theme, active, focus, disabled, dataAttributes].some(isDefined)) {
+-                    this.declarationConfig.rtl ??= rtl
+-                    this.declarationConfig.theme ??= theme
+-                    this.declarationConfig.active ??= active
+-                    this.declarationConfig.focus ??= focus
+-                    this.declarationConfig.disabled ??= disabled
+-                    this.declarationConfig.dataAttributes ??= dataAttributes
+-
+-                    rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration))
+-                    rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true))
+-                    rule.value.rules?.forEach(rule => this.parseRuleRec(rule))
+-
+-                    this.declarationConfig.rtl = null
+-                    this.declarationConfig.theme = null
+-                    this.declarationConfig.active = null
+-                    this.declarationConfig.focus = null
+-                    this.declarationConfig.disabled = null
+-                    this.declarationConfig.dataAttributes = null
++                if (hasVariants) {
++                    this.withSelectorVariants(variants, () => {
++                        rule.value.declarations?.declarations?.forEach(declaration => this.addDeclaration(declaration))
++                        rule.value.declarations?.importantDeclarations?.forEach(declaration => this.addDeclaration(declaration, true))
++                        rule.value.rules?.forEach(rule => this.parseRuleRec(rule))
++                    })
+ 
+                     return
+                 }
 diff --git a/src/core/config/config.native.ts b/src/core/config/config.native.ts
-index 5e0832b..01aed1b 100644
+index 5e0832b5913df6f02604020d7ff5caf3b6a8d912..01aed1be25ca928f3a802996f41cb6b841aaed86 100644
 --- a/src/core/config/config.native.ts
 +++ b/src/core/config/config.native.ts
 @@ -8,6 +8,8 @@ import type { CSSVariables, GenerateStyleSheetsCallback, ThemeName } from '../ty

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ patchedDependencies:
   react-native-keyboard-controller@1.21.13: 6e4339347bc5bb3c9ea67d85ff5c814058b211c5750f247aba59d07869a2e787
   react-native-nitro-modules@0.35.9: 825622aae63a8fb5b904f3c77908a0e216261d727ea171709f2c0b6088422675
   react-native-screens@4.26.2: 149bef30a66351ea9b26b42f87b78c539cb52b880f2387bb323ec80dcac84006
-  uniwind@1.11.0: 329a77525509623d763b738152dbd00ab392cdcdd9fb6ed2b4a20e086e437196
+  uniwind@1.11.0: 17d92be2eec71bb6396b402e8d034968e54b28746876d7977cb3139655f42b90
 
 importers:
 
@@ -449,7 +449,7 @@ importers:
         version: 3.6.0
       uniwind:
         specifier: 1.11.0
-        version: 1.11.0(patch_hash=329a77525509623d763b738152dbd00ab392cdcdd9fb6ed2b4a20e086e437196)(@expo/metro-config@57.0.12(patch_hash=96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2)(bufferutil@4.1.0)(expo@57.0.18)(typescript@6.0.3)(utf-8-validate@6.0.6))(metro-cache@0.84.5)(metro-transform-worker@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(metro@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(tailwindcss@4.3.3)
+        version: 1.11.0(patch_hash=17d92be2eec71bb6396b402e8d034968e54b28746876d7977cb3139655f42b90)(@expo/metro-config@57.0.12(patch_hash=96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2)(bufferutil@4.1.0)(expo@57.0.18)(typescript@6.0.3)(utf-8-validate@6.0.6))(metro-cache@0.84.5)(metro-transform-worker@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(metro@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(tailwindcss@4.3.3)
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.103
@@ -20640,7 +20640,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  uniwind@1.11.0(patch_hash=329a77525509623d763b738152dbd00ab392cdcdd9fb6ed2b4a20e086e437196)(@expo/metro-config@57.0.12(patch_hash=96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2)(bufferutil@4.1.0)(expo@57.0.18)(typescript@6.0.3)(utf-8-validate@6.0.6))(metro-cache@0.84.5)(metro-transform-worker@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(metro@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(tailwindcss@4.3.3):
+  uniwind@1.11.0(patch_hash=17d92be2eec71bb6396b402e8d034968e54b28746876d7977cb3139655f42b90)(@expo/metro-config@57.0.12(patch_hash=96f1a75347e6ea02dc4b7034ace815d8ee39e18b8166ebfb573d9e58328f0dc2)(bufferutil@4.1.0)(expo@57.0.18)(typescript@6.0.3)(utf-8-validate@6.0.6))(metro-cache@0.84.5)(metro-transform-worker@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(metro@0.84.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(tailwindcss@4.3.3):
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3


### PR DESCRIPTION
## Problem

After #9331 pinned the monorepo to `tailwindcss@4.3.3`, every `active:`, `disabled:`, theme, `data-*` and `rtl:` variant on mobile compiled as if it had no condition. The visible symptom (reported in #mobile-ios) was the Appearance screen: each theme card's `active:bg-subtle` press overlay rendered permanently, so every card was tinted pink on T3 Chat. The same applies to every other `active:` press state in the app.

Tailwind 4.3.3 stopped nesting variants under the utility class and emits compound selectors instead:

```css
/* <= 4.3.2 */                          /* 4.3.3 */
.active\:bg-subtle { &:active {…} }     .active\:bg-subtle:active {…}
```

Uniwind 1.11.0 only reads variant tokens from nested rules, so on the flattened form it never sets the `active`/`disabled`/`theme` flag.

## Fix

Extend the existing `patches/uniwind@1.11.0.patch` so the processor also reads variant tokens that follow the leading class token. Compound selectors the runtime cannot express (`[aria-disabled="true"]`) are dropped instead of treated as unconditional, which matches what the nested form compiled to before. Both the four dist bundles and the TypeScript source in the patch are updated.

Verified by running Uniwind's `ProcessorBuilder` on both selector shapes and on the real `apps/mobile/global.css`: `active:*` entries now carry `active: true`, `disabled:*` carry `disabled: true`, plain utilities are unchanged.

No screenshots: this was fixed on a Linux box without an iOS simulator. The before is in the Discord thread; a TestFlight build off this branch should show the theme cards back to `bg-card`.

Written by Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vendored Uniwind CSS compilation and native style reinit behavior; incorrect variant parsing could still mis-apply press/theme/disabled styles app-wide on mobile.
> 
> **Overview**
> **Extends the `uniwind@1.11.0` patch** so mobile styling works again after Tailwind 4.3.3 started emitting flat compound selectors (e.g. `.active\:bg-subtle:active`) instead of nested `&:active` rules. Uniwind’s `ProcessorBuilder` now pulls `active`, `disabled`, `focus`, theme, RTL, and `data-*` variant flags from tokens **after** the utility class via `readSelectorVariants` / `withSelectorVariants`, and **ignores** trailing selector parts the native runtime cannot represent so they are not applied unconditionally.
> 
> The Metro transformer also computes a **SHA-256 fingerprint** of compiled styles plus themes and passes it into `Uniwind.__reinit`; in **`__DEV__`**, native config **skips** full reinit when the fingerprint is unchanged (avoids redundant work on hot reload). **`pnpm-lock.yaml`** updates the patch hash for the enlarged patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff068fe84d9fc5f3d8fdb31ea9b641e1ddbbdb79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pressed and disabled styles applying unconditionally in mobile CSS processor
> Patches `uniwind@1.11.0` to fix selector-variant parsing so `pressed` and `disabled` styles only apply when their conditions match. Updates bundled outputs, Metro transformer sections, and native configuration to stay consistent with the patched parser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff068fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->