### PR TITLE
feat(web): mod+w closes the active right panel tab before the window

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -207,6 +207,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("sidebar.toggle"), "mod+b");
       assert.equal(defaultsByCommand.get("rightPanel.toggle"), "mod+alt+b");
       assert.isFalse(defaultsByCommand.has("rightPanel.toggleMaximized"));
+      assert.equal(defaultsByCommand.get("rightPanel.close"), "mod+w");
       assert.equal(defaultsByCommand.get("terminal.splitVertical"), "mod+shift+d");
       assert.equal(defaultsByCommand.get("modelPicker.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("modelPicker.jump.9"), "mod+9");

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5616,6 +5616,16 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
+      if (command === "rightPanel.close") {
+        // Nothing open: leave the event alone so the shortcut keeps its
+        // native meaning (close window on desktop, close tab in a browser).
+        if (!activeRightPanelSurface) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (!event.repeat) closeRightPanelSurface(activeRightPanelSurface);
+        return;
+      }
+
       if (command === "terminal.split") {
         event.preventDefault();
         event.stopPropagation();
@@ -5704,6 +5714,7 @@ function ChatViewContent(props: ChatViewProps) {
     terminalUiState.terminalOpen,
     terminalUiState.activeTerminalId,
     activeThreadId,
+    closeRightPanelSurface,
     requestCloseTerminal,
     requestClosePanelTerminal,
     createNewTerminal,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -109,6 +109,11 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenIdentifier("terminalFocus"),
   },
   {
+    shortcut: modShortcut("w"),
+    command: "rightPanel.close",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("d"),
     command: "diff.toggle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -748,6 +753,24 @@ describe("resolveShortcutCommand", () => {
         platform: "Linux",
       }),
       "script.setup.run",
+    );
+  });
+
+  it("routes mod+w to the terminal while focused and to the right panel otherwise", () => {
+    const closeEvent = event({ key: "w", metaKey: true });
+    assert.strictEqual(
+      resolveShortcutCommand(closeEvent, DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+      "terminal.close",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(closeEvent, DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "rightPanel.close",
     );
   });
 

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -11,6 +11,7 @@ import type {
   PullRequestListState,
   SourceControlProviderKind,
 } from "@t3tools/contracts";
+import { useAtomValue } from "@effect/atom-react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
   ArrowDownUpIcon,
@@ -34,6 +35,7 @@ import {
 import {
   useCallback,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -107,7 +109,10 @@ import {
 } from "../components/WorkspaceBreadcrumb";
 import { WorkspacePageContainer } from "../components/WorkspacePageContainer";
 import { WorkspacePageHeader } from "../components/WorkspacePageHeader";
+import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { isElectron } from "../env";
+import { resolveShortcutCommand } from "../keybindings";
+import { isTerminalFocused } from "../lib/terminalFocus";
 import { PanelLayoutControls } from "../components/chat/PanelLayoutControls";
 import { Button } from "../components/ui/button";
 import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "../components/ui/menu";
@@ -135,6 +140,7 @@ import {
 } from "../state/pullRequests";
 import { useAtomCommand } from "../state/use-atom-command";
 import { cn } from "~/lib/utils";
+import { primaryServerKeybindingsAtom } from "~/state/server";
 import { getSourceControlPresentationForKind } from "~/sourceControlPresentation";
 
 export interface PullRequestsSearch extends PullRequestListPreferences {
@@ -285,6 +291,7 @@ function PullRequestsRouteView() {
   const statsPolicy: PullRequestStatsPolicy =
     sort === "ready" || sort === "largest" || sort === "smallest" ? "eager" : "visible";
   const navigate = useNavigate({ from: Route.fullPath });
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const { environments } = useEnvironments();
   // Every connected environment that has said it can list pull requests. Sorted, so the query
   // keys, the scope key and the stored snapshot all read the same whichever order the
@@ -1887,6 +1894,26 @@ function PullRequestsRouteView() {
     useRightPanelStore.getState().closeAllSurfaces(rightPanelRef);
     selectSurfaceInUrl(null);
   };
+
+  // This page has no ChatView, so the shared panel handles `rightPanel.close`
+  // itself. With nothing open the event falls through to its native meaning.
+  const closeActiveSurfaceFromShortcut = useEffectEvent((event: KeyboardEvent) => {
+    if (activePullRequestSurface === null) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (!event.repeat) closeSurface(activePullRequestSurface);
+  });
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || isCommandPaletteOpen()) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: { terminalFocus: isTerminalFocused() },
+      });
+      if (command === "rightPanel.close") closeActiveSurfaceFromShortcut(event);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [keybindings]);
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -52,6 +52,12 @@ successful pick; its hover glow and badge preview the element and color family t
 `rightPanel.toggleMaximized` maximizes or restores the open right panel. It has no default shortcut,
 so add one in **Settings** → **Keybindings** if you want to use it.
 
+`rightPanel.close` closes the active right panel tab and defaults to `mod+w`. Press it again to close
+the next tab. With the terminal focused, `mod+w` closes the terminal instead, and with nothing left
+to close it closes the desktop window as before. Browsers reserve `mod+w` for closing their own tab
+and never pass it to the page, so in a browser rebind this command (and `terminal.close`) to a
+shortcut the browser leaves alone, such as `alt+w`.
+
 `thread.copyReference` copies the active thread's pull request link, or its thread ID when no pull
 request is available. Its default shortcut is `mod+shift+c`, and it does not replace terminal copy
 while the terminal has focus.

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -59,6 +59,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "terminal.close",
   "rightPanel.toggle",
   "rightPanel.toggleMaximized",
+  "rightPanel.close",
   "diff.toggle",
   "preview.toggle",
   "preview.refresh",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -26,6 +26,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+d", command: "terminal.splitVertical", when: "terminalFocus" },
   { key: "mod+n", command: "terminal.new", when: "terminalFocus" },
   { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
+  { key: "mod+w", command: "rightPanel.close", when: "!terminalFocus" },
   { key: "mod+d", command: "diff.toggle", when: "!terminalFocus" },
   { key: "mod+shift+j", command: "preview.toggle" },
   { key: "mod+r", command: "preview.refresh", when: "previewFocus" },


### PR DESCRIPTION
## Problem

`Mod+W` only closed a focused terminal. Anywhere else it fell straight through to the desktop close-window accelerator, so closing a stack of right-panel tabs (diff, files, browser, PR) meant reaching for the mouse — or losing the window by accident.

## Fix

Add a `rightPanel.close` keybinding command, bound by default to `mod+w` when the terminal is not focused (the existing `terminal.close` rule keeps winning while it is).

- Closes the active right-panel tab, one per press, through the existing `closeRightPanelSurface` path so terminal-close and agent-controlled-browser confirmations still apply.
- With nothing open the keydown is left alone, so the shortcut keeps its native meaning (close window on desktop). Key repeat is ignored so a held key doesn't chew through every tab and then the window.
- The pull-requests page's shared panel handles the command itself since it renders no `ChatView`.
- Works while the in-app preview has focus: the preview `WebContentsView` already forwards mod+W to the main window.

Browsers reserve `mod+w` and never deliver it to the page; that was already true of `terminal.close`. Docs note the rebind.

## Testing

- `apps/web/src/keybindings.test.ts`: mod+w resolves to `terminal.close` with terminal focus and `rightPanel.close` otherwise.
- `apps/server/src/keybindings.test.ts`: default binding present.
- `apps/web` typecheck clean; targeted lint has no new findings.

Model: Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard UX and default bindings only; behavior is gated on panel/terminal focus and falls through to native close when nothing is open.
> 
> **Overview**
> Adds a **`rightPanel.close`** keybinding (default **`mod+w`** when the terminal is not focused) so users can dismiss right-panel tabs from the keyboard without immediately triggering close-window.
> 
> **`mod+w`** now resolves to **`terminal.close`** with terminal focus and **`rightPanel.close`** otherwise. **ChatView** handles the command by closing the active right-panel surface through the existing close path, skipping key repeat, and leaving the event untouched when no panel is open so desktop **mod+w** still closes the window. The **pull-requests** route registers the same shortcut locally because it does not mount **ChatView**.
> 
> Contracts, shared defaults, server/web tests, and user keybinding docs are updated (including browser **mod+w** rebind guidance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e8bb03e54c24800ede12a761f616adbd217c4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `rightPanel.close` command bound to `mod+w` with terminal-focus precedence
> - Adds `rightPanel.close` to the static keybinding command registry and maps it to `mod+w` with a context gate so it only applies when `terminalFocus` is false; the existing `terminal.close` rule keeps terminal precedence
> - Wires the new command into [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9363/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and the pull-requests route [pull-requests.tsx](https://github.com/pingdotgg/t3code/pull/9363/files#diff-514a5b26d9687035b089d834742d874da174aa0a8a0c7c2fd47c61d11795afa5); an active right-panel surface closes on the first matching keydown, with repeated keydowns ignored
> - Native browser behavior is preserved when no right-panel surface is active; the docs note users may want an alternate binding to avoid the browser closing the window
> - Risk: the pull-requests route installs its own window keydown listener outside `ChatView`; if `rightPanel.close` is not the resolved command it leaves the event untouched, so check the terminal-focus context resolution in [pull-requests.tsx](https://github.com/pingdotgg/t3code/pull/9363/files#diff-514a5b26d9687035b089d834742d874da174aa0a8a0c7c2fd47c61d11795afa5) for regressions
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14e8bb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->