### PR TITLE
fix(mobile): remember model options changed in existing threads

### DIFF
--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -49,8 +49,8 @@ import {
   removeComposerDraftAttachment,
   replaceComposerDraftAttachments,
   scheduleUnusedComposerAttachmentCleanup,
+  setComposerDraftModelSelection,
   setComposerDraftText,
-  setStickyComposerModelSelection,
   updateComposerDraftSettings,
   useComposerDraft,
   useStickyComposerModelSelection,
@@ -486,8 +486,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         return;
       }
       const selection = options ? { ...option.selection, options } : option.selection;
-      updateComposerDraftSettings(selectedProjectDraftKey, { modelSelection: selection });
-      setStickyComposerModelSelection(selection);
+      setComposerDraftModelSelection(selectedProjectDraftKey, selection);
     },
     [modelOptions, selectedProjectDraftKey],
   );
@@ -502,10 +501,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
             instanceId: selectedModel.instanceId,
             model: selectedModel.model,
           };
-      updateComposerDraftSettings(selectedProjectDraftKey, {
-        modelSelection: nextSelection,
-      });
-      setStickyComposerModelSelection(nextSelection);
+      setComposerDraftModelSelection(selectedProjectDraftKey, nextSelection);
     },
     [selectedModel, selectedProjectDraftKey],
   );

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -139,6 +139,7 @@ import {
   retainComposerAttachmentFileForPreview,
   restoreComposerDraftSnapshotState,
   restoreCloudComposerDrafts,
+  setComposerDraftModelSelection,
   setComposerDraftText,
   setComposerDraftAttachmentUpload,
   waitForComposerDraftsLoaded,
@@ -956,6 +957,20 @@ describe("mobile composer drafts", () => {
       instanceId: "codex",
       model: "gpt-5.6-sol",
     });
+  });
+
+  it("remembers a model selection changed in an existing thread", () => {
+    const draftKey = "environment-1:thread-1";
+    const modelSelection = {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5.6-sol",
+      options: [{ id: "reasoningEffort", value: "xhigh" }],
+    };
+
+    setComposerDraftModelSelection(draftKey, modelSelection);
+
+    expect(getComposerDraftSnapshot(draftKey).modelSelection).toEqual(modelSelection);
+    expect(appAtomRegistry.get(stickyComposerModelSelectionAtom)).toEqual(modelSelection);
   });
 
   it("waits for hydration before persisting the latest composer state", async () => {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -974,6 +974,14 @@ export function updateComposerDraftSettings(
   });
 }
 
+export function setComposerDraftModelSelection(
+  draftKey: string,
+  modelSelection: ModelSelection,
+): void {
+  updateComposerDraftSettings(draftKey, { modelSelection });
+  setStickyComposerModelSelection(modelSelection);
+}
+
 export function clearComposerDraftContentState(
   current: Record<string, ComposerDraft>,
   draftKey: string,

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -45,6 +45,7 @@ import {
   mergeComposerDraftContent,
   removeComposerDraftAttachment,
   scheduleUnusedComposerAttachmentCleanup,
+  setComposerDraftModelSelection,
   setComposerDraftText,
   updateComposerDraftSettings,
   useComposerDraft,
@@ -455,7 +456,7 @@ export function useThreadComposerState() {
       if (!selectedThreadKey) {
         return;
       }
-      updateComposerDraftSettings(selectedThreadKey, { modelSelection: value });
+      setComposerDraftModelSelection(selectedThreadKey, value);
     },
     [selectedThreadKey],
   );


### PR DESCRIPTION
## What Changed

Changing the model or provider options in an existing Mobile thread updated only the draft for that thread. The app-wide remembered selection stayed stale, so later threads could revert to an earlier reasoning level.

This PR routes explicit Mobile model selections through one draft-state operation. New-task and existing-thread flows now update both the current draft and the remembered selection.

## Why

The documented model-default behavior applies to provider options such as reasoning effort. Mobile already persisted those options when starting a new task, but not when changing them in an existing thread. Sharing the state operation keeps both entry points consistent without adding server state or changing persistence formats.

## UI Changes

None. This changes persistence behavior only.

## Verification

- vp test run apps/mobile/src/state/use-composer-drafts.test.ts
- Targeted lint on the four changed files
- Targeted formatting check on the four changed files
- vp run --filter @t3tools/mobile typecheck

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there are no visual UI changes
- [x] Video is not applicable because there are no animation or presentation changes

Built with GPT-5.6 Sol using Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model option changes not persisting in existing threads
> Model selections updated in an existing thread were not saved to the sticky atom. Adds a shared `setComposerDraftModelSelection` helper in [use-composer-drafts.ts](https://github.com/pingdotgg/t3code/pull/9372/files#diff-6acb6f89d59b03b7738cacfb4cec712073b5d8c6b8d2abcd3cde1acee04f818e) that updates both the composer draft and the sticky model-selection atom in one operation. Replaces the separate draft-only updates in `NewTaskFlowProvider` and `useThreadComposerState` with calls to this helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8fe89d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->