### PR TITLE
fix(web): allow pinning during worktree creation

### DIFF
--- a/packages/client-runtime/src/state/threadCommands.test.ts
+++ b/packages/client-runtime/src/state/threadCommands.test.ts
@@ -1,0 +1,64 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { AsyncResult, AtomRegistry } from "effect/unstable/reactivity";
+import { describe, expect, it } from "vite-plus/test";
+
+import { threadCommandConcurrency, threadPinCommandConcurrency } from "./threadCommands.ts";
+import { createAtomCommandScheduler } from "./runtime.ts";
+
+const target = {
+  environmentId: EnvironmentId.make("environment-1"),
+  input: { threadId: ThreadId.make("thread-1") },
+};
+
+function startPendingBootstrap() {
+  const scheduler = createAtomCommandScheduler();
+  const registry = AtomRegistry.make();
+  let finishWorktree = () => {};
+  const worktreeReady = new Promise<void>((resolve) => {
+    finishWorktree = resolve;
+  });
+  const bootstrap = scheduler.schedule(registry, threadCommandConcurrency, target, async () => {
+    await worktreeReady;
+    return AsyncResult.success(undefined);
+  });
+  return { scheduler, registry, bootstrap, finishWorktree };
+}
+
+describe("thread command concurrency", () => {
+  it("lets pinning dispatch while first-turn worktree bootstrap is still running", async () => {
+    const { scheduler, registry, bootstrap, finishWorktree } = startPendingBootstrap();
+    let pinDispatched = false;
+
+    await scheduler.schedule(registry, threadPinCommandConcurrency, target, async () => {
+      pinDispatched = true;
+      return AsyncResult.success(undefined);
+    });
+
+    expect(pinDispatched).toBe(true);
+    finishWorktree();
+    await bootstrap;
+    registry.dispose();
+  });
+
+  it("keeps other thread commands such as delete behind worktree bootstrap", async () => {
+    const { scheduler, registry, bootstrap, finishWorktree } = startPendingBootstrap();
+    let deleteDispatched = false;
+
+    const deleteThread = scheduler.schedule(
+      registry,
+      threadCommandConcurrency,
+      target,
+      async () => {
+        deleteDispatched = true;
+        return AsyncResult.success(undefined);
+      },
+    );
+
+    await Promise.resolve();
+    expect(deleteDispatched).toBe(false);
+    finishWorktree();
+    await Promise.all([bootstrap, deleteThread]);
+    expect(deleteDispatched).toBe(true);
+    registry.dispose();
+  });
+});

--- a/packages/client-runtime/src/state/threadCommands.ts
+++ b/packages/client-runtime/src/state/threadCommands.ts
@@ -59,6 +59,25 @@ import {
 } from "../operations/commands.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 
+type ThreadCommandTarget = {
+  readonly environmentId: string;
+  readonly input: { readonly threadId: string };
+};
+
+/** Serializes commands for one thread, including a first turn that is still creating its worktree. */
+export const threadCommandConcurrency = {
+  mode: "serial" as const,
+  key: ({ environmentId, input }: ThreadCommandTarget) =>
+    JSON.stringify([environmentId, input.threadId]),
+};
+
+/** Pin state is independent of worktree bootstrap, so pinning must not wait behind it. */
+export const threadPinCommandConcurrency = {
+  mode: "serial" as const,
+  key: ({ environmentId, input }: ThreadCommandTarget) =>
+    JSON.stringify([environmentId, input.threadId, "pin"]),
+};
+
 export type {
   ArchiveThreadInput,
   CreateThreadInput,
@@ -90,11 +109,7 @@ export function createThreadEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | Crypto.Crypto | R, E>,
 ) {
   const scheduler = createAtomCommandScheduler();
-  const concurrency = {
-    mode: "serial" as const,
-    key: ({ environmentId, input }: { environmentId: string; input: { threadId: string } }) =>
-      JSON.stringify([environmentId, input.threadId]),
-  };
+  const concurrency = threadCommandConcurrency;
   return {
     create: createEnvironmentCommand(runtime, {
       label: "environment-data:commands:thread:create",
@@ -148,19 +163,19 @@ export function createThreadEnvironmentAtoms<R, E>(
       label: "environment-data:commands:thread:pin",
       execute: (input: PinThreadInput) => pinThread(input),
       scheduler,
-      concurrency,
+      concurrency: threadPinCommandConcurrency,
     }),
     unpin: createEnvironmentCommand(runtime, {
       label: "environment-data:commands:thread:unpin",
       execute: (input: UnpinThreadInput) => unpinThread(input),
       scheduler,
-      concurrency,
+      concurrency: threadPinCommandConcurrency,
     }),
     reorderPin: createEnvironmentCommand(runtime, {
       label: "environment-data:commands:thread:reorder-pin",
       execute: (input: ReorderPinnedThreadInput) => reorderPinnedThread(input),
       scheduler,
-      concurrency,
+      concurrency: threadPinCommandConcurrency,
     }),
     reorderActive: createEnvironmentCommand(runtime, {
       label: "environment-data:commands:thread:reorder-active",


### PR DESCRIPTION
Starting a thread in a new worktree keeps its first-turn RPC open while Git creates the worktree. Every per-thread command shared one serial lane, so Pin and Unpin sat behind that RPC until setup finished.

Pin, unpin, and pinned-order changes now use their own per-thread serial lane in `packages/client-runtime` (shared by web, desktop, and mobile). Every other thread command, including delete, archive, active reorder, and dismissing user input, stays on the shared lane so it still waits for the worktree bootstrap. No wire or server change.

## Real-client verification (6 September 2026)

Captured in the full running T3 web app at 1280×800 with disposable seeded data. A test-only Git post-checkout hook held worktree creation at a FIFO. On the base, Pin did not write `pinned_at` until the hook was released. With the fix, Pin wrote `pinned_at` while the hook was still blocked, and Unpin cleared it before release. The sidebar moved the row into and out of Pinned while "Setting up worktree" stayed visible.

![Base and candidate in the real client](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9415-real-comparison.gif)

![Real client interaction](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9415-real-interaction.gif)

[Clean recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9415-real-clean.mp4) · [Annotated recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9415-real-annotated.mp4)

These recordings show the same lane split. The 11 September refresh rebased onto current `main` and removed a per-operation mapping table. It did not change behavior, so the media was not re-recorded.

## Focused verification

- `packages/client-runtime: vp test run src/state/threadCommands.test.ts`: 2 passed. One test shows a pin dispatches while a bootstrap is pending. The other shows a delete waits for it.
- `packages/client-runtime: vp run typecheck`: passed. It printed only existing suggestions in `vcsAction`.
- `vp lint` and `vp fmt --check` on both touched files: passed

A cross-provider review was skipped for this refresh because Codex weekly quota was below 10%.

Coordination trace: T3 thread b4ec3604-30fc-416c-a533-4d9ba2aac779

Rebased and simplified by Claude Opus 5 in Claude Code (running in T3 Code). The original change and media were made by GPT-6 in Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread command handling during worktree setup.
  * Pin actions can now be processed while setup is still running.
  * Destructive actions wait for setup to complete, reducing conflicts.
  * Reordering active items and dismissing input remain safely queued until setup finishes.

* **Tests**
  * Added coverage for command ordering and concurrent thread operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->