### PR TITLE
Let the desktop app be a client of an existing T3 Code server

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -1,9 +1,12 @@
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 
+import type { DesktopBackendMode as DesktopBackendModeValue } from "@t3tools/contracts";
 import * as NetService from "@t3tools/shared/Net";
 import * as Crypto from "effect/Crypto";
 import * as ElectronApp from "../electron/ElectronApp.ts";
@@ -13,6 +16,7 @@ import * as ElectronSafeStorage from "../electron/ElectronSafeStorage.ts";
 import { installDesktopIpcHandlers } from "../ipc/DesktopIpcHandlers.ts";
 import * as DesktopAppActivation from "./DesktopAppActivation.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
@@ -22,6 +26,7 @@ import * as DesktopLifecycle from "./DesktopLifecycle.ts";
 import * as DesktopLinuxUrlHandler from "./DesktopLinuxUrlHandler.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
 import * as DesktopPreReadyPlatform from "./DesktopPreReadyPlatform.ts";
+import * as DesktopRunningLocalServers from "./DesktopRunningLocalServers.ts";
 import * as DesktopShutdown from "./DesktopShutdown.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
@@ -59,6 +64,17 @@ export class DesktopDevelopmentBackendPortRequiredError extends Schema.TaggedErr
 ) {
   override get message(): string {
     return "T3CODE_PORT is required in desktop development.";
+  }
+}
+
+export class DesktopRendererAssetsUnavailableError extends Schema.TaggedErrorClass<DesktopRendererAssetsUnavailableError>()(
+  "DesktopRendererAssetsUnavailableError",
+  {
+    candidates: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    return `The packaged desktop renderer was not found. Checked: ${this.candidates.join(", ")}.`;
   }
 }
 
@@ -141,22 +157,95 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 const fatalStartupCause = <E>(stage: string, cause: Cause.Cause<E>) =>
   handleFatalStartupError(stage, Cause.pretty(cause)).pipe(Effect.andThen(Effect.failCause(cause)));
 
+export const latchDesktopBackendModeForStartup = Effect.fn(
+  "desktop.startup.latchDesktopBackendMode",
+)(function* (configuredMode: DesktopBackendModeValue) {
+  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
+  return yield* backendMode
+    .latch(configuredMode)
+    .pipe(Effect.catchCause((cause) => fatalStartupCause("backendMode", cause)));
+});
+
+export const handleClientOnlyRendererReady = <E extends { readonly message: string }>(
+  rendererReady: Effect.Effect<void, E>,
+): Effect.Effect<void, E> =>
+  rendererReady.pipe(
+    Effect.tapError((error) =>
+      logBootstrapWarning("failed to open main window after renderer readiness", {
+        error: error.message,
+      }),
+    ),
+  );
+
+const resolvePackagedClientRoot = Effect.fn("desktop.bootstrap.resolvePackagedClientRoot")(
+  function* (candidates: readonly string[]) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    for (const candidate of candidates) {
+      if (
+        yield* fileSystem
+          .exists(path.join(candidate, "index.html"))
+          .pipe(Effect.orElseSucceed(() => false))
+      ) {
+        return candidate;
+      }
+    }
+    return yield* new DesktopRendererAssetsUnavailableError({ candidates: [...candidates] });
+  },
+);
+
 const bootstrap = Effect.gen(function* () {
-  const pool = yield* DesktopBackendPool.DesktopBackendPool;
-  const primaryBackend = yield* pool.primary;
+  const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
   const state = yield* DesktopState.DesktopState;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
-  const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
-  const wslBackend = yield* DesktopWslBackend.DesktopWslBackend;
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
   const appActivation = yield* DesktopAppActivation.DesktopAppActivation;
+  const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
+  const backendMode = (yield* launchMode.get).effectiveMode;
   yield* logBootstrapInfo("bootstrap start");
+
+  if (backendMode === "client-only") {
+    if (environment.isDevelopment) {
+      yield* electronProtocol.registerDesktopProtocol({
+        scheme: ElectronProtocol.getDesktopScheme(true),
+        source: "proxy",
+        targetOrigin: Option.getOrThrow(environment.devServerUrl),
+        clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
+      });
+    } else {
+      const staticRoot = yield* resolvePackagedClientRoot(environment.packagedClientRootCandidates);
+      yield* electronProtocol.registerDesktopProtocol({
+        scheme: ElectronProtocol.getDesktopScheme(false),
+        source: "static",
+        staticRoot,
+        clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
+      });
+      yield* logBootstrapInfo("bootstrap resolved packaged renderer", { staticRoot });
+    }
+
+    yield* installDesktopIpcHandlers();
+    yield* logBootstrapInfo("bootstrap ipc handlers registered");
+    if (!(yield* Ref.get(state.quitting))) {
+      yield* appActivation.start.pipe(
+        Effect.tap(() => logBootstrapInfo("desktop app control socket ready")),
+        Effect.catch((error) =>
+          logStartupError("desktop app control socket unavailable", { error }),
+        ),
+      );
+      yield* handleClientOnlyRendererReady(desktopWindow.handleRendererReady);
+    }
+    return;
+  }
 
   if (environment.isDevelopment && Option.isNone(environment.configuredBackendPort)) {
     return yield* new DesktopDevelopmentBackendPortRequiredError();
   }
 
+  const pool = yield* DesktopBackendPool.DesktopBackendPool;
+  const primaryBackend = yield* pool.primary;
+  const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+  const wslBackend = yield* DesktopWslBackend.DesktopWslBackend;
   const backendPortSelection = yield* resolveDesktopBackendPort(environment.configuredBackendPort);
   const backendPort = backendPortSelection.port;
   yield* logBootstrapInfo(
@@ -177,14 +266,13 @@ const bootstrap = Effect.gen(function* () {
   }
   const serverExposureState = yield* serverExposure.configureFromSettings({ port: backendPort });
   const backendConfig = yield* serverExposure.backendConfig;
-  const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
   const rendererTarget = environment.isDevelopment
     ? Option.getOrThrow(environment.devServerUrl)
     : backendConfig.httpBaseUrl;
   yield* electronProtocol.registerDesktopProtocol({
     scheme: ElectronProtocol.getDesktopScheme(environment.isDevelopment),
+    source: "proxy",
     targetOrigin: rendererTarget,
-    backendOrigin: backendConfig.httpBaseUrl,
     clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
   });
   yield* logBootstrapInfo("bootstrap resolved backend endpoint", {
@@ -263,7 +351,33 @@ const startup = Effect.gen(function* () {
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
-  yield* desktopSettings.load;
+  const settings = yield* desktopSettings.load;
+  const latchedLaunchMode = yield* latchDesktopBackendModeForStartup(settings.backendMode);
+  const existingServer =
+    latchedLaunchMode.effectiveMode === "managed" && !environment.isDevelopment
+      ? (yield* (yield* DesktopRunningLocalServers.DesktopRunningLocalServers).discover).find(
+          (server) => server.variant === "userdata",
+        )
+      : undefined;
+  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
+  const launchMode = yield* backendMode.resolveExistingServer({
+    isDevelopment: environment.isDevelopment,
+    hasRunningUserdataServer: existingServer !== undefined,
+  });
+  yield* logStartupInfo("desktop backend mode selected", {
+    effectiveMode: launchMode.effectiveMode,
+    configuredMode: launchMode.configuredMode,
+    source: launchMode.source,
+    ...(launchMode.cliOverride === null ? {} : { cliOverride: launchMode.cliOverride }),
+  });
+  if (launchMode.source === "existing-server" && existingServer !== undefined) {
+    yield* logStartupInfo("using existing local server instead of starting managed backend", {
+      environmentId: existingServer.environmentId,
+      origin: existingServer.httpBaseUrl,
+      pid: existingServer.pid,
+      statePath: existingServer.statePath,
+    });
+  }
 
   if (linuxElectronOptions !== null) {
     yield* logStartupInfo("linux password store configured", {
@@ -308,6 +422,10 @@ const scopedProgram = Effect.scoped(
 
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
+        const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
+        if ((yield* backendMode.get).effectiveMode === "client-only") {
+          return;
+        }
         const pool = yield* DesktopBackendPool.DesktopBackendPool;
         // Stop every backend in the pool, not just the primary. The
         // electronApp.quit() path can race ahead of the layer-scope

--- a/apps/desktop/src/app/DesktopAppErrors.test.ts
+++ b/apps/desktop/src/app/DesktopAppErrors.test.ts
@@ -1,9 +1,22 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import {
   DesktopBackendPortUnavailableError,
   DesktopDevelopmentBackendPortRequiredError,
+  handleClientOnlyRendererReady,
+  latchDesktopBackendModeForStartup,
 } from "./DesktopApp.ts";
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
+import * as DesktopState from "./DesktopState.ts";
 
 describe("DesktopApp errors", () => {
   it("preserves unavailable backend port context", () => {
@@ -27,4 +40,59 @@ describe("DesktopApp errors", () => {
 
     assert.equal(error.message, "T3CODE_PORT is required in desktop development.");
   });
+
+  it.effect("preserves client-only window creation failures after logging", () =>
+    Effect.gen(function* () {
+      const error = new Error("window creation failed");
+
+      const exit = yield* Effect.exit(handleClientOnlyRendererReady(Effect.fail(error)));
+      assert(Exit.isFailure(exit));
+      const failure = Cause.findErrorOption(exit.cause);
+      assert(Option.isSome(failure));
+      assert.strictEqual(failure.value, error);
+    }),
+  );
+
+  it.effect("reports invalid backend-mode launch arguments as fatal startup errors", () =>
+    Effect.gen(function* () {
+      const quitCount = yield* Ref.make(0);
+      const shownErrors = yield* Ref.make<readonly { title: string; content: string }[]>([]);
+
+      const layer = Layer.mergeAll(
+        DesktopBackendMode.layerTest(["electron", "--backend-mode=invalid"]),
+        DesktopShutdown.layer,
+        DesktopState.layer,
+        Layer.mock(ElectronApp.ElectronApp)({
+          quit: Ref.update(quitCount, (count) => count + 1),
+        }),
+        Layer.mock(ElectronDialog.ElectronDialog)({
+          showErrorBox: (title, content) =>
+            Ref.update(shownErrors, (errors) => [...errors, { title, content }]),
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const exit = yield* Effect.exit(latchDesktopBackendModeForStartup("managed"));
+        assert(Exit.isFailure(exit));
+        const failure = Cause.findErrorOption(exit.cause);
+        assert(Option.isSome(failure));
+        assert(
+          DesktopBackendMode.isDesktopBackendModeArgumentError(failure.value),
+          "expected the original backend mode argument error",
+        );
+
+        const errors = yield* Ref.get(shownErrors);
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0]?.title, "T3 Code failed to start");
+        assert.include(errors[0]?.content ?? "", "Stage: backendMode");
+        assert.include(errors[0]?.content ?? "", 'Invalid --backend-mode value "invalid"');
+        assert.equal(yield* Ref.get(quitCount), 1);
+
+        const state = yield* DesktopState.DesktopState;
+        assert.isTrue(yield* Ref.get(state.quitting));
+        const shutdown = yield* DesktopShutdown.DesktopShutdown;
+        yield* shutdown.awaitRequest;
+      }).pipe(Effect.provide(layer));
+    }),
+  );
 });

--- a/apps/desktop/src/app/DesktopBackendMode.test.ts
+++ b/apps/desktop/src/app/DesktopBackendMode.test.ts
@@ -1,0 +1,102 @@
+import { assert, describe, expect, it } from "@effect/vitest";
+
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
+
+describe("DesktopBackendMode", () => {
+  const captureThrown = (run: () => unknown): unknown => {
+    try {
+      run();
+    } catch (error) {
+      return error;
+    }
+    throw new Error("Expected the operation to throw.");
+  };
+
+  it("uses the persisted mode when no CLI override is present", () => {
+    assert.deepEqual(DesktopBackendMode.resolveDesktopBackendModeState([], "client-only"), {
+      effectiveMode: "client-only",
+      configuredMode: "client-only",
+      cliOverride: null,
+      source: "settings",
+    });
+  });
+
+  it("gives the CLI override precedence without changing the configured mode", () => {
+    assert.deepEqual(
+      DesktopBackendMode.resolveDesktopBackendModeState(
+        ["electron", "main.cjs", "--backend-mode=client-only"],
+        "managed",
+      ),
+      {
+        effectiveMode: "client-only",
+        configuredMode: "managed",
+        cliOverride: "client-only",
+        source: "cli",
+      },
+    );
+  });
+
+  it("accepts a separate flag value", () => {
+    assert.equal(
+      DesktopBackendMode.parseDesktopBackendModeOverride(["electron", "--backend-mode", "managed"]),
+      "managed",
+    );
+  });
+
+  it("uses client-only for a packaged launch when the userdata server is already running", () => {
+    expect(
+      DesktopBackendMode.resolveDesktopBackendModeForExistingServer(
+        DesktopBackendMode.resolveDesktopBackendModeState([], "managed"),
+        { isDevelopment: false, hasRunningUserdataServer: true },
+      ),
+    ).toEqual({
+      effectiveMode: "client-only",
+      configuredMode: "managed",
+      cliOverride: null,
+      source: "existing-server",
+    });
+  });
+
+  it("keeps managed mode in development and when no userdata server is running", () => {
+    const state = DesktopBackendMode.resolveDesktopBackendModeState([], "managed");
+    expect(
+      DesktopBackendMode.resolveDesktopBackendModeForExistingServer(state, {
+        isDevelopment: true,
+        hasRunningUserdataServer: true,
+      }),
+    ).toBe(state);
+    expect(
+      DesktopBackendMode.resolveDesktopBackendModeForExistingServer(state, {
+        isDevelopment: false,
+        hasRunningUserdataServer: false,
+      }),
+    ).toBe(state);
+  });
+
+  it.each([
+    ["--backend-mode=other", "invalid-value"],
+    ["--backend-mode=", "missing-value"],
+    ["--backend-mode", "missing-value"],
+  ])("rejects invalid launch argument %s", (argument, reason) => {
+    const error = captureThrown(() =>
+      DesktopBackendMode.parseDesktopBackendModeOverride(["electron", argument]),
+    );
+    assert.isTrue(DesktopBackendMode.isDesktopBackendModeArgumentError(error));
+    if (DesktopBackendMode.isDesktopBackendModeArgumentError(error)) {
+      assert.equal(error.reason, reason);
+    }
+  });
+
+  it("rejects repeated overrides", () => {
+    const error = captureThrown(() =>
+      DesktopBackendMode.parseDesktopBackendModeOverride([
+        "--backend-mode=managed",
+        "--backend-mode=client-only",
+      ]),
+    );
+    assert.isTrue(DesktopBackendMode.isDesktopBackendModeArgumentError(error));
+    if (DesktopBackendMode.isDesktopBackendModeArgumentError(error)) {
+      assert.equal(error.reason, "repeated");
+    }
+  });
+});

--- a/apps/desktop/src/app/DesktopBackendMode.ts
+++ b/apps/desktop/src/app/DesktopBackendMode.ts
@@ -1,0 +1,155 @@
+import {
+  type DesktopBackendMode as DesktopBackendModeValue,
+  type DesktopBackendModeState,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+
+const BACKEND_MODE_FLAG = "--backend-mode";
+
+export class DesktopBackendModeArgumentError extends Schema.TaggedErrorClass<DesktopBackendModeArgumentError>()(
+  "DesktopBackendModeArgumentError",
+  {
+    value: Schema.NullOr(Schema.String),
+    reason: Schema.Literals(["missing-value", "invalid-value", "repeated"]),
+  },
+) {
+  override get message(): string {
+    if (this.reason === "missing-value") {
+      return `${BACKEND_MODE_FLAG} requires either "managed" or "client-only".`;
+    }
+    if (this.reason === "repeated") {
+      return `${BACKEND_MODE_FLAG} may only be specified once.`;
+    }
+    return `Invalid ${BACKEND_MODE_FLAG} value ${JSON.stringify(this.value)}. Expected "managed" or "client-only".`;
+  }
+}
+
+export const isDesktopBackendModeArgumentError = Schema.is(DesktopBackendModeArgumentError);
+
+function parseBackendMode(value: string | undefined): DesktopBackendModeValue {
+  if (value === undefined || value.length === 0) {
+    throw new DesktopBackendModeArgumentError({
+      value: value ?? null,
+      reason: "missing-value",
+    });
+  }
+  if (value === "managed" || value === "client-only") {
+    return value;
+  }
+  throw new DesktopBackendModeArgumentError({
+    value,
+    reason: "invalid-value",
+  });
+}
+
+export function parseDesktopBackendModeOverride(
+  argv: readonly string[],
+): DesktopBackendModeValue | null {
+  let override: DesktopBackendModeValue | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === undefined) continue;
+
+    let value: string | undefined;
+    if (argument === BACKEND_MODE_FLAG) {
+      value = argv[index + 1];
+      index += 1;
+    } else if (argument.startsWith(`${BACKEND_MODE_FLAG}=`)) {
+      value = argument.slice(BACKEND_MODE_FLAG.length + 1);
+    } else {
+      continue;
+    }
+
+    if (override !== null) {
+      throw new DesktopBackendModeArgumentError({
+        value: value ?? null,
+        reason: "repeated",
+      });
+    }
+    override = parseBackendMode(value);
+  }
+
+  return override;
+}
+
+export function resolveDesktopBackendModeState(
+  argv: readonly string[],
+  configuredMode: DesktopBackendModeValue,
+): DesktopBackendModeState {
+  const cliOverride = parseDesktopBackendModeOverride(argv);
+  return {
+    effectiveMode: cliOverride ?? configuredMode,
+    configuredMode,
+    cliOverride,
+    source: cliOverride === null ? "settings" : "cli",
+  };
+}
+
+export function resolveDesktopBackendModeForExistingServer(
+  state: DesktopBackendModeState,
+  input: {
+    readonly isDevelopment: boolean;
+    readonly hasRunningUserdataServer: boolean;
+  },
+): DesktopBackendModeState {
+  if (input.isDevelopment || !input.hasRunningUserdataServer || state.effectiveMode !== "managed") {
+    return state;
+  }
+  return {
+    ...state,
+    effectiveMode: "client-only",
+    source: "existing-server",
+  };
+}
+
+export class DesktopBackendMode extends Context.Service<
+  DesktopBackendMode,
+  {
+    readonly latch: (
+      configuredMode: DesktopBackendModeValue,
+    ) => Effect.Effect<DesktopBackendModeState, DesktopBackendModeArgumentError>;
+    readonly get: Effect.Effect<DesktopBackendModeState>;
+    readonly resolveExistingServer: (input: {
+      readonly isDevelopment: boolean;
+      readonly hasRunningUserdataServer: boolean;
+    }) => Effect.Effect<DesktopBackendModeState>;
+  }
+>()("@t3tools/desktop/app/DesktopBackendMode") {}
+
+export const make = Effect.fn("desktop.backendMode.make")(function* (argv: readonly string[]) {
+  const stateRef = yield* Ref.make<DesktopBackendModeState>({
+    effectiveMode: "managed",
+    configuredMode: "managed",
+    cliOverride: null,
+    source: "settings",
+  });
+
+  return DesktopBackendMode.of({
+    latch: (configuredMode) =>
+      Effect.try({
+        try: () => resolveDesktopBackendModeState(argv, configuredMode),
+        catch: (cause) =>
+          isDesktopBackendModeArgumentError(cause)
+            ? cause
+            : new DesktopBackendModeArgumentError({
+                value: null,
+                reason: "invalid-value",
+              }),
+      }).pipe(Effect.tap((state) => Ref.set(stateRef, state))),
+    get: Ref.get(stateRef),
+    resolveExistingServer: (input) =>
+      Ref.updateAndGet(stateRef, (state) =>
+        resolveDesktopBackendModeForExistingServer(state, input),
+      ),
+  });
+});
+
+export const layer = Layer.effect(DesktopBackendMode, make(process.argv));
+
+export const layerTest = (argv: readonly string[] = []) =>
+  Layer.effect(DesktopBackendMode, make(argv));

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -68,6 +68,10 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.serverRoot, "/repo");
       assert.equal(environment.backendEntryPath, "/repo/apps/server/dist/bin.mjs");
       assert.equal(environment.backendCwd, "/repo");
+      assert.deepEqual(environment.packagedClientRootCandidates, [
+        "/Applications/T3 Code.app/Contents/Resources/app.asar/apps/server/dist/client",
+        "/Applications/T3 Code.app/Contents/Resources/app.asar.unpacked/apps/server/dist/client",
+      ]);
       assert.equal(environment.appUserModelId, "com.t3tools.t3code.dev");
       assert.equal(environment.linuxWmClass, "t3code-dev");
       assert.deepEqual(

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -61,6 +61,7 @@ export class DesktopEnvironment extends Context.Service<
     readonly serverRoot: string;
     readonly backendEntryPath: string;
     readonly backendCwd: string;
+    readonly packagedClientRootCandidates: readonly string[];
     readonly preloadPath: string;
     readonly appUpdateYmlPath: string;
     readonly devServerUrl: Option.Option<URL>;
@@ -211,6 +212,10 @@ const make = Effect.fn("desktop.environment.make")(function* (
     serverRoot,
     backendEntryPath: path.join(serverRoot, "apps/server/dist/bin.mjs"),
     backendCwd: input.isPackaged ? homeDirectory : appRoot,
+    packagedClientRootCandidates: [
+      path.join(input.appPath, "apps/server/dist/client"),
+      path.join(resourcesPath, "app.asar.unpacked/apps/server/dist/client"),
+    ],
     preloadPath: path.join(input.dirname, "preload.cjs"),
     appUpdateYmlPath: input.isPackaged
       ? path.join(resourcesPath, "app-update.yml")

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -90,6 +90,7 @@ function makeDesktopWindowLayer(
     createMainIfBackendReady: Effect.void,
     showConnectingSplash: Effect.void,
     handleBackendReady: () => Effect.void,
+    handleRendererReady: Effect.void,
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: input.flushMainWindowBounds ?? Effect.void,
     dispatchMenuAction: () => Effect.void,

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -48,7 +48,7 @@ export class DesktopLifecycle extends Context.Service<
   {
     readonly relaunch: (
       reason: string,
-    ) => Effect.Effect<void, never, DesktopLifecycleRuntimeServices>;
+    ) => Effect.Effect<void, DesktopLifecycleRelaunchError, DesktopLifecycleRuntimeServices>;
     readonly register: Effect.Effect<
       void,
       never,
@@ -165,6 +165,18 @@ export const make = DesktopLifecycle.of({
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
     const state = yield* DesktopState.DesktopState;
     yield* logLifecycleInfo("desktop relaunch requested", { reason });
+    if (!environment.isDevelopment) {
+      yield* electronApp
+        .relaunch({
+          execPath: process.execPath,
+          args: process.argv.slice(1),
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.fail(new DesktopLifecycleRelaunchError({ reason, cause })),
+          ),
+        );
+    }
     yield* Effect.gen(function* () {
       yield* Effect.yieldNow;
       yield* Ref.set(state.quitting, true);
@@ -173,18 +185,13 @@ export const make = DesktopLifecycle.of({
         yield* electronApp.exit(75);
         return;
       }
-      yield* electronApp.relaunch({
-        execPath: process.execPath,
-        args: process.argv.slice(1),
-      });
       yield* electronApp.exit(0);
     }).pipe(
       Effect.catchCause((cause) => {
         const error = new DesktopLifecycleRelaunchError({ reason, cause });
-        return logLifecycleError(error.message, { error });
+        return Effect.fail(error);
       }),
-      Effect.forkDetach,
-      Effect.asVoid,
+      Effect.tapError((error) => logLifecycleError(error.message, { error })),
     );
   }),
   register: Effect.gen(function* () {

--- a/apps/desktop/src/app/DesktopRunningLocalServers.test.ts
+++ b/apps/desktop/src/app/DesktopRunningLocalServers.test.ts
@@ -1,0 +1,261 @@
+import * as NodePath from "@effect/platform-node/NodePath";
+import { EnvironmentId } from "@t3tools/contracts";
+import { deriveServerRuntimeStatePath } from "@t3tools/shared/serverRuntimeState";
+import { assert, describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import { make } from "./DesktopRunningLocalServers.ts";
+
+const textEncoder = new TextEncoder();
+const baseDir = "/test/.t3";
+const environmentId = EnvironmentId.make("environment-local");
+const descriptor = {
+  environmentId,
+  label: "Local development server",
+  platform: { os: "linux", arch: "x64" },
+  serverVersion: "0.0.28",
+  capabilities: { repositoryIdentity: true },
+} as const;
+
+const runtimeStatePath = (variant: "userdata" | "dev") =>
+  deriveServerRuntimeStatePath({
+    baseDir,
+    variant,
+    joinPath: (...segments) => segments.join("/"),
+  });
+
+const runtimeState = (input: { readonly pid: number; readonly origin: string }) =>
+  JSON.stringify({
+    version: 1,
+    pid: input.pid,
+    port: Number(new URL(input.origin).port),
+    origin: input.origin,
+    startedAt: "2026-01-01T00:00:00.000Z",
+  });
+
+const fakeFileSystemLayer = (files: ReadonlyMap<string, string>) =>
+  FileSystem.layerNoop({
+    readFileString: (path) => {
+      const value = files.get(path);
+      return value === undefined
+        ? Effect.fail(
+            PlatformError.systemError({
+              _tag: "NotFound",
+              module: "FileSystem",
+              method: "readFileString",
+              pathOrDescriptor: path,
+            }),
+          )
+        : Effect.succeed(value);
+    },
+  });
+
+const makeProcess = (input: {
+  readonly stdout: string;
+  readonly stderr?: string;
+  readonly exitCode?: number;
+}) =>
+  ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(123),
+    stdout: Stream.make(textEncoder.encode(input.stdout)),
+    stderr: input.stderr ? Stream.make(textEncoder.encode(input.stderr)) : Stream.empty,
+    all: Stream.empty,
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(input.exitCode ?? 0)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    stdin: Sink.drain,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    unref: Effect.succeed(Effect.void),
+  });
+
+const makeTestService = (input: {
+  readonly files: ReadonlyMap<string, string>;
+  readonly probe?: typeof descriptor | null;
+  readonly processIsAlive?: (pid: number) => boolean;
+  readonly spawner?: ChildProcessSpawner.ChildProcessSpawner["Service"];
+}) =>
+  make({
+    baseDir,
+    backendEntryPath: "/bundle/apps/server/dist/bin.mjs",
+    backendCwd: "/home/user",
+    executablePath: "/bundle/electron",
+    probeEnvironment: () => Effect.succeed(input.probe === undefined ? descriptor : input.probe),
+    processIsAlive: input.processIsAlive ?? (() => true),
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        fakeFileSystemLayer(input.files),
+        NodePath.layer,
+        Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          input.spawner ?? ChildProcessSpawner.make(() => Effect.die("unexpected pairing command")),
+        ),
+      ),
+    ),
+  );
+
+describe("DesktopRunningLocalServers", () => {
+  it.effect("discovers runtime state and confirms its persisted environment identity", () => {
+    const statePath = runtimeStatePath("userdata");
+    return Effect.gen(function* () {
+      const service = yield* makeTestService({
+        files: new Map([
+          [statePath, runtimeState({ pid: 42, origin: "http://127.0.0.1:3773" })],
+          ["/test/.t3/userdata/environment-id", environmentId],
+        ]),
+      });
+
+      expect(yield* service.discover).toEqual([
+        {
+          statePath,
+          baseDir,
+          variant: "userdata",
+          pid: 42,
+          httpBaseUrl: "http://127.0.0.1:3773",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          environmentId,
+          label: descriptor.label,
+        },
+      ]);
+    });
+  });
+
+  it.effect(
+    "skips dead processes before probing and descriptors for another state directory",
+    () => {
+      const userdataPath = runtimeStatePath("userdata");
+      const devPath = runtimeStatePath("dev");
+      let probeCount = 0;
+      return Effect.gen(function* () {
+        const service = yield* make({
+          baseDir,
+          backendEntryPath: "/bundle/apps/server/dist/bin.mjs",
+          backendCwd: "/home/user",
+          executablePath: "/bundle/electron",
+          probeEnvironment: () => {
+            probeCount += 1;
+            return Effect.succeed({
+              ...descriptor,
+              environmentId: EnvironmentId.make("another-environment"),
+            });
+          },
+          processIsAlive: (pid) => pid !== 41,
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              fakeFileSystemLayer(
+                new Map([
+                  [userdataPath, runtimeState({ pid: 41, origin: "http://127.0.0.1:3773" })],
+                  ["/test/.t3/userdata/environment-id", environmentId],
+                  [devPath, runtimeState({ pid: 42, origin: "http://127.0.0.1:3774" })],
+                  ["/test/.t3/dev/environment-id", environmentId],
+                ]),
+              ),
+              NodePath.layer,
+              Layer.succeed(
+                ChildProcessSpawner.ChildProcessSpawner,
+                ChildProcessSpawner.make(() => Effect.die("unexpected pairing command")),
+              ),
+            ),
+          ),
+        );
+
+        expect(yield* service.discover).toEqual([]);
+        expect(probeCount).toBe(1);
+      });
+    },
+  );
+
+  it.effect("pairs through the bundled CLI and validates its JSON result", () => {
+    const statePath = runtimeStatePath("userdata");
+    let command: ChildProcess.StandardCommand | null = null;
+    const spawner = ChildProcessSpawner.make((candidate) => {
+      assert.equal(candidate._tag, "StandardCommand");
+      if (candidate._tag === "StandardCommand") command = candidate;
+      return Effect.succeed(
+        makeProcess({
+          stdout: JSON.stringify({
+            pairingUrl: "http://127.0.0.1:3773/pair#token=PAIRCODE",
+            token: "PAIRCODE",
+            expiresAt: "2099-01-01T00:00:00.000Z",
+            origin: "http://127.0.0.1:3773",
+            environmentId,
+            label: descriptor.label,
+          }),
+        }),
+      );
+    });
+
+    return Effect.gen(function* () {
+      const service = yield* makeTestService({
+        files: new Map([
+          [statePath, runtimeState({ pid: 42, origin: "http://127.0.0.1:3773" })],
+          ["/test/.t3/userdata/environment-id", environmentId],
+        ]),
+        spawner,
+      });
+
+      expect(yield* service.pairLocalServer(environmentId)).toEqual({
+        pairingUrl: "http://127.0.0.1:3773/pair#token=PAIRCODE",
+        pairingExpiresAt: "2099-01-01T00:00:00.000Z",
+      });
+      expect(command?.command).toBe("/bundle/electron");
+      expect(command?.args).toEqual([
+        "/bundle/apps/server/dist/bin.mjs",
+        "pair",
+        "--json",
+        "--label",
+        "T3 Code Desktop",
+        "--base-dir",
+        baseDir,
+      ]);
+      expect(command?.options.env).toEqual({ ELECTRON_RUN_AS_NODE: "1" });
+    });
+  });
+
+  it.effect("rejects malformed JSON and pairing URLs that retarget the credential", () => {
+    const statePath = runtimeStatePath("userdata");
+    const files = new Map([
+      [statePath, runtimeState({ pid: 42, origin: "http://127.0.0.1:3773" })],
+      ["/test/.t3/userdata/environment-id", environmentId],
+    ]);
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(
+        makeProcess({
+          stdout: JSON.stringify({
+            pairingUrl:
+              "http://127.0.0.1:3773/pair?host=https%3A%2F%2Fattacker.example#token=PAIRCODE",
+            token: "PAIRCODE",
+            expiresAt: "2099-01-01T00:00:00.000Z",
+            origin: "http://127.0.0.1:3773",
+            environmentId,
+            label: descriptor.label,
+          }),
+        }),
+      ),
+    );
+    return Effect.gen(function* () {
+      const service = yield* makeTestService({ files, spawner });
+      const invalidUrl = yield* service.pairLocalServer(environmentId).pipe(Effect.flip);
+      expect(invalidUrl.reason).toBe("request_failed");
+      expect(invalidUrl.detail).toContain("invalid pairing link");
+
+      const malformedService = yield* makeTestService({
+        files,
+        spawner: ChildProcessSpawner.make(() =>
+          Effect.succeed(makeProcess({ stdout: "not-json" })),
+        ),
+      });
+      const malformed = yield* malformedService.pairLocalServer(environmentId).pipe(Effect.flip);
+      expect(malformed.reason).toBe("request_failed");
+      expect(malformed.detail).toContain("invalid JSON");
+    });
+  });
+});

--- a/apps/desktop/src/app/DesktopRunningLocalServers.ts
+++ b/apps/desktop/src/app/DesktopRunningLocalServers.ts
@@ -1,0 +1,302 @@
+import { fetchRemoteEnvironmentDescriptor } from "@t3tools/client-runtime/environment";
+import {
+  type EnvironmentId,
+  type ExecutionEnvironmentDescriptor,
+  LocalServerPairCommandOutput,
+  type LocalServerPairingResult,
+  type RunningLocalServer,
+} from "@t3tools/contracts";
+import {
+  deriveServerRuntimeStatePath,
+  isProcessAlive,
+  readPersistedServerRuntimeState,
+  type ServerRuntimeStateVariant,
+} from "@t3tools/shared/serverRuntimeState";
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+
+const LOCAL_SERVER_PAIRING_TIMEOUT = Duration.seconds(10);
+const SERVER_RUNTIME_STATE_VARIANTS = ["userdata", "dev"] as const;
+const decodePairCommandOutput = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(LocalServerPairCommandOutput),
+);
+
+export class LocalServerPairingError extends Schema.TaggedErrorClass<LocalServerPairingError>()(
+  "LocalServerPairingError",
+  {
+    reason: Schema.Literals(["not_found", "request_failed"]),
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return this.detail;
+  }
+}
+
+const isLocalServerPairingError = Schema.is(LocalServerPairingError);
+
+type ProbeEnvironment = (
+  httpBaseUrl: string,
+) => Effect.Effect<ExecutionEnvironmentDescriptor | null>;
+
+export interface DesktopRunningLocalServersOptions {
+  readonly baseDir: string;
+  readonly backendEntryPath: string;
+  readonly backendCwd: string;
+  readonly executablePath: string;
+  readonly probeEnvironment: ProbeEnvironment;
+  readonly processIsAlive?: (pid: number) => boolean;
+}
+
+export class DesktopRunningLocalServers extends Context.Service<
+  DesktopRunningLocalServers,
+  {
+    readonly discover: Effect.Effect<ReadonlyArray<RunningLocalServer>>;
+    readonly pairLocalServer: (
+      environmentId: EnvironmentId,
+    ) => Effect.Effect<LocalServerPairingResult, LocalServerPairingError>;
+  }
+>()("@t3tools/desktop/app/DesktopRunningLocalServers") {}
+
+export function isValidLocalServerPairingUrl(input: {
+  readonly pairingUrl: string;
+  readonly httpBaseUrl: string;
+  readonly token: string;
+}): boolean {
+  try {
+    const pairingUrl = new URL(input.pairingUrl);
+    const httpBaseUrl = new URL(input.httpBaseUrl);
+    const token = new URLSearchParams(pairingUrl.hash.slice(1)).get("token")?.trim();
+    return (
+      pairingUrl.origin === httpBaseUrl.origin &&
+      pairingUrl.username === "" &&
+      pairingUrl.password === "" &&
+      pairingUrl.pathname === "/pair" &&
+      pairingUrl.search === "" &&
+      token !== undefined &&
+      token.length > 0 &&
+      token === input.token
+    );
+  } catch {
+    return false;
+  }
+}
+
+function parseUrlOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+const makePairCommand = (options: DesktopRunningLocalServersOptions, server: RunningLocalServer) =>
+  ChildProcess.make(
+    options.executablePath,
+    [
+      options.backendEntryPath,
+      "pair",
+      "--json",
+      "--label",
+      "T3 Code Desktop",
+      "--base-dir",
+      server.baseDir,
+    ],
+    {
+      cwd: options.backendCwd,
+      env: { ELECTRON_RUN_AS_NODE: "1" },
+      extendEnv: true,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      killSignal: "SIGTERM",
+      forceKillAfter: Duration.seconds(2),
+    },
+  );
+
+export const make = Effect.fn("desktop.runningLocalServers.make")(function* (
+  options: DesktopRunningLocalServersOptions,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const processIsAlive = options.processIsAlive ?? isProcessAlive;
+
+  const discover = Effect.gen(function* () {
+    const discovered = yield* Effect.forEach(
+      SERVER_RUNTIME_STATE_VARIANTS,
+      (variant) =>
+        Effect.gen(function* () {
+          const statePath = deriveServerRuntimeStatePath({
+            baseDir: options.baseDir,
+            variant,
+            joinPath: path.join,
+          });
+          const state = yield* readPersistedServerRuntimeState(statePath).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+          );
+          if (Option.isNone(state) || state.value.pid <= 0 || !processIsAlive(state.value.pid)) {
+            return null;
+          }
+
+          const persistedEnvironmentId = yield* fileSystem
+            .readFileString(path.join(path.dirname(statePath), "environment-id"))
+            .pipe(
+              Effect.map((value) => value.trim()),
+              Effect.option,
+            );
+          if (Option.isNone(persistedEnvironmentId) || persistedEnvironmentId.value.length === 0) {
+            return null;
+          }
+
+          const descriptor = yield* options.probeEnvironment(state.value.origin);
+          if (descriptor === null || descriptor.environmentId !== persistedEnvironmentId.value) {
+            return null;
+          }
+
+          return {
+            statePath,
+            baseDir: options.baseDir,
+            variant,
+            pid: state.value.pid,
+            httpBaseUrl: state.value.origin,
+            startedAt: state.value.startedAt,
+            environmentId: descriptor.environmentId,
+            label: descriptor.label,
+          } satisfies RunningLocalServer;
+        }),
+      { concurrency: "unbounded" },
+    );
+
+    const byEnvironmentId = new Map<EnvironmentId, RunningLocalServer>();
+    for (const server of discovered) {
+      if (server !== null && !byEnvironmentId.has(server.environmentId)) {
+        byEnvironmentId.set(server.environmentId, server);
+      }
+    }
+    return [...byEnvironmentId.values()].toSorted(
+      (left, right) =>
+        left.label.localeCompare(right.label) || left.statePath.localeCompare(right.statePath),
+    );
+  });
+
+  const runPairCommand = (server: RunningLocalServer) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* spawner.spawn(makePairCommand(options, server));
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            handle.stdout.pipe(Stream.decodeText(), Stream.mkString),
+            handle.stderr.pipe(Stream.decodeText(), Stream.mkString),
+            handle.exitCode,
+          ],
+          { concurrency: "unbounded" },
+        );
+        if (exitCode !== ChildProcessSpawner.ExitCode(0)) {
+          return yield* new LocalServerPairingError({
+            reason: "request_failed",
+            detail:
+              stderr.trim() || `The local pairing command exited with code ${String(exitCode)}.`,
+          });
+        }
+        return stdout.trim();
+      }),
+    ).pipe(
+      Effect.timeout(LOCAL_SERVER_PAIRING_TIMEOUT),
+      Effect.mapError((cause) =>
+        isLocalServerPairingError(cause)
+          ? cause
+          : new LocalServerPairingError({
+              reason: "request_failed",
+              detail: "Could not run the bundled T3 Code pairing command.",
+              cause,
+            }),
+      ),
+    );
+
+  const pairLocalServer = Effect.fn("desktop.runningLocalServers.pair")(function* (
+    environmentId: EnvironmentId,
+  ) {
+    const servers = yield* discover;
+    const server = servers.find((candidate) => candidate.environmentId === environmentId);
+    if (server === undefined) {
+      return yield* new LocalServerPairingError({
+        reason: "not_found",
+        detail: "This local T3 Code server is no longer running.",
+      });
+    }
+
+    const rawOutput = yield* runPairCommand(server);
+    const output = yield* decodePairCommandOutput(rawOutput).pipe(
+      Effect.mapError(
+        (cause) =>
+          new LocalServerPairingError({
+            reason: "request_failed",
+            detail: "The local T3 Code pairing command returned invalid JSON.",
+            cause,
+          }),
+      ),
+    );
+
+    const outputOrigin = parseUrlOrigin(output.origin);
+    const discoveredOrigin = parseUrlOrigin(server.httpBaseUrl);
+    if (outputOrigin === null || discoveredOrigin === null) {
+      return yield* new LocalServerPairingError({
+        reason: "request_failed",
+        detail: "The local T3 Code pairing command returned an invalid server origin.",
+      });
+    }
+    if (
+      output.environmentId !== server.environmentId ||
+      outputOrigin !== discoveredOrigin ||
+      !isValidLocalServerPairingUrl({
+        pairingUrl: output.pairingUrl,
+        httpBaseUrl: server.httpBaseUrl,
+        token: output.token,
+      })
+    ) {
+      return yield* new LocalServerPairingError({
+        reason: "request_failed",
+        detail: "The local T3 Code pairing command returned an invalid pairing link.",
+      });
+    }
+
+    return {
+      pairingUrl: output.pairingUrl,
+      pairingExpiresAt: output.expiresAt,
+    } satisfies LocalServerPairingResult;
+  });
+
+  return DesktopRunningLocalServers.of({ discover, pairLocalServer });
+});
+
+export const layer = Layer.effect(
+  DesktopRunningLocalServers,
+  Effect.gen(function* () {
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    const httpClient = yield* HttpClient.HttpClient;
+    return yield* make({
+      baseDir: environment.baseDir,
+      backendEntryPath: environment.backendEntryPath,
+      backendCwd: environment.backendCwd,
+      executablePath: process.execPath,
+      probeEnvironment: (httpBaseUrl) =>
+        fetchRemoteEnvironmentDescriptor({ httpBaseUrl, timeoutMs: 2_000 }).pipe(
+          Effect.provideService(HttpClient.HttpClient, httpClient),
+          Effect.orElseSucceed(() => null),
+        ),
+    });
+  }),
+);

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -654,6 +654,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
   const state = yield* Ref.make(initialState);
+  const startRequestedRef = yield* Ref.make(false);
   const mutex = yield* Semaphore.make(1);
 
   const { logWarning: logInstanceWarning, logError: logInstanceError } =
@@ -693,6 +694,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
   const start: Effect.Effect<void> = Effect.suspend(() =>
     mutex.withPermits(1)(
       Effect.gen(function* () {
+        yield* Ref.set(startRequestedRef, true);
         const current = yield* Ref.get(state);
         if (Option.isSome(current.active)) {
           if (!current.desiredRunning) {
@@ -1156,7 +1158,11 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
       Effect.map(Option.getOrElse(() => false)),
     );
 
-  yield* Effect.addFinalizer(() => stop());
+  yield* Effect.addFinalizer(() =>
+    Ref.get(startRequestedRef).pipe(
+      Effect.flatMap((startRequested) => (startRequested ? stop() : Effect.void)),
+    ),
+  );
 
   return {
     id: spec.id,

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -93,6 +93,7 @@ function makePoolLayer(
           activate: Effect.die("unexpected window activate"),
           createMainIfBackendReady: Effect.die("unexpected window create"),
           showConnectingSplash: Effect.void,
+          handleRendererReady: Effect.void,
           handleBackendReady: () => Effect.void,
           handleBackendNotReady: Effect.void,
           flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -251,6 +251,7 @@ describe("DesktopServerExposure", () => {
       get: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
       load: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
       setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+      setBackendMode: () => Effect.die("unexpected backend mode update"),
       setServerExposureMode: () => Effect.fail(settingsFailure),
       setTailscaleServe: () => Effect.fail(settingsFailure),
       setUpdateChannel: () => Effect.die("unexpected update channel change"),

--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -36,8 +36,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code-dev",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3774/"),
             clerkFrontendApiHostname: "clerk.t3.codes",
           });
           assert.isDefined(handler);
@@ -100,8 +100,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
           return yield* Effect.promise(() => handler!(new Request("t3code://other/")));
@@ -128,8 +128,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code-dev",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:5733/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
           return yield* Effect.promise(() => handler!(new Request("t3code-dev://app/")));
@@ -152,8 +152,8 @@ describe("ElectronProtocol", () => {
       const error = yield* Effect.scoped(
         protocol.registerDesktopProtocol({
           scheme: "t3code-dev",
+          source: "proxy",
           targetOrigin: new URL("http://127.0.0.1:3773/"),
-          backendOrigin: new URL("http://127.0.0.1:3774/"),
           clerkFrontendApiHostname: undefined,
         }),
       ).pipe(Effect.flip);
@@ -177,8 +177,8 @@ describe("ElectronProtocol", () => {
         Effect.scoped(
           protocol.registerDesktopProtocol({
             scheme: "t3code",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           }),
         ),
@@ -198,8 +198,8 @@ describe("ElectronProtocol", () => {
   it("keeps executable sources host-restricted while allowing runtime network resources", () => {
     const policy = ElectronProtocol.makeDesktopContentSecurityPolicy({
       scheme: "t3code",
+      source: "proxy",
       targetOrigin: new URL("http://127.0.0.1:3773/"),
-      backendOrigin: new URL("http://127.0.0.1:3773/"),
       clerkFrontendApiHostname: "clerk.t3.codes",
     });
     const directives = Object.fromEntries(
@@ -228,4 +228,117 @@ describe("ElectronProtocol", () => {
     assert.deepEqual(directives["media-src"], ["'self'", "t3code:", "blob:", "http:", "https:"]);
     assert.deepEqual(directives["font-src"], ["'self'", "t3code:", "data:"]);
   });
+
+  it.effect("serves packaged assets, SPA routes, HEAD requests, and CSP", () =>
+    Effect.gen(function* () {
+      let handler: ((request: Request) => Promise<Response>) | undefined;
+      handleMock.mockImplementation((_scheme, nextHandler) => {
+        handler = nextHandler;
+      });
+      netFetchMock.mockImplementation(async (url: string) => {
+        if (url.endsWith("/index.html")) {
+          return new Response("<main>T3 Code</main>", { status: 200 });
+        }
+        if (url.endsWith("/assets/app-123.js")) {
+          return new Response("export {};", { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const protocol = yield* ElectronProtocol.ElectronProtocol;
+          yield* protocol.registerDesktopProtocol({
+            scheme: "t3code",
+            source: "static",
+            staticRoot: "/opt/t3/apps/server/dist/client",
+            clerkFrontendApiHostname: undefined,
+          });
+          assert.isDefined(handler);
+
+          const root = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(root.status, 200);
+          assert.equal(root.headers.get("content-type"), "text/html; charset=utf-8");
+          assert.include(root.headers.get("content-security-policy") ?? "", "default-src 'self'");
+          assert.equal(yield* Effect.promise(() => root.text()), "<main>T3 Code</main>");
+
+          const asset = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/assets/app-123.js")),
+          );
+          assert.equal(asset.headers.get("content-type"), "text/javascript; charset=utf-8");
+          assert.equal(yield* Effect.promise(() => asset.text()), "export {};");
+
+          const route = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/settings/connections", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(route.status, 200);
+          assert.equal(yield* Effect.promise(() => route.text()), "<main>T3 Code</main>");
+
+          const head = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/assets/app-123.js", {
+                method: "HEAD",
+              }),
+            ),
+          );
+          assert.equal(head.status, 200);
+          assert.equal(yield* Effect.promise(() => head.text()), "");
+        }),
+      );
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
+
+  it.effect("does not fall back missing assets and rejects unsafe static requests", () =>
+    Effect.gen(function* () {
+      let handler: ((request: Request) => Promise<Response>) | undefined;
+      handleMock.mockImplementation((_scheme, nextHandler) => {
+        handler = nextHandler;
+      });
+      netFetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const protocol = yield* ElectronProtocol.ElectronProtocol;
+          yield* protocol.registerDesktopProtocol({
+            scheme: "t3code",
+            source: "static",
+            staticRoot: "/opt/t3/apps/server/dist/client",
+            clerkFrontendApiHostname: undefined,
+          });
+          assert.isDefined(handler);
+
+          const missingAsset = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/assets/missing.js", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(missingAsset.status, 404);
+          assert.equal(netFetchMock.mock.calls.length, 1);
+
+          const traversal = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/%2e%2e%2fsecret.txt")),
+          );
+          assert.equal(traversal.status, 403);
+
+          const unsupported = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/", { method: "POST" })),
+          );
+          assert.equal(unsupported.status, 405);
+          assert.equal(unsupported.headers.get("allow"), "GET, HEAD");
+        }),
+      );
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
 });

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off - Electron static protocol handlers require synchronous platform path validation.
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -5,6 +6,8 @@ import * as NodeTimersPromises from "node:timers/promises";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
 
 import * as Electron from "electron";
 
@@ -48,12 +51,22 @@ export class ElectronProtocolUnregistrationError extends Schema.TaggedErrorClass
   }
 }
 
-export interface DesktopProtocolRegistrationInput {
+interface DesktopProtocolRegistrationBase {
   readonly scheme: string;
-  readonly targetOrigin: URL;
-  readonly backendOrigin: URL;
   readonly clerkFrontendApiHostname: string | undefined;
 }
+
+export type DesktopProtocolRegistrationInput = DesktopProtocolRegistrationBase &
+  (
+    | {
+        readonly source: "proxy";
+        readonly targetOrigin: URL;
+      }
+    | {
+        readonly source: "static";
+        readonly staticRoot: string;
+      }
+  );
 
 export class ElectronProtocol extends Context.Service<
   ElectronProtocol,
@@ -140,6 +153,143 @@ const registerDesktopSchemePrivileges = Effect.sync(registerDesktopSchemePrivile
 
 export const layerSchemePrivileges = Layer.effectDiscard(registerDesktopSchemePrivileges);
 
+const STATIC_CONTENT_TYPES: Readonly<Record<string, string>> = {
+  ".css": "text/css; charset=utf-8",
+  ".gif": "image/gif",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+type StaticPathResolution =
+  | { readonly _tag: "Invalid"; readonly status: 400 | 403 }
+  | { readonly _tag: "Resolved"; readonly path: string; readonly relativePath: string };
+
+export function resolveDesktopStaticPath(
+  staticRoot: string,
+  encodedPathname: string,
+): StaticPathResolution {
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(encodedPathname);
+  } catch {
+    return { _tag: "Invalid", status: 400 };
+  }
+
+  if (
+    decodedPathname.includes("\0") ||
+    decodedPathname.includes("\\") ||
+    /^[a-zA-Z]:/u.test(decodedPathname.replace(/^\/+/u, ""))
+  ) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  const segments = decodedPathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  const relativePath = segments.length === 0 ? "index.html" : segments.join("/");
+  const normalizedRoot = NodePath.resolve(staticRoot);
+  const resolvedPath = NodePath.resolve(normalizedRoot, relativePath);
+  const relativeToRoot = NodePath.relative(normalizedRoot, resolvedPath);
+  if (
+    relativeToRoot === ".." ||
+    relativeToRoot.startsWith(`..${NodePath.sep}`) ||
+    NodePath.isAbsolute(relativeToRoot)
+  ) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  return {
+    _tag: "Resolved",
+    path: resolvedPath,
+    relativePath,
+  };
+}
+
+function shouldUseSpaFallback(request: Request, relativePath: string): boolean {
+  if (NodePath.extname(relativePath) !== "") {
+    return false;
+  }
+  const accept = request.headers.get("accept") ?? "";
+  const mode = request.headers.get("sec-fetch-mode") ?? "";
+  return mode === "navigate" || accept.includes("text/html");
+}
+
+async function fetchStaticFile(path: string): Promise<Response> {
+  try {
+    return await Electron.net.fetch(NodeURL.pathToFileURL(path).href, { method: "GET" });
+  } catch {
+    return new Response(null, { status: 404 });
+  }
+}
+
+function withStaticResponseHeaders(response: Response, path: string, headOnly: boolean): Response {
+  const headers = new Headers(response.headers);
+  const contentType = STATIC_CONTENT_TYPES[NodePath.extname(path).toLowerCase()];
+  if (contentType !== undefined) {
+    headers.set("Content-Type", contentType);
+  }
+  return new Response(headOnly ? null : response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function serveDesktopStaticRequest(
+  request: Request,
+  staticRoot: string,
+  contentSecurityPolicy: string,
+): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  if (requestUrl.host !== DESKTOP_HOST) {
+    return withContentSecurityPolicy(new Response(null, { status: 404 }), contentSecurityPolicy);
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return withContentSecurityPolicy(
+      new Response(null, {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+      }),
+      contentSecurityPolicy,
+    );
+  }
+
+  const resolution = resolveDesktopStaticPath(staticRoot, requestUrl.pathname);
+  if (resolution._tag === "Invalid") {
+    return withContentSecurityPolicy(
+      new Response(null, { status: resolution.status }),
+      contentSecurityPolicy,
+    );
+  }
+
+  let response = await fetchStaticFile(resolution.path);
+  let responsePath = resolution.path;
+  if (response.status === 404 && shouldUseSpaFallback(request, resolution.relativePath)) {
+    // Resolve the shell through the same normalization as asset paths so a
+    // relative or non-normalized staticRoot still falls back correctly.
+    responsePath = NodePath.resolve(staticRoot, "index.html");
+    response = await fetchStaticFile(responsePath);
+  }
+
+  return withContentSecurityPolicy(
+    withStaticResponseHeaders(response, responsePath, request.method === "HEAD"),
+    contentSecurityPolicy,
+  );
+}
+
 async function proxyRequest(
   request: Request,
   targetOrigin: URL,
@@ -217,9 +367,12 @@ export const make = Effect.gen(function* () {
       yield* Effect.acquireRelease(
         Effect.try({
           try: () => {
-            Electron.protocol.handle(input.scheme, (request) =>
-              proxyRequest(request, input.targetOrigin, contentSecurityPolicy),
-            );
+            Electron.protocol.handle(input.scheme, (request) => {
+              if (input.source === "static") {
+                return serveDesktopStaticRequest(request, input.staticRoot, contentSecurityPolicy);
+              }
+              return proxyRequest(request, input.targetOrigin, contentSecurityPolicy);
+            });
           },
           catch: (cause) => new ElectronProtocolRegistrationError({ scheme: input.scheme, cause }),
         }).pipe(Effect.andThen(Ref.set(registered, true))),

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -2,6 +2,8 @@ import * as Effect from "effect/Effect";
 
 import * as DesktopIpc from "./DesktopIpc.ts";
 import { getClientSettings, setClientSettings } from "./methods/clientSettings.ts";
+import { getBackendModeState, setBackendMode } from "./methods/backendMode.ts";
+import { discoverLocalServers, pairLocalServer } from "./methods/localServerDiscovery.ts";
 import {
   clearConnectionCatalog,
   getConnectionCatalog,
@@ -57,9 +59,13 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
 
   yield* ipc.handleSync(getAppBranding);
   yield* ipc.handleSync(getSystemLocale);
+  yield* ipc.handleSync(getBackendModeState);
   yield* ipc.handleSync(getWindowFullscreenState);
   yield* ipc.handleSync(getLocalEnvironmentBootstraps);
   yield* ipc.handle(getLocalEnvironmentBearerToken);
+  yield* ipc.handle(discoverLocalServers);
+  yield* ipc.handle(pairLocalServer);
+  yield* ipc.handle(setBackendMode);
 
   yield* ipc.handle(getClientSettings);
   yield* ipc.handle(setClientSettings);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -20,9 +20,13 @@ export const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 export const UPDATE_CHECK_CHANNEL = "desktop:update-check";
 export const GET_APP_BRANDING_CHANNEL = "desktop:get-app-branding";
 export const GET_SYSTEM_LOCALE_CHANNEL = "desktop:get-system-locale";
+export const GET_BACKEND_MODE_STATE_CHANNEL = "desktop:get-backend-mode-state";
+export const SET_BACKEND_MODE_CHANNEL = "desktop:set-backend-mode";
 export const GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL = "desktop:get-local-environment-bootstraps";
 export const GET_LOCAL_ENVIRONMENT_BEARER_TOKEN_CHANNEL =
   "desktop:get-local-environment-bearer-token";
+export const DISCOVER_LOCAL_SERVERS_CHANNEL = "desktop:discover-local-servers";
+export const PAIR_LOCAL_SERVER_CHANNEL = "desktop:pair-local-server";
 export const GET_CLIENT_SETTINGS_CHANNEL = "desktop:get-client-settings";
 export const SET_CLIENT_SETTINGS_CHANNEL = "desktop:set-client-settings";
 export const GET_CONNECTION_CATALOG_CHANNEL = "desktop:get-connection-catalog";

--- a/apps/desktop/src/ipc/methods/backendMode.test.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.test.ts
@@ -1,0 +1,84 @@
+import { DesktopBackendModeStateSchema } from "@t3tools/contracts";
+import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
+import * as DesktopLifecycle from "../../app/DesktopLifecycle.ts";
+import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
+import { setBackendMode } from "./backendMode.ts";
+
+const decodeBackendModeState = Schema.decodeUnknownEffect(DesktopBackendModeStateSchema);
+
+const unusedLifecycleRuntimeLayer =
+  Layer.empty as Layer.Layer<DesktopLifecycle.DesktopLifecycleRuntimeServices>;
+
+describe("backend mode IPC", () => {
+  it.effect("reports the saved mode while a successful relaunch is pending", () => {
+    const relaunchReasons: Array<string> = [];
+    const layer = Layer.mergeAll(
+      DesktopBackendMode.layerTest(),
+      DesktopAppSettings.layerTest(),
+      Layer.succeed(
+        DesktopLifecycle.DesktopLifecycle,
+        DesktopLifecycle.DesktopLifecycle.of({
+          relaunch: (reason) => Effect.sync(() => relaunchReasons.push(reason)),
+          register: Effect.void,
+        }),
+      ),
+      unusedLifecycleRuntimeLayer,
+    );
+
+    return Effect.gen(function* () {
+      const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+      const settings = yield* DesktopAppSettings.DesktopAppSettings;
+      yield* launchMode.latch("managed");
+
+      const state = yield* setBackendMode
+        .handler("client-only")
+        .pipe(Effect.flatMap(decodeBackendModeState));
+
+      assert.deepEqual(state, {
+        effectiveMode: "managed",
+        configuredMode: "client-only",
+        cliOverride: null,
+        source: "settings",
+      });
+      assert.deepEqual(relaunchReasons, ["backendMode=client-only"]);
+      assert.equal((yield* settings.get).backendMode, "client-only");
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("restores the configured mode when a packaged relaunch cannot be scheduled", () => {
+    const relaunchError = new DesktopLifecycle.DesktopLifecycleRelaunchError({
+      reason: "backendMode=client-only",
+      cause: Cause.die(new Error("relaunch failed")),
+    });
+    const layer = Layer.mergeAll(
+      DesktopBackendMode.layerTest(),
+      DesktopAppSettings.layerTest(),
+      Layer.succeed(
+        DesktopLifecycle.DesktopLifecycle,
+        DesktopLifecycle.DesktopLifecycle.of({
+          relaunch: () => Effect.fail(relaunchError),
+          register: Effect.void,
+        }),
+      ),
+      unusedLifecycleRuntimeLayer,
+    );
+
+    return Effect.gen(function* () {
+      const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+      const settings = yield* DesktopAppSettings.DesktopAppSettings;
+      yield* launchMode.latch("managed");
+      const error = yield* setBackendMode
+        .handler("client-only")
+        .pipe(Effect.flatMap(decodeBackendModeState), Effect.flip);
+
+      assert.strictEqual(error, relaunchError);
+      assert.equal((yield* settings.get).backendMode, "managed");
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/desktop/src/ipc/methods/backendMode.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.ts
@@ -1,0 +1,66 @@
+import {
+  DesktopBackendModeSchema,
+  DesktopBackendModeStateSchema,
+  type DesktopBackendModeState,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
+import * as DesktopLifecycle from "../../app/DesktopLifecycle.ts";
+import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
+import * as IpcChannels from "../channels.ts";
+
+const readBackendModeState: Effect.Effect<
+  DesktopBackendModeState,
+  never,
+  DesktopBackendMode.DesktopBackendMode | DesktopAppSettings.DesktopAppSettings
+> = Effect.gen(function* () {
+  const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+  const settings = yield* DesktopAppSettings.DesktopAppSettings;
+  const launchState = yield* launchMode.get;
+  const configuredMode = (yield* settings.get).backendMode;
+  return {
+    ...launchState,
+    configuredMode,
+  };
+});
+
+export const getBackendModeState = DesktopIpc.makeSyncIpcMethod({
+  channel: IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL,
+  result: DesktopBackendModeStateSchema,
+  handler: Effect.fn("desktop.ipc.backendMode.get")(function* () {
+    return yield* readBackendModeState;
+  }),
+});
+
+export const setBackendMode = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.SET_BACKEND_MODE_CHANNEL,
+  payload: DesktopBackendModeSchema,
+  result: DesktopBackendModeStateSchema,
+  handler: Effect.fn("desktop.ipc.backendMode.set")(function* (mode) {
+    const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+    const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+    const settings = yield* DesktopAppSettings.DesktopAppSettings;
+    const previousMode = (yield* settings.get).backendMode;
+    const change = yield* settings.setBackendMode(mode);
+    const launchState = yield* launchMode.get;
+    const relaunchRequired =
+      change.changed &&
+      launchState.cliOverride === null &&
+      launchState.effectiveMode !== change.settings.backendMode;
+    if (relaunchRequired) {
+      yield* lifecycle
+        .relaunch(`backendMode=${mode}`)
+        .pipe(Effect.tapError(() => settings.setBackendMode(previousMode)));
+      return {
+        ...launchState,
+        configuredMode: change.settings.backendMode,
+      };
+    }
+    return {
+      ...launchState,
+      configuredMode: change.settings.backendMode,
+    };
+  }),
+});

--- a/apps/desktop/src/ipc/methods/localServerDiscovery.ts
+++ b/apps/desktop/src/ipc/methods/localServerDiscovery.ts
@@ -1,0 +1,27 @@
+import { EnvironmentId, LocalServerPairingResult, RunningLocalServer } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import * as DesktopRunningLocalServers from "../../app/DesktopRunningLocalServers.ts";
+import * as IpcChannels from "../channels.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
+
+export const discoverLocalServers = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.DISCOVER_LOCAL_SERVERS_CHANNEL,
+  payload: Schema.Void,
+  result: Schema.Array(RunningLocalServer),
+  handler: Effect.fn("desktop.ipc.localServerDiscovery.discover")(function* () {
+    const discovery = yield* DesktopRunningLocalServers.DesktopRunningLocalServers;
+    return yield* discovery.discover;
+  }),
+});
+
+export const pairLocalServer = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PAIR_LOCAL_SERVER_CHANNEL,
+  payload: EnvironmentId,
+  result: LocalServerPairingResult,
+  handler: Effect.fn("desktop.ipc.localServerDiscovery.pair")(function* (environmentId) {
+    const discovery = yield* DesktopRunningLocalServers.DesktopRunningLocalServers;
+    return yield* discovery.pairLocalServer(environmentId);
+  }),
+});

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -8,6 +8,7 @@ import type * as Electron from "electron";
 
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import {
@@ -70,7 +71,14 @@ describe("getLocalEnvironmentBootstraps", () => {
           bootstrapToken: "bootstrap-token",
         },
       ]);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([defaultWslInstance]))),
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([defaultWslInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    ),
   );
 
   it.effect("publishes a pending bootstrap only while a transient retry is scheduled", () => {
@@ -105,7 +113,14 @@ describe("getLocalEnvironmentBootstraps", () => {
           wsBaseUrl: null,
         },
       ]);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([retryingInstance])));
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([retryingInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    );
   });
 
   it.effect("omits a bounded transient bootstrap after retries stop", () => {
@@ -133,8 +148,30 @@ describe("getLocalEnvironmentBootstraps", () => {
     return Effect.gen(function* () {
       const result = yield* getLocalEnvironmentBootstraps.handler();
       assert.deepEqual(result, []);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([stoppedInstance])));
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([stoppedInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    );
   });
+
+  it.effect("returns no local bootstraps in client-only mode", () =>
+    Effect.gen(function* () {
+      const mode = yield* DesktopBackendMode.DesktopBackendMode;
+      yield* mode.latch("client-only");
+      assert.deepEqual(yield* getLocalEnvironmentBootstraps.handler(), []);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([defaultWslInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    ),
+  );
 });
 
 describe("getWindowFullscreenState", () => {

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -22,6 +22,7 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
 import * as DesktopLocalEnvironmentAuth from "../../backend/DesktopLocalEnvironmentAuth.ts";
 import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
@@ -89,6 +90,10 @@ export const getLocalEnvironmentBootstraps = DesktopIpc.makeSyncIpcMethod({
   channel: IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL,
   result: Schema.Array(DesktopEnvironmentBootstrapSchema),
   handler: Effect.fn("desktop.ipc.window.getLocalEnvironmentBootstraps")(function* () {
+    const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+    if ((yield* launchMode.get).effectiveMode === "client-only") {
+      return [];
+    }
     const pool = yield* DesktopBackendPool.DesktopBackendPool;
     const instances = yield* pool.list;
     const bootstraps: DesktopEnvironmentBootstrap[] = [];

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -33,8 +33,10 @@ import * as ElectronUpdater from "./electron/ElectronUpdater.ts";
 import * as ElectronWindow from "./electron/ElectronWindow.ts";
 import * as DesktopApp from "./app/DesktopApp.ts";
 import * as DesktopAppActivation from "./app/DesktopAppActivation.ts";
+import * as DesktopBackendMode from "./app/DesktopBackendMode.ts";
 import * as DesktopAppIdentity from "./app/DesktopAppIdentity.ts";
 import * as DesktopConnectionCatalogStore from "./app/DesktopConnectionCatalogStore.ts";
+import * as DesktopRunningLocalServers from "./app/DesktopRunningLocalServers.ts";
 import * as DesktopClerk from "./app/DesktopClerk.ts";
 import * as DesktopApplicationMenu from "./window/DesktopApplicationMenu.ts";
 import * as DesktopAssets from "./app/DesktopAssets.ts";
@@ -132,9 +134,11 @@ const electronLayer = Layer.mergeAll(
 const desktopFoundationLayer = Layer.mergeAll(
   DesktopState.layer,
   DesktopShutdown.layer,
+  DesktopBackendMode.layer,
   DesktopAppSettings.layer,
   DesktopClientSettings.layer,
   DesktopConnectionCatalogStore.layer.pipe(Layer.provideMerge(DesktopSavedEnvironments.layer)),
+  DesktopRunningLocalServers.layer,
   DesktopAssets.layer,
   DesktopObservability.layer,
 ).pipe(Layer.provideMerge(desktopEnvironmentLayer));

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -43,6 +43,22 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     const result = ipcRenderer.sendSync(IpcChannels.GET_SYSTEM_LOCALE_CHANNEL);
     return typeof result === "string" ? result : null;
   },
+  getBackendModeState: () => {
+    const result = ipcRenderer.sendSync(IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL);
+    if (typeof result !== "object" || result === null) {
+      // An unavailable mode handler means the renderer cannot safely assume
+      // that this process owns a backend. Fail closed into the connection-only
+      // routing path instead of trying to resolve t3code:// as an HTTP backend.
+      return {
+        effectiveMode: "client-only",
+        configuredMode: "client-only",
+        cliOverride: null,
+        source: "settings",
+      };
+    }
+    return result as ReturnType<DesktopBridge["getBackendModeState"]>;
+  },
+  setBackendMode: (mode) => ipcRenderer.invoke(IpcChannels.SET_BACKEND_MODE_CHANNEL, mode),
   getLocalEnvironmentBootstraps: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL);
     if (!Array.isArray(result)) {
@@ -52,6 +68,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   },
   getLocalEnvironmentBearerToken: () =>
     ipcRenderer.invoke(IpcChannels.GET_LOCAL_ENVIRONMENT_BEARER_TOKEN_CHANNEL),
+  discoverLocalServers: () => ipcRenderer.invoke(IpcChannels.DISCOVER_LOCAL_SERVERS_CHANNEL),
+  pairLocalServer: (environmentId) =>
+    ipcRenderer.invoke(IpcChannels.PAIR_LOCAL_SERVER_CHANNEL, environmentId),
   getClientSettings: () => ipcRenderer.invoke(IpcChannels.GET_CLIENT_SETTINGS_CHANNEL),
   setClientSettings: (settings) =>
     ipcRenderer.invoke(IpcChannels.SET_CLIENT_SETTINGS_CHANNEL, settings),

--- a/apps/desktop/src/settings/DesktopAppSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.test.ts
@@ -11,6 +11,7 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "./DesktopAppSettings.ts";
 
 const DesktopSettingsPatch = Schema.Struct({
+  backendMode: Schema.optionalKey(Schema.Literals(["managed", "client-only"])),
   linuxPasswordStore: Schema.optionalKey(
     Schema.Literals(["auto", "gnome-libsecret", "kwallet", "kwallet5", "kwallet6"]),
   ),
@@ -105,6 +106,7 @@ describe("DesktopSettings", () => {
     assert.deepEqual(
       DesktopAppSettings.resolveDefaultDesktopSettings("0.0.17-nightly.20260415.1"),
       {
+        backendMode: "managed",
         linuxPasswordStore: "auto",
         mainWindowBounds: null,
         mainWindowMaximized: false,
@@ -125,6 +127,7 @@ describe("DesktopSettings", () => {
       Effect.gen(function* () {
         const settings = yield* DesktopAppSettings.DesktopAppSettings;
         yield* writeSettingsPatch({
+          backendMode: "client-only",
           linuxPasswordStore: "gnome-libsecret",
           serverExposureMode: "network-accessible",
           tailscaleServeEnabled: true,
@@ -134,6 +137,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "client-only",
           linuxPasswordStore: "gnome-libsecret",
           mainWindowBounds: null,
           mainWindowMaximized: false,
@@ -162,6 +166,10 @@ describe("DesktopSettings", () => {
         assert.isTrue(updateChannel.changed);
         assert.equal(updateChannel.settings.updateChannel, "nightly");
         assert.equal(updateChannel.settings.updateChannelConfiguredByUser, true);
+
+        const backendMode = yield* settings.setBackendMode("managed");
+        assert.isTrue(backendMode.changed);
+        assert.equal(backendMode.settings.backendMode, "managed");
       }),
     ),
   );
@@ -241,6 +249,7 @@ describe("DesktopSettings", () => {
         );
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           linuxPasswordStore: "auto",
           mainWindowBounds: { x: 120, y: 80, width: 1280, height: 900 },
           mainWindowMaximized: false,
@@ -297,6 +306,7 @@ describe("DesktopSettings", () => {
           );
 
           assert.deepEqual(yield* settings.load, {
+            backendMode: "managed",
             linuxPasswordStore: "auto",
             mainWindowBounds: null,
             mainWindowMaximized: false,
@@ -322,11 +332,13 @@ describe("DesktopSettings", () => {
 
         yield* settings.setMainWindowBounds({ x: -1200, y: 40, width: 1440, height: 960 }, true);
         yield* settings.setServerExposureMode("network-accessible");
+        yield* settings.setBackendMode("client-only");
 
         const persisted = yield* decodeDesktopSettingsPatch(
           yield* fileSystem.readFileString(environment.desktopSettingsPath),
         );
         assert.deepEqual(persisted, {
+          backendMode: "client-only",
           mainWindowBounds: { x: -1200, y: 40, width: 1440, height: 960 },
           mainWindowMaximized: true,
           serverExposureMode: "network-accessible",
@@ -345,6 +357,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           linuxPasswordStore: "auto",
           mainWindowBounds: null,
           mainWindowMaximized: false,
@@ -373,6 +386,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           linuxPasswordStore: "auto",
           mainWindowBounds: null,
           mainWindowMaximized: false,
@@ -400,6 +414,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           linuxPasswordStore: "auto",
           mainWindowBounds: null,
           mainWindowMaximized: false,

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -1,6 +1,8 @@
 import {
   DesktopServerExposureModeSchema,
+  DesktopBackendModeSchema,
   DesktopUpdateChannelSchema,
+  type DesktopBackendMode,
   type DesktopServerExposureMode,
   type DesktopUpdateChannel,
 } from "@t3tools/contracts";
@@ -25,6 +27,7 @@ import { resolveDefaultDesktopUpdateChannel } from "../updates/updateChannels.ts
 import { isValidDistroName } from "../wsl/wslPathParsing.ts";
 
 export interface DesktopSettings {
+  readonly backendMode: DesktopBackendMode;
   readonly linuxPasswordStore: LinuxPasswordStorePreference;
   readonly mainWindowBounds: DesktopWindowBounds | null;
   readonly mainWindowMaximized: boolean;
@@ -73,6 +76,7 @@ export const DEFAULT_MAIN_WINDOW_SIZE = {
 } as const;
 
 export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
+  backendMode: "managed",
   linuxPasswordStore: DEFAULT_LINUX_PASSWORD_STORE,
   mainWindowBounds: null,
   mainWindowMaximized: false,
@@ -94,6 +98,7 @@ const DesktopWindowBoundsDocument = Schema.Struct({
 });
 
 const DesktopSettingsDocument = Schema.Struct({
+  backendMode: Schema.optionalKey(DesktopBackendModeSchema),
   linuxPasswordStore: Schema.optionalKey(Schema.Unknown),
   mainWindowBounds: Schema.optionalKey(Schema.NullOr(DesktopWindowBoundsDocument)),
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
@@ -155,6 +160,9 @@ export class DesktopAppSettings extends Context.Service<
     readonly setMainWindowBounds: (
       bounds: DesktopWindowBounds,
       isMaximized: boolean,
+    ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
+    readonly setBackendMode: (
+      mode: DesktopBackendMode,
     ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
     readonly setServerExposureMode: (
       mode: DesktopServerExposureMode,
@@ -224,6 +232,7 @@ function normalizeDesktopSettingsDocument(
     (parsed.wslBackendEnabled === undefined && parsed.wslMode === "wsl");
 
   return {
+    backendMode: parsed.backendMode === "client-only" ? "client-only" : "managed",
     linuxPasswordStore: normalizeLinuxPasswordStorePreference(parsed.linuxPasswordStore),
     mainWindowBounds,
     mainWindowMaximized: mainWindowBounds !== null && parsed.mainWindowMaximized === true,
@@ -247,6 +256,9 @@ function toDesktopSettingsDocument(
 ): DesktopSettingsDocument {
   const document: Mutable<DesktopSettingsDocument> = {};
 
+  if (settings.backendMode !== defaults.backendMode) {
+    document.backendMode = settings.backendMode;
+  }
   if (settings.linuxPasswordStore !== defaults.linuxPasswordStore) {
     document.linuxPasswordStore = settings.linuxPasswordStore;
   }
@@ -293,6 +305,18 @@ function setServerExposureMode(
     : {
         ...settings,
         serverExposureMode: requestedMode,
+      };
+}
+
+function setBackendMode(
+  settings: DesktopSettings,
+  requestedMode: DesktopBackendMode,
+): DesktopSettings {
+  return settings.backendMode === requestedMode
+    ? settings
+    : {
+        ...settings,
+        backendMode: requestedMode,
       };
 }
 
@@ -518,6 +542,10 @@ export const make = Effect.gen(function* () {
           },
         }),
       ),
+    setBackendMode: (mode) =>
+      persist((settings) => setBackendMode(settings, mode)).pipe(
+        Effect.withSpan("desktop.settings.setBackendMode", { attributes: { mode } }),
+      ),
     setServerExposureMode: (mode) =>
       persist((settings) => setServerExposureMode(settings, mode)).pipe(
         Effect.withSpan("desktop.settings.setServerExposureMode", { attributes: { mode } }),
@@ -577,6 +605,7 @@ export const layerTest = (initialSettings: DesktopSettings = DEFAULT_DESKTOP_SET
         load: SynchronizedRef.get(settingsRef),
         setMainWindowBounds: (bounds, isMaximized) =>
           update((settings) => setMainWindowBounds(settings, bounds, isMaximized)),
+        setBackendMode: (mode) => update((settings) => setBackendMode(settings, mode)),
         setServerExposureMode: (mode) =>
           update((settings) => setServerExposureMode(settings, mode)),
         setTailscaleServe: (input) => update((settings) => setTailscaleServe(settings, input)),

--- a/apps/desktop/src/updates/updatesTestHarness.ts
+++ b/apps/desktop/src/updates/updatesTestHarness.ts
@@ -175,6 +175,7 @@ export function makeHarness(options: UpdatesHarnessOptions = {}) {
           get: Effect.sync(() => testSettings),
           load: Effect.sync(() => testSettings),
           setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+          setBackendMode: () => Effect.die("unexpected backend mode update"),
           setServerExposureMode: () => Effect.die("unexpected server exposure update"),
           setTailscaleServe: () => Effect.die("unexpected Tailscale Serve update"),
           setUpdateChannel: (channel) =>

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -81,6 +81,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     activate: Effect.void,
     createMainIfBackendReady: Effect.void,
     showConnectingSplash: Effect.void,
+    handleRendererReady: Effect.void,
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -234,6 +234,7 @@ function makeTestLayer(input: {
         }
         return { settings: desktopSettings, changed };
       }),
+    setBackendMode: () => Effect.die("unexpected backend mode update"),
     setServerExposureMode: () => Effect.die("unexpected server exposure update"),
     setTailscaleServe: () => Effect.die("unexpected Tailscale Serve update"),
     setUpdateChannel: () => Effect.die("unexpected update channel change"),
@@ -569,6 +570,25 @@ describe("DesktopWindow", () => {
     }),
   );
 
+  it.effect("opens once the renderer is ready without a backend callback", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleRendererReady;
+        assert.equal(yield* Ref.get(createCount), 1);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
   it.effect("uses the persisted main window bounds when opening the window", () =>
     Effect.gen(function* () {
       const fakeWindow = makeFakeBrowserWindow();

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -86,6 +86,9 @@ export class DesktopWindow extends Context.Service<
     // mode), before the WSL backend that serves the renderer is ready. It is
     // dismissed automatically once the real main window reveals.
     readonly showConnectingSplash: Effect.Effect<void>;
+    // Marks the packaged/Vite renderer as loadable independently of whether
+    // this desktop process owns a backend.
+    readonly handleRendererReady: Effect.Effect<void, DesktopWindowError>;
     // Marks the primary backend as ready so `createMainIfBackendReady` and the
     // macOS "activate without windows" path may open the real main window. The
     // renderer now always loads the local client URL (getDesktopUrl) and connects
@@ -850,6 +853,11 @@ export const make = Effect.gen(function* () {
     Effect.withSpan("desktop.window.showConnectingSplash"),
   );
 
+  const handleRendererReady = Ref.set(backendReadyRef, true).pipe(
+    Effect.andThen(createMainIfBackendReady),
+    Effect.withSpan("desktop.window.handleRendererReady"),
+  );
+
   return DesktopWindow.of({
     createMain,
     ensureMain,
@@ -877,10 +885,10 @@ export const make = Effect.gen(function* () {
     }).pipe(Effect.withSpan("desktop.window.activate")),
     createMainIfBackendReady,
     showConnectingSplash,
+    handleRendererReady,
     handleBackendReady: Effect.fn("desktop.window.handleBackendReady")(function* (httpBaseUrl) {
-      yield* Ref.set(backendReadyRef, true);
       yield* logWindowInfo("backend ready", { source: "http", url: httpBaseUrl.href });
-      yield* createMainIfBackendReady;
+      yield* handleRendererReady;
     }),
     handleBackendNotReady: Ref.set(backendReadyRef, false).pipe(
       Effect.withSpan("desktop.window.handleBackendNotReady"),

--- a/apps/server/src/auth/http.ts
+++ b/apps/server/src/auth/http.ts
@@ -233,7 +233,6 @@ export const authHttpApiLayer = HttpApiBuilder.group(
   Effect.fnUntraced(function* (handlers) {
     const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
     const sessions = yield* SessionStore.SessionStore;
-
     return handlers
       .handle(
         "session",

--- a/apps/server/src/cli/pair.test.ts
+++ b/apps/server/src/cli/pair.test.ts
@@ -7,9 +7,11 @@ import * as NodePath from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+import { LocalServerPairCommandOutput } from "@t3tools/contracts";
 import { assert, describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
@@ -194,6 +196,47 @@ describe("t3 pair", () => {
         off: () => undefined,
       }),
     ),
+  );
+
+  it.effect("prints one machine-readable object with --json", () =>
+    withDescriptorServer((origin) =>
+      Effect.gen(function* () {
+        const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-pair-json-test-"));
+        const statePath = NodePath.join(baseDir, "userdata", "server-runtime.json");
+        yield* persistServerRuntimeState({
+          path: statePath,
+          state: yield* makePersistedServerRuntimeState({
+            config: { host: "127.0.0.1", devUrl: undefined },
+            port: Number(new URL(origin).port),
+          }),
+        });
+
+        const output = yield* captureStdout(
+          runCli(["pair", "--base-dir", baseDir, "--label", "Desktop", "--json"]),
+        );
+        const decoded = yield* Schema.decodeUnknownEffect(
+          Schema.fromJsonString(LocalServerPairCommandOutput),
+        )(output);
+
+        assert.deepEqual(Object.keys(decoded), [
+          "pairingUrl",
+          "token",
+          "expiresAt",
+          "origin",
+          "environmentId",
+          "label",
+        ]);
+        assert.equal(decoded.origin, origin);
+        assert.equal(decoded.environmentId, testDescriptor.environmentId);
+        assert.equal(decoded.label, testDescriptor.label);
+        assert.match(String(decoded.pairingUrl), new RegExp(`^${origin}/pair#token=`));
+        assert.equal(
+          new URL(String(decoded.pairingUrl)).hash.slice("#token=".length),
+          decoded.token,
+        );
+        assert.isFalse(/Pairing with|Note:|[█▀▄]/.test(output));
+      }),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("pairs through the recorded dev web URL for dev servers", () =>

--- a/apps/server/src/cli/pair.ts
+++ b/apps/server/src/cli/pair.ts
@@ -12,6 +12,7 @@
 import {
   AuthStandardClientScopes,
   ExecutionEnvironmentDescriptor,
+  type LocalServerPairCommandOutput,
   PortSchema,
 } from "@t3tools/contracts";
 import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
@@ -192,6 +193,23 @@ export const formatPairOutput = (input: {
     ...input.notes.flatMap((note) => ["", `Note: ${note}`]),
     "",
   ].join("\n");
+
+export const formatPairJsonOutput = (input: {
+  readonly pairingUrl: string;
+  readonly token: string;
+  readonly expiresAt: DateTime.Utc;
+  readonly origin: string;
+  readonly environmentId: LocalServerPairCommandOutput["environmentId"];
+  readonly label: string;
+}): string =>
+  JSON.stringify({
+    pairingUrl: input.pairingUrl,
+    token: input.token,
+    expiresAt: DateTime.formatIso(input.expiresAt),
+    origin: input.origin,
+    environmentId: input.environmentId,
+    label: input.label,
+  } satisfies LocalServerPairCommandOutput);
 
 /**
  * Three outcomes, because they drive different decisions: a T3 descriptor
@@ -458,6 +476,11 @@ const labelFlag = Flag.string("label").pipe(
   Flag.optional,
 );
 
+const jsonFlag = Flag.boolean("json").pipe(
+  Flag.withDescription("Emit JSON instead of human-readable output."),
+  Flag.withDefault(false),
+);
+
 const tailscaleFlag = Flag.boolean("tailscale").pipe(
   Flag.withDescription(
     "Publish the server over Tailscale Serve HTTPS and pair through the tailnet URL.",
@@ -475,6 +498,7 @@ export const pairCommand = Command.make("pair", {
   baseDir: baseDirFlag,
   ttl: ttlFlag,
   label: labelFlag,
+  json: jsonFlag,
   tailscale: tailscaleFlag,
   tailscaleServePort: tailscaleServePortFlag,
 }).pipe(
@@ -484,9 +508,11 @@ export const pairCommand = Command.make("pair", {
   Command.withHandler((flags) =>
     Effect.gen(function* () {
       const cliLogLevel = yield* GlobalFlag.LogLevel;
-      // Default to Warn so storage/migration chatter cannot bury the QR code;
-      // an explicit --log-level still wins.
-      const logLevel = Option.getOrElse(cliLogLevel, () => "Warn" as const);
+      // JSON is consumed by other processes, so keep storage/migration chatter
+      // off stdout. Human output defaults to Warn so it cannot bury the QR.
+      const logLevel = flags.json
+        ? ("Error" as const)
+        : Option.getOrElse(cliLogLevel, () => "Warn" as const);
 
       const target = yield* discoverPairTarget(Option.getOrUndefined(flags.baseDir));
 
@@ -518,14 +544,23 @@ export const pairCommand = Command.make("pair", {
       const pairingUrl = buildPairingUrl(pairingBaseUrl, issued.credential);
 
       yield* Console.log(
-        formatPairOutput({
-          serverLabel: target.descriptor.label,
-          origin: target.state.origin,
-          pairingUrl,
-          token: issued.credential,
-          expiresAt: issued.expiresAt,
-          notes,
-        }),
+        flags.json
+          ? formatPairJsonOutput({
+              pairingUrl,
+              token: issued.credential,
+              expiresAt: issued.expiresAt,
+              origin: target.state.origin,
+              environmentId: target.descriptor.environmentId,
+              label: target.descriptor.label,
+            })
+          : formatPairOutput({
+              serverLabel: target.descriptor.label,
+              origin: target.state.origin,
+              pairingUrl,
+              token: issued.credential,
+              expiresAt: issued.expiresAt,
+              notes,
+            }),
       );
     }).pipe(Effect.provide(FetchHttpClient.layer)),
   ),

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -14,6 +14,7 @@ import * as Layer from "effect/Layer";
 import * as LogLevel from "effect/LogLevel";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import { deriveServerRuntimeStatePath } from "@t3tools/shared/serverRuntimeState";
 
 import { sweepStalePendingAttachments } from "./attachmentStore.ts";
 
@@ -133,7 +134,11 @@ export const deriveServerPaths = Effect.fn(function* (
     terminalLogsDir: join(logsDir, "terminals"),
     anonymousIdPath: join(stateDir, "anonymous-id"),
     environmentIdPath: join(stateDir, "environment-id"),
-    serverRuntimeStatePath: join(stateDir, "server-runtime.json"),
+    serverRuntimeStatePath: deriveServerRuntimeStatePath({
+      baseDir,
+      variant: devUrl !== undefined && !options.baseDirIsExplicit ? "dev" : "userdata",
+      joinPath: join,
+    }),
     secretsDir: join(stateDir, "secrets"),
   };
 });

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -1,42 +1,21 @@
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
-import * as Option from "effect/Option";
-import * as Schema from "effect/Schema";
+import {
+  type PersistedServerRuntimeState,
+  ServerRuntimeStateError,
+} from "@t3tools/shared/serverRuntimeState";
 
 import { writeFileStringAtomically } from "./atomicWrite.ts";
 import type * as ServerConfig from "./config.ts";
 import { formatHostForUrl, isWildcardHost } from "./startupAccess.ts";
 
-export const PersistedServerRuntimeState = Schema.Struct({
-  version: Schema.Literal(1),
-  pid: Schema.Int,
-  host: Schema.optional(Schema.String),
-  port: Schema.Int,
-  origin: Schema.String,
-  // Present when the server fronts a dev web server (VITE_DEV_SERVER_URL).
-  // Dev is single-origin: browsers must pair through this URL, not `origin`.
-  devUrl: Schema.optional(Schema.String),
-  startedAt: Schema.String,
-});
-export type PersistedServerRuntimeState = typeof PersistedServerRuntimeState.Type;
-
-export class ServerRuntimeStateError extends Schema.TaggedErrorClass<ServerRuntimeStateError>()(
-  "ServerRuntimeStateError",
-  {
-    operation: Schema.Literals(["persist", "read", "decode", "clear"]),
-    statePath: Schema.String,
-    cause: Schema.Defect(),
-  },
-) {
-  override get message(): string {
-    return `Failed to ${this.operation} server runtime state at ${this.statePath}.`;
-  }
-}
-
-const decodePersistedServerRuntimeState = Schema.decodeUnknownEffect(
-  Schema.fromJsonString(PersistedServerRuntimeState),
-);
+export {
+  PersistedServerRuntimeState,
+  readPersistedServerRuntimeState,
+  isProcessAlive,
+  ServerRuntimeStateError,
+} from "@t3tools/shared/serverRuntimeState";
 
 const runtimeOriginForConfig = (
   config: Pick<ServerConfig.ServerConfig["Service"], "host">,
@@ -103,70 +82,3 @@ export const clearPersistedServerRuntimeState = (path: string) =>
       }),
     );
   });
-
-/**
- * Report whether the pid recorded in a persisted runtime state is still
- * running. Signal 0 delivers nothing; it only reports whether the pid exists.
- * EPERM means it exists but belongs to another user, which still counts as
- * alive.
- */
-export const isProcessAlive = (pid: number): boolean => {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error instanceof Error && "code" in error && error.code === "EPERM";
-  }
-};
-
-export const readPersistedServerRuntimeState = (path: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const raw = yield* fs.readFileString(path).pipe(
-      Effect.matchEffect({
-        onFailure: (cause) =>
-          cause.reason._tag === "NotFound"
-            ? Effect.succeed(Option.none<string>())
-            : Effect.fail(
-                new ServerRuntimeStateError({
-                  operation: "read",
-                  statePath: path,
-                  cause,
-                }),
-              ),
-        onSuccess: (contents) => Effect.succeed(Option.some(contents)),
-      }),
-    );
-    if (Option.isNone(raw)) {
-      return Option.none<PersistedServerRuntimeState>();
-    }
-
-    const trimmed = raw.value.trim();
-    if (trimmed.length === 0) {
-      return Option.none<PersistedServerRuntimeState>();
-    }
-
-    return yield* decodePersistedServerRuntimeState(trimmed).pipe(
-      Effect.map(Option.some),
-      Effect.mapError(
-        (cause) =>
-          new ServerRuntimeStateError({
-            operation: "decode",
-            statePath: path,
-            cause,
-          }),
-      ),
-    );
-  }).pipe(
-    Effect.catchTags({
-      ServerRuntimeStateError: (error) =>
-        Effect.logWarning(error.message).pipe(
-          Effect.annotateLogs({
-            operation: error.operation,
-            statePath: error.statePath,
-            cause: error,
-          }),
-          Effect.as(Option.none<PersistedServerRuntimeState>()),
-        ),
-    }),
-  );

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -82,7 +82,11 @@ import { sourceControlEnvironment } from "../state/sourceControl";
 import { vcsEnvironment } from "../state/vcs";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
-import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../state/environments";
 import { useProject, useProjects, useThreadShells } from "../state/entities";
 import { useThreadSearch } from "../state/queries";
 import * as ThreadPr from "./ThreadStatusIndicators";
@@ -603,6 +607,7 @@ function OpenCommandPaletteDialog(props: {
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const availableSettingsSearchItems = useAvailableSettingsSearchItems();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
@@ -771,12 +776,14 @@ function OpenCommandPaletteDialog(props: {
         projects: clientSettings.sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       }),
     [
       clientSettings.sidebarProjectSortOrder,
       environmentLabelById,
       orderedProjects,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projects,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -73,6 +73,8 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import { isElectron } from "../env";
+import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
+import { isRemoteEnvironmentId } from "../environmentPresence";
 import {
   resolveShortcutCommand,
   shortcutLabelForCommand,
@@ -103,7 +105,12 @@ import { useClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useNowMinute } from "../hooks/useNowMinute";
-import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironmentPresenceScope,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
@@ -731,7 +738,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   isActive: boolean;
   openPullRequestsInRightPanel: boolean;
   jumpLabel: string | null;
-  currentEnvironmentId: string | null;
   environmentLabel: string | null;
   projectCwd: string | null;
   projectFaviconPath: string | null;
@@ -759,6 +765,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     snapshot: ThreadChangeRequestSnapshot | null,
   ) => void;
 }) {
+  const environmentPresenceScope = useEnvironmentPresenceScope();
   const {
     isRenaming,
     changeRequestSnapshot,
@@ -949,8 +956,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
 
-  const isRemote =
-    props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
+  const isRemote = isRemoteEnvironmentId(thread.environmentId, environmentPresenceScope);
 
   const detailsTooltip = (
     <SidebarThreadTooltip
@@ -1809,6 +1815,7 @@ export default function Sidebar() {
   );
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
@@ -1867,11 +1874,20 @@ export default function Sidebar() {
         projects: sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
+        isDesktopLocalEnvironment: (environmentId) =>
+          environments.some(
+            (environment) =>
+              environment.environmentId === environmentId &&
+              isDesktopLocalConnectionTarget(environment.entry.target),
+          ),
       }),
     [
       environmentLabelById,
+      environments,
       orderedProjects,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projects,
@@ -3771,7 +3787,6 @@ export default function Sidebar() {
                         isActive={routeThreadKey === threadKey}
                         openPullRequestsInRightPanel={routeThreadRef !== null}
                         jumpLabel={showJumpHints ? (jumpLabelByKey.get(threadKey) ?? null) : null}
-                        currentEnvironmentId={primaryEnvironmentId}
                         environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
                         projectCwd={
                           projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -9,7 +9,8 @@ import { Atom } from "effect/unstable/reactivity";
 import { CloudIcon, FolderGit2Icon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
 import { useMemo } from "react";
 import { appAtomRegistry } from "../rpc/atomRegistry";
-import { useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
+import { isRemoteEnvironmentId } from "../environmentPresence";
+import { useEnvironment, useEnvironmentPresenceScope } from "../state/environments";
 import { useProject } from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
 import { linkedPullRequestDetailAtom } from "../state/pullRequests";
@@ -631,9 +632,8 @@ export function ThreadRowTrailingStatus({ thread }: { thread: SidebarThreadSumma
     threadId: thread.id,
   });
   const environment = useEnvironment(thread.environmentId);
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const isRemoteThread =
-    primaryEnvironmentId !== null && thread.environmentId !== primaryEnvironmentId;
+  const presenceScope = useEnvironmentPresenceScope();
+  const isRemoteThread = isRemoteEnvironmentId(thread.environmentId, presenceScope);
   const remoteEnvLabel = environment?.label ?? null;
   const threadEnvironmentLabel = isRemoteThread ? (remoteEnvLabel ?? "Remote") : null;
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -14,7 +14,11 @@ import {
   buildSidebarProjectSnapshots,
 } from "~/sidebarProjectGrouping";
 import { useProjects, useThreadShells } from "~/state/entities";
-import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "~/state/environments";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
   Menu,
@@ -42,6 +46,7 @@ export function DraftHeroHeadline({
   const threads = useThreadShells();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
   const setLogicalProjectDraftThreadId = useComposerDraftStore(
@@ -66,6 +71,7 @@ export function DraftHeroHeadline({
           projects,
           settings: projectGroupingSettings,
           primaryEnvironmentId,
+          ownsLocalEnvironment,
           resolveEnvironmentLabel: (environmentId) =>
             environmentLabelById.get(environmentId) ?? null,
         }),
@@ -74,6 +80,7 @@ export function DraftHeroHeadline({
       ),
     [
       environmentLabelById,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projectSortOrder,

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -1,11 +1,81 @@
-import type { AdvertisedEndpoint, DesktopWslState } from "@t3tools/contracts";
+import {
+  BearerConnectionProfile,
+  BearerConnectionTarget,
+  SshConnectionProfile,
+  SshConnectionTarget,
+  type ConnectionCatalogEntry,
+} from "@t3tools/client-runtime/connection";
+import {
+  EnvironmentId,
+  type AdvertisedEndpoint,
+  type DesktopWslState,
+  type RunningLocalServer,
+} from "@t3tools/contracts";
+import * as Option from "effect/Option";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   applyWslEnableSelection,
+  environmentPairingBaseUrl,
   isQrShareableEndpoint,
   isWslSettingsRowVisible,
+  selectLocalServerPairingCandidates,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
+
+const savedEnvironmentId = EnvironmentId.make("saved-environment");
+
+function connectionEntry(
+  target: ConnectionCatalogEntry["target"],
+  profile?: ConnectionCatalogEntry["profile"] extends Option.Option<infer A> ? A : never,
+): ConnectionCatalogEntry {
+  return {
+    target,
+    profile: profile === undefined ? Option.none() : Option.some(profile),
+  };
+}
+
+describe("environmentPairingBaseUrl", () => {
+  it("uses the reachable origin from a bearer environment profile", () => {
+    expect(
+      environmentPairingBaseUrl(
+        connectionEntry(
+          new BearerConnectionTarget({
+            environmentId: savedEnvironmentId,
+            label: "headless",
+            connectionId: "bearer:saved-environment",
+          }),
+          new BearerConnectionProfile({
+            connectionId: "bearer:saved-environment",
+            environmentId: savedEnvironmentId,
+            label: "headless",
+            httpBaseUrl: "https://box.tail.ts.net/",
+            wsBaseUrl: "wss://box.tail.ts.net/",
+          }),
+        ),
+      ),
+    ).toBe("https://box.tail.ts.net/");
+  });
+
+  it("does not share an SSH tunnel's client-local address", () => {
+    expect(
+      environmentPairingBaseUrl(
+        connectionEntry(
+          new SshConnectionTarget({
+            environmentId: savedEnvironmentId,
+            label: "box",
+            connectionId: "ssh:box",
+          }),
+          new SshConnectionProfile({
+            connectionId: "ssh:box",
+            environmentId: savedEnvironmentId,
+            label: "box",
+            target: { alias: "box", hostname: "box", username: "ivan", port: 22 },
+          }),
+        ),
+      ),
+    ).toBeNull();
+  });
+});
 
 const baseWslState: DesktopWslState = {
   enabled: false,
@@ -181,5 +251,33 @@ describe("selectQrEndpointOption", () => {
     const loopbackOnly = options.slice(0, 1);
     expect(selectQrEndpointOption(loopbackOnly, null, null)?.id).toBe("desktop-loopback:4780");
     expect(selectQrEndpointOption([], "anything", "anything")).toBeNull();
+  });
+});
+
+describe("selectLocalServerPairingCandidates", () => {
+  const server = {
+    statePath: "/home/user/.t3/userdata/server-runtime.json",
+    baseDir: "/home/user/.t3",
+    variant: "userdata",
+    pid: 1234,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    httpBaseUrl: "http://127.0.0.1:3773/",
+    environmentId: EnvironmentId.make("environment-local"),
+    label: "Local server",
+  } satisfies RunningLocalServer;
+
+  it("marks connected servers as paired and reconnecting servers for pairing again", () => {
+    expect(
+      selectLocalServerPairingCandidates(
+        [server],
+        [{ environmentId: server.environmentId, connection: { phase: "connected" } }],
+      ),
+    ).toEqual([{ server, pairAgain: false, alreadyPaired: true }]);
+    expect(
+      selectLocalServerPairingCandidates(
+        [server],
+        [{ environmentId: server.environmentId, connection: { phase: "reconnecting" } }],
+      ),
+    ).toEqual([{ server, pairAgain: true, alreadyPaired: false }]);
   });
 });

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -1,6 +1,54 @@
-import type { AdvertisedEndpoint, DesktopBridge, DesktopWslState } from "@t3tools/contracts";
+import type { ConnectionCatalogEntry } from "@t3tools/client-runtime/connection";
+import type {
+  AdvertisedEndpoint,
+  DesktopBridge,
+  DesktopWslState,
+  EnvironmentId,
+  RunningLocalServer,
+} from "@t3tools/contracts";
+import * as Option from "effect/Option";
+
+export function environmentPairingBaseUrl(entry: ConnectionCatalogEntry): string | null {
+  switch (entry.target._tag) {
+    case "PrimaryConnectionTarget":
+      return entry.target.httpBaseUrl;
+    case "BearerConnectionTarget":
+      return Option.isSome(entry.profile) && entry.profile.value._tag === "BearerConnectionProfile"
+        ? entry.profile.value.httpBaseUrl
+        : null;
+    case "RelayConnectionTarget":
+    case "SshConnectionTarget":
+      return null;
+  }
+}
 
 type WslEnableBridge = Pick<DesktopBridge, "setWslBackendEnabled" | "setWslDistro" | "setWslOnly">;
+
+export interface LocalServerPairingCandidate {
+  readonly server: RunningLocalServer;
+  readonly pairAgain: boolean;
+  readonly alreadyPaired: boolean;
+}
+
+export function selectLocalServerPairingCandidates(
+  servers: ReadonlyArray<RunningLocalServer>,
+  environments: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly connection: { readonly phase: string };
+  }>,
+): ReadonlyArray<LocalServerPairingCandidate> {
+  return servers.map((server) => {
+    const savedEnvironment = environments.find(
+      (environment) => environment.environmentId === server.environmentId,
+    );
+    return {
+      server,
+      pairAgain:
+        savedEnvironment !== undefined && savedEnvironment.connection.phase !== "connected",
+      alreadyPaired: savedEnvironment?.connection.phase === "connected",
+    };
+  });
+}
 
 /**
  * A QR code encoding a loopback URL makes the scanning device dial itself, so

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -6,7 +6,7 @@ import {
   TerminalIcon,
 } from "lucide-react";
 import { useAtomValue } from "@effect/atom-react";
-import { type ReactNode, memo, useCallback, useId, useMemo, useState } from "react";
+import { type ReactNode, memo, useCallback, useEffect, useId, useMemo, useState } from "react";
 import {
   AuthAccessReadScope,
   AuthAccessWriteScope,
@@ -23,6 +23,9 @@ import {
   type AuthPairingLink,
   type AdvertisedEndpoint,
   type DesktopDiscoveredSshHost,
+  type DesktopBackendMode,
+  type DesktopBackendModeState,
+  type RunningLocalServer,
   type DesktopSshEnvironmentTarget,
   type DesktopServerExposureState,
   type DesktopWslState,
@@ -42,10 +45,13 @@ import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestam
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
 import {
   applyWslEnableSelection,
+  environmentPairingBaseUrl,
   isQrShareableEndpoint,
   isWslSettingsRowVisible,
+  selectLocalServerPairingCandidates,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import {
   SettingsPageContainer,
   SettingsRow,
@@ -128,6 +134,7 @@ import {
   usePrimaryEnvironment,
 } from "~/state/environments";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { serverEnvironment } from "~/state/server";
 import { ConnectionStatusDot } from "../ConnectionStatusDot";
 import { ServerUpdateAction, ServerUpdateProgress } from "../ServerUpdateAction";
@@ -137,6 +144,7 @@ import { ITEM_ROW_CLASSNAME, ITEM_ROW_INNER_CLASSNAME } from "./itemRows";
 const DEFAULT_TAILSCALE_SERVE_PORT = 443;
 const EMPTY_ADVERTISED_ENDPOINTS: ReadonlyArray<AdvertisedEndpoint> = [];
 const EMPTY_DISCOVERED_SSH_HOSTS: ReadonlyArray<DesktopDiscoveredSshHost> = [];
+const EMPTY_RUNNING_LOCAL_SERVERS: ReadonlyArray<RunningLocalServer> = [];
 
 // Sentinels for the consolidated WSL backend picker. The colon is
 // rejected by DISTRO_NAME_PATTERN (validated on the desktop side) so
@@ -981,12 +989,17 @@ type AuthorizedClientsHeaderActionProps = {
   clientSessions: ReadonlyArray<ServerClientSessionRecord>;
   isRevokingOtherClients: boolean;
   onRevokeOtherClients: () => void;
+  onCreatePairingLink: (input: {
+    readonly label: string;
+    readonly scopes: ReadonlyArray<AuthEnvironmentScope>;
+  }) => Promise<void>;
 };
 
 const AuthorizedClientsHeaderAction = memo(function AuthorizedClientsHeaderAction({
   clientSessions,
   isRevokingOtherClients,
   onRevokeOtherClients,
+  onCreatePairingLink,
 }: AuthorizedClientsHeaderActionProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [pairingLabel, setPairingLabel] = useState("");
@@ -998,7 +1011,7 @@ const AuthorizedClientsHeaderAction = memo(function AuthorizedClientsHeaderActio
   const handleCreatePairingLink = useCallback(async () => {
     setIsCreatingPairingLink(true);
     try {
-      await createServerPairingCredential({ label: pairingLabel, scopes: pairingScopes });
+      await onCreatePairingLink({ label: pairingLabel, scopes: pairingScopes });
       setPairingLabel("");
       setPairingScopes([...AuthStandardClientScopes]);
       setDialogOpen(false);
@@ -1014,7 +1027,7 @@ const AuthorizedClientsHeaderAction = memo(function AuthorizedClientsHeaderActio
     } finally {
       setIsCreatingPairingLink(false);
     }
-  }, [pairingLabel, pairingScopes]);
+  }, [onCreatePairingLink, pairingLabel, pairingScopes]);
 
   const togglePairingScope = useCallback((scope: AuthEnvironmentScope, checked: boolean) => {
     setPairingScopes((current) =>
@@ -1407,14 +1420,12 @@ function SavedBackendListRow({
   const serverUpdateState = useAtomValue(serverEnvironment.updateStateAtom(environmentId));
   const resumingServerUpdate =
     serverUpdateState.status === "running" && serverUpdateState.stage === "resuming";
-  const sshTarget =
-    environment.entry.target._tag === "SshConnectionTarget" &&
-    Option.isSome(environment.entry.profile) &&
-    environment.entry.profile.value._tag === "SshConnectionProfile"
-      ? environment.entry.profile.value.target
-      : null;
   const metadataBits = [
-    sshTarget ? `SSH ${formatDesktopSshTarget(sshTarget)}` : null,
+    environment.displayUrl
+      ? environment.entry.target._tag === "SshConnectionTarget"
+        ? `SSH ${environment.displayUrl}`
+        : environment.displayUrl
+      : null,
     environment.relayManaged ? "T3 Connect" : null,
   ].filter((value): value is string => value !== null);
 
@@ -1752,14 +1763,46 @@ function CloudRemoteEnvironmentRows({
 
 export function ConnectionsSettings() {
   const desktopBridge = window.desktopBridge;
+  const [desktopBackendModeState, setDesktopBackendModeState] =
+    useState<DesktopBackendModeState | null>(() => desktopBridge?.getBackendModeState?.() ?? null);
+  const [desktopBackendModeError, setDesktopBackendModeError] = useState<string | null>(null);
+  const [isUpdatingDesktopBackendMode, setIsUpdatingDesktopBackendMode] = useState(false);
+  const [runningLocalServers, setRunningLocalServers] = useState<ReadonlyArray<RunningLocalServer>>(
+    EMPTY_RUNNING_LOCAL_SERVERS,
+  );
+  const [activeLocalServerDiscoveryCount, setActiveLocalServerDiscoveryCount] = useState(0);
+  const isDiscoveringLocalServers = activeLocalServerDiscoveryCount > 0;
+  const [pairingLocalServerEnvironmentId, setPairingLocalServerEnvironmentId] =
+    useState<EnvironmentId | null>(null);
+  const [localServerDiscoveryError, setLocalServerDiscoveryError] = useState<string | null>(null);
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
+  const {
+    environment: accessEnvironment,
+    environmentId: accessEnvironmentId,
+    environments: settingsEnvironments,
+    primaryEnvironmentId: settingsPrimaryEnvironmentId,
+    selectEnvironment: selectSettingsEnvironment,
+  } = useSettingsEnvironment();
   const connectPairing = useAtomCommand(connectPairingAtom, { reportFailure: false });
   const connectSshEnvironment = useAtomCommand(connectSshEnvironmentAtom, {
     reportFailure: false,
   });
   const removeEnvironment = useAtomCommand(environmentCatalog.remove, { reportFailure: false });
   const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
+  const createEnvironmentPairingLink = useAtomCommand(authEnvironment.createPairingCredential, {
+    reportFailure: false,
+  });
+  const revokeEnvironmentPairingLink = useAtomCommand(authEnvironment.revokePairingLink, {
+    reportFailure: false,
+  });
+  const revokeEnvironmentClientSession = useAtomCommand(authEnvironment.revokeClientSession, {
+    reportFailure: false,
+  });
+  const revokeOtherEnvironmentClientSessions = useAtomCommand(
+    authEnvironment.revokeOtherClientSessions,
+    { reportFailure: false },
+  );
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
   const primarySessionState = usePrimarySessionState();
   const currentSessionScopes = desktopBridge
@@ -1774,6 +1817,86 @@ export function ConnectionsSettings() {
         .filter((environment) => environment.entry.target._tag !== "PrimaryConnectionTarget")
         .toSorted((left, right) => left.label.localeCompare(right.label)),
     [environments],
+  );
+  const hasUsableClientOnlyEnvironment = savedEnvironments.some(
+    (environment) => !isDesktopLocalConnectionTarget(environment.entry.target),
+  );
+  const isClientOnlyDesktop = desktopBackendModeState?.effectiveMode === "client-only";
+  const localServerPairingCandidates = useMemo(
+    () => selectLocalServerPairingCandidates(runningLocalServers, environments),
+    [environments, runningLocalServers],
+  );
+  const hasLocalServerDiscoveryContent =
+    isDiscoveringLocalServers ||
+    localServerPairingCandidates.length > 0 ||
+    localServerDiscoveryError !== null;
+  const refreshRunningLocalServers = useCallback(async () => {
+    const discoverLocalServers = desktopBridge?.discoverLocalServers;
+    if (!discoverLocalServers) {
+      setRunningLocalServers(EMPTY_RUNNING_LOCAL_SERVERS);
+      return EMPTY_RUNNING_LOCAL_SERVERS;
+    }
+    setActiveLocalServerDiscoveryCount((count) => count + 1);
+    try {
+      const discovered = await discoverLocalServers();
+      setRunningLocalServers(discovered);
+      setLocalServerDiscoveryError(null);
+      return discovered;
+    } catch (error) {
+      setRunningLocalServers(EMPTY_RUNNING_LOCAL_SERVERS);
+      setLocalServerDiscoveryError(
+        error instanceof Error ? error.message : "Could not scan for local T3 Code servers.",
+      );
+      return EMPTY_RUNNING_LOCAL_SERVERS;
+    } finally {
+      setActiveLocalServerDiscoveryCount((count) => Math.max(0, count - 1));
+    }
+  }, [desktopBridge]);
+
+  useEffect(() => {
+    void refreshRunningLocalServers();
+  }, [refreshRunningLocalServers]);
+
+  const handlePairLocalServer = useCallback(
+    async (server: RunningLocalServer, pairAgain: boolean) => {
+      const pairLocalServer = desktopBridge?.pairLocalServer;
+      if (!pairLocalServer) return;
+      setPairingLocalServerEnvironmentId(server.environmentId);
+      setLocalServerDiscoveryError(null);
+      try {
+        const { pairingUrl } = await pairLocalServer(server.environmentId);
+
+        const result = await connectPairing({ pairingUrl });
+        if (result._tag === "Failure") {
+          if (isAtomCommandInterrupted(result)) {
+            setPairingLocalServerEnvironmentId(null);
+            return;
+          }
+          throw squashAtomCommandFailure(result);
+        }
+
+        setAddBackendDialogOpen(false);
+        toastManager.add({
+          type: "success",
+          title: pairAgain ? "Environment paired again" : "Environment paired",
+          description: `${server.label} is saved and will reconnect on app startup.`,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Could not pair the local T3 Code server.";
+        setLocalServerDiscoveryError(message);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not pair local server",
+            description: message,
+          }),
+        );
+      } finally {
+        setPairingLocalServerEnvironmentId(null);
+      }
+    },
+    [connectPairing, desktopBridge],
   );
   const savedDesktopSshEnvironmentsByAlias = useMemo(
     () =>
@@ -1885,12 +2008,32 @@ export function ConnectionsSettings() {
   const setDefaultAdvertisedEndpointKey = useUiStateStore(
     (state) => state.setDefaultAdvertisedEndpointKey,
   );
-  const canManageLocalBackend = currentSessionScopes?.includes(AuthAccessWriteScope) ?? false;
+  const canManageLocalBackend =
+    !isClientOnlyDesktop && (currentSessionScopes?.includes(AuthAccessWriteScope) ?? false);
   const canManageRelay = currentSessionScopes?.includes(AuthRelayWriteScope) ?? false;
+  const isAccessEnvironmentPrimary =
+    accessEnvironmentId !== null && accessEnvironmentId === primaryEnvironmentId;
+  const accessEnvironmentSession = useEnvironmentQuery(
+    !isAccessEnvironmentPrimary &&
+      accessEnvironmentId !== null &&
+      accessEnvironment?.connection.phase === "connected"
+      ? authEnvironment.sessionState({ environmentId: accessEnvironmentId, input: null })
+      : null,
+  );
+  const accessSessionScopes = isAccessEnvironmentPrimary
+    ? currentSessionScopes
+    : accessEnvironmentSession.data?.authenticated
+      ? (accessEnvironmentSession.data.scopes ?? null)
+      : null;
+  const canManageEnvironmentAccess = accessSessionScopes?.includes(AuthAccessWriteScope) ?? false;
+  const accessEnvironmentPairingBaseUrl =
+    isAccessEnvironmentPrimary || accessEnvironment === null
+      ? null
+      : environmentPairingBaseUrl(accessEnvironment.entry);
   const authAccessChanges = useEnvironmentQuery(
-    canManageLocalBackend && primaryEnvironmentId !== null
+    canManageEnvironmentAccess && accessEnvironmentId !== null
       ? authEnvironment.accessChanges({
-          environmentId: primaryEnvironmentId,
+          environmentId: accessEnvironmentId,
           input: null,
         })
       : null,
@@ -2080,32 +2223,75 @@ export function ConnectionsSettings() {
     setDisableTailscaleServeDialogOpen(true);
   }, []);
 
-  const handleRevokeDesktopPairingLink = useCallback(async (id: string) => {
-    setRevokingDesktopPairingLinkId(id);
-    setDesktopAccessManagementMutationError(null);
-    try {
-      await revokeServerPairingLink(id);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to revoke pairing link.";
-      setDesktopAccessManagementMutationError(message);
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Could not revoke pairing link",
-          description: message,
-        }),
-      );
-    } finally {
-      setRevokingDesktopPairingLinkId(null);
-    }
-  }, []);
+  const handleCreateAccessPairingLink = useCallback(
+    async (input: {
+      readonly label: string;
+      readonly scopes: ReadonlyArray<AuthEnvironmentScope>;
+    }) => {
+      if (isAccessEnvironmentPrimary || accessEnvironmentId === null) {
+        await createServerPairingCredential(input);
+        return;
+      }
+      const result = await createEnvironmentPairingLink({
+        environmentId: accessEnvironmentId,
+        input,
+      });
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        throw squashAtomCommandFailure(result);
+      }
+    },
+    [accessEnvironmentId, createEnvironmentPairingLink, isAccessEnvironmentPrimary],
+  );
+
+  const handleRevokeDesktopPairingLink = useCallback(
+    async (id: string) => {
+      setRevokingDesktopPairingLinkId(id);
+      setDesktopAccessManagementMutationError(null);
+      try {
+        if (isAccessEnvironmentPrimary || accessEnvironmentId === null) {
+          await revokeServerPairingLink(id);
+        } else {
+          const result = await revokeEnvironmentPairingLink({
+            environmentId: accessEnvironmentId,
+            input: { id },
+          });
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            throw squashAtomCommandFailure(result);
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to revoke pairing link.";
+        setDesktopAccessManagementMutationError(message);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not revoke pairing link",
+            description: message,
+          }),
+        );
+      } finally {
+        setRevokingDesktopPairingLinkId(null);
+      }
+    },
+    [accessEnvironmentId, isAccessEnvironmentPrimary, revokeEnvironmentPairingLink],
+  );
 
   const handleRevokeDesktopClientSession = useCallback(
     async (sessionId: ServerClientSessionRecord["sessionId"]) => {
       setRevokingDesktopClientSessionId(sessionId);
       setDesktopAccessManagementMutationError(null);
       try {
-        await revokeServerClientSession(sessionId);
+        if (isAccessEnvironmentPrimary || accessEnvironmentId === null) {
+          await revokeServerClientSession(sessionId);
+        } else {
+          const result = await revokeEnvironmentClientSession({
+            environmentId: accessEnvironmentId,
+            input: { sessionId },
+          });
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            throw squashAtomCommandFailure(result);
+          }
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : "Failed to revoke client access.";
         setDesktopAccessManagementMutationError(message);
@@ -2120,14 +2306,27 @@ export function ConnectionsSettings() {
         setRevokingDesktopClientSessionId(null);
       }
     },
-    [],
+    [accessEnvironmentId, isAccessEnvironmentPrimary, revokeEnvironmentClientSession],
   );
 
   const handleRevokeOtherDesktopClients = useCallback(async () => {
     setIsRevokingOtherDesktopClients(true);
     setDesktopAccessManagementMutationError(null);
     try {
-      const revokedCount = await revokeOtherServerClientSessions();
+      const revokedCount =
+        isAccessEnvironmentPrimary || accessEnvironmentId === null
+          ? await revokeOtherServerClientSessions()
+          : await (async () => {
+              const result = await revokeOtherEnvironmentClientSessions({
+                environmentId: accessEnvironmentId,
+                input: null,
+              });
+              if (result._tag === "Failure") {
+                if (isAtomCommandInterrupted(result)) return 0;
+                throw squashAtomCommandFailure(result);
+              }
+              return result.value.revokedCount;
+            })();
       toastManager.add({
         type: "success",
         title: revokedCount === 1 ? "Revoked 1 other client" : `Revoked ${revokedCount} clients`,
@@ -2146,7 +2345,7 @@ export function ConnectionsSettings() {
     } finally {
       setIsRevokingOtherDesktopClients(false);
     }
-  }, []);
+  }, [accessEnvironmentId, isAccessEnvironmentPrimary, revokeOtherEnvironmentClientSessions]);
 
   const handleAddSavedBackend = useCallback(async () => {
     if (savedBackendMode === "ssh") {
@@ -2165,7 +2364,7 @@ export function ConnectionsSettings() {
         return;
       }
 
-      const result = await connectSshEnvironment({ target, label: "" });
+      const result = await connectSshEnvironment({ target, label: target.alias });
       if (result._tag === "Failure") {
         if (!isAtomCommandInterrupted(result)) {
           setSavedBackendError(formatDesktopSshConnectionError(squashAtomCommandFailure(result)));
@@ -2353,8 +2552,6 @@ export function ConnectionsSettings() {
         : visibleDesktopNetworkAdvertisedEndpoints,
     [tailscaleHttpsEndpoint, visibleDesktopNetworkAdvertisedEndpoints],
   );
-  const isLocalBackendRemotelyReachable =
-    isLocalBackendNetworkAccessible || tailscaleHttpsEndpoint?.status === "available";
   const defaultDesktopNetworkAdvertisedEndpoint = useMemo(
     () =>
       selectPairingEndpoint(visibleDesktopNetworkAdvertisedEndpoints, defaultAdvertisedEndpointKey),
@@ -2474,6 +2671,48 @@ export function ConnectionsSettings() {
         <PlusIcon className="size-3.5" />
         {isAddingSavedBackend ? "Adding…" : "Add environment"}
       </Button>
+    </div>
+  );
+  const renderLocalServerPairingCandidates = () => (
+    <div className="space-y-2">
+      {isDiscoveringLocalServers && localServerPairingCandidates.length === 0 ? (
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Spinner className="size-3" />
+          Scanning for local T3 Code servers…
+        </p>
+      ) : null}
+      {localServerPairingCandidates.map(({ server, pairAgain, alreadyPaired }) => (
+        <div
+          key={server.environmentId}
+          className="flex items-center gap-3 rounded-lg border border-border/70 bg-background p-3"
+        >
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
+            <TerminalIcon aria-hidden className="size-4" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-sm font-medium text-foreground">
+              {server.label}
+            </span>
+            <span className="block truncate text-xs text-muted-foreground">
+              {server.httpBaseUrl} · process {server.pid}
+            </span>
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pairingLocalServerEnvironmentId !== null || alreadyPaired}
+            onClick={() => void handlePairLocalServer(server, pairAgain)}
+          >
+            {pairingLocalServerEnvironmentId === server.environmentId ? (
+              <Spinner className="size-3.5" />
+            ) : null}
+            {alreadyPaired ? "Paired" : pairAgain ? "Pair again" : "Pair"}
+          </Button>
+        </div>
+      ))}
+      {localServerDiscoveryError ? (
+        <p className="text-xs text-destructive">{localServerDiscoveryError}</p>
+      ) : null}
     </div>
   );
   const renderSshFields = () => (
@@ -2940,27 +3179,90 @@ export function ConnectionsSettings() {
       }
     />
   );
-  const renderAuthorizedClients = (presentation: AccessSectionPresentation) => (
-    <>
-      {desktopAccessManagementError ? (
-        <div className={accessRowClassName(presentation)}>
-          <p className="text-xs text-destructive">{desktopAccessManagementError}</p>
+  const accessEnvironmentConnected = accessEnvironment?.connection.phase === "connected";
+  const accessEnvironmentSessionLoading =
+    !isAccessEnvironmentPrimary &&
+    accessEnvironmentSession.isPending &&
+    accessEnvironmentSession.data === null;
+  const accessEndpointUrl = isAccessEnvironmentPrimary
+    ? desktopServerExposureState?.endpointUrl
+    : accessEnvironmentPairingBaseUrl;
+  const accessEndpoints = isAccessEnvironmentPrimary
+    ? visibleDesktopAdvertisedEndpoints
+    : EMPTY_ADVERTISED_ENDPOINTS;
+  const accessDefaultEndpointKey = isAccessEnvironmentPrimary
+    ? defaultDesktopAdvertisedEndpointKey
+    : null;
+  const renderAccessManagement = () => (
+    <SettingsSection
+      title="Authorized clients"
+      headerAction={
+        <div className="flex items-center gap-2">
+          {accessEnvironmentId === null ? null : (
+            <SettingsEnvironmentSelector
+              environmentId={accessEnvironmentId}
+              environments={settingsEnvironments}
+              primaryEnvironmentId={settingsPrimaryEnvironmentId}
+              onEnvironmentChange={selectSettingsEnvironment}
+            />
+          )}
+          {canManageEnvironmentAccess ? (
+            <AuthorizedClientsHeaderAction
+              clientSessions={desktopClientSessions}
+              isRevokingOtherClients={isRevokingOtherDesktopClients}
+              onRevokeOtherClients={handleRevokeOtherDesktopClients}
+              onCreatePairingLink={handleCreateAccessPairingLink}
+            />
+          ) : null}
         </div>
-      ) : null}
-      <PairingClientsList
-        endpointUrl={desktopServerExposureState?.endpointUrl}
-        endpoints={visibleDesktopAdvertisedEndpoints}
-        defaultEndpointKey={defaultDesktopAdvertisedEndpointKey}
-        presentation={presentation}
-        isLoading={isLoadingDesktopAccessManagement}
-        pairingLinks={visibleDesktopPairingLinks}
-        clientSessions={desktopClientSessions}
-        revokingPairingLinkId={revokingDesktopPairingLinkId}
-        revokingClientSessionId={revokingDesktopClientSessionId}
-        onRevokePairingLink={handleRevokeDesktopPairingLink}
-        onRevokeClientSession={handleRevokeDesktopClientSession}
-      />
-    </>
+      }
+    >
+      {accessEnvironment === null ? (
+        <SettingsRow
+          title="No environment selected"
+          description="Add or connect an environment to manage its pairing links and clients."
+        />
+      ) : !accessEnvironmentConnected ? (
+        <SettingsRow
+          title={accessEnvironment.label}
+          description="Connect this environment to manage its pairing links and clients."
+        />
+      ) : accessEnvironmentSessionLoading ? (
+        <SettingsRow title="Checking administrative access" description="Loading permissions…" />
+      ) : !canManageEnvironmentAccess ? (
+        <SettingsRow
+          title="Administrative access required"
+          description="Pairing links and client-session management require the access:write scope for this environment."
+        />
+      ) : (
+        <>
+          {desktopAccessManagementError ? (
+            <div className={accessRowClassName("current")}>
+              <p className="text-xs text-destructive">{desktopAccessManagementError}</p>
+            </div>
+          ) : null}
+          <ScrollArea
+            scrollFade
+            className="max-h-[22.5rem]"
+            data-testid="authorized-clients-scroll-area"
+          >
+            <PairingClientsList
+              endpointUrl={accessEndpointUrl}
+              endpoints={accessEndpoints}
+              defaultEndpointKey={accessDefaultEndpointKey}
+              presentation="current"
+              isLoading={isLoadingDesktopAccessManagement}
+              pairingLinks={visibleDesktopPairingLinks}
+              clientSessions={desktopClientSessions}
+              revokingPairingLinkId={revokingDesktopPairingLinkId}
+              revokingClientSessionId={revokingDesktopClientSessionId}
+              onRevokePairingLink={handleRevokeDesktopPairingLink}
+              onRevokeClientSession={handleRevokeDesktopClientSession}
+            />
+          </ScrollArea>
+        </>
+      )}
+    </SettingsSection>
   );
   const renderNetworkAccessRow = () => (
     <SettingsRow
@@ -3024,9 +3326,98 @@ export function ConnectionsSettings() {
     />
   );
 
+  const handleDesktopBackendModeChange = async (mode: DesktopBackendMode) => {
+    if (!desktopBridge || !desktopBackendModeState) return;
+    if (mode === desktopBackendModeState.configuredMode) return;
+    if (mode === "client-only" && !hasUsableClientOnlyEnvironment) {
+      setDesktopBackendModeError(
+        "Pair and save an environment before switching to client-only mode.",
+      );
+      setAddBackendDialogOpen(true);
+      void refreshRunningLocalServers();
+      return;
+    }
+
+    setIsUpdatingDesktopBackendMode(true);
+    setDesktopBackendModeError(null);
+    try {
+      const next = await desktopBridge.setBackendMode(mode);
+      setDesktopBackendModeState(next);
+      setIsUpdatingDesktopBackendMode(false);
+    } catch (error) {
+      setDesktopBackendModeError(
+        error instanceof Error ? error.message : "Could not update the desktop backend mode.",
+      );
+      setIsUpdatingDesktopBackendMode(false);
+    }
+  };
+
   return (
     <SettingsPageContainer>
-      {canManageLocalBackend ? (
+      {desktopBridge && desktopBackendModeState ? (
+        <SettingsSection title="Desktop application">
+          <SettingsRow
+            title="Backend mode"
+            description={
+              desktopBackendModeState.source === "existing-server"
+                ? "A T3 Code server is already running for this app's data directory, so the app is connected as a client for this launch."
+                : isClientOnlyDesktop
+                  ? "Connect only to saved environments. This desktop process does not start or control a local backend."
+                  : "Start and manage a local backend while retaining access to saved environments."
+            }
+            status={
+              desktopBackendModeError ? (
+                <span className="block text-destructive">{desktopBackendModeError}</span>
+              ) : desktopBackendModeState.source === "existing-server" ? (
+                <span className="block text-muted-foreground">
+                  The saved backend preference remains unchanged. Pair the running server below to
+                  save this connection.
+                </span>
+              ) : desktopBackendModeState.cliOverride !== null ? (
+                <span className="block text-muted-foreground">
+                  This launch is overridden by --backend-mode=
+                  {desktopBackendModeState.cliOverride}. The saved preference applies when launched
+                  without that flag.
+                </span>
+              ) : null
+            }
+            control={
+              <Select
+                value={desktopBackendModeState.configuredMode}
+                onValueChange={(value) => {
+                  if (value === "managed" || value === "client-only") {
+                    void handleDesktopBackendModeChange(value);
+                  }
+                }}
+              >
+                <SelectTrigger
+                  className="w-full sm:w-48"
+                  aria-label="Desktop backend mode"
+                  disabled={isUpdatingDesktopBackendMode}
+                >
+                  <SelectValue>
+                    {desktopBackendModeState.configuredMode === "managed"
+                      ? "Managed backend"
+                      : "Client only"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="managed">
+                    Managed backend
+                  </SelectItem>
+                  <SelectItem hideIndicator value="client-only">
+                    Client only
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            }
+          />
+        </SettingsSection>
+      ) : null}
+
+      {renderAccessManagement()}
+
+      {isClientOnlyDesktop ? null : canManageLocalBackend ? (
         <>
           <SettingsSection {...searchableSetting("connections-environment")}>
             {primaryVersionMismatch || primaryServerUpdateState.status !== "idle" ? (
@@ -3094,26 +3485,6 @@ export function ConnectionsSettings() {
             )}
           </SettingsSection>
 
-          {isLocalBackendRemotelyReachable ? (
-            <SettingsSection
-              title="Authorized clients"
-              headerAction={
-                <AuthorizedClientsHeaderAction
-                  clientSessions={desktopClientSessions}
-                  isRevokingOtherClients={isRevokingOtherDesktopClients}
-                  onRevokeOtherClients={handleRevokeOtherDesktopClients}
-                />
-              }
-            >
-              <ScrollArea
-                scrollFade
-                className="max-h-[22.5rem]"
-                data-testid="authorized-clients-scroll-area"
-              >
-                {renderAuthorizedClients("current")}
-              </ScrollArea>
-            </SettingsSection>
-          ) : null}
           <AlertDialog
             open={isDesktopServerExposureDialogOpen}
             onOpenChange={(open) => {
@@ -3398,6 +3769,36 @@ export function ConnectionsSettings() {
         </SettingsSection>
       )}
 
+      {hasLocalServerDiscoveryContent ? (
+        <SettingsSection
+          title="Available on this computer"
+          headerAction={
+            <Button
+              size="xs"
+              variant="ghost"
+              disabled={isDiscoveringLocalServers}
+              onClick={() => void refreshRunningLocalServers()}
+            >
+              {isDiscoveringLocalServers ? (
+                <Spinner className="size-3" />
+              ) : (
+                <RefreshCwIcon className="size-3" />
+              )}
+              Scan again
+            </Button>
+          }
+        >
+          {localServerPairingCandidates.length > 0 ? (
+            <p className="px-1 text-xs text-muted-foreground">
+              These servers are running from this app&apos;s local data directory. Pairing uses the
+              bundled T3 command to create a one-time credential, then saves the connection; this
+              desktop will not manage the server process.
+            </p>
+          ) : null}
+          {renderLocalServerPairingCandidates()}
+        </SettingsSection>
+      ) : null}
+
       <SettingsSection
         {...searchableSetting("remote-environments")}
         headerAction={
@@ -3405,6 +3806,9 @@ export function ConnectionsSettings() {
             open={addBackendDialogOpen}
             onOpenChange={(open) => {
               setAddBackendDialogOpen(open);
+              if (open) {
+                void refreshRunningLocalServers();
+              }
               if (!open) {
                 setSavedBackendError(null);
               }
@@ -3437,6 +3841,30 @@ export function ConnectionsSettings() {
               </DialogHeader>
               <DialogPanel>
                 <div className="space-y-4">
+                  {hasLocalServerDiscoveryContent ? (
+                    <div
+                      className={cn(
+                        "space-y-2 rounded-lg border p-3",
+                        localServerPairingCandidates.length > 0
+                          ? "border-primary/20 bg-primary/5"
+                          : localServerDiscoveryError
+                            ? "border-destructive/30 bg-destructive/5"
+                            : "border-border/70 bg-muted/20",
+                      )}
+                    >
+                      {localServerPairingCandidates.length > 0 ? (
+                        <div>
+                          <p className="text-sm font-medium text-foreground">
+                            A local T3 Code server is running
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Pair explicitly to save it without copying its URL.
+                          </p>
+                        </div>
+                      ) : null}
+                      {renderLocalServerPairingCandidates()}
+                    </div>
+                  ) : null}
                   <div className="grid gap-3 sm:grid-cols-2">
                     {renderConnectionModeCard({
                       mode: "remote",

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -7,13 +7,14 @@ import {
   InfoIcon,
   RefreshCwIcon,
 } from "lucide-react";
-import { useAtomValue } from "@effect/atom-react";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import type {
+  EnvironmentId,
+  ServerConfig,
   ServerProcessDiagnosticsEntry,
   ServerProcessResourceHistorySummary,
   ServerProcessSignal,
@@ -26,19 +27,15 @@ import { ensureLocalApi } from "../../localApi";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { useEnvironmentQuery } from "../../state/query";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerObservabilityAtom,
-  serverEnvironment,
-} from "../../state/server";
+import { serverEnvironment } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
-import { usePrimaryEnvironment } from "../../state/environments";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
 import { ResourceTelemetryDiagnostics } from "./ResourceTelemetryDiagnostics";
+import { SettingsEnvironmentScope } from "./SettingsEnvironmentSelector";
 import { SettingsPageContainer, SettingsSection, useRelativeTimeTick } from "./settingsLayout";
 import { useAtomCommand } from "../../state/use-atom-command";
 
@@ -809,10 +806,30 @@ function DiagnosticsRefreshButton({
 }
 
 export function DiagnosticsSettingsPanel() {
-  const observability = useAtomValue(primaryServerObservabilityAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
-  const environmentId = primaryEnvironment?.environmentId ?? null;
+  return (
+    <SettingsPageContainer width="expanded" className="gap-10">
+      <SettingsEnvironmentScope description="Traces, processes, and resource history come from the environment's own server.">
+        {(environment, serverConfig) => (
+          <DiagnosticsSettingsContent
+            key={environment.environmentId}
+            environmentId={environment.environmentId}
+            serverConfig={serverConfig}
+          />
+        )}
+      </SettingsEnvironmentScope>
+    </SettingsPageContainer>
+  );
+}
+
+function DiagnosticsSettingsContent({
+  environmentId,
+  serverConfig,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly serverConfig: ServerConfig;
+}) {
+  const observability = serverConfig.observability;
+  const availableEditors = serverConfig.availableEditors;
   const signalServerProcess = useAtomCommand(serverEnvironment.signalProcess, {
     reportFailure: false,
   });
@@ -824,56 +841,42 @@ export function DiagnosticsSettingsPanel() {
     RESOURCE_HISTORY_WINDOWS.find((option) => option.windowMs === resourceWindowMs) ??
     RESOURCE_HISTORY_WINDOWS[1];
   const { data, error, isPending, refresh } = useEnvironmentQuery(
-    environmentId === null
-      ? null
-      : serverEnvironment.traceDiagnostics({ environmentId, input: {} }),
+    serverEnvironment.traceDiagnostics({ environmentId, input: {} }),
   );
   const {
     data: processData,
     error: processError,
     isPending: isProcessPending,
     refresh: refreshProcesses,
-  } = useEnvironmentQuery(
-    environmentId === null
-      ? null
-      : serverEnvironment.processDiagnostics({ environmentId, input: {} }),
-  );
+  } = useEnvironmentQuery(serverEnvironment.processDiagnostics({ environmentId, input: {} }));
   const {
     data: resourceData,
     error: resourceError,
     isPending: isResourcePending,
     refresh: refreshResources,
   } = useEnvironmentQuery(
-    environmentId === null
-      ? null
-      : serverEnvironment.processResourceHistory({
-          environmentId,
-          input: {
-            windowMs: selectedResourceWindow.windowMs,
-            bucketMs: selectedResourceWindow.bucketMs,
-          },
-        }),
+    serverEnvironment.processResourceHistory({
+      environmentId,
+      input: {
+        windowMs: selectedResourceWindow.windowMs,
+        bucketMs: selectedResourceWindow.bucketMs,
+      },
+    }),
   );
   const [isOpeningLogsDirectory, setIsOpeningLogsDirectory] = useState(false);
   const [openLogsDirectoryError, setOpenLogsDirectoryError] = useState<string | null>(null);
   const [signalingPid, setSignalingPid] = useState<number | null>(null);
   const signalingPidRef = useRef<number | null>(null);
-  const environmentIdRef = useRef(environmentId);
   const processDataRef = useRef(processData);
-  environmentIdRef.current = environmentId;
   processDataRef.current = processData;
 
   const openLogsDirectory = useCallback(() => {
     const logsDirectoryPath = observability?.logsDirectoryPath ?? null;
     if (!logsDirectoryPath) return;
 
-    const editor = resolveAndPersistPreferredEditor(availableEditors ?? []);
+    const editor = resolveAndPersistPreferredEditor(availableEditors);
     if (!editor) {
       setOpenLogsDirectoryError("No available editors found.");
-      return;
-    }
-    if (environmentId === null) {
-      setOpenLogsDirectoryError("No environment is selected.");
       return;
     }
 
@@ -902,6 +905,8 @@ export function DiagnosticsSettingsPanel() {
   const signalProcess = useCallback(
     async (pid: number, signal: ServerProcessSignal) => {
       if (signalingPidRef.current !== null) return;
+      const process = processDataRef.current?.processes.find((entry) => entry.pid === pid);
+      if (process === undefined) return;
       signalingPidRef.current = pid;
       setSignalingPid(pid);
       const clearSignaling = () => {
@@ -929,20 +934,9 @@ export function DiagnosticsSettingsPanel() {
           return;
         }
       }
-      const currentEnvironmentId = environmentIdRef.current;
-      if (currentEnvironmentId === null) {
-        clearSignaling();
-        return;
-      }
-      const process = processDataRef.current?.processes.find((entry) => entry.pid === pid);
-      if (process === undefined) {
-        clearSignaling();
-        return;
-      }
-
       try {
         const result = await signalServerProcess({
-          environmentId: currentEnvironmentId,
+          environmentId,
           input: { pid, startTimeMs: process.startTimeMs, signal },
         });
         if (result._tag === "Failure") {
@@ -981,7 +975,7 @@ export function DiagnosticsSettingsPanel() {
         clearSignaling();
       }
     },
-    [refreshProcesses, signalServerProcess],
+    [environmentId, refreshProcesses, signalServerProcess],
   );
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
@@ -990,10 +984,9 @@ export function DiagnosticsSettingsPanel() {
   const traceDiagnosticsPartialFailure = data
     ? Option.getOrElse(data.partialFailure, () => false)
     : false;
-
   return (
-    <SettingsPageContainer width="expanded" className="gap-10">
-      <ResourceTelemetryDiagnostics />
+    <>
+      <ResourceTelemetryDiagnostics environmentId={environmentId} />
 
       <SettingsSection
         title="Live Processes"
@@ -1386,6 +1379,6 @@ export function DiagnosticsSettingsPanel() {
           <EmptyRows label={isInitialLoading ? "Loading span names..." : "No spans found."} />
         )}
       </SettingsSection>
-    </SettingsPageContainer>
+    </>
   );
 }

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -39,6 +39,7 @@ import { isDesktopLocalConnectionTarget } from "../../connection/desktopLocal";
 import { isElectron } from "../../env";
 import { usePrimarySessionState } from "../../environments/primary";
 import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { cn } from "../../lib/utils";
 import { resolveAppModelSelectionState } from "../../modelSelection";
 import {
@@ -210,19 +211,14 @@ function ProviderSettingsPanelContent() {
   const { environments, isReady } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const searchTargetId = useSettingsSearchTargetId();
+  const { environmentId: settingsEnvironmentId, selectEnvironment } = useSettingsEnvironment();
   const options = useMemo(
     () => buildProviderEnvironmentOptions(environments, primaryEnvironmentId),
     [environments, primaryEnvironmentId],
   );
-  // Raw user intent; the effective selection is re-derived every render so a
-  // device that drops out of the catalog falls back without erasing the pick —
-  // if it reappears (e.g. after a reconnect) the selection is restored.
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(
-    primaryEnvironmentId,
-  );
   const effectiveEnvironmentId = resolveSelectedProviderEnvironmentId(
     options,
-    selectedEnvironmentId,
+    settingsEnvironmentId,
     primaryEnvironmentId,
   );
   const selectedEnvironment =
@@ -245,9 +241,14 @@ function ProviderSettingsPanelContent() {
       !selectedEnvironmentCanRenderSettings &&
       searchableEnvironmentId !== undefined
     ) {
-      setSelectedEnvironmentId(searchableEnvironmentId);
+      selectEnvironment(searchableEnvironmentId);
     }
-  }, [searchTargetId, searchableEnvironmentId, selectedEnvironmentCanRenderSettings]);
+  }, [
+    searchTargetId,
+    searchableEnvironmentId,
+    selectEnvironment,
+    selectedEnvironmentCanRenderSettings,
+  ]);
   const onlyPrimaryDevice =
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
@@ -271,7 +272,7 @@ function ProviderSettingsPanelContent() {
                       type="button"
                       aria-pressed={selected}
                       className={cn(providerSettingsTabClassName(selected), "gap-2 text-left")}
-                      onClick={() => setSelectedEnvironmentId(environment.environmentId)}
+                      onClick={() => selectEnvironment(environment.environmentId)}
                     >
                       <Icon className="size-3.5 shrink-0" aria-hidden />
                       <span className="max-w-40 truncate">{environment.label}</span>

--- a/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
+++ b/apps/web/src/components/settings/ResourceTelemetryDiagnostics.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import type {
   BackgroundBooleanState,
+  EnvironmentId,
   ResourceAttributionEntry,
   ResourceTelemetryAggregate,
   ResourceTelemetryHistoryBucket,
@@ -39,7 +40,6 @@ import {
 } from "../../lib/resourceTelemetryState";
 import { cn } from "../../lib/utils";
 import { ensureLocalApi } from "../../localApi";
-import { usePrimaryEnvironment } from "../../state/environments";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { formatRelativeTime } from "../../timestampFormat";
@@ -831,25 +831,26 @@ function AttributionTable({ entries }: { entries: ReadonlyArray<ResourceAttribut
   );
 }
 
-export function ResourceTelemetryDiagnostics() {
+export function ResourceTelemetryDiagnostics({
+  environmentId,
+}: {
+  readonly environmentId: EnvironmentId;
+}) {
   const [windowMs, setWindowMs] = useState(15 * 60_000);
   const selectedWindow =
     HISTORY_WINDOWS.find((option) => option.windowMs === windowMs) ?? HISTORY_WINDOWS[1];
-  const telemetry = useResourceTelemetry();
+  const telemetry = useResourceTelemetry(environmentId);
   const retryTelemetry = telemetry.retry;
-  const history = useResourceTelemetryHistory({
+  const history = useResourceTelemetryHistory(environmentId, {
     windowMs: selectedWindow.windowMs,
     bucketMs: selectedWindow.bucketMs,
   });
-  const primaryEnvironment = usePrimaryEnvironment();
   const signalServerProcess = useAtomCommand(serverEnvironment.signalProcess, {
     reportFailure: false,
   });
   const [signalingKeys, setSignalingKeys] = useState<ReadonlySet<string>>(() => new Set());
   const signalingKeysRef = useRef<ReadonlySet<string>>(new Set());
   signalingKeysRef.current = signalingKeys;
-  const primaryEnvironmentIdRef = useRef(primaryEnvironment?.environmentId);
-  primaryEnvironmentIdRef.current = primaryEnvironment?.environmentId;
   const [isRetrying, setIsRetrying] = useState(false);
   const snapshot = telemetry.data;
   const allT3 = snapshot?.groups.allT3;
@@ -889,11 +890,6 @@ export function ResourceTelemetryDiagnostics() {
           return;
         }
       }
-      const environmentId = primaryEnvironmentIdRef.current;
-      if (environmentId === undefined) {
-        clearSignaling();
-        return;
-      }
       void signalServerProcess({
         environmentId,
         input: {
@@ -928,7 +924,7 @@ export function ResourceTelemetryDiagnostics() {
           clearSignaling();
         });
     },
-    [signalServerProcess],
+    [environmentId, signalServerProcess],
   );
 
   const retryCollector = useCallback(() => {

--- a/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
+++ b/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
@@ -1,0 +1,143 @@
+import type { EnvironmentId, ServerConfig } from "@t3tools/contracts";
+import { Link } from "@tanstack/react-router";
+import { CloudIcon, MonitorIcon } from "lucide-react";
+import { useMemo, type ReactNode } from "react";
+
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
+import type { EnvironmentPresentation } from "../../state/environments";
+import { Button } from "../ui/button";
+import {
+  Select,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { settingsEnvironmentNotice } from "./SettingsPanels.logic";
+import { SettingsRow, SettingsSection } from "./settingsLayout";
+
+interface SettingsEnvironmentSelectorProps {
+  readonly environmentId: EnvironmentId;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
+}
+
+export function SettingsEnvironmentSelector({
+  environmentId,
+  environments,
+  primaryEnvironmentId,
+  onEnvironmentChange,
+}: SettingsEnvironmentSelectorProps) {
+  const items = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.environmentId,
+        label: environment.label,
+      })),
+    [environments],
+  );
+  const selectedEnvironment =
+    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const SelectedIcon = environmentId === primaryEnvironmentId ? MonitorIcon : CloudIcon;
+
+  return (
+    <Select
+      value={environmentId}
+      items={items}
+      onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
+    >
+      <SelectTrigger size="sm" className="w-36 sm:w-52" aria-label="Settings environment">
+        <SelectedIcon className="size-3.5" />
+        <SelectValue>{selectedEnvironment?.label ?? "Select environment"}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectGroup>
+          <SelectGroupLabel>Configure environment</SelectGroupLabel>
+          {environments.map((environment) => {
+            const Icon =
+              environment.environmentId === primaryEnvironmentId ? MonitorIcon : CloudIcon;
+            return (
+              <SelectItem key={environment.environmentId} value={environment.environmentId}>
+                <span className="inline-flex items-center gap-1.5">
+                  <Icon className="size-3.5" />
+                  {environment.label}
+                </span>
+              </SelectItem>
+            );
+          })}
+        </SelectGroup>
+      </SelectPopup>
+    </Select>
+  );
+}
+
+/**
+ * Header for a panel whose contents belong to one environment: the picker, the
+ * current target, and why that target is unusable. `children` only renders
+ * against an environment that has published its settings, so panels never show
+ * schema defaults as if they were saved.
+ */
+export function SettingsEnvironmentScope({
+  description,
+  children,
+}: {
+  readonly description: string;
+  readonly children: (
+    environment: EnvironmentPresentation,
+    serverConfig: ServerConfig,
+  ) => ReactNode;
+}) {
+  const {
+    isReady,
+    environment,
+    environmentId,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+  } = useSettingsEnvironment();
+  const serverConfig = environment?.serverConfig ?? null;
+  const notice = settingsEnvironmentNotice({
+    isReady,
+    label: environment?.label ?? null,
+    phase: environment?.connection.phase ?? null,
+    hasServerConfig: serverConfig !== null,
+    error: environment?.connection.error ?? null,
+  });
+
+  return (
+    <>
+      <SettingsSection
+        title="Environment"
+        headerAction={
+          environmentId === null ? null : (
+            <SettingsEnvironmentSelector
+              environmentId={environmentId}
+              environments={environments}
+              primaryEnvironmentId={primaryEnvironmentId}
+              onEnvironmentChange={selectEnvironment}
+            />
+          )
+        }
+      >
+        <SettingsRow
+          title={environment?.label ?? "No environment"}
+          description={description}
+          status={notice ?? environment?.displayUrl}
+          control={
+            isReady && environmentId === null ? (
+              <Button render={<Link to="/settings/connections" />} size="sm" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
+      </SettingsSection>
+      {environment !== null && serverConfig !== null && notice === null
+        ? children(environment, serverConfig)
+        : null}
+    </>
+  );
+}

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -19,7 +19,53 @@ import {
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   resolveBackgroundActivityProfileOption,
+  resolveSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
+import { EnvironmentId } from "@t3tools/contracts";
+
+describe("settings environment resolution", () => {
+  const primary = EnvironmentId.make("primary");
+  const active = EnvironmentId.make("active");
+  const selected = EnvironmentId.make("selected");
+
+  it("prefers an explicit selection, then primary, then active", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        selectedEnvironmentId: selected,
+        primaryEnvironmentId: primary,
+        activeEnvironmentId: active,
+        availableEnvironmentIds: [primary, active, selected],
+      }),
+    ).toBe(selected);
+    expect(
+      resolveSettingsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: primary,
+        activeEnvironmentId: active,
+        availableEnvironmentIds: [active, primary],
+      }),
+    ).toBe(primary);
+    expect(
+      resolveSettingsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: active,
+        availableEnvironmentIds: [selected, active],
+      }),
+    ).toBe(active);
+  });
+
+  it("recovers from a stale selection", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        selectedEnvironmentId: selected,
+        primaryEnvironmentId: primary,
+        activeEnvironmentId: active,
+        availableEnvironmentIds: [primary, active],
+      }),
+    ).toBe(primary);
+  });
+});
 
 describe("typography settings restore", () => {
   it("detects family and size changes by font row", () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,6 +1,8 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type {
   BackgroundActivityProfile,
   BackgroundActivitySettings,
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceConfig,
   PreviewViewportSetting,
@@ -18,6 +20,68 @@ import {
 } from "@t3tools/shared/backgroundActivitySettings";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
+
+/**
+ * The environment whose server settings the settings panels address. An
+ * explicit pick wins; otherwise the client's own environment, then the one the
+ * user is working in, then whatever is connected. A pick that leaves the
+ * catalog falls back without being erased, so it is restored on reconnect.
+ */
+export function resolveSettingsEnvironmentId(input: {
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly activeEnvironmentId: EnvironmentId | null;
+  readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
+}): EnvironmentId | null {
+  const available = new Set(input.availableEnvironmentIds);
+  if (input.selectedEnvironmentId !== null && available.has(input.selectedEnvironmentId)) {
+    return input.selectedEnvironmentId;
+  }
+  if (input.primaryEnvironmentId !== null && available.has(input.primaryEnvironmentId)) {
+    return input.primaryEnvironmentId;
+  }
+  if (input.activeEnvironmentId !== null && available.has(input.activeEnvironmentId)) {
+    return input.activeEnvironmentId;
+  }
+  return input.availableEnvironmentIds[0] ?? null;
+}
+
+/**
+ * Why the settings environment cannot be read or written right now, or null
+ * once it is usable. Shared by every panel scoped to one environment so they
+ * all describe the same states the same way.
+ */
+export function settingsEnvironmentNotice(input: {
+  readonly isReady: boolean;
+  readonly label: string | null;
+  readonly phase: EnvironmentConnectionPhase | null;
+  readonly hasServerConfig: boolean;
+  readonly error: string | null;
+}): string | null {
+  if (input.label === null || input.phase === null) {
+    return input.isReady ? "No environment is connected." : "Loading environments...";
+  }
+  switch (input.phase) {
+    case "connected":
+      // Settings only exist once the environment has published its config;
+      // until then a panel would render schema defaults as if they were saved.
+      return input.hasServerConfig ? null : `Loading ${input.label}...`;
+    case "connecting":
+      return `Connecting to ${input.label}...`;
+    case "reconnecting":
+      return input.error
+        ? `Reconnecting to ${input.label}... Reason: ${input.error}`
+        : `Reconnecting to ${input.label}...`;
+    case "offline":
+      return `${input.label} is offline.`;
+    case "available":
+      return `${input.label} is not connected.`;
+    case "error":
+      return input.error
+        ? `Could not connect to ${input.label}. Reason: ${input.error}`
+        : `Could not connect to ${input.label}.`;
+  }
+}
 
 export function isProjectGroupingEnabled(mode: SidebarProjectGroupingMode): boolean {
   return mode !== "separate";

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -6,8 +6,10 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   type BackgroundActivityProfile,
   type DesktopUpdateChannel,
+  type EnvironmentId,
   ProviderDriverKind,
   type ScopedThreadRef,
+  type ServerConfig,
   type SidebarProjectGroupingMode,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
@@ -66,7 +68,13 @@ import {
   useTheme,
 } from "../../hooks/useTheme";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import {
+  useEnvironmentSettings,
+  usePrimarySettings,
+  useUpdateEnvironmentSettings,
+  useUpdatePrimarySettings,
+} from "../../hooks/useSettings";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -81,11 +89,7 @@ import {
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
-import {
-  primaryServerConfigAtom,
-  primaryServerObservabilityAtom,
-  primaryServerProvidersAtom,
-} from "../../state/server";
+import type { EnvironmentPresentation } from "../../state/environments";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
@@ -153,6 +157,7 @@ import {
 } from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
 import { ProjectFavicon } from "../ProjectFavicon";
+import { SettingsEnvironmentScope } from "./SettingsEnvironmentSelector";
 
 const ENVIRONMENT_IDENTIFICATION_LABELS: Record<EnvironmentIdentificationMode, string> = {
   artwork: "Artwork",
@@ -466,7 +471,15 @@ function AboutVersionSection() {
   );
 }
 
-export function useSettingsRestore(onRestored?: () => void) {
+export type SettingsOwnership = "client" | "environment";
+
+export interface SettingsRestore {
+  readonly canRestoreDefaults: boolean;
+  readonly changedSettingLabels: ReadonlyArray<string>;
+  readonly restoreDefaults: () => Promise<void>;
+}
+
+function useClientSettingsRestore(onRestored?: () => void): SettingsRestore {
   const {
     theme,
     setTheme,
@@ -478,12 +491,6 @@ export function useSettingsRestore(onRestored?: () => void) {
   } = useTheme();
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
-
-  const isTextGenerationModelDirty = !Equal.equals(
-    settings.textGenerationModelSelection ?? null,
-    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
-  );
-  const isBackgroundActivityDirty = hasChangedBackgroundActivitySettings(settings);
 
   const changedSettingLabels = useMemo(
     () => [
@@ -508,13 +515,6 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode
         ? ["Project Grouping"]
         : []),
-      ...(settings.sidebarAutoSettleAfterDays !==
-      DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
-        ? ["Auto-settle inactive threads"]
-        : []),
-      ...(settings.sidebarAutoSettleOnMerge !== DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge
-        ? ["Auto-settle merged threads"]
-        : []),
       ...(settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? ["Word wrap"] : []),
       ...getChangedTypographySettingLabels(settings),
       ...(settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
@@ -526,28 +526,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.contextWindowMeterEnabled !== DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled
         ? ["Context window indicator"]
         : []),
-      ...(settings.enableLegacyTokenStreaming !==
-      DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming
-        ? ["Stream token by token"]
-        : []),
-      ...(settings.enableProviderUpdateChecks !==
-      DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks
-        ? ["Provider update checks"]
-        : []),
       ...(settings.continueThreadsAfterServerUpdate !==
       DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate
         ? ["Continue threads after server updates"]
-        : []),
-      ...(isBackgroundActivityDirty ? ["Background activity"] : []),
-      ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
-        ? ["New thread mode"]
-        : []),
-      ...(settings.newWorktreesStartFromOrigin !==
-      DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
-        ? ["New worktrees start from origin"]
-        : []),
-      ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
-        ? ["Add project base directory"]
         : []),
       ...(settings.confirmThreadUnpin !== DEFAULT_UNIFIED_SETTINGS.confirmThreadUnpin
         ? ["Unpin confirmation"]
@@ -559,32 +540,23 @@ export function useSettingsRestore(onRestored?: () => void) {
         ? ["Delete confirmation"]
         : []),
       ...(settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit ? ["Quit shortcut"] : []),
-      ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
       ...getChangedBrowserSettingLabels(settings),
-      ...(settings.enableAgentBrowserAccess !== DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess
-        ? ["Agent browser access"]
-        : []),
     ],
     [
-      isTextGenerationModelDirty,
-      isBackgroundActivityDirty,
+      settings.appearanceContrast,
+      settings.browserAutoShowFloatingPreview,
+      settings.browserDefaultAppearance,
       settings.browserDefaultViewport,
       settings.browserDefaultZoomFactor,
-      settings.browserDefaultAppearance,
       settings.browserRecordingFrameRate,
-      settings.browserAutoShowFloatingPreview,
-      settings.appearanceContrast,
-      settings.enableAgentBrowserAccess,
       settings.confirmQuit,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.confirmThreadUnpin,
-      settings.addProjectBaseDirectory,
-      settings.defaultThreadEnvMode,
-      settings.newWorktreesStartFromOrigin,
+      settings.contextWindowMeterEnabled,
+      settings.continueThreadsAfterServerUpdate,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
-      settings.contextWindowMeterEnabled,
       settings.fontFamilyCode,
       settings.fontFamilyComposer,
       settings.fontFamilySans,
@@ -594,15 +566,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.fontSizePrompt,
       settings.fontSizeTerminal,
       settings.glassOpacity,
-      settings.enableLegacyTokenStreaming,
       settings.persistComposerContextStrip,
-      settings.enableProviderUpdateChecks,
-      settings.continueThreadsAfterServerUpdate,
-      settings.sidebarAutoSettleAfterDays,
-      settings.sidebarAutoSettleOnMerge,
+      settings.showSkillsInSlashMenu,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
-      settings.showSkillsInSlashMenu,
       settings.timestampFormat,
       settings.wordWrap,
       followSystem,
@@ -685,23 +652,11 @@ export function useSettingsRestore(onRestored?: () => void) {
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
-      sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
-      sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
-      enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
-      enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
       continueThreadsAfterServerUpdate: DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate,
-      backgroundActivity: DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
-      backgroundActivityProfile: DEFAULT_UNIFIED_SETTINGS.backgroundActivityProfile,
-      automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
-      providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
-      defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
-      newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-      addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       confirmThreadUnpin: DEFAULT_UNIFIED_SETTINGS.confirmThreadUnpin,
       confirmQuit: DEFAULT_UNIFIED_SETTINGS.confirmQuit,
-      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
       fontFamilySans: DEFAULT_UNIFIED_SETTINGS.fontFamilySans,
       fontFamilyComposer: DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer,
       fontFamilyCode: DEFAULT_UNIFIED_SETTINGS.fontFamilyCode,
@@ -715,10 +670,6 @@ export function useSettingsRestore(onRestored?: () => void) {
       browserDefaultAppearance: DEFAULT_UNIFIED_SETTINGS.browserDefaultAppearance,
       browserRecordingFrameRate: DEFAULT_UNIFIED_SETTINGS.browserRecordingFrameRate,
       browserAutoShowFloatingPreview: DEFAULT_UNIFIED_SETTINGS.browserAutoShowFloatingPreview,
-      // Re-granted like any other default. The confirmation dialog lists it by
-      // name, so a user restoring defaults is told the agent regains access
-      // rather than discovering it later.
-      enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
     });
     onRestored?.();
   }, [
@@ -734,20 +685,122 @@ export function useSettingsRestore(onRestored?: () => void) {
   ]);
 
   return {
+    canRestoreDefaults: true,
     changedSettingLabels,
     restoreDefaults,
   };
 }
 
+function useEnvironmentSettingsRestore(onRestored?: () => void): SettingsRestore {
+  const { environmentId, environment } = useSettingsEnvironment();
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const isTextGenerationModelDirty = !Equal.equals(
+    settings.textGenerationModelSelection ?? null,
+    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
+  );
+
+  const changedSettingLabels = useMemo(
+    () => [
+      ...(settings.sidebarAutoSettleAfterDays !==
+      DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays
+        ? ["Auto-settle inactive threads"]
+        : []),
+      ...(settings.sidebarAutoSettleOnMerge !== DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge
+        ? ["Auto-settle merged threads"]
+        : []),
+      ...(settings.enableLegacyTokenStreaming !==
+      DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming
+        ? ["Stream token by token"]
+        : []),
+      ...(settings.enableProviderUpdateChecks !==
+      DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks
+        ? ["Provider update checks"]
+        : []),
+      ...(hasChangedBackgroundActivitySettings(settings) ? ["Background activity"] : []),
+      ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
+        ? ["New thread mode"]
+        : []),
+      ...(settings.newWorktreesStartFromOrigin !==
+      DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
+        ? ["New worktrees start from origin"]
+        : []),
+      ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
+        ? ["Add project base directory"]
+        : []),
+      ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
+      ...(settings.enableAgentBrowserAccess !== DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess
+        ? ["Agent browser access"]
+        : []),
+    ],
+    [isTextGenerationModelDirty, settings],
+  );
+
+  const restoreDefaults = useCallback(async () => {
+    if (changedSettingLabels.length === 0) return;
+    const api = readLocalApi();
+    const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
+      ["Restore default settings?", `This will reset: ${changedSettingLabels.join(", ")}.`].join(
+        "\n",
+      ),
+      { variant: "destructive" },
+    );
+    if (!confirmed) return;
+
+    updateSettings({
+      sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
+      sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
+      enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
+      enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+      backgroundActivity: DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
+      backgroundActivityProfile: DEFAULT_UNIFIED_SETTINGS.backgroundActivityProfile,
+      automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+      providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
+      defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+      newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+      // Re-granted like any other default. The confirmation dialog lists it by
+      // name, so a user restoring defaults is told the agent regains access
+      // rather than discovering it later.
+      enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
+    });
+    onRestored?.();
+  }, [changedSettingLabels, onRestored, updateSettings]);
+
+  return {
+    // Writes go to a server, so there is nothing to restore while the settings
+    // environment is unreachable.
+    canRestoreDefaults: environment?.connection.phase === "connected",
+    changedSettingLabels,
+    restoreDefaults,
+  };
+}
+
+/**
+ * Restore-to-defaults for one settings page. Client and environment settings
+ * live in separate stores, so a page only resets the keys it owns.
+ */
+export function useSettingsRestore(
+  ownership: SettingsOwnership,
+  onRestored?: () => void,
+): SettingsRestore {
+  const client = useClientSettingsRestore(onRestored);
+  const environment = useEnvironmentSettingsRestore(onRestored);
+  return ownership === "client" ? client : environment;
+}
+
 function BackgroundActivityAdvancedDialog({
+  environmentId,
   open,
   onOpenChange,
 }: {
+  readonly environmentId: EnvironmentId;
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
   const activeProfile = resolvedBackgroundActivity.profile;
   const automaticGitFetchIntervalSeconds = durationToSeconds(
@@ -1817,7 +1870,6 @@ function AutoSettleDaysInput({
 const LEGACY_FEATURE_TARGET_IDS: ReadonlySet<string> = new Set([
   "legacy-plan-mode",
   "legacy-context-window-indicator",
-  "legacy-token-streaming",
   "legacy-sidebar",
 ]);
 
@@ -1907,33 +1959,6 @@ function LegacyFeaturesSection() {
               }
             />
             <SettingsRow
-              serverScoped
-              {...searchableSetting("legacy-token-streaming")}
-              description="Paints assistant output token by token instead of in complete chunks. Not recommended: it is significantly slower, and long responses become harder to follow. Kept only for compatibility with the old behavior."
-              control={
-                <Switch
-                  checked={settings.enableLegacyTokenStreaming}
-                  onCheckedChange={(checked) => {
-                    if (!checked) {
-                      updateSettings({ enableLegacyTokenStreaming: false });
-                      return;
-                    }
-                    void (async () => {
-                      const api = readLocalApi();
-                      const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
-                        [
-                          "Turn on token-by-token output?",
-                          "It is significantly slower than the default buffered output and hurts the reading experience. This switch exists only for backwards compatibility.",
-                        ].join("\n"),
-                      );
-                      if (confirmed) updateSettings({ enableLegacyTokenStreaming: true });
-                    })();
-                  }}
-                  aria-label="Stream token by token (legacy)"
-                />
-              }
-            />
-            <SettingsRow
               {...searchableSetting("legacy-sidebar")}
               description="Brings back the original sidebar with per-project thread trees. The default sidebar shows one flat list: active work as rich cards, settled threads as compact rows."
               control={
@@ -1956,61 +1981,12 @@ function LegacyFeaturesSection() {
 export function GeneralSettingsPanel() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
-  const [backgroundActivityDialogOpen, setBackgroundActivityDialogOpen] = useState(false);
   const lastEnabledProjectGroupingMode = useRef<SidebarProjectGroupingMode>(
     readLastEnabledProjectGroupingMode(),
-  );
-  const observability = useAtomValue(primaryServerObservabilityAtom);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
-  const supportsAutoSettlement =
-    useAtomValue(primaryServerConfigAtom)?.environment.capabilities.threadAutoSettlement === true;
-  const diagnosticsDescription = formatDiagnosticsDescription({
-    localTracingEnabled: observability?.localTracingEnabled ?? false,
-    otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
-    otlpTracesUrl: observability?.otlpTracesUrl,
-    otlpMetricsEnabled: observability?.otlpMetricsEnabled ?? false,
-    otlpMetricsUrl: observability?.otlpMetricsUrl,
-  });
-
-  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
-  const textGenInstanceId = textGenerationModelSelection.instanceId;
-  const textGenModel = textGenerationModelSelection.model;
-  const textGenModelOptions = textGenerationModelSelection.options;
-  const textGenerationModelInstanceEntries = sortProviderInstanceEntries(
-    applyProviderInstanceSettings(deriveProviderInstanceEntries(serverProviders), settings),
-  );
-  const textGenInstanceEntry = textGenerationModelInstanceEntries.find(
-    (entry) => entry.instanceId === textGenInstanceId,
-  );
-  const textGenProvider: ProviderDriverKind =
-    textGenInstanceEntry?.driverKind ?? DEFAULT_DRIVER_KIND;
-  const textGenerationModelOptionsByInstance = getCustomModelOptionsByInstance(
-    settings,
-    serverProviders,
-    textGenInstanceId,
-    textGenModel,
-  );
-  const isTextGenerationModelDirty = !Equal.equals(
-    settings.textGenerationModelSelection ?? null,
-    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
-  );
-  const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
-  const activeBackgroundActivityProfile = resolvedBackgroundActivity.profile;
-  const backgroundActivityProfileOption = resolveBackgroundActivityProfileOption(settings);
-  const backgroundActivityDescription =
-    backgroundActivityProfileOption === "advanced"
-      ? `${ADVANCED_BACKGROUND_ACTIVITY_DESCRIPTION} Current shared policy: ${
-          BACKGROUND_ACTIVITY_PROFILE_LABELS[activeBackgroundActivityProfile]
-        }.`
-      : BACKGROUND_ACTIVITY_PROFILE_DESCRIPTIONS[resolvedBackgroundActivity.profile];
-  const canResetBackgroundActivity = !Equal.equals(
-    settings.backgroundActivity,
-    DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
   );
 
   return (
     <SettingsPageContainer>
-      <SharedSettingsMismatchAlert />
       <SettingsSection title="General">
         <SettingsRow
           {...searchableSetting("project-grouping")}
@@ -2047,82 +2023,6 @@ export function GeneralSettingsPanel() {
             />
           }
         />
-
-        {supportsAutoSettlement ? (
-          <>
-            <SettingsRow
-              serverScoped
-              {...searchableSetting("auto-settle-merged-threads")}
-              description="Settle a thread when its pull request merges. Closed pull requests still settle automatically."
-              resetAction={
-                settings.sidebarAutoSettleOnMerge !==
-                DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge ? (
-                  <SettingResetButton
-                    label="auto-settle on merge"
-                    onClick={() =>
-                      updateSettings({
-                        sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
-                      })
-                    }
-                  />
-                ) : null
-              }
-              control={
-                <Switch
-                  checked={settings.sidebarAutoSettleOnMerge}
-                  onCheckedChange={(checked) =>
-                    updateSettings({ sidebarAutoSettleOnMerge: Boolean(checked) })
-                  }
-                  aria-label="Auto-settle merged threads"
-                />
-              }
-            />
-
-            <SettingsRow
-              serverScoped
-              {...searchableSetting("auto-settle-inactive-threads")}
-              description="Sidebar threads with no activity for this long settle automatically."
-              resetAction={
-                settings.sidebarAutoSettleAfterDays !==
-                DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays ? (
-                  <SettingResetButton
-                    label="auto-settle"
-                    onClick={() =>
-                      updateSettings({
-                        sidebarAutoSettleAfterDays:
-                          DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
-                      })
-                    }
-                  />
-                ) : null
-              }
-              control={
-                <Switch
-                  checked={settings.sidebarAutoSettleAfterDays !== null}
-                  onCheckedChange={(checked) =>
-                    updateSettings({
-                      sidebarAutoSettleAfterDays: checked ? AUTO_SETTLE_DEFAULT_DAYS : null,
-                    })
-                  }
-                  aria-label="Auto-settle inactive threads"
-                />
-              }
-            />
-            {settings.sidebarAutoSettleAfterDays !== null ? (
-              <SettingsRow
-                serverScoped
-                title={searchableSetting("days-before-auto-settle").title}
-                description="Any new activity un-settles a thread automatically."
-                control={
-                  <AutoSettleDaysInput
-                    value={settings.sidebarAutoSettleAfterDays}
-                    onCommit={(days) => updateSettings({ sidebarAutoSettleAfterDays: days })}
-                  />
-                }
-              />
-            ) : null}
-          </>
-        ) : null}
 
         <SettingsRow
           {...searchableSetting("time-format")}
@@ -2219,6 +2119,321 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          {...searchableSetting("continue-threads-after-server-update")}
+          description="Automatically resume active threads after a server update restarts the environment."
+          resetAction={
+            settings.continueThreadsAfterServerUpdate !==
+            DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate ? (
+              <SettingResetButton
+                label="continue threads after server updates"
+                onClick={() =>
+                  updateSettings({
+                    continueThreadsAfterServerUpdate:
+                      DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.continueThreadsAfterServerUpdate}
+              onCheckedChange={(checked) =>
+                updateSettings({ continueThreadsAfterServerUpdate: Boolean(checked) })
+              }
+              aria-label="Continue threads after server updates"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("unpin-confirmation")}
+          description="Ask before unpinning a thread from the pinned section."
+          resetAction={
+            settings.confirmThreadUnpin !== DEFAULT_UNIFIED_SETTINGS.confirmThreadUnpin ? (
+              <SettingResetButton
+                label="unpin confirmation"
+                onClick={() =>
+                  updateSettings({
+                    confirmThreadUnpin: DEFAULT_UNIFIED_SETTINGS.confirmThreadUnpin,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.confirmThreadUnpin}
+              onCheckedChange={(checked) =>
+                updateSettings({ confirmThreadUnpin: Boolean(checked) })
+              }
+              aria-label="Confirm thread unpinning"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("archive-confirmation")}
+          description="Require a second click on the inline archive action before a thread is archived."
+          resetAction={
+            settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive ? (
+              <SettingResetButton
+                label="archive confirmation"
+                onClick={() =>
+                  updateSettings({
+                    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.confirmThreadArchive}
+              onCheckedChange={(checked) =>
+                updateSettings({ confirmThreadArchive: Boolean(checked) })
+              }
+              aria-label="Confirm thread archiving"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("delete-confirmation")}
+          description="Ask before deleting a thread and its chat history."
+          resetAction={
+            settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete ? (
+              <SettingResetButton
+                label="delete confirmation"
+                onClick={() =>
+                  updateSettings({
+                    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.confirmThreadDelete}
+              onCheckedChange={(checked) =>
+                updateSettings({ confirmThreadDelete: Boolean(checked) })
+              }
+              aria-label="Confirm thread deletion"
+            />
+          }
+        />
+
+        {isElectron ? (
+          <SettingsRow
+            {...searchableSetting("quit-confirmation")}
+            description="Choose whether the desktop app quits immediately, after a hold, or after two quick presses."
+            resetAction={
+              settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit ? (
+                <SettingResetButton
+                  label="quit shortcut behavior"
+                  onClick={() =>
+                    updateSettings({ confirmQuit: DEFAULT_UNIFIED_SETTINGS.confirmQuit })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <Select
+                value={settings.confirmQuit}
+                onValueChange={(value) => {
+                  if (value === "direct" || value === "hold" || value === "double-click") {
+                    updateSettings({ confirmQuit: value });
+                  }
+                }}
+              >
+                <SelectTrigger
+                  size="sm"
+                  className="w-full sm:w-40"
+                  aria-label="Quit shortcut behavior"
+                >
+                  <SelectValue>{QUIT_CONFIRMATION_MODE_LABELS[settings.confirmQuit]}</SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  {Object.entries(QUIT_CONFIRMATION_MODE_LABELS).map(([value, label]) => (
+                    <SelectItem hideIndicator key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
+            }
+          />
+        ) : null}
+      </SettingsSection>
+
+      <SettingsSection title="About">
+        {isElectron || HOSTED_APP_CHANNEL ? (
+          <AboutVersionSection />
+        ) : (
+          <SettingsRow
+            title={<AboutVersionTitle />}
+            description="Current version of the application."
+          />
+        )}
+      </SettingsSection>
+
+      <LegacyFeaturesSection />
+    </SettingsPageContainer>
+  );
+}
+
+export function EnvironmentSettingsPanel() {
+  return (
+    <SettingsPageContainer>
+      <SharedSettingsMismatchAlert />
+      <SettingsEnvironmentScope description="Workspace defaults and background behavior are stored on the environment's own server.">
+        {(environment, serverConfig) => (
+          <EnvironmentSettingsSections environment={environment} serverConfig={serverConfig} />
+        )}
+      </SettingsEnvironmentScope>
+    </SettingsPageContainer>
+  );
+}
+
+function EnvironmentSettingsSections({
+  environment,
+  serverConfig,
+}: {
+  readonly environment: EnvironmentPresentation;
+  readonly serverConfig: ServerConfig;
+}) {
+  const environmentId = environment.environmentId;
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const [backgroundActivityDialogOpen, setBackgroundActivityDialogOpen] = useState(false);
+  const observability = serverConfig.observability;
+  const serverProviders = serverConfig.providers;
+  const supportsAutoSettlement = serverConfig.environment.capabilities.threadAutoSettlement;
+  const diagnosticsDescription = formatDiagnosticsDescription({
+    localTracingEnabled: observability?.localTracingEnabled ?? false,
+    otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
+    otlpTracesUrl: observability?.otlpTracesUrl,
+    otlpMetricsEnabled: observability?.otlpMetricsEnabled ?? false,
+    otlpMetricsUrl: observability?.otlpMetricsUrl,
+  });
+
+  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
+  const textGenInstanceId = textGenerationModelSelection.instanceId;
+  const textGenModel = textGenerationModelSelection.model;
+  const textGenModelOptions = textGenerationModelSelection.options;
+  const textGenerationModelInstanceEntries = sortProviderInstanceEntries(
+    applyProviderInstanceSettings(deriveProviderInstanceEntries(serverProviders), settings),
+  );
+  const textGenInstanceEntry = textGenerationModelInstanceEntries.find(
+    (entry) => entry.instanceId === textGenInstanceId,
+  );
+  const textGenProvider: ProviderDriverKind =
+    textGenInstanceEntry?.driverKind ?? DEFAULT_DRIVER_KIND;
+  const textGenerationModelOptionsByInstance = getCustomModelOptionsByInstance(
+    settings,
+    serverProviders,
+    textGenInstanceId,
+    textGenModel,
+  );
+  const isTextGenerationModelDirty = !Equal.equals(
+    settings.textGenerationModelSelection ?? null,
+    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
+  );
+  const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
+  const activeBackgroundActivityProfile = resolvedBackgroundActivity.profile;
+  const backgroundActivityProfileOption = resolveBackgroundActivityProfileOption(settings);
+  const backgroundActivityDescription =
+    backgroundActivityProfileOption === "advanced"
+      ? `${ADVANCED_BACKGROUND_ACTIVITY_DESCRIPTION} Current shared policy: ${
+          BACKGROUND_ACTIVITY_PROFILE_LABELS[activeBackgroundActivityProfile]
+        }.`
+      : BACKGROUND_ACTIVITY_PROFILE_DESCRIPTIONS[resolvedBackgroundActivity.profile];
+  const canResetBackgroundActivity = !Equal.equals(
+    settings.backgroundActivity,
+    DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
+  );
+
+  return (
+    <>
+      <SettingsSection title="Workspace">
+        {supportsAutoSettlement ? (
+          <>
+            <SettingsRow
+              serverScoped
+              {...searchableSetting("auto-settle-merged-threads")}
+              description="Settle a thread when its pull request merges. Closed pull requests still settle automatically."
+              resetAction={
+                settings.sidebarAutoSettleOnMerge !==
+                DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge ? (
+                  <SettingResetButton
+                    label="auto-settle on merge"
+                    onClick={() =>
+                      updateSettings({
+                        sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.sidebarAutoSettleOnMerge}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ sidebarAutoSettleOnMerge: Boolean(checked) })
+                  }
+                  aria-label="Auto-settle merged threads"
+                />
+              }
+            />
+
+            <SettingsRow
+              serverScoped
+              {...searchableSetting("auto-settle-inactive-threads")}
+              description="Sidebar threads with no activity for this long settle automatically."
+              resetAction={
+                settings.sidebarAutoSettleAfterDays !==
+                DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays ? (
+                  <SettingResetButton
+                    label="auto-settle"
+                    onClick={() =>
+                      updateSettings({
+                        sidebarAutoSettleAfterDays:
+                          DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.sidebarAutoSettleAfterDays !== null}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      sidebarAutoSettleAfterDays: checked ? AUTO_SETTLE_DEFAULT_DAYS : null,
+                    })
+                  }
+                  aria-label="Auto-settle inactive threads"
+                />
+              }
+            />
+            {settings.sidebarAutoSettleAfterDays !== null ? (
+              <SettingsRow
+                serverScoped
+                title={searchableSetting("days-before-auto-settle").title}
+                description="Any new activity un-settles a thread automatically."
+                control={
+                  <AutoSettleDaysInput
+                    value={settings.sidebarAutoSettleAfterDays}
+                    onCommit={(days) => updateSettings({ sidebarAutoSettleAfterDays: days })}
+                  />
+                }
+              />
+            ) : null}
+          </>
+        ) : null}
+
+        <SettingsRow
           serverScoped
           {...searchableSetting("provider-update-checks")}
           description="Check installed provider CLIs for newer available versions."
@@ -2247,29 +2462,29 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
-          {...searchableSetting("continue-threads-after-server-update")}
-          description="Automatically resume active threads after a server update restarts the environment."
-          resetAction={
-            settings.continueThreadsAfterServerUpdate !==
-            DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate ? (
-              <SettingResetButton
-                label="continue threads after server updates"
-                onClick={() =>
-                  updateSettings({
-                    continueThreadsAfterServerUpdate:
-                      DEFAULT_UNIFIED_SETTINGS.continueThreadsAfterServerUpdate,
-                  })
-                }
-              />
-            ) : null
-          }
+          serverScoped
+          {...searchableSetting("legacy-token-streaming")}
+          description="Paints assistant output token by token instead of in complete chunks. Not recommended: it is significantly slower, and long responses become harder to follow. Kept only for compatibility with the old behavior."
           control={
             <Switch
-              checked={settings.continueThreadsAfterServerUpdate}
-              onCheckedChange={(checked) =>
-                updateSettings({ continueThreadsAfterServerUpdate: Boolean(checked) })
-              }
-              aria-label="Continue threads after server updates"
+              checked={settings.enableLegacyTokenStreaming}
+              onCheckedChange={(checked) => {
+                if (!checked) {
+                  updateSettings({ enableLegacyTokenStreaming: false });
+                  return;
+                }
+                void (async () => {
+                  const api = readLocalApi();
+                  const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
+                    [
+                      "Turn on token-by-token output?",
+                      "It is significantly slower than the default buffered output and hurts the reading experience. This switch exists only for backwards compatibility.",
+                    ].join("\n"),
+                  );
+                  if (confirmed) updateSettings({ enableLegacyTokenStreaming: true });
+                })();
+              }}
+              aria-label="Stream token by token (legacy)"
             />
           }
         />
@@ -2351,6 +2566,7 @@ export function GeneralSettingsPanel() {
                 </Tooltip>
               ) : null}
               <BackgroundActivityAdvancedDialog
+                environmentId={environmentId}
                 open={backgroundActivityDialogOpen}
                 onOpenChange={setBackgroundActivityDialogOpen}
               />
@@ -2466,122 +2682,6 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
-          {...searchableSetting("unpin-confirmation")}
-          description="Ask before unpinning a thread from the pinned section."
-          resetAction={
-            settings.confirmThreadUnpin !== DEFAULT_UNIFIED_SETTINGS.confirmThreadUnpin ? (
-              <SettingResetButton
-                label="unpin confirmation"
-                onClick={() =>
-                  updateSettings({
-                    confirmThreadUnpin: DEFAULT_UNIFIED_SETTINGS.confirmThreadUnpin,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.confirmThreadUnpin}
-              onCheckedChange={(checked) =>
-                updateSettings({ confirmThreadUnpin: Boolean(checked) })
-              }
-              aria-label="Confirm thread unpinning"
-            />
-          }
-        />
-
-        <SettingsRow
-          {...searchableSetting("archive-confirmation")}
-          description="Require a second click on the inline archive action before a thread is archived."
-          resetAction={
-            settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive ? (
-              <SettingResetButton
-                label="archive confirmation"
-                onClick={() =>
-                  updateSettings({
-                    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.confirmThreadArchive}
-              onCheckedChange={(checked) =>
-                updateSettings({ confirmThreadArchive: Boolean(checked) })
-              }
-              aria-label="Confirm thread archiving"
-            />
-          }
-        />
-
-        <SettingsRow
-          {...searchableSetting("delete-confirmation")}
-          description="Ask before deleting a thread and its chat history."
-          resetAction={
-            settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete ? (
-              <SettingResetButton
-                label="delete confirmation"
-                onClick={() =>
-                  updateSettings({
-                    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.confirmThreadDelete}
-              onCheckedChange={(checked) =>
-                updateSettings({ confirmThreadDelete: Boolean(checked) })
-              }
-              aria-label="Confirm thread deletion"
-            />
-          }
-        />
-
-        {isElectron ? (
-          <SettingsRow
-            {...searchableSetting("quit-confirmation")}
-            description="Choose whether the desktop app quits immediately, after a hold, or after two quick presses."
-            resetAction={
-              settings.confirmQuit !== DEFAULT_UNIFIED_SETTINGS.confirmQuit ? (
-                <SettingResetButton
-                  label="quit shortcut behavior"
-                  onClick={() =>
-                    updateSettings({ confirmQuit: DEFAULT_UNIFIED_SETTINGS.confirmQuit })
-                  }
-                />
-              ) : null
-            }
-            control={
-              <Select
-                value={settings.confirmQuit}
-                onValueChange={(value) => {
-                  if (value === "direct" || value === "hold" || value === "double-click") {
-                    updateSettings({ confirmQuit: value });
-                  }
-                }}
-              >
-                <SelectTrigger className="w-full sm:w-40" aria-label="Quit shortcut behavior">
-                  <SelectValue>{QUIT_CONFIRMATION_MODE_LABELS[settings.confirmQuit]}</SelectValue>
-                </SelectTrigger>
-                <SelectPopup align="end" alignItemWithTrigger={false}>
-                  {Object.entries(QUIT_CONFIRMATION_MODE_LABELS).map(([value, label]) => (
-                    <SelectItem hideIndicator key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectPopup>
-              </Select>
-            }
-          />
-        ) : null}
-
-        <SettingsRow
           serverScoped
           {...searchableSetting("text-generation-model")}
           description="Default model for generated text like thread titles and source control content. Source control settings can override it with a dedicated source control writer model."
@@ -2658,15 +2758,7 @@ export function GeneralSettingsPanel() {
         />
       </SettingsSection>
 
-      <SettingsSection title="About">
-        {isElectron || HOSTED_APP_CHANNEL ? (
-          <AboutVersionSection />
-        ) : (
-          <SettingsRow
-            title={<AboutVersionTitle />}
-            description="Current version of the application."
-          />
-        )}
+      <SettingsSection title="Diagnostics">
         <SettingsRow
           {...searchableSetting("diagnostics")}
           description={diagnosticsDescription}
@@ -2677,9 +2769,7 @@ export function GeneralSettingsPanel() {
           }
         />
       </SettingsSection>
-
-      <LegacyFeaturesSection />
-    </SettingsPageContainer>
+    </>
   );
 }
 

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -4,10 +4,12 @@ import {
   useMemo,
   useRef,
   useState,
+  Fragment,
   type ComponentType,
   type KeyboardEvent,
 } from "react";
 import {
+  ActivityIcon,
   ArchiveIcon,
   BlocksIcon,
   BotIcon,
@@ -30,6 +32,7 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -50,6 +53,7 @@ const SETTINGS_SECTION_ICONS: Readonly<
   Record<SettingsPath, ComponentType<{ className?: string }>>
 > = {
   "/settings/general": Settings2Icon,
+  "/settings/environment": Settings2Icon,
   "/settings/appearance": PaletteIcon,
   "/settings/keybindings": KeyboardIcon,
   "/settings/providers": BotIcon,
@@ -57,6 +61,7 @@ const SETTINGS_SECTION_ICONS: Readonly<
   "/settings/scheduled-tasks": CalendarClockIcon,
   "/settings/source-control": GitBranchIcon,
   "/settings/connections": Link2Icon,
+  "/settings/diagnostics": ActivityIcon,
   "/settings/archived": ArchiveIcon,
 };
 
@@ -68,6 +73,33 @@ export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
   to,
   label: SETTINGS_SECTION_LABELS[to],
   icon: SETTINGS_SECTION_ICONS[to],
+}));
+
+const SETTINGS_NAV_GROUP_LABELS = ["Client", "Environments", "Other"] as const;
+type SettingsNavGroupLabel = (typeof SETTINGS_NAV_GROUP_LABELS)[number];
+
+/**
+ * Which heading each section sits under. Typed as a total record so a new
+ * settings section cannot compile without being placed in a group, and
+ * sections keep the order they are declared in within their group.
+ */
+const SETTINGS_SECTION_GROUPS: Readonly<Record<SettingsPath, SettingsNavGroupLabel>> = {
+  "/settings/general": "Client",
+  "/settings/appearance": "Client",
+  "/settings/connections": "Environments",
+  "/settings/environment": "Environments",
+  "/settings/keybindings": "Environments",
+  "/settings/providers": "Environments",
+  "/settings/integrations": "Environments",
+  "/settings/source-control": "Environments",
+  "/settings/scheduled-tasks": "Environments",
+  "/settings/diagnostics": "Environments",
+  "/settings/archived": "Other",
+};
+
+const SETTINGS_NAV_GROUPS = SETTINGS_NAV_GROUP_LABELS.map((label) => ({
+  label,
+  items: SETTINGS_NAV_ITEMS.filter((item) => SETTINGS_SECTION_GROUPS[item.to] === label),
 }));
 
 function SettingsSectionIcon({ to }: { to: SettingsPath }) {
@@ -274,21 +306,26 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 ))
-              : SETTINGS_NAV_ITEMS.map((item) => {
-                  const Icon = item.icon;
-                  const isActive = pathname === item.to || pathname.startsWith(`${item.to}/`);
-                  return (
-                    <SidebarMenuItem key={item.to}>
-                      <SidebarMenuButton
-                        isActive={isActive}
-                        onClick={() => handleSectionClick(item.to)}
-                      >
-                        <Icon />
-                        <span className="truncate">{item.label}</span>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  );
-                })}
+              : SETTINGS_NAV_GROUPS.map((group) => (
+                  <Fragment key={group.label}>
+                    <SidebarGroupLabel className="mt-2 first:mt-0">{group.label}</SidebarGroupLabel>
+                    {group.items.map((item) => {
+                      const Icon = item.icon;
+                      const isActive = pathname === item.to || pathname.startsWith(`${item.to}/`);
+                      return (
+                        <SidebarMenuItem key={item.to}>
+                          <SidebarMenuButton
+                            isActive={isActive}
+                            onClick={() => handleSectionClick(item.to)}
+                          >
+                            <Icon />
+                            <span className="truncate">{item.label}</span>
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
+                      );
+                    })}
+                  </Fragment>
+                ))}
           </SidebarMenu>
         </SidebarGroup>
       </SidebarContent>

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -3,6 +3,7 @@ import { isMacPlatform, isWindowsPlatform, normalizeSearchText } from "~/lib/uti
 
 export type SettingsPath =
   | "/settings/general"
+  | "/settings/environment"
   | "/settings/appearance"
   | "/settings/keybindings"
   | "/settings/providers"
@@ -10,6 +11,7 @@ export type SettingsPath =
   | "/settings/scheduled-tasks"
   | "/settings/source-control"
   | "/settings/connections"
+  | "/settings/diagnostics"
   | "/settings/archived";
 
 export interface SettingsSearchItem {
@@ -49,6 +51,7 @@ export interface SettingsSearchAvailability {
  */
 export const SETTINGS_SECTION_LABELS: Readonly<Record<SettingsPath, string>> = {
   "/settings/general": "General",
+  "/settings/environment": "Environment",
   "/settings/appearance": "Appearance",
   "/settings/keybindings": "Keybindings",
   "/settings/providers": "Providers",
@@ -56,6 +59,7 @@ export const SETTINGS_SECTION_LABELS: Readonly<Record<SettingsPath, string>> = {
   "/settings/scheduled-tasks": "Schedule Tasks",
   "/settings/source-control": "Source Control",
   "/settings/connections": "Connections",
+  "/settings/diagnostics": "Diagnostics",
   "/settings/archived": "Archive",
 };
 
@@ -155,21 +159,21 @@ export const SETTINGS_SEARCH_ITEMS = [
   {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: ["sidebar inactivity days no activity automatically"],
     requiresThreadAutoSettlement: true,
   },
   {
     id: "auto-settle-merged-threads",
     title: "Auto-settle merged threads",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: ["pull request merge closed automatically sidebar"],
     requiresThreadAutoSettlement: true,
   },
   {
     id: "days-before-auto-settle",
     title: "Days of inactivity before auto-settle",
-    to: "/settings/general",
+    to: "/settings/environment",
     targetId: "auto-settle-inactive-threads",
     searchTerms: ["thread timeout activity sidebar"],
     requiresThreadAutoSettlement: true,
@@ -195,7 +199,7 @@ export const SETTINGS_SEARCH_ITEMS = [
   {
     id: "provider-update-checks",
     title: "Provider update checks",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: ["installed cli versions newer available codex claude cursor grok opencode"],
   },
   {
@@ -207,7 +211,7 @@ export const SETTINGS_SEARCH_ITEMS = [
   {
     id: "background-activity",
     title: "Background activity",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: [
       "balanced performance battery saver advanced git fetch provider health refresh host power monitor idle policy",
     ],
@@ -215,20 +219,20 @@ export const SETTINGS_SEARCH_ITEMS = [
   {
     id: "new-threads",
     title: "New threads",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: ["default workspace mode draft local worktree"],
   },
   {
     id: "start-from-origin",
     title: "Start from origin",
-    to: "/settings/general",
+    to: "/settings/environment",
     targetId: "new-threads",
     searchTerms: ["new worktrees latest matching remote branch local"],
   },
   {
     id: "add-project-starts-in",
     title: "Add project starts in",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: ["base directory folder browser path home"],
   },
   {
@@ -259,13 +263,13 @@ export const SETTINGS_SEARCH_ITEMS = [
   {
     id: "text-generation-model",
     title: "Text generation model",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: ["generated thread titles source control content default provider"],
   },
   {
     id: "diagnostics",
     title: "Diagnostics",
-    to: "/settings/general",
+    to: "/settings/diagnostics",
     searchTerms: ["logs traces processes resource history failures spans cpu memory"],
   },
   {
@@ -283,7 +287,7 @@ export const SETTINGS_SEARCH_ITEMS = [
   {
     id: "legacy-token-streaming",
     title: "Stream token by token (legacy)",
-    to: "/settings/general",
+    to: "/settings/environment",
     searchTerms: ["response output old compatibility"],
   },
   {

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -46,7 +46,8 @@ import { APP_VERSION } from "../branding";
 import { readDesktopPrimaryBearerToken } from "../environments/primary/desktopAuth";
 import { primaryEnvironmentHttpLayer } from "../environments/primary/httpLayer";
 import {
-  readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
+  isDesktopClientOnlyMode,
   type PrimaryEnvironmentTarget,
 } from "../environments/primary/target";
 import { clearComposerDraftsEnvironment } from "../composerDraftStore";
@@ -404,7 +405,7 @@ export type PrimaryEnvironmentTargetRead =
     };
 
 export function readPrimaryEnvironmentTargetResult(
-  readTarget: () => PrimaryEnvironmentTarget | null = readPrimaryEnvironmentTarget,
+  readTarget: () => PrimaryEnvironmentTarget | null = readOptionalPrimaryEnvironmentTarget,
 ): PrimaryEnvironmentTargetRead {
   try {
     return { _tag: "Success", target: readTarget() };
@@ -461,7 +462,7 @@ export function secondaryRegistrationsToRetainAfterTopologyRead(
 const platformConnectionSourceLayer = Layer.effect(
   PlatformConnectionSource,
   Effect.gen(function* () {
-    if (isHostedStaticApp()) {
+    if (isHostedStaticApp() || isDesktopClientOnlyMode()) {
       return PlatformConnectionSource.of({
         registrations: Stream.empty,
       });

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -81,6 +81,33 @@ describe("environment grouping", () => {
     expect(projectGroupCount).toBe(1);
   });
 
+  it("marks every project remote for an app with no local backend of its own", () => {
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+    });
+
+    const [clientOnly] = buildSidebarProjectSnapshots({
+      projects: [remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId: null,
+      ownsLocalEnvironment: false,
+      resolveEnvironmentLabel: () => "remote",
+    });
+
+    expect(clientOnly?.environmentPresence).toBe("remote-only");
+    expect(clientOnly?.remoteEnvironmentLabels).toEqual(["remote"]);
+
+    const [managed] = buildSidebarProjectSnapshots({
+      projects: [remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId: null,
+      resolveEnvironmentLabel: () => "remote",
+    });
+
+    expect(managed?.environmentPresence).toBe("local-only");
+  });
+
   it("keeps projects without repository identity physically scoped", () => {
     const primary = makeProject();
     const remote = makeProject({
@@ -284,6 +311,24 @@ describe("environment grouping", () => {
     expect(
       deriveLogicalProjectKeyFromSettings(staleWithoutRepositoryIdentity, defaultGroupingSettings),
     ).not.toBe(repositoryIdentity.canonicalKey);
+  });
+
+  it("reports the remote environments backing a group's remote labels", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: [primary, remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: (environmentId) =>
+        environmentId === remoteEnvironmentId ? "ryzen-shine" : null,
+    });
+
+    expect(group?.remoteEnvironmentLabels).toEqual(["ryzen-shine"]);
   });
 
   it("builds one picker entry per logical project and targets the preferred environment", () => {

--- a/apps/web/src/environmentPresence.test.ts
+++ b/apps/web/src/environmentPresence.test.ts
@@ -1,0 +1,29 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { isRemoteEnvironmentId } from "./environmentPresence";
+
+const primaryEnvironmentId = EnvironmentId.make("env-primary");
+const remoteEnvironmentId = EnvironmentId.make("env-remote");
+
+describe("isRemoteEnvironmentId", () => {
+  it("treats the primary environment as local and everything else as remote", () => {
+    const scope = { primaryEnvironmentId, ownsLocalEnvironment: true };
+
+    expect(isRemoteEnvironmentId(primaryEnvironmentId, scope)).toBe(false);
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(true);
+  });
+
+  it("treats every environment as remote when the app owns no local backend", () => {
+    const scope = { primaryEnvironmentId: null, ownsLocalEnvironment: false };
+
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(true);
+    expect(isRemoteEnvironmentId(primaryEnvironmentId, scope)).toBe(true);
+  });
+
+  it("treats nothing as remote while a managed app's primary is still registering", () => {
+    const scope = { primaryEnvironmentId: null, ownsLocalEnvironment: true };
+
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(false);
+  });
+});

--- a/apps/web/src/environmentPresence.ts
+++ b/apps/web/src/environmentPresence.ts
@@ -1,0 +1,28 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+/**
+ * The comparison the UI uses to decide whether an environment is "remote" —
+ * i.e. somewhere other than the machine this app runs its own backend on.
+ */
+export interface EnvironmentPresenceScope {
+  /** The environment served by the app's own backend, when it has one. */
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  /**
+   * False when this app can never own a local backend: a client-only desktop
+   * and the hosted static web app only ever talk to backends they paired with,
+   * so every environment they reach is remote. This is deliberately separate
+   * from a null `primaryEnvironmentId`, which a managed app also reports while
+   * its local backend is still registering — there, nothing is remote yet.
+   */
+  readonly ownsLocalEnvironment: boolean;
+}
+
+export function isRemoteEnvironmentId(
+  environmentId: EnvironmentId,
+  scope: EnvironmentPresenceScope,
+): boolean {
+  if (!scope.ownsLocalEnvironment) {
+    return true;
+  }
+  return scope.primaryEnvironmentId !== null && environmentId !== scope.primaryEnvironmentId;
+}

--- a/apps/web/src/environments/primary/bootstrap.test.ts
+++ b/apps/web/src/environments/primary/bootstrap.test.ts
@@ -8,6 +8,7 @@ import {
   isPrimaryEnvironmentProtocolUnsupportedError,
   isPrimaryEnvironmentUrlInvalidError,
   readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
   resolvePrimaryEnvironmentHttpUrl,
   resolveInitialPrimaryEnvironmentDescriptor,
   resetPrimaryEnvironmentDescriptorForTests,
@@ -274,5 +275,23 @@ describe("environmentBootstrap", () => {
       protocol: "file:",
       message: "The window-origin primary environment target uses unsupported protocol file:.",
     });
+  });
+
+  it("returns no primary target for a client-only desktop without using the custom origin", () => {
+    vi.stubGlobal("window", {
+      location: new URL("t3code://app/"),
+      history: { replaceState: vi.fn() },
+      desktopBridge: {
+        getBackendModeState: () => ({
+          effectiveMode: "client-only",
+          configuredMode: "client-only",
+          cliOverride: null,
+          source: "settings",
+        }),
+        getLocalEnvironmentBootstraps: () => [],
+      },
+    });
+
+    expect(readOptionalPrimaryEnvironmentTarget()).toBeNull();
   });
 });

--- a/apps/web/src/environments/primary/index.ts
+++ b/apps/web/src/environments/primary/index.ts
@@ -46,6 +46,8 @@ export {
   PrimaryEnvironmentProtocolUnsupportedError,
   PrimaryEnvironmentUrlInvalidError,
   readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
+  isDesktopClientOnlyMode,
   resolvePrimaryEnvironmentHttpUrl,
   isLoopbackHostname,
   type PrimaryEnvironmentTarget,

--- a/apps/web/src/environments/primary/target.ts
+++ b/apps/web/src/environments/primary/target.ts
@@ -73,6 +73,11 @@ export interface PrimaryEnvironmentTarget {
   };
 }
 
+export function isDesktopClientOnlyMode(): boolean {
+  const bridge = window.desktopBridge;
+  return bridge?.getBackendModeState?.().effectiveMode === "client-only";
+}
+
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 
 function getDesktopLocalEnvironmentBootstrap(): DesktopEnvironmentBootstrap | null {
@@ -295,4 +300,8 @@ export function readPrimaryEnvironmentTarget(): PrimaryEnvironmentTarget {
     resolveConfiguredPrimaryTarget() ??
     resolveWindowOriginPrimaryTarget()
   );
+}
+
+export function readOptionalPrimaryEnvironmentTarget(): PrimaryEnvironmentTarget | null {
+  return isDesktopClientOnlyMode() ? null : readPrimaryEnvironmentTarget();
 }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -126,7 +126,10 @@ async function hydrateClientSettings(): Promise<void> {
         return;
       }
       if (persistedSettings) {
-        replaceClientSettingsSnapshot({ ...DEFAULT_CLIENT_SETTINGS, ...persistedSettings });
+        replaceClientSettingsSnapshot({
+          ...DEFAULT_CLIENT_SETTINGS,
+          ...persistedSettings,
+        });
       }
     } catch (error) {
       console.error(`${CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE} hydrate failed`, {
@@ -160,6 +163,17 @@ function persistClientSettings(settings: ClientSettings): void {
         ...safeErrorLogAttributes(error),
       });
     });
+}
+
+function updateClientSettings(deriveSettings: (settings: ClientSettings) => ClientSettings): void {
+  if (!clientSettingsHydrated) {
+    void hydrateClientSettings().then(() => {
+      updateClientSettings(deriveSettings);
+    });
+    return;
+  }
+
+  persistClientSettings(deriveSettings(getClientSettingsSnapshot()));
 }
 
 // ── Key sets for routing patches ─────────────────────────────────────
@@ -304,10 +318,10 @@ export function useLegacySidebarEnabled(): boolean {
 
 /** Read current settings for one environment, merged with client-local preferences. */
 export function useEnvironmentSettings<T = UnifiedSettings>(
-  environmentId: EnvironmentId,
+  environmentId: EnvironmentId | null,
   selector?: (settings: UnifiedSettings) => T,
 ): T {
-  const serverSettings = useAtomValue(serverEnvironment.settingsValueAtom(environmentId));
+  const serverSettings = useAtomValue(serverEnvironment.configValueAtom(environmentId))?.settings;
   return useMergedSettings(serverSettings ?? DEFAULT_SERVER_SETTINGS, selector);
 }
 
@@ -404,10 +418,10 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
         }
       }
       if (Object.keys(clientPatch).length > 0) {
-        persistClientSettings({
-          ...getClientSettingsSnapshot(),
+        updateClientSettings((settings) => ({
+          ...settings,
           ...clientPatch,
-        });
+        }));
       }
     },
     [connectedEnvironmentIds, environmentId, persistServerSettings],
@@ -470,7 +484,7 @@ export function useSharedSettingsSync() {
   return { mismatches, applyToAll };
 }
 
-export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {
+export function useUpdateEnvironmentSettings(environmentId: EnvironmentId | null) {
   return useUpdateSettingsTarget(environmentId);
 }
 
@@ -480,9 +494,19 @@ export function useUpdatePrimarySettings() {
 
 export function useUpdateClientSettings() {
   return useCallback((patch: ClientSettingsPatch) => {
-    persistClientSettings({
-      ...getClientSettingsSnapshot(),
+    updateClientSettings((settings) => ({
+      ...settings,
       ...patch,
-    });
+    }));
+  }, []);
+}
+
+/** Derive a client-settings patch from the latest persisted snapshot. */
+export function useUpdateClientSettingsWith() {
+  return useCallback((derivePatch: (settings: ClientSettings) => ClientSettingsPatch) => {
+    updateClientSettings((settings) => ({
+      ...settings,
+      ...derivePatch(settings),
+    }));
   }, []);
 }

--- a/apps/web/src/hooks/useSettingsEnvironment.ts
+++ b/apps/web/src/hooks/useSettingsEnvironment.ts
@@ -1,0 +1,49 @@
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+
+import { resolveSettingsEnvironmentId } from "../components/settings/SettingsPanels.logic";
+import { useActiveEnvironmentId } from "../state/entities";
+import {
+  useEnvironments,
+  usePrimaryEnvironmentId,
+  type EnvironmentPresentation,
+} from "../state/environments";
+import {
+  selectedSettingsEnvironmentIdAtom,
+  setSelectedSettingsEnvironmentId,
+} from "../state/settingsEnvironment";
+
+export interface SettingsEnvironmentTarget {
+  readonly isReady: boolean;
+  readonly environmentId: EnvironmentId | null;
+  readonly environment: EnvironmentPresentation | null;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly selectEnvironment: (environmentId: EnvironmentId) => void;
+}
+
+export function useSettingsEnvironment(): SettingsEnvironmentTarget {
+  const { isReady, environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const selectedEnvironmentId = useAtomValue(selectedSettingsEnvironmentIdAtom);
+  const environmentId = resolveSettingsEnvironmentId({
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+    selectedEnvironmentId,
+    primaryEnvironmentId,
+    activeEnvironmentId,
+  });
+  const environment =
+    environmentId === null
+      ? null
+      : (environments.find((candidate) => candidate.environmentId === environmentId) ?? null);
+
+  return {
+    isReady,
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment: setSelectedSettingsEnvironmentId,
+  };
+}

--- a/apps/web/src/lib/resourceTelemetryState.ts
+++ b/apps/web/src/lib/resourceTelemetryState.ts
@@ -1,8 +1,11 @@
-import type { ResourceTelemetryHistoryInput, ResourceTelemetrySnapshot } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  ResourceTelemetryHistoryInput,
+  ResourceTelemetrySnapshot,
+} from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import { useCallback } from "react";
 
-import { usePrimaryEnvironment } from "../state/environments";
 import { useEnvironmentQuery } from "../state/query";
 import { serverEnvironment } from "../state/server";
 import { useAtomCommand } from "../state/use-atom-command";
@@ -15,9 +18,7 @@ export interface ResourceTelemetryState {
   readonly retry: () => Promise<ResourceTelemetrySnapshot>;
 }
 
-export function useResourceTelemetry(): ResourceTelemetryState {
-  const primaryEnvironment = usePrimaryEnvironment();
-  const environmentId = primaryEnvironment?.environmentId ?? null;
+export function useResourceTelemetry(environmentId: EnvironmentId | null): ResourceTelemetryState {
   const query = useEnvironmentQuery(
     environmentId === null
       ? null
@@ -40,9 +41,10 @@ export function useResourceTelemetry(): ResourceTelemetryState {
   return { ...query, retry };
 }
 
-export function useResourceTelemetryHistory(input: ResourceTelemetryHistoryInput) {
-  const primaryEnvironment = usePrimaryEnvironment();
-  const environmentId = primaryEnvironment?.environmentId ?? null;
+export function useResourceTelemetryHistory(
+  environmentId: EnvironmentId | null,
+  input: ResourceTelemetryHistoryInput,
+) {
   return useEnvironmentQuery(
     environmentId === null
       ? null

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as SettingsProvidersRouteImport } from './routes/settings.provide
 import { Route as SettingsKeybindingsRouteImport } from './routes/settings.keybindings'
 import { Route as SettingsIntegrationsRouteImport } from './routes/settings.integrations'
 import { Route as SettingsGeneralRouteImport } from './routes/settings.general'
+import { Route as SettingsEnvironmentRouteImport } from './routes/settings.environment'
 import { Route as SettingsDiagnosticsRouteImport } from './routes/settings.diagnostics'
 import { Route as SettingsConnectionsRouteImport } from './routes/settings.connections'
 import { Route as SettingsArchivedRouteImport } from './routes/settings.archived'
@@ -90,6 +91,11 @@ const SettingsGeneralRoute = SettingsGeneralRouteImport.update({
   path: '/general',
   getParentRoute: () => SettingsRoute,
 } as any)
+const SettingsEnvironmentRoute = SettingsEnvironmentRouteImport.update({
+  id: '/environment',
+  path: '/environment',
+  getParentRoute: () => SettingsRoute,
+} as any)
 const SettingsDiagnosticsRoute = SettingsDiagnosticsRouteImport.update({
   id: '/diagnostics',
   path: '/diagnostics',
@@ -150,6 +156,7 @@ export interface FileRoutesByFullPath {
   '/settings/archived': typeof SettingsArchivedRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
@@ -171,6 +178,7 @@ export interface FileRoutesByTo {
   '/settings/archived': typeof SettingsArchivedRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
@@ -195,6 +203,7 @@ export interface FileRoutesById {
   '/settings/archived': typeof SettingsArchivedRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
@@ -220,6 +229,7 @@ export interface FileRouteTypes {
     | '/settings/archived'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/integrations'
     | '/settings/keybindings'
@@ -241,6 +251,7 @@ export interface FileRouteTypes {
     | '/settings/archived'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/integrations'
     | '/settings/keybindings'
@@ -264,6 +275,7 @@ export interface FileRouteTypes {
     | '/settings/archived'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/integrations'
     | '/settings/keybindings'
@@ -371,6 +383,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsGeneralRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/settings/environment': {
+      id: '/settings/environment'
+      path: '/environment'
+      fullPath: '/settings/environment'
+      preLoaderRoute: typeof SettingsEnvironmentRouteImport
+      parentRoute: typeof SettingsRoute
+    }
     '/settings/diagnostics': {
       id: '/settings/diagnostics'
       path: '/diagnostics'
@@ -458,6 +477,7 @@ interface SettingsRouteChildren {
   SettingsArchivedRoute: typeof SettingsArchivedRoute
   SettingsConnectionsRoute: typeof SettingsConnectionsRoute
   SettingsDiagnosticsRoute: typeof SettingsDiagnosticsRoute
+  SettingsEnvironmentRoute: typeof SettingsEnvironmentRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
   SettingsIntegrationsRoute: typeof SettingsIntegrationsRoute
   SettingsKeybindingsRoute: typeof SettingsKeybindingsRoute
@@ -471,6 +491,7 @@ const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsArchivedRoute: SettingsArchivedRoute,
   SettingsConnectionsRoute: SettingsConnectionsRoute,
   SettingsDiagnosticsRoute: SettingsDiagnosticsRoute,
+  SettingsEnvironmentRoute: SettingsEnvironmentRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
   SettingsIntegrationsRoute: SettingsIntegrationsRoute,
   SettingsKeybindingsRoute: SettingsKeybindingsRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -47,7 +47,10 @@ import {
 import { useUiStateStore } from "../uiStateStore";
 import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import { configureClientTracing } from "../observability/clientTracing";
-import { resolveInitialServerAuthGateState } from "../environments/primary";
+import {
+  isDesktopClientOnlyMode,
+  resolveInitialServerAuthGateState,
+} from "../environments/primary";
 import { hasHostedPairingRequest, isHostedStaticApp } from "../hostedPairing";
 import { shellEnvironment } from "../state/shell";
 import { useAtomValue } from "@effect/atom-react";
@@ -74,7 +77,7 @@ export const Route = createRootRoute({
       };
     }
 
-    if (isHostedStaticApp(new URL(window.location.href))) {
+    if (isHostedStaticApp(new URL(window.location.href)) || isDesktopClientOnlyMode()) {
       return {
         authGateState: {
           status: "hosted-static",

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -6,7 +6,7 @@ import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
-import { usePrimaryEnvironmentId } from "../state/environments";
+import { useAppOwnsLocalEnvironment, usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
@@ -32,15 +32,17 @@ function ChatRouteGlobalShortcuts() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const projectGroupCount = useMemo(
     () =>
       buildSidebarProjectSnapshots({
         projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: () => null,
       }).length,
-    [primaryEnvironmentId, projectGroupingSettings, projects],
+    [ownsLocalEnvironment, primaryEnvironmentId, projectGroupingSettings, projects],
   );
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef

--- a/apps/web/src/routes/settings.environment.tsx
+++ b/apps/web/src/routes/settings.environment.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { EnvironmentSettingsPanel } from "../components/settings/SettingsPanels";
+
+function SettingsEnvironmentRoute() {
+  return <EnvironmentSettingsPanel />;
+}
+
+export const Route = createFileRoute("/settings/environment")({
+  component: SettingsEnvironmentRoute,
+});

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -9,21 +9,30 @@ import {
 } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
 
-import { useSettingsRestore } from "../components/settings/SettingsPanels";
+import { type SettingsOwnership, useSettingsRestore } from "../components/settings/SettingsPanels";
 import { SettingsBreadcrumb } from "../components/settings/SettingsBreadcrumb";
 import { Button } from "../components/ui/button";
 import { SidebarInset } from "../components/ui/sidebar";
 import { WorkspacePageHeader } from "../components/WorkspacePageHeader";
 import { isElectron } from "../env";
 
-function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
-  const { changedSettingLabels, restoreDefaults } = useSettingsRestore(onRestored);
+function RestoreDefaultsButton({
+  ownership,
+  onRestored,
+}: {
+  ownership: SettingsOwnership;
+  onRestored: () => void;
+}) {
+  const { canRestoreDefaults, changedSettingLabels, restoreDefaults } = useSettingsRestore(
+    ownership,
+    onRestored,
+  );
 
   return (
     <Button
       size="xs"
       variant="ghost"
-      disabled={changedSettingLabels.length === 0}
+      disabled={!canRestoreDefaults || changedSettingLabels.length === 0}
       onClick={() => void restoreDefaults()}
     >
       <RotateCcwIcon className="mx-1 size-3.5" />
@@ -37,7 +46,12 @@ function SettingsContentLayout() {
   const navigate = useNavigate();
   const canGoBack = useCanGoBack();
   const [restoreSignal, setRestoreSignal] = useState(0);
-  const showRestoreDefaults = location.pathname === "/settings/general";
+  const restoreOwnership: SettingsOwnership | null =
+    location.pathname === "/settings/general"
+      ? "client"
+      : location.pathname === "/settings/environment"
+        ? "environment"
+        : null;
   const handleRestored = () => setRestoreSignal((value) => value + 1);
   const navigateBackWithinApp = useCallback(() => {
     if (canGoBack) {
@@ -74,9 +88,9 @@ function SettingsContentLayout() {
         <WorkspacePageHeader electron={isElectron}>
           <div className="flex w-full items-center gap-3">
             <SettingsBreadcrumb pathname={location.pathname} />
-            {showRestoreDefaults ? (
+            {restoreOwnership ? (
               <div className="ms-auto flex items-center gap-2">
-                <RestoreDefaultsButton onRestored={handleRestored} />
+                <RestoreDefaultsButton ownership={restoreOwnership} onRestored={handleRestored} />
               </div>
             ) : null}
           </div>

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
+import { isRemoteEnvironmentId, type EnvironmentPresenceScope } from "./environmentPresence";
 import { buildProjectGroups, type ProjectGroupingSettings } from "./logicalProject";
 import type { Project } from "./types";
 
@@ -54,6 +55,7 @@ export function buildSidebarProjectSnapshots(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;
   primaryEnvironmentId: EnvironmentId | null;
+  ownsLocalEnvironment?: boolean;
   resolveEnvironmentLabel: (environmentId: EnvironmentId) => string | null;
   // Returns true when an env id maps to a desktopLocal saved-env
   // record (today: the WSL backend). Defaults to "false for every
@@ -61,6 +63,10 @@ export function buildSidebarProjectSnapshots(input: {
   // legacy behavior.
   isDesktopLocalEnvironment?: (environmentId: EnvironmentId) => boolean;
 }): SidebarProjectSnapshot[] {
+  const presenceScope: EnvironmentPresenceScope = {
+    primaryEnvironmentId: input.primaryEnvironmentId,
+    ownsLocalEnvironment: input.ownsLocalEnvironment ?? true,
+  };
   return buildProjectGroups({
     projects: input.projects,
     settings: input.settings,
@@ -80,17 +86,11 @@ export function buildSidebarProjectSnapshots(input: {
           member.id === group.representative.id,
       ) ?? members[0]!;
 
-    const hasLocal =
-      input.primaryEnvironmentId !== null &&
-      members.some((member) => member.environmentId === input.primaryEnvironmentId);
-    const hasRemote =
-      input.primaryEnvironmentId !== null
-        ? members.some((member) => member.environmentId !== input.primaryEnvironmentId)
-        : false;
-    const remoteMembers = members.filter(
-      (member) =>
-        input.primaryEnvironmentId !== null && member.environmentId !== input.primaryEnvironmentId,
+    const remoteMembers = members.filter((member) =>
+      isRemoteEnvironmentId(member.environmentId, presenceScope),
     );
+    const hasRemote = remoteMembers.length > 0;
+    const hasLocal = remoteMembers.length < members.length;
     const remoteEnvironmentLabels = remoteMembers
       .flatMap((member) => (member.environmentLabel ? [member.environmentLabel] : []))
       .filter((label, index, labels) => labels.indexOf(label) === index);

--- a/apps/web/src/state/environments.ts
+++ b/apps/web/src/state/environments.ts
@@ -9,6 +9,9 @@ import * as Option from "effect/Option";
 import { useMemo } from "react";
 
 import { environmentCatalog } from "../connection/catalog";
+import type { EnvironmentPresenceScope } from "../environmentPresence";
+import { isDesktopClientOnlyMode } from "../environments/primary";
+import { isHostedStaticApp } from "../hostedPairing";
 import { environmentPresentations, useEnvironmentPresentation } from "./presentation";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 import { useEnvironmentQuery } from "./query";
@@ -58,6 +61,23 @@ export function useEnvironments() {
 
 export function usePrimaryEnvironmentId(): EnvironmentId | null {
   return useAtomValue(primaryEnvironmentIdAtom);
+}
+
+export function appOwnsLocalEnvironment(): boolean {
+  return !isHostedStaticApp() && !isDesktopClientOnlyMode();
+}
+
+export function useAppOwnsLocalEnvironment(): boolean {
+  return useMemo(appOwnsLocalEnvironment, []);
+}
+
+export function useEnvironmentPresenceScope(): EnvironmentPresenceScope {
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
+  return useMemo(
+    () => ({ primaryEnvironmentId, ownsLocalEnvironment }),
+    [primaryEnvironmentId, ownsLocalEnvironment],
+  );
 }
 
 export function useEnvironment(

--- a/apps/web/src/state/settingsEnvironment.ts
+++ b/apps/web/src/state/settingsEnvironment.ts
@@ -1,0 +1,13 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../rpc/atomRegistry";
+
+export const selectedSettingsEnvironmentIdAtom = Atom.make<EnvironmentId | null>(null).pipe(
+  Atom.keepAlive,
+  Atom.withLabel("web-selected-settings-environment-id"),
+);
+
+export function setSelectedSettingsEnvironmentId(environmentId: EnvironmentId): void {
+  appAtomRegistry.set(selectedSettingsEnvironmentIdAtom, environmentId);
+}

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -113,7 +113,7 @@ describe("connection onboarding", () => {
           : String(tokenRequest?.init.body);
       const tokenParams = new URLSearchParams(tokenBody);
       expect(tokenParams.get("subject_token")).toBe("pairing-token");
-      expect(tokenParams.get("scope")).toBe(AuthStandardClientScopes.join(" "));
+      expect(tokenParams.get("scope")).toBeNull();
       expect(tokenParams.get("client_label")).toBe("T3 Code Test");
     }),
   );

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -94,7 +94,6 @@ export const preparePairingRegistration = Effect.fn(
   const access = yield* bootstrapRemoteBearerSession({
     httpBaseUrl: target.httpBaseUrl,
     credential: target.credential,
-    scopes: presentation.scopes,
     clientMetadata: presentation.metadata,
   }).pipe(Effect.mapError(mapRemoteEnvironmentError));
   const connectionId = `bearer:${descriptor.environmentId}`;

--- a/packages/client-runtime/src/connection/presentation.test.ts
+++ b/packages/client-runtime/src/connection/presentation.test.ts
@@ -2,10 +2,15 @@ import { EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Option from "effect/Option";
 
-import { BearerConnectionProfile, type ConnectionCatalogEntry } from "./catalog.ts";
+import {
+  BearerConnectionProfile,
+  type ConnectionCatalogEntry,
+  SshConnectionProfile,
+} from "./catalog.ts";
 import {
   BearerConnectionTarget,
   ConnectionTransientError,
+  SshConnectionTarget,
   type SupervisorConnectionState,
 } from "./model.ts";
 import {
@@ -53,6 +58,32 @@ function supervisorState(overrides: Partial<SupervisorConnectionState>): Supervi
 describe("connection presentation", () => {
   it("preserves profile display information without exposing credentials", () => {
     expect(connectionCatalogDisplayUrl(ENTRY)).toBe("https://environment.example.test");
+  });
+
+  it("formats SSH display information without a missing username and preserves the port", () => {
+    const target = new SshConnectionTarget({
+      environmentId: EnvironmentId.make("environment-ssh"),
+      label: "SSH environment",
+      connectionId: "connection-ssh",
+    });
+    const entry: ConnectionCatalogEntry = {
+      target,
+      profile: Option.some(
+        new SshConnectionProfile({
+          connectionId: target.connectionId,
+          environmentId: target.environmentId,
+          label: target.label,
+          target: {
+            alias: "devbox",
+            hostname: "devbox.example.test",
+            username: null,
+            port: 2222,
+          },
+        }),
+      ),
+    };
+
+    expect(connectionCatalogDisplayUrl(entry)).toBe("devbox.example.test:2222");
   });
 
   it("distinguishes initial connection, reconnect, and retry errors", () => {

--- a/packages/client-runtime/src/connection/presentation.ts
+++ b/packages/client-runtime/src/connection/presentation.ts
@@ -100,9 +100,12 @@ export function connectionCatalogDisplayUrl(entry: ConnectionCatalogEntry): stri
         ? entry.profile.value.httpBaseUrl
         : null;
     case "SshConnectionTarget":
-      return Option.isSome(entry.profile) && entry.profile.value._tag === "SshConnectionProfile"
-        ? `${entry.profile.value.target.username}@${entry.profile.value.target.hostname}`
-        : null;
+      if (Option.isNone(entry.profile) || entry.profile.value._tag !== "SshConnectionProfile") {
+        return null;
+      }
+      const { hostname, port, username } = entry.profile.value.target;
+      const authority = username ? `${username}@${hostname}` : hostname;
+      return port ? `${authority}:${port}` : authority;
   }
 }
 

--- a/packages/client-runtime/src/state/auth.ts
+++ b/packages/client-runtime/src/state/auth.ts
@@ -2,14 +2,29 @@ import type {
   AuthAccessSnapshot,
   AuthAccessStreamEvent,
   AuthAccessStreamSnapshotEvent,
+  AuthEnvironmentScope,
+  AuthSessionId,
 } from "@t3tools/contracts";
 import { WS_METHODS } from "@t3tools/contracts";
 import * as Stream from "effect/Stream";
+import type { HttpClient } from "effect/unstable/http";
 import { Atom } from "effect/unstable/reactivity";
 
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 import { subscribe } from "../rpc/client.ts";
-import { createEnvironmentSubscriptionAtomFamily } from "./runtime.ts";
+export { EnvironmentNotConnectedError } from "./authHttp.ts";
+import {
+  createEnvironmentPairingCredential,
+  fetchEnvironmentSessionState,
+  revokeEnvironmentClientSession,
+  revokeEnvironmentPairingLink,
+  revokeOtherEnvironmentClientSessions,
+} from "./authHttp.ts";
+import {
+  createEnvironmentCommand,
+  createEnvironmentQueryAtomFamily,
+  createEnvironmentSubscriptionAtomFamily,
+} from "./runtime.ts";
 
 export const EMPTY_AUTH_ACCESS_SNAPSHOT: AuthAccessSnapshot = {
   pairingLinks: [],
@@ -76,7 +91,7 @@ export function projectAuthAccessSnapshot(
 }
 
 export function createAuthEnvironmentAtoms<R, E>(
-  runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
+  runtime: Atom.AtomRuntime<EnvironmentRegistry | HttpClient.HttpClient | R, E>,
 ) {
   return {
     accessChanges: createEnvironmentSubscriptionAtomFamily(runtime, {
@@ -85,6 +100,30 @@ export function createAuthEnvironmentAtoms<R, E>(
         subscribe(WS_METHODS.subscribeAuthAccess, {}).pipe(
           Stream.mapAccum(() => EMPTY_AUTH_ACCESS_SNAPSHOT, projectAuthAccessSnapshot),
         ),
+    }),
+    sessionState: createEnvironmentQueryAtomFamily(runtime, {
+      label: "environment-data:server:auth-session-state",
+      execute: (_input: null) => fetchEnvironmentSessionState(),
+    }),
+    createPairingCredential: createEnvironmentCommand(runtime, {
+      label: "environment-command:server:create-pairing-credential",
+      execute: (input: {
+        readonly label?: string;
+        readonly scopes?: ReadonlyArray<AuthEnvironmentScope>;
+      }) => createEnvironmentPairingCredential(input),
+    }),
+    revokePairingLink: createEnvironmentCommand(runtime, {
+      label: "environment-command:server:revoke-pairing-link",
+      execute: (input: { readonly id: string }) => revokeEnvironmentPairingLink(input),
+    }),
+    revokeClientSession: createEnvironmentCommand(runtime, {
+      label: "environment-command:server:revoke-client-session",
+      execute: (input: { readonly sessionId: AuthSessionId }) =>
+        revokeEnvironmentClientSession(input),
+    }),
+    revokeOtherClientSessions: createEnvironmentCommand(runtime, {
+      label: "environment-command:server:revoke-other-client-sessions",
+      execute: (_input: null) => revokeOtherEnvironmentClientSessions(),
     }),
   };
 }

--- a/packages/client-runtime/src/state/authHttp.ts
+++ b/packages/client-runtime/src/state/authHttp.ts
@@ -1,0 +1,126 @@
+import type { AuthEnvironmentScope, AuthSessionId } from "@t3tools/contracts";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+import type { HttpMethod } from "effect/unstable/http";
+
+import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import { environmentEndpointUrl } from "../environment/endpoint.ts";
+import { ManagedRelayDpopSigner } from "../relay/managedRelay.ts";
+import { executeEnvironmentHttpRequest, makeEnvironmentHttpApiClient } from "../rpc/http.ts";
+import { buildEnvironmentAuthHeaders, withEnvironmentCredentials } from "./environmentHttpAuth.ts";
+
+const AUTH_MUTATION_TIMEOUT_MS = 10_000;
+
+export class EnvironmentNotConnectedError extends Data.TaggedError(
+  "@t3tools/client-runtime/state/authHttp/EnvironmentNotConnectedError",
+)<{ readonly message: string }> {}
+
+const prepareAuthRequest = Effect.fn("clientRuntime.state.authHttp.prepareAuthRequest")(function* (
+  method: HttpMethod.HttpMethod,
+  pathname: string,
+) {
+  const supervisor = yield* EnvironmentSupervisor;
+  const prepared = yield* SubscriptionRef.get(supervisor.prepared);
+  if (Option.isNone(prepared)) {
+    return yield* new EnvironmentNotConnectedError({
+      message: "This environment is not connected, so its access settings cannot be changed.",
+    });
+  }
+  const { httpAuthorization, httpBaseUrl } = prepared.value;
+  const requestUrl = environmentEndpointUrl(httpBaseUrl, pathname);
+  const client = yield* makeEnvironmentHttpApiClient(httpBaseUrl);
+  const signer = yield* Effect.serviceOption(ManagedRelayDpopSigner);
+  const headers = yield* buildEnvironmentAuthHeaders(httpAuthorization, method, requestUrl, signer);
+  return { client, headers, httpAuthorization, requestUrl };
+});
+
+export const fetchEnvironmentSessionState = Effect.fn(
+  "clientRuntime.state.authHttp.fetchEnvironmentSessionState",
+)(function* () {
+  const { client, headers, httpAuthorization, requestUrl } = yield* prepareAuthRequest(
+    "GET",
+    "/api/auth/session",
+  );
+  return yield* executeEnvironmentHttpRequest(
+    requestUrl,
+    AUTH_MUTATION_TIMEOUT_MS,
+    withEnvironmentCredentials(httpAuthorization, client.auth.session({ headers })),
+  );
+});
+
+export const createEnvironmentPairingCredential = Effect.fn(
+  "clientRuntime.state.authHttp.createEnvironmentPairingCredential",
+)(function* (input: {
+  readonly label?: string;
+  readonly scopes?: ReadonlyArray<AuthEnvironmentScope>;
+}) {
+  const { client, headers, httpAuthorization, requestUrl } = yield* prepareAuthRequest(
+    "POST",
+    "/api/auth/pairing-token",
+  );
+  const trimmedLabel = input.label?.trim();
+  return yield* executeEnvironmentHttpRequest(
+    requestUrl,
+    AUTH_MUTATION_TIMEOUT_MS,
+    withEnvironmentCredentials(
+      httpAuthorization,
+      client.auth.pairingCredential({
+        headers,
+        payload: {
+          ...(trimmedLabel ? { label: trimmedLabel } : {}),
+          ...(input.scopes ? { scopes: input.scopes } : {}),
+        },
+      }),
+    ),
+  );
+});
+
+export const revokeEnvironmentPairingLink = Effect.fn(
+  "clientRuntime.state.authHttp.revokeEnvironmentPairingLink",
+)(function* (input: { readonly id: string }) {
+  const { client, headers, httpAuthorization, requestUrl } = yield* prepareAuthRequest(
+    "POST",
+    "/api/auth/pairing-links/revoke",
+  );
+  return yield* executeEnvironmentHttpRequest(
+    requestUrl,
+    AUTH_MUTATION_TIMEOUT_MS,
+    withEnvironmentCredentials(
+      httpAuthorization,
+      client.auth.revokePairingLink({ headers, payload: { id: input.id } }),
+    ),
+  );
+});
+
+export const revokeEnvironmentClientSession = Effect.fn(
+  "clientRuntime.state.authHttp.revokeEnvironmentClientSession",
+)(function* (input: { readonly sessionId: AuthSessionId }) {
+  const { client, headers, httpAuthorization, requestUrl } = yield* prepareAuthRequest(
+    "POST",
+    "/api/auth/clients/revoke",
+  );
+  return yield* executeEnvironmentHttpRequest(
+    requestUrl,
+    AUTH_MUTATION_TIMEOUT_MS,
+    withEnvironmentCredentials(
+      httpAuthorization,
+      client.auth.revokeClient({ headers, payload: { sessionId: input.sessionId } }),
+    ),
+  );
+});
+
+export const revokeOtherEnvironmentClientSessions = Effect.fn(
+  "clientRuntime.state.authHttp.revokeOtherEnvironmentClientSessions",
+)(function* () {
+  const { client, headers, httpAuthorization, requestUrl } = yield* prepareAuthRequest(
+    "POST",
+    "/api/auth/clients/revoke-others",
+  );
+  return yield* executeEnvironmentHttpRequest(
+    requestUrl,
+    AUTH_MUTATION_TIMEOUT_MS,
+    withEnvironmentCredentials(httpAuthorization, client.auth.revokeOtherClients({ headers })),
+  );
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ export * from "./background.ts";
 export * from "./auth.ts";
 export * from "./environment.ts";
 export * from "./environmentHttp.ts";
+export * from "./localServerDiscovery.ts";
 export * from "./relayClient.ts";
 export * from "./desktopBootstrap.ts";
 export * from "./desktopAppActivation.ts";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -26,6 +26,7 @@ import type {
 } from "./review.ts";
 import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem.ts";
 import type { AssetCreateUrlInput, AssetCreateUrlResult } from "./assets.ts";
+import type { LocalServerPairingResult, RunningLocalServer } from "./localServerDiscovery.ts";
 import type {
   ProjectListEntriesInput,
   ProjectListEntriesResult,
@@ -161,6 +162,8 @@ export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
 export type DesktopUpdateChannel = "latest" | "nightly";
 export type DesktopAppStageLabel = "Alpha" | "Dev" | "Nightly";
+export type DesktopBackendMode = "managed" | "client-only";
+export type DesktopBackendModeSource = "settings" | "cli" | "existing-server";
 
 export const DesktopUpdateStatusSchema = Schema.Literals([
   "disabled",
@@ -176,6 +179,26 @@ export const DesktopRuntimeArchSchema = Schema.Literals(["arm64", "x64", "other"
 export const DesktopThemeSchema = Schema.Literals(["light", "dark", "system"]);
 export const DesktopUpdateChannelSchema = Schema.Literals(["latest", "nightly"]);
 export const DesktopAppStageLabelSchema = Schema.Literals(["Alpha", "Dev", "Nightly"]);
+export const DesktopBackendModeSchema = Schema.Literals(["managed", "client-only"]);
+export const DesktopBackendModeSourceSchema = Schema.Literals([
+  "settings",
+  "cli",
+  "existing-server",
+]);
+
+export interface DesktopBackendModeState {
+  effectiveMode: DesktopBackendMode;
+  configuredMode: DesktopBackendMode;
+  cliOverride: DesktopBackendMode | null;
+  source: DesktopBackendModeSource;
+}
+
+export const DesktopBackendModeStateSchema = Schema.Struct({
+  effectiveMode: DesktopBackendModeSchema,
+  configuredMode: DesktopBackendModeSchema,
+  cliOverride: Schema.NullOr(DesktopBackendModeSchema),
+  source: DesktopBackendModeSourceSchema,
+});
 
 export interface DesktopAppBranding {
   baseName: string;
@@ -1038,11 +1061,15 @@ export interface DesktopBridge {
    * regardless of OS settings.
    */
   getSystemLocale?: () => string | null;
+  getBackendModeState: () => DesktopBackendModeState;
+  setBackendMode: (mode: DesktopBackendMode) => Promise<DesktopBackendModeState>;
   // One bootstrap per pool instance currently registered with bootstrap
   // info (omits instances whose backend hasn't produced a config yet).
   // The primary backend is identified by id === PRIMARY_LOCAL_ENVIRONMENT_ID.
   getLocalEnvironmentBootstraps: () => readonly DesktopEnvironmentBootstrap[];
   getLocalEnvironmentBearerToken: () => Promise<string>;
+  discoverLocalServers?: () => Promise<readonly RunningLocalServer[]>;
+  pairLocalServer?: (environmentId: EnvironmentId) => Promise<LocalServerPairingResult>;
   getClientSettings: () => Promise<ClientSettings | null>;
   setClientSettings: (settings: ClientSettings) => Promise<void>;
   getConnectionCatalog?: () => Promise<string | null>;

--- a/packages/contracts/src/localServerDiscovery.ts
+++ b/packages/contracts/src/localServerDiscovery.ts
@@ -1,0 +1,34 @@
+import * as Schema from "effect/Schema";
+
+import { EnvironmentId, PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+
+export const LocalServerRuntimeVariant = Schema.Literals(["userdata", "dev"]);
+export type LocalServerRuntimeVariant = typeof LocalServerRuntimeVariant.Type;
+
+export const RunningLocalServer = Schema.Struct({
+  statePath: Schema.String.check(Schema.isMinLength(1)),
+  baseDir: Schema.String.check(Schema.isMinLength(1)),
+  variant: LocalServerRuntimeVariant,
+  pid: PositiveInt,
+  httpBaseUrl: TrimmedNonEmptyString,
+  startedAt: TrimmedNonEmptyString,
+  environmentId: EnvironmentId,
+  label: TrimmedNonEmptyString,
+});
+export type RunningLocalServer = typeof RunningLocalServer.Type;
+
+export const LocalServerPairCommandOutput = Schema.Struct({
+  pairingUrl: TrimmedNonEmptyString,
+  token: TrimmedNonEmptyString,
+  expiresAt: TrimmedNonEmptyString,
+  origin: TrimmedNonEmptyString,
+  environmentId: EnvironmentId,
+  label: TrimmedNonEmptyString,
+});
+export type LocalServerPairCommandOutput = typeof LocalServerPairCommandOutput.Type;
+
+export const LocalServerPairingResult = Schema.Struct({
+  pairingUrl: TrimmedNonEmptyString,
+  pairingExpiresAt: TrimmedNonEmptyString,
+});
+export type LocalServerPairingResult = typeof LocalServerPairingResult.Type;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -262,6 +262,14 @@
     "./claudeCompaction": {
       "types": "./src/claudeCompaction.ts",
       "import": "./src/claudeCompaction.ts"
+    },
+    "./nodeSqliteClient": {
+      "types": "./src/nodeSqliteClient.ts",
+      "import": "./src/nodeSqliteClient.ts"
+    },
+    "./serverRuntimeState": {
+      "types": "./src/serverRuntimeState.ts",
+      "import": "./src/serverRuntimeState.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/serverRuntimeState.test.ts
+++ b/packages/shared/src/serverRuntimeState.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveServerRuntimeStatePath } from "./serverRuntimeState.ts";
+
+describe("deriveServerRuntimeStatePath", () => {
+  it("places runtime state under the selected state variant", () => {
+    expect(
+      deriveServerRuntimeStatePath({
+        baseDir: "/home/user/.t3",
+        variant: "userdata",
+        joinPath: (...segments) => segments.join("/"),
+      }),
+    ).toBe("/home/user/.t3/userdata/server-runtime.json");
+    expect(
+      deriveServerRuntimeStatePath({
+        baseDir: "C:\\Users\\user\\.t3",
+        variant: "dev",
+        joinPath: (...segments) => segments.join("\\"),
+      }),
+    ).toBe("C:\\Users\\user\\.t3\\dev\\server-runtime.json");
+  });
+});

--- a/packages/shared/src/serverRuntimeState.ts
+++ b/packages/shared/src/serverRuntimeState.ts
@@ -1,0 +1,107 @@
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+export type ServerRuntimeStateVariant = "userdata" | "dev";
+
+export const PersistedServerRuntimeState = Schema.Struct({
+  version: Schema.Literal(1),
+  pid: Schema.Int,
+  host: Schema.optional(Schema.String),
+  port: Schema.Int,
+  origin: Schema.String,
+  devUrl: Schema.optional(Schema.String),
+  startedAt: Schema.String,
+});
+export type PersistedServerRuntimeState = typeof PersistedServerRuntimeState.Type;
+
+export class ServerRuntimeStateError extends Schema.TaggedErrorClass<ServerRuntimeStateError>()(
+  "ServerRuntimeStateError",
+  {
+    operation: Schema.Literals(["persist", "read", "decode", "clear"]),
+    statePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} server runtime state at ${this.statePath}.`;
+  }
+}
+
+const decodePersistedServerRuntimeState = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(PersistedServerRuntimeState),
+);
+
+export function deriveServerRuntimeStatePath(input: {
+  readonly baseDir: string;
+  readonly variant: ServerRuntimeStateVariant;
+  readonly joinPath: (first: string, ...segments: ReadonlyArray<string>) => string;
+}): string {
+  return input.joinPath(input.baseDir, input.variant, "server-runtime.json");
+}
+
+/**
+ * Signal 0 does not deliver a signal; it only reports whether the process
+ * exists. EPERM still means the process is alive but belongs to another user.
+ */
+export const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "EPERM";
+  }
+};
+
+export const readPersistedServerRuntimeState = (path: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const raw = yield* fs.readFileString(path).pipe(
+      Effect.matchEffect({
+        onFailure: (cause) =>
+          cause.reason._tag === "NotFound"
+            ? Effect.succeed(Option.none<string>())
+            : Effect.fail(
+                new ServerRuntimeStateError({
+                  operation: "read",
+                  statePath: path,
+                  cause,
+                }),
+              ),
+        onSuccess: (contents) => Effect.succeed(Option.some(contents)),
+      }),
+    );
+    if (Option.isNone(raw)) {
+      return Option.none<PersistedServerRuntimeState>();
+    }
+
+    const trimmed = raw.value.trim();
+    if (trimmed.length === 0) {
+      return Option.none<PersistedServerRuntimeState>();
+    }
+
+    return yield* decodePersistedServerRuntimeState(trimmed).pipe(
+      Effect.map(Option.some),
+      Effect.mapError(
+        (cause) =>
+          new ServerRuntimeStateError({
+            operation: "decode",
+            statePath: path,
+            cause,
+          }),
+      ),
+    );
+  }).pipe(
+    Effect.catchTags({
+      ServerRuntimeStateError: (error) =>
+        Effect.logWarning(error.message).pipe(
+          Effect.annotateLogs({
+            operation: error.operation,
+            statePath: error.statePath,
+            cause: error,
+          }),
+          Effect.as(Option.none<PersistedServerRuntimeState>()),
+        ),
+    }),
+  );


### PR DESCRIPTION
# Let the desktop app be a client of an existing T3 Code server

Fixes #6097. Supersedes #4444 and folds in #4496 and #4559.

Based on #2829's branch (`t3code/codex-turn-mapping`) rather than `main`: the new orchestrator rewrites the client state and settings surfaces this change touches, so a `main`-based version would only conflict with it. The same series against `main` is kept at `colonelpanic8/t3code:t3code/client-environment-suite-main` for reference.

## The problem

Since `t3 service` (#4286, #6286) a T3 Code server can outlive the desktop app. But the desktop app still assumes it owns the machine's backend: on launch it sees port 3773 busy, picks 3774, and starts a second backend against the same `~/.t3/userdata/state.sqlite`. Two servers then contend for one SQLite database and requests fail with `database is locked` (#6097). Users in that thread asked for the obvious alternative, a thin client, and explained why the browser PWA is not a substitute: browser hotkeys conflict and several settings are unavailable outside the app.

The mobile app already works this way. It owns no backend and pairs with whatever environments it is given. This PR gives the desktop app the same option.

## What changes

**The desktop app never starts a second backend against a state directory that already has one.** On launch it reads the `server-runtime.json` a live server persists next to its database, exactly as `t3 pair` does, confirms the pid is alive and the process answers with the environment descriptor recorded next to it, and if so runs this launch as a client of that server instead of spawning its own. This is the same discovery `t3 pair` and `t3 triage` already rely on, so there is no new on-disk format and no new HTTP surface. Connections explains why the app is in this state and offers to pair with the running server.

**Client-only mode.** Users can also opt into this permanently (Settings → Connections → Backend mode) or per launch (`--backend-mode client-only`). In client-only mode the app serves its packaged renderer from static assets, opens the window when the renderer is ready rather than when a backend is, and does not stop any backend on quit. A client-only app with no saved connections lands on Connections instead of a dead primary-backend state.

**Pairing with a server on this computer.** Connections lists servers discovered through their runtime state. Pairing mints a one-time credential by running the bundled server's `t3 pair --json` against that state directory, which writes into the running server's own database. Same-user proof is filesystem access to the state directory, which is the trust model `t3 pair` already uses. Works on every platform.

**Settings target an environment.** A client with no backend of its own has nothing to call "primary", so settings that live on a server (environment general settings, providers, source control, keybindings, diagnostics) are addressed to an explicitly selected environment through one shared header that shows the same loading/offline/error state everywhere, and settings that belong to the client (general, appearance) are grouped separately in the navigation. Restore-to-defaults resets only the keys a page owns. Any connected client can manage pairing links and authorized clients for that environment, not only for a locally spawned one.

## Commits

The series is squashed onto the orchestrator branch as one commit; the original seven-commit series is on the `main`-based reference branch and is meant to be read in that order.

1. `feat: client-only desktop mode and environment-scoped settings`, the mode, IPC, static renderer serving, web routing, presence scope, and settings pages.
2. `shared: move server runtime state reading into packages/shared`, so the desktop can read runtime state without depending on the server package.
3. `cli: add --json to t3 pair`, following the existing `t3 auth ... --json` convention.
4. `desktop: discover local servers through runtime state and pair via t3 pair`, replacing an earlier Linux-only advertisement scheme that needed a new unauthenticated endpoint.
5. `desktop: attach to a running server instead of spawning a second backend`, the #6097 fix.
6. `web: unify environment-scoped settings selection and presentation`.
7. `web: drop per-environment accent colors and display names`, cosmetic client preferences split to a follow-up.

## Prior art

Paseo, another local-first agent runner, settled on this shape: the daemon runs detached, the desktop app reuses a daemon that is already running rather than starting another, and a `manageBuiltInDaemon` setting turns the desktop into a pure client. Its desktop shells out to the bundled CLI for `daemon status --json` the way this PR shells out to `t3 pair --json`.

## Not in this PR

Per-environment accent colors and custom display names, which were part of earlier revisions, are split out to keep this reviewable. Auto-pairing on attach is a one-line follow-up once the approach is agreed; this PR asks for one explicit Pair click.

## Verification

- `vp run --filter @t3tools/desktop --filter t3 --filter @t3tools/web --filter @t3tools/contracts --filter @t3tools/client-runtime --filter @t3tools/shared typecheck`: clean.
- `vp lint --report-unused-disable-directives` and `vp fmt --check` over every changed file: clean.
- Focused `vp test run` over apps/desktop (app, ipc, settings, electron, backend pool, exposure, updates, window), apps/server (cli, auth, startup access, server), apps/web (settings, environments, presence, grouping, hooks), packages/client-runtime (connection), packages/shared, packages/contracts: 132 files, 1307 tests, all passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches desktop startup, shutdown, custom protocol static serving, and local pairing subprocesses—areas where mistakes could cause double backends, failed launches, or unsafe pairing links.
> 
> **Overview**
> The desktop app can run as a **thin client** instead of always spawning its own backend. **Managed** vs **client-only** mode is persisted in settings, overridable with `--backend-mode`, and on packaged launch the app **auto-switches to client-only** when it finds a live userdata server via existing `server-runtime.json` discovery—avoiding a second process on the same SQLite state.
> 
> In **client-only** mode, startup skips the backend pool, serves the renderer via a new **static** custom protocol (or dev proxy), opens the window on **renderer readiness**, and does not stop backends on quit. **Connections** gains discovery of local servers and pairing by shelling out to **`t3 pair --json`**, with strict validation of pairing URLs and origins.
> 
> **IPC/preload** expose backend mode state, mode changes (relaunch with rollback on failure), and local-server discover/pair. The web UI uses **environment presence scope** (whether the app owns a local backend) for remote indicators and sidebar grouping, plus helpers for pairing candidates in Connections settings.
> 
> Supporting changes: shared **server runtime state** helpers, server config path derivation by dev/userdata variant, and **`--json`** on the `pair` CLI for machine-readable output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82443106f8503bb8f3ad53fa8c2fcf9723ba6f45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add desktop `client-only` backend mode to connect to an existing T3 Code server
> - Adds a `DesktopBackendMode` service supporting `managed` (default) and `client-only` modes, with CLI parsing (`--backend-mode`), persisted settings, and automatic fallback to `client-only` when a packaged launch detects an already-running userdata server
> - Adds `DesktopRunningLocalServers` service for discovering running local T3 servers from persisted runtime state and pairing with a selected environment via an Electron-as-Node child process
> - Adds IPC channels and handlers for backend-mode state reads/updates, local-server discovery, and local-server pairing, exposed to renderers through the desktop bridge
> - Introduces the full Orchestration V2 system: new provider adapters (Claude, Codex, Cursor, Grok, ACP Registry, OpenCode), projection/event/command-receipt stores, thread lifecycle/fork/launch/settlement services, checkpoint capture/rollback, effect outbox/worker, scheduled tasks, legacy V1 thread importer, and MCP orchestrator/worktree toolkits — replacing the V1 orchestration surface across server, web, and mobile clients
> - Migrates client-runtime connection to perform remote descriptor discovery with orchestration protocol negotiation and bounded thread snapshot loading
> - Risk: `EnvironmentApi` replaces the V1 orchestration dispatch/snapshot/stream surface with `orchestrationV2`; out-of-tree consumers of the prior V1 interface will break. The server no longer advertises `serverUpdateThreadContinuation` capability, meaning running threads are terminalized on restart. Cursor provider settings no longer expose `binaryPath` or `apiEndpoint` fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8244310.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->