### PR TITLE
fix(web): match composer pull request state icons

### DIFF
--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -745,7 +745,11 @@ export function BranchToolbarBranchSelector({
                 />
               }
             >
-              <ChangeRequestStatusIcon className="size-3" />
+              <ChangeRequestStatusIcon
+                state={branchPr.state}
+                isDraft={branchPr.isDraft}
+                className="size-3"
+              />
               <span
                 data-composer-label
                 className="min-w-0 max-w-12 overflow-hidden group-data-[compact]/composer-context:max-w-0"

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -720,7 +720,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         onContextMenu={handleRowContextMenu}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
-          {prStatus && (
+          {prStatus && pr && (
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -733,7 +733,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                     onPointerDown={(event) => event.stopPropagation()}
                     onClick={handlePrClick}
                   >
-                    <ChangeRequestStatusIcon className="size-3" />
+                    <ChangeRequestStatusIcon
+                      state={pr.state}
+                      isDraft={pr.isDraft}
+                      className="size-3"
+                    />
                   </a>
                 }
               />

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -2,8 +2,15 @@ import { ProjectId, type PullRequestSummary, type VcsStatusResult } from "@t3too
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { AtomRegistry } from "effect/unstable/reactivity";
+import {
+  GitMergeIcon,
+  GitPullRequestClosedIcon,
+  GitPullRequestDraftIcon,
+  GitPullRequestIcon,
+} from "lucide-react";
 
 import {
+  ChangeRequestStatusIcon,
   nextThreadChangeRequestSnapshot,
   prStatusIndicator,
   resolveDisplayedThreadPr,
@@ -15,6 +22,17 @@ import {
   type ThreadChangeRequestSnapshot,
 } from "./ThreadStatusIndicators";
 import { newestPullRequestSummary } from "../state/pullRequests";
+
+describe("ChangeRequestStatusIcon", () => {
+  it.each([
+    ["open", "open", false, GitPullRequestIcon],
+    ["draft", "open", true, GitPullRequestDraftIcon],
+    ["closed", "closed", false, GitPullRequestClosedIcon],
+    ["merged", "merged", false, GitMergeIcon],
+  ] as const)("uses the %s pull request glyph", (_label, state, isDraft, expectedIcon) => {
+    expect(ChangeRequestStatusIcon({ state, isDraft }).type).toBe(expectedIcon);
+  });
+});
 
 function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
   return {

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -11,7 +11,7 @@ import {
   type VcsStatusResult,
 } from "@t3tools/contracts";
 import { Atom } from "effect/unstable/reactivity";
-import { FolderGit2Icon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
+import { FolderGit2Icon, TerminalIcon } from "lucide-react";
 import { useMemo } from "react";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
@@ -24,6 +24,7 @@ import { vcsEnvironment } from "../state/vcs";
 import { useUiStateStore } from "../uiStateStore";
 import { resolveChangeRequestPresentation } from "../sourceControlPresentation";
 import { resolveThreadStatusPill, type ThreadStatusPill } from "./Sidebar.logic";
+import { resolvePullRequestState } from "./pullRequest/pullRequestPresentation";
 import type { SidebarThreadSummary } from "../types";
 import { formatWorktreePathForDisplay } from "../worktreeCleanup";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
@@ -155,8 +156,16 @@ export function prStatusIndicator(
   return null;
 }
 
-export function ChangeRequestStatusIcon({ className }: { className?: string }) {
-  return <GitPullRequestIcon className={className} />;
+export function ChangeRequestStatusIcon({
+  state,
+  isDraft = false,
+  className,
+}: Pick<NonNullable<ThreadPr>, "state"> & {
+  readonly isDraft?: boolean | undefined;
+  readonly className?: string | undefined;
+}) {
+  const presentation = resolvePullRequestState({ state, isDraft });
+  return <presentation.Icon className={className} />;
 }
 
 export function PrStatusTooltipContent({ status }: { status: PrStatusIndicator }) {
@@ -585,7 +594,7 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
 
   return (
     <span className="inline-flex shrink-0 items-center gap-1.5">
-      {prStatus ? (
+      {prStatus && pr ? (
         <Tooltip>
           <TooltipTrigger
             render={
@@ -595,7 +604,7 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
               />
             }
           >
-            <ChangeRequestStatusIcon className="size-3" />
+            <ChangeRequestStatusIcon state={pr.state} isDraft={pr.isDraft} className="size-3" />
           </TooltipTrigger>
           <TooltipPopup side="top">
             <PrStatusTooltipContent status={prStatus} />


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-5.6 Sol on behalf of Oliver**

## Problem

Composer and sidebar thread badges use the open pull request icon for every state. Closed, merged, and draft pull requests therefore disagree with the icons shown in the pull request tab.

## Fix

Pass each pull request's state to the existing shared presentation mapping. Composer and sidebar badges now use the matching open, draft, closed, or merged icon.

## UI changes

### Before

<img width="820" height="352" alt="Composer and sidebar using the open pull request icon for merged pull requests" src="https://github.com/user-attachments/assets/e77d6bee-c80a-403d-b548-715dbf5d2b33" />

### After

<img width="826" height="380" alt="Composer and sidebar using the merged pull request icon for merged pull requests" src="https://github.com/user-attachments/assets/396e3a3e-d74e-4589-990b-34a2c753bc83" />

## Verification

- `vp test run apps/web/src/components/ThreadStatusIndicators.test.ts`, 41 tests passed
- `vp run --filter @t3tools/web typecheck`
- Targeted lint and formatting checks for the four changed files
- `git diff --check origin/main...HEAD`

Changes prepared by GPT-5.6 Sol through Codex in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer pull request icons to match PR state and draft status
> - Updates `ChangeRequestStatusIcon` to select the rendered glyph from the pull request state and draft flag instead of always rendering `GitPullRequestIcon`
> - Updates `BranchToolbarBranchSelector`, `SidebarThreadRow`, and `ThreadRowLeadingStatus` to pass the linked PR's state and draft flag through to the icon component
> - Adds a parameterized test covering open, draft, closed, and merged glyph selection
> - Risk: `SidebarThreadRow` and `ThreadRowLeadingStatus` now require both pull-request status and pull-request data before rendering the icon; rows missing either will no longer show a PR indicator
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1531800.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->