### PR TITLE
perf(server): make terminal history updates incremental

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1090,6 +1090,25 @@ it.layer(
     }),
   );
 
+  it.effect("caps incrementally appended history without losing partial or empty lines", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(3);
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("line1\n");
+      process.emitData("\n");
+      process.emitData("line3");
+      process.emitData("-continued\nline4");
+      yield* manager.close({ threadId: "thread-1" });
+
+      const reopened = yield* manager.open(openInput());
+      expect(reopened.history).toBe("\nline3-continued\nline4");
+    }),
+  );
+
   it.effect("strips replay-unsafe terminal query and reply sequences from persisted history", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -238,14 +238,14 @@ export interface TerminalStartInput extends TerminalOpenInput {
   rows: number;
 }
 
-export interface TerminalSessionState {
+interface TerminalSessionState {
   threadId: string;
   terminalId: string;
   cwd: string;
   worktreePath: string | null;
   status: TerminalSessionStatus;
   pid: number | null;
-  history: string;
+  history: BoundedTerminalHistory;
   pendingHistoryControlSequence: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
@@ -266,7 +266,7 @@ export interface TerminalSessionState {
 }
 
 interface PersistHistoryRequest {
-  history: string;
+  history: BoundedTerminalHistory;
   immediate: boolean;
 }
 
@@ -281,7 +281,7 @@ type DrainProcessEventAction =
       threadId: string;
       terminalId: string;
       sequence: number;
-      history: string | null;
+      history: BoundedTerminalHistory | null;
       data: string;
     }
   | {
@@ -340,7 +340,7 @@ function snapshot(session: TerminalSessionState): TerminalSessionSnapshot {
     worktreePath: session.worktreePath,
     status: session.status,
     pid: session.pid,
-    history: session.history,
+    history: session.history.value(),
     exitCode: session.exitCode,
     exitSignal: session.exitSignal,
     label: terminalWireLabel(session),
@@ -794,6 +794,63 @@ function capHistory(history: string, maxLines: number): string {
   if (lines.length <= maxLines) return history;
   const capped = lines.slice(lines.length - maxLines).join("\n");
   return hasTrailingNewline ? `${capped}\n` : capped;
+}
+
+class BoundedTerminalHistory {
+  private readonly maxLines: number;
+  private lines: Array<string>;
+  private start = 0;
+  private trailingNewline: boolean;
+  private cachedValue: string | null = null;
+
+  constructor(maxLines: number, initial: string) {
+    this.maxLines = maxLines;
+    const capped = capHistory(initial, maxLines);
+    this.trailingNewline = capped.endsWith("\n");
+    this.lines = capped.length === 0 ? [] : capped.split("\n");
+    if (this.trailingNewline) this.lines.pop();
+  }
+
+  append(text: string): void {
+    if (text.length === 0) return;
+
+    const trailingNewline = text.endsWith("\n");
+    const appendedLines = text.split("\n");
+    if (trailingNewline) appendedLines.pop();
+
+    const activeLines = this.lines.length - this.start;
+    if (activeLines === 0 || this.trailingNewline) {
+      for (const line of appendedLines) this.lines.push(line);
+    } else {
+      this.lines[this.lines.length - 1] += appendedLines[0] ?? "";
+      for (let index = 1; index < appendedLines.length; index += 1) {
+        this.lines.push(appendedLines[index] ?? "");
+      }
+    }
+    this.trailingNewline = trailingNewline;
+
+    const overflow = this.lines.length - this.start - this.maxLines;
+    if (overflow > 0) this.start += overflow;
+    if (this.start > 2_048 && this.start * 2 >= this.lines.length) {
+      this.lines = this.lines.slice(this.start);
+      this.start = 0;
+    }
+    this.cachedValue = null;
+  }
+
+  clear(): void {
+    this.lines = [];
+    this.start = 0;
+    this.trailingNewline = false;
+    this.cachedValue = "";
+  }
+
+  value(): string {
+    if (this.cachedValue !== null) return this.cachedValue;
+    const joined = this.lines.slice(this.start).join("\n");
+    this.cachedValue = this.trailingNewline ? `${joined}\n` : joined;
+    return this.cachedValue;
+  }
 }
 
 function isCsiFinalByte(codePoint: number): boolean {
@@ -1372,22 +1429,24 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         return;
       }
 
-      yield* fileSystem.writeFileString(historyPath(threadId, terminalId), request.history).pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to persist terminal history", {
-            threadId,
-            terminalId,
-            error,
-          }),
-        ),
-      );
+      yield* fileSystem
+        .writeFileString(historyPath(threadId, terminalId), request.history.value())
+        .pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("failed to persist terminal history", {
+              threadId,
+              terminalId,
+              error,
+            }),
+          ),
+        );
     }),
   });
 
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
     threadId: string,
     terminalId: string,
-    history: string,
+    history: BoundedTerminalHistory,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       history,
@@ -1405,7 +1464,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const persistHistory = Effect.fn("terminal.persistHistory")(function* (
     threadId: string,
     terminalId: string,
-    history: string,
+    history: BoundedTerminalHistory,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       history,
@@ -1661,10 +1720,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           );
           session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
           if (sanitized.visibleText.length > 0) {
-            session.history = capHistory(
-              `${session.history}${sanitized.visibleText}`,
-              historyLineLimit,
-            );
+            session.history.append(sanitized.visibleText);
           }
           const eventStamp = advanceEventSequence(session);
 
@@ -2160,7 +2216,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         worktreePath: input.worktreePath ?? null,
         status: "starting",
         pid: null,
-        history,
+        history: new BoundedTerminalHistory(historyLineLimit, history),
         pendingHistoryControlSequence: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
@@ -2221,7 +2277,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.cwd = input.cwd;
       liveSession.worktreePath = nextWorktreePath;
       liveSession.runtimeEnv = nextRuntimeEnv;
-      liveSession.history = "";
+      liveSession.history.clear();
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2230,7 +2286,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     } else if (liveSession.status === "exited" || liveSession.status === "error") {
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.worktreePath = nextWorktreePath;
-      liveSession.history = "";
+      liveSession.history.clear();
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2535,7 +2591,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       Effect.gen(function* () {
         const terminalId = input.terminalId;
         const session = yield* requireSession(input.threadId, terminalId);
-        session.history = "";
+        session.history.clear();
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
@@ -2572,7 +2628,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             worktreePath: input.worktreePath ?? null,
             status: "starting",
             pid: null,
-            history: "",
+            history: new BoundedTerminalHistory(historyLineLimit, ""),
             pendingHistoryControlSequence: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
@@ -2608,7 +2664,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const cols = input.cols ?? session.cols;
         const rows = input.rows ?? session.rows;
 
-        session.history = "";
+        session.history.clear();
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;

--- a/docs/internals/terminal-runtime.md
+++ b/docs/internals/terminal-runtime.md
@@ -1,0 +1,46 @@
+# Terminal runtime
+
+The environment server owns terminal processes, retained output history, and
+session lifecycle. Web and desktop clients attach to the same server-owned
+session over the environment RPC connection. Desktop must not replace this
+with a renderer-owned PTY: reconnect, remote access, and multi-client attach
+all depend on the environment remaining authoritative.
+
+## Output path
+
+PTY output follows this path:
+
+```text
+PTY callback
+  -> ordered process-event drain
+  -> bounded retained-history append
+  -> live terminal output event
+  -> coalesced history persistence
+```
+
+Live output events contain only the new PTY data. A full retained-history
+snapshot is materialized only when a client attaches or when the coalescing
+persistence worker writes the latest state.
+
+Retained history uses an incremental bounded line buffer. Appending one PTY
+chunk may scan and allocate for that new chunk, but it must not split, join, or
+copy the entire retained history for every callback. Empty lines, incomplete
+final lines, trailing newlines, and the configured line limit are preserved
+exactly when history is materialized.
+
+This is a performance invariant, not an implementation detail to discard
+during refactors. Measure sustained-output changes against a full retained
+history so terminal throughput does not regress unnoticed.
+
+## Persistence and transport changes
+
+History persistence is keyed by terminal session and coalesces pending writes.
+The worker reads the newest bounded-history state after its debounce instead
+of receiving a newly materialized full string for every PTY callback. Clear,
+restart, close, and final flush operations still force the latest state to
+disk before their lifecycle boundary completes.
+
+If measurements later justify a binary terminal data channel, keep snapshots,
+lifecycle commands, and PTY ownership on the environment server. Do not share
+the terminal data channel with port-forward payloads: a bulk TCP transfer must
+not head-of-line block interactive terminal input or output.


### PR DESCRIPTION
## What Changed

- Replace repeated full-string terminal history rebuilding with an incremental bounded line buffer.
- Materialize retained history only for snapshots and coalesced persistence writes.
- Preserve partial lines, empty lines, trailing newlines, clearing, and the configured line cap.
- Document the server-owned terminal output and persistence path.

## Why

Every PTY output chunk currently concatenates, splits, caps, and rejoins the entire retained history. Once the default 5,000-line buffer is full, sustained output repeatedly copies the whole buffer and makes callback cost proportional to retained history size.

The bounded buffer processes only newly received text during the hot path while keeping the existing wire format, persistence format, and terminal behavior unchanged.

A local Node 26.2 benchmark appended 50,000 representative one-line chunks while retaining 5,000 lines. The existing implementation took 7,342.5 ms; the incremental buffer took 5.5 ms (approximately 1,325x faster). Both produced byte-for-byte identical 230,000-byte output. These are machine-specific measurements rather than a product budget.

## Verification

- `vp test run apps/server/src/terminal/Manager.test.ts` — 55 tests passed
- `vp run --filter t3 typecheck` — passed (pre-existing Effect suggestions only)
- `vp fmt --check apps/server/src/terminal/Manager.ts apps/server/src/terminal/Manager.test.ts docs/internals/terminal-runtime.md` — passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] Interaction video is not applicable

Created with GPT-5.6 in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core terminal output and persistence on every PTY chunk; behavior is heavily tested but regressions in line boundaries or capping would affect all integrated terminals.
> 
> **Overview**
> Replaces per-chunk **full-string history rebuild** (concatenate, split, cap, rejoin) with an incremental **`BoundedTerminalHistory`** line buffer on the PTY output hot path. Sessions now **`append`** sanitized chunks and only **`value()`** materialize the full transcript for client snapshots and debounced disk writes.
> 
> **Clear**, **restart**, and cwd/context resets use **`history.clear()`** instead of assigning an empty string; the coalescing persist worker still receives the live buffer object and writes **`history.value()`** after debounce. Wire format and line-cap semantics stay the same, with a new test covering chunked partial lines, empty lines, and trailing newlines.
> 
> Adds **`docs/internals/terminal-runtime.md`** documenting the output path and the performance invariant that retained history must not be copied on every PTY callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed17b7de7f95e532693be8b18fa3e2bb2e3dfc64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make terminal history updates incremental in `TerminalManager`
> - Replaces full-string concatenation on every PTY output event with an incremental line buffer (`BoundedTerminalHistory`) that caps retained lines and materializes the full string only on demand
> - Persistence worker now holds the bounded buffer reference and calls `value()` at write time, so debounced writes reflect the latest state instead of a snapshot string enqueued earlier
> - Session open, reset, clear, and restart paths all operate on the bounded buffer API; initial history is capped during construction and existing buffers are cleared before re-persistence on context change or error
> - Adds a regression test for empty lines, partial-line continuation, and line-limit preservation, plus internal runtime documentation
> - Risk: `BoundedTerminalHistory` handles trailing-newline and partial-line state internally; any out-of-tree code reading the `history` field via snapshot will still get a string, but the value is now materialized through `BoundedTerminalHistory.value()` rather than maintained eagerly
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ed17b7d. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/terminal/Manager.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 823](https://github.com/pingdotgg/t3code/blob/ed17b7de7f95e532693be8b18fa3e2bb2e3dfc64/apps/server/src/terminal/Manager.ts#L823): `append` drops a newline-only chunk when the existing history already ends in a newline. For example, appending `"\n"` to retained `"a\n"` takes the `this.trailingNewline` branch with an empty `appendedLines` array, leaving the value `"a\n"` rather than `"a\n\n"`. PTY chunk boundaries can split consecutive blank lines this way, so terminal history and persisted/snapshotted output silently lose empty lines. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->