### PR TITLE
feat(web): copy chat and terminal selections automatically, Herdr-style

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -60,7 +60,7 @@ const clientSettings: ClientSettings = {
   legacySidebarEnabled: false,
   timestampFormat: "24-hour",
   wordWrap: true,
-  copyOnSelect: true,
+  copyOnSelect: false,
   copyOnSelectToast: true,
 };
 

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -60,6 +60,8 @@ const clientSettings: ClientSettings = {
   legacySidebarEnabled: false,
   timestampFormat: "24-hour",
   wordWrap: true,
+  copyOnSelect: true,
+  copyOnSelectToast: true,
 };
 
 const decodeClientSettingsJson = Schema.decodeEffect(Schema.fromJsonString(ClientSettingsSchema));

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -42,6 +42,9 @@ import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { Button } from "~/components/ui/button";
 import { PanelTabCloseButton } from "~/components/ui/panel-tab-close-button";
 import { readTextFromClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
+import { getClientSettings } from "~/hooks/useSettings";
+import { normalizeTerminalSelectionText } from "~/lib/copyOnSelect";
+import { toastManager } from "~/components/ui/toast";
 import { cn } from "~/lib/utils";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
 import {
@@ -460,6 +463,9 @@ export function TerminalViewport({
     let setupTerminal: GhosttyTerminalSurface | null = null;
     let setupCleanups: Array<() => void> = [];
     let selectionActions: ReturnType<typeof observeSelectionActions> | null = null;
+    // Last text confirmed via copy-on-select, so repeat gestures over an
+    // unchanged selection stay quiet instead of re-toasting.
+    let lastAutoCopiedText: string | null = null;
 
     const setup = async (): Promise<(() => void) | null> => {
       const setupFont = terminalFontRef.current;
@@ -594,11 +600,37 @@ export function TerminalViewport({
 
       const copySelection = async (text: string, requestId: number) => {
         try {
-          await writeTextToClipboard(text, "terminal selection");
+          const didCopy = await writeTextToClipboard(text, "terminal selection");
+          if (didCopy) {
+            lastAutoCopiedText = text;
+            toastManager.add({ type: "success", title: "Copied to clipboard" });
+          }
         } catch (error) {
           reportIfCurrent(requestId, error, "Unable to copy terminal selection");
         }
         focusIfCurrent(requestId);
+      };
+
+      // Herdr-style copy-on-select: a completed selection gesture copies on
+      // release. Only call with a fresh, non-empty selection read for this
+      // gesture (as `showSelectionAction` does) — never with pre-existing
+      // text, so application clicks can't clobber the clipboard with stale
+      // content. The toast fires only after a successful write.
+      const autoCopyTerminalSelection = async (text: string) => {
+        const settings = getClientSettings();
+        if (!settings.copyOnSelect) return;
+        if (normalizeTerminalSelectionText(text) === null) return;
+        if (text === lastAutoCopiedText) return;
+        try {
+          const didCopy = await writeTextToClipboard(text, "terminal selection");
+          if (!didCopy) return;
+        } catch {
+          return;
+        }
+        lastAutoCopiedText = text;
+        if (getClientSettings().copyOnSelectToast) {
+          toastManager.add({ type: "success", title: "Copied to clipboard" });
+        }
       };
 
       const pasteFromClipboard = async (requestId: number) => {
@@ -669,6 +701,10 @@ export function TerminalViewport({
           clearSelectionAction();
           return;
         }
+        // Copy-on-select fires on release, before the popup opens; the popup
+        // stays for Add to chat (and Copy as a fallback when auto-copy is
+        // off or the clipboard write failed).
+        void autoCopyTerminalSelection(nextAction.clipboardText);
         const requestId = ++selectionActionRequestIdRef.current;
         openSelectionMenuRequestIdRef.current = requestId;
         const clicked = await localApi.contextMenu

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -601,7 +601,10 @@ export function TerminalViewport({
       const copySelection = async (text: string, requestId: number) => {
         try {
           const didCopy = await writeTextToClipboard(text, "terminal selection");
-          if (didCopy) {
+          // A superseded request must stay silent: another selection or
+          // right-click started while this write was pending, so toasting
+          // now would confirm a no-longer-active selection.
+          if (didCopy && requestId === selectionActionRequestIdRef.current) {
             lastAutoCopiedText = text;
             toastManager.add({ type: "success", title: "Copied to clipboard" });
           }
@@ -621,13 +624,17 @@ export function TerminalViewport({
         if (!settings.copyOnSelect) return;
         if (normalizeTerminalSelectionText(text) === null) return;
         if (text === lastAutoCopiedText) return;
+        // Claim before the await so a repeat gesture started while this
+        // write is pending can't issue a second write and toast.
+        lastAutoCopiedText = text;
         try {
           const didCopy = await writeTextToClipboard(text, "terminal selection");
+          if (!didCopy && lastAutoCopiedText === text) lastAutoCopiedText = null;
           if (!didCopy) return;
         } catch {
+          if (lastAutoCopiedText === text) lastAutoCopiedText = null;
           return;
         }
-        lastAutoCopiedText = text;
         if (getClientSettings().copyOnSelectToast) {
           toastManager.add({ type: "success", title: "Copied to clipboard" });
         }

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -43,7 +43,10 @@ import { Button } from "~/components/ui/button";
 import { PanelTabCloseButton } from "~/components/ui/panel-tab-close-button";
 import { readTextFromClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { getClientSettings } from "~/hooks/useSettings";
-import { normalizeTerminalSelectionText } from "~/lib/copyOnSelect";
+import {
+  createTerminalSelectionAutoCopy,
+  normalizeTerminalSelectionText,
+} from "~/lib/copyOnSelect";
 import { toastManager } from "~/components/ui/toast";
 import { cn } from "~/lib/utils";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
@@ -463,9 +466,17 @@ export function TerminalViewport({
     let setupTerminal: GhosttyTerminalSurface | null = null;
     let setupCleanups: Array<() => void> = [];
     let selectionActions: ReturnType<typeof observeSelectionActions> | null = null;
-    // Last text confirmed via copy-on-select, so repeat gestures over an
-    // unchanged selection stay quiet instead of re-toasting.
-    let lastAutoCopiedText: string | null = null;
+    const autoCopyTerminalSelection = createTerminalSelectionAutoCopy({
+      readSettings: () => {
+        const settings = getClientSettings();
+        return {
+          enabled: settings.copyOnSelect,
+          showToast: settings.copyOnSelectToast,
+        };
+      },
+      writeText: (text) => writeTextToClipboard(text, "terminal selection"),
+      onCopied: () => toastManager.add({ type: "success", title: "Copied to clipboard" }),
+    });
 
     const setup = async (): Promise<(() => void) | null> => {
       const setupFont = terminalFontRef.current;
@@ -551,8 +562,8 @@ export function TerminalViewport({
         }
         const selectionText = activeTerminal.getSelection();
         const selectionPosition = activeTerminal.getSelectionPosition();
-        const normalizedText = selectionText.replace(/\r\n/g, "\n").replace(/^\n+|\n+$/g, "");
-        if (!selectionPosition || normalizedText.length === 0) {
+        const normalizedText = normalizeTerminalSelectionText(selectionText);
+        if (!selectionPosition || normalizedText === null) {
           return null;
         }
         const { lineStart, lineEnd } = terminalSelectionLineRange(selectionPosition);
@@ -605,39 +616,13 @@ export function TerminalViewport({
           // right-click started while this write was pending, so toasting
           // now would confirm a no-longer-active selection.
           if (didCopy && requestId === selectionActionRequestIdRef.current) {
-            lastAutoCopiedText = text;
+            autoCopyTerminalSelection.rememberCopied(text);
             toastManager.add({ type: "success", title: "Copied to clipboard" });
           }
         } catch (error) {
           reportIfCurrent(requestId, error, "Unable to copy terminal selection");
         }
         focusIfCurrent(requestId);
-      };
-
-      // Herdr-style copy-on-select: a completed selection gesture copies on
-      // release. Only call with a fresh, non-empty selection read for this
-      // gesture (as `showSelectionAction` does) — never with pre-existing
-      // text, so application clicks can't clobber the clipboard with stale
-      // content. The toast fires only after a successful write.
-      const autoCopyTerminalSelection = async (text: string) => {
-        const settings = getClientSettings();
-        if (!settings.copyOnSelect) return;
-        if (normalizeTerminalSelectionText(text) === null) return;
-        if (text === lastAutoCopiedText) return;
-        // Claim before the await so a repeat gesture started while this
-        // write is pending can't issue a second write and toast.
-        lastAutoCopiedText = text;
-        try {
-          const didCopy = await writeTextToClipboard(text, "terminal selection");
-          if (!didCopy && lastAutoCopiedText === text) lastAutoCopiedText = null;
-          if (!didCopy) return;
-        } catch {
-          if (lastAutoCopiedText === text) lastAutoCopiedText = null;
-          return;
-        }
-        if (getClientSettings().copyOnSelectToast) {
-          toastManager.add({ type: "success", title: "Copied to clipboard" });
-        }
       };
 
       const pasteFromClipboard = async (requestId: number) => {
@@ -711,7 +696,7 @@ export function TerminalViewport({
         // Copy-on-select fires on release, before the popup opens; the popup
         // stays for Add to chat (and Copy as a fallback when auto-copy is
         // off or the clipboard write failed).
-        void autoCopyTerminalSelection(nextAction.clipboardText);
+        void autoCopyTerminalSelection.copy(nextAction.clipboardText);
         const requestId = ++selectionActionRequestIdRef.current;
         openSelectionMenuRequestIdRef.current = requestId;
         const clicked = await localApi.contextMenu

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -116,6 +116,7 @@ import { CHAT_TIMELINE_ANCHOR_OFFSET } from "./timelineScrollAnchoring";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { PierreEntryIcon } from "./PierreEntryIcon";
 import { AssistantSelectionToolbar } from "./AssistantSelectionToolbar";
+import { useCopyOnSelect } from "../../hooks/useCopyOnSelect";
 import type { AssistantCitationSourceAnchor } from "~/lib/assistantTextSelection";
 import {
   AssistantCitationSource,
@@ -551,6 +552,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
     null,
   );
+  // Herdr-style copy-on-select for chat text; the cite toolbar keeps working
+  // alongside it (a selection both copies and offers Cite).
+  useCopyOnSelect(timelineViewportElement);
   const {
     target: readyCitationRequest,
     positioning: citationPositioning,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -551,6 +551,12 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.composerCollapseOnScroll !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll
         ? ["Collapse composer"]
         : []),
+      ...(settings.copyOnSelect !== DEFAULT_UNIFIED_SETTINGS.copyOnSelect
+        ? ["Copy on select"]
+        : []),
+      ...(settings.copyOnSelectToast !== DEFAULT_UNIFIED_SETTINGS.copyOnSelectToast
+        ? ["Copy on select toast"]
+        : []),
       ...(settings.contextWindowMeterEnabled !== DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled
         ? ["Context window indicator"]
         : []),
@@ -636,6 +642,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.showSkillsInSlashMenu,
+      settings.copyOnSelect,
+      settings.copyOnSelectToast,
       settings.timestampFormat,
       settings.wordWrap,
       followSystem,
@@ -716,6 +724,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
       composerCollapseOnBlur: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur,
       composerCollapseOnScroll: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll,
+      copyOnSelect: DEFAULT_UNIFIED_SETTINGS.copyOnSelect,
+      copyOnSelectToast: DEFAULT_UNIFIED_SETTINGS.copyOnSelectToast,
       contextWindowMeterEnabled: DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
@@ -2407,6 +2417,61 @@ export function GeneralSettingsPanel() {
             </Select>
           }
         />
+
+
+        <SettingsRow
+          {...searchableSetting("copy-on-select")}
+          description="Automatically copy text selected with the mouse in chat and the terminal, Herdr-style."
+          resetAction={
+            settings.copyOnSelect !== DEFAULT_UNIFIED_SETTINGS.copyOnSelect ? (
+              <SettingResetButton
+                label="copy on select"
+                onClick={() =>
+                  updateSettings({
+                    copyOnSelect: DEFAULT_UNIFIED_SETTINGS.copyOnSelect,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.copyOnSelect}
+              onCheckedChange={(checked) =>
+                updateSettings({ copyOnSelect: Boolean(checked) })
+              }
+              aria-label="Copy on select"
+            />
+          }
+        />
+
+        {settings.copyOnSelect ? (
+          <SettingsRow
+            {...searchableSetting("copy-on-select-toast")}
+            description="Show a confirmation toast after an automatic copy."
+            resetAction={
+              settings.copyOnSelectToast !== DEFAULT_UNIFIED_SETTINGS.copyOnSelectToast ? (
+                <SettingResetButton
+                  label="copy on select toast"
+                  onClick={() =>
+                    updateSettings({
+                      copyOnSelectToast: DEFAULT_UNIFIED_SETTINGS.copyOnSelectToast,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <Switch
+                checked={settings.copyOnSelectToast}
+                onCheckedChange={(checked) =>
+                  updateSettings({ copyOnSelectToast: Boolean(checked) })
+                }
+                aria-label="Copy on select toast"
+              />
+            }
+          />
+        ) : null}
 
         <SettingsRow
           serverScoped

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -211,6 +211,19 @@ export const SETTINGS_SEARCH_ITEMS = [
     ],
   },
   {
+    id: "copy-on-select",
+    title: "Copy on select",
+    to: "/settings/general",
+    searchTerms: ["clipboard automatic selection herdr copy select drag highlight"],
+  },
+  {
+    id: "copy-on-select-toast",
+    title: "Copy on select toast",
+    to: "/settings/general",
+    targetId: "copy-on-select",
+    searchTerms: ["clipboard notification popup copied confirmation"],
+  },
+  {
     id: "provider-update-checks",
     title: "Provider update checks",
     to: "/settings/general",

--- a/apps/web/src/hooks/useCopyOnSelect.ts
+++ b/apps/web/src/hooks/useCopyOnSelect.ts
@@ -42,8 +42,7 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
     snapshot: null,
     armed: false,
   });
-  const settingsRef = React.useRef({ copyOnSelect, showToast });
-  settingsRef.current = { copyOnSelect, showToast };
+  const readSettings = React.useEffectEvent(() => ({ copyOnSelect, showToast }));
 
   React.useEffect(() => {
     if (!container) return;
@@ -74,7 +73,7 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
       const { snapshot: startSnapshot, armed } = gestureStartRef.current;
       gestureStartRef.current = { snapshot: null, armed: false };
       if (!armed) return;
-      if (!settingsRef.current.copyOnSelect) return;
+      if (!readSettings().copyOnSelect) return;
       if (!shouldAutoCopyOnMouseUp(event)) return;
       const selection = view.getSelection();
       if (sameDomSelectionSnapshot(startSnapshot, snapshotDomSelection(selection))) return;
@@ -82,7 +81,7 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
       if (text === null || text === lastCopiedRef.current) return;
       const fireCopy = () => {
         pendingMultiClickTimer = null;
-        if (!settingsRef.current.copyOnSelect) return;
+        if (!readSettings().copyOnSelect) return;
         if (text === lastCopiedRef.current) return;
         // Reserve before the await so a repeated gesture while this write is
         // pending can't issue a second write and toast.
@@ -93,7 +92,7 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
               if (lastCopiedRef.current === text) lastCopiedRef.current = null;
               return;
             }
-            if (settingsRef.current.showToast) {
+            if (readSettings().showToast) {
               toastManager.add({ type: "success", title: "Copied to clipboard" });
             }
           },

--- a/apps/web/src/hooks/useCopyOnSelect.ts
+++ b/apps/web/src/hooks/useCopyOnSelect.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+
+import { toastManager } from "../components/ui/toast";
+import {
+  getCopyableDomSelectionText,
+  isCopyOnSelectInteractiveTarget,
+  shouldAutoCopyOnMouseUp,
+} from "../lib/copyOnSelect";
+import { writeTextToClipboard } from "./useCopyToClipboard";
+import { useClientSettings } from "./useSettings";
+
+/**
+ * Herdr-style copy-on-select for DOM surfaces (the chat timeline): releasing
+ * a left-button drag or double-click inside `container` copies the selection
+ * and shows the "copied to clipboard" toast.
+ *
+ * Keyboard selections never trigger it (no mouseup), editable and
+ * interactive targets are skipped, and consecutive copies of identical text
+ * are deduplicated so clicking around a stable selection stays quiet. The
+ * toast only fires after a successful clipboard write — never optimistically.
+ */
+export function useCopyOnSelect(container: HTMLElement | null): void {
+  const copyOnSelect = useClientSettings((settings) => settings.copyOnSelect);
+  const showToast = useClientSettings((settings) => settings.copyOnSelectToast);
+  const lastCopiedRef = React.useRef<string | null>(null);
+  const settingsRef = React.useRef({ copyOnSelect, showToast });
+  settingsRef.current = { copyOnSelect, showToast };
+
+  React.useEffect(() => {
+    if (!container) return;
+    const onMouseUp = (event: MouseEvent) => {
+      if (!settingsRef.current.copyOnSelect) return;
+      if (!shouldAutoCopyOnMouseUp(event)) return;
+      if (isCopyOnSelectInteractiveTarget(event.target)) return;
+      const text = getCopyableDomSelectionText(window.getSelection(), container);
+      if (text === null || text === lastCopiedRef.current) return;
+      void writeTextToClipboard(text, "selection").then(
+        (didCopy) => {
+          if (!didCopy) return;
+          lastCopiedRef.current = text;
+          if (settingsRef.current.showToast) {
+            toastManager.add({ type: "success", title: "Copied to clipboard" });
+          }
+        },
+        () => {
+          // Silent on failure: no false toast when the clipboard API is
+          // unavailable (e.g. plain-HTTP remote sessions).
+        },
+      );
+    };
+    container.addEventListener("mouseup", onMouseUp);
+    return () => {
+      container.removeEventListener("mouseup", onMouseUp);
+    };
+  }, [container]);
+}

--- a/apps/web/src/hooks/useCopyOnSelect.ts
+++ b/apps/web/src/hooks/useCopyOnSelect.ts
@@ -11,6 +11,7 @@ import {
   snapshotDomSelection,
   type DomSelectionSnapshot,
 } from "../lib/copyOnSelect";
+import { SELECTION_MULTI_CLICK_INTERVAL_MS } from "../lib/selectionActions";
 import { writeTextToClipboard } from "./useCopyToClipboard";
 import { useClientSettings } from "./useSettings";
 
@@ -25,11 +26,13 @@ import { useClientSettings } from "./useSettings";
  * release outside its surface. Keyboard selections never trigger it (no
  * mouseup), editable targets never arm it, and only a gesture that created
  * or changed the selection may copy — a plain click over an existing
- * selection leaves the clipboard alone. The copied text is reserved before
- * the async write starts so a repeated gesture can't double-copy while the
- * first write is pending; the reservation is released if the write fails.
- * The toast only fires after a successful clipboard write — never
- * optimistically.
+ * selection leaves the clipboard alone. Multi-click releases wait out the
+ * click sequence so a triple-click copies the paragraph once instead of
+ * the word and then the paragraph, mirroring the terminal path. The copied
+ * text is reserved before the async write starts so a repeated gesture
+ * can't double-copy while the first write is pending; the reservation is
+ * released if the write fails. The toast only fires after a successful
+ * clipboard write — never optimistically.
  */
 export function useCopyOnSelect(container: HTMLElement | null): void {
   const copyOnSelect = useClientSettings((settings) => settings.copyOnSelect);
@@ -45,10 +48,19 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
   React.useEffect(() => {
     if (!container) return;
     const view = container.ownerDocument.defaultView ?? window;
+    let pendingMultiClickTimer: number | null = null;
+    const cancelPendingCopy = () => {
+      if (pendingMultiClickTimer !== null) {
+        view.clearTimeout(pendingMultiClickTimer);
+        pendingMultiClickTimer = null;
+      }
+    };
     const pressStartedInContainer = (target: EventTarget | null): boolean =>
       target instanceof Node && container.contains(target);
     const onMouseDown = (event: MouseEvent) => {
       gestureStartRef.current = { snapshot: null, armed: false };
+      // A new press in the sequence supersedes a deferred multi-click copy.
+      cancelPendingCopy();
       if (event.button !== 0) return;
       if (event.ctrlKey || event.metaKey || event.altKey) return;
       if (!pressStartedInContainer(event.target)) return;
@@ -68,29 +80,43 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
       if (sameDomSelectionSnapshot(startSnapshot, snapshotDomSelection(selection))) return;
       const text = getCopyableDomSelectionText(selection, container);
       if (text === null || text === lastCopiedRef.current) return;
-      // Reserve before the await so a repeated gesture while this write is
-      // pending can't issue a second write and toast.
-      lastCopiedRef.current = text;
-      void writeTextToClipboard(text, "selection").then(
-        (didCopy) => {
-          if (!didCopy) {
+      const fireCopy = () => {
+        pendingMultiClickTimer = null;
+        if (!settingsRef.current.copyOnSelect) return;
+        if (text === lastCopiedRef.current) return;
+        // Reserve before the await so a repeated gesture while this write is
+        // pending can't issue a second write and toast.
+        lastCopiedRef.current = text;
+        void writeTextToClipboard(text, "selection").then(
+          (didCopy) => {
+            if (!didCopy) {
+              if (lastCopiedRef.current === text) lastCopiedRef.current = null;
+              return;
+            }
+            if (settingsRef.current.showToast) {
+              toastManager.add({ type: "success", title: "Copied to clipboard" });
+            }
+          },
+          () => {
+            // Silent on failure: no false toast when the clipboard API is
+            // unavailable (e.g. plain-HTTP remote sessions).
             if (lastCopiedRef.current === text) lastCopiedRef.current = null;
-            return;
-          }
-          if (settingsRef.current.showToast) {
-            toastManager.add({ type: "success", title: "Copied to clipboard" });
-          }
-        },
-        () => {
-          // Silent on failure: no false toast when the clipboard API is
-          // unavailable (e.g. plain-HTTP remote sessions).
-          if (lastCopiedRef.current === text) lastCopiedRef.current = null;
-        },
-      );
+          },
+        );
+      };
+      if (event.detail >= 2) {
+        // Double/triple-click: hold the copy so the next press in the
+        // sequence can supersede it; only the final selection copies once.
+        cancelPendingCopy();
+        pendingMultiClickTimer = view.setTimeout(fireCopy, SELECTION_MULTI_CLICK_INTERVAL_MS);
+        return;
+      }
+      fireCopy();
     };
     view.addEventListener("mousedown", onMouseDown);
     view.addEventListener("mouseup", onMouseUp);
     return () => {
+      cancelPendingCopy();
       view.removeEventListener("mousedown", onMouseDown);
       view.removeEventListener("mouseup", onMouseUp);
     };

--- a/apps/web/src/hooks/useCopyOnSelect.ts
+++ b/apps/web/src/hooks/useCopyOnSelect.ts
@@ -6,7 +6,10 @@ import { toastManager } from "../components/ui/toast";
 import {
   getCopyableDomSelectionText,
   isCopyOnSelectInteractiveTarget,
+  sameDomSelectionSnapshot,
   shouldAutoCopyOnMouseUp,
+  snapshotDomSelection,
+  type DomSelectionSnapshot,
 } from "../lib/copyOnSelect";
 import { writeTextToClipboard } from "./useCopyToClipboard";
 import { useClientSettings } from "./useSettings";
@@ -17,24 +20,45 @@ import { useClientSettings } from "./useSettings";
  * and shows the "copied to clipboard" toast.
  *
  * Keyboard selections never trigger it (no mouseup), editable and
- * interactive targets are skipped, and consecutive copies of identical text
- * are deduplicated so clicking around a stable selection stays quiet. The
- * toast only fires after a successful clipboard write — never optimistically.
+ * interactive targets are skipped, and only a gesture that created or
+ * changed the selection may copy — a plain click over an existing selection
+ * leaves the clipboard alone. Consecutive copies of identical text are
+ * deduplicated so clicking around a stable selection stays quiet. The toast
+ * only fires after a successful clipboard write — never optimistically.
  */
 export function useCopyOnSelect(container: HTMLElement | null): void {
   const copyOnSelect = useClientSettings((settings) => settings.copyOnSelect);
   const showToast = useClientSettings((settings) => settings.copyOnSelectToast);
   const lastCopiedRef = React.useRef<string | null>(null);
+  const gestureStartRef = React.useRef<{ snapshot: DomSelectionSnapshot; armed: boolean }>({
+    snapshot: null,
+    armed: false,
+  });
   const settingsRef = React.useRef({ copyOnSelect, showToast });
   settingsRef.current = { copyOnSelect, showToast };
 
   React.useEffect(() => {
     if (!container) return;
+    const onMouseDown = (event: MouseEvent) => {
+      gestureStartRef.current = { snapshot: null, armed: false };
+      if (event.button !== 0) return;
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+      if (isCopyOnSelectInteractiveTarget(event.target)) return;
+      gestureStartRef.current = {
+        snapshot: snapshotDomSelection(window.getSelection()),
+        armed: true,
+      };
+    };
     const onMouseUp = (event: MouseEvent) => {
+      const { snapshot: startSnapshot, armed } = gestureStartRef.current;
+      gestureStartRef.current = { snapshot: null, armed: false };
+      if (!armed) return;
       if (!settingsRef.current.copyOnSelect) return;
       if (!shouldAutoCopyOnMouseUp(event)) return;
       if (isCopyOnSelectInteractiveTarget(event.target)) return;
-      const text = getCopyableDomSelectionText(window.getSelection(), container);
+      const selection = window.getSelection();
+      if (sameDomSelectionSnapshot(startSnapshot, snapshotDomSelection(selection))) return;
+      const text = getCopyableDomSelectionText(selection, container);
       if (text === null || text === lastCopiedRef.current) return;
       void writeTextToClipboard(text, "selection").then(
         (didCopy) => {
@@ -50,8 +74,10 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
         },
       );
     };
+    container.addEventListener("mousedown", onMouseDown);
     container.addEventListener("mouseup", onMouseUp);
     return () => {
+      container.removeEventListener("mousedown", onMouseDown);
       container.removeEventListener("mouseup", onMouseUp);
     };
   }, [container]);

--- a/apps/web/src/hooks/useCopyOnSelect.ts
+++ b/apps/web/src/hooks/useCopyOnSelect.ts
@@ -5,7 +5,7 @@ import * as React from "react";
 import { toastManager } from "../components/ui/toast";
 import {
   getCopyableDomSelectionText,
-  isCopyOnSelectInteractiveTarget,
+  isCopyOnSelectEditableTarget,
   sameDomSelectionSnapshot,
   shouldAutoCopyOnMouseUp,
   snapshotDomSelection,
@@ -16,15 +16,20 @@ import { useClientSettings } from "./useSettings";
 
 /**
  * Herdr-style copy-on-select for DOM surfaces (the chat timeline): releasing
- * a left-button drag or double-click inside `container` copies the selection
- * and shows the "copied to clipboard" toast.
+ * a left-button drag or double-click copies the selection and shows the
+ * "copied to clipboard" toast.
  *
- * Keyboard selections never trigger it (no mouseup), editable and
- * interactive targets are skipped, and only a gesture that created or
- * changed the selection may copy — a plain click over an existing selection
- * leaves the clipboard alone. Consecutive copies of identical text are
- * deduplicated so clicking around a stable selection stays quiet. The toast
- * only fires after a successful clipboard write — never optimistically.
+ * The gesture may end anywhere (composer, sidebar, another panel): as long
+ * as the press started on chat text and the released selection sits inside
+ * `container`, it copies — mirroring the terminal path, which also accepts
+ * release outside its surface. Keyboard selections never trigger it (no
+ * mouseup), editable targets never arm it, and only a gesture that created
+ * or changed the selection may copy — a plain click over an existing
+ * selection leaves the clipboard alone. The copied text is reserved before
+ * the async write starts so a repeated gesture can't double-copy while the
+ * first write is pending; the reservation is released if the write fails.
+ * The toast only fires after a successful clipboard write — never
+ * optimistically.
  */
 export function useCopyOnSelect(container: HTMLElement | null): void {
   const copyOnSelect = useClientSettings((settings) => settings.copyOnSelect);
@@ -39,13 +44,17 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
 
   React.useEffect(() => {
     if (!container) return;
+    const view = container.ownerDocument.defaultView ?? window;
+    const pressStartedInContainer = (target: EventTarget | null): boolean =>
+      target instanceof Node && container.contains(target);
     const onMouseDown = (event: MouseEvent) => {
       gestureStartRef.current = { snapshot: null, armed: false };
       if (event.button !== 0) return;
       if (event.ctrlKey || event.metaKey || event.altKey) return;
-      if (isCopyOnSelectInteractiveTarget(event.target)) return;
+      if (!pressStartedInContainer(event.target)) return;
+      if (isCopyOnSelectEditableTarget(event.target)) return;
       gestureStartRef.current = {
-        snapshot: snapshotDomSelection(window.getSelection()),
+        snapshot: snapshotDomSelection(view.getSelection()),
         armed: true,
       };
     };
@@ -55,15 +64,19 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
       if (!armed) return;
       if (!settingsRef.current.copyOnSelect) return;
       if (!shouldAutoCopyOnMouseUp(event)) return;
-      if (isCopyOnSelectInteractiveTarget(event.target)) return;
-      const selection = window.getSelection();
+      const selection = view.getSelection();
       if (sameDomSelectionSnapshot(startSnapshot, snapshotDomSelection(selection))) return;
       const text = getCopyableDomSelectionText(selection, container);
       if (text === null || text === lastCopiedRef.current) return;
+      // Reserve before the await so a repeated gesture while this write is
+      // pending can't issue a second write and toast.
+      lastCopiedRef.current = text;
       void writeTextToClipboard(text, "selection").then(
         (didCopy) => {
-          if (!didCopy) return;
-          lastCopiedRef.current = text;
+          if (!didCopy) {
+            if (lastCopiedRef.current === text) lastCopiedRef.current = null;
+            return;
+          }
           if (settingsRef.current.showToast) {
             toastManager.add({ type: "success", title: "Copied to clipboard" });
           }
@@ -71,14 +84,15 @@ export function useCopyOnSelect(container: HTMLElement | null): void {
         () => {
           // Silent on failure: no false toast when the clipboard API is
           // unavailable (e.g. plain-HTTP remote sessions).
+          if (lastCopiedRef.current === text) lastCopiedRef.current = null;
         },
       );
     };
-    container.addEventListener("mousedown", onMouseDown);
-    container.addEventListener("mouseup", onMouseUp);
+    view.addEventListener("mousedown", onMouseDown);
+    view.addEventListener("mouseup", onMouseUp);
     return () => {
-      container.removeEventListener("mousedown", onMouseDown);
-      container.removeEventListener("mouseup", onMouseUp);
+      view.removeEventListener("mousedown", onMouseDown);
+      view.removeEventListener("mouseup", onMouseUp);
     };
   }, [container]);
 }

--- a/apps/web/src/lib/copyOnSelect.test.ts
+++ b/apps/web/src/lib/copyOnSelect.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   getCopyableDomSelectionText,
+  isCopyOnSelectEditableTarget,
   normalizeTerminalSelectionText,
   sameDomSelectionSnapshot,
   shouldAutoCopyOnMouseUp,
@@ -21,14 +22,31 @@ class FakeElement {
   parentNode: FakeElement | null = null;
   constructor(
     readonly tagName = "DIV",
-    readonly interactive = false,
+    readonly kind: "plain" | "control" | "editable" = "plain",
     parent: FakeElement | null = null,
   ) {
     this.parentNode = parent;
   }
   closest(selector: string): FakeElement | null {
-    // Mirrors the interactive guard: only elements flagged interactive match.
-    if (this.interactive && selector.length > 0) return this;
+    // Mirrors the real selectors: controls match button/a/role queries,
+    // editables match form-field queries, plain elements match neither.
+    const parts = selector.split(",").map((part) => part.trim());
+    const selfMatch = parts.some((part) => {
+      if (part === "button" || part === "a" || part === "[role=button]") {
+        return this.kind === "control";
+      }
+      if (
+        part === "input" ||
+        part === "textarea" ||
+        part === "select" ||
+        part === "[contenteditable]" ||
+        part === "[data-no-copy-on-select]"
+      ) {
+        return this.kind === "editable";
+      }
+      return false;
+    });
+    if (selfMatch) return this;
     return this.parentNode?.closest(selector) ?? null;
   }
   contains(node: unknown): boolean {
@@ -148,7 +166,7 @@ describe("dom selection snapshots", () => {
 describe("getCopyableDomSelectionText", () => {
   it("returns selected text inside its container", () => {
     const container = new FakeElement();
-    const message = new FakeElement("DIV", false, container);
+    const message = new FakeElement("DIV", "plain", container);
     const node = textNode("hello", message);
     expect(
       getCopyableDomSelectionText(
@@ -158,9 +176,22 @@ describe("getCopyableDomSelectionText", () => {
     ).toBe("hello");
   });
 
+  it("allows selections inside links and other clickable chips", () => {
+    const container = new FakeElement();
+    const message = new FakeElement("DIV", "plain", container);
+    const link = new FakeElement("A", "control", message);
+    const node = textNode("docs", link);
+    expect(
+      getCopyableDomSelectionText(
+        selectionOf("docs", node, node),
+        container as unknown as HTMLElement,
+      ),
+    ).toBe("docs");
+  });
+
   it("rejects collapsed, multi-range, and whitespace-only selections", () => {
     const container = new FakeElement();
-    const node = textNode("hi", new FakeElement("DIV", false, container));
+    const node = textNode("hi", new FakeElement("DIV", "plain", container));
     const collapsed = { ...selectionOf("hi", node, node), isCollapsed: true } as Selection;
     expect(getCopyableDomSelectionText(collapsed, container as unknown as HTMLElement)).toBeNull();
     const multi = { ...selectionOf("hi", node, node), rangeCount: 2 } as Selection;
@@ -176,7 +207,7 @@ describe("getCopyableDomSelectionText", () => {
 
   it("rejects selections in editable elements and outside the container", () => {
     const container = new FakeElement();
-    const composer = new FakeElement("TEXTAREA", true, container);
+    const composer = new FakeElement("TEXTAREA", "editable", container);
     const composerNode = textNode("draft", composer);
     expect(
       getCopyableDomSelectionText(
@@ -193,5 +224,11 @@ describe("getCopyableDomSelectionText", () => {
         container as unknown as HTMLElement,
       ),
     ).toBeNull();
+  });
+});
+
+describe("isCopyOnSelectEditableTarget", () => {
+  it("ignores null targets without a DOM", () => {
+    expect(isCopyOnSelectEditableTarget(null)).toBe(false);
   });
 });

--- a/apps/web/src/lib/copyOnSelect.test.ts
+++ b/apps/web/src/lib/copyOnSelect.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 
 import {
+  createTerminalSelectionAutoCopy,
   getCopyableDomSelectionText,
   isCopyOnSelectEditableTarget,
   normalizeTerminalSelectionText,
@@ -8,6 +11,93 @@ import {
   shouldAutoCopyOnMouseUp,
   snapshotDomSelection,
 } from "./copyOnSelect";
+
+describe("terminal copy on select", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves terminal input when the browser rejects the clipboard write", async () => {
+    const terminalInput = {
+      value: "にほんご",
+      selectionStart: 4,
+      selectionEnd: 4,
+      select: vi.fn(),
+    };
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    const onCopied = vi.fn();
+    const autoCopy = createTerminalSelectionAutoCopy({
+      readSettings: () => ({ enabled: true, showToast: true }),
+      writeText: (text) => writeTextToClipboard(text, "terminal selection"),
+      onCopied,
+    });
+
+    await expect(autoCopy.copy("git status")).resolves.toBe(false);
+    expect(terminalInput.value).toBe("にほんご");
+    expect(terminalInput.selectionStart).toBe(4);
+    expect(terminalInput.selectionEnd).toBe(4);
+    expect(terminalInput.select).not.toHaveBeenCalled();
+    expect(onCopied).not.toHaveBeenCalled();
+  });
+
+  it("allows the same selection to retry after a failed write", async () => {
+    const writeText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("denied"))
+      .mockResolvedValueOnce(true);
+    const onCopied = vi.fn();
+    const autoCopy = createTerminalSelectionAutoCopy({
+      readSettings: () => ({ enabled: true, showToast: true }),
+      writeText,
+      onCopied,
+    });
+
+    await expect(autoCopy.copy("git status")).resolves.toBe(false);
+    await expect(autoCopy.copy("git status")).resolves.toBe(true);
+    expect(onCopied).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces a pending write and honors the current toast setting", async () => {
+    let finishWrite: ((didCopy: boolean) => void) | undefined;
+    const writeText = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishWrite = resolve;
+        }),
+    );
+    const onCopied = vi.fn();
+    const autoCopy = createTerminalSelectionAutoCopy({
+      readSettings: () => ({ enabled: true, showToast: false }),
+      writeText,
+      onCopied,
+    });
+
+    const firstCopy = autoCopy.copy("git status");
+    await expect(autoCopy.copy("git status")).resolves.toBe(false);
+    expect(writeText).toHaveBeenCalledOnce();
+
+    finishWrite?.(true);
+    await expect(firstCopy).resolves.toBe(true);
+    expect(onCopied).not.toHaveBeenCalled();
+  });
+
+  it("keeps a successful explicit copy from immediately auto-copying the same selection", async () => {
+    const writeText = vi.fn().mockResolvedValue(true);
+    const autoCopy = createTerminalSelectionAutoCopy({
+      readSettings: () => ({ enabled: true, showToast: true }),
+      writeText,
+      onCopied: vi.fn(),
+    });
+
+    autoCopy.rememberCopied("git status");
+
+    await expect(autoCopy.copy("git status")).resolves.toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
 
 function mouseUp(overrides: Partial<MouseEvent> = {}): MouseEvent {
   return { button: 0, ctrlKey: false, metaKey: false, altKey: false, ...overrides } as MouseEvent;
@@ -67,12 +157,23 @@ class FakeElement {
   }
 }
 
-function selectionOf(text: string, startContainer: unknown, endContainer: unknown) {
+function selectionOf(
+  text: string,
+  startContainer: unknown,
+  endContainer: unknown,
+  options: { crossesExcludedContent?: boolean } = {},
+) {
   return {
     isCollapsed: false,
     rangeCount: 1,
     toString: () => text,
-    getRangeAt: () => ({ startContainer, endContainer }),
+    getRangeAt: () => ({
+      startContainer,
+      endContainer,
+      cloneContents: () => ({
+        querySelector: () => (options.crossesExcludedContent ? new FakeElement() : null),
+      }),
+    }),
   } as unknown as Selection;
 }
 
@@ -118,6 +219,10 @@ describe("normalizeTerminalSelectionText", () => {
     expect(normalizeTerminalSelectionText("git status")).toBe("git status");
   });
 
+  it("normalizes line endings and trims blank boundary lines", () => {
+    expect(normalizeTerminalSelectionText("\r\n\r\ngit status\r\n\r\n")).toBe("git status");
+  });
+
   it("rejects empty and blank-line-only selections", () => {
     expect(normalizeTerminalSelectionText("")).toBeNull();
     expect(normalizeTerminalSelectionText("\n\n")).toBeNull();
@@ -128,19 +233,13 @@ describe("normalizeTerminalSelectionText", () => {
 describe("dom selection snapshots", () => {
   it("snapshots null for missing or collapsed selections", () => {
     expect(snapshotDomSelection(null)).toBeNull();
-    expect(
-      snapshotDomSelection({ isCollapsed: true } as unknown as Selection),
-    ).toBeNull();
+    expect(snapshotDomSelection({ isCollapsed: true } as unknown as Selection)).toBeNull();
   });
 
   it("treats an unchanged selection across a click as the same", () => {
     const node = textNode("hello");
-    const before = snapshotDomSelection(
-      selectionWithAnchors("hello", node, 0, node, 5),
-    );
-    const after = snapshotDomSelection(
-      selectionWithAnchors("hello", node, 0, node, 5),
-    );
+    const before = snapshotDomSelection(selectionWithAnchors("hello", node, 0, node, 5));
+    const after = snapshotDomSelection(selectionWithAnchors("hello", node, 0, node, 5));
     expect(sameDomSelectionSnapshot(before, after)).toBe(true);
   });
 
@@ -221,6 +320,20 @@ describe("getCopyableDomSelectionText", () => {
         ),
       ).toBeNull();
     }
+  });
+
+  it("rejects a range that crosses opted-out content between ordinary endpoints", () => {
+    const container = new FakeElement();
+    const message = new FakeElement("DIV", "plain", container);
+    const start = textNode("before", message);
+    const end = textNode("after", message);
+
+    expect(
+      getCopyableDomSelectionText(
+        selectionOf("before private after", start, end, { crossesExcludedContent: true }),
+        container as unknown as HTMLElement,
+      ),
+    ).toBeNull();
   });
 
   it("rejects collapsed, multi-range, and whitespace-only selections", () => {

--- a/apps/web/src/lib/copyOnSelect.test.ts
+++ b/apps/web/src/lib/copyOnSelect.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getCopyableDomSelectionText,
+  normalizeTerminalSelectionText,
+  shouldAutoCopyOnMouseUp,
+} from "./copyOnSelect";
+
+function mouseUp(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return { button: 0, ctrlKey: false, metaKey: false, altKey: false, ...overrides } as MouseEvent;
+}
+
+function textNode(data = "", parent: FakeElement | null = null) {
+  return { nodeType: 3, data, parentNode: parent };
+}
+
+class FakeElement {
+  nodeType = 1;
+  parentNode: FakeElement | null = null;
+  constructor(
+    readonly tagName = "DIV",
+    readonly interactive = false,
+    parent: FakeElement | null = null,
+  ) {
+    this.parentNode = parent;
+  }
+  closest(selector: string): FakeElement | null {
+    // Mirrors the interactive guard: only elements flagged interactive match.
+    if (this.interactive && selector.length > 0) return this;
+    return this.parentNode?.closest(selector) ?? null;
+  }
+  contains(node: unknown): boolean {
+    let current = node as { parentNode?: unknown } | null;
+    while (current !== null && current !== undefined) {
+      if (current === (this as unknown)) return true;
+      current = (current as { parentNode?: typeof current }).parentNode ?? null;
+    }
+    return false;
+  }
+}
+
+function selectionOf(text: string, startContainer: unknown, endContainer: unknown) {
+  return {
+    isCollapsed: false,
+    rangeCount: 1,
+    toString: () => text,
+    getRangeAt: () => ({ startContainer, endContainer }),
+  } as unknown as Selection;
+}
+
+describe("shouldAutoCopyOnMouseUp", () => {
+  it("copies on a plain left-button release", () => {
+    expect(shouldAutoCopyOnMouseUp(mouseUp())).toBe(true);
+  });
+
+  it("allows shift-extended selections", () => {
+    expect(shouldAutoCopyOnMouseUp(mouseUp({ shiftKey: true }))).toBe(true);
+  });
+
+  it("rejects non-left buttons and modifier clicks that may activate links", () => {
+    expect(shouldAutoCopyOnMouseUp(mouseUp({ button: 1 }))).toBe(false);
+    expect(shouldAutoCopyOnMouseUp(mouseUp({ button: 2 }))).toBe(false);
+    expect(shouldAutoCopyOnMouseUp(mouseUp({ ctrlKey: true }))).toBe(false);
+    expect(shouldAutoCopyOnMouseUp(mouseUp({ metaKey: true }))).toBe(false);
+    expect(shouldAutoCopyOnMouseUp(mouseUp({ altKey: true }))).toBe(false);
+  });
+});
+
+describe("normalizeTerminalSelectionText", () => {
+  it("keeps copyable text as-is", () => {
+    expect(normalizeTerminalSelectionText("git status")).toBe("git status");
+  });
+
+  it("rejects empty and blank-line-only selections", () => {
+    expect(normalizeTerminalSelectionText("")).toBeNull();
+    expect(normalizeTerminalSelectionText("\n\n")).toBeNull();
+    expect(normalizeTerminalSelectionText("\r\n\r\n")).toBeNull();
+  });
+});
+
+describe("getCopyableDomSelectionText", () => {
+  it("returns selected text inside its container", () => {
+    const container = new FakeElement();
+    const message = new FakeElement("DIV", false, container);
+    const node = textNode("hello", message);
+    expect(
+      getCopyableDomSelectionText(
+        selectionOf("hello", node, node),
+        container as unknown as HTMLElement,
+      ),
+    ).toBe("hello");
+  });
+
+  it("rejects collapsed, multi-range, and whitespace-only selections", () => {
+    const container = new FakeElement();
+    const node = textNode("hi", new FakeElement("DIV", false, container));
+    const collapsed = { ...selectionOf("hi", node, node), isCollapsed: true } as Selection;
+    expect(getCopyableDomSelectionText(collapsed, container as unknown as HTMLElement)).toBeNull();
+    const multi = { ...selectionOf("hi", node, node), rangeCount: 2 } as Selection;
+    expect(getCopyableDomSelectionText(multi, container as unknown as HTMLElement)).toBeNull();
+    expect(
+      getCopyableDomSelectionText(
+        selectionOf("   ", node, node),
+        container as unknown as HTMLElement,
+      ),
+    ).toBeNull();
+    expect(getCopyableDomSelectionText(null, container as unknown as HTMLElement)).toBeNull();
+  });
+
+  it("rejects selections in editable elements and outside the container", () => {
+    const container = new FakeElement();
+    const composer = new FakeElement("TEXTAREA", true, container);
+    const composerNode = textNode("draft", composer);
+    expect(
+      getCopyableDomSelectionText(
+        selectionOf("draft", composerNode, composerNode),
+        container as unknown as HTMLElement,
+      ),
+    ).toBeNull();
+
+    const elsewhere = new FakeElement();
+    const outsideNode = textNode("other", elsewhere);
+    expect(
+      getCopyableDomSelectionText(
+        selectionOf("other", outsideNode, outsideNode),
+        container as unknown as HTMLElement,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/copyOnSelect.test.ts
+++ b/apps/web/src/lib/copyOnSelect.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   getCopyableDomSelectionText,
   normalizeTerminalSelectionText,
+  sameDomSelectionSnapshot,
   shouldAutoCopyOnMouseUp,
+  snapshotDomSelection,
 } from "./copyOnSelect";
 
 function mouseUp(overrides: Partial<MouseEvent> = {}): MouseEvent {
@@ -48,6 +50,25 @@ function selectionOf(text: string, startContainer: unknown, endContainer: unknow
   } as unknown as Selection;
 }
 
+function selectionWithAnchors(
+  text: string,
+  anchorNode: unknown,
+  anchorOffset: number,
+  focusNode: unknown,
+  focusOffset: number,
+) {
+  return {
+    isCollapsed: false,
+    rangeCount: 1,
+    toString: () => text,
+    anchorNode,
+    anchorOffset,
+    focusNode,
+    focusOffset,
+    getRangeAt: () => ({ startContainer: anchorNode, endContainer: focusNode }),
+  } as unknown as Selection;
+}
+
 describe("shouldAutoCopyOnMouseUp", () => {
   it("copies on a plain left-button release", () => {
     expect(shouldAutoCopyOnMouseUp(mouseUp())).toBe(true);
@@ -75,6 +96,52 @@ describe("normalizeTerminalSelectionText", () => {
     expect(normalizeTerminalSelectionText("")).toBeNull();
     expect(normalizeTerminalSelectionText("\n\n")).toBeNull();
     expect(normalizeTerminalSelectionText("\r\n\r\n")).toBeNull();
+  });
+});
+
+describe("dom selection snapshots", () => {
+  it("snapshots null for missing or collapsed selections", () => {
+    expect(snapshotDomSelection(null)).toBeNull();
+    expect(
+      snapshotDomSelection({ isCollapsed: true } as unknown as Selection),
+    ).toBeNull();
+  });
+
+  it("treats an unchanged selection across a click as the same", () => {
+    const node = textNode("hello");
+    const before = snapshotDomSelection(
+      selectionWithAnchors("hello", node, 0, node, 5),
+    );
+    const after = snapshotDomSelection(
+      selectionWithAnchors("hello", node, 0, node, 5),
+    );
+    expect(sameDomSelectionSnapshot(before, after)).toBe(true);
+  });
+
+  it("detects a gesture that created or changed the selection", () => {
+    const startNode = textNode("hello");
+    const endNode = textNode("hello world");
+    // Plain click away collapses the selection.
+    expect(
+      sameDomSelectionSnapshot(
+        snapshotDomSelection(selectionWithAnchors("hello", startNode, 0, startNode, 5)),
+        snapshotDomSelection({ isCollapsed: true } as unknown as Selection),
+      ),
+    ).toBe(false);
+    // Drag extends the focus.
+    expect(
+      sameDomSelectionSnapshot(
+        snapshotDomSelection(selectionWithAnchors("hello", startNode, 0, startNode, 5)),
+        snapshotDomSelection(selectionWithAnchors("hello world", endNode, 0, endNode, 11)),
+      ),
+    ).toBe(false);
+    // Same text reselected at other offsets still counts as a new gesture.
+    expect(
+      sameDomSelectionSnapshot(
+        snapshotDomSelection(selectionWithAnchors("hi", startNode, 0, startNode, 2)),
+        snapshotDomSelection(selectionWithAnchors("hi", startNode, 1, startNode, 3)),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/copyOnSelect.test.ts
+++ b/apps/web/src/lib/copyOnSelect.test.ts
@@ -24,12 +24,14 @@ class FakeElement {
     readonly tagName = "DIV",
     readonly kind: "plain" | "control" | "editable" = "plain",
     parent: FakeElement | null = null,
+    readonly contentEditable: string | null = null,
   ) {
     this.parentNode = parent;
   }
   closest(selector: string): FakeElement | null {
     // Mirrors the real selectors: controls match button/a/role queries,
-    // editables match form-field queries, plain elements match neither.
+    // editables match form-field queries, and only editable contenteditable
+    // values match — "false" islands (e.g. citation chips) match nothing.
     const parts = selector.split(",").map((part) => part.trim());
     const selfMatch = parts.some((part) => {
       if (part === "button" || part === "a" || part === "[role=button]") {
@@ -39,10 +41,16 @@ class FakeElement {
         part === "input" ||
         part === "textarea" ||
         part === "select" ||
-        part === "[contenteditable]" ||
         part === "[data-no-copy-on-select]"
       ) {
         return this.kind === "editable";
+      }
+      if (part.startsWith("[contenteditable")) {
+        return (
+          this.contentEditable === "" ||
+          this.contentEditable === "true" ||
+          this.contentEditable === "plaintext-only"
+        );
       }
       return false;
     });
@@ -187,6 +195,32 @@ describe("getCopyableDomSelectionText", () => {
         container as unknown as HTMLElement,
       ),
     ).toBe("docs");
+  });
+
+  it("allows selections on contenteditable=false islands such as citation chips", () => {
+    const container = new FakeElement();
+    const chip = new FakeElement("SPAN", "plain", container, "false");
+    const node = textNode("cite", chip);
+    expect(
+      getCopyableDomSelectionText(
+        selectionOf("cite", node, node),
+        container as unknown as HTMLElement,
+      ),
+    ).toBe("cite");
+  });
+
+  it("still excludes genuinely editable contenteditable regions", () => {
+    const container = new FakeElement();
+    for (const value of ["", "true", "plaintext-only"]) {
+      const field = new FakeElement("DIV", "plain", container, value);
+      const node = textNode("edit", field);
+      expect(
+        getCopyableDomSelectionText(
+          selectionOf("edit", node, node),
+          container as unknown as HTMLElement,
+        ),
+      ).toBeNull();
+    }
   });
 
   it("rejects collapsed, multi-range, and whitespace-only selections", () => {

--- a/apps/web/src/lib/copyOnSelect.ts
+++ b/apps/web/src/lib/copyOnSelect.ts
@@ -1,0 +1,74 @@
+/**
+ * Copy-on-select helpers (Herdr-style: selecting text copies it and shows a
+ * toast). The DOM side owns reading `window.getSelection()`; the terminal
+ * side owns reading the canvas surface. Both sides share the emptiness and
+ * gesture guards here so neither path copies stale or empty selections.
+ *
+ * Used by `useCopyOnSelect` (chat timeline) and `ThreadTerminalDrawer`.
+ */
+
+/** Interactive elements whose mouseup must never trigger an auto-copy. */
+export const COPY_ON_SELECT_INTERACTIVE_SELECTOR =
+  "button, a, input, textarea, select, [role=button], [contenteditable], [data-no-copy-on-select]";
+
+/**
+ * Herdr copies on mouse release after a drag or double-click. Only the
+ * primary (left) button without clipboard-conflicting modifiers qualifies:
+ * Ctrl/Cmd/Alt-clicks can activate links or OS gestures, where copying the
+ * pre-existing selection would clobber the clipboard with stale text.
+ */
+export function shouldAutoCopyOnMouseUp(event: MouseEvent): boolean {
+  if (event.button !== 0) return false;
+  if (event.ctrlKey || event.metaKey || event.altKey) return false;
+  return true;
+}
+
+/** True when the mouseup landed on (or inside) an interactive element. */
+export function isCopyOnSelectInteractiveTarget(target: EventTarget | null): boolean {
+  if (target === null || typeof Element === "undefined") return false;
+  if (!(target instanceof Element)) return false;
+  return target.closest(COPY_ON_SELECT_INTERACTIVE_SELECTOR) !== null;
+}
+
+/**
+ * Terminal selections use `\r\n` line endings and can carry blank leading or
+ * trailing lines from block drag-selects. Returns the copyable text, or null
+ * when there is nothing worth copying.
+ */
+export function normalizeTerminalSelectionText(text: string): string | null {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/^\n+|\n+$/g, "");
+  return normalized.length > 0 ? text : null;
+}
+
+function nodeInEditable(node: Node | null): boolean {
+  let current: Node | null = node;
+  while (current !== null) {
+    if (current.nodeType === 1) {
+      const element = current as Element;
+      if (element.closest(COPY_ON_SELECT_INTERACTIVE_SELECTOR) !== null) return true;
+    }
+    current = current.parentNode;
+  }
+  return false;
+}
+
+/**
+ * Returns the selected text when it is worth auto-copying, otherwise null.
+ * Skips collapsed/multi-range selections, whitespace-only text, selections
+ * rooted in editable or interactive elements, and (when given) selections
+ * outside `container`.
+ */
+export function getCopyableDomSelectionText(
+  selection: Selection | null,
+  container?: HTMLElement | null,
+): string | null {
+  if (selection === null || selection.isCollapsed || selection.rangeCount !== 1) return null;
+  const text = selection.toString();
+  if (text.trim().length === 0) return null;
+  const range = selection.getRangeAt(0);
+  if (nodeInEditable(range.startContainer) || nodeInEditable(range.endContainer)) return null;
+  if (container && (!container.contains(range.startContainer) || !container.contains(range.endContainer))) {
+    return null;
+  }
+  return text;
+}

--- a/apps/web/src/lib/copyOnSelect.ts
+++ b/apps/web/src/lib/copyOnSelect.ts
@@ -13,9 +13,13 @@
  * intentionally NOT excluded — chat is full of selectable controls, and a
  * drag across them is still a real selection. Clicks on those controls
  * without a drag are filtered by gesture-identity comparison instead.
+ *
+ * Note the `contenteditable` values are enumerated instead of using a bare
+ * `[contenteditable]`: that would also match `contenteditable="false"`
+ * islands such as citation chips, which are explicitly non-editable.
  */
 export const COPY_ON_SELECT_EDITABLE_SELECTOR =
-  "input, textarea, select, [contenteditable], [data-no-copy-on-select]";
+  'input, textarea, select, [contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"], [data-no-copy-on-select]';
 
 /**
  * Herdr copies on mouse release after a drag or double-click. Only the

--- a/apps/web/src/lib/copyOnSelect.ts
+++ b/apps/web/src/lib/copyOnSelect.ts
@@ -7,9 +7,15 @@
  * Used by `useCopyOnSelect` (chat timeline) and `ThreadTerminalDrawer`.
  */
 
-/** Interactive elements whose mouseup must never trigger an auto-copy. */
-export const COPY_ON_SELECT_INTERACTIVE_SELECTOR =
-  "button, a, input, textarea, select, [role=button], [contenteditable], [data-no-copy-on-select]";
+/**
+ * Subtrees whose text must never auto-copy: form fields and explicitly
+ * opted-out regions. Links, buttons, and other clickable chips are
+ * intentionally NOT excluded — chat is full of selectable controls, and a
+ * drag across them is still a real selection. Clicks on those controls
+ * without a drag are filtered by gesture-identity comparison instead.
+ */
+export const COPY_ON_SELECT_EDITABLE_SELECTOR =
+  "input, textarea, select, [contenteditable], [data-no-copy-on-select]";
 
 /**
  * Herdr copies on mouse release after a drag or double-click. Only the
@@ -23,11 +29,11 @@ export function shouldAutoCopyOnMouseUp(event: MouseEvent): boolean {
   return true;
 }
 
-/** True when the mouseup landed on (or inside) an interactive element. */
-export function isCopyOnSelectInteractiveTarget(target: EventTarget | null): boolean {
+/** True when the target is inside an editable or opted-out element. */
+export function isCopyOnSelectEditableTarget(target: EventTarget | null): boolean {
   if (target === null || typeof Element === "undefined") return false;
   if (!(target instanceof Element)) return false;
-  return target.closest(COPY_ON_SELECT_INTERACTIVE_SELECTOR) !== null;
+  return target.closest(COPY_ON_SELECT_EDITABLE_SELECTOR) !== null;
 }
 
 /**
@@ -45,7 +51,7 @@ function nodeInEditable(node: Node | null): boolean {
   while (current !== null) {
     if (current.nodeType === 1) {
       const element = current as Element;
-      if (element.closest(COPY_ON_SELECT_INTERACTIVE_SELECTOR) !== null) return true;
+      if (element.closest(COPY_ON_SELECT_EDITABLE_SELECTOR) !== null) return true;
     }
     current = current.parentNode;
   }
@@ -55,8 +61,9 @@ function nodeInEditable(node: Node | null): boolean {
 /**
  * Returns the selected text when it is worth auto-copying, otherwise null.
  * Skips collapsed/multi-range selections, whitespace-only text, selections
- * rooted in editable or interactive elements, and (when given) selections
- * outside `container`.
+ * rooted in editable elements, and (when given) selections outside
+ * `container`. Selections inside links, buttons, and other clickable chips
+ * are allowed: only form fields opt out.
  */
 export function getCopyableDomSelectionText(
   selection: Selection | null,

--- a/apps/web/src/lib/copyOnSelect.ts
+++ b/apps/web/src/lib/copyOnSelect.ts
@@ -72,3 +72,42 @@ export function getCopyableDomSelectionText(
   }
   return text;
 }
+
+/**
+ * Identity of a DOM selection at one moment of a mouse gesture. Compared
+ * between mousedown and mouseup so a plain click over an existing selection
+ * never re-copies it: only a gesture that created or changed the selection
+ * may trigger an auto-copy.
+ */
+export type DomSelectionSnapshot = {
+  text: string;
+  anchorNode: Node | null;
+  anchorOffset: number;
+  focusNode: Node | null;
+  focusOffset: number;
+} | null;
+
+export function snapshotDomSelection(selection: Selection | null): DomSelectionSnapshot {
+  if (selection === null || selection.isCollapsed) return null;
+  return {
+    text: selection.toString(),
+    anchorNode: selection.anchorNode,
+    anchorOffset: selection.anchorOffset,
+    focusNode: selection.focusNode,
+    focusOffset: selection.focusOffset,
+  };
+}
+
+export function sameDomSelectionSnapshot(
+  before: DomSelectionSnapshot,
+  after: DomSelectionSnapshot,
+): boolean {
+  if (before === null || after === null) return before === after;
+  return (
+    before.text === after.text &&
+    before.anchorNode === after.anchorNode &&
+    before.anchorOffset === after.anchorOffset &&
+    before.focusNode === after.focusNode &&
+    before.focusOffset === after.focusOffset
+  );
+}

--- a/apps/web/src/lib/copyOnSelect.ts
+++ b/apps/web/src/lib/copyOnSelect.ts
@@ -47,7 +47,49 @@ export function isCopyOnSelectEditableTarget(target: EventTarget | null): boolea
  */
 export function normalizeTerminalSelectionText(text: string): string | null {
   const normalized = text.replace(/\r\n/g, "\n").replace(/^\n+|\n+$/g, "");
-  return normalized.length > 0 ? text : null;
+  return normalized.length > 0 ? normalized : null;
+}
+
+/**
+ * Owns terminal auto-copy state without receiving the terminal surface or its
+ * hidden IME input, so clipboard failure cannot mutate terminal input state.
+ */
+export function createTerminalSelectionAutoCopy({
+  readSettings,
+  writeText,
+  onCopied,
+}: {
+  readSettings: () => { enabled: boolean; showToast: boolean };
+  writeText: (text: string) => Promise<boolean>;
+  onCopied: () => void;
+}) {
+  let lastCopiedText: string | null = null;
+
+  return {
+    copy: async (text: string): Promise<boolean> => {
+      if (!readSettings().enabled) return false;
+      if (normalizeTerminalSelectionText(text) === null) return false;
+      if (text === lastCopiedText) return false;
+
+      lastCopiedText = text;
+      try {
+        const didCopy = await writeText(text);
+        if (!didCopy) {
+          if (lastCopiedText === text) lastCopiedText = null;
+          return false;
+        }
+      } catch {
+        if (lastCopiedText === text) lastCopiedText = null;
+        return false;
+      }
+
+      if (readSettings().showToast) onCopied();
+      return true;
+    },
+    rememberCopied: (text: string): void => {
+      lastCopiedText = text;
+    },
+  };
 }
 
 function nodeInEditable(node: Node | null): boolean {
@@ -78,7 +120,11 @@ export function getCopyableDomSelectionText(
   if (text.trim().length === 0) return null;
   const range = selection.getRangeAt(0);
   if (nodeInEditable(range.startContainer) || nodeInEditable(range.endContainer)) return null;
-  if (container && (!container.contains(range.startContainer) || !container.contains(range.endContainer))) {
+  if (range.cloneContents().querySelector(COPY_ON_SELECT_EDITABLE_SELECTOR) !== null) return null;
+  if (
+    container &&
+    (!container.contains(range.startContainer) || !container.contains(range.endContainer))
+  ) {
     return null;
   }
   return text;

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 - [Messages and context](./user/composer.md)
 - [Working with threads](./user/thread-sidebar.md)
 - [Permission modes](./user/permission-modes.md)
-- [Terminal history](./user/terminal.md)
+- [Terminal](./user/terminal.md)
 - [Source control](./user/source-control.md)
 - [Project settings](./user/project-settings.md)
 - [Appearance and themes](./user/appearance.md)

--- a/docs/user/terminal.md
+++ b/docs/user/terminal.md
@@ -1,4 +1,20 @@
-# Terminal history
+# Terminal
+
+## Copy selections automatically
+
+On web and desktop, enable **Settings → General → Copy on select** to copy text when you
+finish selecting it with the mouse in either the conversation or the terminal. The setting is
+off by default. Mobile keeps its native long-press selection behavior.
+
+**Copy on select toast** controls whether a successful automatic copy shows a confirmation.
+T3 Code does not show the confirmation when clipboard access is unavailable, such as from an
+insecure remote browser connection. A failed terminal copy leaves terminal input and in-progress
+IME text unchanged.
+
+Automatic copying only follows a new selection gesture. Clicking an existing selection does not
+copy it again, and double- or triple-click selection produces one copy after the gesture settles.
+
+## History
 
 Each terminal keeps up to 5,000 lines and 8 MiB of scrollback on its environment
 server. T3 Code removes the oldest output when either limit is reached. A long

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -77,13 +77,13 @@ describe("ClientSettings proactive panels", () => {
 });
 
 describe("ClientSettings copy on select", () => {
-  it("defaults copy and its toast on, matching Herdr", () => {
-    expect(decodeClientSettings({}).copyOnSelect).toBe(true);
+  it("is opt-in, with the toast defaulting on for when it is enabled", () => {
+    expect(decodeClientSettings({}).copyOnSelect).toBe(false);
     expect(decodeClientSettings({}).copyOnSelectToast).toBe(true);
   });
 
   it("accepts client-local updates", () => {
-    expect(decodeClientSettingsPatch({ copyOnSelect: false }).copyOnSelect).toBe(false);
+    expect(decodeClientSettingsPatch({ copyOnSelect: true }).copyOnSelect).toBe(true);
     expect(decodeClientSettingsPatch({ copyOnSelectToast: false }).copyOnSelectToast).toBe(false);
   });
 });

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -76,6 +76,18 @@ describe("ClientSettings proactive panels", () => {
   });
 });
 
+describe("ClientSettings copy on select", () => {
+  it("defaults copy and its toast on, matching Herdr", () => {
+    expect(decodeClientSettings({}).copyOnSelect).toBe(true);
+    expect(decodeClientSettings({}).copyOnSelectToast).toBe(true);
+  });
+
+  it("accepts client-local updates", () => {
+    expect(decodeClientSettingsPatch({ copyOnSelect: false }).copyOnSelect).toBe(false);
+    expect(decodeClientSettingsPatch({ copyOnSelectToast: false }).copyOnSelectToast).toBe(false);
+  });
+});
+
 describe("ClientSettings quit confirmation", () => {
   it("defaults to hold", () => {
     expect(decodeClientSettings({}).confirmQuit).toBe("hold");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -351,6 +351,19 @@ export const ClientSettingsSchema = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
   wordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  /**
+   * Herdr-style copy-on-select: releasing a mouse drag or double-click
+   * copies the selection to the clipboard. Matches Herdr's
+   * `ui.copy_on_select` (default true); the terminal pane and the chat
+   * timeline both honor it.
+   */
+  copyOnSelect: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  /**
+   * Shows the "copied to clipboard" toast after an automatic copy.
+   * Matches Herdr's `ui.toast.clipboard.enabled` (default true); turning
+   * it off keeps the copy but stays silent.
+   */
+  copyOnSelectToast: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 });
 export type ClientSettings = typeof ClientSettingsSchema.Type;
 
@@ -1210,5 +1223,7 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   wordWrap: Schema.optionalKey(Schema.Boolean),
+  copyOnSelect: Schema.optionalKey(Schema.Boolean),
+  copyOnSelectToast: Schema.optionalKey(Schema.Boolean),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -354,10 +354,13 @@ export const ClientSettingsSchema = Schema.Struct({
   /**
    * Herdr-style copy-on-select: releasing a mouse drag or double-click
    * copies the selection to the clipboard. Matches Herdr's
-   * `ui.copy_on_select` (default true); the terminal pane and the chat
-   * timeline both honor it.
+   * `ui.copy_on_select`, but opt-in rather than default-on: automatically
+   * writing to the clipboard changes everyday behavior, so existing users
+   * keep the current explicit-copy flow until they enable this in
+   * Settings → General. The terminal pane and the chat timeline both
+   * honor it.
    */
-  copyOnSelect: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  copyOnSelect: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   /**
    * Shows the "copied to clipboard" toast after an automatic copy.
    * Matches Herdr's `ui.toast.clipboard.enabled` (default true); turning


### PR DESCRIPTION
## What Changed

Adds opt-in, Herdr-style copy-on-select for the web and desktop clients. When **Settings → General → Copy on select** is enabled, completing a fresh mouse selection in chat or the integrated terminal writes that selection to the clipboard. **Copy on select toast** independently controls the success confirmation.

- The master setting remains **off by default**; the toast setting defaults on and is only shown while copy-on-select is enabled.
- Chat ignores collapsed, unchanged, multi-range, modifier-key, editable, and explicitly opted-out selections. A range is rejected when any part of it crosses an input, textarea, select, editable content, or `data-no-copy-on-select` subtree, even if both endpoints are ordinary text.
- Links, buttons, and `contenteditable="false"` citation chips remain selectable.
- Terminal copying uses the browser Clipboard API directly. It does not prime, focus, select, or mutate Ghostty's hidden input, so failed clipboard writes leave terminal input and in-progress IME composition unchanged.
- Clipboard failures remain silent, same-text writes are deduplicated, failed writes can be retried, and double/triple clicks coalesce into one copy.

## Why

Herdr copies mouse selections automatically. T3 Code previously required an explicit copy action. This adds the same fast workflow without changing behavior for existing users who do not opt in.

## Relationship to #9091

#9091 proposed terminal-only auto-copy. This PR supersedes it with chat and terminal coverage, an opt-out, optional success feedback, stale-selection guards, and a Clipboard API path that avoids hidden terminal-input mutation. Credit to @jonathanmeier5 for the original proposal and implementation direction.

## Surfaces Checklist

- **Entry points:** chat timeline and terminal selection gestures; searchable Settings → General controls; restore-defaults wiring.
- **Clients:** web and desktop. Mobile keeps native long-press selection behavior.
- **Providers:** not provider-shaped; all adapters are unaffected.
- **Contracts:** backward-compatible `ClientSettingsSchema` and patch defaults.
- **Connection modes:** local, remote, relay, and tunnel share the same client behavior; unavailable clipboard access produces no false toast.
- **Docs:** [Terminal user guide](https://github.com/pingdotgg/t3code/blob/8b9c050a74a529f54cde7d92598d568ff41e3d02/docs/user/terminal.md).

## Verification

- `vp test run apps/web/src/lib/copyOnSelect.test.ts apps/web/src/components/ThreadTerminalDrawer.test.ts apps/web/src/hooks/useCopyToClipboard.test.ts packages/contracts/src/settings.test.ts apps/desktop/src/settings/DesktopClientSettings.test.ts` — **117 tests passed**.
- Targeted lint on the four changed TypeScript files — no new warnings.
- Targeted typechecks for `@t3tools/web`, `@t3tools/contracts`, and `@t3tools/desktop` — passed.
- Merge-tree against `origin/main` at `9e1fb459a` — clean.
- Integrated browser pass in an isolated T3 environment:
  - default-off and dependent-setting visibility;
  - chat copy with toast on and off;
  - plain click over an existing selection leaves a clipboard sentinel unchanged;
  - real DOM range crossing an interior textarea leaves the clipboard unchanged;
  - real Ghostty canvas selection copies `terminal-copy-check`;
  - failed Clipboard API unit path preserves a sentinel terminal input/selection and emits no toast.

## Evidence

| Default (off) | Enabled |
| --- | --- |
| ![Copy on select disabled by default](https://github.com/SotoAugusto/t3code/releases/download/pr-9409-evidence-v1/copy-on-select-default-off.png) | ![Copy on select enabled with its toast option](https://github.com/SotoAugusto/t3code/releases/download/pr-9409-evidence-v1/copy-on-select-enabled.png) |

The clip covers chat selection, the plain-click no-op, toggling toast feedback off, and terminal selection:

[Watch the 20-second interaction demo](https://github.com/SotoAugusto/t3code/releases/download/pr-9409-evidence-v1/copy-on-select-demo.mp4). Review-only assets are hosted in the [fork evidence release](https://github.com/SotoAugusto/t3code/releases/tag/pr-9409-evidence-v1) and are not committed to this branch.

Built with GPT-5.6 Sol in Codex via the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in client-local clipboard behavior with extensive gesture guards and tests; default-off preserves existing workflows, with main risk being unexpected clipboard writes for users who enable the setting.
> 
> **Overview**
> Adds **opt-in copy-on-select** for web/desktop: new client settings `copyOnSelect` (default **off**) and `copyOnSelectToast` (default **on**, shown only when copy-on-select is enabled), wired through contracts, desktop settings tests, General settings UI/search, and restore-defaults.
> 
> **Chat** uses a new `useCopyOnSelect` hook on the message timeline: on mouse release after a fresh left-drag or settled multi-click, eligible selections copy via the clipboard API, with guards for unchanged selections, modifiers, editables, and opted-out subtrees. **Terminal** auto-copies on selection release via `createTerminalSelectionAutoCopy`, sharing normalization/dedup logic in `copyOnSelect.ts`; explicit Copy still toasts and records the selection so auto-copy does not immediately repeat.
> 
> Clipboard writes stay **silent on failure**; success toasts only after a confirmed write. Terminal copying does not touch Ghostty’s hidden input. Docs rename/extend the terminal user guide for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b9c050a74a529f54cde7d92598d568ff41e3d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automatic copy-on-select for chat timeline and terminal selections
> - Adds `copyOnSelect` and `copyOnSelectToast` client settings with defaults of disabled and enabled respectively, wired into [settings.ts](https://github.com/pingdotgg/t3code/pull/9409/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) and the desktop settings fixture
> - Introduces [useCopyOnSelect.ts](https://github.com/pingdotgg/t3code/pull/9409/files#diff-68b01aa448c379ed94303d21d21b77e46927d4f147455a2ebaa2eb67e45a27cb) to auto-copy qualifying single-range mouse selections in the chat timeline on release, deferring multi-click sequences and ignoring editable/modifier/non-primary gestures
> - Adds terminal auto-copy coordination in [copyOnSelect.ts](https://github.com/pingdotgg/t3code/pull/9409/files#diff-0da27137c766761435e4b35cb7a2715999dd90e2f66541f59928b4f1ac2d56ad) that de-duplicates pending and repeated writes, normalizes terminal line endings, retries after failure, and toasts only on successful writes when enabled
> - Integrates both paths into [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/9409/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) and [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9409/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), and adds settings UI toggles plus search entries in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/9409/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18)
> - Behavioral Change: terminal and chat selections are now copied automatically when the new `copyOnSelect` setting is enabled; existing selection-menu and citation-toolbar flows are unchanged when it is disabled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b9c050.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

