### PR TITLE
fix(server): unset the allow-scripts policy npx exports before installing the pinned runtime

### DIFF
--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -228,6 +228,67 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
     }),
   );
 
+  it.effect("drops every spelling of the inherited allow-scripts policy from the installer", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-runtime-env-" });
+      // npx exports the lowercase name and npm reads the uppercase one just the
+      // same. Unrelated npm configuration must still reach the child.
+      const stubbed = {
+        npm_config_allow_scripts: "true",
+        NPM_CONFIG_ALLOW_SCRIPTS: "true",
+        npm_config_registry: "https://registry.example.test/",
+      };
+      const previous = Object.fromEntries(
+        Object.keys(stubbed).map((key) => [key, process.env[key]]),
+      );
+      Object.assign(process.env, stubbed);
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          for (const [key, value] of Object.entries(previous)) {
+            if (value === undefined) delete process.env[key];
+            else process.env[key] = value;
+          }
+        }),
+      );
+
+      // Spawn a real child with exactly what the installer hands npm, so the
+      // assertion covers the environment the child sees rather than the input.
+      const real = yield* Effect.service(ProcessRunner.ProcessRunner).pipe(
+        Effect.provide(ProcessRunner.layer),
+      );
+      const inner = successfulRunner(fs, path);
+      let childEnv: Record<string, string | undefined> | undefined;
+      const runner = ProcessRunner.ProcessRunner.of({
+        run: (input) =>
+          Effect.gen(function* () {
+            const probe = yield* real.run({
+              ...input,
+              command: process.execPath,
+              args: ["-e", "process.stdout.write(JSON.stringify(process.env))"],
+            });
+            childEnv = JSON.parse(probe.stdout) as Record<string, string | undefined>;
+            return yield* inner.run(input);
+          }),
+      });
+
+      yield* ensurePinnedRuntimeInstalled({
+        baseDir,
+        version: "1.2.3",
+        fs,
+        path,
+        runner,
+        validate: () => Effect.void,
+      });
+
+      assert.isDefined(childEnv);
+      assert.notProperty(childEnv, "npm_config_allow_scripts");
+      assert.notProperty(childEnv, "NPM_CONFIG_ALLOW_SCRIPTS");
+      assert.equal(childEnv.npm_config_registry, "https://registry.example.test/");
+    }),
+  );
+
   it.effect("removes staging when installation is interrupted", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -6,6 +6,7 @@ import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Option from "effect/Option";
 import * as Semaphore from "effect/Semaphore";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 
 import * as ProcessRunner from "../processRunner.ts";
 
@@ -161,10 +162,22 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
       "--no-audit",
       `t3@${input.version}`,
     ];
+    // npx exports its resolved allow-scripts policy as npm_config_allow_scripts,
+    // which npm 12 reads as a project-scoped --allow-scripts and refuses with
+    // EALLOWSCRIPTS. npm matches config variable names case-insensitively, so
+    // unset every spelling the child would inherit (Node drops undefined
+    // entries) and leave the rest of the npm configuration alone.
+    const hostEnvironment = yield* HostProcessEnvironment;
+    const installEnv = Object.fromEntries(
+      Object.keys(hostEnvironment)
+        .filter((key) => /^npm_config_allow[-_]scripts$/i.test(key))
+        .map((key) => [key, undefined]),
+    );
     yield* runner
       .run({
         command: "npm",
         args: installArgs,
+        env: installEnv,
         // Native dependencies may compile from source on slower machines.
         timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
       })
@@ -178,6 +191,7 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
                 runner.run({
                   command: "pnpm",
                   args: ["--package=npm@11", "dlx", "npm", ...installArgs],
+                  env: installEnv,
                   timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
                 })
               : Effect.fail(error),


### PR DESCRIPTION
## What Changed

`apps/server/src/cloud/pinnedRuntime.ts`: the `npm install --prefix <staging>` child that installs the pinned runtime now runs with `npm_config_allow_scripts` unset. One `env` entry plus a comment.

`apps/server/src/cloud/pinnedRuntime.test.ts`: a focused test that the install runner receives the variable overridden to `undefined`. It fails without the fix.

## Why

Fixes #9398.

npx exports its resolved allow-scripts config to child processes as `npm_config_allow_scripts`. The CLI inherits it and hands it to the pinned-runtime `npm install`. npm 12 treats an env-sourced policy like a `--allow-scripts` flag and refuses project-scoped installs with `EALLOWSCRIPTS`, so `npx t3 service install` and `npx t3 service update` fail whenever `~/.npmrc` holds an `allow-scripts` entry. The reporter confirmed the same CLI succeeds once the variable is unset.

The runner extends the host environment and Node drops `undefined` entries, so the override removes the variable for the child only. The user-level `.npmrc` policy still applies to the install, which is the layer that should grant native builds.

This is scoped to the one variable that is proven to break the install. It is independent of #9380, which grants the native builds through the staged manifest; both can land.

Verification:

```
vp test run apps/server/src/cloud/pinnedRuntime.test.ts   # 6 passed
```

Server typecheck and lint are clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (no UI changes)
- [ ] I included a video for animation/interaction changes (not applicable)

Model and harness: Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow env override on one subprocess during pinned-runtime install; behavior is covered by a unit test and targets a known npm 12 / npx interaction.
> 
> **Overview**
> Fixes pinned runtime installation failing when the CLI is started via **npx** and the host has an `allow-scripts` policy in `~/.npmrc` (npm 12 treats npx-exported `npm_config_allow_scripts` like a project-scoped `--allow-scripts` and aborts with **EALLOWSCRIPTS**).
> 
> The staged `npm install --prefix …` for the pinned `t3@<version>` runtime now passes **`env: { npm_config_allow_scripts: undefined }`** so the child process does not inherit npx’s resolved policy; the process runner still merges the host environment and Node omits `undefined` keys, so user-level `.npmrc` rules remain in effect for that install.
> 
> A new **`pinnedRuntime.test.ts`** case asserts the install runner receives `npm_config_allow_scripts` as an own property set to `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70662afee2db1c616080ea8da920ec22815dd6bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unset `npm_config_allow_scripts` in `installPinnedRuntime` child-process env
> The pinned runtime install was inheriting the `npx` allow-scripts policy, which npm 12 could interpret as a project-scoped install option. The fix sets `npm_config_allow_scripts` to `undefined` at the child-process environment boundary so the install does not inherit it. Adds a test in [pinnedRuntime.test.ts](https://github.com/pingdotgg/t3code/pull/9403/files#diff-1937e937286135087a07abf3ef962719a67ecb201224aa6ea8ae8bf730fe2e19) asserting the install runner receives the undefined override.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70662af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime installation reliability by preventing inherited npm script-approval settings from affecting installation processes.
  * Preserved unrelated npm configuration, such as custom registry settings, during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->