### PR TITLE
fix(web): keep the sidebar project filter across navigation

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -111,7 +111,11 @@ import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import {
+  useAllEnvironmentShellsBootstrapped,
+  useProjects,
+  useThreadShells,
+} from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
@@ -2167,13 +2171,15 @@ export default function Sidebar() {
     [scopedProjectGroup],
   );
   // A persisted scope whose project is gone falls back to all projects, but
-  // only once groups exist: projects stream in after mount, so clearing while
-  // the list is still empty would drop the restored scope every launch.
+  // only after every catalog environment has delivered its project snapshot:
+  // environments populate independently, so a partial list must not clear a
+  // scope whose project lives in an environment that is still loading.
+  const allShellsBootstrapped = useAllEnvironmentShellsBootstrapped();
   useEffect(() => {
-    if (projectScopeKey !== null && projectGroups.length > 0 && scopedProjectGroup === null) {
+    if (projectScopeKey !== null && allShellsBootstrapped && scopedProjectGroup === null) {
       setProjectScopeKey(null);
     }
-  }, [projectGroups.length, projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
+  }, [allShellsBootstrapped, projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
   // Count-only subscription: the parent needs "are there draft rows" for the
   // empty state, while SidebarDraftBlock owns the per-keystroke content
   // subscription. Selecting a number keeps typing in a draft composer from

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -112,7 +112,7 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import {
-  useAllEnvironmentShellsBootstrapped,
+  useAllEnvironmentProjectSnapshotsReady,
   useProjects,
   useThreadShells,
 } from "../state/entities";
@@ -2171,15 +2171,14 @@ export default function Sidebar() {
     [scopedProjectGroup],
   );
   // A persisted scope whose project is gone falls back to all projects, but
-  // only after every catalog environment has delivered its project snapshot:
-  // environments populate independently, so a partial list must not clear a
-  // scope whose project lives in an environment that is still loading.
-  const allShellsBootstrapped = useAllEnvironmentShellsBootstrapped();
+  // only after every catalog environment has a live project snapshot. Cached
+  // or disconnected environments cannot establish that the project is gone.
+  const allProjectSnapshotsReady = useAllEnvironmentProjectSnapshotsReady();
   useEffect(() => {
-    if (projectScopeKey !== null && allShellsBootstrapped && scopedProjectGroup === null) {
+    if (projectScopeKey !== null && allProjectSnapshotsReady && scopedProjectGroup === null) {
       setProjectScopeKey(null);
     }
-  }, [allShellsBootstrapped, projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
+  }, [allProjectSnapshotsReady, projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
   // Count-only subscription: the parent needs "are there draft rows" for the
   // empty state, while SidebarDraftBlock owns the per-keystroke content
   // subscription. Selecting a number keeps typing in a draft composer from

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2098,7 +2098,11 @@ export default function Sidebar() {
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
-  const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
+  // The selection lives in the persisted UI store next to the other sidebar
+  // project preferences, so routes that unmount the sidebar (Settings) and
+  // app restarts keep it.
+  const projectScopeKey = useUiStateStore((store) => store.sidebarProjectScopeKey);
+  const setProjectScopeKey = useUiStateStore((store) => store.setSidebarProjectScopeKey);
   // {value, label} items let Base UI drive the combobox selection contract
   // while the popup search filters the same collection.
   const projectScopeItems = useMemo(
@@ -2162,11 +2166,14 @@ export default function Sidebar() {
           ),
     [scopedProjectGroup],
   );
+  // A persisted scope whose project is gone falls back to all projects, but
+  // only once groups exist: projects stream in after mount, so clearing while
+  // the list is still empty would drop the restored scope every launch.
   useEffect(() => {
-    if (projectScopeKey !== null && scopedProjectGroup === null) {
+    if (projectScopeKey !== null && projectGroups.length > 0 && scopedProjectGroup === null) {
       setProjectScopeKey(null);
     }
-  }, [projectScopeKey, scopedProjectGroup]);
+  }, [projectGroups.length, projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
   // Count-only subscription: the parent needs "are there draft rows" for the
   // empty state, while SidebarDraftBlock owns the per-keystroke content
   // subscription. Selecting a number keeps typing in a draft composer from

--- a/apps/web/src/hostedPairing.ts
+++ b/apps/web/src/hostedPairing.ts
@@ -40,8 +40,9 @@ export function isHostedStaticApp(url?: URL): boolean {
     return true;
   }
 
-  // No window (tests, static render) means no origin to be hosted at.
-  if (url === undefined && typeof window === "undefined") {
+  // No window, or a window without a location (tests, static render), means
+  // no origin to be hosted at.
+  if (url === undefined && (typeof window === "undefined" || window.location === undefined)) {
     return false;
   }
 

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -15,7 +15,10 @@ import { useMemo } from "react";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentProjects } from "./projects";
 import { environmentServerConfigsAtom } from "./server";
-import { allEnvironmentShellsBootstrappedAtom } from "./shell";
+import {
+  allEnvironmentProjectSnapshotsReadyAtom,
+  allEnvironmentShellsBootstrappedAtom,
+} from "./shell";
 import { environmentThreadDetails, environmentThreadShells } from "./threads";
 
 const EMPTY_THREAD_REFS: ReadonlyArray<ScopedThreadRef> = Object.freeze([]);
@@ -77,6 +80,10 @@ export function useThreadShells(): ReadonlyArray<EnvironmentThreadShell> {
 
 export function useAllEnvironmentShellsBootstrapped(): boolean {
   return useAtomValue(allEnvironmentShellsBootstrappedAtom);
+}
+
+export function useAllEnvironmentProjectSnapshotsReady(): boolean {
+  return useAtomValue(allEnvironmentProjectSnapshotsReadyAtom);
 }
 
 export function useThreadShellsForProjectRefs(

--- a/apps/web/src/state/shell.test.ts
+++ b/apps/web/src/state/shell.test.ts
@@ -1,4 +1,7 @@
-import { BearerConnectionTarget, PrimaryConnectionTarget } from "@t3tools/client-runtime/connection";
+import {
+  BearerConnectionTarget,
+  PrimaryConnectionTarget,
+} from "@t3tools/client-runtime/connection";
 import type { EnvironmentCatalogState } from "@t3tools/client-runtime/state/connections";
 import type { EnvironmentShellState } from "@t3tools/client-runtime/state/shell";
 import { EnvironmentId } from "@t3tools/contracts";

--- a/apps/web/src/state/shell.test.ts
+++ b/apps/web/src/state/shell.test.ts
@@ -1,4 +1,4 @@
-import { PrimaryConnectionTarget } from "@t3tools/client-runtime/connection";
+import { BearerConnectionTarget, PrimaryConnectionTarget } from "@t3tools/client-runtime/connection";
 import type { EnvironmentCatalogState } from "@t3tools/client-runtime/state/connections";
 import type { EnvironmentShellState } from "@t3tools/client-runtime/state/shell";
 import { EnvironmentId } from "@t3tools/contracts";
@@ -34,12 +34,19 @@ function catalogState(environmentIds: readonly EnvironmentId[]): EnvironmentCata
       environmentIds.map((environmentId) => [
         environmentId,
         {
-          target: new PrimaryConnectionTarget({
-            environmentId,
-            label: environmentId,
-            httpBaseUrl: `https://${environmentId}.example.test`,
-            wsBaseUrl: `wss://${environmentId}.example.test`,
-          }),
+          target:
+            environmentId === LOCAL
+              ? new PrimaryConnectionTarget({
+                  environmentId,
+                  label: environmentId,
+                  httpBaseUrl: `https://${environmentId}.example.test`,
+                  wsBaseUrl: `wss://${environmentId}.example.test`,
+                })
+              : new BearerConnectionTarget({
+                  environmentId,
+                  connectionId: environmentId,
+                  label: environmentId,
+                }),
           profile: Option.none(),
         },
       ]),
@@ -47,7 +54,7 @@ function catalogState(environmentIds: readonly EnvironmentId[]): EnvironmentCata
   };
 }
 
-function makeHarness() {
+function makeHarness(requiresPrimaryEnvironment = true) {
   const catalog = Atom.make<EnvironmentCatalogState>({ isReady: false, entries: new Map() });
   const shells = Atom.family((_environmentId: EnvironmentId) =>
     Atom.make<EnvironmentShellState>(shellState("empty")),
@@ -55,16 +62,39 @@ function makeHarness() {
   const ready = createAllEnvironmentProjectSnapshotsReadyAtom({
     catalogValueAtom: catalog,
     shellStateValueAtom: shells,
+    requiresPrimaryEnvironment,
   });
   const registry = AtomRegistry.make();
   return { catalog, shells, ready, registry };
 }
 
 describe("project snapshot readiness", () => {
-  it("does not clear a saved scope before catalog loading finishes", () => {
+  it("does not clear a saved scope while the ready catalog is still empty", () => {
     const { catalog, ready, registry } = makeHarness();
     expect(registry.get(ready)).toBe(false);
     registry.set(catalog, catalogState([]));
+    expect(registry.get(ready)).toBe(false);
+    registry.dispose();
+  });
+
+  it("waits for primary discovery even if a persisted remote is already live", () => {
+    const { catalog, shells, ready, registry } = makeHarness();
+    registry.set(catalog, catalogState([REMOTE]));
+    registry.set(shells(REMOTE), shellState("live"));
+    expect(registry.get(ready)).toBe(false);
+
+    registry.set(catalog, catalogState([LOCAL, REMOTE]));
+    expect(registry.get(ready)).toBe(false);
+    registry.set(shells(LOCAL), shellState("live"));
+    expect(registry.get(ready)).toBe(true);
+    registry.dispose();
+  });
+
+  it("allows a hosted client to load projects without a primary environment", () => {
+    const { catalog, shells, ready, registry } = makeHarness(false);
+    registry.set(catalog, catalogState([REMOTE]));
+    expect(registry.get(ready)).toBe(false);
+    registry.set(shells(REMOTE), shellState("live"));
     expect(registry.get(ready)).toBe(true);
     registry.dispose();
   });

--- a/apps/web/src/state/shell.test.ts
+++ b/apps/web/src/state/shell.test.ts
@@ -1,0 +1,102 @@
+import { PrimaryConnectionTarget } from "@t3tools/client-runtime/connection";
+import type { EnvironmentCatalogState } from "@t3tools/client-runtime/state/connections";
+import type { EnvironmentShellState } from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { Atom, AtomRegistry } from "effect/unstable/reactivity";
+import { describe, expect, it } from "vite-plus/test";
+
+import { createAllEnvironmentProjectSnapshotsReadyAtom } from "./shell";
+
+const LOCAL = EnvironmentId.make("local");
+const REMOTE = EnvironmentId.make("remote");
+
+function shellState(status: EnvironmentShellState["status"]): EnvironmentShellState {
+  return {
+    status,
+    snapshot:
+      status === "empty"
+        ? Option.none()
+        : Option.some({
+            snapshotSequence: 1,
+            updatedAt: "2026-09-04T00:00:00.000Z",
+            projects: [],
+            threads: [],
+          }),
+    error: Option.none(),
+  };
+}
+
+function catalogState(environmentIds: readonly EnvironmentId[]): EnvironmentCatalogState {
+  return {
+    isReady: true,
+    entries: new Map(
+      environmentIds.map((environmentId) => [
+        environmentId,
+        {
+          target: new PrimaryConnectionTarget({
+            environmentId,
+            label: environmentId,
+            httpBaseUrl: `https://${environmentId}.example.test`,
+            wsBaseUrl: `wss://${environmentId}.example.test`,
+          }),
+          profile: Option.none(),
+        },
+      ]),
+    ),
+  };
+}
+
+function makeHarness() {
+  const catalog = Atom.make<EnvironmentCatalogState>({ isReady: false, entries: new Map() });
+  const shells = Atom.family((_environmentId: EnvironmentId) =>
+    Atom.make<EnvironmentShellState>(shellState("empty")),
+  );
+  const ready = createAllEnvironmentProjectSnapshotsReadyAtom({
+    catalogValueAtom: catalog,
+    shellStateValueAtom: shells,
+  });
+  const registry = AtomRegistry.make();
+  return { catalog, shells, ready, registry };
+}
+
+describe("project snapshot readiness", () => {
+  it("does not clear a saved scope before catalog loading finishes", () => {
+    const { catalog, ready, registry } = makeHarness();
+    expect(registry.get(ready)).toBe(false);
+    registry.set(catalog, catalogState([]));
+    expect(registry.get(ready)).toBe(true);
+    registry.dispose();
+  });
+
+  it("waits for live snapshots through offline startup and reconnect", () => {
+    const { catalog, shells, ready, registry } = makeHarness();
+    registry.set(catalog, catalogState([LOCAL, REMOTE]));
+    registry.set(shells(LOCAL), shellState("live"));
+    expect(registry.get(ready)).toBe(false);
+
+    // An old cache and a reconnect in progress can both omit a real project.
+    registry.set(shells(REMOTE), shellState("cached"));
+    expect(registry.get(ready)).toBe(false);
+    registry.set(shells(REMOTE), shellState("synchronizing"));
+    expect(registry.get(ready)).toBe(false);
+    registry.set(shells(REMOTE), shellState("live"));
+    expect(registry.get(ready)).toBe(true);
+
+    registry.set(shells(REMOTE), shellState("cached"));
+    expect(registry.get(ready)).toBe(false);
+    registry.set(shells(REMOTE), shellState("live"));
+    expect(registry.get(ready)).toBe(true);
+    registry.dispose();
+  });
+
+  it("stops waiting for an environment only when it leaves the catalog", () => {
+    const { catalog, shells, ready, registry } = makeHarness();
+    registry.set(catalog, catalogState([LOCAL, REMOTE]));
+    registry.set(shells(LOCAL), shellState("live"));
+    expect(registry.get(ready)).toBe(false);
+    registry.set(catalog, catalogState([LOCAL]));
+    expect(registry.get(ready)).toBe(true);
+    registry.dispose();
+  });
+});

--- a/apps/web/src/state/shell.ts
+++ b/apps/web/src/state/shell.ts
@@ -7,7 +7,10 @@ import {
   createEnvironmentShellSummaryAtom,
   createEnvironmentSnapshotAtom,
   createShellEnvironmentAtoms,
+  type EnvironmentShellState,
 } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentCatalogState } from "@t3tools/client-runtime/state/connections";
+import type { EnvironmentId } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
@@ -46,3 +49,25 @@ export const allEnvironmentShellsBootstrappedAtom = Atom.make((get) => {
   }
   return true;
 }).pipe(Atom.withLabel("web-all-environment-shells-bootstrapped"));
+
+/** Cached or missing snapshots cannot establish that a saved project no longer exists. */
+export function createAllEnvironmentProjectSnapshotsReadyAtom(input: {
+  readonly catalogValueAtom: Atom.Atom<EnvironmentCatalogState>;
+  readonly shellStateValueAtom: (environmentId: EnvironmentId) => Atom.Atom<EnvironmentShellState>;
+}) {
+  return Atom.make((get) => {
+    const catalog = get(input.catalogValueAtom);
+    if (!catalog.isReady) return false;
+    for (const environmentId of catalog.entries.keys()) {
+      const shell = get(input.shellStateValueAtom(environmentId));
+      if (shell.status !== "live" || Option.isNone(shell.snapshot)) return false;
+    }
+    return true;
+  }).pipe(Atom.withLabel("web-all-environment-project-snapshots-ready"));
+}
+
+export const allEnvironmentProjectSnapshotsReadyAtom =
+  createAllEnvironmentProjectSnapshotsReadyAtom({
+    catalogValueAtom: environmentCatalog.catalogValueAtom,
+    shellStateValueAtom: environmentShell.stateValueAtom,
+  });

--- a/apps/web/src/state/shell.ts
+++ b/apps/web/src/state/shell.ts
@@ -16,6 +16,7 @@ import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
+import { isHostedStaticApp } from "../hostedPairing";
 
 export const shellEnvironment = createShellEnvironmentAtoms(connectionAtomRuntime);
 export const environmentShell = createEnvironmentShellAtoms(connectionAtomRuntime);
@@ -54,10 +55,21 @@ export const allEnvironmentShellsBootstrappedAtom = Atom.make((get) => {
 export function createAllEnvironmentProjectSnapshotsReadyAtom(input: {
   readonly catalogValueAtom: Atom.Atom<EnvironmentCatalogState>;
   readonly shellStateValueAtom: (environmentId: EnvironmentId) => Atom.Atom<EnvironmentShellState>;
+  readonly requiresPrimaryEnvironment: boolean;
 }) {
   return Atom.make((get) => {
     const catalog = get(input.catalogValueAtom);
-    if (!catalog.isReady) return false;
+    // The persisted catalog can emit before platform discovery registers the
+    // primary environment. Neither that gap nor an empty catalog proves absence.
+    if (!catalog.isReady || catalog.entries.size === 0) return false;
+    if (
+      input.requiresPrimaryEnvironment &&
+      !Array.from(catalog.entries.values()).some(
+        (entry) => entry.target._tag === "PrimaryConnectionTarget",
+      )
+    ) {
+      return false;
+    }
     for (const environmentId of catalog.entries.keys()) {
       const shell = get(input.shellStateValueAtom(environmentId));
       if (shell.status !== "live" || Option.isNone(shell.snapshot)) return false;
@@ -70,4 +82,5 @@ export const allEnvironmentProjectSnapshotsReadyAtom =
   createAllEnvironmentProjectSnapshotsReadyAtom({
     catalogValueAtom: environmentCatalog.catalogValueAtom,
     shellStateValueAtom: environmentShell.stateValueAtom,
+    requiresPrimaryEnvironment: !isHostedStaticApp(),
   });

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -13,6 +13,7 @@ import {
   resolveProjectExpanded,
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
+  setSidebarProjectScopeKey,
   setThreadChangedFilesExpanded,
   type UiState,
 } from "./uiStateStore";
@@ -21,6 +22,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
   return {
     projectExpandedById: {},
     projectOrder: [],
+    sidebarProjectScopeKey: null,
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
@@ -144,6 +146,15 @@ describe("uiStateStore pure functions", () => {
       defaultAdvertisedEndpointKey: null,
     });
   });
+
+  it("stores the sidebar project scope and resets it to all projects", () => {
+    const scoped = setSidebarProjectScopeKey(makeUiState(), "github.com/pingdotgg/t3code");
+
+    expect(scoped.sidebarProjectScopeKey).toBe("github.com/pingdotgg/t3code");
+    expect(setSidebarProjectScopeKey(scoped, "github.com/pingdotgg/t3code")).toBe(scoped);
+    expect(setSidebarProjectScopeKey(scoped, null).sidebarProjectScopeKey).toBeNull();
+    expect(setSidebarProjectScopeKey(scoped, "").sidebarProjectScopeKey).toBeNull();
+  });
 });
 
 describe("parsePersistedState", () => {
@@ -177,6 +188,7 @@ describe("parsePersistedState", () => {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
+      sidebarProjectScopeKey: null,
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
           "turn-1": false,
@@ -297,6 +309,7 @@ describe("uiStateStore persistence", () => {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
+      sidebarProjectScopeKey: null,
       threadChangedFilesExpansionVersion: 2,
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
@@ -308,6 +321,18 @@ describe("uiStateStore persistence", () => {
     expect(parsePersistedState(persisted)).toEqual({
       ...state,
     });
+  });
+
+  it("restores the sidebar project scope across reloads", () => {
+    persistState(makeUiState({ sidebarProjectScopeKey: "github.com/pingdotgg/t3code" }));
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+
+    expect(parsePersistedState(persisted).sidebarProjectScopeKey).toBe(
+      "github.com/pingdotgg/t3code",
+    );
   });
 
   it("drops the temporary expanded-only migration fallback when rewriting state", () => {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -26,6 +26,7 @@ export interface PersistedUiState {
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
   defaultAdvertisedEndpointKey?: string | null;
+  sidebarProjectScopeKey?: string | null;
   threadChangedFilesExpansionVersion?: number;
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
 }
@@ -33,6 +34,10 @@ export interface PersistedUiState {
 export interface UiProjectState {
   projectExpandedById: Record<string, boolean>;
   projectOrder: string[];
+  // Logical project key the sidebar list is scoped to, or null for "all
+  // projects". Lives here so routes that unmount the sidebar (Settings)
+  // cannot reset the filter.
+  sidebarProjectScopeKey: string | null;
 }
 
 export interface UiThreadState {
@@ -49,6 +54,7 @@ export interface UiState extends UiProjectState, UiThreadState, UiEndpointState 
 const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
+  sidebarProjectScopeKey: null,
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
@@ -82,6 +88,10 @@ function sanitizeBooleanRecord(value: unknown): Record<string, boolean> {
       (entry): entry is [string, boolean] => entry[0].length > 0 && typeof entry[1] === "boolean",
     ),
   );
+}
+
+function sanitizeOptionalKey(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function sanitizeTimestampRecord(value: unknown): Record<string, string> {
@@ -131,11 +141,8 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
         ? sanitizePersistedThreadChangedFilesExpanded(parsed.threadChangedFilesExpandedById)
         : {},
-    defaultAdvertisedEndpointKey:
-      typeof parsed.defaultAdvertisedEndpointKey === "string" &&
-      parsed.defaultAdvertisedEndpointKey.length > 0
-        ? parsed.defaultAdvertisedEndpointKey
-        : null,
+    defaultAdvertisedEndpointKey: sanitizeOptionalKey(parsed.defaultAdvertisedEndpointKey),
+    sidebarProjectScopeKey: sanitizeOptionalKey(parsed.sidebarProjectScopeKey),
   };
 }
 
@@ -206,6 +213,7 @@ export function persistState(state: UiState): void {
         projectOrder: state.projectOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
+        sidebarProjectScopeKey: state.sidebarProjectScopeKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
         threadChangedFilesExpandedById: state.threadChangedFilesExpandedById,
       } satisfies PersistedUiState),
@@ -305,6 +313,17 @@ export function setDefaultAdvertisedEndpointKey(state: UiState, key: string | nu
   };
 }
 
+export function setSidebarProjectScopeKey(state: UiState, projectKey: string | null): UiState {
+  const nextKey = sanitizeOptionalKey(projectKey);
+  if (state.sidebarProjectScopeKey === nextKey) {
+    return state;
+  }
+  return {
+    ...state,
+    sidebarProjectScopeKey: nextKey,
+  };
+}
+
 export function resolveProjectExpanded(
   projectExpandedById: Readonly<Record<string, boolean>>,
   preferenceKeys: readonly string[],
@@ -387,6 +406,7 @@ interface UiStateStore extends UiState {
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
+  setSidebarProjectScopeKey: (projectKey: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
   reorderProjects: (
     currentProjectOrder: readonly string[],
@@ -405,6 +425,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
   setDefaultAdvertisedEndpointKey: (key) =>
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
+  setSidebarProjectScopeKey: (projectKey) =>
+    set((state) => setSidebarProjectScopeKey(state, projectKey)),
   setProjectExpanded: (projectIds, expanded) =>
     set((state) => setProjectExpanded(state, projectIds, expanded)),
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>


### PR DESCRIPTION
The sidebar's project filter lived in component state, so any route that unmounts the sidebar (Settings, most visibly) reset it to all projects on the way back.

The selection now lives in the persisted UI state store, next to the other sidebar project preferences (expansion, order), so it survives the Settings round-trip and app restarts. A stored key whose project no longer exists falls back to all projects, and only once the project list has actually loaded, since projects stream in after mount and clearing earlier would wipe the restored scope on every launch.

To verify: filter the sidebar to one project, open Settings, come back. The filter used to snap back to all projects; now it stays.

Fixes [#9379](https://github.com/pingdotgg/t3code/issues/9379).

Implemented with Claude Code (Claude Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI preference persistence with sanitization and guarded fallback; no auth or server behavior changes.
> 
> **Overview**
> **Persists the sidebar “filter by project” choice** so it no longer resets when the sidebar unmounts (e.g. visiting Settings) or after an app restart.
> 
> The combobox selection is read and updated via `useUiStateStore` (`sidebarProjectScopeKey` / `setSidebarProjectScopeKey`) instead of local `useState`. That value is included in the existing debounced `localStorage` UI state alongside project order and expansion.
> 
> **Invalid scope handling** is tightened: if a saved project key no longer exists, the filter still resets to “All projects”, but only after `projectGroups` has loaded—avoiding a race where an empty project list on startup cleared a valid restored scope every launch.
> 
> Tests cover the pure setter, parse/persist round-trip, and reload hydration for `sidebarProjectScopeKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db4f0a413850ee7582164ea6e89528d158922cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist sidebar project filter in `uiStateStore` across navigation and restarts
> - Replaces local component state in the `Sidebar` component with the persisted UI store's sidebar scope field and setter, so the selected project survives unmounts and app reloads.
> - Adds `allEnvironmentProjectSnapshotsReadyAtom` in [shell.ts](https://github.com/pingdotgg/t3code/pull/9416/files#diff-448cd0158f3f3e6a19177e04bab1754e24dfeb285d537eee9c187fe9df239e5a) — a derived readiness atom that is true only when the catalog is ready, the required primary environment is present, and every catalog environment has a live shell snapshot.
> - The stale-scope cleanup effect in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9416/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) now waits for that readiness atom before clearing a missing selected project, avoiding premature resets.
> - Adds `sanitizeOptionalKey` normalization, `setSidebarProjectScopeKey` updater, and persistence for the sidebar scope in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/9416/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8); endpoint-key parsing reuses the same helper.
> - Fixes `isHostedStaticApp` in [hostedPairing.ts](https://github.com/pingdotgg/t3code/pull/9416/files#diff-f791c48c17f96ca81a039bf7675078f1327912cc3498bbc304fcc289408524ea) to return false when `window` exists but has no `location`.
> - Risk: stale scope cleanup is now delayed until all environments report ready; if a selected project is genuinely missing, the sidebar keeps the stale selection longer than before. Reviewers should check the readiness conditions in `createAllEnvironmentProjectSnapshotsReadyAtom` and the cleanup effect in `Sidebar.tsx`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2c528d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## September 4 audit verification

Reproduced the Settings round-trip reset in the actual web client on main [5a433244](https://github.com/pingdotgg/t3code/commit/5a433244d0b827176df8b76a05959cd1a7a98ce2). Reload testing then found an additional startup race, which the live-snapshot and primary-environment guards fix. The final [a2c528da](https://github.com/Mnigos/t3code/commit/a2c528da01d038f9afc912924ebb3adabc77a757) implementation, integrated into main [4d3907f6](https://github.com/pingdotgg/t3code/commit/4d3907f63), now preserves both the selected project and its stored key across Settings navigation and repeated full reloads. Selecting All projects clears the key as expected. All 67 focused state/readiness/timeline/hosted-pairing tests, web typecheck, lint, and current-head CI pass. Disconnected and partial-catalog readiness are covered by the focused tests; a native or multi-device end-to-end run is not claimed. All browser evidence uses disposable audit state; no provider turn was sent.

Before — returning from Settings resets the filter:

![Before: the sidebar filter resets to All projects](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/995a719510277189/9379-before-reset-clean.png)

After — returning from Settings retains the project:

![After: the sidebar retains the selected project](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c780eeebfdcbbbcc/9379-after-retained.png)

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0a6293e1cdf4953c/9379-before-short.mp4) · [After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bdd9d53ec9e88c83/9379-after-short.mp4)

This is shared web/desktop sidebar state, independent of the provider. Mobile has separate navigation; no wire contract, migration, or user workflow changed. The bootstrap guard was reviewed against the multi-environment shell selector. No native Electron or multi-device end-to-end run is claimed.

Additional audit and verification: GPT 6 Astra via Codex in T3 Code.

Final-head reload verification:

![Final head: Audit Project stays selected after full reload](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/50472ab40095a4fa/9379-final-reload-retained.png)
