### PR TITLE
perf(ci): reuse dependency checks in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,8 @@ jobs:
           node-version-file: package.json
           cache: true
           run-install: true
+        env:
+          pnpm_config_cache_dir: ${{ runner.temp }}/pnpm-metadata
 
       - id: release_meta
         name: Resolve release version
@@ -173,6 +175,14 @@ jobs:
             --channel "${{ steps.release_meta.outputs.release_channel }}" \
             --current-tag "${{ steps.release_meta.outputs.tag }}" \
             --github-output
+
+      # Share only the verification results, not the large registry metadata cache.
+      - name: Upload dependency verification
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dependency-verification
+          path: ${{ runner.temp }}/pnpm-metadata/lockfile-verified.jsonl
 
   quality:
     name: Release quality checks
@@ -446,7 +456,18 @@ jobs:
           path: ${{ steps.package_cache_path.outputs.path }}
           key: windows-release-packages-v1-${{ matrix.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
 
+      # pnpm checks the lockfile and policy before reusing this result. A missing
+      # artifact leaves the cache empty, so installation runs the checks again.
+      - name: Download dependency verification
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: release-dependency-verification
+          path: ${{ runner.temp }}/pnpm-metadata
+
       - name: Install desktop dependencies
+        env:
+          pnpm_config_cache_dir: ${{ runner.temp }}/pnpm-metadata
         run: vp install --filter=@t3tools/desktop... --filter=t3... --filter=@t3tools/scripts...
 
       - name: Cache resource monitor
@@ -583,6 +604,7 @@ jobs:
       - name: Build desktop artifact
         shell: bash
         env:
+          pnpm_config_cache_dir: ${{ runner.temp }}/pnpm-metadata
           T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR: ${{ steps.resource_monitor_cache.outputs.cache-hit == 'true' }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -28,4 +28,9 @@ signing only when platform credentials are present. macOS passkey builds additio
 `APPLE_TEAM_ID` and the `MACOS_PROVISIONING_PROFILE` secret; Windows uses Azure Trusted Signing.
 Without the core signing credentials, it still releases unsigned artifacts.
 
+Preflight shares pnpm's lockfile verification results with the desktop build jobs through a small
+artifact. This avoids repeating dependency checks, especially on Windows, without transferring the
+large registry metadata cache. pnpm checks the current lockfile and policy before it reuses a result.
+If the artifact is unavailable, installation runs the checks again.
+
 See [Release Checklist](../operations/release.md) for the full release/signing setup checklist.


### PR DESCRIPTION
Windows release builds repeat pnpm's lockfile checks after preflight already ran them. A [recent Windows run](https://github.com/pingdotgg/t3code/actions/runs/33725449896) spent 49 seconds on these checks alongside package installation.

Pass preflight's small verification file to the desktop builds. pnpm checks the current lockfile and policy before reusing it. If the artifact is unavailable, installation runs the checks again. Build order, package caches, signing, and release quality checks stay unchanged.

## Validation

- Tested pnpm 11.10.0 with only the verification file copied to a new workspace. Missing files, changed lockfiles, and changed policies triggered verification again.
- Targeted format checks passed. Actionlint found no new diagnostics against main.
- Windows time savings are not measured. No release was triggered.

Implemented with GPT-5.6 Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with graceful fallback when the artifact is absent; no application runtime or security logic changes.
> 
> **Overview**
> Release desktop builds were redoing pnpm lockfile/policy checks after **preflight** had already run them (notably costly on Windows). This PR **reuses** only the small verification output instead of copying the full registry metadata cache.
> 
> **Preflight** now sets `pnpm_config_cache_dir` under the runner temp dir during install, then uploads `lockfile-verified.jsonl` as the `release-dependency-verification` artifact (`continue-on-error: true`). **Matrix build** jobs download that artifact into the same cache dir, set the same env on **Install desktop dependencies** and **Build desktop artifact**, so pnpm can skip redundant checks when the lockfile and policy still match. If the artifact is missing, install falls back to running verification again.
> 
> `docs/internals/ci.md` documents this handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee93f51d72526f325410e9a69572863ee93f59e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache release preflight dependency checks for desktop build jobs
> - The release preflight job uploads a `release-dependency-verification` artifact containing `lockfile-verified.jsonl`.
> - Desktop dependency installation and artifact build jobs download this artifact into the pnpm metadata cache directory to reuse the verification data.
> - Updates [docs/internals/ci.md](https://github.com/pingdotgg/t3code/pull/9399/files#diff-d88698dc5909f010b1462a8ad36a3f429f191b627825e2acac8214ba2ec254b3) to document the lockfile verification sharing mechanism.
> - Risk: Artifact upload and download steps are best-effort; failures do not fail the job and checks rerun normally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee93f51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->