### PR TITLE
test(server): resolve the temp dir before matching the symlinked entrypoint

### DIFF
--- a/apps/server/src/entrypoint.test.ts
+++ b/apps/server/src/entrypoint.test.ts
@@ -54,9 +54,11 @@ describe("isEntrypoint", () => {
       NodeFS.writeFileSync(real, "");
       NodeFS.symlinkSync(real, link);
 
+      // Node resolves the module URL to the real path, and on macOS the temp
+      // directory itself sits behind a symlink (`/var` -> `/private/var`).
       expect(
         isEntrypoint({
-          moduleUrl: NodeURL.pathToFileURL(real).href,
+          moduleUrl: NodeURL.pathToFileURL(NodeFS.realpathSync(real)).href,
           entryPath: link,
           runtimeMain: undefined,
         }),


### PR DESCRIPTION
## What Changed

`apps/server/src/entrypoint.test.ts`, "matches through a symlinked entrypoint": the expected module URL is now built from `realpathSync(real)` instead of the raw temp path. One line plus a comment.

## Why

Fixes #9389.

`isEntrypoint` compares the module URL against the realpath of the entry, which is what makes npm/npx-style symlinked entrypoints match. The fixture built its expected URL from the un-resolved temp path. On macOS the temp dir lives under `/var`, itself a symlink to `/private/var`, so the two strings never matched and the test failed on every run. Linux CI is unaffected, which is why this only shows up locally on macOS.

The product code is correct. Canonicalizing the fixture path keeps the test focused on the symlink it is meant to exercise.

Before, on macOS:

```
× matches through a symlinked entrypoint, as npm and npx install it
AssertionError: expected false to be true
```

After:

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Server typecheck and lint are clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (no UI changes)
- [ ] I included a video for animation/interaction changes (not applicable)

Model and harness: Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; entrypoint detection logic is untouched.
> 
> **Overview**
> Fixes a **macOS-only failure** in `entrypoint.test.ts` for the symlinked npm/npx entrypoint case (#9389).
> 
> The test now builds the expected `moduleUrl` from `NodeFS.realpathSync(real)` instead of the raw temp path, matching how `isEntrypoint` compares against the realpath of `entryPath`. On macOS, temp dirs under `/var` (symlinked to `/private/var`) made the old expected string never match even though production behavior is correct.
> 
> Adds a short comment explaining Node URL resolution and the `/var` symlink. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f629824f6ff2e61f18d6c3fbb4db9e19a790f34c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve temp dir real path in `isEntrypoint` symlinked-entrypoint test
> Updates the test fixture's module URL in [entrypoint.test.ts](https://github.com/pingdotgg/t3code/pull/9400/files#diff-d5f73be07c19ce8ffb26e958045929c084f6d206e6f52a6b3faf9faafa52ddd2) to use the filesystem-resolved real path of the target file. Node resolves module URLs to real paths, and macOS temp directories can be symlinked, which caused the previous assertion to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f629824.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed symlinked entrypoint testing to correctly resolve module URLs to the underlying real file path, including environments where temporary directories use symlinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->