### PR TITLE
fix(web): stop usage summary requests reporting slow RPCs

### DIFF
--- a/apps/web/src/rpc/requestLatencyState.test.ts
+++ b/apps/web/src/rpc/requestLatencyState.test.ts
@@ -59,6 +59,13 @@ describe("requestLatencyState", () => {
     expect(getSlowRpcAckRequests()).toEqual([]);
   });
 
+  it("ignores usage summary requests", () => {
+    trackRpcRequestSent("1", WS_METHODS.serverGetUsageSummary);
+    vi.advanceTimersByTime(SLOW_RPC_ACK_THRESHOLD_MS * 2);
+
+    expect(getSlowRpcAckRequests()).toEqual([]);
+  });
+
   it.each(Object.values(WS_METHODS).filter((method) => method.startsWith("pullRequests.")))(
     "ignores pull request workspace request %s",
     (method) => {

--- a/apps/web/src/rpc/requestLatencyState.ts
+++ b/apps/web/src/rpc/requestLatencyState.ts
@@ -28,7 +28,10 @@ interface PendingRpcAckRequest {
 }
 
 const pendingRpcAckRequests = new Map<string, PendingRpcAckRequest>();
-const untrackedRpcAckMethods = new Set<string>([WS_METHODS.previewAutomationConnect]);
+const untrackedRpcAckMethods = new Set<string>([
+  WS_METHODS.previewAutomationConnect,
+  WS_METHODS.serverGetUsageSummary,
+]);
 const longRunningRpcAckMethods = new Set<string>([
   WS_METHODS.serverUpdateProvider,
   WS_METHODS.serverRefreshProviders,


### PR DESCRIPTION
## What Changed

Usage summary RPC requests are now excluded from slow RPC acknowledgment tracking, matching the existing behavior for other intentionally untracked request types.

Added a focused test covering `serverGetUsageSummary` so it does not appear in `getSlowRpcAckRequests()` after the slow acknowledgment threshold passes.

## Why

Usage summary requests can run in the background and should not surface as slow RPC warnings in the web client. Treating them as latency-tracked requests creates noisy slow request state without giving users or maintainers useful signal.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows slow-RPC tracking for one WS method only; behavior matches other intentionally untracked RPCs with no auth or data-path changes.
> 
> **Overview**
> **Usage summary RPCs are no longer tracked for slow acknowledgment warnings**, alongside existing exclusions like preview automation connect.
> 
> `serverGetUsageSummary` is added to `untrackedRpcAckMethods` in `requestLatencyState.ts`, so background usage fetches that exceed the 15s threshold will not populate slow RPC UI state. A unit test asserts `getSlowRpcAckRequests()` stays empty after the threshold when that method is tracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b78066cac966150e2e3a54e992517321675614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `usage-summary` RPC from slow request ack tracking
> Adds the server `usage-summary` RPC method to the set of methods whose acknowledgements are not tracked for slow-request reporting, so `getSlowRpcAckRequests` no longer returns them. Adds a test in [requestLatencyState.test.ts](https://github.com/pingdotgg/t3code/pull/9358/files#diff-94a0d6329bb65d12161e10109ce80438ba415d5245f933a168210c33b6f75f40) confirming usage-summary requests stay excluded even after twice the slow-ack threshold elapses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08b7806.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->