### PR TITLE
Feat/mid thread provider switching

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -309,6 +309,7 @@ export function NewTaskDraftScreen(props: {
         ? selectedProject?.workspaceRoot
         : (flow.selectedWorktreePath ?? selectedProject?.workspaceRoot)) || null,
     selectedProviderStatus: flow.selectedProviderStatus,
+    providerStatuses: selectedEnvironmentServerConfig?.providers,
     hasThread: false,
     enabled: isComposerFocused && !isComposerInteractionLocked,
     onChangeDraftMessage: flow.setPrompt,

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -355,6 +355,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     environmentId: props.environmentId,
     projectCwd: props.projectCwd,
     selectedProviderStatus,
+    providerStatuses: props.serverConfig?.providers,
     hasThread: true,
     onChangeDraftMessage: props.onChangeDraftMessage,
     onUpdateInteractionMode: props.onUpdateInteractionMode,

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -5,7 +5,7 @@ import {
 } from "@t3tools/client-runtime/codex-artifact-templates";
 import type { EnvironmentThreadStatus } from "@t3tools/client-runtime/state/threads";
 import { useKeyboardChatComposerInset, useKeyboardScrollToEnd } from "@legendapp/list/keyboard";
-import { resolveProviderSkillsForCwd } from "@t3tools/client-runtime/providerSkills";
+import { resolveProviderSkillsForCwdAcrossProviders } from "@t3tools/client-runtime/providerSkills";
 import type { LegendListRef } from "@legendapp/list/react-native";
 import { HeaderHeightContext } from "@react-navigation/elements";
 import type {
@@ -90,6 +90,8 @@ import {
 import { ThreadFeed } from "./ThreadFeed";
 import type { ThreadContentPresentation } from "./threadContentPresentation";
 import { resolveThreadFeedSubmissionAnchor } from "./thread-feed-live-follow";
+
+const EMPTY_PROVIDERS: ReadonlyArray<T3ServerConfig["providers"][number]> = [];
 
 export interface ThreadDetailScreenProps {
   readonly selectedThread: OrchestrationThreadShell;
@@ -509,16 +511,13 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const layoutVariant = props.layoutVariant ?? "compact";
   const isSplitLayout = layoutVariant === "split";
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
-  const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
   useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
-  const selectedProviderSkills = useMemo(() => {
-    const provider = props.serverConfig?.providers.find(
-      (candidate) => candidate.instanceId === selectedInstanceId,
-    );
-    return provider
-      ? resolveProviderSkillsForCwd(provider, props.threadCwd ?? props.projectWorkspaceRoot)
-      : [];
-  }, [props.projectWorkspaceRoot, props.serverConfig, props.threadCwd, selectedInstanceId]);
+  const providerStatuses = props.serverConfig?.providers ?? EMPTY_PROVIDERS;
+  const timelineCwd = props.threadCwd ?? props.projectWorkspaceRoot;
+  const timelineSkills = useMemo(
+    () => resolveProviderSkillsForCwdAcrossProviders(providerStatuses, timelineCwd),
+    [providerStatuses, timelineCwd],
+  );
 
   useLayoutEffect(() => {
     selectedThreadKeyRef.current = selectedThreadKey;
@@ -714,7 +713,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             usesAutomaticContentInsets={props.usesAutomaticContentInsets}
             onHeaderMaterialVisibilityChange={props.onHeaderMaterialVisibilityChange}
             onEndFollowEnabledChange={setEndFollowEnabled}
-            skills={selectedProviderSkills}
+            skills={timelineSkills}
             onUseArtifactTemplate={handleUseArtifactTemplate}
             loadEarlier={props.loadEarlier ?? null}
           />

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -14,6 +14,7 @@ import {
   getProviderSkillsForSlashMenu,
   isProviderSkillUserInvocable,
   resolveProviderSkillsForCwd,
+  resolveProviderSkillsForCwdAcrossProviders,
 } from "@t3tools/client-runtime/providerSkills";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -25,6 +26,7 @@ import type { ComposerCommandItem } from "./ComposerCommandPopover";
 import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
 
 const WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS = 10_000;
+const EMPTY_PROVIDER_STATUSES: ReadonlyArray<ServerProvider> = [];
 
 export function composerSelectionAtEnd(draftMessage: string): ComposerEditorSelection {
   return { start: draftMessage.length, end: draftMessage.length };
@@ -37,6 +39,7 @@ export function useComposerCommandMenu({
   environmentId,
   projectCwd,
   selectedProviderStatus,
+  providerStatuses = EMPTY_PROVIDER_STATUSES,
   hasThread,
   enabled = true,
   onChangeDraftMessage,
@@ -47,6 +50,7 @@ export function useComposerCommandMenu({
   readonly environmentId: EnvironmentId | null;
   readonly projectCwd: string | null;
   readonly selectedProviderStatus: ServerProvider | null;
+  readonly providerStatuses?: ReadonlyArray<ServerProvider>;
   readonly hasThread: boolean;
   readonly enabled?: boolean;
   readonly onChangeDraftMessage: (value: string) => void;
@@ -74,11 +78,14 @@ export function useComposerCommandMenu({
     setSelection(composerSelectionAtEnd(draftMessage));
   }, [draftMessage, ownerKey]);
 
-  const skills = useMemo(
-    () =>
-      selectedProviderStatus ? resolveProviderSkillsForCwd(selectedProviderStatus, projectCwd) : [],
-    [projectCwd, selectedProviderStatus],
-  );
+  const skills = useMemo(() => {
+    const directSkills = selectedProviderStatus
+      ? resolveProviderSkillsForCwd(selectedProviderStatus, projectCwd)
+      : [];
+    return directSkills.length > 0
+      ? directSkills
+      : resolveProviderSkillsForCwdAcrossProviders(providerStatuses, projectCwd);
+  }, [projectCwd, providerStatuses, selectedProviderStatus]);
   const slashCommands = selectedProviderStatus?.slashCommands ?? [];
   const refreshProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2612,9 +2612,42 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.providerName).toBe("claudeAgent");
     expect(thread?.session?.providerInstanceId).toBe("claudeAgent");
+    expect(thread?.modelSelection).toMatchObject({
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      model: "claude-opus-4-6",
+    });
     expect(
       thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
     ).toBeUndefined();
+
+    // Subsequent turn without modelSelection should continue on the switched provider
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-provider-switch-3"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-provider-switch-3"),
+          role: "user",
+          text: "third turn without modelSelection",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 3);
+    const thirdTurnInput = harness.sendTurn.mock.calls[2]?.[0] as
+      | {
+          modelSelection?: ModelSelection;
+          input?: string;
+        }
+      | undefined;
+    expect(thirdTurnInput?.input).toBe("third turn without modelSelection");
+    // Ensure it stayed with claudeAgent and did not revert to codex
+    expect(harness.startSession.mock.calls.length).toBe(2);
   });
 
   it("retries provider continuity context after a failed switched-provider turn", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -169,6 +169,10 @@ describe("ProviderCommandReactor", () => {
     readonly serverActivation?: Effect.Effect<void>;
     readonly interruptTurnEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly stopSessionEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
+    readonly sendTurnEffect?: () => Effect.Effect<
+      { readonly threadId: ThreadId; readonly turnId: TurnId },
+      ProviderAdapterRequestError
+    >;
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
@@ -248,11 +252,13 @@ describe("ProviderCommandReactor", () => {
         ),
       );
     });
-    const sendTurn = vi.fn((_: unknown) =>
-      Effect.succeed({
-        threadId: ThreadId.make("thread-1"),
-        turnId: asTurnId("turn-1"),
-      }),
+    const sendTurn = vi.fn(
+      (_: unknown) =>
+        input?.sendTurnEffect?.() ??
+        Effect.succeed({
+          threadId: ThreadId.make("thread-1"),
+          turnId: asTurnId("turn-1"),
+        }),
     );
     const interruptTurn = vi.fn((_: unknown) => input?.interruptTurnEffect?.() ?? Effect.void);
     const respondToRequest = vi.fn<ProviderServiceShape["respondToRequest"]>(() => Effect.void);
@@ -2504,8 +2510,16 @@ describe("ProviderCommandReactor", () => {
         message: {
           messageId: asMessageId("user-message-provider-switch-1"),
           role: "user",
-          text: "first",
-          attachments: [],
+          text: "$caveman",
+          attachments: [
+            {
+              type: "file",
+              id: "provider-switch-context-file",
+              name: "investigation.md",
+              mimeType: "text/markdown",
+              sizeBytes: 128,
+            },
+          ],
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
@@ -2515,7 +2529,7 @@ describe("ProviderCommandReactor", () => {
 
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
-    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({ input: "first" });
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({ input: "$caveman" });
 
     await Effect.runPromise(
       harness.engine.dispatch({
@@ -2573,7 +2587,8 @@ describe("ProviderCommandReactor", () => {
       model: "claude-opus-4-6",
     });
     expect(secondTurnInput?.input).toContain("[Thread Continuity Context]");
-    expect(secondTurnInput?.input).toContain("User: first");
+    expect(secondTurnInput?.input).toContain("User: \\$caveman");
+    expect(secondTurnInput?.input).not.toContain("User: $caveman");
     expect(secondTurnInput?.input).toContain(
       "Assistant: I found stale state in the session binding.",
     );
@@ -2582,6 +2597,15 @@ describe("ProviderCommandReactor", () => {
     expect(secondTurnInput?.input).not.toContain("Codex");
     expect(secondTurnInput?.input).not.toContain("Claude");
     expect(secondTurnInput?.input).not.toContain("previous agent");
+    expect(
+      (secondTurnInput as { attachments?: ReadonlyArray<{ id: string }> } | undefined)?.attachments,
+    ).toEqual([
+      expect.objectContaining({
+        id: "provider-switch-context-file",
+        name: "investigation.md",
+      }),
+    ]);
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({ resumeCursor: null });
 
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
@@ -2591,6 +2615,98 @@ describe("ProviderCommandReactor", () => {
     expect(
       thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
     ).toBeUndefined();
+  });
+
+  it("retries provider continuity context after a failed switched-provider turn", async () => {
+    let sendCount = 0;
+    const harness = await createHarness({
+      sendTurnEffect: () => {
+        sendCount += 1;
+        return sendCount === 2
+          ? Effect.fail(
+              new ProviderAdapterRequestError({
+                provider: "claudeAgent",
+                method: "thread.turn.start",
+                detail: "simulated switched-provider failure",
+              }),
+            )
+          : Effect.succeed({
+              threadId: ThreadId.make("thread-1"),
+              turnId: asTurnId(`turn-${sendCount}`),
+            });
+      },
+    });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-continuity-retry-first"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("message-continuity-retry-first"),
+          role: "user",
+          text: "inspect session state",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-continuity-retry-switch"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("message-continuity-retry-switch"),
+          role: "user",
+          text: "continue inspection",
+          attachments: [],
+        },
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          model: "claude-opus-4-6",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(async () => {
+      const readModel = await harness.readModel();
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      return (
+        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
+        false
+      );
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-continuity-retry-third"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("message-continuity-retry-third"),
+          role: "user",
+          text: "retry",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.sendTurn.mock.calls.length === 3);
+
+    const retryInput = harness.sendTurn.mock.calls[2]?.[0] as { input?: string } | undefined;
+    expect(retryInput?.input).toContain("[Thread Continuity Context]");
+    expect(retryInput?.input).toContain("User: inspect session state");
+    expect(retryInput?.input).toContain("Current Request:\nretry");
   });
 
   it("switches providers after an existing thread session has stopped", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2492,7 +2492,7 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.runtimeMode).toBe("full-access");
   });
 
-  it("switches providers mid-thread with context handoff", async () => {
+  it("switches providers mid-thread with continuous conversation context", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2516,6 +2516,26 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({ input: "first" });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.delta",
+        commandId: CommandId.make("cmd-assistant-provider-switch-1"),
+        threadId: ThreadId.make("thread-1"),
+        messageId: asMessageId("assistant-message-provider-switch-1"),
+        delta: "I found stale state in the session binding.",
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.complete",
+        commandId: CommandId.make("cmd-assistant-complete-provider-switch-1"),
+        threadId: ThreadId.make("thread-1"),
+        messageId: asMessageId("assistant-message-provider-switch-1"),
+        createdAt: now,
+      }),
+    );
 
     await Effect.runPromise(
       harness.engine.dispatch({
@@ -2552,9 +2572,16 @@ describe("ProviderCommandReactor", () => {
       instanceId: ProviderInstanceId.make("claudeAgent"),
       model: "claude-opus-4-6",
     });
-    expect(secondTurnInput?.input).toContain("[Context Handoff:");
+    expect(secondTurnInput?.input).toContain("[Thread Continuity Context]");
     expect(secondTurnInput?.input).toContain("User: first");
+    expect(secondTurnInput?.input).toContain(
+      "Assistant: I found stale state in the session binding.",
+    );
     expect(secondTurnInput?.input).toContain("Current Request:\nsecond");
+    expect(secondTurnInput?.input).not.toContain("Context Handoff");
+    expect(secondTurnInput?.input).not.toContain("Codex");
+    expect(secondTurnInput?.input).not.toContain("Claude");
+    expect(secondTurnInput?.input).not.toContain("previous agent");
 
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2492,7 +2492,7 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.runtimeMode).toBe("full-access");
   });
 
-  it("rejects provider changes after a thread is already bound to a session provider", async () => {
+  it("switches providers mid-thread with context handoff", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2515,6 +2515,7 @@ describe("ProviderCommandReactor", () => {
 
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({ input: "first" });
 
     await Effect.runPromise(
       harness.engine.dispatch({
@@ -2537,34 +2538,35 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    expect(harness.stopSession.mock.calls.length).toBe(1);
 
-    expect(harness.startSession.mock.calls.length).toBe(1);
-    expect(harness.sendTurn.mock.calls.length).toBe(1);
-    expect(harness.stopSession.mock.calls.length).toBe(0);
+    const secondTurnInput = harness.sendTurn.mock.calls[1]?.[0] as
+      | {
+          modelSelection?: ModelSelection;
+          input?: string;
+        }
+      | undefined;
+    expect(secondTurnInput?.modelSelection).toMatchObject({
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      model: "claude-opus-4-6",
+    });
+    expect(secondTurnInput?.input).toContain("[Context Handoff:");
+    expect(secondTurnInput?.input).toContain("User: first");
+    expect(secondTurnInput?.input).toContain("Current Request:\nsecond");
 
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
-    expect(thread?.session?.providerName).toBe("codex");
-    expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(thread?.session?.providerName).toBe("claudeAgent");
+    expect(thread?.session?.providerInstanceId).toBe("claudeAgent");
     expect(
       thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
-    });
+    ).toBeUndefined();
   });
 
-  it("rejects cross-driver provider changes after the existing thread session has stopped", async () => {
+  it("switches providers after an existing thread session has stopped", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2608,26 +2610,16 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
 
-    expect(harness.startSession.mock.calls.length).toBe(0);
-    expect(harness.sendTurn.mock.calls.length).toBe(0);
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.providerName).toBe("claudeAgent");
+    expect(thread?.session?.providerInstanceId).toBe("claudeAgent");
     expect(
       thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
-    });
+    ).toBeUndefined();
   });
 
   it("reacts to thread.turn.interrupt-requested by calling provider interrupt", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -626,10 +626,6 @@ const make = Effect.gen(function* () {
       requestedModelSelection.instanceId !== currentInstanceId &&
       (isDriverChanged || isContinuationIncompatible);
 
-    if (isHandoffSwitch) {
-      threadContinuityPending.add(threadId);
-    }
-
     if (
       options?.pendingTurnStart === true &&
       (thread.session?.status !== "running" || isHandoffSwitch)
@@ -667,6 +663,14 @@ const make = Effect.gen(function* () {
         requestedModelSelection,
       });
     }
+
+    // Marked only once the switch is accepted: a rejected model change leaves the
+    // session on its current provider, and a stale flag would synthesize continuity
+    // context into the next ordinary turn.
+    if (isHandoffSwitch) {
+      threadContinuityPending.add(threadId);
+    }
+
     const project = yield* resolveProject(thread.projectId);
     const effectiveCwd = resolveThreadWorkspaceCwd({
       thread,
@@ -987,7 +991,6 @@ const make = Effect.gen(function* () {
       });
       if (continuityContext.length > 0) {
         continuityContextIncluded = true;
-        threadContinuityPending.delete(input.threadId);
         effectiveInput = normalizedInput
           ? `${continuityContext}${CURRENT_REQUEST_PREFIX}${normalizedInput}`
           : continuityContext;
@@ -995,8 +998,6 @@ const make = Effect.gen(function* () {
           ...collectThreadContinuityAttachments(priorMessages, normalizedAttachments),
           ...normalizedAttachments,
         ];
-      } else {
-        threadContinuityPending.delete(input.threadId);
       }
     }
 
@@ -1027,6 +1028,14 @@ const make = Effect.gen(function* () {
             }
           : requestedModelSelection
         : input.modelSelection;
+
+    // Consumed only after every fallible step above. Clearing it as soon as the
+    // handoff prompt was built lost the conversation history whenever listSessions
+    // or getCapabilities failed: the session is already bound to the new provider,
+    // so the retry no longer looks like a handoff and nothing would carry it over.
+    if (needsContinuityContext) {
+      threadContinuityPending.delete(input.threadId);
+    }
 
     return {
       request: {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2,6 +2,7 @@ import {
   type ChatAttachment,
   CommandId,
   EventId,
+  type MessageId,
   type ModelSelection,
   type OrchestrationEvent,
   type OrchestrationMessage,
@@ -758,7 +759,7 @@ const make = Effect.gen(function* () {
 
       const resumeCursor =
         shouldRestartForModelChange || shouldRestartForHandoff
-          ? undefined
+          ? null
           : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
@@ -795,7 +796,9 @@ const make = Effect.gen(function* () {
       return restartedSession.threadId;
     }
 
-    const startedSession = yield* startProviderSession(undefined);
+    const startedSession = yield* startProviderSession(
+      isHandoffSwitch ? { resumeCursor: null } : undefined,
+    );
     yield* bindSessionToThread(startedSession);
     return startedSession.threadId;
   });
@@ -804,13 +807,16 @@ const make = Effect.gen(function* () {
     readonly previousProviderLabel: string;
     readonly newProviderLabel: string;
     readonly messages: ReadonlyArray<OrchestrationMessage>;
-    readonly currentMessageText?: string;
+    readonly currentMessageId?: MessageId | undefined;
+    readonly currentMessageText?: string | undefined;
   }): string => {
     let priorMessages = input.messages.filter(
       (entry) => entry.role === "user" || entry.role === "assistant",
     );
 
-    if (
+    if (input.currentMessageId !== undefined) {
+      priorMessages = priorMessages.filter((entry) => entry.id !== input.currentMessageId);
+    } else if (
       input.currentMessageText !== undefined &&
       priorMessages.length > 0 &&
       priorMessages[priorMessages.length - 1]?.role === "user" &&
@@ -830,14 +836,46 @@ const make = Effect.gen(function* () {
     ];
 
     const MAX_MESSAGE_CHARS = 4000;
+    const MAX_TOTAL_HANDOFF_CHARS = 60_000;
+    const messageBlocks: string[] = [];
+
     for (const msg of priorMessages) {
-      const roleLabel = msg.role === "user" ? "User" : input.previousProviderLabel;
+      const roleLabel = msg.role === "user" ? "User" : `Assistant (${input.previousProviderLabel})`;
       let text = assistantCitationsToPlainText(msg.text).trim();
+      const attachmentNames = (msg.attachments ?? []).map((a) => a.name).filter(Boolean);
+      const attachmentSummary =
+        attachmentNames.length > 0 ? `\n[Attachments: ${attachmentNames.join(", ")}]` : "";
       if (text.length > MAX_MESSAGE_CHARS) {
         text = text.slice(0, MAX_MESSAGE_CHARS) + " ...[truncated]";
       }
-      if (text.length > 0) {
-        parts.push(`${roleLabel}: ${text}`);
+      const separator = text.includes("\n") ? ":\n" : ": ";
+      if (text.length > 0 || attachmentSummary.length > 0) {
+        messageBlocks.push(`${roleLabel}${separator}${text}${attachmentSummary}`.trim());
+      }
+    }
+
+    if (messageBlocks.length > 0) {
+      const totalLength = messageBlocks.reduce((acc, b) => acc + b.length + 2, 0);
+      if (totalLength > MAX_TOTAL_HANDOFF_CHARS) {
+        const firstBlock = messageBlocks[0];
+        const recentBlocks: string[] = [];
+        let remainingBudget = MAX_TOTAL_HANDOFF_CHARS - (firstBlock?.length ?? 0) - 100;
+        for (let i = messageBlocks.length - 1; i >= 1; i--) {
+          const block = messageBlocks[i]!;
+          if (remainingBudget - block.length > 0) {
+            recentBlocks.unshift(block);
+            remainingBudget -= block.length;
+          } else {
+            break;
+          }
+        }
+        if (firstBlock) {
+          parts.push(firstBlock);
+        }
+        parts.push("[Earlier context truncated...]");
+        parts.push(...recentBlocks);
+      } else {
+        parts.push(...messageBlocks);
       }
     }
 
@@ -850,6 +888,7 @@ const make = Effect.gen(function* () {
 
   const buildSendTurnRequestForThread = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
+    readonly messageId?: MessageId | undefined;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
     readonly modelSelection?: ModelSelection;
@@ -880,6 +919,7 @@ const make = Effect.gen(function* () {
         previousProviderLabel: handoff.previousProviderLabel,
         newProviderLabel: handoff.newProviderLabel,
         messages: thread.messages,
+        currentMessageId: input.messageId,
         currentMessageText: input.messageText,
       });
       if (handoffContext.length > 0) {
@@ -1308,6 +1348,7 @@ const make = Effect.gen(function* () {
 
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
+      messageId: message.id,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
       ...(event.payload.modelSelection !== undefined

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -6,6 +6,8 @@ import {
   type ModelSelection,
   type OrchestrationEvent,
   type OrchestrationMessage,
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -101,8 +103,19 @@ const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 const MAX_REGENERATION_ATTACHMENTS = 4;
 const MAX_THREAD_TITLE_CONTEXT_CHARS = 8_000;
 const MAX_FIRST_USER_TITLE_CONTEXT_CHARS = 2_000;
+const MAX_THREAD_CONTINUITY_CONTEXT_CHARS = 60_000;
+const MAX_THREAD_CONTINUITY_MESSAGE_CHARS = 4_000;
+const CURRENT_REQUEST_PREFIX = "\n\nCurrent Request:\n";
+const THREAD_CONTINUITY_SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s|$)/g;
 const THREAD_TITLE_CONTEXT_TRUNCATION_MARKER = "[Earlier content truncated]\n\n";
 const FIRST_USER_CONTEXT_TRUNCATION_MARKER = "\n[First user message truncated]";
+
+function escapeThreadContinuitySkillTokens(value: string): string {
+  return value.replace(
+    THREAD_CONTINUITY_SKILL_TOKEN_REGEX,
+    (_match, prefix: string, name: string) => `${prefix}\\$${name}`,
+  );
+}
 
 type ThreadTitleMessage = {
   readonly role: "user" | "assistant" | "system";
@@ -794,11 +807,11 @@ const make = Effect.gen(function* () {
     return startedSession.threadId;
   });
 
-  const formatThreadContinuityContext = (input: {
+  const priorConversationMessages = (input: {
     readonly messages: ReadonlyArray<OrchestrationMessage>;
     readonly currentMessageId?: MessageId | undefined;
     readonly currentMessageText?: string | undefined;
-  }): string => {
+  }): ReadonlyArray<OrchestrationMessage> => {
     let priorMessages = input.messages.filter(
       (entry) => entry.role === "user" || entry.role === "assistant",
     );
@@ -814,6 +827,44 @@ const make = Effect.gen(function* () {
       priorMessages = priorMessages.slice(0, -1);
     }
 
+    return priorMessages;
+  };
+
+  const collectThreadContinuityAttachments = (
+    messages: ReadonlyArray<OrchestrationMessage>,
+    currentAttachments: ReadonlyArray<ChatAttachment>,
+  ): ReadonlyArray<ChatAttachment> => {
+    const remainingSlots = Math.max(
+      0,
+      PROVIDER_SEND_TURN_MAX_ATTACHMENTS - currentAttachments.length,
+    );
+    if (remainingSlots === 0) {
+      return [];
+    }
+
+    const seenIds = new Set(currentAttachments.map((attachment) => attachment.id));
+    const recentAttachments: ChatAttachment[] = [];
+    for (const message of messages.toReversed()) {
+      for (const attachment of (message.attachments ?? []).toReversed()) {
+        if (seenIds.has(attachment.id)) {
+          continue;
+        }
+        seenIds.add(attachment.id);
+        recentAttachments.unshift(attachment);
+        if (recentAttachments.length === remainingSlots) {
+          return recentAttachments;
+        }
+      }
+    }
+    return recentAttachments;
+  };
+
+  const formatThreadContinuityContext = (input: {
+    readonly messages: ReadonlyArray<OrchestrationMessage>;
+    readonly maxChars: number;
+  }): string => {
+    const priorMessages = input.messages;
+
     if (priorMessages.length === 0) {
       return "";
     }
@@ -824,19 +875,31 @@ const make = Effect.gen(function* () {
       "Conversation before the current request:",
       "---",
     ];
+    const suffix = [
+      "---",
+      "Repository workspace already reflects all file edits and commits from this thread.",
+    ];
+    const fixedLength = [...parts, ...suffix].join("\n").length;
+    const messageBudget = Math.min(
+      MAX_THREAD_CONTINUITY_CONTEXT_CHARS - fixedLength,
+      input.maxChars - fixedLength,
+    );
+    if (messageBudget <= 0) {
+      return "";
+    }
 
-    const MAX_MESSAGE_CHARS = 4000;
-    const MAX_TOTAL_HANDOFF_CHARS = 60_000;
     const messageBlocks: string[] = [];
 
     for (const msg of priorMessages) {
       const roleLabel = msg.role === "user" ? "User" : "Assistant";
-      let text = assistantCitationsToPlainText(msg.text).trim();
-      const attachmentNames = (msg.attachments ?? []).map((a) => a.name).filter(Boolean);
+      let text = escapeThreadContinuitySkillTokens(assistantCitationsToPlainText(msg.text)).trim();
+      const attachmentNames = (msg.attachments ?? [])
+        .map((attachment) => escapeThreadContinuitySkillTokens(attachment.name))
+        .filter(Boolean);
       const attachmentSummary =
         attachmentNames.length > 0 ? `\n[Attachments: ${attachmentNames.join(", ")}]` : "";
-      if (text.length > MAX_MESSAGE_CHARS) {
-        text = text.slice(0, MAX_MESSAGE_CHARS) + " ...[truncated]";
+      if (text.length > MAX_THREAD_CONTINUITY_MESSAGE_CHARS) {
+        text = text.slice(0, MAX_THREAD_CONTINUITY_MESSAGE_CHARS) + " ...[truncated]";
       }
       const separator = text.includes("\n") ? ":\n" : ": ";
       if (text.length > 0 || attachmentSummary.length > 0) {
@@ -845,35 +908,39 @@ const make = Effect.gen(function* () {
     }
 
     if (messageBlocks.length > 0) {
-      const totalLength = messageBlocks.reduce((acc, b) => acc + b.length + 2, 0);
-      if (totalLength > MAX_TOTAL_HANDOFF_CHARS) {
+      const totalLength = messageBlocks.reduce((acc, block) => acc + block.length + 1, 0);
+      if (totalLength > messageBudget) {
         const firstBlock = messageBlocks[0];
         const recentBlocks: string[] = [];
-        let remainingBudget = MAX_TOTAL_HANDOFF_CHARS - (firstBlock?.length ?? 0) - 100;
-        for (let i = messageBlocks.length - 1; i >= 1; i--) {
-          const block = messageBlocks[i]!;
-          if (remainingBudget - block.length > 0) {
-            recentBlocks.unshift(block);
-            remainingBudget -= block.length;
-          } else {
-            break;
+        const truncationMarker = "[Earlier context truncated...]";
+        const markerCost = truncationMarker.length + 1;
+        if (markerCost <= messageBudget) {
+          let remainingBudget = messageBudget - markerCost;
+          const keepFirst = firstBlock !== undefined && firstBlock.length + 1 <= remainingBudget;
+          if (keepFirst) {
+            remainingBudget -= firstBlock.length + 1;
           }
+          for (let i = messageBlocks.length - 1; i >= 1; i--) {
+            const block = messageBlocks[i]!;
+            if (remainingBudget - block.length - 1 >= 0) {
+              recentBlocks.unshift(block);
+              remainingBudget -= block.length + 1;
+            } else {
+              break;
+            }
+          }
+          if (keepFirst) {
+            parts.push(firstBlock);
+          }
+          parts.push(truncationMarker);
+          parts.push(...recentBlocks);
         }
-        if (firstBlock) {
-          parts.push(firstBlock);
-        }
-        parts.push("[Earlier context truncated...]");
-        parts.push(...recentBlocks);
       } else {
         parts.push(...messageBlocks);
       }
     }
 
-    parts.push("---");
-    parts.push(
-      "Repository workspace already reflects all file edits and commits from this thread.",
-    );
-    return parts.join("\n");
+    return [...parts, ...suffix].join("\n");
   };
 
   const buildSendTurnRequestForThread = Effect.fnUntraced(function* (input: {
@@ -901,18 +968,35 @@ const make = Effect.gen(function* () {
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
     const normalizedAttachments = input.attachments ?? [];
 
-    const needsContinuityContext = threadContinuityPending.delete(input.threadId);
+    const needsContinuityContext = threadContinuityPending.has(input.threadId);
     let effectiveInput = normalizedInput;
+    let effectiveAttachments = normalizedAttachments;
+    let continuityContextIncluded = false;
     if (needsContinuityContext) {
-      const continuityContext = formatThreadContinuityContext({
+      const priorMessages = priorConversationMessages({
         messages: thread.messages,
         currentMessageId: input.messageId,
         currentMessageText: input.messageText,
       });
+      const currentRequestChars = normalizedInput
+        ? CURRENT_REQUEST_PREFIX.length + normalizedInput.length
+        : 0;
+      const continuityContext = formatThreadContinuityContext({
+        messages: priorMessages,
+        maxChars: PROVIDER_SEND_TURN_MAX_INPUT_CHARS - currentRequestChars,
+      });
       if (continuityContext.length > 0) {
+        continuityContextIncluded = true;
+        threadContinuityPending.delete(input.threadId);
         effectiveInput = normalizedInput
-          ? `${continuityContext}\n\nCurrent Request:\n${normalizedInput}`
+          ? `${continuityContext}${CURRENT_REQUEST_PREFIX}${normalizedInput}`
           : continuityContext;
+        effectiveAttachments = [
+          ...collectThreadContinuityAttachments(priorMessages, normalizedAttachments),
+          ...normalizedAttachments,
+        ];
+      } else {
+        threadContinuityPending.delete(input.threadId);
       }
     }
 
@@ -945,13 +1029,16 @@ const make = Effect.gen(function* () {
         : input.modelSelection;
 
     return {
-      threadId: input.threadId,
-      ...(toNonEmptyProviderInput(effectiveInput)
-        ? { input: toNonEmptyProviderInput(effectiveInput) }
-        : {}),
-      ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
-      ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
-      ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+      request: {
+        threadId: input.threadId,
+        ...(toNonEmptyProviderInput(effectiveInput)
+          ? { input: toNonEmptyProviderInput(effectiveInput) }
+          : {}),
+        ...(effectiveAttachments.length > 0 ? { attachments: effectiveAttachments } : {}),
+        ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
+        ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+      },
+      continuityContextIncluded,
     };
   });
 
@@ -1352,9 +1439,16 @@ const make = Effect.gen(function* () {
       return;
     }
 
+    const restoreContinuityContextOnFailure = (cause: Cause.Cause<unknown>) =>
+      Effect.sync(() => {
+        if (sendTurnRequest.value.continuityContextIncluded) {
+          threadContinuityPending.add(event.payload.threadId);
+        }
+      }).pipe(Effect.andThen(recoverTurnStartFailure(cause)));
+
     yield* providerService
-      .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
+      .sendTurn(sendTurnRequest.value.request)
+      .pipe(Effect.catchCause(restoreContinuityContextOnFailure), Effect.forkScoped);
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   type ModelSelection,
   type OrchestrationEvent,
+  type OrchestrationMessage,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -332,6 +333,11 @@ const make = Effect.gen(function* () {
     );
 
   const threadModelSelections = new Map<string, ModelSelection>();
+  interface ThreadHandoffPending {
+    readonly previousProviderLabel: string;
+    readonly newProviderLabel: string;
+  }
+  const threadHandoffPending = new Map<string, ThreadHandoffPending>();
 
   const appendProviderFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -599,14 +605,41 @@ const make = Effect.gen(function* () {
       });
     }
     const preferredProvider: ProviderDriverKind = desiredDriverKind;
-    if (options?.pendingTurnStart === true && thread.session?.status !== "running") {
+
+    const isDriverChanged = currentInfo.driverKind !== desiredInfo.driverKind;
+    const isContinuationIncompatible =
+      currentInfo.continuationIdentity.continuationKey !==
+      desiredInfo.continuationIdentity.continuationKey;
+    const isHandoffSwitch =
+      (thread.session !== null || thread.messages.length > 0) &&
+      requestedModelSelection !== undefined &&
+      requestedModelSelection.instanceId !== currentInstanceId &&
+      (isDriverChanged || isContinuationIncompatible);
+
+    if (isHandoffSwitch) {
+      threadHandoffPending.set(threadId, {
+        previousProviderLabel:
+          currentInfo.displayName ?? providerErrorLabel(String(currentInfo.driverKind)),
+        newProviderLabel:
+          desiredInfo.displayName ?? providerErrorLabel(String(desiredInfo.driverKind)),
+      });
+    }
+
+    if (
+      options?.pendingTurnStart === true &&
+      (thread.session?.status !== "running" || isHandoffSwitch)
+    ) {
       yield* setThreadSession({
         threadId,
         session: {
           threadId,
           status: "starting",
-          providerName: activeSession?.provider ?? preferredProvider,
-          providerInstanceId: activeSession?.providerInstanceId ?? desiredInstanceId,
+          providerName: isHandoffSwitch
+            ? preferredProvider
+            : (activeSession?.provider ?? preferredProvider),
+          providerInstanceId: isHandoffSwitch
+            ? desiredInstanceId
+            : (activeSession?.providerInstanceId ?? desiredInstanceId),
           runtimeMode: desiredRuntimeMode,
           activeTurnId: null,
           lastError: null,
@@ -628,29 +661,6 @@ const make = Effect.gen(function* () {
             : thread.modelSelection,
         requestedModelSelection,
       });
-    }
-    if (
-      thread.session !== null &&
-      requestedModelSelection !== undefined &&
-      requestedModelSelection.instanceId !== currentInstanceId
-    ) {
-      if (currentInfo.driverKind !== desiredInfo.driverKind) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' is bound to driver '${currentInfo.driverKind}' and cannot switch to '${desiredInfo.driverKind}'.`,
-        });
-      }
-      if (
-        currentInfo.continuationIdentity.continuationKey !==
-        desiredInfo.continuationIdentity.continuationKey
-      ) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' cannot switch from instance '${currentInstanceId}' to '${desiredInstanceId}' because their provider resume state is incompatible.`,
-        });
-      }
     }
     const project = yield* resolveProject(thread.projectId);
     const effectiveCwd = resolveThreadWorkspaceCwd({
@@ -722,6 +732,7 @@ const make = Effect.gen(function* () {
       const instanceChanged =
         requestedModelSelection !== undefined &&
         activeSession?.providerInstanceId !== requestedModelSelection.instanceId;
+      const shouldRestartForHandoff = isHandoffSwitch;
       const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "unsupported";
       const previousModelSelection = threadModelSelections.get(threadId);
       const shouldRestartForModelSelectionChange =
@@ -734,15 +745,21 @@ const make = Effect.gen(function* () {
         !cwdChanged &&
         !instanceChanged &&
         !shouldRestartForModelChange &&
-        !shouldRestartForModelSelectionChange
+        !shouldRestartForModelSelectionChange &&
+        !shouldRestartForHandoff
       ) {
         yield* refreshWorkspaceSnapshot;
         return existingSessionThreadId;
       }
 
-      const resumeCursor = shouldRestartForModelChange
-        ? undefined
-        : (activeSession?.resumeCursor ?? undefined);
+      if (shouldRestartForHandoff && activeSession) {
+        yield* providerService.stopSession({ threadId }).pipe(Effect.ignore);
+      }
+
+      const resumeCursor =
+        shouldRestartForModelChange || shouldRestartForHandoff
+          ? undefined
+          : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,
@@ -760,6 +777,7 @@ const make = Effect.gen(function* () {
         instanceChanged,
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
+        shouldRestartForHandoff,
         hasResumeCursor: resumeCursor !== undefined,
       });
       const restartedSession = yield* startProviderSession(
@@ -781,6 +799,54 @@ const make = Effect.gen(function* () {
     yield* bindSessionToThread(startedSession);
     return startedSession.threadId;
   });
+
+  const formatThreadHandoffContext = (input: {
+    readonly previousProviderLabel: string;
+    readonly newProviderLabel: string;
+    readonly messages: ReadonlyArray<OrchestrationMessage>;
+    readonly currentMessageText?: string;
+  }): string => {
+    let priorMessages = input.messages.filter(
+      (entry) => entry.role === "user" || entry.role === "assistant",
+    );
+
+    if (
+      input.currentMessageText !== undefined &&
+      priorMessages.length > 0 &&
+      priorMessages[priorMessages.length - 1]?.role === "user" &&
+      priorMessages[priorMessages.length - 1]?.text === input.currentMessageText
+    ) {
+      priorMessages = priorMessages.slice(0, -1);
+    }
+
+    if (priorMessages.length === 0) {
+      return "";
+    }
+
+    const parts: string[] = [
+      `[Context Handoff: The conversation has switched from ${input.previousProviderLabel} to ${input.newProviderLabel}]`,
+      "Below is the conversation history in this thread prior to this request:",
+      "---",
+    ];
+
+    const MAX_MESSAGE_CHARS = 4000;
+    for (const msg of priorMessages) {
+      const roleLabel = msg.role === "user" ? "User" : input.previousProviderLabel;
+      let text = assistantCitationsToPlainText(msg.text).trim();
+      if (text.length > MAX_MESSAGE_CHARS) {
+        text = text.slice(0, MAX_MESSAGE_CHARS) + " ...[truncated]";
+      }
+      if (text.length > 0) {
+        parts.push(`${roleLabel}: ${text}`);
+      }
+    }
+
+    parts.push("---");
+    parts.push(
+      "Note: The repository workspace on disk already reflects all file edits and commits made by the previous agent.",
+    );
+    return parts.join("\n");
+  };
 
   const buildSendTurnRequestForThread = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
@@ -805,6 +871,24 @@ const make = Effect.gen(function* () {
     }
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
     const normalizedAttachments = input.attachments ?? [];
+
+    const handoff = threadHandoffPending.get(input.threadId);
+    threadHandoffPending.delete(input.threadId);
+    let effectiveInput = normalizedInput;
+    if (handoff) {
+      const handoffContext = formatThreadHandoffContext({
+        previousProviderLabel: handoff.previousProviderLabel,
+        newProviderLabel: handoff.newProviderLabel,
+        messages: thread.messages,
+        currentMessageText: input.messageText,
+      });
+      if (handoffContext.length > 0) {
+        effectiveInput = normalizedInput
+          ? `${handoffContext}\n\nCurrent Request:\n${normalizedInput}`
+          : handoffContext;
+      }
+    }
+
     const activeSession = yield* providerService
       .listSessions()
       .pipe(
@@ -835,7 +919,9 @@ const make = Effect.gen(function* () {
 
     return {
       threadId: input.threadId,
-      ...(normalizedInput ? { input: normalizedInput } : {}),
+      ...(toNonEmptyProviderInput(effectiveInput)
+        ? { input: toNonEmptyProviderInput(effectiveInput) }
+        : {}),
       ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
       ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
       ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -334,11 +334,7 @@ const make = Effect.gen(function* () {
     );
 
   const threadModelSelections = new Map<string, ModelSelection>();
-  interface ThreadHandoffPending {
-    readonly previousProviderLabel: string;
-    readonly newProviderLabel: string;
-  }
-  const threadHandoffPending = new Map<string, ThreadHandoffPending>();
+  const threadContinuityPending = new Set<string>();
 
   const appendProviderFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -618,12 +614,7 @@ const make = Effect.gen(function* () {
       (isDriverChanged || isContinuationIncompatible);
 
     if (isHandoffSwitch) {
-      threadHandoffPending.set(threadId, {
-        previousProviderLabel:
-          currentInfo.displayName ?? providerErrorLabel(String(currentInfo.driverKind)),
-        newProviderLabel:
-          desiredInfo.displayName ?? providerErrorLabel(String(desiredInfo.driverKind)),
-      });
+      threadContinuityPending.add(threadId);
     }
 
     if (
@@ -803,9 +794,7 @@ const make = Effect.gen(function* () {
     return startedSession.threadId;
   });
 
-  const formatThreadHandoffContext = (input: {
-    readonly previousProviderLabel: string;
-    readonly newProviderLabel: string;
+  const formatThreadContinuityContext = (input: {
     readonly messages: ReadonlyArray<OrchestrationMessage>;
     readonly currentMessageId?: MessageId | undefined;
     readonly currentMessageText?: string | undefined;
@@ -830,8 +819,9 @@ const make = Effect.gen(function* () {
     }
 
     const parts: string[] = [
-      `[Context Handoff: The conversation has switched from ${input.previousProviderLabel} to ${input.newProviderLabel}]`,
-      "Below is the conversation history in this thread prior to this request:",
+      "[Thread Continuity Context]",
+      "Continue this existing conversation as one continuous thread. Prior assistant messages, actions, and workspace changes are part of your own conversation history. Respond directly from that history. Do not mention internal context transfer.",
+      "Conversation before the current request:",
       "---",
     ];
 
@@ -840,7 +830,7 @@ const make = Effect.gen(function* () {
     const messageBlocks: string[] = [];
 
     for (const msg of priorMessages) {
-      const roleLabel = msg.role === "user" ? "User" : `Assistant (${input.previousProviderLabel})`;
+      const roleLabel = msg.role === "user" ? "User" : "Assistant";
       let text = assistantCitationsToPlainText(msg.text).trim();
       const attachmentNames = (msg.attachments ?? []).map((a) => a.name).filter(Boolean);
       const attachmentSummary =
@@ -881,7 +871,7 @@ const make = Effect.gen(function* () {
 
     parts.push("---");
     parts.push(
-      "Note: The repository workspace on disk already reflects all file edits and commits made by the previous agent.",
+      "Repository workspace already reflects all file edits and commits from this thread.",
     );
     return parts.join("\n");
   };
@@ -911,21 +901,18 @@ const make = Effect.gen(function* () {
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
     const normalizedAttachments = input.attachments ?? [];
 
-    const handoff = threadHandoffPending.get(input.threadId);
-    threadHandoffPending.delete(input.threadId);
+    const needsContinuityContext = threadContinuityPending.delete(input.threadId);
     let effectiveInput = normalizedInput;
-    if (handoff) {
-      const handoffContext = formatThreadHandoffContext({
-        previousProviderLabel: handoff.previousProviderLabel,
-        newProviderLabel: handoff.newProviderLabel,
+    if (needsContinuityContext) {
+      const continuityContext = formatThreadContinuityContext({
         messages: thread.messages,
         currentMessageId: input.messageId,
         currentMessageText: input.messageText,
       });
-      if (handoffContext.length > 0) {
+      if (continuityContext.length > 0) {
         effectiveInput = normalizedInput
-          ? `${handoffContext}\n\nCurrent Request:\n${normalizedInput}`
-          : handoffContext;
+          ? `${continuityContext}\n\nCurrent Request:\n${normalizedInput}`
+          : continuityContext;
       }
     }
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -973,6 +973,21 @@ const make = Effect.gen(function* () {
     const normalizedAttachments = input.attachments ?? [];
 
     const needsContinuityContext = threadContinuityPending.has(input.threadId);
+    if (
+      input.modelSelection !== undefined &&
+      (needsContinuityContext ||
+        input.modelSelection.instanceId !== thread.modelSelection.instanceId ||
+        input.modelSelection.model !== thread.modelSelection.model)
+    ) {
+      yield* orchestrationEngine.dispatch({
+        type: "thread.meta.update",
+        commandId: yield* serverCommandId(
+          needsContinuityContext ? "thread-model-handoff" : "thread-model-selection",
+        ),
+        threadId: input.threadId,
+        modelSelection: input.modelSelection,
+      });
+    }
     let effectiveInput = normalizedInput;
     let effectiveAttachments = normalizedAttachments;
     let continuityContextIncluded = false;

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1349,6 +1349,37 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("uses an explicit null resume cursor to start a clean provider session", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-explicit-clean-start");
+      const initial = yield* provider.startSession(threadId, {
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId,
+        cwd: "/tmp/project-explicit-clean-start",
+        runtimeMode: "full-access",
+      });
+      yield* provider.stopSession({ threadId: initial.threadId });
+      routing.codex.startSession.mockClear();
+
+      yield* provider.startSession(threadId, {
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId,
+        cwd: "/tmp/project-explicit-clean-start",
+        resumeCursor: null,
+        runtimeMode: "full-access",
+      });
+
+      const cleanStartInput = routing.codex.startSession.mock.calls[0]?.[0];
+      assert.equal(typeof cleanStartInput === "object" && cleanStartInput !== null, true);
+      if (cleanStartInput && typeof cleanStartInput === "object") {
+        assert.equal("resumeCursor" in cleanStartInput, false);
+      }
+    }),
+  );
+
   it.effect("routes explicit claudeAgent provider session starts to the claude adapter", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -621,10 +621,11 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }
         const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
         const effectiveResumeCursor =
-          input.resumeCursor ??
-          (persistedBinding?.providerInstanceId === resolvedInstanceId
-            ? persistedBinding.resumeCursor
-            : undefined);
+          input.resumeCursor !== undefined
+            ? (input.resumeCursor ?? undefined)
+            : persistedBinding?.providerInstanceId === resolvedInstanceId
+              ? persistedBinding.resumeCursor
+              : undefined;
         const effectiveCwd =
           input.cwd ??
           (persistedBinding?.providerInstanceId === resolvedInstanceId

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -613,6 +613,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           threadId,
           provider: resolvedProvider,
         };
+        const { resumeCursor: requestedResumeCursor, ...inputWithoutResumeCursor } = input;
         if (!instanceInfo.enabled) {
           return yield* toValidationError(
             "ProviderService.startSession",
@@ -621,8 +622,8 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }
         const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
         const effectiveResumeCursor =
-          input.resumeCursor !== undefined
-            ? (input.resumeCursor ?? undefined)
+          requestedResumeCursor !== undefined
+            ? (requestedResumeCursor ?? undefined)
             : persistedBinding?.providerInstanceId === resolvedInstanceId
               ? persistedBinding.resumeCursor
               : undefined;
@@ -634,7 +635,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         yield* Effect.annotateCurrentSpan({
           "provider.kind": resolvedProvider,
           "provider.resume_cursor.source":
-            input.resumeCursor !== undefined
+            requestedResumeCursor !== undefined
               ? "request"
               : effectiveResumeCursor !== undefined &&
                   persistedBinding?.providerInstanceId === resolvedInstanceId
@@ -654,7 +655,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         yield* prepareMcpSession(threadId, resolvedInstanceId);
         const session = yield* adapter
           .startSession({
-            ...input,
+            ...inputWithoutResumeCursor,
             providerInstanceId: resolvedInstanceId,
             ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
             ...(effectiveResumeCursor !== undefined ? { resumeCursor: effectiveResumeCursor } : {}),

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -21,6 +21,7 @@ import {
   buildThreadTurnInterruptInput,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  deriveLockedProvider,
   dismissBranchMismatchForSession,
   ENVIRONMENT_RECONNECT_WARNING_GRACE_MS,
   getStartedThreadModelChangeBlockReason,
@@ -811,6 +812,100 @@ describe("getStartedThreadModelChangeBlockReason", () => {
       description:
         "This provider does not allow switching models after a conversation has started.",
     });
+  });
+});
+
+describe("deriveLockedProvider", () => {
+  it("returns null when thread has not started", () => {
+    expect(
+      deriveLockedProvider({
+        thread: null,
+        selectedProvider: "codex",
+        threadProvider: "codex",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for started threads when provider allows switching", () => {
+    const thread = {
+      id: ThreadId.make("thread-1"),
+      session: {
+        providerName: "claudeAgent",
+        providerInstanceId: ProviderInstanceId.make("claude"),
+        status: "ready",
+      },
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("claude"),
+        model: "claude-3-7-sonnet",
+      },
+      messages: [
+        {
+          id: MessageId.make("m1"),
+          role: "user",
+          text: "hello",
+          streaming: false,
+          turnId: TurnId.make("t1"),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    } as unknown as Thread;
+
+    expect(
+      deriveLockedProvider({
+        thread,
+        selectedProvider: "claudeAgent",
+        threadProvider: "claude",
+        providers: [
+          {
+            instanceId: ProviderInstanceId.make("claude"),
+          },
+          {
+            instanceId: ProviderInstanceId.make("codex"),
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("locks provider when provider explicitly requires a new thread for model changes", () => {
+    const thread = {
+      id: ThreadId.make("thread-1"),
+      session: {
+        providerName: "grok",
+        providerInstanceId: ProviderInstanceId.make("grok"),
+        status: "ready",
+      },
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("grok"),
+        model: "grok-build",
+      },
+      messages: [
+        {
+          id: MessageId.make("m1"),
+          role: "user",
+          text: "hello",
+          streaming: false,
+          turnId: TurnId.make("t1"),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    } as unknown as Thread;
+
+    expect(
+      deriveLockedProvider({
+        thread,
+        selectedProvider: "grok",
+        threadProvider: "grok",
+        providers: [
+          {
+            instanceId: ProviderInstanceId.make("grok"),
+            requiresNewThreadForModelChange: true,
+          },
+        ],
+      }),
+    ).toBe("grok");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -616,23 +616,32 @@ export function deriveLockedProvider(input: {
   thread: Thread | null | undefined;
   selectedProvider: string | null;
   threadProvider: string | null;
+  providers?: ReadonlyArray<Pick<ServerProvider, "instanceId" | "requiresNewThreadForModelChange">>;
 }): ProviderDriverKind | null {
   if (!threadHasStarted(input.thread)) {
     return null;
   }
-  const sessionProvider = input.thread?.session?.providerName ?? null;
-  if (sessionProvider && isProviderDriverKind(sessionProvider)) {
-    return sessionProvider;
+  const sessionInstanceId =
+    input.thread?.session?.providerInstanceId ?? input.thread?.modelSelection.instanceId;
+  const currentProvider = input.providers?.find(
+    (snapshot) => snapshot.instanceId === sessionInstanceId,
+  );
+  if (currentProvider?.requiresNewThreadForModelChange === true) {
+    const sessionProvider = input.thread?.session?.providerName ?? null;
+    if (sessionProvider && isProviderDriverKind(sessionProvider)) {
+      return sessionProvider;
+    }
+    const narrowedThreadProvider =
+      input.threadProvider && isProviderDriverKind(input.threadProvider)
+        ? input.threadProvider
+        : null;
+    const narrowedSelectedProvider =
+      input.selectedProvider && isProviderDriverKind(input.selectedProvider)
+        ? input.selectedProvider
+        : null;
+    return narrowedThreadProvider ?? narrowedSelectedProvider ?? null;
   }
-  const narrowedThreadProvider =
-    input.threadProvider && isProviderDriverKind(input.threadProvider)
-      ? input.threadProvider
-      : null;
-  const narrowedSelectedProvider =
-    input.selectedProvider && isProviderDriverKind(input.selectedProvider)
-      ? input.selectedProvider
-      : null;
-  return narrowedThreadProvider ?? narrowedSelectedProvider ?? null;
+  return null;
 }
 
 export function getStartedThreadModelChangeBlockReason(input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2198,11 +2198,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread?.modelSelection.instanceId ??
     activeProject?.defaultModelSelection?.instanceId ??
     null;
-  const lockedProvider = deriveLockedProvider({
-    thread: activeThread,
-    selectedProvider: selectedProviderByThreadId,
-    threadProvider,
-  });
+
   // Once a thread selects an environment, never substitute the primary
   // environment's config while the selected environment is still loading.
   const serverConfig = activeThread
@@ -2417,6 +2413,12 @@ function ChatViewContent(props: ChatViewProps) {
     versionMismatchServerLabel,
   ]);
   const providerStatuses = serverConfig?.providers ?? EMPTY_PROVIDERS;
+  const lockedProvider = deriveLockedProvider({
+    thread: activeThread,
+    selectedProvider: selectedProviderByThreadId,
+    threadProvider,
+    providers: providerStatuses,
+  });
   const unlockedSelectedProvider = resolveSelectableProvider(
     providerStatuses,
     selectedProviderByThreadId ?? threadProvider,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -13,7 +13,6 @@ import {
   type PreviewAnnotationPayload,
   ProviderInstanceId,
   type ServerProvider,
-  type ServerProviderSkill,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
   type ThreadId,
@@ -280,7 +279,7 @@ import {
   requestOlderThreadTurns,
   threadHasOlderTurns,
 } from "@t3tools/client-runtime/state/threads";
-import { resolveProviderSkillsForCwd } from "@t3tools/client-runtime/providerSkills";
+import { resolveProviderSkillsForCwdAcrossProviders } from "@t3tools/client-runtime/providerSkills";
 import { vcsEnvironment } from "../state/vcs";
 import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
 import {
@@ -2962,16 +2961,8 @@ function ChatViewContent(props: ChatViewProps) {
     return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
   }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
   const timelineSkills = useMemo(() => {
-    const map = new Map<string, ServerProviderSkill>();
-    for (const provider of providerStatuses) {
-      const skills = resolveProviderSkillsForCwd(provider, gitCwd);
-      for (const skill of skills) {
-        if (!map.has(skill.name)) {
-          map.set(skill.name, skill);
-        }
-      }
-    }
-    return map.size > 0 ? Array.from(map.values()) : EMPTY_PROVIDER_SKILLS;
+    const skills = resolveProviderSkillsForCwdAcrossProviders(providerStatuses, gitCwd);
+    return skills.length > 0 ? skills : EMPTY_PROVIDER_SKILLS;
   }, [providerStatuses, gitCwd]);
   const [resumeCompactionPermanentlyDismissed, setResumeCompactionPermanentlyDismissed] =
     useLocalStorage(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -13,6 +13,7 @@ import {
   type PreviewAnnotationPayload,
   ProviderInstanceId,
   type ServerProvider,
+  type ServerProviderSkill,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
   type ThreadId,
@@ -2960,6 +2961,18 @@ function ChatViewContent(props: ChatViewProps) {
     const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
     return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
   }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
+  const timelineSkills = useMemo(() => {
+    const map = new Map<string, ServerProviderSkill>();
+    for (const provider of providerStatuses) {
+      const skills = resolveProviderSkillsForCwd(provider, gitCwd);
+      for (const skill of skills) {
+        if (!map.has(skill.name)) {
+          map.set(skill.name, skill);
+        }
+      }
+    }
+    return map.size > 0 ? Array.from(map.values()) : EMPTY_PROVIDER_SKILLS;
+  }, [providerStatuses, gitCwd]);
   const [resumeCompactionPermanentlyDismissed, setResumeCompactionPermanentlyDismissed] =
     useLocalStorage(
       `t3code:resume-compaction-dismissed:${environmentId}:${activeProviderInstanceId ?? "claudeAgent"}`,
@@ -7616,11 +7629,7 @@ function ChatViewContent(props: ChatViewProps) {
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
                 workspaceRoot={activeWorkspaceRoot}
-                skills={
-                  activeProviderStatus
-                    ? resolveProviderSkillsForCwd(activeProviderStatus, gitCwd)
-                    : EMPTY_PROVIDER_SKILLS
-                }
+                skills={timelineSkills}
                 anchorMessageId={timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
                 contentInsetEndAdjustment={composerOverlayHeight}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -11,7 +11,6 @@ import type {
   RuntimeMode,
   ScopedThreadRef,
   ServerProvider,
-  ServerProviderSkill,
   ThreadId,
 } from "@t3tools/contracts";
 import {
@@ -339,6 +338,7 @@ import {
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
   resolveProviderSkillsForCwd,
+  resolveProviderSkillsForCwdAcrossProviders,
   resolveProviderSlashCommandsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
 import { searchProviderSkills } from "../../providerSkillSearch";
@@ -1134,16 +1134,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (directSkills.length > 0) {
       return directSkills;
     }
-    const fallbackMap = new Map<string, ServerProviderSkill>();
-    for (const provider of providerStatuses) {
-      const skills = resolveProviderSkillsForCwd(provider, gitCwd);
-      for (const skill of skills) {
-        if (!fallbackMap.has(skill.name)) {
-          fallbackMap.set(skill.name, skill);
-        }
-      }
-    }
-    return Array.from(fallbackMap.values());
+    return resolveProviderSkillsForCwdAcrossProviders(providerStatuses, gitCwd);
   }, [selectedProviderStatus, providerStatuses, gitCwd]);
   const selectedProviderSlashCommands = selectedProviderStatus
     ? resolveProviderSlashCommandsForCwd(selectedProviderStatus, gitCwd)

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -11,6 +11,7 @@ import type {
   RuntimeMode,
   ScopedThreadRef,
   ServerProvider,
+  ServerProviderSkill,
   ThreadId,
 } from "@t3tools/contracts";
 import {
@@ -1126,9 +1127,24 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => selectedProviderEntry?.snapshot ?? null,
     [selectedProviderEntry],
   );
-  const selectedProviderSkills = selectedProviderStatus
-    ? resolveProviderSkillsForCwd(selectedProviderStatus, gitCwd)
-    : [];
+  const selectedProviderSkills = useMemo(() => {
+    const directSkills = selectedProviderStatus
+      ? resolveProviderSkillsForCwd(selectedProviderStatus, gitCwd)
+      : [];
+    if (directSkills.length > 0) {
+      return directSkills;
+    }
+    const fallbackMap = new Map<string, ServerProviderSkill>();
+    for (const provider of providerStatuses) {
+      const skills = resolveProviderSkillsForCwd(provider, gitCwd);
+      for (const skill of skills) {
+        if (!fallbackMap.has(skill.name)) {
+          fallbackMap.set(skill.name, skill);
+        }
+      }
+    }
+    return Array.from(fallbackMap.values());
+  }, [selectedProviderStatus, providerStatuses, gitCwd]);
   const selectedProviderSlashCommands = selectedProviderStatus
     ? resolveProviderSlashCommandsForCwd(selectedProviderStatus, gitCwd)
     : [];

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -7,6 +7,7 @@ import {
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
   resolveProviderSkillsForCwd,
+  resolveProviderSkillsForCwdAcrossProviders,
   resolveProviderSlashCommandsForCwd,
   resolveProviderSkillSourceKind,
 } from "./providerSkills.ts";
@@ -250,5 +251,39 @@ describe("workspace provider snapshots", () => {
   it("keeps the machine snapshot before this cwd has a provider snapshot", () => {
     expect(resolveProviderSkillsForCwd(provider, "/workspace/project-b")).toEqual(provider.skills);
     expect(resolveProviderSlashCommandsForCwd(provider, null)).toEqual(provider.slashCommands);
+  });
+
+  it("keeps skills from every provider available for persisted thread rendering", () => {
+    const openCode = {
+      ...provider,
+      instanceId: ProviderInstanceId.make("opencode"),
+      driver: ProviderDriverKind.make("opencode"),
+      skills: [{ name: "review", path: "/opencode/review/SKILL.md", enabled: true }],
+      workspaceSnapshots: [],
+    } satisfies ServerProvider;
+
+    expect(resolveProviderSkillsForCwdAcrossProviders([provider, openCode], null)).toEqual([
+      { name: "global", path: "/global/SKILL.md", enabled: true },
+      { name: "review", path: "/opencode/review/SKILL.md", enabled: true },
+    ]);
+  });
+
+  it("deduplicates shared skill names across providers", () => {
+    const duplicateProvider = {
+      ...provider,
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      driver: ProviderDriverKind.make("claudeAgent"),
+      skills: [
+        { name: "GLOBAL", path: "/claude/global/SKILL.md", enabled: true },
+        { name: "deploy", path: "/claude/deploy/SKILL.md", enabled: true },
+      ],
+      workspaceSnapshots: [],
+    } satisfies ServerProvider;
+
+    expect(
+      resolveProviderSkillsForCwdAcrossProviders([provider, duplicateProvider], null).map(
+        (skill) => skill.name,
+      ),
+    ).toEqual(["global", "deploy"]);
   });
 });

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -118,6 +118,16 @@ export function resolveProviderSkillsForCwd(
   return resolveProviderWorkspaceSnapshot(provider, cwd)?.skills ?? provider.skills;
 }
 
+/** Skills known anywhere in an environment, kept available across provider changes. */
+export function resolveProviderSkillsForCwdAcrossProviders(
+  providers: ReadonlyArray<ServerProvider>,
+  cwd: string | null | undefined,
+): ServerProviderSkill[] {
+  return dedupeProviderSkillsByName(
+    providers.flatMap((provider) => resolveProviderSkillsForCwd(provider, cwd)),
+  );
+}
+
 export function resolveProviderSlashCommandsForCwd(
   provider: ServerProvider,
   cwd: string | null | undefined,


### PR DESCRIPTION
## What Changed

Unlocks mid-thread provider switching. Previously threads were locked to their initial provider instance, switching Codex/Claude/OpenCode mid-conversation was either blocked in the UI or failed with a hard driver-mismatch error. Now the server stops the previous provider session cleanly, starts a fresh one without incompatible driver cursors, and injects a synthesized Markdown conversation-history block into the initial turn prompt so the new provider has context. Follow-up fixes keep skill chips intact across the switch, keep the handoff transparent to the user (no "previous agent" leakage), and preserve session state correctly across switches.

## Why

Users want to change providers mid-conversation, e.g. moving from Codex to Claude when they hit a subscription usage limit,without losing thread history or starting over. The previous hard-block/driver-mismatch failure made that impossible.

## UI Changes
NONE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core turn/session orchestration and injects large synthesized prompts on provider handoff; regressions could affect session binding, input limits, or continuity on retry/failure paths.
> 
> **Overview**
> **Mid-thread provider switching** is now supported end-to-end. The server no longer rejects cross-driver or incompatible-continuation switches; on handoff it stops the prior session, starts the new provider with an explicit clean resume (`resumeCursor: null`), and on the first post-switch turn prepends a bounded `[Thread Continuity Context]` block (prior user/assistant text, re-carried attachments, escaped `$skill` tokens) plus **Current Request**. Failed sends that included that context re-queue the handoff so retries still carry history.
> 
> **ProviderService** treats `resumeCursor: null` as a forced fresh session; omitting the field still reuses a persisted cursor when the instance matches.
> 
> **Clients** unlock the provider picker for started threads unless the active instance sets `requiresNewThreadForModelChange`. Composers and timelines use **`resolveProviderSkillsForCwdAcrossProviders`** (with per-provider fallback in slash menus) so skills stay visible after a switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfe9088b2d27b42b5fcb2dac60ebebfb63265ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mid-thread provider switching with conversation continuity and cross-provider skills
> - `ProviderCommandReactor.ensureSessionForThread` replaces rejection of cross-driver model switches with handoff handling: stops the old session, starts the new provider with a null resume cursor, and builds a bounded continuity prompt from prior user/assistant messages and attachments.
> - `ProviderService.startSession` distinguishes omitted vs explicit `null` resume cursors, forcing a clean adapter session when `null` is passed so persisted cursors are not reused.
> - `deriveLockedProvider` in `ChatView.logic.ts` now uses provider snapshots to lock a started thread only when the current provider explicitly requires a new thread for model changes.
> - Web and mobile composers and timelines use the new `resolveProviderSkillsForCwdAcrossProviders` to show deduplicated skills from all configured providers, falling back when the selected provider has no cwd-resolved skills.
> - `escapeThreadContinuitySkillTokens` prefixes standalone dollar skill tokens with a backslash so continuity prompts do not trigger skill execution on the replacement provider.
> - Risk: `buildSendTurnRequestForThread` clears the pending-continuity flag only after session/capability checks; a send failure restores it via the turn-start processor. Reviewers should verify the flag lifecycle in `ProviderCommandReactor.ts` to ensure retries rebuild context and that no path leaves the flag stuck.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bfe908.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->