### PR TITLE
feat(web): filter threads by project from context menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1937,6 +1937,21 @@ export default function Sidebar() {
       ),
     [projectGroups],
   );
+  const projectScopeByMemberKey = useMemo(
+    () =>
+      new Map(
+        projectGroups.flatMap((group) =>
+          group.memberProjectRefs.map(
+            (projectRef) =>
+              [
+                `${projectRef.environmentId}:${projectRef.projectId}`,
+                { key: group.projectKey, label: group.displayName },
+              ] as const,
+          ),
+        ),
+      ),
+    [projectGroups],
+  );
 
   // now is quantized to the minute so effectiveSettled memoization doesn't
   // churn on every render; auto-settle thresholds are day-granular anyway.
@@ -3129,6 +3144,9 @@ export default function Sidebar() {
         const isSettled = settledThreadKeysRef.current.has(threadKey);
         const isSnoozed = snoozedThreadKeysRef.current.has(threadKey);
         const isPinned = thread.pinnedAt != null;
+        const threadProjectScope = projectScopeByMemberKey.get(
+          `${thread.environmentId}:${thread.projectId}`,
+        );
         // Presets resolve at menu-open time (same as the popover).
         const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
         const clicked = await settlePromise(() =>
@@ -3142,6 +3160,7 @@ export default function Sidebar() {
               isRegeneratingTitle,
               isRunning:
                 thread.session?.status === "running" && thread.session.activeTurnId != null,
+              filterByProjectLabel: threadProjectScope?.label ?? null,
               supports: {
                 settlement: supportsSettlement,
                 snooze: supportsSnooze,
@@ -3223,6 +3242,11 @@ export default function Sidebar() {
           }
           case "mark-unread":
             markThreadUnread(threadKey, thread.latestTurn?.completedAt);
+            return;
+          case "filter-by-project":
+            if (threadProjectScope) {
+              setProjectScopeKey(threadProjectScope.key);
+            }
             return;
           case "copy-path":
             if (!threadWorkspacePath) {
@@ -3322,6 +3346,7 @@ export default function Sidebar() {
       handleMultiSelectContextMenu,
       markThreadUnread,
       projectCwdByKey,
+      projectScopeByMemberKey,
       serverConfigs,
       startThreadRename,
       updateThreadMetadata,

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -10,6 +10,7 @@ const baseState: ThreadActionMenuState = {
   canSnoozeNow: true,
   isRegeneratingTitle: false,
   isRunning: false,
+  filterByProjectLabel: null,
   supports: { settlement: true, snooze: true, pinning: true, titleRegeneration: true },
   snoozePresets: [
     { id: "hour", label: "In 1 hour", whenLabel: "3:00 PM", snoozedUntil: "2026-08-07T15:00:00Z" },
@@ -64,6 +65,15 @@ describe("buildThreadActionMenuItems", () => {
       (candidate) => candidate.id === "regenerate-title",
     );
     expect(item).toMatchObject({ label: "Regenerating…", disabled: true });
+  });
+
+  it("includes the project filter action when requested by the thread list", () => {
+    const item = buildThreadActionMenuItems({
+      ...baseState,
+      filterByProjectLabel: "T3 Code",
+    }).find((candidate) => candidate.id === "filter-by-project");
+
+    expect(item).toMatchObject({ label: "Filter by T3 Code" });
   });
 
   it("marks delete as destructive and keeps it last", () => {

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -18,6 +18,7 @@ export type ThreadActionMenuId =
   | "rename"
   | "regenerate-title"
   | "mark-unread"
+  | "filter-by-project"
   | "copy"
   | "copy-path"
   | "copy-branch"
@@ -34,6 +35,7 @@ export interface ThreadActionMenuState {
   readonly isRegeneratingTitle: boolean;
   /** Archive rejects a thread with an active turn, so disable it here rather than let the action fail. */
   readonly isRunning: boolean;
+  readonly filterByProjectLabel: string | null;
   readonly supports: {
     readonly settlement: boolean;
     readonly snooze: boolean;
@@ -106,6 +108,15 @@ export function buildThreadActionMenuItems(
         ]
       : []),
     { id: "mark-unread", label: "Mark unread", icon: "mail-open" },
+    ...(state.filterByProjectLabel
+      ? [
+          {
+            id: "filter-by-project" as const,
+            label: `Filter by ${state.filterByProjectLabel}`,
+            icon: "folder" as const,
+          },
+        ]
+      : []),
     {
       id: "copy",
       label: "Copy",

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -142,6 +142,7 @@ export function useThreadActionMenu(input: {
           canSnoozeNow: canSnooze(thread, { now: now.toISOString() }),
           isRegeneratingTitle,
           isRunning: thread.session?.status === "running" && thread.session.activeTurnId != null,
+          filterByProjectLabel: null,
           supports,
           snoozePresets,
         });


### PR DESCRIPTION
Superseded by the consolidated implementation in #8719, which retains this PR's named **Filter by {project}** label and adds the reversible **Show all projects** action. Integrated verification of #8719 passed: named filtering reduced three visible threads to one, Show all projects restored three, and the selected scope survived reload. This PR is closed as superseded; merge #8719 rather than both alternatives.

## What Changed

Adds **Filter by {project}** to each sidebar thread’s context menu. Selecting it applies the existing logical-project scope, including linked projects grouped across environments. The shared chat-header action menu remains unchanged.

## Why

When a visible thread identifies the project the user wants, the sidebar can be narrowed directly from that row instead of requiring another lookup in the project picker.

The useful named-label behavior has been incorporated into #8719.

## UI Changes

The original implementation report supplies these candidate captures of the action and its result. They were not recaptured or visually rechecked in this description audit. A comparable baseline capture is not included.

![Thread context menu with Filter by Beta Project](https://raw.githubusercontent.com/saphid/t3code/pr-media/.github/pr-media/thread-project-filter-before-menu.png)

![Sidebar filtered to Beta Project, with the Alpha thread hidden](https://raw.githubusercontent.com/saphid/t3code/pr-media/.github/pr-media/thread-project-filter-after-filter.png)

[Interaction video: filter the sidebar from a thread row](https://raw.githubusercontent.com/saphid/t3code/pr-media/.github/pr-media/thread-project-filter-demo.mp4)

## Verification reported by the implementation

The following results are retained from the existing implementation report; this description audit did not rerun tests or launch a client.

- `CI=true vp test run apps/web/src/components/threadActionMenu.logic.test.ts` — 10 passed
- `CI=true vp run --filter @t3tools/web typecheck` — passed
- Integrated web pass — the context-menu action appeared and scoped the sidebar to the selected thread project
- Independent Claude Opus 5 high review was attempted but unavailable because local Claude OAuth had expired

Implemented with GPT-5.6 Sol in the Codex harness via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar filtering wired through existing project scope state; chat header menu explicitly omits the new action.
> 
> **Overview**
> Adds a **Filter by {project}** item to the **sidebar thread** context menu when the thread’s project maps to a logical project group (including cross-environment groups).
> 
> Choosing it calls the same **`setProjectScopeKey`** path as the header project combobox, so the thread list narrows without opening the filter control. **`threadActionMenu.logic`** gains optional `filterByProjectLabel` and a `filter-by-project` action id; **`useThreadActionMenu`** passes `filterByProjectLabel: null` so the chat header menu stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49467b71cd9275a2b0ba59d126da0a7d76d10078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `filter-by-project` action to sidebar thread context menu
> - Adds a `filter-by-project` entry to the shared thread action menu union type and conditionally renders a `Filter by <label>` item when the caller supplies a non-empty project label.
> - [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/9418/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) now maps each member project reference to its containing project group's key and label, passes the label into the menu builder, and handles the new action by setting the project scope to the group's project key.
> - The chat-header menu path in [useThreadActionMenu.ts](https://github.com/pingdotgg/t3code/pull/9418/files#diff-d31aea23d18521fa1c03e05a4d3c2e45d0ca6fab34084d74f072cecc48d21e17) passes a null label, so the item is omitted there.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 49467b7. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
