### PR TITLE
fix(web): match project icon chooser button sizes

### DIFF
--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -873,7 +873,7 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                   Choose icon
                 </Button>
                 <Button
-                  size="xs"
+                  size="sm"
                   variant="outline"
                   type="button"
                   aria-label="Choose a project icon file"


### PR DESCRIPTION
## What Changed

Updated the project icon file chooser button from `xs` to `sm` so it matches the adjacent icon chooser button.

## Why

Keeps the project icon controls visually consistent in the project settings panel.

## UI Changes

Adjusted the project icon file chooser button size in web project settings. No screenshots included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single visual prop change in project settings with no behavior, data, or security impact.
> 
> **Overview**
> Aligns the **Choose file** and **Choose icon** controls in project settings so they use the same button size.
> 
> The file-picker button in the **Project icon** row now uses `size="sm"` instead of `size="xs"`, matching the adjacent icon picker button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d4c473cc598f8bd64580e642bb5d04cf5021d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Match project favicon chooser button size to `sm` in `ProjectDetail`
> Changes the project favicon file picker button size from `xs` to `sm` so it matches the icon picker button in [ProjectSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/9368/files#diff-0240d4863349583155edae77c3bfab65683d7e019508379850a5b96167960cdc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90d4c47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->