### PR TITLE
fix(web): settled sidebar rows use the project fallback icon

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -49,7 +49,6 @@ import {
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
-  MessageSquareIcon,
   PinIcon,
   PlusIcon,
   SearchIcon,
@@ -1309,7 +1308,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                 faviconPath={props.projectFaviconPath}
                 projectIcon={props.projectIcon}
                 className="size-4"
-                fallbackIcon={MessageSquareIcon}
               />
             </span>
             {title}
@@ -1757,7 +1755,6 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
             faviconPath={props.projectFaviconPath}
             projectIcon={props.projectIcon}
             className="size-4 shrink-0"
-            fallbackIcon={MessageSquareIcon}
           />
           <span className="min-w-0 flex-1 truncate">{thread.title}</span>
           <span className="shrink-0 text-xs text-muted-foreground/55 tabular-nums">


### PR DESCRIPTION
Settled/snoozed sidebar rows (and command-palette thread rows) rendered a generic chat-bubble icon when the project had no favicon, while every other row for the same project showed the automatically derived project icon.

Cause: those rows passed `fallbackIcon={MessageSquareIcon}` to `ProjectFavicon`, and an explicit `fallbackIcon` skips `selectProjectIcon` entirely. Removed the override in both places so all rows fall back the same way. The `FolderGit2Icon` override on the PR list "all projects" filter chip is intentional and untouched.

**Before** — settled row shows a chat bubble; sibling rows for the same project show the T3 icon:

![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5b90f5988fbb1abb/settled-fallback-before.png)

**After** — a favicon-less project (`fleet`): the active row and both settled rows render the same derived 💻 icon:

![after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/391769b45e3ffc0b/settled-fallback-after.png)

Model: Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)