### PR TITLE
fix(mobile): size expanded tool groups correctly

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -638,7 +638,10 @@ function ThreadWorkGroupList(props: {
         scrollsToTop={false}
         bounces={false}
         keyboardShouldPersistTaps="handled"
-        style={StyleSheet.absoluteFill}
+        // MaskedView bridges through a native host whose absolute-fill bounds
+        // can lag behind a resize. Keep the list's viewport at the group's
+        // current height when expanding details or appending calls.
+        style={[StyleSheet.absoluteFill, { height }]}
       />
     </MaskedView>
   );


### PR DESCRIPTION
Expanding a tool call could leave a blank band at the bottom of its group once the group became scrollable. The outer container grew, but the inner list retained its previous height through the native mask wrapper.

Give the inner list the group's current height explicitly. This is a mobile-only layout fix; web, desktop, providers, and wire contracts are unchanged.

## Verification

- Reproduced with a six-call group on iPhone 17 Pro, iOS 26.5 Simulator. Verified expansion past the scroll threshold, scrolling details, and collapse after the fix.
- 69 focused layout and scroll-follow tests passed.
- Mobile typecheck, formatting, and diff checks passed. Targeted lint has only existing warnings.

## Before and after

| Before | After |
| --- | --- |
| <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4b51611125e9e973/before.png" width="320" /> | <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/946042220b4b6e71/after.png" width="320" /> |

## Simulator recording

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/59999bd4c10e0085/verification.mp4

Prepared with the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow mobile UI layout fix for list viewport sizing inside MaskedView; no auth, data, or backend impact.
> 
> **Overview**
> Fixes a **blank band at the bottom** of scrollable tool-call groups on mobile when expanding a row or when new calls grow the group.
> 
> The grouped work log list inside `MaskedView` no longer relies on `StyleSheet.absoluteFill` alone. It now also sets **`height` to the group's computed viewport height** (`Math.min(contentHeight, WORK_GROUP_MAX_HEIGHT)`), because the mask's native wrapper can keep stale absolute-fill bounds after the outer container resizes.
> 
> Mobile-only layout change in `thread-work-log.tsx`; no API or shared contract changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e8e490bfbb5421e0556ef440efb4daa2270f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix expanded tool group sizing in `ThreadWorkGroupList`
> The masked list in [thread-work-log.tsx](https://github.com/pingdotgg/t3code/pull/9359/files#diff-06f278f3ca8d6524ea378cdd0d5fea4e0a691986d150c0b93b43724ed8d40909) now uses an explicit height matching the current group height instead of relying solely on absolute-fill bounds. This compensates for a lag in the MaskedView native host during resizing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8e8e49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->