### PR TITLE
fix(settings): report rejected shared-settings writes on every environment

### DIFF
--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -45,6 +45,7 @@ import {
   type ServerSettingsPatch,
 } from "@t3tools/contracts";
 import {
+  describeRejectedSettingsWrites,
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   supportsSharedSettings,
@@ -594,16 +595,9 @@ function AutoSettleSettingsRows() {
           }
         }),
       );
-      if (failed.length === 0) {
-        return;
+      if (failed.length > 0) {
+        Alert.alert("Setting not saved", describeRejectedSettingsWrites(failed));
       }
-      const error = failed[0]?.error;
-      Alert.alert(
-        "Setting not saved",
-        `${failed.map(({ label }) => label).join(", ")}: ${
-          error instanceof Error ? error.message : "The server rejected the change."
-        }`,
-      );
     },
     [updateSettings],
   );

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -39,6 +39,7 @@ import { useAtomCommand } from "../../state/use-atom-command";
 import { useEnvironments } from "../../state/environments";
 import {
   DEFAULT_SERVER_SETTINGS,
+  type EnvironmentId,
   MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
   MIN_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
   type ServerSettingsPatch,
@@ -46,6 +47,7 @@ import {
 import {
   findSharedSettingsMismatches,
   pickSharedServerSettings,
+  supportsSharedSettings,
 } from "@t3tools/client-runtime/state/shared-settings";
 import { useThreadListV2Enabled } from "../threads/use-thread-list-v2-enabled";
 import {
@@ -556,33 +558,61 @@ const AUTO_SETTLE_DEFAULT_DAYS = DEFAULT_SERVER_SETTINGS.sidebarAutoSettleAfterD
  * has no primary environment, so the first connected environment that
  * supports it is the reference value. Edits fan out to every connected
  * environment, and a mismatch row lets the user push the reference out.
+ *
+ * Writes are awaited so a rejected environment (a dropped session, a server
+ * that refuses the scope) is reported instead of leaving the control looking
+ * saved. The server echoes every accepted write through the config
+ * subscription, so no optimistic state is kept here.
  */
 function AutoSettleSettingsRows() {
   const { environments } = useEnvironments();
   const updateSettings = useAtomCommand(serverEnvironment.updateSettings, {
     label: "server settings update",
-    reportFailure: true,
+    reportFailure: false,
   });
 
-  const connected = environments.filter(
-    (environment) =>
-      environment.connection.phase === "connected" &&
-      environment.serverConfig?.environment.capabilities.threadAutoSettlement === true,
-  );
+  const connected = environments.filter(supportsSharedSettings);
   const reference = connected[0] ?? null;
   const referenceSettings = reference?.serverConfig?.settings ?? null;
 
   const [daysDraft, setDaysDraft] = useState<string | null>(null);
 
+  const writeTo = useCallback(
+    async (
+      targets: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>,
+      patch: ServerSettingsPatch,
+    ) => {
+      const failed: Array<{ readonly label: string; readonly error: unknown }> = [];
+      await Promise.all(
+        targets.map(async (target) => {
+          const result = await updateSettings({
+            environmentId: target.environmentId,
+            input: { patch },
+          });
+          if (AsyncResult.isFailure(result) && !isAtomCommandInterrupted(result)) {
+            failed.push({ label: target.label, error: squashAtomCommandFailure(result) });
+          }
+        }),
+      );
+      if (failed.length === 0) {
+        return;
+      }
+      const error = failed[0]?.error;
+      Alert.alert(
+        "Setting not saved",
+        `${failed.map(({ label }) => label).join(", ")}: ${
+          error instanceof Error ? error.message : "The server rejected the change."
+        }`,
+      );
+    },
+    [updateSettings],
+  );
+
   if (reference === null || referenceSettings === null) {
     return null;
   }
 
-  const writeToAll = (patch: ServerSettingsPatch) => {
-    for (const environment of connected) {
-      void updateSettings({ environmentId: environment.environmentId, input: { patch } });
-    }
-  };
+  const writeToAll = (patch: ServerSettingsPatch) => void writeTo(connected, patch);
 
   const mismatches = findSharedSettingsMismatches({
     primaryEnvironmentId: reference.environmentId,
@@ -590,7 +620,7 @@ function AutoSettleSettingsRows() {
     environments: environments.map((environment) => ({
       environmentId: environment.environmentId,
       label: environment.label,
-      connected: environment.connection.phase === "connected",
+      connected: supportsSharedSettings(environment),
       settings: environment.serverConfig?.settings ?? null,
     })),
   });
@@ -623,7 +653,6 @@ function AutoSettleSettingsRows() {
       <SettingsSwitchRow
         icon="clock"
         label="Auto-settle inactive threads"
-        subtitle={afterDays === null ? undefined : `After ${afterDays} days without activity`}
         value={afterDays !== null}
         onValueChange={(value) =>
           writeToAll({ sidebarAutoSettleAfterDays: value ? AUTO_SETTLE_DEFAULT_DAYS : null })
@@ -631,7 +660,7 @@ function AutoSettleSettingsRows() {
       />
       {afterDays !== null ? (
         <View className="flex-row items-center gap-4 border-t border-border-subtle p-4">
-          <Text className="flex-1 text-lg text-foreground">Days before auto-settle</Text>
+          <Text className="flex-1 text-lg text-foreground">Days without activity</Text>
           <TextInput
             className="min-h-10 w-20 rounded-xl px-3 py-2 text-center text-base"
             keyboardType="number-pad"
@@ -640,7 +669,7 @@ function AutoSettleSettingsRows() {
             onChangeText={setDaysDraft}
             onBlur={commitDays}
             onSubmitEditing={commitDays}
-            accessibilityLabel="Days before auto-settle"
+            accessibilityLabel="Days without activity before auto-settle"
           />
         </View>
       ) : null}
@@ -654,15 +683,7 @@ function AutoSettleSettingsRows() {
           </View>
           <Pressable
             accessibilityRole="button"
-            onPress={() => {
-              const patch = pickSharedServerSettings(referenceSettings);
-              for (const mismatch of mismatches) {
-                void updateSettings({
-                  environmentId: mismatch.environmentId,
-                  input: { patch },
-                });
-              }
-            }}
+            onPress={() => void writeTo(mismatches, pickSharedServerSettings(referenceSettings))}
             className="rounded-full bg-subtle px-4 py-2 active:opacity-70"
           >
             <Text className="text-base font-t3-medium text-foreground">Apply to all</Text>

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -30,6 +30,7 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import {
+  describeRejectedSettingsWrites,
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   splitSharedServerPatch,
@@ -374,17 +375,13 @@ function useWriteServerSettings() {
           }
         }),
       );
-      if (failed.length === 0) {
-        return;
+      if (failed.length > 0) {
+        toastManager.add({
+          type: "error",
+          title: "Setting not saved",
+          description: describeRejectedSettingsWrites(failed),
+        });
       }
-      const error = failed[0]?.error;
-      toastManager.add({
-        type: "error",
-        title: "Setting not saved",
-        description: `${failed.map(({ label }) => label).join(", ")}: ${
-          error instanceof Error ? error.message : "The server rejected the change."
-        }`,
-      });
     },
     [persistServerSettings],
   );

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -26,9 +26,14 @@ import {
 } from "@t3tools/contracts/settings";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import {
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   splitSharedServerPatch,
+  supportsSharedSettings,
 } from "@t3tools/client-runtime/state/shared-settings";
 import { ensureLocalApi } from "~/localApi";
 import {
@@ -42,11 +47,7 @@ import * as Struct from "effect/Struct";
 import { toastManager } from "~/components/ui/toast";
 import { isHostedStaticApp } from "~/hostedPairing";
 import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
-import {
-  type EnvironmentPresentation,
-  useEnvironments,
-  usePrimaryEnvironment,
-} from "~/state/environments";
+import { useEnvironments, usePrimaryEnvironment } from "~/state/environments";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { useTheme } from "./useTheme";
 
@@ -332,27 +333,60 @@ export function usePrimarySettingsAvailable(): boolean {
   return primaryEnvironment !== null || !isHostedStaticApp();
 }
 
-/**
- * Whether an environment can hold every shared key right now. Gated on the
- * auto-settlement capability because it is the newest of the shared keys: a
- * server that has it has all of them. Older servers drop unknown keys on
- * write, so a mismatch against them could never clear, and their decoded
- * defaults must not be treated as real values.
- */
-function supportsSharedSettings(environment: EnvironmentPresentation): boolean {
-  return (
-    environment.connection.phase === "connected" &&
-    environment.serverConfig?.environment.capabilities.threadAutoSettlement === true
-  );
-}
-
 /** Environments that can receive a shared settings write right now. */
-function useConnectedEnvironmentIds(): ReadonlyArray<EnvironmentId> {
+function useConnectedEnvironments(): ReadonlyArray<SettingsWriteTarget> {
   const { environments } = useEnvironments();
   return useMemo(
     () =>
-      environments.filter(supportsSharedSettings).map((environment) => environment.environmentId),
+      environments
+        .filter(supportsSharedSettings)
+        .map(({ environmentId, label }) => ({ environmentId, label })),
     [environments],
+  );
+}
+
+interface SettingsWriteTarget {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+}
+
+/**
+ * A silent failure leaves the control looking saved, so every rejected write
+ * (a dropped session, a server that refuses the scope) is named in a toast.
+ * Accepted writes come back through the config subscription and need nothing.
+ */
+function useWriteServerSettings() {
+  const persistServerSettings = useAtomCommand(serverEnvironment.updateSettings, {
+    label: "server settings update",
+    reportFailure: false,
+  });
+  return useCallback(
+    async (targets: ReadonlyArray<SettingsWriteTarget>, patch: ServerSettingsPatch) => {
+      const failed: Array<{ readonly label: string; readonly error: unknown }> = [];
+      await Promise.all(
+        targets.map(async (target) => {
+          const result = await persistServerSettings({
+            environmentId: target.environmentId,
+            input: { patch },
+          });
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            failed.push({ label: target.label, error: squashAtomCommandFailure(result) });
+          }
+        }),
+      );
+      if (failed.length === 0) {
+        return;
+      }
+      const error = failed[0]?.error;
+      toastManager.add({
+        type: "error",
+        title: "Setting not saved",
+        description: `${failed.map(({ label }) => label).join(", ")}: ${
+          error instanceof Error ? error.message : "The server rejected the change."
+        }`,
+      });
+    },
+    [persistServerSettings],
   );
 }
 
@@ -366,11 +400,12 @@ function useConnectedEnvironmentIds(): ReadonlyArray<EnvironmentId> {
  * client persistence.
  */
 function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
-  const persistServerSettings = useAtomCommand(
-    serverEnvironment.updateSettings,
-    "server settings update",
-  );
-  const connectedEnvironmentIds = useConnectedEnvironmentIds();
+  const writeServerSettings = useWriteServerSettings();
+  const connectedEnvironments = useConnectedEnvironments();
+  const { environments } = useEnvironments();
+  const targetLabel =
+    environments.find((environment) => environment.environmentId === environmentId)?.label ??
+    "This environment";
   const updateSettings = useCallback(
     (patch: UnifiedSettingsPatch) => {
       const { serverPatch, clientPatch } = splitPatch(patch);
@@ -386,28 +421,22 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
           });
         if (Object.keys(localPatch).length > 0) {
           if (environmentId) {
-            void persistServerSettings({
-              environmentId,
-              input: { patch: localPatch },
-            });
+            void writeServerSettings([{ environmentId, label: targetLabel }], localPatch);
           } else {
             warnUnsaved();
           }
         }
         if (Object.keys(sharedPatch).length > 0) {
-          const targets = new Set(connectedEnvironmentIds);
-          if (environmentId) {
-            targets.add(environmentId);
+          const targets = new Map(
+            connectedEnvironments.map((target) => [target.environmentId, target]),
+          );
+          if (environmentId && !targets.has(environmentId)) {
+            targets.set(environmentId, { environmentId, label: targetLabel });
           }
           if (targets.size === 0) {
             warnUnsaved();
           }
-          for (const targetId of targets) {
-            void persistServerSettings({
-              environmentId: targetId,
-              input: { patch: sharedPatch },
-            });
-          }
+          void writeServerSettings([...targets.values()], sharedPatch);
         }
       }
       if (Object.keys(clientPatch).length > 0) {
@@ -417,7 +446,7 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
         });
       }
     },
-    [connectedEnvironmentIds, environmentId, persistServerSettings],
+    [connectedEnvironments, environmentId, targetLabel, writeServerSettings],
   );
 
   return updateSettings;
@@ -441,10 +470,7 @@ export function useSharedSettingsSync() {
       ? (primaryEnvironment.serverConfig?.settings ?? null)
       : null;
   const { environments } = useEnvironments();
-  const persistServerSettings = useAtomCommand(
-    serverEnvironment.updateSettings,
-    "server settings update",
-  );
+  const writeServerSettings = useWriteServerSettings();
 
   const mismatches = useMemo(
     () =>
@@ -465,14 +491,8 @@ export function useSharedSettingsSync() {
     if (primarySettings === null) {
       return;
     }
-    const patch = pickSharedServerSettings(primarySettings);
-    for (const mismatch of mismatches) {
-      void persistServerSettings({
-        environmentId: mismatch.environmentId,
-        input: { patch },
-      });
-    }
-  }, [mismatches, persistServerSettings, primarySettings]);
+    void writeServerSettings(mismatches, pickSharedServerSettings(primarySettings));
+  }, [mismatches, primarySettings, writeServerSettings]);
 
   return { mismatches, applyToAll };
 }

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -25,8 +25,9 @@ turn, not by when the server noticed it was inactive.
 Change these rules in **Settings > General**. The change is written to every environment you are
 connected to at that moment. An environment that is offline keeps its old value. When a connected
 environment holds a different value, **Settings > General** shows a warning that names it. Choose
-**Apply to all** to write your current values to every connected environment. The same applies to
-the new-thread workspace mode and the source control writing style.
+**Apply to all** to write your current values to every connected environment. If an environment
+rejects the write, the app tells you which one and why. The same applies to the new-thread workspace
+mode and the source control writing style.
 
 A settings change affects future settlement and does not reopen a settled thread. Settings saved
 by older clients on one device no longer control this behavior.

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -1,10 +1,18 @@
-import { DEFAULT_SERVER_SETTINGS, EnvironmentId } from "@t3tools/contracts";
+import { DEFAULT_SERVER_SETTINGS, EnvironmentId, type ServerConfig } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
+import * as Option from "effect/Option";
 
+import { BearerConnectionProfile, type ConnectionCatalogEntry } from "../connection/catalog.ts";
+import { BearerConnectionTarget } from "../connection/model.ts";
+import type {
+  EnvironmentConnectionPhase,
+  EnvironmentPresentation,
+} from "../connection/presentation.ts";
 import {
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   splitSharedServerPatch,
+  supportsSharedSettings,
 } from "./sharedSettings.ts";
 
 const primaryId = EnvironmentId.make("env-primary");
@@ -37,6 +45,40 @@ describe("pickSharedServerSettings", () => {
 
 describe("findSharedSettingsMismatches", () => {
   const primarySettings = { ...DEFAULT_SERVER_SETTINGS, sidebarAutoSettleAfterDays: 7 };
+
+  it("compares nested shared keys by value so an applied write clears the mismatch", () => {
+    const environments = [
+      {
+        environmentId: boxId,
+        label: "Remote Box",
+        connected: true,
+        settings: {
+          ...primarySettings,
+          sourceControlWritingStyle: { ...primarySettings.sourceControlWritingStyle },
+        },
+      },
+    ];
+    expect(
+      findSharedSettingsMismatches({
+        primaryEnvironmentId: primaryId,
+        primarySettings,
+        environments,
+      }),
+    ).toEqual([]);
+    expect(
+      findSharedSettingsMismatches({
+        primaryEnvironmentId: primaryId,
+        primarySettings: {
+          ...primarySettings,
+          sourceControlWritingStyle: {
+            ...primarySettings.sourceControlWritingStyle,
+            customInstructions: "Keep it short.",
+          },
+        },
+        environments,
+      }),
+    ).toEqual([{ environmentId: boxId, label: "Remote Box" }]);
+  });
 
   it("lists connected environments whose shared settings differ", () => {
     const mismatches = findSharedSettingsMismatches({
@@ -103,5 +145,46 @@ describe("findSharedSettingsMismatches", () => {
       ],
     });
     expect(mismatches).toEqual([]);
+  });
+});
+
+describe("supportsSharedSettings", () => {
+  const target = new BearerConnectionTarget({
+    environmentId: boxId,
+    label: "Remote Box",
+    connectionId: "connection-1",
+  });
+  const entry: ConnectionCatalogEntry = {
+    target,
+    profile: Option.some(
+      new BearerConnectionProfile({
+        connectionId: target.connectionId,
+        environmentId: target.environmentId,
+        label: target.label,
+        httpBaseUrl: "https://environment.example.test",
+        wsBaseUrl: "wss://environment.example.test",
+      }),
+    ),
+  };
+  const presentation = (
+    phase: EnvironmentConnectionPhase,
+    threadAutoSettlement: boolean | null,
+  ): EnvironmentPresentation => ({
+    entry,
+    connection: { phase, error: null, traceId: null },
+    serverConfig:
+      threadAutoSettlement === null
+        ? null
+        : ({
+            environment: { capabilities: { repositoryIdentity: true, threadAutoSettlement } },
+            settings: DEFAULT_SERVER_SETTINGS,
+          } as ServerConfig),
+  });
+
+  it("requires a live connection to a server that holds every shared key", () => {
+    expect(supportsSharedSettings(presentation("connected", true))).toBe(true);
+    expect(supportsSharedSettings(presentation("connecting", true))).toBe(false);
+    expect(supportsSharedSettings(presentation("connected", false))).toBe(false);
+    expect(supportsSharedSettings(presentation("connected", null))).toBe(false);
   });
 });

--- a/packages/client-runtime/src/state/sharedSettings.test.ts
+++ b/packages/client-runtime/src/state/sharedSettings.test.ts
@@ -9,6 +9,7 @@ import type {
   EnvironmentPresentation,
 } from "../connection/presentation.ts";
 import {
+  describeRejectedSettingsWrites,
   findSharedSettingsMismatches,
   pickSharedServerSettings,
   splitSharedServerPatch,
@@ -186,5 +187,16 @@ describe("supportsSharedSettings", () => {
     expect(supportsSharedSettings(presentation("connecting", true))).toBe(false);
     expect(supportsSharedSettings(presentation("connected", false))).toBe(false);
     expect(supportsSharedSettings(presentation("connected", null))).toBe(false);
+  });
+});
+
+describe("describeRejectedSettingsWrites", () => {
+  it("keeps each environment's own reason", () => {
+    expect(
+      describeRejectedSettingsWrites([
+        { label: "Laptop", error: new Error("Laptop is not connected.") },
+        { label: "Remote Box", error: { _tag: "EnvironmentAuthorizationError" } },
+      ]),
+    ).toBe("Laptop: Laptop is not connected.\nRemote Box: The server rejected the change.");
   });
 });

--- a/packages/client-runtime/src/state/sharedSettings.ts
+++ b/packages/client-runtime/src/state/sharedSettings.ts
@@ -66,6 +66,22 @@ export function supportsSharedSettings(environment: EnvironmentPresentation): bo
   );
 }
 
+/**
+ * One line per environment that rejected a settings write, each with its own
+ * reason. Two environments can fail for different reasons (one dropped its
+ * session, one refused the scope), so the reasons are never collapsed.
+ */
+export function describeRejectedSettingsWrites(
+  failed: ReadonlyArray<{ readonly label: string; readonly error: unknown }>,
+): string {
+  return failed
+    .map(
+      ({ label, error }) =>
+        `${label}: ${error instanceof Error ? error.message : "The server rejected the change."}`,
+    )
+    .join("\n");
+}
+
 export interface SharedSettingsEnvironment {
   readonly environmentId: EnvironmentId;
   readonly label: string;

--- a/packages/client-runtime/src/state/sharedSettings.ts
+++ b/packages/client-runtime/src/state/sharedSettings.ts
@@ -12,6 +12,8 @@ import type { EnvironmentId, ServerSettings, ServerSettingsPatch } from "@t3tool
 import * as Equal from "effect/Equal";
 import * as Struct from "effect/Struct";
 
+import type { EnvironmentPresentation } from "../connection/presentation.ts";
+
 /** Server keys that hold a user preference rather than machine config. */
 export const SHARED_SERVER_SETTING_KEYS = [
   "sidebarAutoSettleAfterDays",
@@ -48,6 +50,20 @@ export function splitSharedServerPatch(patch: ServerSettingsPatch): {
 /** The shared subset of one environment's settings, as a patch that can be written elsewhere. */
 export function pickSharedServerSettings(settings: ServerSettings): ServerSettingsPatch {
   return Struct.pick(settings, SHARED_SERVER_SETTING_KEYS);
+}
+
+/**
+ * Whether an environment can hold every shared key right now. Gated on the
+ * auto-settlement capability because it is the newest of the shared keys: a
+ * server that has it has all of them. Older servers drop unknown keys on
+ * write, so a mismatch against them could never clear, and their decoded
+ * defaults must not be treated as real values.
+ */
+export function supportsSharedSettings(environment: EnvironmentPresentation): boolean {
+  return (
+    environment.connection.phase === "connected" &&
+    environment.serverConfig?.environment.capabilities.threadAutoSettlement === true
+  );
 }
 
 export interface SharedSettingsEnvironment {


### PR DESCRIPTION
## Problem

#9147 made auto-settle, thread env mode and source control writing style fan out to every connected environment, with a "Settings differ / Apply to all" row when one holds a different value. A rejected write (dropped session, server that refuses `orchestration:operate`, a settings file that cannot be written) only reached `console.warn`. On mobile that meant "Apply to all" and the auto-settle switches looked saved while nothing changed and the mismatch row never cleared. Web had the same gap.

Mobile also decided "connected" with a looser check than web, so it listed environments as mismatched that it could never write to.

## Fix

- Await each fan-out write and name every environment that rejected it, each with its own reason: `Alert` on mobile, error toast on web. Accepted writes already come back through the config subscription, so no optimistic state is added.
- Move `supportsSharedSettings` (connected + `threadAutoSettlement` capability) into `packages/client-runtime/state/shared-settings` so web and mobile agree on which environments are write targets. Tests added.
- Mobile: drop the duplicated day count from the inactive-threads row (the field below already shows it), per Wout's note.

## Proof

Two dev servers on this box, both connected from one web client. Environment B (`nucbox-1` in the remote list) has its `userdata` directory made read-only so its `settings.json` write fails with a real `ServerSettingsError`; environment A accepts the same write.

**Before** — same rejected write on `main`. The mismatch banner appears because B still holds the old value, but nothing tells the user the write failed or why:

![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e26d3be32b87c0d2/before-rejected-write-silent.png)

**After** — the write is reported with the environment name and the server's reason:

![after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b5682af26b9cb8ca/after-rejected-write-reported.png)

**Apply to all** on the mismatch banner fails the same way and says so; once B can write again the same button succeeds and the banner clears:

![apply rejected](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/178eafb26330c0f5/after-apply-to-all-rejected.png)
![apply cleared](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4b6c3a8c0fb74af9/after-apply-to-all-cleared.png)

Full run (toggle with both healthy → B goes read-only → toggle → Apply to all rejected → B restored → Apply to all clears):

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/178486f7368218cf/after-demo.webm

Mobile shares the same `writeTo`/`describeRejectedSettingsWrites` path with an `Alert` instead of a toast; no simulator on this machine to record it.

## Surfaces

- Web (Settings → General, Source Control), mobile (Settings → General). Desktop wraps web.
- `docs/user/thread-sidebar.md` updated.

Written by Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
