### PR TITLE
ci: request Bugbot only after Vouch passes

### DIFF
--- a/.github/scripts/pr-vouch.cjs
+++ b/.github/scripts/pr-vouch.cjs
@@ -1,0 +1,48 @@
+const BUGBOT_COMMAND = "bugbot run verbose=true";
+const TRUSTED_VOUCH_STATUSES = new Set(["bot", "collaborator", "vouched"]);
+
+function bugbotMarker(headSha) {
+  return `<!-- pr-vouch:bugbot:${headSha} -->`;
+}
+
+function hasBugbotRequest(comments, headSha) {
+  const marker = bugbotMarker(headSha);
+  return comments.some(
+    (comment) => comment.user?.login === "github-actions[bot]" && comment.body?.includes(marker),
+  );
+}
+
+function getBugbotDecision({ status, state, draft, eventName, wasTrusted, alreadyRequested }) {
+  if (!TRUSTED_VOUCH_STATUSES.has(status)) {
+    return { trigger: false, reason: `vouch status is ${status}` };
+  }
+
+  if (state !== "open") {
+    return { trigger: false, reason: `PR is ${state}` };
+  }
+
+  if (draft) {
+    return { trigger: false, reason: "PR is a draft" };
+  }
+
+  if (eventName === "push" && wasTrusted) {
+    return { trigger: false, reason: "bulk vouch sync found an existing trusted label" };
+  }
+
+  if (alreadyRequested) {
+    return { trigger: false, reason: "Bugbot was already requested for this commit" };
+  }
+
+  return { trigger: true, reason: "trusted PR needs a Bugbot review" };
+}
+
+function renderBugbotRequest(headSha) {
+  return `${BUGBOT_COMMAND}\n\n${bugbotMarker(headSha)}`;
+}
+
+module.exports = {
+  BUGBOT_COMMAND,
+  getBugbotDecision,
+  hasBugbotRequest,
+  renderBugbotRequest,
+};

--- a/.github/scripts/pr-vouch.test.cjs
+++ b/.github/scripts/pr-vouch.test.cjs
@@ -1,0 +1,85 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  BUGBOT_COMMAND,
+  getBugbotDecision,
+  hasBugbotRequest,
+  renderBugbotRequest,
+} = require("./pr-vouch.cjs");
+
+const eligible = {
+  status: "vouched",
+  state: "open",
+  draft: false,
+  eventName: "pull_request_target",
+  wasTrusted: true,
+  alreadyRequested: false,
+};
+
+test("triggers Bugbot for every trusted vouch status", () => {
+  for (const status of ["bot", "collaborator", "vouched"]) {
+    assert.equal(getBugbotDecision({ ...eligible, status }).trigger, true);
+  }
+});
+
+test("does not trigger Bugbot for untrusted or denounced authors", () => {
+  for (const status of ["unknown", "denounced", undefined]) {
+    assert.equal(getBugbotDecision({ ...eligible, status }).trigger, false);
+  }
+});
+
+test("does not trigger Bugbot for closed or draft PRs", () => {
+  assert.equal(getBugbotDecision({ ...eligible, state: "closed" }).trigger, false);
+  assert.equal(getBugbotDecision({ ...eligible, draft: true }).trigger, false);
+});
+
+test("only triggers newly trusted PRs during a bulk vouch sync", () => {
+  assert.equal(
+    getBugbotDecision({ ...eligible, eventName: "push", wasTrusted: false }).trigger,
+    true,
+  );
+  assert.equal(
+    getBugbotDecision({ ...eligible, eventName: "push", wasTrusted: true }).trigger,
+    false,
+  );
+});
+
+test("does not trigger Bugbot twice for one head commit", () => {
+  assert.equal(getBugbotDecision({ ...eligible, alreadyRequested: true }).trigger, false);
+});
+
+test("only accepts the matching marker from github-actions", () => {
+  const headSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const marker = `<!-- pr-vouch:bugbot:${headSha} -->`;
+
+  assert.equal(
+    hasBugbotRequest([{ user: { login: "github-actions[bot]" }, body: marker }], headSha),
+    true,
+  );
+  assert.equal(
+    hasBugbotRequest([{ user: { login: "someone-else" }, body: marker }], headSha),
+    false,
+  );
+  assert.equal(
+    hasBugbotRequest(
+      [
+        {
+          user: { login: "github-actions[bot]" },
+          body: "<!-- pr-vouch:bugbot:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb -->",
+        },
+      ],
+      headSha,
+    ),
+    false,
+  );
+});
+
+test("renders the documented verbose Bugbot command with the commit marker", () => {
+  const headSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  assert.equal(
+    renderBugbotRequest(headSha),
+    `${BUGBOT_COMMAND}\n\n<!-- pr-vouch:bugbot:${headSha} -->`,
+  );
+});

--- a/.github/scripts/pr-vouch.test.cjs
+++ b/.github/scripts/pr-vouch.test.cjs
@@ -34,7 +34,7 @@ test("does not trigger Bugbot for closed or draft PRs", () => {
   assert.equal(getBugbotDecision({ ...eligible, draft: true }).trigger, false);
 });
 
-test("only triggers newly trusted PRs during a bulk vouch sync", () => {
+test("keeps a newly trusted bulk PR eligible until its label is synced", () => {
   assert.equal(
     getBugbotDecision({ ...eligible, eventName: "push", wasTrusted: false }).trigger,
     true,

--- a/.github/workflows/pr-vouch.yml
+++ b/.github/workflows/pr-vouch.yml
@@ -216,36 +216,6 @@ jobs:
             });
             const wasTrusted = currentLabels.some((label) => label.name === "vouch:trusted");
 
-            for (const label of currentLabels) {
-              if (!managedLabelNames.has(label.name) || label.name === nextLabelName) {
-                continue;
-              }
-
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber,
-                  name: label.name,
-                });
-              } catch (removeError) {
-                if (removeError.status !== 404) {
-                  throw removeError;
-                }
-              }
-            }
-
-            if (!currentLabels.some((label) => label.name === nextLabelName)) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                labels: [nextLabelName],
-              });
-            }
-
-            core.info(`PR #${issueNumber}: ${status} -> ${nextLabelName}`);
-
             const { data: pull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -276,13 +246,44 @@ jobs:
 
             if (!decision.trigger) {
               core.info(`PR #${issueNumber}: skipped Bugbot because ${decision.reason}`);
-              return;
+            } else {
+              const { data: comment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: renderBugbotRequest(pull.head.sha),
+              });
+              core.info(`PR #${issueNumber}: requested Bugbot at ${comment.html_url}`);
             }
 
-            const { data: comment } = await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body: renderBugbotRequest(pull.head.sha),
-            });
-            core.info(`PR #${issueNumber}: requested Bugbot at ${comment.html_url}`);
+            // Keep the old trust label until a required Bugbot request is recorded.
+            // A later bulk Vouch sync can then retry if comment creation fails.
+            for (const label of currentLabels) {
+              if (!managedLabelNames.has(label.name) || label.name === nextLabelName) {
+                continue;
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label.name,
+                });
+              } catch (removeError) {
+                if (removeError.status !== 404) {
+                  throw removeError;
+                }
+              }
+            }
+
+            if (!currentLabels.some((label) => label.name === nextLabelName)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [nextLabelName],
+              });
+            }
+
+            core.info(`PR #${issueNumber}: ${status} -> ${nextLabelName}`);

--- a/.github/workflows/pr-vouch.yml
+++ b/.github/workflows/pr-vouch.yml
@@ -1,6 +1,12 @@
 name: PR Vouch
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to recheck
+        required: true
+        type: number
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
   issue_comment:
@@ -28,6 +34,25 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            if (context.eventName === "workflow_dispatch") {
+              const issueNumber = Number(context.payload.inputs?.pr_number);
+              if (!Number.isSafeInteger(issueNumber) || issueNumber < 1) {
+                core.setFailed("pr_number must be a positive integer");
+                return;
+              }
+
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: issueNumber,
+              });
+              core.setOutput(
+                "targets",
+                JSON.stringify([{ number: pr.number, user: pr.user.login }]),
+              );
+              return;
+            }
+
             if (context.eventName === "pull_request_target") {
               const pr = context.payload.pull_request;
               core.setOutput("targets", JSON.stringify([{ number: pr.number, user: pr.user.login }]));
@@ -75,6 +100,19 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.collect-targets.outputs.targets) }}
     steps:
+      - name: Check out workflow helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/pr-vouch.cjs
+            .github/scripts/pr-vouch.test.cjs
+          sparse-checkout-cone-mode: false
+
+      - name: Test workflow helper
+        run: node --test .github/scripts/pr-vouch.test.cjs
+
       - id: vouch
         name: Check PR author trust
         uses: mitchellh/vouch/action/check-user@v1
@@ -91,6 +129,16 @@ jobs:
           VOUCH_STATUS: ${{ steps.vouch.outputs.status }}
         with:
           script: |
+            const path = require("node:path");
+            const {
+              getBugbotDecision,
+              hasBugbotRequest,
+              renderBugbotRequest,
+            } = require(path.join(
+              process.env.GITHUB_WORKSPACE,
+              ".github/scripts/pr-vouch.cjs",
+            ));
+
             const issueNumber = Number(process.env.PR_NUMBER);
             const status = process.env.VOUCH_STATUS;
             const managedLabels = [
@@ -167,6 +215,7 @@ jobs:
               issue_number: issueNumber,
               per_page: 100,
             });
+            const wasTrusted = currentLabels.some((label) => label.name === "vouch:trusted");
 
             for (const label of currentLabels) {
               if (!managedLabelNames.has(label.name) || label.name === nextLabelName) {
@@ -197,3 +246,44 @@ jobs:
             }
 
             core.info(`PR #${issueNumber}: ${status} -> ${nextLabelName}`);
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: issueNumber,
+            });
+            const decisionInput = {
+              status,
+              state: pull.state,
+              draft: pull.draft,
+              eventName: context.eventName,
+              wasTrusted,
+              alreadyRequested: false,
+            };
+            let decision = getBugbotDecision(decisionInput);
+
+            if (decision.trigger) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              decision = getBugbotDecision({
+                ...decisionInput,
+                alreadyRequested: hasBugbotRequest(comments, pull.head.sha),
+              });
+            }
+
+            if (!decision.trigger) {
+              core.info(`PR #${issueNumber}: skipped Bugbot because ${decision.reason}`);
+              return;
+            }
+
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: renderBugbotRequest(pull.head.sha),
+            });
+            core.info(`PR #${issueNumber}: requested Bugbot at ${comment.html_url}`);

--- a/.github/workflows/pr-vouch.yml
+++ b/.github/workflows/pr-vouch.yml
@@ -104,7 +104,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.workflow_sha }}
-          persist-credentials: false
           sparse-checkout: |
             .github/scripts/pr-vouch.cjs
             .github/scripts/pr-vouch.test.cjs

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -40,7 +40,8 @@ workflow.
 A change to `.github/VOUCHED.td` rechecks every open PR. This bulk check requests Bugbot only for a
 PR that changes to `vouch:trusted`. Existing trusted PRs wait for their next commit. Maintainers can
 also run the workflow for one PR with the `pr_number` workflow input. Manual runs still apply the
-same Vouch check.
+same Vouch check. For a newly trusted PR, the workflow records the Bugbot request before it updates
+the trust label. If the request fails, the next bulk check can retry it.
 
 Before this workflow reaches `main`, set Cursor Bugbot to **Run only when mentioned** for this
 repository. The API equivalent is `manualTriggerOnly: true`. If automatic reviews stay enabled,

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -29,3 +29,20 @@ signing only when platform credentials are present. macOS passkey builds additio
 Without the core signing credentials, it still releases unsigned artifacts.
 
 See [Release Checklist](../operations/release.md) for the full release/signing setup checklist.
+
+## PR trust and Bugbot
+
+The [`PR Vouch`](../../.github/workflows/pr-vouch.yml) workflow labels each PR from the Vouch result.
+It requests a Cursor Bugbot review only when Vouch reports `bot`, `collaborator`, or `vouched`.
+The PR must also be open and ready for review. Each head commit gets at most one request from the
+workflow.
+
+A change to `.github/VOUCHED.td` rechecks every open PR. This bulk check requests Bugbot only for a
+PR that changes to `vouch:trusted`. Existing trusted PRs wait for their next commit. Maintainers can
+also run the workflow for one PR with the `pr_number` workflow input. Manual runs still apply the
+same Vouch check.
+
+Before this workflow reaches `main`, set Cursor Bugbot to **Run only when mentioned** for this
+repository. The API equivalent is `manualTriggerOnly: true`. If automatic reviews stay enabled,
+Cursor can review a trusted PR twice: once from its automatic hook and once from the workflow
+comment.


### PR DESCRIPTION
> [!WARNING]
> Not ready to merge. The trust gate works, but a live workflow comment did not start a new Cursor review. The end-to-end trigger is not verified.

Cursor Bugbot automatically reviews PRs before Vouch has trusted their authors. This spends review runs on PRs that maintainers have not accepted for review.

This moves repository-managed Bugbot requests into PR Vouch. The workflow requests Bugbot only after Vouch reports `bot`, `collaborator`, or `vouched`. It skips draft and closed PRs, records one request per head commit, and handles new commits, ready PRs, and Vouch list promotions. It records the Bugbot request before it changes the trust label, so a failed comment stays eligible for a later bulk retry. Direct Bugbot commands from people remain available.

The [live trust check and workflow request](https://github.com/pingdotgg/t3code/actions/runs/33728512323) passed with `collaborator`. A [second run](https://github.com/pingdotgg/t3code/actions/runs/33728568409) found the same commit marker and did not post a duplicate.

The existing automatic Cursor check completed on the unchanged head. After it finished, the [workflow request](https://github.com/pingdotgg/t3code/pull/9377#issuecomment-5522332000) and an [exact bare bot request](https://github.com/pingdotgg/t3code/pull/9377#issuecomment-5522397785) did not create a new Cursor check through 07:49:30 UTC. Human controls using [`bugbot run`](https://github.com/pingdotgg/t3code/pull/9377#issuecomment-5522347302) and [`@cursor review`](https://github.com/pingdotgg/t3code/pull/9377#issuecomment-5522360278) also got no response, so this test does not isolate the bot identity as the cause.

The Cursor setting is unchanged. For the next clean test, first set this repository to **Run only when mentioned**, which is `manualTriggerOnly: true` in the API. Then test a fresh head and confirm that the workflow comment creates the only Cursor check.

Seven focused tests, workflow lint, and targeted formatting pass.

Made with GPT-5.6 Sol in the Codex harness through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Request Bugbot only after Vouch passes in `pr-vouch` workflow
> - Adds helper logic in [pr-vouch.cjs](https://github.com/pingdotgg/t3code/pull/9377/files#diff-d77b122558058b26049c43e2d933fba366756fea06508872a080baf4faa82c0a) that triggers a Bugbot request only for trusted, open, non-draft pull requests without an existing request for the same head SHA
> - Deduplicates requests via a commit-specific HTML comment marker authored by `github-actions[bot]`; during bulk `push` sync, already-trusted pull requests are skipped
> - Adds a `workflow_dispatch` trigger with a required `pr_number` input for manual runs, plus a checkout and Node test step that runs [pr-vouch.test.cjs](https://github.com/pingdotgg/t3code/pull/9377/files#diff-85c30f668b48dc127737d925777a2852043827d37455a632530349d1c160c25a) before label sync
> - Updates [ci.md](https://github.com/pingdotgg/t3code/pull/9377/files#diff-d88698dc5909f010b1462a8ad36a3f429f191b627825e2acac8214ba2ec254b3) with the trust, eligibility, and retry rules for the Bugbot flow
> - Behavioral Change: `sync-labels` step now creates at most one Bugbot comment per head commit; previously it could request Bugbot regardless of Vouch status or duplicate requests
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4192b66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->