### PR TITLE
test(server): resolve the temp dir before asserting discovered Cursor skill paths

### DIFF
--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -328,10 +328,13 @@ describe("Cursor skills", () => {
           directory: NodeOS.tmpdir(),
           prefix: "cursor-skills-home-",
         });
-        const workspace = yield* fileSystem.makeTempDirectory({
+        const workspaceDirectory = yield* fileSystem.makeTempDirectory({
           directory: NodeOS.tmpdir(),
           prefix: "cursor-skills-workspace-",
         });
+        // Discovery canonicalizes skill paths, and on macOS the temp directory
+        // itself sits behind a symlink (`/var` -> `/private/var`).
+        const workspace = yield* fileSystem.realPath(workspaceDirectory);
         const writeSkill = Effect.fn("writeCursorSkill")(function* (
           root: string,
           name: string,


### PR DESCRIPTION
## What Changed

`apps/server/src/provider/Layers/CursorProvider.test.ts`, "discovers recursive project skills with project precedence": the workspace temp directory is resolved with `fileSystem.realPath` before the fixture is written, so the expected skill paths are built from the canonical path. Two lines plus a comment.

## Why

Fixes #9388.

Cursor skill discovery (from #9180) canonicalizes every skill path with `realpath`, but the fixture built its expectations from the raw `os.tmpdir()` workspace. On macOS the temp dir lives under `/var`, itself a symlink to `/private/var`, so expected and received paths never matched and the test failed on every run. Linux CI is unaffected, which is why this only shows up locally on macOS.

The product code is correct. Canonicalizing the workspace in the fixture matches what discovery reports, the same approach other server tests already use with `fileSystem.realPath`.

Before, on macOS:

```
× discovers recursive project skills with project precedence
-     "path": "/var/folders/.../cursor-skills-workspace-XXXX/.cursor/skills/internal/SKILL.md",
+     "path": "/private/var/folders/.../cursor-skills-workspace-XXXX/.cursor/skills/internal/SKILL.md",
```

After:

```
Test Files  1 passed (1)
     Tests  25 passed (25)
```

Server typecheck and lint are clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (no UI changes)
- [ ] I included a video for animation/interaction changes (not applicable)

Model and harness: Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior impact.
> 
> **Overview**
> Fixes a **macOS-only failure** in the Cursor skills discovery test by building expected skill paths from the **canonical workspace path** instead of the raw temp directory.
> 
> The fixture now calls `fileSystem.realPath` on the workspace temp dir before writing skills and asserting paths, matching production behavior in `discoverCursorSkills`, which canonicalizes directories via `realPath`. On macOS, `os.tmpdir()` often resolves under `/var` while `realPath` yields `/private/var`, so expectations and discovered paths previously diverged; Linux CI was unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d778d70eaf373d7e1cd3bd86d21301eb06d625e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve temp dir via `realPath` before asserting Cursor skill paths in test
> The recursive project-skills discovery test in [CursorProvider.test.ts](https://github.com/pingdotgg/t3code/pull/9401/files#diff-5d4e43078b6cc1220d1a70c97c171118d5ee124ae17ac8d3d620432f9c402c36) now canonicalizes the temporary workspace path through the filesystem service's `realPath` operation before setting up and asserting project skills. This avoids mismatches caused by the macOS `/var` to `/private/var` symlink, where the raw temp dir path and the discovered path differ.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d778d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->