### PR TITLE
fix(web): separate connection failure reasons

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -33,7 +33,7 @@ import {
   type EnvironmentId,
   resolveEnvironmentMachineKind,
 } from "@t3tools/contracts";
-import { connectionStatusText } from "@t3tools/client-runtime/connection";
+import { connectionStatusText, connectionStatusTitle } from "@t3tools/client-runtime/connection";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -1504,18 +1504,21 @@ function SavedBackendListRow({
             </Tooltip>
           ) : null}
           {environment.connection.error && !resumingServerUpdate ? (
-            <p className="flex min-w-0 items-center gap-2 text-destructive text-xs">
-              <span className="truncate">{connectionStatusText(environment.connection)}</span>
-              {errorTraceId ? (
-                <button
-                  type="button"
-                  className="shrink-0 underline underline-offset-2"
-                  onClick={() => copyTraceId(errorTraceId)}
-                >
-                  Copy trace ID
-                </button>
-              ) : null}
-            </p>
+            <div className="min-w-0 text-destructive text-xs">
+              <p className="truncate">{connectionStatusTitle(environment.connection)}</p>
+              <p className="flex min-w-0 items-center gap-2">
+                <span className="truncate">Reason: {environment.connection.error}</span>
+                {errorTraceId ? (
+                  <button
+                    type="button"
+                    className="shrink-0 underline underline-offset-2"
+                    onClick={() => copyTraceId(errorTraceId)}
+                  >
+                    Copy trace ID
+                  </button>
+                ) : null}
+              </p>
+            </div>
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">


### PR DESCRIPTION
## What Changed

Connection failures in Settings → Connections now display the connection status and technical failure reason on separate lines. The existing trace-ID action remains beside the reason.

## Why

The current single-line message combines status and technical detail, then truncates the result. Long errors make the state harder to scan and can hide the useful failure reason. Separating the stable status title from the underlying error keeps both understandable without changing connection behavior.

## Before

<img width="1280" height="800" alt="connection-error-before" src="https://github.com/user-attachments/assets/058ba712-96be-4216-828d-6ff44ae1719e" />

## After

<img width="1280" height="800" alt="connection-error-after" src="https://github.com/user-attachments/assets/69b865ad-7704-4cf5-b979-bd67d6c45f91" />

## Verification

- `vp test run packages/client-runtime/src/connection/presentation.test.ts` — 8 tests passed
- `vp run --filter @t3tools/web typecheck` — passed
- Targeted lint and formatting — passed
- Verified in isolated upstream and patched web environments with the same unreachable remote fixture

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] A video is not applicable because there is no motion or interaction change

Created with GPT-5.6 in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in Connections settings; no connection or auth logic is modified.
> 
> **Overview**
> Connection errors on **Settings → Connections** saved backend rows no longer cram status and technical detail into one truncated line.
> 
> The error block now shows **`connectionStatusTitle`** on the first line (e.g. “Connection failed” or “Failed to connect. Reconnecting…”) and a second line with **`Reason: {error}`**, with **Copy trace ID** unchanged beside the reason. Status dot tooltips still use **`connectionStatusText`**, so combined messaging remains there only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d529fdc450d1a9c8db8e3dc8e0458f85109b10ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split connection failure display into status title and `Reason:` line in `SavedBackendListRow`
> Connection error rows now show a connection status title on the first line and the raw error prefixed with `Reason:` on the second line. The trace ID copy action remains on the reason line. Changes are in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/9367/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d529fdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->