### PR TITLE
fix(web): avoid duplicate Antigravity install status

### DIFF
--- a/apps/web/src/components/settings/ProviderSetupSection.test.tsx
+++ b/apps/web/src/components/settings/ProviderSetupSection.test.tsx
@@ -1,4 +1,4 @@
-import type { FunctionComponent, ReactElement } from "react";
+import { isValidElement, type FunctionComponent, type ReactElement } from "react";
 import {
   EnvironmentId,
   ProviderDriverKind,
@@ -139,6 +139,23 @@ function button(view: unknown, label: string) {
   return visitElements(
     view,
     (element) => element.props.children === label && typeof element.props.onClick === "function",
+  );
+}
+
+function countElements(
+  node: unknown,
+  predicate: (element: ReactElement<Record<string, unknown>>) => boolean,
+): number {
+  if (Array.isArray(node)) {
+    return node.reduce((total, child) => total + countElements(child, predicate), 0);
+  }
+  if (!isValidElement<Record<string, unknown>>(node)) return 0;
+  return (
+    Number(predicate(node)) +
+    Object.values(node.props).reduce<number>(
+      (total, value) => total + countElements(value, predicate),
+      0,
+    )
   );
 }
 
@@ -283,6 +300,23 @@ describe("Antigravity setup", () => {
     expect(setup.startAuth).toHaveBeenCalledWith({ environmentId, input: { instanceId } });
     completeStart({ _tag: "Success", value: undefined });
     await flushPromises();
+  });
+
+  it("shows a repeated runtime status message only once", () => {
+    setup.installation = {
+      ...setup.installation!,
+      operationId: "install-1",
+      phase: "verifying",
+      message: "Checking the downloaded runtime.",
+    };
+
+    const view = renderSetup();
+    expect(
+      countElements(
+        view,
+        (element) => element.props.children === "Checking the downloaded runtime.",
+      ),
+    ).toBe(1);
   });
 
   it("removes an owned damaged runtime only after confirmation", async () => {

--- a/apps/web/src/components/settings/ProviderSetupSection.tsx
+++ b/apps/web/src/components/settings/ProviderSetupSection.tsx
@@ -169,6 +169,20 @@ function ProviderSetupActions({
   const authorizationUrl = auth?.phase === "waiting" ? auth.authorizationUrl : null;
   const queryError = authQuery.error ?? installQuery.error;
   const actionsDisabled = pendingLabel !== null || queryError !== null;
+  const installationStatusMessage =
+    installation?.phase === "downloading"
+      ? `Downloading ${(installation.downloadedBytes / 1_000_000).toFixed(1)} MB${installation.totalBytes === null ? "" : ` of ${(installation.totalBytes / 1_000_000).toFixed(1)} MB`}.`
+      : installation?.phase === "extracting"
+        ? "Extracting Antigravity."
+        : installation?.phase === "verifying"
+          ? "Checking the downloaded runtime."
+          : installed
+            ? "Antigravity is installed."
+            : usesCustomBinary
+              ? enabled
+                ? "The configured Antigravity runtime is unavailable."
+                : "The configured Antigravity runtime has not been checked."
+              : "Install the official Antigravity runtime before signing in.";
 
   async function runCommand<A, E>(
     label: string,
@@ -252,19 +266,7 @@ function ProviderSetupActions({
       <div className="grid gap-2">
         <p className="font-medium">Runtime</p>
         <p role="status" className="text-muted-foreground">
-          {installation?.phase === "downloading"
-            ? `Downloading ${(installation.downloadedBytes / 1_000_000).toFixed(1)} MB${installation.totalBytes === null ? "" : ` of ${(installation.totalBytes / 1_000_000).toFixed(1)} MB`}.`
-            : installation?.phase === "extracting"
-              ? "Extracting Antigravity."
-              : installation?.phase === "verifying"
-                ? "Checking the downloaded runtime."
-                : installed
-                  ? "Antigravity is installed."
-                  : usesCustomBinary
-                    ? enabled
-                      ? "The configured Antigravity runtime is unavailable."
-                      : "The configured Antigravity runtime has not been checked."
-                    : "Install the official Antigravity runtime before signing in."}
+          {installationStatusMessage}
         </p>
         {installation?.phase === "downloading" &&
         installation.totalBytes !== null &&
@@ -276,7 +278,7 @@ function ProviderSetupActions({
             max={installation.totalBytes}
           />
         ) : null}
-        {installation?.message ? (
+        {installation?.message && installation.message !== installationStatusMessage ? (
           <p className="text-muted-foreground [overflow-wrap:anywhere]">{installation.message}</p>
         ) : null}
         {usesCustomBinary ? (


### PR DESCRIPTION
Antigravity installation could render the same runtime status twice when the provider message matched the phase-derived label. “Checking the downloaded runtime.” therefore appeared on two consecutive lines.

The setup UI now computes the phase label once and only adds provider detail when it differs. Distinct installation details remain visible.

Tests: 11 focused tests, web typecheck, targeted lint, and a browser install pass.

| Before | After |
| --- | --- |
| ![Before: duplicated Antigravity runtime status](https://github.com/user-attachments/assets/eab08a1e-1cb1-4543-a347-45b901133300) | ![After: single Antigravity runtime status](https://github.com/user-attachments/assets/9e27124e-9759-4d97-9435-ba12efecbb30) |

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in settings UI with a focused regression test; no auth, install APIs, or data handling changes.
> 
> **Overview**
> Fixes **duplicate runtime status text** in Antigravity provider setup when the server’s `installation.message` matches the phase-derived label (e.g. “Checking the downloaded runtime.” on two lines).
> 
> The setup UI now derives **`installationStatusMessage` once** for the primary `role="status"` line and only renders the extra provider `installation.message` paragraph when it **differs** from that label, so redundant copies are hidden while distinct detail still shows.
> 
> Tests add a **`countElements`** tree helper and assert the verifying-phase message appears **only once** when message and phase label match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5246c56735b28f403a4a5a8bc68ceab45ae42551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate Antigravity install status in `ProviderSetupActions`
> The runtime status area rendered the same message twice when `installation.message` matched the primary install status. Extracts the status text into a derived value and only renders the secondary message when it differs from that value. Adds a regression test using a new `countElements` React tree traversal helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5246c56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->