### PR TITLE
fix(web): honor browser profile for agent-opened tabs

### DIFF
--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -41,7 +41,11 @@ import {
   acquireBrowserSurfaceActivity,
   useBrowserSurfaceStore,
 } from "~/browser/browserSurfaceStore";
-import { browserDefaultOpenViewport, resolveBrowserDefaults } from "~/browser/browserDefaults";
+import {
+  browserDefaultOpenProfileId,
+  browserDefaultOpenViewport,
+  resolveBrowserDefaults,
+} from "~/browser/browserDefaults";
 import { runBrowserViewportMutation } from "~/browser/browserViewportActions";
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { isElectron } from "~/env";
@@ -390,14 +394,16 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const reusedExistingTab = activeTabId !== null;
             tabId = activeTabId;
             if (!activeTabId) {
+              const browserDefaults = await resolveBrowserDefaults();
               const result = await open({
                 environmentId,
                 input: {
                   threadId: request.threadId,
                   ...(resolvedInputUrl ? { url: resolvedInputUrl } : {}),
-                  // An agent that didn't state a size gets the user's
-                  // configured default, same as a hand-opened tab.
-                  viewport: browserDefaultOpenViewport(await resolveBrowserDefaults()),
+                  // New agent tabs use the same configured browser profile
+                  // and viewport as tabs opened by the user.
+                  viewport: browserDefaultOpenViewport(browserDefaults),
+                  profileId: browserDefaultOpenProfileId(browserDefaults),
                 },
               });
               if (result._tag === "Failure") {


### PR DESCRIPTION
## What changed

- Pass the selected browser profile when an agent creates a preview tab.
- Keep the existing configured viewport behavior and leave reused tabs on their current profile.

## Why

Agent-driven `preview_open` calls already used the configured viewport, but they omitted the configured profile. A newly created agent tab therefore opened in the built-in Default browser partition even when the user selected another default profile.

Browser profiles are fixed when Electron attaches the guest. The change uses the existing `browserDefaultOpenProfileId` resolution at session creation. It does not change the product default, profile fallback rules, contracts, or old and reused tabs.

## UI changes

No layout, copy, or motion changes. New agent-created preview tabs now use the browser profile selected in Settings.

## Verification

- `./node_modules/.bin/vp test run apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts apps/web/src/browser/browserDefaults.test.ts apps/web/src/components/preview/openPreviewSession.test.ts apps/web/src/components/preview/addBrowserSurface.test.ts apps/web/src/components/preview/openTerminalLinkInPreview.test.ts apps/web/src/components/preview/previewAutomationTarget.test.ts apps/server/src/preview/Manager.test.ts apps/web/src/browser/previewWebviewConfigState.test.ts apps/desktop/src/ipc/methods/preview.test.ts apps/desktop/src/preview/BrowserSession.test.ts` (65 tests passed)
- `./node_modules/.bin/vp run --filter @t3tools/web typecheck`
- `./node_modules/.bin/vpr --filter @t3tools/web typecheck`
- `npx --yes fallow audit --format json --quiet --explain --base upstream/main --workspace @t3tools/web` (`pass`; 0 introduced findings)
- `./node_modules/.bin/vp lint --report-unused-disable-directives apps/web/src/components/preview/PreviewAutomationHosts.tsx`
- `./node_modules/.bin/vp fmt --check apps/web/src/components/preview/PreviewAutomationHosts.tsx`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before and after screenshots for UI changes (not applicable: no visual design or copy change)
- [x] I included a video for animation or interaction changes (not applicable: no motion change)

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session-creation behavior for agent preview tabs only; aligns with existing user-open paths and does not touch auth or reused tabs.
> 
> **Overview**
> Agent-driven **`preview_open`** now passes the user’s configured **browser profile** and **viewport** when it creates a new tab, via a shared **`previewAutomationNewTabDefaults`** helper, so automation matches hand-opened preview sessions instead of falling back to the default partition.
> 
> **`PreviewAutomationHosts`** resolves **`resolveBrowserDefaults()`** once per open request and spreads those defaults into **`preview.open`**; reused tabs are unchanged. A regression test asserts the helper forwards **`profileId`** and **`viewport`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25126bb72d6c2b8e8359494b2c667b1d6bf2838e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `PreviewAutomationHost` to pass browser profile and viewport to new tabs
> - Adds the `previewAutomationNewTabDefaults` helper to supply the configured browser viewport and profile to new agent-opened tabs.
> - `PreviewAutomationHost` resolves browser defaults once per tab opening instead of resolving them a second time for the floating-preview preference.
> - Behavioral Change: Automation-created tabs now open with the configured browser profile and viewport instead of falling back to default values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25126bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Opening a new browser tab now applies the configured default browser profile.
  * Browser defaults are resolved consistently when setting the new tab’s profile and viewport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
