### PR TITLE
fix(claude): match selectors to available models

### DIFF
--- a/apps/server/src/provider/ClaudeModelCatalog.test.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.test.ts
@@ -147,7 +147,9 @@ describe("Claude model catalog", () => {
     const availability = resolveClaudeModelAvailability(catalog, "3.1.9", [
       { value: "default", displayName: "Default" },
       { value: "synthetic[large]", displayName: "Synthetic" },
-      { value: "claude-runtime-only", displayName: "Claude Runtime Only" },
+      { value: "  claude-runtime-only  ", displayName: "  Claude Runtime Only  " },
+      { value: "claude-runtime-only", displayName: "Duplicate Runtime Model" },
+      { value: " ", displayName: "Empty Model" },
       { value: "synthetic", displayName: "Duplicate Synthetic" },
     ]);
 

--- a/apps/server/src/provider/ClaudeModelCatalog.test.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeClaudeCatalogEffort,
   resolveClaudeCatalogApiModelId,
   resolveClaudeCatalogEffort,
+  resolveClaudeModelAvailability,
   resolveClaudeModelCatalog,
   resolveClaudeModelsForVersion,
   resolveClaudeModelSlug,
@@ -113,6 +114,72 @@ describe("Claude model catalog", () => {
         model: "synthetic",
       }),
       "claude-synthetic-next[large]",
+    );
+  });
+
+  it("uses runtime availability while preserving manifest metadata and legacy models", () => {
+    const base = manifest();
+    const input: ModelManifestData = {
+      ...base,
+      providers: {
+        ...base.providers,
+        claudeAgent: {
+          ...base.providers!.claudeAgent!,
+          models: [
+            ...base.providers!.claudeAgent!.models,
+            {
+              slug: "claude-synthetic-hidden",
+              name: "Claude Synthetic Hidden",
+              status: "current",
+              profile: "synthetic",
+            },
+            {
+              slug: "claude-synthetic-legacy",
+              name: "Claude Synthetic Legacy",
+              status: "legacy",
+              profile: "synthetic",
+            },
+          ],
+        },
+      },
+    };
+    const catalog = resolveClaudeModelCatalog(input);
+    const availability = resolveClaudeModelAvailability(catalog, "3.1.9", [
+      { value: "default", displayName: "Default" },
+      { value: "synthetic[large]", displayName: "Synthetic" },
+      { value: "claude-runtime-only", displayName: "Claude Runtime Only" },
+      { value: "synthetic", displayName: "Duplicate Synthetic" },
+    ]);
+
+    assert.strictEqual(availability.source, "runtime");
+    assert.deepStrictEqual(
+      availability.models.map((model) => model.slug),
+      ["claude-synthetic-next", "claude-runtime-only", "claude-synthetic-legacy"],
+    );
+    assert.deepStrictEqual(
+      availability.models[0]?.capabilities,
+      catalog.models[0]?.model.capabilities,
+    );
+    assert.deepStrictEqual(availability.models[1], {
+      slug: "claude-runtime-only",
+      name: "Claude Runtime Only",
+      isCustom: false,
+      capabilities: { optionDescriptors: [] },
+    });
+  });
+
+  it("falls back to version-compatible manifest models without a concrete runtime inventory", () => {
+    const catalog = resolveClaudeModelCatalog(manifest());
+
+    assert.deepStrictEqual(resolveClaudeModelAvailability(catalog, "3.1.9", []).models, []);
+    assert.deepStrictEqual(
+      resolveClaudeModelAvailability(catalog, "3.2.0", [
+        { value: "default", displayName: "Default" },
+      ]),
+      {
+        models: [catalog.models[0]!.model],
+        source: "manifest",
+      },
     );
   });
 

--- a/apps/server/src/provider/ClaudeModelCatalog.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.ts
@@ -86,12 +86,14 @@ export const BUNDLED_CLAUDE_MODEL_CATALOG = resolveClaudeModelCatalog(BUNDLED_MO
  * (a built-in alias they shadow is dropped, canonical slugs and capabilities
  * are preserved), and custom entries that declare their own capabilities are
  * appended so the adapter resolves effort / fast mode / thinking against the
- * user's descriptors instead of the empty default. Custom entries carry no
+ * user's descriptors instead of the empty default. A supplied fallback includes
+ * bare custom entries when building a provider snapshot. Custom entries carry no
  * runtime profile, so option values pass through to Claude Code verbatim.
  */
 export function scopeClaudeModelCatalog(
   catalog: ClaudeModelCatalog,
   customModels: ReadonlyArray<CustomModelSetting>,
+  defaultCustomCapabilities?: ModelCapabilities,
 ): ClaudeModelCatalog {
   const customEntries = readCustomModelEntries(customModels);
   if (customEntries.length === 0) return catalog;
@@ -112,13 +114,14 @@ export function scopeClaudeModelCatalog(
   const builtInSlugs = new Set(builtInModels.map((entry) => entry.model.slug));
   const customCatalogModels: Array<ClaudeCatalogModel> = [];
   for (const entry of customEntries) {
-    if (!entry.capabilities || builtInSlugs.has(entry.slug)) continue;
+    const capabilities = entry.capabilities ?? defaultCustomCapabilities;
+    if (!capabilities || builtInSlugs.has(entry.slug)) continue;
     customCatalogModels.push({
       model: {
         slug: entry.slug,
         name: entry.name,
         isCustom: true,
-        capabilities: entry.capabilities,
+        capabilities,
       },
       runtime: {},
       compatibility: {},

--- a/apps/server/src/provider/ClaudeModelCatalog.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.ts
@@ -39,6 +39,16 @@ export interface ClaudeModelCatalog {
   readonly models: ReadonlyArray<ClaudeCatalogModel>;
 }
 
+export interface ClaudeRuntimeModel {
+  readonly value: string;
+  readonly displayName: string;
+}
+
+export interface ClaudeModelAvailability {
+  readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly source: "runtime" | "manifest";
+}
+
 function tryResolveClaudeModelCatalog(manifest: ModelManifestData): ClaudeModelCatalog | null {
   const resolved = resolveProviderCatalog(manifest, CLAUDE);
   if (!resolved) return null;
@@ -165,6 +175,80 @@ export function resolveClaudeModelsForVersion(
   return catalog.models
     .filter((entry) => isVersionSupported(entry.compatibility, version))
     .map((entry) => entry.model);
+}
+
+function resolveClaudeCatalogModelFromRuntimeValue(
+  catalog: ClaudeModelCatalog,
+  value: string,
+): ClaudeCatalogModel | undefined {
+  const direct = resolveClaudeCatalogModel(catalog, value);
+  if (direct) return direct;
+
+  const suffixes = new Set(
+    catalog.models.flatMap((entry) =>
+      Object.values(entry.runtime.modelSuffixes ?? {}).flatMap((mapping) => Object.values(mapping)),
+    ),
+  );
+  for (const suffix of suffixes) {
+    if (!value.endsWith(suffix)) continue;
+    const resolved = resolveClaudeCatalogModel(catalog, value.slice(0, -suffix.length));
+    if (resolved) return resolved;
+  }
+  return undefined;
+}
+
+/**
+ * Uses Claude Code's session inventory to decide which current models are
+ * selectable. The manifest still owns metadata and the legacy escape hatch.
+ */
+export function resolveClaudeModelAvailability(
+  catalog: ClaudeModelCatalog,
+  version: string | null | undefined,
+  runtimeModels: ReadonlyArray<ClaudeRuntimeModel> | null | undefined,
+): ClaudeModelAvailability {
+  const compatibleModels = resolveClaudeModelsForVersion(catalog, version);
+  if (!runtimeModels || runtimeModels.length === 0) {
+    return { models: compatibleModels, source: "manifest" };
+  }
+
+  const availableCatalogSlugs = new Set<string>();
+  const runtimeOnlyModels: ServerProviderModel[] = [];
+  const seenRuntimeOnlySlugs = new Set<string>();
+  for (const runtimeModel of runtimeModels) {
+    const value = runtimeModel.value.trim();
+    if (!value || value.toLowerCase() === "default") continue;
+
+    const catalogEntry = resolveClaudeCatalogModelFromRuntimeValue(catalog, value);
+    if (catalogEntry) {
+      availableCatalogSlugs.add(catalogEntry.model.slug);
+      continue;
+    }
+    if (seenRuntimeOnlySlugs.has(value)) continue;
+    seenRuntimeOnlySlugs.add(value);
+    runtimeOnlyModels.push({
+      slug: value,
+      name: runtimeModel.displayName.trim() || value,
+      isCustom: false,
+      capabilities: EMPTY_CAPABILITIES,
+    });
+  }
+
+  if (availableCatalogSlugs.size === 0 && runtimeOnlyModels.length === 0) {
+    return { models: compatibleModels, source: "manifest" };
+  }
+
+  const compatibleSlugs = new Set(compatibleModels.map((model) => model.slug));
+  const selectedCatalogModels = catalog.models.flatMap(({ model }) =>
+    availableCatalogSlugs.has(model.slug) || (model.isLegacy && compatibleSlugs.has(model.slug))
+      ? [model]
+      : [],
+  );
+  const currentModels = selectedCatalogModels.filter((model) => !model.isLegacy);
+  const legacyModels = selectedCatalogModels.filter((model) => model.isLegacy);
+  return {
+    models: [...currentModels, ...runtimeOnlyModels, ...legacyModels],
+    source: "runtime",
+  };
 }
 
 export function formatClaudeVersionUpgradeMessage(

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -114,7 +114,7 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
           "      agents: [],",
           '      output_style: "default",',
           '      available_output_styles: ["default"],',
-          "      models: [],",
+          '      models: [{ value: "synthetic[large]", displayName: "Synthetic", description: "Test model" }],',
           '      account: { email: "dev@example.com", subscriptionType: "pro", tokenSource: "oauth" },',
           "    });",
           "  }",

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -157,6 +157,9 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
             input: { hint: "[path]" },
           },
         ],
+        models: [
+          { value: "synthetic[large]", displayName: "Synthetic", description: "Test model" },
+        ],
         usage: {
           rate_limits_available: true,
           rate_limits: { five_hour: { utilization: 12, resets_at: "2026-07-18T14:39:00Z" } },

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -530,7 +530,11 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
   const modelAvailability = resolveClaudeModelAvailability(
-    scopeClaudeModelCatalog(modelCatalog, claudeSettings.customModels),
+    scopeClaudeModelCatalog(
+      modelCatalog,
+      claudeSettings.customModels,
+      DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+    ),
     parsedVersion,
     capabilities?.models,
   );

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -15,7 +15,6 @@ import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import {
   query as claudeQuery,
-  type ModelInfo as ClaudeModelInfo,
   type Options as ClaudeQueryOptions,
   type SlashCommand as ClaudeSlashCommand,
   type SDKControlGetUsageResponse,
@@ -48,6 +47,7 @@ import {
   type ClaudeRuntimeModel,
   formatClaudeVersionUpgradeMessage,
   resolveClaudeModelAvailability,
+  scopeClaudeModelCatalog,
 } from "../ClaudeModelCatalog.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
@@ -245,23 +245,6 @@ type ClaudeCapabilitiesProbe = {
   readonly models: ReadonlyArray<ClaudeRuntimeModel>;
 };
 
-function parseClaudeInitializationModels(
-  models: ReadonlyArray<ClaudeModelInfo> | undefined,
-): ReadonlyArray<ClaudeRuntimeModel> {
-  const seen = new Set<string>();
-  return (models ?? []).flatMap((model) => {
-    const value = nonEmptyProbeString(model.value);
-    if (!value || seen.has(value)) return [];
-    seen.add(value);
-    return [
-      {
-        value,
-        displayName: nonEmptyProbeString(model.displayName) ?? value,
-      },
-    ];
-  });
-}
-
 function parseClaudeInitializationCommands(
   commands: ReadonlyArray<ClaudeSlashCommand> | undefined,
 ): ReadonlyArray<ServerProviderSlashCommand> {
@@ -405,7 +388,7 @@ const probeClaudeCapabilities = (
           tokenSource: account?.tokenSource,
           apiProvider: account?.apiProvider,
           slashCommands: parseClaudeInitializationCommands(init.commands),
-          models: parseClaudeInitializationModels(init.models),
+          models: init.models ?? [],
           ...(usage ? { usage } : {}),
         } satisfies ClaudeCapabilitiesProbe;
       }),
@@ -547,7 +530,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
   const modelAvailability = resolveClaudeModelAvailability(
-    modelCatalog,
+    scopeClaudeModelCatalog(modelCatalog, claudeSettings.customModels),
     parsedVersion,
     capabilities?.models,
   );

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -15,6 +15,7 @@ import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import {
   query as claudeQuery,
+  type ModelInfo as ClaudeModelInfo,
   type Options as ClaudeQueryOptions,
   type SlashCommand as ClaudeSlashCommand,
   type SDKControlGetUsageResponse,
@@ -44,8 +45,9 @@ import {
 import {
   BUNDLED_CLAUDE_MODEL_CATALOG,
   type ClaudeModelCatalog,
+  type ClaudeRuntimeModel,
   formatClaudeVersionUpgradeMessage,
-  resolveClaudeModelsForVersion,
+  resolveClaudeModelAvailability,
 } from "../ClaudeModelCatalog.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
@@ -240,7 +242,25 @@ type ClaudeCapabilitiesProbe = {
    * otherwise successful response mean the account has none (API key).
    */
   readonly usage?: Pick<SDKControlGetUsageResponse, "rate_limits_available" | "rate_limits">;
+  readonly models: ReadonlyArray<ClaudeRuntimeModel>;
 };
+
+function parseClaudeInitializationModels(
+  models: ReadonlyArray<ClaudeModelInfo> | undefined,
+): ReadonlyArray<ClaudeRuntimeModel> {
+  const seen = new Set<string>();
+  return (models ?? []).flatMap((model) => {
+    const value = nonEmptyProbeString(model.value);
+    if (!value || seen.has(value)) return [];
+    seen.add(value);
+    return [
+      {
+        value,
+        displayName: nonEmptyProbeString(model.displayName) ?? value,
+      },
+    ];
+  });
+}
 
 function parseClaudeInitializationCommands(
   commands: ReadonlyArray<ClaudeSlashCommand> | undefined,
@@ -385,6 +405,7 @@ const probeClaudeCapabilities = (
           tokenSource: account?.tokenSource,
           apiProvider: account?.apiProvider,
           slashCommands: parseClaudeInitializationCommands(init.commands),
+          models: parseClaudeInitializationModels(init.models),
           ...(usage ? { usage } : {}),
         } satisfies ClaudeCapabilitiesProbe;
       }),
@@ -522,16 +543,23 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     });
   }
 
-  const models = providerModelsFromSettings(
-    resolveClaudeModelsForVersion(modelCatalog, parsedVersion),
-    claudeSettings.customModels,
-    DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-  );
-  const versionUpgradeMessage = formatClaudeVersionUpgradeMessage(modelCatalog, parsedVersion);
-
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
+  const modelAvailability = resolveClaudeModelAvailability(
+    modelCatalog,
+    parsedVersion,
+    capabilities?.models,
+  );
+  const models = providerModelsFromSettings(
+    modelAvailability.models,
+    claudeSettings.customModels,
+    DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+  );
+  const versionUpgradeMessage =
+    modelAvailability.source === "manifest"
+      ? formatClaudeVersionUpgradeMessage(modelCatalog, parsedVersion)
+      : undefined;
   const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
   const slashCommands = [COMPACT_SLASH_COMMAND, ...(capabilities?.slashCommands ?? [])];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -599,6 +599,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     presentation: CLAUDE_PRESENTATION,
     enabled: claudeSettings.enabled,
     checkedAt,
+    ...(modelAvailability.source === "runtime" ? { modelInventory: "authoritative" as const } : {}),
     models,
     slashCommands: dedupedSlashCommands,
     skills,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -2789,10 +2789,11 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             capabilities: SYNTHETIC_CLAUDE_MODEL_CATALOG.models[0]!.model.capabilities!,
           };
           const status = yield* checkClaudeProviderStatus(
-            { ...defaultClaudeSettings, customModels: [customModel] },
+            { ...defaultClaudeSettings, customModels: [customModel, "bare-runtime-custom"] },
             claudeCapabilities({
               models: [
                 { value: customModel.slug, displayName: "Runtime Name" },
+                { value: "bare-runtime-custom", displayName: "Bare Runtime Name" },
                 {
                   value: `${SYNTHETIC_CLAUDE_COLLIDING_ALIAS}[expanded]`,
                   displayName: "Synthetic Capable",
@@ -2806,13 +2807,22 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
           assert.deepStrictEqual(
             status.models.filter((model) => !model.isLegacy).map((model) => model.slug),
-            [SYNTHETIC_CLAUDE_CAPABLE_MODEL, customModel.slug],
+            [SYNTHETIC_CLAUDE_CAPABLE_MODEL, customModel.slug, "bare-runtime-custom"],
           );
           assert.deepStrictEqual(
             status.models.find((model) => model.slug === customModel.slug),
             {
               ...customModel,
               isCustom: true,
+            },
+          );
+          assert.deepStrictEqual(
+            status.models.find((model) => model.slug === "bare-runtime-custom"),
+            {
+              slug: "bare-runtime-custom",
+              name: "bare-runtime-custom",
+              isCustom: true,
+              capabilities: { optionDescriptors: [] },
             },
           );
           assert.strictEqual(status.modelInventory, "authoritative");

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -653,7 +653,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         );
       });
 
-      it("drops Claude models omitted by a successful refresh", () => {
+      it("uses Claude inventory authority when reconciling snapshots", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("claudeAgent"),
           driver: ProviderDriverKind.make("claudeAgent"),
@@ -689,11 +689,23 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         const refreshedProvider = {
           ...previousProvider,
           checkedAt: "2026-04-14T00:01:00.000Z",
+          modelInventory: "authoritative",
+          models: [previousProvider.models[0]],
+        } satisfies ServerProvider;
+        const partialProvider = {
+          ...previousProvider,
+          status: "warning",
+          auth: { status: "unknown" },
+          checkedAt: "2026-04-14T00:02:00.000Z",
           models: [previousProvider.models[0]],
         } satisfies ServerProvider;
 
         assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
           ...refreshedProvider.models,
+        ]);
+        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, partialProvider).models, [
+          previousProvider.models[0],
+          previousProvider.models[1],
         ]);
       });
 
@@ -2790,6 +2802,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             status.models.filter((model) => !model.isLegacy).map((model) => model.slug),
             [SYNTHETIC_CLAUDE_CAPABLE_MODEL],
           );
+          assert.strictEqual(status.modelInventory, "authoritative");
           assert.ok((status.models[0]?.capabilities?.optionDescriptors?.length ?? 0) > 0);
         }).pipe(
           Effect.provide(
@@ -2922,6 +2935,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.strictEqual(status.status, "warning");
           assert.strictEqual(status.installed, true);
           assert.strictEqual(status.auth.status, "unknown");
+          assert.strictEqual(status.modelInventory, undefined);
           assert.strictEqual(
             status.message,
             "Could not verify Claude authentication status from initialization result.",

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -653,7 +653,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         );
       });
 
-      it("drops custom models the refreshed snapshot no longer carries", () => {
+      it("drops Claude models omitted by a successful refresh", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("claudeAgent"),
           driver: ProviderDriverKind.make("claudeAgent"),
@@ -667,6 +667,12 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             {
               slug: "claude-sonnet-4-6",
               name: "Sonnet 4.6",
+              isCustom: false,
+              capabilities: null,
+            },
+            {
+              slug: "claude-stale-model",
+              name: "Stale model",
               isCustom: false,
               capabilities: null,
             },

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -37,6 +37,11 @@ import { checkCodexProviderStatus, type CodexAppServerProviderSnapshot } from ".
 import { checkClaudeProviderStatus } from "./ClaudeProvider.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { AntigravityInstallation } from "../AntigravityInstallation.ts";
+import {
+  SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+  SYNTHETIC_CLAUDE_COLLIDING_ALIAS,
+  SYNTHETIC_CLAUDE_MODEL_CATALOG,
+} from "../ClaudeModelCatalog.testFixtures.ts";
 import * as ModelManifest from "../ModelManifest.ts";
 import * as CodexResetCredit from "./codexResetCredit.ts";
 import * as OpenCodeRuntime from "../opencodeRuntime.ts";
@@ -143,6 +148,7 @@ type TestClaudeCapabilities = {
   readonly tokenSource: string | undefined;
   readonly apiProvider: string | undefined;
   readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly models: ReadonlyArray<{ readonly value: string; readonly displayName: string }>;
 };
 
 function claudeCapabilities(overrides: Partial<TestClaudeCapabilities> = {}) {
@@ -153,6 +159,7 @@ function claudeCapabilities(overrides: Partial<TestClaudeCapabilities> = {}) {
       tokenSource: undefined,
       apiProvider: undefined,
       slashCommands: [],
+      models: [],
       ...overrides,
     });
 }
@@ -2750,6 +2757,39 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                   stderr: "",
                   code: 0,
                 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("publishes the models reported by Claude initialization", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities({
+              models: [
+                {
+                  value: `${SYNTHETIC_CLAUDE_COLLIDING_ALIAS}[expanded]`,
+                  displayName: "Synthetic Capable",
+                },
+              ],
+            }),
+            undefined,
+            undefined,
+            SYNTHETIC_CLAUDE_MODEL_CATALOG,
+          );
+
+          assert.deepStrictEqual(
+            status.models.filter((model) => !model.isLegacy).map((model) => model.slug),
+            [SYNTHETIC_CLAUDE_CAPABLE_MODEL],
+          );
+          assert.ok((status.models[0]?.capabilities?.optionDescriptors?.length ?? 0) > 0);
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
               throw new Error(`Unexpected args: ${joined}`);
             }),
           ),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -2783,10 +2783,16 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
       it.effect("publishes the models reported by Claude initialization", () =>
         Effect.gen(function* () {
+          const customModel = {
+            slug: "runtime-custom",
+            name: "Configured Runtime Model",
+            capabilities: SYNTHETIC_CLAUDE_MODEL_CATALOG.models[0]!.model.capabilities!,
+          };
           const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
+            { ...defaultClaudeSettings, customModels: [customModel] },
             claudeCapabilities({
               models: [
+                { value: customModel.slug, displayName: "Runtime Name" },
                 {
                   value: `${SYNTHETIC_CLAUDE_COLLIDING_ALIAS}[expanded]`,
                   displayName: "Synthetic Capable",
@@ -2800,7 +2806,14 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
           assert.deepStrictEqual(
             status.models.filter((model) => !model.isLegacy).map((model) => model.slug),
-            [SYNTHETIC_CLAUDE_CAPABLE_MODEL],
+            [SYNTHETIC_CLAUDE_CAPABLE_MODEL, customModel.slug],
+          );
+          assert.deepStrictEqual(
+            status.models.find((model) => model.slug === customModel.slug),
+            {
+              ...customModel,
+              isCustom: true,
+            },
           );
           assert.strictEqual(status.modelInventory, "authoritative");
           assert.ok((status.models[0]?.capabilities?.optionDescriptors?.length ?? 0) > 0);

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -101,6 +101,9 @@ export function upsertProviderWorkspaceSnapshot(
 }
 
 const shouldRetainMissingProviderModels = (provider: ServerProvider): boolean => {
+  if (provider.modelInventory === "authoritative") {
+    return false;
+  }
   const isAntigravity = provider.driver === ProviderDriverKind.make("antigravity");
   const isCodex = provider.driver === ProviderDriverKind.make("codex");
   if (!isAntigravity && !isCodex && provider.driver !== ProviderDriverKind.make("opencode")) {

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -230,6 +230,7 @@ export function buildServerProvider(input: {
   presentation: ServerProviderPresentation;
   enabled: boolean;
   checkedAt: string;
+  modelInventory?: ServerProvider["modelInventory"];
   models: ReadonlyArray<ServerProviderModel>;
   slashCommands?: ReadonlyArray<ServerProviderSlashCommand>;
   skills?: ReadonlyArray<ServerProviderSkill>;
@@ -258,6 +259,7 @@ export function buildServerProvider(input: {
     auth: input.probe.auth,
     checkedAt: input.checkedAt,
     ...(input.probe.message ? { message: input.probe.message } : {}),
+    ...(input.modelInventory ? { modelInventory: input.modelInventory } : {}),
     models: input.models,
     slashCommands: [...(input.slashCommands ?? [])],
     skills: [...(input.skills ?? [])],

--- a/docs/internals/model-manifest.md
+++ b/docs/internals/model-manifest.md
@@ -10,19 +10,16 @@ A newer bundle outranks the cached remote manifest by `updatedAt`, so a release 
 correct model data before the next successful fetch. Bump `updatedAt` whenever the
 file changes. Fetch time cannot establish which copy contains the newer edit.
 
-Claude Code reports the current session's available models during provider initialization. A
-runtime inventory with at least one concrete model filters the manifest's current models and can
-add a model before the manifest knows about it. Matching manifest entries still own presentation,
-aliases, capabilities, legacy status, and dispatch metadata. T3 keeps version-compatible legacy
-entries as an explicit escape hatch and falls back to the version-filtered manifest when runtime
-discovery is empty, unavailable, or contains only `default`. Only snapshots backed by a concrete
-runtime inventory mark that inventory as authoritative, so provider reconciliation does not
-restore models Claude omitted.
+Generic catalog data describes presentation and capabilities. Each provider owns
+its adapter schema and dispatch mappings. Claude gets current availability from
+its initialization inventory, while the manifest owns metadata and compatible
+legacy entries. Empty, unavailable, or `default`-only inventories fall back to the
+version-filtered manifest. Only concrete runtime inventories are authoritative,
+so reconciliation can remove models Claude omitted.
 
-To add metadata for a Claude model that uses an existing profile, add one object to
-`providers.claudeAgent.models`. Do not add a test or change application code. Add or change a
-profile in the same JSON file only when the model exposes a capability combination that does not
-already exist.
+Adding metadata for a model with an existing capability profile is a JSON edit;
+a new profile is needed only for a new capability combination. Codex gets its
+model list from its app server.
 
 `currentModels.claudeAgent` is frozen for releases that predate catalog discovery.
 Do not extend it when adding Claude models. Codex uses `currentModels.codex` as a

--- a/docs/internals/model-manifest.md
+++ b/docs/internals/model-manifest.md
@@ -10,11 +10,17 @@ A newer bundle outranks the cached remote manifest by `updatedAt`, so a release 
 correct model data before the next successful fetch. Bump `updatedAt` whenever the
 file changes. Fetch time cannot establish which copy contains the newer edit.
 
-Generic catalog data describes presentation and capabilities. Each provider owns
-its adapter schema and dispatch mappings. Claude uses the manifest for its entire
-built-in catalog. Adding a model with an existing capability profile is a JSON
-edit; a new profile is needed only for a new capability combination. Codex still
-gets its model list from its app server.
+Claude Code reports the current session's available models during provider initialization. A
+non-empty runtime inventory filters the manifest's current models and can add a model before the
+manifest knows about it. Matching manifest entries still own presentation, aliases, capabilities,
+legacy status, and dispatch metadata. T3 keeps version-compatible legacy entries as an explicit
+escape hatch and falls back to the version-filtered manifest when runtime discovery is empty or
+unavailable.
+
+To add metadata for a Claude model that uses an existing profile, add one object to
+`providers.claudeAgent.models`. Do not add a test or change application code. Add or change a
+profile in the same JSON file only when the model exposes a capability combination that does not
+already exist.
 
 `currentModels.claudeAgent` is frozen for releases that predate catalog discovery.
 Do not extend it when adding Claude models. Codex uses `currentModels.codex` as a

--- a/docs/internals/model-manifest.md
+++ b/docs/internals/model-manifest.md
@@ -15,7 +15,8 @@ non-empty runtime inventory filters the manifest's current models and can add a 
 manifest knows about it. Matching manifest entries still own presentation, aliases, capabilities,
 legacy status, and dispatch metadata. T3 keeps version-compatible legacy entries as an explicit
 escape hatch and falls back to the version-filtered manifest when runtime discovery is empty or
-unavailable.
+unavailable. Runtime-backed snapshots mark their model inventory as authoritative so provider
+reconciliation does not restore models Claude omitted.
 
 To add metadata for a Claude model that uses an existing profile, add one object to
 `providers.claudeAgent.models`. Do not add a test or change application code. Add or change a

--- a/docs/internals/model-manifest.md
+++ b/docs/internals/model-manifest.md
@@ -11,12 +11,13 @@ correct model data before the next successful fetch. Bump `updatedAt` whenever t
 file changes. Fetch time cannot establish which copy contains the newer edit.
 
 Claude Code reports the current session's available models during provider initialization. A
-non-empty runtime inventory filters the manifest's current models and can add a model before the
-manifest knows about it. Matching manifest entries still own presentation, aliases, capabilities,
-legacy status, and dispatch metadata. T3 keeps version-compatible legacy entries as an explicit
-escape hatch and falls back to the version-filtered manifest when runtime discovery is empty or
-unavailable. Runtime-backed snapshots mark their model inventory as authoritative so provider
-reconciliation does not restore models Claude omitted.
+runtime inventory with at least one concrete model filters the manifest's current models and can
+add a model before the manifest knows about it. Matching manifest entries still own presentation,
+aliases, capabilities, legacy status, and dispatch metadata. T3 keeps version-compatible legacy
+entries as an explicit escape hatch and falls back to the version-filtered manifest when runtime
+discovery is empty, unavailable, or contains only `default`. Only snapshots backed by a concrete
+runtime inventory mark that inventory as authoritative, so provider reconciliation does not
+restore models Claude omitted.
 
 To add metadata for a Claude model that uses an existing profile, add one object to
 `providers.claudeAgent.models`. Do not add a test or change application code. Add or change a

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -59,7 +59,6 @@ When Claude Code cannot return a model list, T3 Code falls back to its model man
 installed Claude Code version. Models configured manually on the provider remain available in
 either case.
 
-
 ## Usage limits
 
 If your Claude subscription runs out of usage mid-turn, the thread shows which

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -49,6 +49,17 @@ You can also send `/compact` in an existing conversation. Web and desktop offer
 a large older thread. See [commands and skills](./composer.md#commands-and-skills)
 for using composer commands.
 
+## Model list
+
+T3 Code reads the available model list from Claude Code when it checks the provider. The project
+default picker and the chat composer use that same provider list. If Claude adds a model while T3
+Code is running, update Claude Code, then restart T3 Code to refresh the list immediately.
+
+When Claude Code cannot return a model list, T3 Code falls back to its model manifest and the
+installed Claude Code version. Models configured manually on the provider remain available in
+either case.
+
+
 ## Usage limits
 
 If your Claude subscription runs out of usage mid-turn, the thread shows which

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -46,8 +46,18 @@ describe("ServerProvider", () => {
 
     expect(parsed.slashCommands).toEqual([]);
     expect(parsed.skills).toEqual([]);
+    expect(parsed.modelInventory).toBeUndefined();
     expect(parsed.versionAdvisory).toBeUndefined();
     expect(parsed.updateState).toBeUndefined();
+  });
+
+  it("decodes authoritative model inventories", () => {
+    const parsed = decodeServerProvider({
+      ...baseProviderSnapshot,
+      modelInventory: "authoritative",
+    });
+
+    expect(parsed.modelInventory).toBe("authoritative");
   });
 
   it("defaults one-click update support when decoding older advisory snapshots", () => {

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -222,6 +222,10 @@ export const ServerProvider = Schema.Struct({
   // Human-readable reason populated when `availability === "unavailable"`.
   // Surfaces in the UI alongside the missing-driver affordance.
   unavailableReason: Schema.optional(TrimmedNonEmptyString),
+  // A successful runtime inventory is complete, so server reconciliation may
+  // remove models omitted from it. Absence keeps the additive behavior used by
+  // older and partial provider snapshots.
+  modelInventory: Schema.optionalKey(Schema.Literal("authoritative")),
   models: Schema.Array(ServerProviderModel),
   slashCommands: Schema.Array(ServerProviderSlashCommand).pipe(
     Schema.withDecodingDefault(Effect.succeed([])),


### PR DESCRIPTION
Claude model selectors can lag behind the models an account can use. Provider snapshots now use Claude Code's initialization inventory, retain manifest metadata and compatible legacy models, and preserve manually configured capabilities. Empty or failed discovery falls back to the manifest; partial snapshots retain previously discovered models.

Concrete runtime inventories are authoritative, so reconciliation removes models omitted by Claude. The project picker and composer consume the same provider list. Model normalization and deduplication happen once in the catalog resolver.

Rebased onto current main, preserving the newer usage probe and other providers' reconciliation behavior.

Validation: 70 focused contract, catalog, SDK-boundary, and registry tests passed. The complete 48-test registry suite passed again after the custom-capability fix. Server and contracts typechecks and targeted lint passed.

Original implementation by gpt-5.6-sol. Rebase, fixes, and review by GPT-6 in T3 Code via Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Source Claude model availability from runtime inventory and mark it authoritative
> - Adds `resolveClaudeModelAvailability` in [ClaudeModelCatalog.ts](https://github.com/pingdotgg/t3code/pull/9369/files#diff-870489ca53b30490568a8e002e32b0e2b331e5ab59fe69b346fd83543bd3ee6e) to resolve models from the Claude initialization inventory, including runtime-only models and suffix/alias mappings, while preserving compatible legacy manifest models and falling back to version-filtered manifest models when inventory is absent
> - Adds an optional `modelInventory` field to `ServerProvider` in [server.ts](https://github.com/pingdotgg/t3code/pull/9369/files#diff-e575e7eac4053ca860f2d99f4f5bf09331b4e959961ac7bfed0562e916fc5dbb) so snapshots can carry the `authoritative` marker; `buildServerProvider` in [providerSnapshot.ts](https://github.com/pingdotgg/t3code/pull/9369/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26) forwards it into the snapshot
> - Updates `shouldRetainMissingProviderModels` in [ProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/9369/files#diff-5c33694fd7889294ecb21a88beafee2debe92f779baab4629651d4c8be8a9a97) to remove models omitted from snapshots marked `authoritative`, instead of always retaining them
> - `checkClaudeProviderStatus` in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/9369/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) scopes the catalog with fallback capabilities, resolves availability from the probed inventory and version, and emits version-upgrade messaging only for manifest-sourced results
> - Behavioral Change: Claude provider snapshots from a concrete runtime inventory now prune stale models that are absent from that inventory; previous behavior retained built-in models across partial refreshes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc6af7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which models appear in selectors and can remove stale built-in/custom rows after authoritative refreshes; manifest-only fallback remains when initialization fails.
> 
> **Overview**
> Claude provider snapshots now **derive selectable models from Claude Code’s initialization inventory** instead of only the version-filtered manifest, so the project default picker and chat composer see the same list the account can actually use.
> 
> **`resolveClaudeModelAvailability`** filters manifest “current” models against runtime values (including suffix/alias matching), adds runtime-only models with empty capabilities, keeps compatible **legacy** entries, and falls back to the manifest when discovery is empty or only `default`. Successful runtime-backed snapshots set **`modelInventory: "authoritative"`** on `ServerProvider`; registry merge then **drops models omitted** from that inventory (partial/failed probes keep prior additive behavior). Version-upgrade messaging is skipped when sourcing from runtime.
> 
> Docs describe the new manifest vs runtime split; tests cover resolver behavior, probe parsing, reconciliation, and contract decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 942cc4c91debae379309e5b060d162fbfb0a6d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->