### PR TITLE
fix(triage): file reports through the issue form so via-triage sticks

### DIFF
--- a/.github/triage/PLAYBOOK.md
+++ b/.github/triage/PLAYBOOK.md
@@ -104,14 +104,22 @@ of `main` for that work, never the tag-pinned diagnosis clone.
 - Match the structure of the `via-triage` issue template
   (`.github/ISSUE_TEMPLATE/via-triage.yml` in the repo): what happened, diagnosis,
   repro steps, environment, evidence, related issues.
-- Label it `via-triage`. Use a plain, specific title with no prefix.
+- Use a plain, specific title with no prefix.
+- The issue needs the `via-triage` label. `gh issue create --label via-triage`
+  drops it silently unless the account has triage or write permission; check with
+  `gh api repos/pingdotgg/t3code --jq .permissions.triage` before posting.
+- Without that permission, file through the issue form: it carries the template's
+  label whoever submits. Build `issues/new?template=via-triage.yml` with `&title=`
+  and one `&<field-id>=` per field in `via-triage.yml`, url-encoded. Never pass
+  `labels`; GitHub answers 404 when the reader cannot apply it.
+- When the report is too long to prefill in a URL, open the bare
+  `issues/new?template=via-triage.yml` form and have the user paste the approved
+  text into the fields. That path needs no `gh` and still carries the label.
 - Show the user the complete final issue text and get an explicit yes before
   posting. Never post without it.
 - Note at the end of the issue which model and agent produced it.
-- If `gh` is not authenticated, offer `gh auth login`, or build a prefilled
-  https://github.com/pingdotgg/t3code/issues/new URL with title and body query
-  parameters; print the URL, and open it in their browser only after they
-  approve.
+- If `gh` is not authenticated, offer `gh auth login`, or fall back to the issue
+  form; print the URL, and open it in their browser only after they approve.
 - If the user pasted screenshots, remind them to drag the images into the issue
   after it is created; they cannot be attached from here.
 

--- a/apps/server/src/cli/triagePrompt.ts
+++ b/apps/server/src/cli/triagePrompt.ts
@@ -116,14 +116,22 @@ of \`main\` for that work, never the tag-pinned diagnosis clone.
 - Match the structure of the \`via-triage\` issue template
   (\`.github/ISSUE_TEMPLATE/via-triage.yml\` in the repo): what happened, diagnosis,
   repro steps, environment, evidence, related issues.
-- Label it \`via-triage\`. Use a plain, specific title with no prefix.
+- Use a plain, specific title with no prefix.
+- The issue needs the \`via-triage\` label. \`gh issue create --label via-triage\`
+  drops it silently unless the account has triage or write permission; check with
+  \`gh api repos/pingdotgg/t3code --jq .permissions.triage\` before posting.
+- Without that permission, file through the issue form: it carries the template's
+  label whoever submits. Build \`issues/new?template=via-triage.yml\` with \`&title=\`
+  and one \`&<field-id>=\` per field in \`via-triage.yml\`, url-encoded. Never pass
+  \`labels\`; GitHub answers 404 when the reader cannot apply it.
+- When the report is too long to prefill in a URL, open the bare
+  \`issues/new?template=via-triage.yml\` form and have the user paste the approved
+  text into the fields. That path needs no \`gh\` and still carries the label.
 - Show the user the complete final issue text and get an explicit yes before
   posting. Never post without it.
 - Note at the end of the issue which model and agent produced it.
-- If \`gh\` is not authenticated, offer \`gh auth login\`, or build a prefilled
-  https://github.com/pingdotgg/t3code/issues/new URL with title and body query
-  parameters; print the URL, and open it in their browser only after they
-  approve.
+- If \`gh\` is not authenticated, offer \`gh auth login\`, or fall back to the issue
+  form; print the URL, and open it in their browser only after they approve.
 - If the user pasted screenshots, remind them to drag the images into the issue
   after it is created; they cannot be attached from here.
 


### PR DESCRIPTION
Fixes #8061.

The playbook tells the triage agent to label the issue `via-triage`, but neither
path it offers can apply that label from an ordinary contributor account.

`gh issue create --label via-triage` needs triage or write permission. Without it
the label is dropped, and the command still exits 0 and prints the issue URL, so
the agent reports success:

```
$ gh api repos/pingdotgg/t3code --jq '.permissions'
{"admin":false,"maintain":false,"pull":true,"push":false,"triage":false}
```

That is how #8059 was filed. It is still unlabelled.

The fallback does not work either. It builds
`https://github.com/pingdotgg/t3code/issues/new` with `title` and `body`
parameters, which selects no template, so `via-triage.yml`'s `labels:` block never
applies. `blank_issues_enabled` is `false`, so that URL lands on the template
chooser rather than a form, and issue forms prefill by field `id` anyway, not
`body`.

The playbook now says to check `gh api repos/pingdotgg/t3code --jq
.permissions.triage` first, and when that is not `true`, to file through
`?template=via-triage.yml` with one url-encoded parameter per field id. GitHub
applies the template's labels whoever submits, so that is the one path that
reliably lands `via-triage`. It also warns off the `labels` query parameter, which
404s for anyone who cannot apply labels, and says what to do when the report is
too long to carry in a URL.

Both files changed together: `TRIAGE_PLAYBOOK` in
`apps/server/src/cli/triagePrompt.ts` has to stay byte-identical to
`.github/triage/PLAYBOOK.md`, and `triagePrompt.test.ts` already checks that. Text
only, no code paths touched, no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP4xv7WtAw6hteCNMu7cfn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only playbook text for triage agents; no runtime code or GitHub integration paths changed.
> 
> **Overview**
> **Section 8** of the triage playbook is expanded so agents stop filing unlabeled issues when the submitter lacks GitHub triage/write permission.
> 
> The old single bullet about `via-triage` labeling is split into explicit steps: check `gh api repos/pingdotgg/t3code --jq .permissions.triage` before `gh issue create --label via-triage` (the label is dropped silently on failure). Without permission, agents must use `issues/new?template=via-triage.yml` with URL-encoded `title` and per-field ids from `via-triage.yml`, and must not pass `labels` (404 for readers who cannot apply labels). Long reports use the bare template form with user paste instead of URL prefill.
> 
> The unauthenticated fallback no longer points at a generic `issues/new` URL with `title`/`body`; it defers to the same issue-form flow. **`TRIAGE_PLAYBOOK`** in `triagePrompt.ts` is updated in lockstep with `.github/triage/PLAYBOOK.md` (existing byte-identity test unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9749497667e6526f93c9269a1d10a7422e186b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### File triage reports through issue form so `via-triage` label sticks
> - Updates triage filing guidance in both [PLAYBOOK.md](https://github.com/pingdotgg/t3code/pull/9412/files#diff-cbe7d196084ff56b6376185996f09fd148ccc992f52541a28832c6fb8ecba5b1) and [triagePrompt.ts](https://github.com/pingdotgg/t3code/pull/9412/files#diff-c5aeeb2637b82eccf4c570164fa66d774a23ee7314725497025414a0ecdf6be6) to check label-application permission before applying the `via-triage` label
> - When the account lacks permission or GitHub CLI is unauthenticated, falls back to the issue-template form with URL-prefilled template fields instead of label query parameters
> - Adds a bare-form path for long reports and separates title formatting from label application
> - Behavioral Change: unauthenticated fallback changes from a body-prefilled URL to the issue form; label query parameters are prohibited in the form fallback
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b97494.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->