### PR TITLE
feat(web): preview pull request links on hover

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -72,6 +72,11 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 import { parseAssistantCitationHref } from "@t3tools/shared/assistantCitations";
 import { AssistantCitationChip } from "./chat/AssistantCitationChip";
+import {
+  PullRequestLinkPreview,
+  PullRequestLinkStateIcon,
+} from "./pullRequest/PullRequestLinkPreview";
+import { resolvePullRequestLinkPreviewTarget } from "./pullRequest/pullRequestLinkPreview.logic";
 import remarkGfm from "remark-gfm";
 import { remarkGithubAlerts } from "../markdown-github-alerts";
 import {
@@ -1130,27 +1135,20 @@ const failedFaviconHosts = new Set<string>();
 
 const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: string }) {
   const [failedHost, setFailedHost] = useState<string | null>(null);
-  return (
-    <span
-      className="ms-[0.25em] me-[0.2em] inline-flex size-[14px] [vertical-align:-0.125em]"
-      aria-hidden
-    >
-      {failedHost === host || failedFaviconHosts.has(host) ? (
-        <GlobeIcon className={MARKDOWN_LINK_FAVICON_CLASS_NAME} />
-      ) : (
-        <img
-          src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=32`}
-          alt=""
-          loading="lazy"
-          draggable={false}
-          className={cn(MARKDOWN_LINK_FAVICON_CLASS_NAME, "rounded-sm")}
-          onError={() => {
-            failedFaviconHosts.add(host);
-            setFailedHost(host);
-          }}
-        />
-      )}
-    </span>
+  return failedHost === host || failedFaviconHosts.has(host) ? (
+    <GlobeIcon className={MARKDOWN_LINK_FAVICON_CLASS_NAME} />
+  ) : (
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=32`}
+      alt=""
+      loading="lazy"
+      draggable={false}
+      className={cn(MARKDOWN_LINK_FAVICON_CLASS_NAME, "rounded-sm")}
+      onError={() => {
+        failedFaviconHosts.add(host);
+        setFailedHost(host);
+      }}
+    />
   );
 });
 
@@ -1529,21 +1527,35 @@ function handleMarkdownFragmentClick(event: ReactMouseEvent<HTMLAnchorElement>, 
   target.scrollIntoView({ block: "nearest" });
 }
 
+/**
+ * Link text led by a 14px glyph that stays on the line with the first word. The host's favicon by
+ * default; a caller that knows what the link is can put its own icon in the slot instead.
+ */
 function MarkdownExternalLinkContent({
   host,
+  icon,
   plainText,
   children,
 }: {
   host: string;
+  icon?: ReactNode;
   plainText: string | null;
   children: ReactNode;
 }) {
+  const leadingIcon = (
+    <span
+      className="ms-[0.25em] me-[0.2em] inline-flex size-[14px] [vertical-align:-0.125em]"
+      aria-hidden
+    >
+      {icon ?? <MarkdownLinkFavicon host={host} />}
+    </span>
+  );
   if (plainText) {
     const leadingLength = leadingExternalLinkTextLength(plainText);
     return (
       <>
         <span className="whitespace-nowrap">
-          <MarkdownLinkFavicon host={host} />
+          {leadingIcon}
           {plainText.slice(0, leadingLength)}
         </span>
         {breakableExternalLinkText(plainText.slice(leadingLength))}
@@ -1559,7 +1571,7 @@ function MarkdownExternalLinkContent({
     return (
       <>
         <span className="whitespace-nowrap">
-          <MarkdownLinkFavicon host={host} />
+          {leadingIcon}
           {firstChild.slice(0, leadingLength)}
         </span>
         {breakableExternalLinkText(firstChild.slice(leadingLength))}
@@ -1571,7 +1583,7 @@ function MarkdownExternalLinkContent({
   return (
     <>
       <span className="whitespace-nowrap">
-        <MarkdownLinkFavicon host={host} />
+        {leadingIcon}
         {firstChild}
       </span>
       {childNodes.slice(1)}
@@ -2121,6 +2133,17 @@ function ChatMarkdown({
     event.clipboardData.setData("text/html", payload.html);
   }, []);
   const openChangeRequestLink = useOpenChangeRequestLink(threadRef);
+  const resolvePullRequestPreviewTarget = useCallback(
+    (href: string, isRepositoryReference: boolean) =>
+      resolvePullRequestLinkPreviewTarget({
+        href,
+        environmentId,
+        canReadPullRequests: serverConfig?.environment.capabilities.pullRequests === true,
+        projects,
+        isRepositoryReference,
+      }),
+    [environmentId, projects, serverConfig],
+  );
   // Subscribed rather than read at click time: the anchor has to decide
   // synchronously whether to intercept its `_blank`, and a subscription is what
   // makes a persisted "app" apply once settings hydrate after launch.
@@ -2435,6 +2458,9 @@ function ChatMarkdown({
           const pullRequestAutolink = String(
             (props as Record<string, unknown>)["data-pull-request-autolink"] ?? "",
           );
+          const pullRequestPreviewTarget = href
+            ? resolvePullRequestPreviewTarget(href, pullRequestAutolink === "reference")
+            : null;
           const pullRequestCopy =
             pullRequestAutolink === "commit"
               ? /\/commit\/([0-9a-f]{40})$/iu.exec(href ?? "")?.[1]
@@ -2564,7 +2590,13 @@ function ChatMarkdown({
               }}
             >
               {faviconHost && hastHasText(node) && !isPullRequestAutolink ? (
-                <MarkdownExternalLinkContent host={faviconHost} plainText={plainHastText(node)}>
+                <MarkdownExternalLinkContent
+                  host={faviconHost}
+                  icon={
+                    pullRequestPreviewTarget === null ? undefined : <PullRequestLinkStateIcon />
+                  }
+                  plainText={plainHastText(node)}
+                >
                   {linkChildren}
                 </MarkdownExternalLinkContent>
               ) : (
@@ -2574,6 +2606,9 @@ function ChatMarkdown({
           );
           if (!faviconHost || !href) {
             return link;
+          }
+          if (pullRequestPreviewTarget !== null) {
+            return <PullRequestLinkPreview target={pullRequestPreviewTarget} trigger={link} />;
           }
           return (
             <Tooltip>
@@ -2756,6 +2791,7 @@ function ChatMarkdown({
     openMarkdownFileInPreview,
     preferredEditorMenuLabel,
     resolveThreadPullRequest,
+    resolvePullRequestPreviewTarget,
     resolvedTheme,
     revealMarkdownFileInFileManager,
     revealInFileManagerLabel,

--- a/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
@@ -21,7 +21,7 @@ import {
   resolvePullRequestState,
 } from "./pullRequestPresentation";
 
-function GhostBar({ className }: { className?: string | undefined }) {
+export function GhostBar({ className }: { className?: string | undefined }) {
   return <div aria-hidden className={cn("h-3 rounded bg-muted-foreground/15", className)} />;
 }
 

--- a/apps/web/src/components/pullRequest/PullRequestLinkPreview.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestLinkPreview.tsx
@@ -1,0 +1,158 @@
+import { PreviewCard } from "@base-ui/react/preview-card";
+import type { PullRequestRef, PullRequestSummary } from "@t3tools/contracts";
+import { ArrowLeftIcon, GitBranchIcon, GitPullRequestIcon } from "lucide-react";
+import type { ReactElement, ReactNode } from "react";
+
+import { getSourceControlPresentationForKind } from "~/sourceControlPresentation";
+import { linkedPullRequestDetailAtom, useSharedPullRequestSummary } from "~/state/pullRequests";
+import { useEnvironmentQuery } from "~/state/query";
+import { formatRelativeTimeLabel } from "~/timestampFormat";
+
+import { GhostBar } from "./PullRequestGhosts";
+import type { PullRequestLinkPreviewTarget } from "./pullRequestLinkPreview.logic";
+import { PullRequestMetaLine, resolvePullRequestState } from "./pullRequestPresentation";
+
+/**
+ * The "owner/repo #N" line every state shares, in the list row's meta ink. The provider icon
+ * only arrives with the summary, so the ghost holds its slot to keep the card from shifting.
+ */
+function PullRequestLinkPreviewHeading({
+  reference,
+  icon,
+  trailing,
+}: {
+  reference: PullRequestRef;
+  icon?: ReactNode;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/70">
+      {icon}
+      <span className="min-w-0 truncate">{reference.repository}</span>
+      <span className="shrink-0">#{reference.number}</span>
+      {trailing ? <span className="ml-auto shrink-0 pl-3 tabular-nums">{trailing}</span> : null}
+    </div>
+  );
+}
+
+function PullRequestLinkPreviewLoading({ reference }: { reference: PullRequestRef }) {
+  return (
+    <div aria-busy className="flex animate-ghost-pulse flex-col gap-2 p-3">
+      <PullRequestLinkPreviewHeading
+        reference={reference}
+        icon={<GhostBar className="size-3.5 shrink-0" />}
+        trailing={<GhostBar className="w-16" />}
+      />
+      {/* Each bar sits in the line box of the text it stands for, so the loaded card lands on
+          the same rows: title at leading-5, meta at the xs line height. */}
+      <div className="flex h-5 items-center">
+        <GhostBar className="h-3.5 w-4/5" />
+      </div>
+      <div className="flex h-4 items-center">
+        <GhostBar className="w-1/2" />
+      </div>
+    </div>
+  );
+}
+
+function PullRequestLinkPreviewUnavailable({ reference }: { reference: PullRequestRef }) {
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      <PullRequestLinkPreviewHeading reference={reference} />
+      <p className="text-sm font-medium text-foreground">Preview unavailable</p>
+    </div>
+  );
+}
+
+function PullRequestLinkPreviewSummary({ summary }: { summary: PullRequestSummary }) {
+  const { Icon, providerName } = getSourceControlPresentationForKind(summary.provider);
+  const state = resolvePullRequestState({
+    state: summary.state,
+    isDraft: summary.isDraft === true,
+  });
+  const updatedAt = formatRelativeTimeLabel(summary.updatedAt);
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      <PullRequestLinkPreviewHeading
+        reference={summary}
+        icon={<Icon aria-label={providerName} className="size-3.5 shrink-0" />}
+        trailing={updatedAt ? `Updated ${updatedAt}` : undefined}
+      />
+      <p className="line-clamp-2 text-sm font-medium leading-5 text-foreground">{summary.title}</p>
+      <PullRequestMetaLine className="text-xs text-muted-foreground">
+        <span
+          className={`inline-flex shrink-0 items-center gap-1 font-medium ${state.toneClassName}`}
+        >
+          <state.Icon aria-hidden className="size-3.5" />
+          {state.label}
+        </span>
+        {/* Base first, as on the detail panel: the short branch stays visible and the long head
+            branch takes the truncation. */}
+        <span className="flex min-w-0 items-center gap-1">
+          <GitBranchIcon aria-hidden className="size-3.5 shrink-0" />
+          <code className="max-w-[45%] shrink-0 truncate">{summary.baseBranch}</code>
+          <ArrowLeftIcon
+            aria-label="receives changes from"
+            className="size-3 shrink-0 opacity-60"
+          />
+          <code className="min-w-0 truncate">{summary.headBranch}</code>
+        </span>
+      </PullRequestMetaLine>
+    </div>
+  );
+}
+
+function PullRequestLinkPreviewContent({ target }: { target: PullRequestLinkPreviewTarget }) {
+  const query = useEnvironmentQuery(
+    linkedPullRequestDetailAtom({
+      environmentId: target.environmentId,
+      input: target.reference,
+    }),
+  );
+  const summary = useSharedPullRequestSummary(target.environmentId, target.reference, query.data);
+  if (summary !== null) return <PullRequestLinkPreviewSummary summary={summary} />;
+  if (query.error !== null) {
+    return <PullRequestLinkPreviewUnavailable reference={target.reference} />;
+  }
+  return <PullRequestLinkPreviewLoading reference={target.reference} />;
+}
+
+/**
+ * The mark a pull request link wears in place of a favicon: one neutral glyph saying "this is a
+ * pull request with a preview", never its state. State would need a request per link, or a glyph
+ * that only changes once the reader has already hovered; the card carries it instead.
+ */
+export function PullRequestLinkStateIcon() {
+  return <GitPullRequestIcon className="size-full shrink-0 text-muted-foreground" />;
+}
+
+/** A hover/focus preview whose query exists only while Base UI has the card mounted. */
+export function PullRequestLinkPreview({
+  target,
+  trigger,
+}: {
+  readonly target: PullRequestLinkPreviewTarget;
+  readonly trigger: ReactElement;
+}) {
+  return (
+    <PreviewCard.Root>
+      <PreviewCard.Trigger render={trigger} delay={450} closeDelay={125} />
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner
+          side="top"
+          align="start"
+          sideOffset={6}
+          className="z-[130] max-w-(--available-width)"
+        >
+          {/* Same glass, radius and shadow as the app's menus, so the card reads as one of them. */}
+          <PreviewCard.Popup
+            aria-label={`${target.reference.repository} #${target.reference.number} preview`}
+            className="dropdown-glass w-[min(22rem,calc(100vw-2rem))] origin-(--transform-origin) rounded-lg text-popover-foreground shadow-[0_16px_40px_-18px_rgb(0_0_0/55%)] outline-none transition-[scale,opacity] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 dark:shadow-[0_18px_44px_-18px_rgb(0_0_0/80%)]"
+          >
+            <PullRequestLinkPreviewContent target={target} />
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
+  );
+}

--- a/apps/web/src/components/pullRequest/pullRequestLinkPreview.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestLinkPreview.logic.test.ts
@@ -1,0 +1,146 @@
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolvePullRequestLinkPreviewTarget } from "./pullRequestLinkPreview.logic";
+
+const localEnvironmentId = EnvironmentId.make("environment-local");
+const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+
+function project(input: {
+  readonly id: string;
+  readonly environmentId: EnvironmentId;
+  readonly displayName: string;
+}) {
+  return {
+    id: ProjectId.make(input.id),
+    environmentId: input.environmentId,
+    repositoryIdentity: {
+      canonicalKey: `github.com/${input.displayName.toLowerCase()}`,
+      locator: {
+        source: "git-remote" as const,
+        remoteName: "origin",
+        remoteUrl: `https://github.com/${input.displayName}.git`,
+      },
+      displayName: input.displayName,
+      provider: "github",
+    },
+  };
+}
+
+describe("resolvePullRequestLinkPreviewTarget", () => {
+  it("resolves the project on the markdown's environment and preserves provider spelling", () => {
+    const local = project({
+      id: "project-local",
+      environmentId: localEnvironmentId,
+      displayName: "PingDotGG/T3Code",
+    });
+    const remote = project({
+      id: "project-remote",
+      environmentId: remoteEnvironmentId,
+      displayName: "pingdotgg/t3code",
+    });
+
+    expect(
+      resolvePullRequestLinkPreviewTarget({
+        href: "https://github.com/pingdotgg/t3code/pull/9171/files",
+        environmentId: localEnvironmentId,
+        canReadPullRequests: true,
+        projects: [remote, local],
+      }),
+    ).toEqual({
+      environmentId: localEnvironmentId,
+      reference: {
+        projectId: local.id,
+        repository: "PingDotGG/T3Code",
+        number: 9171,
+      },
+    });
+  });
+
+  it("does not cross environments to find a matching repository", () => {
+    expect(
+      resolvePullRequestLinkPreviewTarget({
+        href: "https://github.com/pingdotgg/t3code/pull/9171",
+        environmentId: localEnvironmentId,
+        canReadPullRequests: true,
+        projects: [
+          project({
+            id: "project-remote",
+            environmentId: remoteEnvironmentId,
+            displayName: "pingdotgg/t3code",
+          }),
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    {
+      name: "the environment cannot read pull requests",
+      environmentId: localEnvironmentId,
+      canReadPullRequests: false,
+      href: "https://github.com/pingdotgg/t3code/pull/9171",
+    },
+    {
+      name: "the markdown has no environment",
+      environmentId: null,
+      canReadPullRequests: true,
+      href: "https://github.com/pingdotgg/t3code/pull/9171",
+    },
+    {
+      name: "the link is an issue",
+      environmentId: localEnvironmentId,
+      canReadPullRequests: true,
+      href: "https://github.com/pingdotgg/t3code/issues/9171",
+    },
+  ])("leaves the link alone when $name", ({ environmentId, canReadPullRequests, href }) => {
+    expect(
+      resolvePullRequestLinkPreviewTarget({
+        href,
+        environmentId,
+        canReadPullRequests,
+        projects: [
+          project({
+            id: "project-local",
+            environmentId: localEnvironmentId,
+            displayName: "pingdotgg/t3code",
+          }),
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolvePullRequestLinkPreviewTarget for repository references", () => {
+  const local = project({
+    id: "project-local",
+    environmentId: localEnvironmentId,
+    displayName: "PingDotGG/T3Code",
+  });
+
+  it("reads a same-repository #N autolink through the host's issue page", () => {
+    expect(
+      resolvePullRequestLinkPreviewTarget({
+        href: "https://github.com/pingdotgg/t3code/issues/9171",
+        environmentId: localEnvironmentId,
+        canReadPullRequests: true,
+        projects: [local],
+        isRepositoryReference: true,
+      }),
+    ).toEqual({
+      environmentId: localEnvironmentId,
+      reference: { projectId: local.id, repository: "PingDotGG/T3Code", number: 9171 },
+    });
+  });
+
+  it("leaves an authored issue link alone", () => {
+    expect(
+      resolvePullRequestLinkPreviewTarget({
+        href: "https://github.com/pingdotgg/t3code/issues/9171",
+        environmentId: localEnvironmentId,
+        canReadPullRequests: true,
+        projects: [local],
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/pullRequest/pullRequestLinkPreview.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestLinkPreview.logic.ts
@@ -1,0 +1,66 @@
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentId, PullRequestRef } from "@t3tools/contracts";
+
+import {
+  findProjectForChangeRequest,
+  parseChangeRequestUrl,
+  type ChangeRequestLink,
+} from "~/lib/openPullRequestLink";
+
+type LinkPreviewProject = Pick<EnvironmentProject, "id" | "environmentId" | "repositoryIdentity">;
+
+export interface PullRequestLinkPreviewTarget {
+  readonly environmentId: EnvironmentId;
+  readonly reference: PullRequestRef;
+}
+
+/**
+ * A same-repository `#N` autolink points at the host's issue page, since the writer's number may
+ * name an issue or a pull request. Only an autolink is read this way: an authored issue link stays
+ * an ordinary link, as it does for clicks.
+ */
+function parseRepositoryIssueUrl(href: string): ChangeRequestLink | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  const match = /^\/(.+?)\/(?:-\/)?issues\/(\d+)(?:\/|$)/u.exec(url.pathname);
+  const repository = match?.[1];
+  const number = Number(match?.[2]);
+  return repository && Number.isSafeInteger(number) && number > 0
+    ? { host: url.hostname.toLowerCase(), repository: repository.toLowerCase(), number }
+    : null;
+}
+
+/**
+ * Resolves only against projects on the environment that will answer the preview query. A link
+ * that merely resembles a change request stays an ordinary link, as does one from another server.
+ */
+export function resolvePullRequestLinkPreviewTarget(input: {
+  readonly href: string;
+  readonly environmentId: EnvironmentId | null;
+  readonly canReadPullRequests: boolean;
+  readonly projects: ReadonlyArray<LinkPreviewProject>;
+  readonly isRepositoryReference?: boolean;
+}): PullRequestLinkPreviewTarget | null {
+  if (input.environmentId === null || !input.canReadPullRequests) return null;
+  const parsed =
+    parseChangeRequestUrl(input.href) ??
+    (input.isRepositoryReference ? parseRepositoryIssueUrl(input.href) : null);
+  if (parsed === null) return null;
+  const project = findProjectForChangeRequest(
+    input.projects.filter((candidate) => candidate.environmentId === input.environmentId),
+    parsed,
+  );
+  if (project === undefined) return null;
+  return {
+    environmentId: input.environmentId,
+    reference: {
+      projectId: project.id,
+      repository: project.repositoryIdentity?.displayName ?? parsed.repository,
+      number: parsed.number,
+    },
+  };
+}

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -214,10 +214,9 @@ function claim(host: string, match: RegExpExecArray | null): ChangeRequestLink |
  * groups and Azure project paths need — and the host is the first segment of the canonical
  * remote, so github.com and an Enterprise install stay apart.
  */
-export function findProjectForChangeRequest(
-  projects: ReadonlyArray<EnvironmentProject>,
-  link: ChangeRequestLink,
-): EnvironmentProject | undefined {
+export function findProjectForChangeRequest<
+  Project extends Pick<EnvironmentProject, "repositoryIdentity">,
+>(projects: ReadonlyArray<Project>, link: ChangeRequestLink): Project | undefined {
   return projects.find((project) => {
     const identity = project.repositoryIdentity;
     if (!identity) return false;


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Fable 5.1 on behalf of Oliver**

## Problem

A pull request link in a message tells you nothing until you open it. Links into a workspace project's repository also showed a blank slot where the favicon belongs: the favicon service returns GitHub's dark mark, which disappears on the dark theme.

## Fix

Hover or focus a pull request link to see a card with the repository, number, title, state, base and head branches, and last update. The card only queries while it is open, and it matches the pull request list row's ink, so a pull request reads the same in the list, in a message, and in the card.

Links that can be previewed carry a neutral pull request glyph in the favicon's slot. It never changes, so it makes one claim, that this is a pull request with a preview, and the card carries the state.

`#123` references in a pull request's description and comments preview the same way. They point at the host's issue page, which the click path deliberately refuses, so the preview resolver reads them only when the markdown marked them as a same-repository reference. A number that names an issue shows "Preview unavailable" until issues are readable.

The loading ghost mirrors the loaded card row for row, so nothing shifts when the data lands.

Draft pull requests show the gray Draft state, using the draft flag #9537 added to the summary.

## UI changes

### Before

https://github.com/user-attachments/assets/0195ca58-a096-4742-864f-7a94e9117001


### After

https://github.com/user-attachments/assets/80b6e693-ef72-426c-808e-4b5cea69e38a

The video predates the rebase onto #9537. The draft pull request it shows as Open now reads as Draft.


## Verification

- Added 2 focused cases for `#N` reference resolution and authored issue links staying ordinary
- `vp test run apps/web/src/components/ChatMarkdown.test.tsx apps/web/src/components/pullRequest/pullRequestLinkPreview.logic.test.ts`, 2 files and 53 tests passed
- `vp lint <changed files> --report-unused-disable-directives`
- `vp fmt --check <changed files>`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check origin/main...HEAD`

Changes prepared by Claude Fable 5.1 through Claude Code in T3 Code, with a GPT-5.6 Sol subagent diagnosing the blank favicon slot.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pull request link previews on hover in `ChatMarkdown`
> - Adds `PullRequestLinkPreview` which opens a portal-based card above the link on hover or focus, showing provider, repository, title, state, and branch metadata for resolved pull requests
> - Adds `resolvePullRequestLinkPreviewTarget` in [pullRequestLinkPreview.logic.ts](apps/web/src/components/pullRequest/pullRequestLinkPreview.logic.ts) to parse issue-page URLs, gate on pull-request read capability, and match projects in the current environment
> - Updates the `ChatMarkdown` link renderer to supply a pull-request glyph as the leading icon and wrap eligible links in the preview, while omitting the URL tooltip for those links
> - Refactors `MarkdownLinkFavicon` to return only the icon or fallback and moves the inline layout slot into `MarkdownExternalLinkContent` so callers can replace the favicon with a custom icon
> - Generalizes `findProjectForChangeRequest` to accept any project shape with repository identity, letting the preview logic pass a narrowed project type
> - Risk: links that previously showed a host favicon and URL tooltip now show a pull-request icon and hover preview instead when they resolve to a PR for a same-environment project; reviewers should check the resolver and capability gating in `resolvePullRequestLinkPreviewTarget` to ensure non-PR links still fall through to the existing path
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 266d3c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
