### PR TITLE
fix(antigravity): discover legacy workspace skills

### DIFF
--- a/apps/server/src/provider/Drivers/AntigravitySkills.test.ts
+++ b/apps/server/src/provider/Drivers/AntigravitySkills.test.ts
@@ -28,7 +28,7 @@ const makeWorkspace = Effect.fn("makeWorkspace")(function* () {
 });
 
 it.layer(NodeServices.layer)("discoverAntigravitySkills", (it) => {
-  it.effect("reads skill names, descriptions and paths from all four native roots", () =>
+  it.effect("reads skill names, descriptions and paths from the current native roots", () =>
     Effect.gen(function* () {
       const path = yield* Path.Path;
       const input = yield* makeWorkspace();
@@ -63,6 +63,27 @@ it.layer(NodeServices.layer)("discoverAntigravitySkills", (it) => {
     }),
   );
 
+  it.effect("discovers skills from the legacy workspace root", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const input = yield* makeWorkspace();
+      const skillPath = yield* writeSkill(
+        path.join(input.cwd, ".agent", "skills", "review"),
+        "---\nname: review\ndescription: Review changes.\n---\n",
+      );
+
+      assert.deepEqual(yield* discoverAntigravitySkills(input), [
+        {
+          name: "review",
+          description: "Review changes.",
+          path: skillPath,
+          scope: "project",
+          enabled: true,
+        },
+      ]);
+    }),
+  );
+
   it.effect("uses native root order for duplicate names", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
@@ -73,6 +94,7 @@ it.layer(NodeServices.layer)("discoverAntigravitySkills", (it) => {
         path.join(input.cwd, ".gemini", "skills"),
         path.join(input.profileDirectory, "antigravity-cli", "skills"),
         path.join(input.cwd, ".agents", "skills"),
+        path.join(input.cwd, ".agent", "skills"),
       ];
       for (const [index, root] of roots.entries()) {
         yield* writeSkill(

--- a/apps/server/src/provider/Drivers/AntigravitySkills.ts
+++ b/apps/server/src/provider/Drivers/AntigravitySkills.ts
@@ -134,6 +134,7 @@ export const discoverAntigravitySkills = Effect.fn("discoverAntigravitySkills")(
       scope: "user",
     },
     { directory: path.resolve(input.cwd, ".agents", "skills"), scope: "project" },
+    { directory: path.resolve(input.cwd, ".agent", "skills"), scope: "project" },
   ];
   const budget: ScanBudget = {
     remainingBytes: MAX_SCAN_BYTES,

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -117,6 +117,10 @@ T3 Code asks you to select an available model instead of silently changing it.
 Use Antigravity's native `/plan` command to request a plan. T3 Code's separate Plan mode control
 is not available for this provider.
 
+Project skills belong in `.agents/skills`. T3 Code also discovers the legacy `.agent/skills`
+location for existing projects. When both locations define the same skill name, `.agents/skills`
+takes precedence.
+
 Antigravity reads and edits workspace files through T3 Code. Each write shows up as a file
 change approval with the content, so **Supervised** and **Auto-accept edits** behave the same way
 they do for other providers. Attach images, PDFs, text files, or audio clips to a message and

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -117,9 +117,9 @@ T3 Code asks you to select an available model instead of silently changing it.
 Use Antigravity's native `/plan` command to request a plan. T3 Code's separate Plan mode control
 is not available for this provider.
 
-Project skills belong in `.agents/skills`. T3 Code also discovers the legacy `.agent/skills`
-location for existing projects. When both locations define the same skill name, `.agents/skills`
-takes precedence.
+Project skills should use `.agents/skills`. T3 Code also discovers `.gemini/skills` and the legacy
+`.agent/skills` location. When multiple locations define the same skill name, `.gemini/skills`
+takes precedence, followed by `.agents/skills` and then `.agent/skills`.
 
 Antigravity reads and edits workspace files through T3 Code. Each write shows up as a file
 change approval with the content, so **Supervised** and **Auto-accept edits** behave the same way


### PR DESCRIPTION
## What Changed

- Add the legacy `.agent/skills` workspace location to Antigravity skill discovery.
- Keep `.agents/skills` ahead of the legacy location when both define the same skill name.
- Cover legacy discovery and duplicate-name precedence with focused tests.
- Document both workspace locations in the Antigravity user guide.

## Why

Google Antigravity defaults to `.agents/skills`, but its [official documentation](https://antigravity.google/docs/skills) says it still supports `.agent/skills` for backward compatibility. The native agent could load a legacy project skill while T3 Code omitted it from the provider catalog.

Scanning the legacy location after `.agents/skills` keeps T3 Code's catalog aligned with Antigravity without changing the preferred location.

## Discovery order

```mermaid
flowchart TD
    A["Scan .agents/skills"] --> B["Record discovered skill names"]
    B --> C["Scan legacy .agent/skills"]
    C --> D{"Name already discovered?"}
    D -->|Yes| E["Keep .agents/skills version"]
    D -->|No| F["Add legacy skill"]
```

## Verification

- `vp test run apps/server/src/provider/Drivers/AntigravitySkills.test.ts apps/server/src/provider/Drivers/AntigravityDriver.test.ts apps/server/src/provider/Layers/AntigravityProvider.test.ts` (35 tests passed)
- `vp lint apps/server/src/provider/Drivers/AntigravitySkills.ts apps/server/src/provider/Drivers/AntigravitySkills.test.ts --report-unused-disable-directives`
- `vp fmt apps/server/src/provider/Drivers/AntigravitySkills.ts apps/server/src/provider/Drivers/AntigravitySkills.test.ts docs/user/providers-antigravity.md --check`
- `vp run --filter t3 typecheck`
- `fallow audit --base upstream/main` (`pass`, no introduced findings)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable, no UI changes)
- [x] I included a video for animation/interaction changes (not applicable, no interaction changes)

Built with GPT-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive discovery path and docs/tests only; no auth, security, or breaking behavior beyond filling in missing legacy skills.
> 
> **Overview**
> Antigravity skill discovery now includes the legacy project directory **`.agent/skills`**, so T3 Code’s catalog matches Antigravity when projects still use that path.
> 
> The new root is scanned **after** `.agents/skills` (and the other existing roots), so duplicate skill names keep the version from the preferred location. Tests cover legacy-only discovery and updated duplicate-name ordering; the Antigravity user guide documents `.agents/skills`, `.gemini/skills`, `.agent/skills`, and name precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec7e5734a9b8da91ceeb74c672b54740aad24f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discover legacy `.agent/skills` workspace roots in `discoverAntigravitySkills`
> - Appends the workspace-relative `.agent/skills` directory to the discovery roots in [AntigravitySkills.ts](https://github.com/pingdotgg/t3code/pull/9410/files#diff-e01dce716579d61669fa25efc5771746eb90026c0597636950b49eb83a2fce22), marked as project-scoped, so skills there are discovered alongside existing roots.
> - Earlier roots keep precedence in duplicate-name resolution; the legacy location is scanned last.
> - Updates [providers-antigravity.md](https://github.com/pingdotgg/t3code/pull/9410/files#diff-62b2768fa557094d146d5aace8e013a4781458c8e9d23aeb4facd6a205bd64e7) to document `.agents/skills`, `.gemini/skills`, and the legacy `.agent/skills` location and their precedence order.
> - Risk: skills under `.agent/skills` now appear in discovery results as project-scoped and enabled, which may surface previously hidden skills in workspaces that still use the legacy path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ec7e57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Antigravity now discovers project skills stored in the legacy `.agent/skills` directory.
  - Skill discovery precedence is documented as `.gemini/skills`, then `.agents/skills`, then `.agent/skills`.

- **Documentation**
  - Updated the Antigravity provider guide with supported project skill locations and their precedence order.

- **Tests**
  - Expanded coverage for legacy skill-directory discovery and duplicate-name precedence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->