### PR TITLE
fix(desktop): stop backend when Linux owner exits

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -251,6 +251,7 @@ describe("DesktopBackendConfiguration", () => {
         assert.equal(first.bootstrap.t3Home, environment.baseDir);
         assert.equal(first.bootstrap.tailscaleServeEnabled, true);
         assert.equal(first.bootstrap.tailscaleServePort, 8443);
+        assert.notProperty(first.bootstrap, "desktopLifetimeFd");
         assert.match(first.bootstrap.desktopBootstrapToken, /^[0-9a-f]{48}$/i);
         assert.equal(second.bootstrap.desktopBootstrapToken, first.bootstrap.desktopBootstrapToken);
       }),
@@ -300,6 +301,7 @@ describe("DesktopBackendConfiguration", () => {
         path.join(resourcesPath, "server.asar/apps/server/dist/bin.mjs"),
       );
       assert.equal(config.env.ELECTRON_RUN_AS_NODE, "1");
+      assert.notProperty(config.bootstrap, "desktopLifetimeFd");
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
@@ -890,6 +892,7 @@ describe("DesktopBackendConfiguration", () => {
           assert.equal(config.bootstrap.host, "0.0.0.0");
           assert.equal(config.bootstrap.tailscaleServeEnabled, false);
           assert.notProperty(config.bootstrap, "desktopTelemetryFd");
+          assert.notProperty(config.bootstrap, "desktopLifetimeFd");
           assert.notProperty(config.bootstrap, "resourceMonitorPath");
           // httpBaseUrl uses the resolved distro IP from the test stub,
           // not localhost — the renderer reaches the backend directly to
@@ -1217,6 +1220,7 @@ describe("DesktopBackendConfiguration", () => {
         assert.equal(config.bootstrap.resourceMonitorPath, monitorPath);
         assert.equal(config.bootstrap.desktopTelemetryFd, 4);
         assert.equal(config.bootstrap.desktopTelemetryControlFd, 5);
+        assert.equal(config.bootstrap.desktopLifetimeFd, 6);
       }).pipe(
         Effect.provide(
           DesktopBackendConfiguration.layer.pipe(
@@ -1229,6 +1233,7 @@ describe("DesktopBackendConfiguration", () => {
                 appPath: `${resourcesPath}/app.asar`,
                 dirname,
                 isPackaged: true,
+                platform: "linux",
                 resourcesPath,
               }),
             ),

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -94,6 +94,7 @@ const DESKTOP_BACKEND_ENV_NAMES = [
 const WSL_FORWARDED_ENV_NAMES = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"] as const;
 
 const WSL_SERVER_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const DESKTOP_LIFETIME_FD = 6;
 
 const backendChildEnvPatch = (): Record<string, string | undefined> =>
   Object.fromEntries(DESKTOP_BACKEND_ENV_NAMES.map((name) => [name, undefined]));
@@ -492,6 +493,7 @@ const resolvePrimaryStartConfig = Effect.fn("desktop.backendConfiguration.resolv
       tailscaleServePort: backendExposure.tailscaleServePort,
       desktopTelemetryFd: 4,
       desktopTelemetryControlFd: 5,
+      ...(environment.platform === "linux" ? { desktopLifetimeFd: DESKTOP_LIFETIME_FD } : {}),
       ...Option.match(input.resourceMonitorPath, {
         onNone: () => ({}),
         onSome: (resourceMonitorPath) => ({ resourceMonitorPath }),

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -52,6 +52,7 @@ const baseConfig: DesktopBackendManager.DesktopBackendStartConfig = {
     tailscaleServePort: 443,
     desktopTelemetryFd: 4,
     desktopTelemetryControlFd: 5,
+    desktopLifetimeFd: 6,
   },
   bootstrapDelivery: "fd3",
   extendEnv: true,
@@ -191,7 +192,7 @@ function makeTestInstance(input: MakeInstanceInput) {
 }
 
 describe("DesktopBackendManager", () => {
-  it.effect("spawns the backend with fd3 bootstrap and fd4 telemetry", () =>
+  it.effect("spawns the backend with bootstrap, telemetry, and desktop lifetime fds", () =>
     Effect.scoped(
       Effect.gen(function* () {
         let spawnedCommand: ChildProcess.Command | undefined;
@@ -260,6 +261,7 @@ describe("DesktopBackendManager", () => {
         assert.isDefined(spawnedCommand.options.forceKillAfter);
         assert.equal(spawnedCommand.options.additionalFds?.fd4?.type, "input");
         assert.equal(spawnedCommand.options.additionalFds?.fd5?.type, "output");
+        assert.deepEqual(spawnedCommand.options.additionalFds?.fd6, { type: "input" });
         assert.equal(
           Duration.toMillis(Duration.fromInputUnsafe(spawnedCommand.options.forceKillAfter)),
           2_000,

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -472,6 +472,11 @@ export const runBackendProcess = Effect.fn("runBackendProcess")(function* (
         type: "output",
       };
     }
+    if (options.bootstrap.desktopLifetimeFd !== undefined) {
+      additionalFds[`fd${options.bootstrap.desktopLifetimeFd}`] = {
+        type: "input",
+      };
+    }
   }
   const command = ChildProcess.make(options.executablePath, options.args, {
     cwd: options.cwd,

--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -18,6 +18,7 @@ import {
   BootstrapFdStatError,
   BootstrapInputStreamOpenError,
   readBootstrapEnvelope,
+  waitForDesktopLifetimeEnd,
 } from "./bootstrap.ts";
 import { assertNone, assertSome } from "@effect/vitest/utils";
 
@@ -236,5 +237,38 @@ it.layer(NodeServices.layer)("readBootstrapEnvelope", (it) => {
       const payload = yield* Fiber.join(fiber);
       assertNone(payload);
     }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it.layer(NodeServices.layer)("waitForDesktopLifetimeEnd", (it) => {
+  it.effect("completes when the desktop closes its end of the pipe", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-lifetime-" });
+      const fifoPath = NodePath.join(tempDir, "desktop.pipe");
+
+      yield* Effect.sync(() => NodeChildProcess.execFileSync("mkfifo", [fifoPath]));
+
+      const writer = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          NodeChildProcess.spawn("sh", ["-c", 'exec 3>"$1"; exec sleep 60', "sh", fifoPath], {
+            stdio: ["ignore", "ignore", "ignore"],
+          }),
+        ),
+        (writer) =>
+          Effect.sync(() => {
+            writer.kill("SIGKILL");
+          }),
+      );
+      // The lifetime watcher owns this fd and closes it when the pipe ends.
+      const fd = NodeFS.openSync(fifoPath, "r");
+
+      const watcher = yield* waitForDesktopLifetimeEnd(fd).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+      assert.isUndefined(watcher.pollUnsafe());
+
+      writer.kill("SIGKILL");
+      yield* Fiber.join(watcher);
+    }),
   );
 });

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -63,6 +63,18 @@ export class BootstrapEnvelopeDecodeError extends Schema.TaggedErrorClass<Bootst
   }
 }
 
+export class DesktopLifetimeReadError extends Schema.TaggedErrorClass<DesktopLifetimeReadError>()(
+  "DesktopLifetimeReadError",
+  {
+    fd: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to monitor desktop lifetime file descriptor ${this.fd}.`;
+  }
+}
+
 export const BootstrapError = Schema.Union([
   BootstrapFdStatError,
   BootstrapInputStreamOpenError,
@@ -143,6 +155,39 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
 
     return Effect.sync(cleanup);
   }).pipe(Effect.timeoutOption(timeoutMs), Effect.map(Option.flatten));
+});
+
+export const waitForDesktopLifetimeEnd = Effect.fn("waitForDesktopLifetimeEnd")(function* (
+  fd: number,
+) {
+  const stream = yield* Effect.try({
+    try: () => makeDirectBootstrapStream(fd),
+    catch: (cause) => new DesktopLifetimeReadError({ fd, cause }),
+  });
+
+  return yield* Effect.callback<void, DesktopLifetimeReadError>((resume) => {
+    const cleanup = () => {
+      stream.removeListener("error", handleError);
+      stream.removeListener("end", handleEnd);
+      stream.removeListener("close", handleEnd);
+      stream.destroy();
+    };
+
+    const handleError = (cause: Error) => {
+      resume(Effect.fail(new DesktopLifetimeReadError({ fd, cause })));
+    };
+
+    const handleEnd = () => {
+      resume(Effect.void);
+    };
+
+    stream.once("error", handleError);
+    stream.once("end", handleEnd);
+    stream.once("close", handleEnd);
+    stream.resume();
+
+    return Effect.sync(cleanup);
+  });
 });
 
 const isUnavailableBootstrapFdError = Predicate.compose(

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -292,6 +292,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           desktopBootstrapToken: "desktop-token",
           desktopTelemetryFd: 4,
           desktopTelemetryControlFd: 5,
+          desktopLifetimeFd: 6,
           tailscaleServeEnabled: false,
           tailscaleServePort: 443,
           otlpTracesUrl: "http://localhost:4318/v1/traces",
@@ -349,6 +350,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         desktopBootstrapToken: "desktop-token",
         desktopTelemetryFd: 4,
         desktopTelemetryControlFd: 5,
+        desktopLifetimeFd: 6,
         resourceMonitorPath: undefined,
         autoBootstrapProjectFromCwd: false,
         logWebSocketEvents: false,
@@ -358,6 +360,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
       assert.equal(join(baseDir, "userdata"), resolved.stateDir);
       assert.equal(resolved.desktopTelemetryFd, 4);
       assert.equal(resolved.desktopTelemetryControlFd, 5);
+      assert.equal(resolved.desktopLifetimeFd, 6);
     }),
   );
 

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -303,6 +303,7 @@ export const resolveServerConfig = (
     const desktopBootstrapToken = bootstrap?.desktopBootstrapToken;
     const desktopTelemetryFd = bootstrap?.desktopTelemetryFd;
     const desktopTelemetryControlFd = bootstrap?.desktopTelemetryControlFd;
+    const desktopLifetimeFd = bootstrap?.desktopLifetimeFd;
     const resourceMonitorPath = bootstrap?.resourceMonitorPath;
     const autoBootstrapProjectFromCwd = Option.getOrElse(
       resolveOptionPrecedence(
@@ -379,6 +380,7 @@ export const resolveServerConfig = (
       desktopBootstrapToken,
       desktopTelemetryFd,
       desktopTelemetryControlFd,
+      desktopLifetimeFd,
       resourceMonitorPath,
       autoBootstrapProjectFromCwd,
       logWebSocketEvents,

--- a/apps/server/src/cli/server.ts
+++ b/apps/server/src/cli/server.ts
@@ -3,6 +3,7 @@ import { Command, GlobalFlag } from "effect/unstable/cli";
 
 import { ServerConfig, type StartupPresentation } from "../config.ts";
 import { runServer } from "../server.ts";
+import { waitForDesktopLifetimeEnd } from "../bootstrap.ts";
 import { type CliServerFlags, resolveServerConfig, sharedServerCommandFlags } from "./config.ts";
 
 export const runServerCommand = (
@@ -15,7 +16,17 @@ export const runServerCommand = (
   Effect.gen(function* () {
     const logLevel = yield* GlobalFlag.LogLevel;
     const config = yield* resolveServerConfig(flags, logLevel, options);
-    return yield* runServer.pipe(Effect.provideService(ServerConfig, config));
+    const server = runServer.pipe(Effect.provideService(ServerConfig, config));
+    if (config.desktopLifetimeFd === undefined) {
+      return yield* server;
+    }
+
+    return yield* Effect.raceFirst(
+      server,
+      waitForDesktopLifetimeEnd(config.desktopLifetimeFd).pipe(
+        Effect.andThen(Effect.logInfo("Desktop owner exited; shutting down embedded server")),
+      ),
+    );
   });
 
 export const startCommand = Command.make("start", { ...sharedServerCommandFlags }).pipe(

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -83,6 +83,7 @@ export class ServerConfig extends Context.Service<
     readonly desktopBootstrapToken: string | undefined;
     readonly desktopTelemetryFd?: number | undefined;
     readonly desktopTelemetryControlFd?: number | undefined;
+    readonly desktopLifetimeFd?: number | undefined;
     readonly resourceMonitorPath?: string | undefined;
     readonly autoBootstrapProjectFromCwd: boolean;
     readonly logWebSocketEvents: boolean;
@@ -205,6 +206,7 @@ const makeTest = Effect.fn("ServerConfig.makeTest")(function* (
     desktopBootstrapToken: undefined,
     desktopTelemetryFd: undefined,
     desktopTelemetryControlFd: undefined,
+    desktopLifetimeFd: undefined,
     resourceMonitorPath: undefined,
     staticDir: undefined,
     devUrl,

--- a/packages/contracts/src/desktopBootstrap.ts
+++ b/packages/contracts/src/desktopBootstrap.ts
@@ -18,6 +18,9 @@ export const DesktopBackendBootstrap = Schema.Struct({
   otlpMetricsUrl: Schema.optional(Schema.String),
   desktopTelemetryFd: Schema.optionalKey(PositiveInt),
   desktopTelemetryControlFd: Schema.optionalKey(PositiveInt),
+  // Linux desktop backends watch this pipe for EOF so they also stop when
+  // Electron exits before its normal shutdown handlers can run.
+  desktopLifetimeFd: Schema.optionalKey(PositiveInt),
   resourceMonitorPath: Schema.optionalKey(TrimmedNonEmptyString),
 });
 


### PR DESCRIPTION
## What Changed

- Add a Linux-only lifetime pipe between the Electron desktop process and its embedded backend.
- Keep the desktop end open while Electron owns the backend.
- Race the embedded server against EOF on that pipe, allowing the server's existing Effect scope to shut down normally when Electron disappears.
- Leave standalone, Windows, and WSL server startup unchanged.

## Why

If Electron crashes or is killed before its normal `before-quit` cleanup runs, the embedded backend is reparented and can remain alive indefinitely. On Linux under systemd, that surviving backend keeps the application's transient scope active after logout.

A kernel-owned pipe models ownership directly: when Electron exits for any reason, the OS closes its end. This avoids PID polling and PID-reuse races while preserving the normal graceful shutdown path.

## Testing

- `vp test run apps/desktop/src/backend/DesktopBackendConfiguration.test.ts apps/desktop/src/backend/DesktopBackendManager.test.ts apps/server/src/bootstrap.test.ts apps/server/src/cli/config.test.ts` — 72 passed
- `pnpm --filter @t3tools/contracts typecheck`
- `pnpm --filter @t3tools/desktop typecheck`
- `pnpm --filter t3 typecheck`
- Focused lint and formatting checks for all changed files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

---

Model: GPT-5.6 Sol (high reasoning). Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes embedded-server lifecycle on Linux desktop only; mis-wiring the lifetime fd could cause premature shutdown or leave orphans, but Windows/WSL/standalone paths are unchanged.
> 
> **Overview**
> Adds a **Linux-only desktop lifetime pipe** so the embedded server can exit when Electron disappears without running normal shutdown.
> 
> The bootstrap contract gains optional `desktopLifetimeFd` (fd **6** on Linux primary backends). `DesktopBackendConfiguration` includes it only when `platform === "linux"`; Windows primary and WSL configs omit it. `DesktopBackendManager` passes that fd to the child as an extra inherited input alongside bootstrap and telemetry fds.
> 
> On the server, `waitForDesktopLifetimeEnd` watches the inherited fd for **end/close** (pipe EOF when the desktop owner exits). `runServerCommand` **races** the normal server effect against that watcher when `desktopLifetimeFd` is set, logging and shutting down through the existing scope instead of leaving a reparented backend alive (e.g. under systemd after crash/kill).
> 
> Config resolution and tests are updated to plumb and assert the new field where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d43e0d91f9054e30a19d2e330cf5c2d6bfd000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop backend when Linux desktop owner exits via `desktopLifetimeFd` pipe
> - Adds optional `desktopLifetimeFd` to the `DesktopBackendBootstrap` contract; the desktop app passes descriptor 6 to the backend only on Linux.
> - The server's `runServerCommand` races its main effect against `waitForDesktopLifetimeEnd`, which awaits EOF or closure on the lifetime pipe and stops the server when the desktop owner exits.
> - `DesktopBackendManager.runBackendProcess` spawns the child with the lifetime descriptor as an input pipe; config resolution and bootstrap decoding preserve the field end-to-end.
> - Behavioral Change: non-Linux desktop configurations omit `desktopLifetimeFd` and use the existing direct execution path unchanged; Linux configurations now stop the backend on pipe close and surface `DesktopLifetimeReadError` if the descriptor cannot be read.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31d43e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
