### PR TITLE
fix(server): resume active turns when T3 Code reopens

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -4247,6 +4247,52 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("rejects an echoed Claude resume cursor when the SDK starts a fresh session", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const persistedResumeCursor = {
+        threadId: RESUME_THREAD_ID,
+        resume: "550e8400-e29b-41d4-a716-446655440000",
+        turnCount: 3,
+      };
+      const session = yield* adapter.startSession({
+        threadId: RESUME_THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        resumeCursor: persistedResumeCursor,
+        runtimeMode: "full-access",
+      });
+      assert.notEqual(adapter.isSameResumeCursor, undefined);
+      if (adapter.isSameResumeCursor === undefined) return;
+
+      const verification = yield* adapter
+        .isSameResumeCursor(RESUME_THREAD_ID, persistedResumeCursor, session.resumeCursor)
+        .pipe(Effect.forkChild);
+      harness.query.emit({
+        type: "system",
+        subtype: "init",
+        apiKeySource: "none",
+        claude_code_version: "test",
+        cwd: "/tmp/claude-adapter-test",
+        tools: [],
+        mcp_servers: [],
+        model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
+        permissionMode: "bypassPermissions",
+        slash_commands: [],
+        output_style: "default",
+        skills: [],
+        plugins: [],
+        session_id: "7368d0c7-40a3-4d8a-bcc1-ac80c49f2719",
+        uuid: "fresh-init",
+      } as unknown as SDKMessage);
+
+      assert.equal(yield* Fiber.join(verification), false);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("preserves durable resume ids across Claude resume hooks", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -4259,7 +4305,7 @@ describe("ClaudeAdapterLive", () => {
         Effect.forkChild,
       );
 
-      yield* adapter.startSession({
+      const session = yield* adapter.startSession({
         threadId: RESUME_THREAD_ID,
         provider: ProviderDriverKind.make("claudeAgent"),
         resumeCursor: {
@@ -4331,6 +4377,17 @@ describe("ClaudeAdapterLive", () => {
           }
         | undefined;
       assert.equal(resumeCursor?.resume, durableSessionId);
+      assert.notEqual(adapter.isSameResumeCursor, undefined);
+      if (adapter.isSameResumeCursor !== undefined) {
+        assert.equal(
+          yield* adapter.isSameResumeCursor(
+            RESUME_THREAD_ID,
+            session.resumeCursor,
+            activeSessions[0]?.resumeCursor,
+          ),
+          true,
+        );
+      }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -69,6 +69,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
@@ -291,6 +292,7 @@ interface ClaudeSessionContext {
    * effort override inherit this. */
   currentEffort: string | undefined;
   resumeSessionId: string | undefined;
+  readonly confirmedResumeSessionId: Deferred.Deferred<string>;
   readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
   readonly turns: Array<{
@@ -2047,6 +2049,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const nextThreadId = message.session_id;
     context.resumeSessionId = message.session_id;
     yield* updateResumeCursor(context);
+    yield* Deferred.succeed(context.confirmedResumeSessionId, message.session_id);
 
     if (context.lastThreadStartedId !== nextThreadId) {
       context.lastThreadStartedId = nextThreadId;
@@ -3886,6 +3889,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const runPromise = Effect.runPromiseWith(runtimeContext);
 
       const promptQueue = yield* Queue.unbounded<PromptQueueItem>();
+      const confirmedResumeSessionId = yield* Deferred.make<string>();
       const prompt = Stream.fromQueue(promptQueue).pipe(
         Stream.filter((item) => item.type === "message"),
         Stream.map((item) => item.message),
@@ -4461,6 +4465,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         currentApiModelId: apiModelId,
         currentEffort: effectiveEffort ?? undefined,
         resumeSessionId: sessionId,
+        confirmedResumeSessionId,
         pendingApprovals,
         pendingUserInputs,
         turns: [],
@@ -4804,15 +4809,24 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       sessionModelSwitch: "in-session",
     },
     startSession,
-    isSameResumeCursor: (persisted, recovered) => {
-      const persistedResume = readClaudeResumeState(persisted)?.resume;
-      const recoveredResume = readClaudeResumeState(recovered)?.resume;
-      return (
-        persistedResume !== undefined &&
-        recoveredResume !== undefined &&
-        persistedResume === recoveredResume
-      );
-    },
+    isSameResumeCursor: (threadId, persisted, recovered) =>
+      Effect.gen(function* () {
+        const persistedResume = readClaudeResumeState(persisted)?.resume;
+        const recoveredResume = readClaudeResumeState(recovered)?.resume;
+        const context = sessions.get(threadId);
+        if (
+          persistedResume === undefined ||
+          recoveredResume === undefined ||
+          persistedResume !== recoveredResume ||
+          context === undefined
+        ) {
+          return false;
+        }
+        const confirmed = yield* Deferred.await(context.confirmedResumeSessionId).pipe(
+          Effect.timeoutOption("10 seconds"),
+        );
+        return Option.isSome(confirmed) && confirmed.value === persistedResume;
+      }),
     sendTurn,
     interruptTurn,
     readThread,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4804,6 +4804,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       sessionModelSwitch: "in-session",
     },
     startSession,
+    isSameResumeCursor: (persisted, recovered) => {
+      const persistedResume = readClaudeResumeState(persisted)?.resume;
+      const recoveredResume = readClaudeResumeState(recovered)?.resume;
+      return (
+        persistedResume !== undefined &&
+        recoveredResume !== undefined &&
+        persistedResume === recoveredResume
+      );
+    },
     sendTurn,
     interruptTurn,
     readThread,

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2324,10 +2324,12 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       promptlessTurnContinuation: true,
     },
     startSession,
-    isSameResumeCursor: (persisted, recovered) =>
-      isCodexResumeCursorSchema(persisted) &&
-      isCodexResumeCursorSchema(recovered) &&
-      persisted.threadId === recovered.threadId,
+    isSameResumeCursor: (_threadId, persisted, recovered) =>
+      Effect.succeed(
+        isCodexResumeCursorSchema(persisted) &&
+          isCodexResumeCursorSchema(recovered) &&
+          persisted.threadId === recovered.threadId,
+      ),
     sendTurn,
     interruptTurn,
     readThread,

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2324,6 +2324,10 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       promptlessTurnContinuation: true,
     },
     startSession,
+    isSameResumeCursor: (persisted, recovered) =>
+      isCodexResumeCursorSchema(persisted) &&
+      isCodexResumeCursorSchema(recovered) &&
+      persisted.threadId === recovered.threadId,
     sendTurn,
     interruptTurn,
     readThread,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -1205,6 +1205,15 @@ export function makeCursorAdapter(
       provider: PROVIDER,
       capabilities: { sessionModelSwitch: "in-session" },
       startSession,
+      isSameResumeCursor: (persisted, recovered) => {
+        const persistedSession = parseCursorResume(persisted);
+        const recoveredSession = parseCursorResume(recovered);
+        return (
+          persistedSession !== undefined &&
+          recoveredSession !== undefined &&
+          persistedSession.sessionId === recoveredSession.sessionId
+        );
+      },
       sendTurn,
       interruptTurn,
       readThread,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -1205,13 +1205,13 @@ export function makeCursorAdapter(
       provider: PROVIDER,
       capabilities: { sessionModelSwitch: "in-session" },
       startSession,
-      isSameResumeCursor: (persisted, recovered) => {
+      isSameResumeCursor: (_threadId, persisted, recovered) => {
         const persistedSession = parseCursorResume(persisted);
         const recoveredSession = parseCursorResume(recovered);
-        return (
+        return Effect.succeed(
           persistedSession !== undefined &&
-          recoveredSession !== undefined &&
-          persistedSession.sessionId === recoveredSession.sessionId
+            recoveredSession !== undefined &&
+            persistedSession.sessionId === recoveredSession.sessionId,
         );
       },
       sendTurn,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -2114,6 +2114,15 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
       provider: PROVIDER,
       capabilities: { sessionModelSwitch: "in-session" },
       startSession,
+      isSameResumeCursor: (persisted, recovered) => {
+        const persistedSession = parseGrokResume(persisted);
+        const recoveredSession = parseGrokResume(recovered);
+        return (
+          persistedSession !== undefined &&
+          recoveredSession !== undefined &&
+          persistedSession.sessionId === recoveredSession.sessionId
+        );
+      },
       sendTurn,
       interruptTurn,
       readThread,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -2114,13 +2114,13 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
       provider: PROVIDER,
       capabilities: { sessionModelSwitch: "in-session" },
       startSession,
-      isSameResumeCursor: (persisted, recovered) => {
+      isSameResumeCursor: (_threadId, persisted, recovered) => {
         const persistedSession = parseGrokResume(persisted);
         const recoveredSession = parseGrokResume(recovered);
-        return (
+        return Effect.succeed(
           persistedSession !== undefined &&
-          recoveredSession !== undefined &&
-          persistedSession.sessionId === recoveredSession.sessionId
+            recoveredSession !== undefined &&
+            persistedSession.sessionId === recoveredSession.sessionId,
         );
       },
       sendTurn,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3267,13 +3267,13 @@ export function makeOpenCodeAdapter(
         sessionModelSwitch: "in-session",
       },
       startSession,
-      isSameResumeCursor: (persisted, recovered) => {
+      isSameResumeCursor: (_threadId, persisted, recovered) => {
         const persistedSession = parseOpenCodeResume(persisted);
         const recoveredSession = parseOpenCodeResume(recovered);
-        return (
+        return Effect.succeed(
           persistedSession !== undefined &&
-          recoveredSession !== undefined &&
-          persistedSession.sessionId === recoveredSession.sessionId
+            recoveredSession !== undefined &&
+            persistedSession.sessionId === recoveredSession.sessionId,
         );
       },
       sendTurn,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3267,6 +3267,15 @@ export function makeOpenCodeAdapter(
         sessionModelSwitch: "in-session",
       },
       startSession,
+      isSameResumeCursor: (persisted, recovered) => {
+        const persistedSession = parseOpenCodeResume(persisted);
+        const recoveredSession = parseOpenCodeResume(recovered);
+        return (
+          persistedSession !== undefined &&
+          recoveredSession !== undefined &&
+          persistedSession.sessionId === recoveredSession.sessionId
+        );
+      },
       sendTurn,
       interruptTurn,
       respondToRequest,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -246,7 +246,7 @@ function makeFakeCodexAdapter(provider: ProviderDriverKind = CODEX_DRIVER) {
       ...(provider === CODEX_DRIVER ? { promptlessTurnContinuation: true } : {}),
     },
     startSession,
-    isSameResumeCursor: (persisted, recovered) => {
+    isSameResumeCursor: (_threadId, persisted, recovered) => {
       const readOpaque = (value: unknown) =>
         typeof value === "object" &&
         value !== null &&
@@ -255,7 +255,9 @@ function makeFakeCodexAdapter(provider: ProviderDriverKind = CODEX_DRIVER) {
           ? (value as { opaque: string }).opaque
           : undefined;
       const persistedOpaque = readOpaque(persisted);
-      return persistedOpaque !== undefined && persistedOpaque === readOpaque(recovered);
+      return Effect.succeed(
+        persistedOpaque !== undefined && persistedOpaque === readOpaque(recovered),
+      );
     },
     sendTurn,
     interruptTurn,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -246,6 +246,17 @@ function makeFakeCodexAdapter(provider: ProviderDriverKind = CODEX_DRIVER) {
       ...(provider === CODEX_DRIVER ? { promptlessTurnContinuation: true } : {}),
     },
     startSession,
+    isSameResumeCursor: (persisted, recovered) => {
+      const readOpaque = (value: unknown) =>
+        typeof value === "object" &&
+        value !== null &&
+        !Array.isArray(value) &&
+        typeof (value as { opaque?: unknown }).opaque === "string"
+          ? (value as { opaque: string }).opaque
+          : undefined;
+      const persistedOpaque = readOpaque(persisted);
+      return persistedOpaque !== undefined && persistedOpaque === readOpaque(recovered);
+    },
     sendTurn,
     interruptTurn,
     respondToRequest,
@@ -1464,11 +1475,14 @@ routing.layer("ProviderServiceLive routing", (it) => {
       routing.codex.startSession.mockClear();
       routing.codex.sendTurn.mockClear();
 
-      yield* provider.sendTurn({
-        threadId: initial.threadId,
-        input: "resume",
-        attachments: [],
-      });
+      yield* provider.sendTurn(
+        {
+          threadId: initial.threadId,
+          input: "resume",
+          attachments: [],
+        },
+        { requireResumeCursor: initial.resumeCursor },
+      );
 
       assert.equal(routing.codex.startSession.mock.calls.length, 1);
       const resumedStartInput = routing.codex.startSession.mock.calls[0]?.[0];
@@ -1486,6 +1500,47 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(startPayload.threadId, initial.threadId);
       }
       assert.equal(routing.codex.sendTurn.mock.calls.length, 1);
+    }),
+  );
+
+  it.effect("rejects automatic continuation when recovery starts a fresh conversation", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-strict-resume-mismatch");
+      const initial = yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId,
+        cwd: "/tmp/project-strict-resume",
+        runtimeMode: "full-access",
+      });
+
+      yield* routing.codex.stopAll();
+      routing.codex.startSession.mockClear();
+      routing.codex.sendTurn.mockClear();
+      routing.codex.stopSession.mockClear();
+      routing.codex.startSession.mockImplementationOnce(() =>
+        Effect.succeed({
+          ...initial,
+          resumeCursor: { opaque: "fresh-provider-conversation" },
+        }),
+      );
+
+      const failure = yield* provider
+        .sendTurn(
+          {
+            threadId,
+            input: "Continue where you left off.",
+            attachments: [],
+          },
+          { requireResumeCursor: initial.resumeCursor },
+        )
+        .pipe(Effect.flip);
+
+      assert.instanceOf(failure, ProviderValidationError);
+      assert.match(failure.message, /did not resume the persisted conversation/u);
+      assert.equal(routing.codex.sendTurn.mock.calls.length, 0);
+      assert.deepStrictEqual(routing.codex.stopSession.mock.calls, [[threadId]]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -412,6 +412,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const recoverSessionForThread = Effect.fn("recoverSessionForThread")(function* (input: {
     readonly binding: ProviderSessionDirectory.ProviderRuntimeBinding;
     readonly operation: string;
+    readonly requireResumeCursor?: unknown;
   }) {
     const bindingInstanceId = yield* requireBindingInstanceId(input.operation, input.binding);
     yield* Effect.annotateCurrentSpan({
@@ -431,6 +432,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           (session) => session.threadId === input.binding.threadId,
         );
         if (existing) {
+          if (
+            input.requireResumeCursor !== undefined &&
+            adapter.isSameResumeCursor?.(input.requireResumeCursor, existing.resumeCursor) !== true
+          ) {
+            return yield* toValidationError(
+              input.operation,
+              `Cannot automatically continue thread '${input.binding.threadId}' because its active provider session does not match the persisted conversation.`,
+            );
+          }
           yield* upsertSessionBinding(
             { ...existing, providerInstanceId: bindingInstanceId },
             input.binding.threadId,
@@ -474,6 +484,18 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         );
       }
 
+      if (
+        input.requireResumeCursor !== undefined &&
+        adapter.isSameResumeCursor?.(input.requireResumeCursor, resumed.resumeCursor) !== true
+      ) {
+        yield* adapter.stopSession(input.binding.threadId).pipe(Effect.ignore);
+        yield* clearMcpSession(input.binding.threadId);
+        return yield* toValidationError(
+          input.operation,
+          `Cannot automatically continue thread '${input.binding.threadId}' because the provider did not resume the persisted conversation.`,
+        );
+      }
+
       yield* upsertSessionBinding(
         { ...resumed, providerInstanceId: bindingInstanceId },
         input.binding.threadId,
@@ -498,6 +520,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     readonly threadId: ThreadId;
     readonly operation: string;
     readonly allowRecovery: boolean;
+    readonly requireResumeCursor?: unknown;
   }) {
     const bindingOption = yield* directory.getBinding(input.threadId);
     const binding = Option.getOrUndefined(bindingOption);
@@ -512,6 +535,20 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
 
     const hasRequestedSession = yield* adapter.hasSession(input.threadId);
     if (hasRequestedSession) {
+      if (input.requireResumeCursor !== undefined) {
+        const activeSessions = yield* adapter.listSessions();
+        const activeSession = activeSessions.find((session) => session.threadId === input.threadId);
+        if (
+          activeSession === undefined ||
+          adapter.isSameResumeCursor?.(input.requireResumeCursor, activeSession.resumeCursor) !==
+            true
+        ) {
+          return yield* toValidationError(
+            input.operation,
+            `Cannot automatically continue thread '${input.threadId}' because its active provider session does not match the persisted conversation.`,
+          );
+        }
+      }
       return {
         adapter,
         instanceId,
@@ -534,6 +571,9 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     const recovered = yield* recoverSessionForThread({
       binding,
       operation: input.operation,
+      ...(input.requireResumeCursor !== undefined
+        ? { requireResumeCursor: input.requireResumeCursor }
+        : {}),
     });
     return {
       adapter: recovered.adapter,
@@ -715,7 +755,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     },
   );
 
-  const sendTurn: ProviderServiceMethod<"sendTurn"> = Effect.fn("sendTurn")(function* (rawInput) {
+  const sendTurnImpl = function* (
+    rawInput: Parameters<ProviderServiceMethod<"sendTurn">>[0],
+    options: Parameters<ProviderServiceMethod<"sendTurn">>[1],
+  ) {
     const parsed = yield* decodeInputOrValidationError({
       operation: "ProviderService.sendTurn",
       schema: ProviderSendTurnInput,
@@ -781,6 +824,9 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         threadId: input.threadId,
         operation: "ProviderService.sendTurn",
         allowRecovery: false,
+        ...(options?.requireResumeCursor !== undefined
+          ? { requireResumeCursor: options.requireResumeCursor }
+          : {}),
       });
       if (
         input.continuation === true &&
@@ -798,6 +844,9 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           threadId: input.threadId,
           operation: "ProviderService.sendTurn",
           allowRecovery: true,
+          ...(options?.requireResumeCursor !== undefined
+            ? { requireResumeCursor: options.requireResumeCursor }
+            : {}),
         });
       }
       metricProvider = routed.adapter.provider;
@@ -852,7 +901,8 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           }),
       }),
     );
-  });
+  };
+  const sendTurn: ProviderServiceMethod<"sendTurn"> = Effect.fn("sendTurn")(sendTurnImpl);
 
   const interruptTurn: ProviderServiceMethod<"interruptTurn"> = Effect.fn("interruptTurn")(
     function* (rawInput) {

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -409,6 +409,13 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     () => reconcileInstanceSubscriptions,
   ).pipe(Effect.forkScoped);
 
+  const isSameResumeCursor = (
+    adapter: ProviderAdapterShape<ProviderAdapterError>,
+    threadId: ThreadId,
+    persisted: unknown,
+    recovered: unknown,
+  ) => adapter.isSameResumeCursor?.(threadId, persisted, recovered) ?? Effect.succeed(false);
+
   const recoverSessionForThread = Effect.fn("recoverSessionForThread")(function* (input: {
     readonly binding: ProviderSessionDirectory.ProviderRuntimeBinding;
     readonly operation: string;
@@ -432,10 +439,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           (session) => session.threadId === input.binding.threadId,
         );
         if (existing) {
-          if (
-            input.requireResumeCursor !== undefined &&
-            adapter.isSameResumeCursor?.(input.requireResumeCursor, existing.resumeCursor) !== true
-          ) {
+          const resumeCursorMatches =
+            input.requireResumeCursor === undefined ||
+            (yield* isSameResumeCursor(
+              adapter,
+              input.binding.threadId,
+              input.requireResumeCursor,
+              existing.resumeCursor,
+            ));
+          if (input.requireResumeCursor !== undefined && !resumeCursorMatches) {
             return yield* toValidationError(
               input.operation,
               `Cannot automatically continue thread '${input.binding.threadId}' because its active provider session does not match the persisted conversation.`,
@@ -484,10 +496,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         );
       }
 
-      if (
-        input.requireResumeCursor !== undefined &&
-        adapter.isSameResumeCursor?.(input.requireResumeCursor, resumed.resumeCursor) !== true
-      ) {
+      const resumeCursorMatches =
+        input.requireResumeCursor === undefined ||
+        (yield* isSameResumeCursor(
+          adapter,
+          input.binding.threadId,
+          input.requireResumeCursor,
+          resumed.resumeCursor,
+        ));
+      if (input.requireResumeCursor !== undefined && !resumeCursorMatches) {
         yield* adapter.stopSession(input.binding.threadId).pipe(Effect.ignore);
         yield* clearMcpSession(input.binding.threadId);
         return yield* toValidationError(
@@ -538,11 +555,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       if (input.requireResumeCursor !== undefined) {
         const activeSessions = yield* adapter.listSessions();
         const activeSession = activeSessions.find((session) => session.threadId === input.threadId);
-        if (
-          activeSession === undefined ||
-          adapter.isSameResumeCursor?.(input.requireResumeCursor, activeSession.resumeCursor) !==
-            true
-        ) {
+        const resumeCursorMatches =
+          activeSession !== undefined &&
+          (yield* isSameResumeCursor(
+            adapter,
+            input.threadId,
+            input.requireResumeCursor,
+            activeSession.resumeCursor,
+          ));
+        if (activeSession === undefined || !resumeCursorMatches) {
           return yield* toValidationError(
             input.operation,
             `Cannot automatically continue thread '${input.threadId}' because its active provider session does not match the persisted conversation.`,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -66,7 +66,11 @@ export interface ProviderAdapterShape<TError> {
    * conversation. Used by automatic restart recovery to avoid sending a
    * continuation turn into a newly-created empty session.
    */
-  readonly isSameResumeCursor?: (persisted: unknown, recovered: unknown) => boolean;
+  readonly isSameResumeCursor?: (
+    threadId: ThreadId,
+    persisted: unknown,
+    recovered: unknown,
+  ) => Effect.Effect<boolean, TError>;
 
   /**
    * Send a turn to an active provider session.

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -62,6 +62,13 @@ export interface ProviderAdapterShape<TError> {
   ) => Effect.Effect<ProviderSession, TError>;
 
   /**
+   * Confirms that a recovered session still represents the persisted provider
+   * conversation. Used by automatic restart recovery to avoid sending a
+   * continuation turn into a newly-created empty session.
+   */
+  readonly isSameResumeCursor?: (persisted: unknown, recovered: unknown) => boolean;
+
+  /**
    * Send a turn to an active provider session.
    */
   readonly sendTurn: (

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -51,6 +51,10 @@ export interface ProviderServiceShape {
    */
   readonly sendTurn: (
     input: ProviderSendTurnInput,
+    options?: {
+      /** Fail recovery unless the adapter resumed this exact provider conversation. */
+      readonly requireResumeCursor?: unknown;
+    },
   ) => Effect.Effect<ProviderTurnStartResult, ProviderServiceError>;
 
   /**

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -397,7 +397,7 @@ it.effect.each([
   { markerState: "absent", markerCleared: false },
   { markerState: "cleared", markerCleared: true },
 ] as const)(
-  "continues an active session after an ordinary server restart when the update marker is $markerState",
+  "continues an active session after reopening T3 Code when the update marker is $markerState",
   ({ markerCleared }) => verifyOrdinaryRestartContinuation(markerCleared),
 );
 

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -307,7 +307,7 @@ it.effect("continues marked sessions after activation with provider-specific inp
   }),
 );
 
-it.effect("continues an unmarked active session after an ordinary server restart", () =>
+const verifyOrdinaryRestartContinuation = (markerCleared: boolean) =>
   Effect.gen(function* () {
     const thread = makeThread(
       "thread-continue-after-restart",
@@ -350,6 +350,7 @@ it.effect("continues an unmarked active session after an ordinary server restart
               runtimePayload: {
                 activeTurnId: thread.session.activeTurnId,
                 lastRuntimeEvent: "provider.sendTurn",
+                ...(markerCleared ? { continueAfterServerUpdate: null } : {}),
               },
             }),
           ),
@@ -386,10 +387,18 @@ it.effect("continues an unmarked active session after an ordinary server restart
         {
           activeTurnId: null,
           lastRuntimeEvent: "provider.sendTurn",
+          ...(markerCleared ? { continueAfterServerUpdate: null } : {}),
         },
       ],
     );
-  }),
+  });
+
+it.effect.each([
+  { markerState: "absent", markerCleared: false },
+  { markerState: "cleared", markerCleared: true },
+] as const)(
+  "continues an active session after an ordinary server restart when the update marker is $markerState",
+  ({ markerCleared }) => verifyOrdinaryRestartContinuation(markerCleared),
 );
 
 it.effect("does not continue archived or deleted marked sessions", () => {

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -315,7 +315,11 @@ const verifyOrdinaryRestartContinuation = (markerCleared: boolean) =>
       TurnId.make("turn-continue-after-restart"),
     );
     const continuationSent = yield* Deferred.make<void>();
+    const continuationCleared = yield* Deferred.make<void>();
     const sends: ProviderSendTurnInput[] = [];
+    const sendOptions: Array<
+      Parameters<ProviderService.ProviderService["Service"]["sendTurn"]>[1]
+    > = [];
     const dispatched: OrchestrationCommand[] = [];
     const upserts: ProviderSessionDirectory.ProviderRuntimeBinding[] = [];
     const providerService: ProviderService.ProviderService["Service"] = {
@@ -325,9 +329,10 @@ const verifyOrdinaryRestartContinuation = (markerCleared: boolean) =>
           sessionModelSwitch: "in-session",
           promptlessTurnContinuation: true,
         }),
-      sendTurn: (input) =>
+      sendTurn: (input, options) =>
         Effect.sync(() => {
           sends.push(input);
+          sendOptions.push(options);
           return {
             threadId: input.threadId,
             turnId: TurnId.make("continued-after-restart"),
@@ -354,7 +359,22 @@ const verifyOrdinaryRestartContinuation = (markerCleared: boolean) =>
               },
             }),
           ),
-        upsert: (binding) => Effect.sync(() => upserts.push(binding)),
+        upsert: (binding) =>
+          Effect.sync(() => {
+            upserts.push(binding);
+            const payload = binding.runtimePayload;
+            return (
+              payload !== null &&
+              typeof payload === "object" &&
+              !Array.isArray(payload) &&
+              "continueAfterServerUpdate" in payload &&
+              payload.continueAfterServerUpdate === null
+            );
+          }).pipe(
+            Effect.flatMap((cleared) =>
+              cleared ? Deferred.succeed(continuationCleared, undefined) : Effect.void,
+            ),
+          ),
         getProvider: () => Effect.die("unused"),
         listThreadIds: () => Effect.die("unused"),
         listBindings: () => Effect.die("unused"),
@@ -365,9 +385,13 @@ const verifyOrdinaryRestartContinuation = (markerCleared: boolean) =>
         ),
     });
     yield* Deferred.await(continuationSent);
+    yield* Deferred.await(continuationCleared);
 
     assert.deepStrictEqual(sends, [
       { threadId: thread.id, continuation: true, interactionMode: "default" },
+    ]);
+    assert.deepStrictEqual(sendOptions, [
+      { requireResumeCursor: { threadId: "provider-thread-resume" } },
     ]);
     assert.deepStrictEqual(
       dispatched.map((command) =>
@@ -387,7 +411,12 @@ const verifyOrdinaryRestartContinuation = (markerCleared: boolean) =>
         {
           activeTurnId: null,
           lastRuntimeEvent: "provider.sendTurn",
-          ...(markerCleared ? { continueAfterServerUpdate: null } : {}),
+          continueAfterServerUpdate: thread.session.activeTurnId,
+        },
+        {
+          activeTurnId: thread.session.activeTurnId,
+          lastRuntimeEvent: "provider.sendTurn",
+          continueAfterServerUpdate: null,
         },
       ],
     );

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -307,6 +307,91 @@ it.effect("continues marked sessions after activation with provider-specific inp
   }),
 );
 
+it.effect("continues an unmarked active session after an ordinary server restart", () =>
+  Effect.gen(function* () {
+    const thread = makeThread(
+      "thread-continue-after-restart",
+      "running",
+      TurnId.make("turn-continue-after-restart"),
+    );
+    const continuationSent = yield* Deferred.make<void>();
+    const sends: ProviderSendTurnInput[] = [];
+    const dispatched: OrchestrationCommand[] = [];
+    const upserts: ProviderSessionDirectory.ProviderRuntimeBinding[] = [];
+    const providerService: ProviderService.ProviderService["Service"] = {
+      ...makeProviderService(),
+      getCapabilities: () =>
+        Effect.succeed({
+          sessionModelSwitch: "in-session",
+          promptlessTurnContinuation: true,
+        }),
+      sendTurn: (input) =>
+        Effect.sync(() => {
+          sends.push(input);
+          return {
+            threadId: input.threadId,
+            turnId: TurnId.make("continued-after-restart"),
+          };
+        }).pipe(Effect.tap(() => Deferred.succeed(continuationSent, undefined))),
+    };
+
+    yield* runReconciliation({
+      threads: [thread],
+      providerService,
+      directory: {
+        getBinding: () =>
+          Effect.succeed(
+            Option.some({
+              threadId: thread.id,
+              provider: ProviderDriverKind.make("codex"),
+              providerInstanceId,
+              status: "running" as const,
+              resumeCursor: { threadId: "provider-thread-resume" },
+              runtimePayload: {
+                activeTurnId: thread.session.activeTurnId,
+                lastRuntimeEvent: "provider.sendTurn",
+              },
+            }),
+          ),
+        upsert: (binding) => Effect.sync(() => upserts.push(binding)),
+        getProvider: () => Effect.die("unused"),
+        listThreadIds: () => Effect.die("unused"),
+        listBindings: () => Effect.die("unused"),
+      },
+      dispatch: (command) =>
+        Effect.sync(() => dispatched.push(command)).pipe(
+          Effect.as({ sequence: dispatched.length }),
+        ),
+    });
+    yield* Deferred.await(continuationSent);
+
+    assert.deepStrictEqual(sends, [
+      { threadId: thread.id, continuation: true, interactionMode: "default" },
+    ]);
+    assert.deepStrictEqual(
+      dispatched.map((command) =>
+        command.type === "thread.session.set"
+          ? {
+              status: command.session.status,
+              activeTurnId: command.session.activeTurnId,
+              lastError: command.session.lastError,
+            }
+          : null,
+      ),
+      [{ status: "starting", activeTurnId: null, lastError: null }],
+    );
+    assert.deepStrictEqual(
+      upserts.map((binding) => binding.runtimePayload),
+      [
+        {
+          activeTurnId: null,
+          lastRuntimeEvent: "provider.sendTurn",
+        },
+      ],
+    );
+  }),
+);
+
 it.effect("does not continue archived or deleted marked sessions", () => {
   const archived = makeThread(
     "thread-continue-archived",
@@ -438,7 +523,7 @@ it.effect("retries continuation preparation before settling a persistent failure
 
 it.effect("reconciles multiple active and archived orphans but skips live sessions", () => {
   const starting = makeThread("thread-starting", "starting");
-  const running = makeThread("thread-running", "running", TurnId.make("turn-running"));
+  const running = makeThread("thread-running", "running");
   const staleActiveTurn = makeThread(
     "thread-stale-active-turn",
     "ready",

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -479,11 +479,12 @@ export const reconcileProviderSessions = Effect.gen(function* () {
     const continuationMarked =
       continuationTurnId !== null &&
       (session.activeTurnId === null || continuationTurnId === session.activeTurnId);
-    // A normal desktop quit does not pass through the self-update marker flow,
-    // but the projected active turn and persisted provider cursor still prove
-    // that this session can be resumed. Preserve the pre-#9167 behavior by
-    // continuing that turn after any server restart. A stale explicit update
-    // marker remains authoritative and must not resume a different turn.
+    // Quitting the T3 Code desktop app also stops its embedded backend, but
+    // unlike a managed self-update it does not write a continuation marker.
+    // On the next app launch, the projected active turn and persisted provider
+    // cursor still prove that the interrupted session can be resumed. The same
+    // startup path also covers standalone backend restarts. A stale explicit
+    // update marker remains authoritative and must not resume a different turn.
     const restartContinuationEligible =
       continuationMarked ||
       (!continuationMarkerPresent &&
@@ -619,12 +620,12 @@ export const reconcileProviderSessions = Effect.gen(function* () {
             }
             return;
           }
-          yield* Effect.logWarning("failed to continue provider session after server restart", {
+          yield* Effect.logWarning("failed to continue provider session after T3 Code restarted", {
             threadId: thread.id,
             cause: continuationExit.cause,
           });
           yield* settleAsError(
-            "Could not continue this thread after the server restart. Send a new message to continue.",
+            "Could not continue this thread after T3 Code restarted. Send a new message to continue.",
           ).pipe(Effect.ignoreCause);
         }),
       );

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -472,11 +472,10 @@ export const reconcileProviderSessions = Effect.gen(function* () {
             }).pipe(Effect.as(Option.none())),
       ),
     );
-    const continuationMarkerPresent =
-      Option.isSome(binding) && hasServerUpdateContinuationMarker(binding.value.runtimePayload);
     const continuationTurnId = Option.isSome(binding)
       ? readServerUpdateContinuationTurnId(binding.value.runtimePayload)
       : null;
+    const continuationMarkerPresent = continuationTurnId !== null;
     const continuationMarked =
       continuationTurnId !== null &&
       (session.activeTurnId === null || continuationTurnId === session.activeTurnId);

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -480,6 +480,18 @@ export const reconcileProviderSessions = Effect.gen(function* () {
     const continuationMarked =
       continuationTurnId !== null &&
       (session.activeTurnId === null || continuationTurnId === session.activeTurnId);
+    // A normal desktop quit does not pass through the self-update marker flow,
+    // but the projected active turn and persisted provider cursor still prove
+    // that this session can be resumed. Preserve the pre-#9167 behavior by
+    // continuing that turn after any server restart. A stale explicit update
+    // marker remains authoritative and must not resume a different turn.
+    const restartContinuationEligible =
+      continuationMarked ||
+      (!continuationMarkerPresent &&
+        session.activeTurnId !== null &&
+        Option.isSome(binding) &&
+        binding.value.resumeCursor !== null &&
+        binding.value.resumeCursor !== undefined);
     const settleAsError = (lastError: string) =>
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
@@ -535,7 +547,7 @@ export const reconcileProviderSessions = Effect.gen(function* () {
 
     if (
       Option.isSome(binding) &&
-      continuationMarked &&
+      restartContinuationEligible &&
       thread.archivedAt === null &&
       thread.deletedAt === null
     ) {
@@ -595,7 +607,7 @@ export const reconcileProviderSessions = Effect.gen(function* () {
           });
           const continuationExit = yield* Effect.exit(continuation);
           if (Exit.isSuccess(continuationExit) || Cause.hasInterrupts(continuationExit.cause)) {
-            if (Exit.isSuccess(continuationExit)) {
+            if (Exit.isSuccess(continuationExit) && continuationMarkerPresent) {
               yield* clearContinuationMarkers(directory, [thread.id]).pipe(
                 Effect.uninterruptible,
                 Effect.catchCause((cause) =>
@@ -608,12 +620,12 @@ export const reconcileProviderSessions = Effect.gen(function* () {
             }
             return;
           }
-          yield* Effect.logWarning("failed to continue provider session after server update", {
+          yield* Effect.logWarning("failed to continue provider session after server restart", {
             threadId: thread.id,
             cause: continuationExit.cause,
           });
           yield* settleAsError(
-            "Could not continue this thread after the server update. Send a new message to continue.",
+            "Could not continue this thread after the server restart. Send a new message to continue.",
           ).pipe(Effect.ignoreCause);
         }),
       );

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -482,9 +482,11 @@ export const reconcileProviderSessions = Effect.gen(function* () {
     // Quitting the T3 Code desktop app also stops its embedded backend, but
     // unlike a managed self-update it does not write a continuation marker.
     // On the next app launch, the projected active turn and persisted provider
-    // cursor still prove that the interrupted session can be resumed. The same
-    // startup path also covers standalone backend restarts. A stale explicit
-    // update marker remains authoritative and must not resume a different turn.
+    // cursor make the interrupted session a continuation candidate. Before a
+    // turn is sent, ProviderService verifies that recovery retained the same
+    // provider conversation. The same startup path also covers standalone
+    // backend restarts. A stale explicit update marker remains authoritative
+    // and must not resume a different turn.
     const restartContinuationEligible =
       continuationMarked ||
       (!continuationMarkerPresent &&
@@ -551,6 +553,11 @@ export const reconcileProviderSessions = Effect.gen(function* () {
       thread.archivedAt === null &&
       thread.deletedAt === null
     ) {
+      const recoveryTurnId = continuationTurnId ?? session.activeTurnId;
+      if (recoveryTurnId === null) {
+        yield* settleAsError(ORPHANED_PROVIDER_SESSION_ERROR);
+        continue;
+      }
       const prepared = yield* Effect.gen(function* () {
         yield* directory.upsert({
           ...binding.value,
@@ -558,6 +565,7 @@ export const reconcileProviderSessions = Effect.gen(function* () {
           runtimePayload: {
             ...readRuntimePayload(binding.value.runtimePayload),
             activeTurnId: null,
+            [SERVER_UPDATE_CONTINUATION_KEY]: recoveryTurnId,
           },
         });
         const resumedAt = DateTime.formatIso(yield* DateTime.now);
@@ -597,17 +605,20 @@ export const reconcileProviderSessions = Effect.gen(function* () {
               });
             }
             const capabilities = yield* providerService.getCapabilities(providerInstanceId);
-            yield* providerService.sendTurn({
-              threadId: thread.id,
-              ...(capabilities.promptlessTurnContinuation === true
-                ? { continuation: true }
-                : { input: SERVER_UPDATE_CONTINUATION_PROMPT }),
-              interactionMode: thread.interactionMode,
-            });
+            yield* providerService.sendTurn(
+              {
+                threadId: thread.id,
+                ...(capabilities.promptlessTurnContinuation === true
+                  ? { continuation: true }
+                  : { input: SERVER_UPDATE_CONTINUATION_PROMPT }),
+                interactionMode: thread.interactionMode,
+              },
+              { requireResumeCursor: binding.value.resumeCursor },
+            );
           });
           const continuationExit = yield* Effect.exit(continuation);
           if (Exit.isSuccess(continuationExit) || Cause.hasInterrupts(continuationExit.cause)) {
-            if (Exit.isSuccess(continuationExit) && continuationMarkerPresent) {
+            if (Exit.isSuccess(continuationExit)) {
               yield* clearContinuationMarkers(directory, [thread.id]).pipe(
                 Effect.uninterruptible,
                 Effect.catchCause((cause) =>


### PR DESCRIPTION
## User-facing behavior

This PR fixes one specific desktop-app failure:

1. A model is still working in a T3 Code thread.
2. The user fully quits T3 Code.
3. The user opens T3 Code again.

Previously, the reopened app treated that active turn as an orphaned provider session and stopped it with an error. The user had to send another message manually.

With this change, reopening T3 Code recognizes the interrupted active turn, restores its saved provider conversation, and asks that conversation to continue.

> [!IMPORTANT]
> This is restart recovery, not background execution. Fully quitting T3 Code still stops its local backend and provider processes. The model does not continue computing while the app is closed; it resumes after the app is opened again.

## Why this code lives in the server

The T3 Code desktop app starts an embedded local backend. Quitting the app stops that backend, and reopening the app starts a new backend process. The recovery decision therefore happens during backend startup even though the user-facing action is simply quitting and reopening the desktop app.

The same startup logic also benefits standalone T3 Code server processes, but the motivating and tested user flow is the desktop app restart described above. Reloading only the browser or frontend is unrelated.

## How recovery works

At startup, an interrupted turn becomes a candidate for automatic continuation when:

- the stored thread session still has an active turn ID;
- the provider binding has a saved resume cursor;
- the thread is not archived or deleted; and
- there is no conflicting valid self-update continuation marker.

A previously cleared marker (`continueAfterServerUpdate: null`) counts as no marker. A valid marker containing a different turn ID remains authoritative and prevents the wrong turn from being resumed.

Before starting background recovery, T3 Code persists the interrupted turn ID as a continuation marker. If the app quits again during recovery, the next launch can retry instead of orphaning the turn. The marker is cleared only after the provider accepts the continuation.

Provider recovery is verified before any continuation turn is sent. Each adapter must prove that the live provider session corresponds to the saved resume cursor. Claude waits for the SDK to report its actual durable session ID instead of trusting the requested ID echoed during startup; OpenCode validates the session returned by its API; ACP providers require a successful native session load. A malformed cursor, a failed native load, or a confirmed identity mismatch fails closed rather than continuing in the wrong conversation.

Once verified, the existing continuation path is reused:

- providers with native promptless continuation, currently Codex, receive a continuation turn;
- other providers receive the existing “Continue where you left off” fallback prompt.

If continuation fails, the thread reports that it could not continue after T3 Code restarted and asks the user to send a new message.

## Relationship to existing work

#9167 added continuation for a managed T3 Code self-update. That flow writes an explicit continuation marker before restarting. An ordinary desktop-app quit does not write that marker, which is the gap fixed here.

Other open PRs address different behavior:

- #7463 settles stale sessions instead of automatically continuing them;
- #9189 offers a manual Continue action after a turn is already interrupted;
- #9211 releases an existing Codex writer during cross-instance resume.

This also restores the user-visible quit/reopen behavior covered downstream by [patroza/t3code#442](https://github.com/patroza/t3code/pull/442) and [patroza/t3code#443](https://github.com/patroza/t3code/pull/443), while reusing upstream’s continuation path instead of importing their larger recovery subsystem.

## Out of scope

- Keeping models running while the desktop app is closed
- Adding a macOS LaunchAgent or other background service
- Resuming an exact half-finished local tool process
- Changing frontend-only reload behavior

## Verification

- `vp test run src/provider/Layers/ClaudeAdapter.test.ts src/provider/Layers/ProviderService.test.ts src/serverRuntimeStartup.reconcile.test.ts` — 136 tests passed
- `vp run typecheck` in `apps/server` — passed (existing suggestions only)
- Targeted `vp lint` across the changed server files — passed (one pre-existing warning)
- Targeted formatting across the changed server files — passed
- `git diff --check` — passed
- Live Grok ACP probe confirmed that loading a nonexistent session fails instead of creating a fresh conversation
- Cursor Bugbot summary on commit `bc0226f7e` includes the durable Claude session-ID guard

Regression coverage includes absent and cleared self-update markers, crash-safe retry state, successful same-conversation recovery, and rejection of a fresh replacement conversation.

## Checklist

- [x] This PR remains focused on restart recovery
- [x] I explained what changed and why
- [x] No UI changes
- [x] No animation or interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Recovery now auto-continues more orphaned sessions at startup; a cursor mismatch fails closed (session stopped, user must send again), but wrong eligibility could still attempt continuation on edge cases.
> 
> **Overview**
> Reopening T3 Code after a full quit can now **automatically continue an interrupted active turn** instead of orphaning the provider session, when the thread still has an active turn ID and a persisted resume cursor (and no conflicting self-update continuation marker).
> 
> **Provider recovery is gated by resume-cursor equality.** Adapters gain optional `isSameResumeCursor`; `ProviderService.sendTurn` accepts `requireResumeCursor` and rejects recovery when the live or newly started session does not match the saved conversation (stopping the bad session on fresh-start mismatch). Claude’s check waits for the SDK’s durable `session_id` confirmation so an echoed cursor on a brand-new session is treated as a failed resume.
> 
> **Startup reconciliation** widens continuation eligibility beyond the explicit update marker, persists a retry marker for crash-safe recovery, and issues continuation turns with `requireResumeCursor` (promptless where supported). User-facing failure copy now refers to T3 Code restarting rather than a server update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0226f7ec0f5f592e6adf6a7572b1871245f4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume active turns when T3 Code reopens by validating provider resume cursors
> - On restart, orphaned active sessions with an active turn and persisted resume cursor now automatically resume, even without a continuation marker. The persisted cursor is passed as a strict requirement to `ProviderService.sendTurn`.
> - Adds an optional `isSameResumeCursor` comparison operation to `ProviderAdapterShape`; each adapter (Claude, Codex, Cursor, Grok, OpenCode) implements it. Claude additionally waits up to 10 seconds for the SDK to confirm the durable session id.
> - `ProviderService.recoverSessionForThread` and `resolveRoutableSession` now reject sessions whose cursor does not match the required persisted cursor; a mismatched recovered session is stopped and its MCP state cleared.
> - Behavioral Change: `reconcileProviderSessions` in [serverRuntimeStartup.ts](https://github.com/pingdotgg/t3code/pull/9360/files#diff-1930335d6e319fc5766e0578303e19f9d788e9990f87604b77f9f768e61d7118) now resumes unmarked orphaned sessions with an active turn and persisted cursor. Adapters without a resume-cursor comparator are treated as unable to prove recovery and will not auto-continue. Explicit markers whose turn id does not match remain ineligible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc0226f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
