### PR TITLE
fix(server): explain switchRef checkout failures with the fix to try next

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1345,6 +1345,77 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.equal(result.branch, current);
       }),
     );
+
+    it.effect("explains checkout failures caused by uncommitted changes", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        yield* git(cwd, ["checkout", "-b", "feature/target"]);
+        yield* writeTextFile(cwd, "README.md", "# target\n");
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "target commit"]);
+        yield* git(cwd, ["checkout", initialBranch]);
+        yield* writeTextFile(cwd, "README.md", "# dirty\n");
+
+        const error = yield* driver.switchRef({ cwd, refName: "feature/target" }).pipe(Effect.flip);
+
+        assert.deepInclude(error, {
+          _tag: "GitCommandError",
+          operation: "GitVcsDriver.switchRef.checkout",
+          cwd,
+        });
+        assert.include(error.detail, "uncommitted changes would be overwritten");
+        assert.include(error.detail, "Commit, stash, or discard");
+        assert.notProperty(error, "stderr");
+      }),
+    );
+
+    it.effect("explains checkout failures when the branch is checked out in another worktree", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const worktreesRoot = yield* makeTmpDir("git-vcs-driver-worktrees-");
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+        const worktreePath = pathService.join(worktreesRoot, "linked-worktree");
+        yield* fileSystem.makeDirectory(worktreesRoot, { recursive: true });
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        yield* git(cwd, ["worktree", "add", "-b", "feature/linked", worktreePath]);
+
+        const error = yield* driver.switchRef({ cwd, refName: "feature/linked" }).pipe(Effect.flip);
+
+        assert.deepInclude(error, {
+          _tag: "GitCommandError",
+          operation: "GitVcsDriver.switchRef.checkout",
+          cwd,
+        });
+        assert.include(error.detail, "already checked out in another worktree");
+        assert.notProperty(error, "stderr");
+      }),
+    );
+
+    it.effect("explains checkout failures for unknown refs", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        const error = yield* driver
+          .switchRef({ cwd, refName: "does/not-exist-xyz" })
+          .pipe(Effect.flip);
+
+        assert.deepInclude(error, {
+          _tag: "GitCommandError",
+          operation: "GitVcsDriver.switchRef.checkout",
+          cwd,
+        });
+        assert.include(error.detail, "not found locally or on remotes");
+        assert.notProperty(error, "stderr");
+      }),
+    );
   });
 
   describe("worktree operations", () => {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -443,6 +443,27 @@ function isMissingWorktreeStderr(stderr: string): boolean {
   );
 }
 
+// Classifies `git checkout` stderr into a closed set of static sentences.
+// Raw stderr never leaves the driver (it can carry remote URLs with embedded
+// credentials), so every branch returns a fixed string that names the cause
+// and the fix instead of echoing git's output.
+function classifySwitchRefCheckoutError(stderr: string): string {
+  const normalized = stderr.toLowerCase();
+  if (normalized.includes("used by worktree")) {
+    return "git checkout failed because the branch is already checked out in another worktree. Switch in that worktree or check out a different branch.";
+  }
+  if (
+    normalized.includes("would be overwritten by checkout") ||
+    normalized.includes("stash them before you switch")
+  ) {
+    return "git checkout failed because uncommitted changes would be overwritten. Commit, stash, or discard those changes, then try again.";
+  }
+  if (normalized.includes("did not match any file") || normalized.includes("pathspec")) {
+    return "git checkout failed because the ref was not found locally or on remotes. Fetch the latest refs and check the branch name, then try again.";
+  }
+  return "git checkout failed";
+}
+
 interface Trace2Monitor {
   readonly env: NodeJS.ProcessEnv;
   readonly flush: Effect.Effect<void, never>;
@@ -3207,10 +3228,33 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
               ? ["checkout", localTrackingBranch]
               : ["checkout", input.refName];
 
-      yield* executeGit("GitVcsDriver.switchRef.checkout", input.cwd, checkoutArgs, {
-        timeoutMs: 10_000,
-        fallbackErrorDetail: "git checkout failed",
-      });
+      const checkoutResult = yield* executeGit(
+        "GitVcsDriver.switchRef.checkout",
+        input.cwd,
+        checkoutArgs,
+        {
+          timeoutMs: 10_000,
+          allowNonZeroExit: true,
+        },
+      );
+      if (checkoutResult.exitCode !== 0) {
+        // Raw stderr stays out of the wire error (it can carry secrets); the
+        // classified detail names the cause and the fix instead.
+        yield* Effect.logWarning(
+          `GitVcsDriver.switchRef: git checkout exited with code ${checkoutResult.exitCode} (stderr length ${checkoutResult.stderr.length}).`,
+        );
+        return yield* new GitCommandError({
+          ...gitCommandContext({
+            operation: "GitVcsDriver.switchRef.checkout",
+            cwd: input.cwd,
+            args: checkoutArgs,
+          }),
+          detail: classifySwitchRefCheckoutError(checkoutResult.stderr),
+          ...(checkoutResult.exitCode === null ? {} : { exitCode: checkoutResult.exitCode }),
+          stdoutLength: checkoutResult.stdout.length,
+          stderrLength: checkoutResult.stderr.length,
+        });
+      }
 
       const refName = yield* runGitStdout("GitVcsDriver.switchRef.currentBranch", input.cwd, [
         "branch",


### PR DESCRIPTION
Every switchRef checkout failure surfaced as `Git command failed in GitVcsDriver.switchRef.checkout: git checkout failed` because the driver drops stderr on the wire, so users could not tell uncommitted changes, a worktree conflict, or a bad ref name apart (issue #7928).

The checkout now classifies stderr into static sentences that name the cause and the fix: commit/stash/discard for uncommitted changes, switch in the other worktree for worktree conflicts, fetch and check the name for unknown refs. Raw stderr still never leaves the driver, so the redaction guarantee holds. This covers the switchRef construction that open PR #8645 deliberately left out of its shared-funnel classification.

Verification: vp test run apps/server/src/vcs/GitVcsDriverCore.test.ts (59 passed, 3 new), tsgo --noEmit clean for the touched files, vp lint + vp fmt + git diff --check clean.

Model: Muse Spark. Harness: OpenCode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized VCS error messaging for branch switch only; preserves existing stderr redaction and does not change successful checkout behavior.
> 
> **Overview**
> **`switchRef`** no longer surfaces every failed `git checkout` as a generic `git checkout failed` message. The driver runs checkout with **`allowNonZeroExit`**, classifies stderr locally via **`classifySwitchRefCheckoutError`**, and returns **`GitCommandError.detail`** as fixed copy for common cases: uncommitted changes (commit/stash/discard), branch already checked out in another worktree, and missing refs (fetch and verify the name). Raw **stderr** still never leaves the server; failures log exit code and stderr length only.
> 
> Three integration tests in **`GitVcsDriverCore.test.ts`** lock in those messages and assert errors omit **`stderr`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f3b27fd39424abf014ae061cfb1b7adc1edf2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return classified structured errors for `GitVcsDriver.switchRef` checkout failures
> - Adds `classifySwitchRefCheckoutError` to map Git stderr patterns (worktree conflicts, overwritten uncommitted changes, missing refs) to fixed explanatory messages; unrecognized failures get a generic checkout-failed message.
> - `switchRef` now inspects nonzero checkout exits instead of using a fallback error, and returns a `GitCommandError` with checkout context, classified detail, exit code, and stdout/stderr lengths. Raw stderr is omitted from the returned error.
> - Adds integration tests covering uncommitted-changes, linked-worktree, and unknown-ref checkout failures.
> - Behavioral Change: `switchRef` checkout errors no longer expose raw Git `stderr`; consumers relying on stderr text must use the classified `detail` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 71f3b27. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->