### PR TITLE
feat(usage): Limits tab with provider quota windows and Codex banked resets

### DIFF
--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -1,0 +1,178 @@
+import { View } from "react-native";
+
+import { AppText as Text } from "../../components/AppText";
+import type { EnvironmentProviderLimits } from "../../state/usage";
+import { SettingsSection } from "../settings/components/SettingsSection";
+import { PROVIDER_LABEL, useProviderColors } from "./usageProviders";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/** `2h 13m`, `3d 4h`, `12m`. */
+function formatDuration(ms: number): string {
+  const remaining = Math.max(0, ms);
+  const days = Math.floor(remaining / DAY);
+  const hours = Math.floor((remaining % DAY) / HOUR);
+  const minutes = Math.floor((remaining % HOUR) / 60000);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+type LimitWindow = EnvironmentProviderLimits["windows"][number];
+
+function resetMillis(window: LimitWindow): number | null {
+  if (window.resetsAt === null) return null;
+  const at = Date.parse(window.resetsAt);
+  return Number.isFinite(at) ? at : null;
+}
+
+/** Elapsed share of the window, 0..1, or null when the window has no known length. */
+function elapsedShare(window: LimitWindow, now: number): number | null {
+  const resetsAt = resetMillis(window);
+  if (resetsAt === null || window.windowMinutes === null) return null;
+  const length = window.windowMinutes * 60000;
+  return Math.max(0, Math.min(1, (length - (resetsAt - now)) / length));
+}
+
+/** Usage against the clock: within five points is on pace. */
+function paceLabel(window: LimitWindow, now: number): string | null {
+  const elapsed = elapsedShare(window, now);
+  if (elapsed === null) return null;
+  const gap = window.usedPercent - elapsed * 100;
+  if (gap > 5) return "ahead of pace";
+  if (gap < -5) return "under pace";
+  return "on pace";
+}
+
+/**
+ * One window as a full-width bar from the moment it opened to its reset.
+ * Usage fills from the left; the hairline sits at the elapsed fraction, which
+ * is also where even spending would have put the fill.
+ */
+function WindowBar({
+  window,
+  now,
+  color,
+}: {
+  readonly window: LimitWindow;
+  readonly now: number;
+  readonly color: string;
+}) {
+  const elapsed = elapsedShare(window, now);
+  const used = Math.max(0, Math.min(100, window.usedPercent)) / 100;
+  return (
+    <View className="h-4 justify-center">
+      <View className="h-2 flex-row overflow-hidden rounded-full bg-subtle">
+        <View className="h-full rounded-full" style={{ flex: used, backgroundColor: color }} />
+        <View style={{ flex: 1 - used }} />
+      </View>
+      {elapsed !== null ? (
+        <View
+          className="absolute top-0 bottom-0 w-px bg-foreground"
+          style={{ left: `${elapsed * 100}%`, opacity: 0.6 }}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+/**
+ * Limits card: one block per provider with a bar per window in use, the pace
+ * against the clock, and the reset countdown. Unused windows have nothing to
+ * show and stay out.
+ */
+export function UsageLimitsSection(props: {
+  readonly providers: readonly EnvironmentProviderLimits[];
+  readonly failedEnvironments: readonly string[];
+  readonly now: number;
+  readonly isPending: boolean;
+}) {
+  const { providers, failedEnvironments, now, isPending } = props;
+  const colors = useProviderColors();
+  const environmentCount = new Set(providers.map((entry) => entry.environmentId)).size;
+  const instanceCounts = new Map<string, number>();
+  for (const entry of providers) {
+    const key = `${entry.environmentId}:${entry.provider}`;
+    instanceCounts.set(key, (instanceCounts.get(key) ?? 0) + 1);
+  }
+
+  return (
+    <SettingsSection title="Limits" card>
+      {failedEnvironments.map((label) => (
+        <Text key={label} className="p-4 text-sm text-foreground-muted">
+          {label} could not report limits.
+        </Text>
+      ))}
+      {providers.length === 0 && failedEnvironments.length === 0 ? (
+        <Text className="p-4 text-sm text-foreground-muted">
+          {isPending ? "Reading limits…" : "No limits reported yet."}
+        </Text>
+      ) : null}
+      {providers.map((entry, index) => {
+        const qualifier = [
+          environmentCount > 1 ? entry.environmentLabel : null,
+          (instanceCounts.get(`${entry.environmentId}:${entry.provider}`) ?? 0) > 1
+            ? (entry.instanceLabel ?? entry.instanceId)
+            : null,
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        const windows = entry.windows.filter((window) => window.usedPercent > 0);
+        return (
+          <View
+            key={`${entry.environmentId}:${entry.provider}:${entry.instanceId}`}
+            className={index === 0 ? "gap-3 p-4" : "gap-3 border-t border-border-subtle p-4"}
+          >
+            <View className="flex-row items-baseline gap-2">
+              <View
+                className="size-2.5 self-center rounded-full"
+                style={{ backgroundColor: colors[entry.provider] }}
+              />
+              <Text className="text-lg text-foreground">{PROVIDER_LABEL[entry.provider]}</Text>
+              {qualifier ? (
+                <Text className="text-sm text-foreground-muted">{qualifier}</Text>
+              ) : null}
+              {entry.plan ? (
+                <Text className="text-sm text-foreground-muted">· {entry.plan}</Text>
+              ) : null}
+            </View>
+            {windows.length === 0 ? (
+              <Text className="text-sm text-foreground-muted">No usage in any window.</Text>
+            ) : (
+              windows.map((window) => {
+                const resetsAt = resetMillis(window);
+                const pace = paceLabel(window, now);
+                return (
+                  <View key={window.id} className="gap-1.5">
+                    <View className="flex-row items-baseline justify-between gap-3">
+                      <Text className="text-sm text-foreground-muted">{window.label}</Text>
+                      <Text className="text-sm tabular-nums text-foreground">
+                        {Math.round(window.usedPercent)}%
+                      </Text>
+                    </View>
+                    <WindowBar window={window} now={now} color={colors[entry.provider]} />
+                    <Text className="text-xs tabular-nums text-foreground-muted">
+                      {[
+                        pace,
+                        resetsAt === null ? null : `resets in ${formatDuration(resetsAt - now)}`,
+                      ]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </Text>
+                  </View>
+                );
+              })
+            )}
+            {entry.resetCredits && entry.resetCredits.availableCount > 0 ? (
+              <Text className="text-xs tabular-nums text-foreground-muted">
+                {entry.resetCredits.availableCount}{" "}
+                {entry.resetCredits.availableCount === 1 ? "reset" : "resets"} banked
+              </Text>
+            ) : null}
+          </View>
+        );
+      })}
+    </SettingsSection>
+  );
+}

--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -1,3 +1,4 @@
+import { elapsedShare, formatDuration, paceOf, resetMillis } from "@t3tools/shared/usageLimits";
 import { View } from "react-native";
 
 import { AppText as Text } from "../../components/AppText";
@@ -5,44 +6,13 @@ import type { EnvironmentProviderLimits } from "../../state/usage";
 import { SettingsSection } from "../settings/components/SettingsSection";
 import { PROVIDER_LABEL, useProviderColors } from "./usageProviders";
 
-const HOUR = 60 * 60 * 1000;
-const DAY = 24 * HOUR;
-
-/** `2h 13m`, `3d 4h`, `12m`. */
-function formatDuration(ms: number): string {
-  const remaining = Math.max(0, ms);
-  const days = Math.floor(remaining / DAY);
-  const hours = Math.floor((remaining % DAY) / HOUR);
-  const minutes = Math.floor((remaining % HOUR) / 60000);
-  if (days > 0) return `${days}d ${hours}h`;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  return `${minutes}m`;
-}
-
 type LimitWindow = EnvironmentProviderLimits["windows"][number];
 
-function resetMillis(window: LimitWindow): number | null {
-  if (window.resetsAt === null) return null;
-  const at = Date.parse(window.resetsAt);
-  return Number.isFinite(at) ? at : null;
-}
+const PACE_LABEL = { ahead: "ahead of pace", on: "on pace", under: "under pace" } as const;
 
-/** Elapsed share of the window, 0..1, or null when the window has no known length. */
-function elapsedShare(window: LimitWindow, now: number): number | null {
-  const resetsAt = resetMillis(window);
-  if (resetsAt === null || window.windowMinutes === null) return null;
-  const length = window.windowMinutes * 60000;
-  return Math.max(0, Math.min(1, (length - (resetsAt - now)) / length));
-}
-
-/** Usage against the clock: within five points is on pace. */
 function paceLabel(window: LimitWindow, now: number): string | null {
-  const elapsed = elapsedShare(window, now);
-  if (elapsed === null) return null;
-  const gap = window.usedPercent - elapsed * 100;
-  if (gap > 5) return "ahead of pace";
-  if (gap < -5) return "under pace";
-  return "on pace";
+  const pace = paceOf(window, now);
+  return pace === null ? null : PACE_LABEL[pace];
 }
 
 /**
@@ -85,10 +55,11 @@ function WindowBar({
 export function UsageLimitsSection(props: {
   readonly providers: readonly EnvironmentProviderLimits[];
   readonly failedEnvironments: readonly string[];
+  readonly pendingEnvironments: readonly string[];
   readonly now: number;
   readonly isPending: boolean;
 }) {
-  const { providers, failedEnvironments, now, isPending } = props;
+  const { providers, failedEnvironments, pendingEnvironments, now, isPending } = props;
   const colors = useProviderColors();
   const environmentCount = new Set(providers.map((entry) => entry.environmentId)).size;
   const instanceCounts = new Map<string, number>();
@@ -104,6 +75,13 @@ export function UsageLimitsSection(props: {
           {label} could not report limits.
         </Text>
       ))}
+      {providers.length > 0
+        ? pendingEnvironments.map((label) => (
+            <Text key={label} className="p-4 text-sm text-foreground-muted">
+              {label} is still reading its limits.
+            </Text>
+          ))
+        : null}
       {providers.length === 0 && failedEnvironments.length === 0 ? (
         <Text className="p-4 text-sm text-foreground-muted">
           {isPending ? "Reading limits…" : "No limits reported yet."}
@@ -124,19 +102,31 @@ export function UsageLimitsSection(props: {
             key={`${entry.environmentId}:${entry.provider}:${entry.instanceId}`}
             className={index === 0 ? "gap-3 p-4" : "gap-3 border-t border-border-subtle p-4"}
           >
-            <View className="flex-row items-baseline gap-2">
+            <View className="flex-row flex-wrap items-baseline gap-x-2 gap-y-0.5">
               <View
                 className="size-2.5 self-center rounded-full"
                 style={{ backgroundColor: colors[entry.provider] }}
               />
-              <Text className="text-lg text-foreground">{PROVIDER_LABEL[entry.provider]}</Text>
+              <Text className="shrink text-lg text-foreground" numberOfLines={1}>
+                {PROVIDER_LABEL[entry.provider]}
+              </Text>
               {qualifier ? (
-                <Text className="text-sm text-foreground-muted">{qualifier}</Text>
+                <Text className="shrink text-sm text-foreground-muted" numberOfLines={1}>
+                  {qualifier}
+                </Text>
               ) : null}
               {entry.plan ? (
                 <Text className="text-sm text-foreground-muted">· {entry.plan}</Text>
               ) : null}
             </View>
+            {entry.readError ? (
+              <Text className="text-xs text-foreground-muted">
+                Could not read limits.
+                {entry.windows.length > 0
+                  ? ` Showing the last report from ${formatDuration(now - Date.parse(entry.observedAt))} ago.`
+                  : ""}
+              </Text>
+            ) : null}
             {windows.length === 0 ? (
               <Text className="text-sm text-foreground-muted">No usage in any window.</Text>
             ) : (

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -18,9 +18,10 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { AppText as Text } from "../../components/AppText";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
-import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
+import { useUsage, useUsageLimits, type EnvironmentUsageStatus } from "../../state/usage";
 import { SettingsSection } from "../settings/components/SettingsSection";
 import { UsageDailyChart } from "./UsageDailyChart";
+import { UsageLimitsSection } from "./UsageLimitsSection";
 import type { UsageChartMetric } from "./usageChartData";
 import { PROVIDER_LABEL, useProviderColors } from "./usageProviders";
 
@@ -43,6 +44,7 @@ export function UsageRouteScreen() {
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
   const { days: windowDays, window } = windowSelection;
   const isPast24Hours = windowDays === 1;
+  const limits = useUsageLimits();
   const { merged, environments, isPending, isPartial, refresh } = useUsage(window);
 
   const days = useMemo(
@@ -139,6 +141,12 @@ export function UsageRouteScreen() {
               timeZone={window.timeZone}
             />
             <ProviderSection merged={merged} metric={metric} />
+            <UsageLimitsSection
+              providers={limits.providers}
+              failedEnvironments={limits.failedEnvironments}
+              now={limits.receivedAt}
+              isPending={limits.isPending}
+            />
             <TotalsSection merged={merged} isPast24Hours={isPast24Hours} />
             <ModelsSection merged={merged} />
           </>

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -74,7 +74,8 @@ export function UsageRouteScreen() {
   // The pull spinner tracks re-scans of environments that have answered
   // before. The initial scan renders its own placeholder, and an unreachable
   // environment stays pending forever — neither may pin the spinner on.
-  const refreshing = environments.some((entry) => entry.isPending && entry.summary !== null);
+  const refreshing =
+    environments.some((entry) => entry.isPending && entry.summary !== null) || limits.isRefreshing;
   const selectWindow = (days: number) => {
     setWindowSelection({
       days,
@@ -145,6 +146,7 @@ export function UsageRouteScreen() {
             <UsageLimitsSection
               providers={limits.providers}
               failedEnvironments={limits.failedEnvironments}
+              pendingEnvironments={limits.pendingEnvironments}
               now={limits.receivedAt}
               isPending={limits.isPending}
             />

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -82,6 +82,7 @@ export function UsageRouteScreen() {
     });
   };
   const refreshWindow = () => {
+    limits.refresh();
     const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
     if (
       nextWindow.sinceDay === window.sinceDay &&

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -12,6 +12,7 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   USAGE_CONTRACT_VERSION,
+  type UsageProviderLimits,
   type EnvironmentId,
   type UsageSummary,
   type UsageSummaryInput,
@@ -144,6 +145,91 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     environments,
     isPending: answeredCount === 0 && stillReporting > 0,
     isPartial: answeredCount > 0 && stillReporting > 0,
+    refresh,
+  };
+}
+
+/** One provider instance's limits, tagged with the environment that reported them. */
+export interface EnvironmentProviderLimits extends UsageProviderLimits {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+}
+
+interface EnvironmentLimitsStatus {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly isPending: boolean;
+  readonly failed: boolean;
+  readonly providers: readonly UsageProviderLimits[] | null;
+}
+
+/**
+ * Every environment's live limits subscription. Subscribing makes the server
+ * read fresh numbers first, so a refresh is a resubscribe.
+ */
+const usageLimitsAtom = Atom.make((get) => {
+  const presentations = get(environmentPresentations.presentationsAtom);
+  const statuses: EnvironmentLimitsStatus[] = [];
+  for (const [environmentId, presentation] of presentations) {
+    const result = get(serverEnvironment.usageLimits({ environmentId, input: {} }));
+    const snapshot = Option.getOrNull(AsyncResult.value(result));
+    statuses.push({
+      environmentId,
+      label: presentation.entry.target.label,
+      isPending: result.waiting && snapshot === null,
+      failed: result._tag === "Failure",
+      providers: snapshot?.providers ?? null,
+    });
+  }
+  // Countdowns anchor to the moment a report lands rather than ticking.
+  return { environments: statuses, receivedAt: Date.now() };
+}).pipe(Atom.withLabel("mobile-usage:limits"));
+
+export interface UsageLimitsView {
+  readonly providers: readonly EnvironmentProviderLimits[];
+  readonly failedEnvironments: readonly string[];
+  /** Wall-clock time of the latest report, for reset countdowns. */
+  readonly receivedAt: number;
+  /** True until at least one environment has answered. */
+  readonly isPending: boolean;
+  readonly refresh: () => void;
+}
+
+export function useUsageLimits(): UsageLimitsView {
+  const { environments, receivedAt } = useAtomValue(usageLimitsAtom);
+
+  const providers = useMemo(
+    () =>
+      environments.flatMap((environment) =>
+        (environment.providers ?? []).map((entry) => ({
+          ...entry,
+          environmentId: environment.environmentId,
+          environmentLabel: environment.label,
+        })),
+      ),
+    [environments],
+  );
+  const failedEnvironments = useMemo(
+    () => environments.filter((environment) => environment.failed).map((e) => e.label),
+    [environments],
+  );
+
+  const refresh = useCallback(() => {
+    for (const environment of environments) {
+      appAtomRegistry.refresh(
+        serverEnvironment.usageLimits({ environmentId: environment.environmentId, input: {} }),
+      );
+    }
+  }, [environments]);
+
+  return {
+    providers,
+    failedEnvironments,
+    receivedAt,
+    isPending:
+      environments.length > 0 &&
+      environments.every((environment) => environment.providers === null) &&
+      environments.some((environment) => environment.isPending),
     refresh,
   };
 }

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -176,7 +176,7 @@ const usageLimitsAtom = Atom.make((get) => {
     statuses.push({
       environmentId,
       label: presentation.entry.target.label,
-      isPending: result.waiting && snapshot === null,
+      isPending: result.waiting,
       failed: result._tag === "Failure",
       providers: snapshot?.providers ?? null,
     });
@@ -188,6 +188,10 @@ const usageLimitsAtom = Atom.make((get) => {
 export interface UsageLimitsView {
   readonly providers: readonly EnvironmentProviderLimits[];
   readonly failedEnvironments: readonly string[];
+  /** Labels of environments that have not answered yet while others have. */
+  readonly pendingEnvironments: readonly string[];
+  /** True while any environment is re-reading after a refresh. */
+  readonly isRefreshing: boolean;
   /** Wall-clock time of the latest report, for reset countdowns. */
   readonly receivedAt: number;
   /** True until at least one environment has answered. */
@@ -222,9 +226,21 @@ export function useUsageLimits(): UsageLimitsView {
     }
   }, [environments]);
 
+  const pendingEnvironments = useMemo(
+    () =>
+      environments
+        .filter((environment) => environment.isPending && !environment.failed)
+        .map((e) => e.label),
+    [environments],
+  );
+
   return {
     providers,
     failedEnvironments,
+    pendingEnvironments,
+    isRefreshing: environments.some(
+      (environment) => environment.providers !== null && environment.isPending,
+    ),
     receivedAt,
     isPending:
       environments.length > 0 &&

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -57,6 +57,8 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverRetryResourceTelemetry]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverGetUsageSummary]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshUsageRates]: AuthOrchestrationReadScope,
+  [WS_METHODS.serverConsumeUsageLimitReset]: AuthOrchestrationOperateScope,
+  [WS_METHODS.subscribeUsageLimits]: AuthOrchestrationReadScope,
   [WS_METHODS.serverSignalProcess]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverReportClientActivity]: AuthOrchestrationReadScope,
   [WS_METHODS.serverReportHostPowerState]: AuthOrchestrationOperateScope,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -28,6 +28,7 @@ import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderDriverError } from "../Errors.ts";
+import { makeClaudeAccountLimitsReader } from "../Layers/claudeAccountLimits.ts";
 import { makeClaudeAdapter } from "../Layers/ClaudeAdapter.ts";
 import {
   checkClaudeProviderStatus,
@@ -138,6 +139,12 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         instanceId,
         environment: processEnv,
         modelCatalog,
+        accountLimits: makeClaudeAccountLimitsReader({
+          settings: effectiveConfig,
+          fileSystem,
+          path,
+          httpClient,
+        }),
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       };
       const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -141,6 +141,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         modelCatalog,
         accountLimits: makeClaudeAccountLimitsReader({
           settings: effectiveConfig,
+          environment: processEnv,
           fileSystem,
           path,
           httpClient,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -19,6 +19,7 @@ import {
   type SDKUserMessage,
   type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
+import { normalizeClaudeRateLimit } from "./claudeRateLimits.ts";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 import {
@@ -26,6 +27,7 @@ import {
   type CanonicalItemType,
   type CanonicalRequestType,
   type ClaudeSettings,
+  type UsageLimitsUpdate,
   EventId,
   type ProviderApprovalDecision,
   ProviderDriverKind,
@@ -342,6 +344,8 @@ export interface ClaudeAdapterLiveOptions {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
   readonly modelCatalog?: Effect.Effect<ClaudeModelCatalog>;
+  /** On-demand account limits; the driver builds it with its HTTP and process services. */
+  readonly accountLimits?: Effect.Effect<UsageLimitsUpdate | null, ProviderAdapterError>;
 }
 
 function isUuid(value: string): boolean {
@@ -3595,12 +3599,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (message.type === "rate_limit_event") {
+      const limits = normalizeClaudeRateLimit(message.rate_limit_info);
+      if (limits === null) return;
       yield* offerRuntimeEvent({
         ...base,
         type: "account.rate-limits.updated",
-        payload: {
-          rateLimits: message,
-        },
+        payload: { limits },
       });
       return;
     }
@@ -4815,6 +4819,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     listSessions,
     hasSession,
     stopAll,
+    ...(options?.accountLimits ? { readAccountLimits: options.accountLimits } : {}),
     get streamEvents() {
       return Stream.fromQueue(runtimeEventQueue);
     },

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -106,6 +106,12 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
     Promise.resolve({ threadId: "provider-thread-1" }),
   );
 
+  readRateLimits = Effect.succeed({ rateLimits: {} });
+
+  consumeRateLimitResetCredit(_idempotencyKey: string) {
+    return Effect.succeed({ outcome: "reset" as const });
+  }
+
   public readonly respondToRequestImpl = vi.fn(
     (_requestId: ApprovalRequestId, _decision: ProviderApprovalDecision): Promise<void> =>
       Promise.resolve(undefined),

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -108,8 +108,22 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
 
   readRateLimits = Effect.succeed({ rateLimits: {} });
 
-  consumeRateLimitResetCredit(_idempotencyKey: string) {
-    return Effect.succeed({ outcome: "reset" as const });
+  public readonly consumeResetImpl = vi.fn(
+    (_idempotencyKey: string): Promise<{ outcome: "reset" | "nothingToReset" }> =>
+      Promise.resolve({ outcome: "reset" as const }),
+  );
+
+  consumeRateLimitResetCredit(idempotencyKey: string) {
+    return Effect.tryPromise({
+      try: () => this.consumeResetImpl(idempotencyKey),
+      catch: (cause) =>
+        new CodexErrors.CodexAppServerRequestError({
+          code: -1,
+          errorMessage: cause instanceof Error ? cause.message : String(cause),
+          method: "account/rateLimitResetCredit/consume",
+          cause,
+        }),
+    });
   }
 
   public readonly respondToRequestImpl = vi.fn(
@@ -308,7 +322,9 @@ const sessionErrorLayer = it.layer(
   Layer.effect(
     CodexAdapter,
     Effect.gen(function* () {
-      const codexConfig = decodeCodexSettings({});
+      // Account requests can spawn a real app-server when no fake session
+      // answers; a binary that cannot exist guarantees these tests never do.
+      const codexConfig = decodeCodexSettings({ binaryPath: "/nonexistent/codex-test-binary" });
       return yield* makeCodexAdapter(codexConfig, {
         makeRuntime: sessionRuntimeFactory.factory,
       });
@@ -340,6 +356,52 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
     }),
   );
 
+  it.effect("redeems reset credits one at a time and reuses the key until an outcome lands", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("sess-reset"),
+        cwd: process.cwd(),
+        runtimeMode: "approval-required",
+      });
+      const runtime = sessionRuntimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      const consume = adapter.consumeRateLimitResetCredit;
+      NodeAssert.ok(consume);
+
+      // First attempt hangs until released; the second must wait, not race.
+      let release = (): void => {};
+      const gate = new Promise<{ outcome: "reset" }>((resolve) => {
+        release = () => resolve({ outcome: "reset" });
+      });
+      runtime.consumeResetImpl.mockImplementationOnce(() => gate);
+      const first = yield* Effect.forkChild(consume);
+      const second = yield* Effect.forkChild(consume);
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtime.consumeResetImpl.mock.calls.length, 1);
+      release();
+      NodeAssert.equal(yield* Fiber.join(first), "reset");
+      NodeAssert.equal(yield* Fiber.join(second), "reset");
+      NodeAssert.equal(runtime.consumeResetImpl.mock.calls.length, 2);
+      const [firstKey, secondKey] = runtime.consumeResetImpl.mock.calls.map(([key]) => key);
+      NodeAssert.notEqual(firstKey, secondKey);
+
+      // A failed attempt has no known outcome, so the retry re-sends its key.
+      runtime.consumeResetImpl.mockImplementationOnce(() =>
+        Promise.reject(new Error("socket hang up")),
+      );
+      const failed = yield* consume.pipe(Effect.result);
+      NodeAssert.equal(failed._tag, "Failure");
+      NodeAssert.equal(yield* consume, "reset");
+      const [failedKey, retriedKey] = runtime.consumeResetImpl.mock.calls
+        .slice(-2)
+        .map(([key]) => key);
+      NodeAssert.equal(failedKey, retriedKey);
+    }),
+  );
+
   it.effect("uploads feedback for the active Codex thread", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;
@@ -351,6 +413,8 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
       });
       const runtime = sessionRuntimeFactory.lastRuntime;
       NodeAssert.ok(runtime);
+      const consume = adapter.consumeRateLimitResetCredit;
+      NodeAssert.ok(consume);
 
       const result = yield* adapter.uploadFeedback({
         threadId,
@@ -386,6 +450,8 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
       });
       const runtime = sessionRuntimeFactory.lastRuntime;
       NodeAssert.ok(runtime);
+      const consume = adapter.consumeRateLimitResetCredit;
+      NodeAssert.ok(consume);
       runtime.sendTurnImpl.mockClear();
 
       yield* Effect.ignore(

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2245,6 +2245,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   };
 
   const ACCOUNT_REQUEST_TIMEOUT = "20 seconds";
+  const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
+  /** A live session that does not answer quickly is treated as unusable and bypassed. */
+  const LIVE_SESSION_TIMEOUT = "8 seconds";
 
   const accountRequest = <A>(
     method: string,
@@ -2271,23 +2274,29 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       viaClient,
     ).pipe(
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+      Effect.timeout(ACCOUNT_REQUEST_TIMEOUT),
+      Effect.catchTags({
+        TimeoutError: () =>
+          requestError(`Codex did not answer ${method} within ${ACCOUNT_REQUEST_TIMEOUT}.`),
+      }),
+      // A stable description; the spawn or protocol failure travels in `cause`.
       Effect.mapError((cause) =>
-        requestError(cause instanceof Error ? cause.message : String(cause), cause),
+        isProviderAdapterRequestError(cause)
+          ? cause
+          : requestError(`Codex could not answer ${method}.`, cause),
       ),
     );
     return Effect.suspend(() => {
       const session = liveSession();
-      // A session whose app-server died is still in the map until it is
-      // stopped, so any failure there falls through to a fresh process.
-      const request = session
-        ? viaSession(session.runtime).pipe(Effect.catch(() => standalone))
+      // A session whose app-server died, or one that hangs, is still in the
+      // map until it is stopped; any failure there falls through to a fresh
+      // process with its own budget.
+      return session
+        ? viaSession(session.runtime).pipe(
+            Effect.timeout(LIVE_SESSION_TIMEOUT),
+            Effect.catch(() => standalone),
+          )
         : standalone;
-      return request.pipe(
-        Effect.timeout(ACCOUNT_REQUEST_TIMEOUT),
-        Effect.catchTag("TimeoutError", () =>
-          requestError(`Codex did not answer ${method} within ${ACCOUNT_REQUEST_TIMEOUT}.`),
-        ),
-      );
     });
   };
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -67,6 +67,8 @@ import {
   type CodexSessionRuntimeOptions,
   type CodexSessionRuntimeShape,
 } from "./CodexSessionRuntime.ts";
+import { withCodexAccountClient } from "./codexAccountClient.ts";
+import { normalizeCodexRateLimits } from "./codexRateLimits.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 import { resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 const isCodexAppServerProcessExitedError = Schema.is(CodexErrors.CodexAppServerProcessExitedError);
@@ -1725,7 +1727,11 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "account/rateLimits/updated") {
-    if (!readPayload(EffectCodexSchema.V2AccountRateLimitsUpdatedNotification, event.payload)) {
+    const payload = readPayload(
+      EffectCodexSchema.V2AccountRateLimitsUpdatedNotification,
+      event.payload,
+    );
+    if (!payload) {
       return [];
     }
     return [
@@ -1733,7 +1739,7 @@ function mapToRuntimeEvents(
         type: "account.rate-limits.updated",
         ...runtimeEventBase(event, canonicalThreadId),
         payload: {
-          rateLimits: event.payload ?? {},
+          limits: normalizeCodexRateLimits(payload),
         },
       },
     ];
@@ -2229,6 +2235,68 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     );
   };
 
+  // Account requests ride on a live session's app-server when one exists and
+  // otherwise on a short-lived process, so limits never need an open thread.
+  const liveSession = () => {
+    for (const session of sessions.values()) {
+      if (!session.stopped) return session;
+    }
+    return undefined;
+  };
+
+  const accountRequest = <A>(
+    method: string,
+    viaSession: (runtime: CodexSessionRuntimeShape) => Effect.Effect<A, CodexSessionRuntimeError>,
+    viaClient: (
+      client: Parameters<Parameters<typeof withCodexAccountClient<A, never>>[1]>[0],
+    ) => Effect.Effect<A, CodexErrors.CodexAppServerError>,
+  ): Effect.Effect<A, ProviderAdapterError> =>
+    Effect.suspend(() => {
+      const session = liveSession();
+      if (session) {
+        return viaSession(session.runtime).pipe(
+          Effect.mapError((cause) => mapCodexRuntimeError(session.threadId, method, cause)),
+        );
+      }
+      return withCodexAccountClient(
+        {
+          binaryPath: codexConfig.binaryPath,
+          launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
+          environment: options?.environment,
+          homePath: codexConfig.homePath,
+          cwd: process.cwd(),
+        },
+        viaClient,
+      ).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method,
+              detail: cause instanceof Error ? cause.message : String(cause),
+              cause,
+            }),
+        ),
+      );
+    });
+
+  const readAccountLimits: NonNullable<CodexAdapterShape["readAccountLimits"]> = accountRequest(
+    "account/rateLimits/read",
+    (runtime) => runtime.readRateLimits,
+    (client) => client.request("account/rateLimits/read", undefined),
+  ).pipe(Effect.map((response) => normalizeCodexRateLimits(response)));
+
+  const consumeRateLimitResetCredit: NonNullable<CodexAdapterShape["consumeRateLimitResetCredit"]> =
+    Effect.suspend(() => {
+      const idempotencyKey = NodeCrypto.randomUUID();
+      return accountRequest(
+        "account/rateLimitResetCredit/consume",
+        (runtime) => runtime.consumeRateLimitResetCredit(idempotencyKey),
+        (client) => client.request("account/rateLimitResetCredit/consume", { idempotencyKey }),
+      ).pipe(Effect.map((response) => response.outcome));
+    });
+
   const uploadFeedback: CodexAdapterShape["uploadFeedback"] = (input) =>
     requireSession(input.threadId).pipe(
       Effect.flatMap((session) => session.runtime.uploadFeedback(input.reason)),
@@ -2329,6 +2397,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     readThread,
     rollbackThread,
     uploadFeedback,
+    readAccountLimits,
+    consumeRateLimitResetCredit,
     respondToRequest,
     respondToUserInput,
     stopSession,

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2244,42 +2244,52 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     return undefined;
   };
 
+  const ACCOUNT_REQUEST_TIMEOUT = "20 seconds";
+
   const accountRequest = <A>(
     method: string,
     viaSession: (runtime: CodexSessionRuntimeShape) => Effect.Effect<A, CodexSessionRuntimeError>,
     viaClient: (
       client: Parameters<Parameters<typeof withCodexAccountClient<A, never>>[1]>[0],
     ) => Effect.Effect<A, CodexErrors.CodexAppServerError>,
-  ): Effect.Effect<A, ProviderAdapterError> =>
-    Effect.suspend(() => {
+  ): Effect.Effect<A, ProviderAdapterError> => {
+    const requestError = (detail: string, cause?: unknown) =>
+      new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method,
+        detail,
+        ...(cause === undefined ? {} : { cause }),
+      });
+    const standalone = withCodexAccountClient(
+      {
+        binaryPath: codexConfig.binaryPath,
+        launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
+        environment: options?.environment,
+        homePath: codexConfig.homePath,
+        cwd: process.cwd(),
+      },
+      viaClient,
+    ).pipe(
+      Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+      Effect.mapError((cause) =>
+        requestError(cause instanceof Error ? cause.message : String(cause), cause),
+      ),
+    );
+    return Effect.suspend(() => {
       const session = liveSession();
-      if (session) {
-        return viaSession(session.runtime).pipe(
-          Effect.mapError((cause) => mapCodexRuntimeError(session.threadId, method, cause)),
-        );
-      }
-      return withCodexAccountClient(
-        {
-          binaryPath: codexConfig.binaryPath,
-          launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
-          environment: options?.environment,
-          homePath: codexConfig.homePath,
-          cwd: process.cwd(),
-        },
-        viaClient,
-      ).pipe(
-        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
-        Effect.mapError(
-          (cause) =>
-            new ProviderAdapterRequestError({
-              provider: PROVIDER,
-              method,
-              detail: cause instanceof Error ? cause.message : String(cause),
-              cause,
-            }),
+      // A session whose app-server died is still in the map until it is
+      // stopped, so any failure there falls through to a fresh process.
+      const request = session
+        ? viaSession(session.runtime).pipe(Effect.catch(() => standalone))
+        : standalone;
+      return request.pipe(
+        Effect.timeout(ACCOUNT_REQUEST_TIMEOUT),
+        Effect.catchTag("TimeoutError", () =>
+          requestError(`Codex did not answer ${method} within ${ACCOUNT_REQUEST_TIMEOUT}.`),
         ),
       );
     });
+  };
 
   const readAccountLimits: NonNullable<CodexAdapterShape["readAccountLimits"]> = accountRequest(
     "account/rateLimits/read",

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -38,6 +38,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as CodexErrors from "effect-codex-app-server/errors";
@@ -1739,7 +1740,7 @@ function mapToRuntimeEvents(
         type: "account.rate-limits.updated",
         ...runtimeEventBase(event, canonicalThreadId),
         payload: {
-          limits: normalizeCodexRateLimits(payload),
+          limits: normalizeCodexRateLimits(payload, { complete: false }),
         },
       },
     ];
@@ -2255,6 +2256,12 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     viaClient: (
       client: Parameters<Parameters<typeof withCodexAccountClient<A, never>>[1]>[0],
     ) => Effect.Effect<A, CodexErrors.CodexAppServerError>,
+    /**
+     * Whether a failing live session may be retried on a fresh process. Reads
+     * are harmless to repeat; a redemption is not, so it surfaces the failure
+     * and keeps its idempotency key for the user's own retry.
+     */
+    policy: { readonly fallbackAfterSession: boolean },
   ): Effect.Effect<A, ProviderAdapterError> => {
     const requestError = (detail: string, cause?: unknown) =>
       new ProviderAdapterRequestError({
@@ -2291,12 +2298,16 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       // A session whose app-server died, or one that hangs, is still in the
       // map until it is stopped; any failure there falls through to a fresh
       // process with its own budget.
-      return session
-        ? viaSession(session.runtime).pipe(
-            Effect.timeout(LIVE_SESSION_TIMEOUT),
-            Effect.catch(() => standalone),
-          )
-        : standalone;
+      if (!session) return standalone;
+      const viaLive = viaSession(session.runtime).pipe(
+        Effect.timeout(LIVE_SESSION_TIMEOUT),
+        Effect.mapError((cause) =>
+          cause._tag === "TimeoutError"
+            ? requestError(`Codex did not answer ${method} within ${LIVE_SESSION_TIMEOUT}.`, cause)
+            : mapCodexRuntimeError(session.threadId, method, cause),
+        ),
+      );
+      return policy.fallbackAfterSession ? viaLive.pipe(Effect.catch(() => standalone)) : viaLive;
     });
   };
 
@@ -2304,17 +2315,32 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     "account/rateLimits/read",
     (runtime) => runtime.readRateLimits,
     (client) => client.request("account/rateLimits/read", undefined),
-  ).pipe(Effect.map((response) => normalizeCodexRateLimits(response)));
+    { fallbackAfterSession: true },
+  ).pipe(Effect.map((response) => normalizeCodexRateLimits(response, { complete: true })));
 
+  // Redemption is single-flight per instance, and one idempotency key is kept
+  // until Codex reports an outcome: overlapping confirmations serialise, and
+  // a retry after a timeout re-sends the same attempt instead of a new one.
+  const consumeResetLock = yield* Semaphore.make(1);
+  let pendingResetKey: string | null = null;
   const consumeRateLimitResetCredit: NonNullable<CodexAdapterShape["consumeRateLimitResetCredit"]> =
-    Effect.suspend(() => {
-      const idempotencyKey = NodeCrypto.randomUUID();
-      return accountRequest(
-        "account/rateLimitResetCredit/consume",
-        (runtime) => runtime.consumeRateLimitResetCredit(idempotencyKey),
-        (client) => client.request("account/rateLimitResetCredit/consume", { idempotencyKey }),
-      ).pipe(Effect.map((response) => response.outcome));
-    });
+    consumeResetLock.withPermits(1)(
+      Effect.suspend(() => {
+        const idempotencyKey = pendingResetKey ?? NodeCrypto.randomUUID();
+        pendingResetKey = idempotencyKey;
+        return accountRequest(
+          "account/rateLimitResetCredit/consume",
+          (runtime) => runtime.consumeRateLimitResetCredit(idempotencyKey),
+          (client) => client.request("account/rateLimitResetCredit/consume", { idempotencyKey }),
+          { fallbackAfterSession: false },
+        ).pipe(
+          Effect.map((response) => {
+            pendingResetKey = null;
+            return response.outcome;
+          }),
+        );
+      }),
+    );
 
   const uploadFeedback: CodexAdapterShape["uploadFeedback"] = (input) =>
     requireSession(input.threadId).pipe(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -204,6 +204,17 @@ export interface CodexSessionRuntimeShape {
   readonly uploadFeedback: (
     reason?: string,
   ) => Effect.Effect<EffectCodexSchema.V2FeedbackUploadResponse, CodexSessionRuntimeError>;
+  /** Account-level reads ride on this session's app-server process. */
+  readonly readRateLimits: Effect.Effect<
+    EffectCodexSchema.V2GetAccountRateLimitsResponse,
+    CodexSessionRuntimeError
+  >;
+  readonly consumeRateLimitResetCredit: (
+    idempotencyKey: string,
+  ) => Effect.Effect<
+    EffectCodexSchema.V2ConsumeAccountRateLimitResetCreditResponse,
+    CodexSessionRuntimeError
+  >;
   readonly respondToRequest: (
     requestId: ApprovalRequestId,
     decision: ProviderApprovalDecision,
@@ -2414,6 +2425,9 @@ export const makeCodexSessionRuntime = (
             threadId: providerThreadId,
           });
         }),
+      readRateLimits: client.request("account/rateLimits/read", undefined),
+      consumeRateLimitResetCredit: (idempotencyKey) =>
+        client.request("account/rateLimitResetCredit/consume", { idempotencyKey }),
       respondToRequest: (requestId, decision) =>
         Effect.gen(function* () {
           const pending = (yield* Ref.get(pendingApprovalsRef)).get(requestId);

--- a/apps/server/src/provider/Layers/claudeAccountLimits.test.ts
+++ b/apps/server/src/provider/Layers/claudeAccountLimits.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { normalizeClaudeUsage, tierLabel } from "./claudeAccountLimits.ts";
+
+describe("normalizeClaudeUsage", () => {
+  it("reads the structured limits array, naming scoped weekly buckets after their model", () => {
+    expect(
+      normalizeClaudeUsage(
+        {
+          limits: [
+            { kind: "session", percent: 40, resets_at: "2026-09-03T09:40:00+00:00", scope: null },
+            {
+              kind: "weekly_all",
+              percent: 18,
+              resets_at: "2026-09-08T11:00:00+00:00",
+              scope: null,
+            },
+            {
+              kind: "weekly_scoped",
+              percent: 36,
+              resets_at: "2026-09-08T11:00:00+00:00",
+              scope: { model: { display_name: "Fable" }, surface: null },
+            },
+          ],
+          five_hour: { utilization: 99, resets_at: null },
+        },
+        "Max 20x",
+      ),
+    ).toEqual({
+      plan: "Max 20x",
+      windows: [
+        {
+          id: "five_hour",
+          label: "5 hour",
+          usedPercent: 40,
+          resetsAt: "2026-09-03T09:40:00+00:00",
+          windowMinutes: 300,
+        },
+        {
+          id: "seven_day",
+          label: "Weekly",
+          usedPercent: 18,
+          resetsAt: "2026-09-08T11:00:00+00:00",
+          windowMinutes: 10080,
+        },
+        {
+          id: "seven_day_fable",
+          label: "Weekly Fable",
+          usedPercent: 36,
+          resetsAt: "2026-09-08T11:00:00+00:00",
+          windowMinutes: 10080,
+        },
+      ],
+    });
+  });
+
+  it("falls back to the named top-level windows without a limits array", () => {
+    expect(
+      normalizeClaudeUsage(
+        {
+          five_hour: { utilization: 31, resets_at: "2026-09-03T09:40:00+00:00" },
+          seven_day_opus: null,
+          seven_day_sonnet: { utilization: null, resets_at: null },
+        },
+        "Pro",
+      ).windows.map((window) => [window.id, window.usedPercent]),
+    ).toEqual([["five_hour", 31]]);
+  });
+
+  it("derives the tier from the rate limit tier before the subscription type", () => {
+    expect(tierLabel("max", "default_claude_max_20x")).toBe("Max 20x");
+    expect(tierLabel("max", "default_claude_max_5x")).toBe("Max 5x");
+    expect(tierLabel("pro", null)).toBe("Pro");
+    expect(tierLabel(null, null)).toBeNull();
+  });
+});

--- a/apps/server/src/provider/Layers/claudeAccountLimits.test.ts
+++ b/apps/server/src/provider/Layers/claudeAccountLimits.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { normalizeClaudeUsage, tierLabel } from "./claudeAccountLimits.ts";
+import { claudeConfigDir, normalizeClaudeUsage, tierLabel } from "./claudeAccountLimits.ts";
 
 describe("normalizeClaudeUsage", () => {
   it("reads the structured limits array, naming scoped weekly buckets after their model", () => {
@@ -27,6 +27,7 @@ describe("normalizeClaudeUsage", () => {
         "Max 20x",
       ),
     ).toEqual({
+      complete: true,
       plan: "Max 20x",
       windows: [
         {
@@ -72,5 +73,36 @@ describe("normalizeClaudeUsage", () => {
     expect(tierLabel("max", "default_claude_max_5x")).toBe("Max 5x");
     expect(tierLabel("pro", null)).toBe("Pro");
     expect(tierLabel(null, null)).toBeNull();
+  });
+
+  it("resolves the credentials directory the way the CLI would for this instance", () => {
+    const join = (...parts: string[]) => parts.join("/");
+    expect(
+      claudeConfigDir({
+        environment: { CLAUDE_CONFIG_DIR: "/work/claude-config" },
+        homePath: "",
+        resolvedHome: "/home/me",
+        join,
+      }),
+    ).toBe("/work/claude-config");
+    expect(
+      claudeConfigDir({
+        environment: {},
+        homePath: "~/.claude_work",
+        resolvedHome: "/home/me/.claude_work",
+        join,
+      }),
+    ).toBe("/home/me/.claude_work");
+    expect(
+      claudeConfigDir({
+        environment: { HOME: "/srv/other" },
+        homePath: "",
+        resolvedHome: "/home/me",
+        join,
+      }),
+    ).toBe("/srv/other/.claude");
+    expect(
+      claudeConfigDir({ environment: undefined, homePath: "", resolvedHome: "/home/me", join }),
+    ).toBe("/home/me/.claude");
   });
 });

--- a/apps/server/src/provider/Layers/claudeAccountLimits.test.ts
+++ b/apps/server/src/provider/Layers/claudeAccountLimits.test.ts
@@ -23,6 +23,7 @@ describe("normalizeClaudeUsage", () => {
             },
           ],
           five_hour: { utilization: 99, resets_at: null },
+          extra_usage: { is_enabled: true, utilization: 12 },
         },
         "Max 20x",
       ),
@@ -50,6 +51,13 @@ describe("normalizeClaudeUsage", () => {
           usedPercent: 36,
           resetsAt: "2026-09-08T11:00:00+00:00",
           windowMinutes: 10080,
+        },
+        {
+          id: "overage",
+          label: "Extra usage",
+          usedPercent: 12,
+          resetsAt: null,
+          windowMinutes: null,
         },
       ],
     });
@@ -85,6 +93,15 @@ describe("normalizeClaudeUsage", () => {
         join,
       }),
     ).toBe("/work/claude-config");
+    // The driver hands a configured home to the CLI as CLAUDE_CONFIG_DIR, so it wins.
+    expect(
+      claudeConfigDir({
+        environment: { CLAUDE_CONFIG_DIR: "/work/claude-config" },
+        homePath: "~/.claude_work",
+        resolvedHome: "/home/me/.claude_work",
+        join,
+      }),
+    ).toBe("/home/me/.claude_work");
     expect(
       claudeConfigDir({
         environment: {},

--- a/apps/server/src/provider/Layers/claudeAccountLimits.ts
+++ b/apps/server/src/provider/Layers/claudeAccountLimits.ts
@@ -60,8 +60,15 @@ const UsageLimit = Schema.Struct({
     ),
   ),
 });
+const ExtraUsage = Schema.NullOr(
+  Schema.Struct({
+    is_enabled: Schema.Boolean,
+    utilization: Schema.NullOr(Schema.Number),
+  }),
+);
 const UsageResponse = Schema.Struct({
   limits: Schema.optional(Schema.NullOr(Schema.Array(UsageLimit))),
+  extra_usage: Schema.optional(ExtraUsage),
   five_hour: Schema.optional(UsageWindow),
   seven_day: Schema.optional(UsageWindow),
   seven_day_opus: Schema.optional(UsageWindow),
@@ -128,6 +135,18 @@ export function normalizeClaudeUsage(
         resetsAt: limit.resets_at,
       });
     }
+    // Turn events report extra usage under `overage`; a complete read must
+    // carry the same window or it would delete what an event created.
+    const extra = response.extra_usage;
+    if (extra && extra.is_enabled && extra.utilization !== null) {
+      windows.push({
+        id: "overage",
+        label: "Extra usage",
+        usedPercent: clamp(extra.utilization),
+        resetsAt: null,
+        windowMinutes: null,
+      });
+    }
     return { complete: true, windows, plan };
   }
 
@@ -142,7 +161,8 @@ export function normalizeClaudeUsage(
       windowMinutes: legacy.windowMinutes,
     });
   }
-  return { complete: true, windows, plan };
+  // The named keys are a partial view, so they merge rather than replace.
+  return { complete: false, windows, plan };
 }
 
 const requestError = (detail: string, cause?: unknown) =>
@@ -154,9 +174,10 @@ const requestError = (detail: string, cause?: unknown) =>
   });
 
 /**
- * Where Claude Code keeps this instance's credentials. A configured home is
- * handed to the CLI as `CLAUDE_CONFIG_DIR`, and an instance environment may
- * override that or `HOME` itself, so the same precedence applies here.
+ * Where Claude Code keeps this instance's credentials, with the precedence
+ * the driver gives the CLI: a configured home becomes `CLAUDE_CONFIG_DIR`
+ * and wins outright; otherwise the instance environment's own
+ * `CLAUDE_CONFIG_DIR` or `HOME` applies, then the machine's home.
  */
 export function claudeConfigDir(input: {
   readonly environment: NodeJS.ProcessEnv | undefined;
@@ -164,9 +185,9 @@ export function claudeConfigDir(input: {
   readonly resolvedHome: string;
   readonly join: (...parts: string[]) => string;
 }): string {
+  if (input.homePath.trim().length > 0) return input.resolvedHome;
   const configured = input.environment?.CLAUDE_CONFIG_DIR?.trim();
   if (configured) return configured;
-  if (input.homePath.trim().length > 0) return input.resolvedHome;
   const home = input.environment?.HOME?.trim();
   return input.join(home || input.resolvedHome, ".claude");
 }

--- a/apps/server/src/provider/Layers/claudeAccountLimits.ts
+++ b/apps/server/src/provider/Layers/claudeAccountLimits.ts
@@ -1,0 +1,223 @@
+/**
+ * On-demand Claude Code account limits. The SDK only reports limits during a
+ * turn, so this reads the same claude.ai usage endpoint the CLI's `/usage`
+ * dialog uses, authenticated with the OAuth token Claude Code already stored
+ * on disk. The token never leaves the server; only normalised percentages do.
+ *
+ * @module provider/Layers/claudeAccountLimits
+ */
+import type { ClaudeSettings, UsageLimitWindow, UsageLimitsUpdate } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import type * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import type { HttpClient } from "effect/unstable/http";
+import { HttpClientResponse } from "effect/unstable/http";
+
+import { resolveClaudeHomePath } from "../Drivers/ClaudeHome.ts";
+import { type ProviderAdapterError, ProviderAdapterRequestError } from "../Errors.ts";
+
+const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+const REQUEST_TIMEOUT = "10 seconds";
+const METHOD = "claude.ai/usage";
+
+const StoredCredentials = Schema.Struct({
+  claudeAiOauth: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        accessToken: Schema.String,
+        expiresAt: Schema.optional(Schema.NullOr(Schema.Number)),
+        subscriptionType: Schema.optional(Schema.NullOr(Schema.String)),
+        rateLimitTier: Schema.optional(Schema.NullOr(Schema.String)),
+      }),
+    ),
+  ),
+});
+const decodeStoredCredentials = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(
+    StoredCredentials as unknown as Schema.Codec<typeof StoredCredentials.Type>,
+  ),
+);
+
+const UsageWindow = Schema.NullOr(
+  Schema.Struct({
+    utilization: Schema.NullOr(Schema.Number),
+    resets_at: Schema.NullOr(Schema.String),
+  }),
+);
+/** One entry of the endpoint's self-describing `limits` array. */
+const UsageLimit = Schema.Struct({
+  kind: Schema.String,
+  percent: Schema.NullOr(Schema.Number),
+  resets_at: Schema.NullOr(Schema.String),
+  scope: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        model: Schema.optional(
+          Schema.NullOr(Schema.Struct({ display_name: Schema.NullOr(Schema.String) })),
+        ),
+        surface: Schema.optional(Schema.NullOr(Schema.String)),
+      }),
+    ),
+  ),
+});
+const UsageResponse = Schema.Struct({
+  limits: Schema.optional(Schema.NullOr(Schema.Array(UsageLimit))),
+  five_hour: Schema.optional(UsageWindow),
+  seven_day: Schema.optional(UsageWindow),
+  seven_day_opus: Schema.optional(UsageWindow),
+  seven_day_sonnet: Schema.optional(UsageWindow),
+});
+const isUsageResponse = Schema.is(UsageResponse);
+export type ClaudeUsageResponse = typeof UsageResponse.Type;
+
+const SESSION_MINUTES = 300;
+const WEEK_MINUTES = 10080;
+
+/** Legacy top-level keys, used only when the `limits` array is absent. */
+const LEGACY_WINDOWS = [
+  { key: "five_hour", label: "5 hour", windowMinutes: SESSION_MINUTES },
+  { key: "seven_day", label: "Weekly", windowMinutes: WEEK_MINUTES },
+  { key: "seven_day_opus", label: "Weekly Opus", windowMinutes: WEEK_MINUTES },
+  { key: "seven_day_sonnet", label: "Weekly Sonnet", windowMinutes: WEEK_MINUTES },
+] as const;
+
+/** Ids match the SDK's `rate_limit_event` types so turn-driven updates merge onto the same rows. */
+function scopedId(name: string): string {
+  return `seven_day_${name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+}
+
+/** `default_claude_max_20x` → `Max 20x`, otherwise the subscription type capitalised. */
+export function tierLabel(
+  subscriptionType: string | null | undefined,
+  rateLimitTier: string | null | undefined,
+): string | null {
+  const multiple = rateLimitTier?.match(/max_(\d+)x/);
+  if (multiple) return `Max ${multiple[1]}x`;
+  if (!subscriptionType) return null;
+  return subscriptionType.charAt(0).toUpperCase() + subscriptionType.slice(1);
+}
+
+/** Endpoint percentages are already 0..100. */
+export function normalizeClaudeUsage(
+  response: ClaudeUsageResponse,
+  plan: string | null,
+): UsageLimitsUpdate {
+  const windows: UsageLimitWindow[] = [];
+  const clamp = (value: number) => Math.max(0, Math.min(100, value));
+
+  if (response.limits) {
+    for (const limit of response.limits) {
+      if (limit.percent === null) continue;
+      const scopeName = limit.scope?.model?.display_name ?? limit.scope?.surface ?? null;
+      const window =
+        limit.kind === "session"
+          ? { id: "five_hour", label: "5 hour", windowMinutes: SESSION_MINUTES }
+          : limit.kind === "weekly_all"
+            ? { id: "seven_day", label: "Weekly", windowMinutes: WEEK_MINUTES }
+            : limit.kind === "weekly_scoped" && scopeName
+              ? {
+                  id: scopedId(scopeName),
+                  label: `Weekly ${scopeName}`,
+                  windowMinutes: WEEK_MINUTES,
+                }
+              : null;
+      if (window === null) continue;
+      windows.push({
+        ...window,
+        usedPercent: clamp(limit.percent),
+        resetsAt: limit.resets_at,
+      });
+    }
+    return { windows, plan };
+  }
+
+  for (const legacy of LEGACY_WINDOWS) {
+    const value = response[legacy.key];
+    if (!value || value.utilization === null) continue;
+    windows.push({
+      id: legacy.key,
+      label: legacy.label,
+      usedPercent: clamp(value.utilization),
+      resetsAt: value.resets_at,
+      windowMinutes: legacy.windowMinutes,
+    });
+  }
+  return { windows, plan };
+}
+
+const requestError = (detail: string, cause?: unknown) =>
+  new ProviderAdapterRequestError({
+    provider: "claudeAgent",
+    method: METHOD,
+    detail,
+    ...(cause === undefined ? {} : { cause }),
+  });
+
+export interface ClaudeAccountLimitsServices {
+  readonly settings: Pick<ClaudeSettings, "homePath">;
+  readonly fileSystem: FileSystem.FileSystem;
+  readonly path: Path.Path;
+  readonly httpClient: HttpClient.HttpClient;
+}
+
+/**
+ * Builds the reader once per adapter with its services captured, so the
+ * adapter can expose it with no requirements. Yields null when this machine
+ * has no usable claude.ai sign-in (API key sessions, expired token); the
+ * runtime event path still updates limits during turns.
+ */
+export function makeClaudeAccountLimitsReader(
+  services: ClaudeAccountLimitsServices,
+): Effect.Effect<UsageLimitsUpdate | null, ProviderAdapterError> {
+  const { settings, fileSystem, path, httpClient } = services;
+
+  const readCredentials = Effect.gen(function* () {
+    // A configured home is used as CLAUDE_CONFIG_DIR itself; the default home
+    // keeps Claude Code's config under `~/.claude`.
+    const home = yield* resolveClaudeHomePath(settings).pipe(
+      Effect.provideService(Path.Path, path),
+    );
+    const configDir = settings.homePath.trim().length > 0 ? home : path.join(home, ".claude");
+    // macOS keeps Claude Code's credentials in the login keychain, and reading
+    // that item from another process triggers a Keychain prompt on every
+    // refresh. Until that is an explicit opt-in, macOS relies on turn events.
+    const raw = yield* fileSystem
+      .readFileString(path.join(configDir, ".credentials.json"))
+      .pipe(Effect.orElseSucceed(() => null));
+    if (raw === null) return null;
+    const parsed = yield* decodeStoredCredentials(raw).pipe(Effect.orElseSucceed(() => null));
+    const oauth = parsed?.claudeAiOauth;
+    if (!oauth) return null;
+    const now = yield* Clock.currentTimeMillis;
+    if (typeof oauth.expiresAt === "number" && oauth.expiresAt <= now) return null;
+    return oauth;
+  });
+
+  return Effect.gen(function* () {
+    const credentials = yield* readCredentials;
+    if (credentials === null) return null;
+    const body = yield* httpClient
+      .get(USAGE_URL, {
+        headers: {
+          Authorization: `Bearer ${credentials.accessToken}`,
+          "anthropic-beta": "oauth-2025-04-20",
+          Accept: "application/json",
+        },
+      })
+      .pipe(
+        Effect.flatMap(HttpClientResponse.filterStatusOk),
+        Effect.flatMap((response) => response.json),
+        Effect.timeout(REQUEST_TIMEOUT),
+        Effect.mapError((cause) => requestError("The claude.ai usage request failed.", cause)),
+      );
+    if (!isUsageResponse(body)) {
+      return yield* requestError("The claude.ai usage response had an unexpected shape.");
+    }
+    return normalizeClaudeUsage(
+      body,
+      tierLabel(credentials.subscriptionType, credentials.rateLimitTier),
+    );
+  });
+}

--- a/apps/server/src/provider/Layers/claudeAccountLimits.ts
+++ b/apps/server/src/provider/Layers/claudeAccountLimits.ts
@@ -35,9 +35,7 @@ const StoredCredentials = Schema.Struct({
   ),
 });
 const decodeStoredCredentials = Schema.decodeUnknownEffect(
-  Schema.fromJsonString(
-    StoredCredentials as unknown as Schema.Codec<typeof StoredCredentials.Type>,
-  ),
+  Schema.fromJsonString(StoredCredentials),
 );
 
 const UsageWindow = Schema.NullOr(

--- a/apps/server/src/provider/Layers/claudeAccountLimits.ts
+++ b/apps/server/src/provider/Layers/claudeAccountLimits.ts
@@ -128,7 +128,7 @@ export function normalizeClaudeUsage(
         resetsAt: limit.resets_at,
       });
     }
-    return { windows, plan };
+    return { complete: true, windows, plan };
   }
 
   for (const legacy of LEGACY_WINDOWS) {
@@ -142,7 +142,7 @@ export function normalizeClaudeUsage(
       windowMinutes: legacy.windowMinutes,
     });
   }
-  return { windows, plan };
+  return { complete: true, windows, plan };
 }
 
 const requestError = (detail: string, cause?: unknown) =>
@@ -153,8 +153,28 @@ const requestError = (detail: string, cause?: unknown) =>
     ...(cause === undefined ? {} : { cause }),
   });
 
+/**
+ * Where Claude Code keeps this instance's credentials. A configured home is
+ * handed to the CLI as `CLAUDE_CONFIG_DIR`, and an instance environment may
+ * override that or `HOME` itself, so the same precedence applies here.
+ */
+export function claudeConfigDir(input: {
+  readonly environment: NodeJS.ProcessEnv | undefined;
+  readonly homePath: string;
+  readonly resolvedHome: string;
+  readonly join: (...parts: string[]) => string;
+}): string {
+  const configured = input.environment?.CLAUDE_CONFIG_DIR?.trim();
+  if (configured) return configured;
+  if (input.homePath.trim().length > 0) return input.resolvedHome;
+  const home = input.environment?.HOME?.trim();
+  return input.join(home || input.resolvedHome, ".claude");
+}
+
 export interface ClaudeAccountLimitsServices {
   readonly settings: Pick<ClaudeSettings, "homePath">;
+  /** The instance's process environment, for `CLAUDE_CONFIG_DIR` and `HOME` overrides. */
+  readonly environment: NodeJS.ProcessEnv | undefined;
   readonly fileSystem: FileSystem.FileSystem;
   readonly path: Path.Path;
   readonly httpClient: HttpClient.HttpClient;
@@ -169,15 +189,18 @@ export interface ClaudeAccountLimitsServices {
 export function makeClaudeAccountLimitsReader(
   services: ClaudeAccountLimitsServices,
 ): Effect.Effect<UsageLimitsUpdate | null, ProviderAdapterError> {
-  const { settings, fileSystem, path, httpClient } = services;
+  const { settings, environment, fileSystem, path, httpClient } = services;
 
   const readCredentials = Effect.gen(function* () {
-    // A configured home is used as CLAUDE_CONFIG_DIR itself; the default home
-    // keeps Claude Code's config under `~/.claude`.
     const home = yield* resolveClaudeHomePath(settings).pipe(
       Effect.provideService(Path.Path, path),
     );
-    const configDir = settings.homePath.trim().length > 0 ? home : path.join(home, ".claude");
+    const configDir = claudeConfigDir({
+      environment,
+      homePath: settings.homePath,
+      resolvedHome: home,
+      join: (...parts) => path.join(...parts),
+    });
     // macOS keeps Claude Code's credentials in the login keychain, and reading
     // that item from another process triggers a Keychain prompt on every
     // refresh. Until that is an explicit opt-in, macOS relies on turn events.

--- a/apps/server/src/provider/Layers/claudeRateLimits.test.ts
+++ b/apps/server/src/provider/Layers/claudeRateLimits.test.ts
@@ -31,6 +31,16 @@ describe("normalizeClaudeRateLimit", () => {
     ).toBe(100);
   });
 
+  it("names scoped weekly buckets after their model so reads and events share rows", () => {
+    expect(
+      normalizeClaudeRateLimit({
+        status: "allowed",
+        rateLimitType: "seven_day_fable",
+        utilization: 0.36,
+      })?.windows[0],
+    ).toMatchObject({ id: "seven_day_fable", label: "Weekly Fable", usedPercent: 36 });
+  });
+
   it("drops events without a known window", () => {
     expect(normalizeClaudeRateLimit({ status: "allowed", utilization: 0.2 })).toBeNull();
     expect(

--- a/apps/server/src/provider/Layers/claudeRateLimits.test.ts
+++ b/apps/server/src/provider/Layers/claudeRateLimits.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { normalizeClaudeRateLimit } from "./claudeRateLimits.ts";
+
+describe("normalizeClaudeRateLimit", () => {
+  it("maps one window per event from a utilization fraction", () => {
+    expect(
+      normalizeClaudeRateLimit({
+        status: "allowed_warning",
+        rateLimitType: "seven_day_opus",
+        utilization: 0.91,
+        resetsAt: 1_800_000_000,
+      }),
+    ).toEqual({
+      windows: [
+        {
+          id: "seven_day_opus",
+          label: "Weekly Opus",
+          usedPercent: 91,
+          resetsAt: "2027-01-15T08:00:00.000Z",
+          windowMinutes: 10080,
+        },
+      ],
+    });
+  });
+
+  it("treats a rejection without utilization as a full window", () => {
+    expect(
+      normalizeClaudeRateLimit({ status: "rejected", rateLimitType: "five_hour" })?.windows[0]
+        ?.usedPercent,
+    ).toBe(100);
+  });
+
+  it("drops events without a known window", () => {
+    expect(normalizeClaudeRateLimit({ status: "allowed", utilization: 0.2 })).toBeNull();
+    expect(
+      normalizeClaudeRateLimit({ status: "allowed", rateLimitType: "mystery", utilization: 0.2 }),
+    ).toBeNull();
+  });
+});

--- a/apps/server/src/provider/Layers/claudeRateLimits.test.ts
+++ b/apps/server/src/provider/Layers/claudeRateLimits.test.ts
@@ -12,6 +12,7 @@ describe("normalizeClaudeRateLimit", () => {
         resetsAt: 1_800_000_000,
       }),
     ).toEqual({
+      complete: false,
       windows: [
         {
           id: "seven_day_opus",

--- a/apps/server/src/provider/Layers/claudeRateLimits.ts
+++ b/apps/server/src/provider/Layers/claudeRateLimits.ts
@@ -25,9 +25,23 @@ const WINDOWS: Record<string, { readonly label: string; readonly windowMinutes: 
   overage: { label: "Extra usage", windowMinutes: null },
 };
 
+/** `seven_day_fable` → `Weekly Fable`, matching the ids the on-demand read produces. */
+function scopedWeekly(
+  type: string,
+): { readonly label: string; readonly windowMinutes: number } | null {
+  const scope = type.startsWith("seven_day_") ? type.slice("seven_day_".length) : "";
+  if (scope.length === 0) return null;
+  const name = scope
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+  return { label: `Weekly ${name}`, windowMinutes: 10080 };
+}
+
 export function normalizeClaudeRateLimit(info: ClaudeRateLimitInfo): UsageLimitsUpdate | null {
-  const kind = info.rateLimitType === undefined ? undefined : WINDOWS[info.rateLimitType];
-  if (info.rateLimitType === undefined || kind === undefined) return null;
+  if (info.rateLimitType === undefined) return null;
+  const kind = WINDOWS[info.rateLimitType] ?? scopedWeekly(info.rateLimitType);
+  if (kind === null) return null;
   const usedPercent =
     info.utilization === undefined
       ? info.status === "rejected"

--- a/apps/server/src/provider/Layers/claudeRateLimits.ts
+++ b/apps/server/src/provider/Layers/claudeRateLimits.ts
@@ -1,0 +1,49 @@
+/**
+ * Normalises one Claude Code `rate_limit_event` into a sparse usage limits
+ * update. The SDK reports a single window per event, so callers merge by id.
+ * Only claude.ai subscriptions emit these; API key sessions never do.
+ *
+ * @module provider/Layers/claudeRateLimits
+ */
+import type { UsageLimitsUpdate } from "@t3tools/contracts";
+
+import { epochToIso } from "./codexRateLimits.ts";
+
+export interface ClaudeRateLimitInfo {
+  readonly status: "allowed" | "allowed_warning" | "rejected";
+  readonly resetsAt?: number;
+  readonly rateLimitType?: string;
+  /** Fraction of the window used, 0..1, as the unified rate-limit headers report it. */
+  readonly utilization?: number;
+}
+
+const WINDOWS: Record<string, { readonly label: string; readonly windowMinutes: number | null }> = {
+  five_hour: { label: "5 hour", windowMinutes: 300 },
+  seven_day: { label: "Weekly", windowMinutes: 10080 },
+  seven_day_opus: { label: "Weekly Opus", windowMinutes: 10080 },
+  seven_day_sonnet: { label: "Weekly Sonnet", windowMinutes: 10080 },
+  overage: { label: "Extra usage", windowMinutes: null },
+};
+
+export function normalizeClaudeRateLimit(info: ClaudeRateLimitInfo): UsageLimitsUpdate | null {
+  const kind = info.rateLimitType === undefined ? undefined : WINDOWS[info.rateLimitType];
+  if (info.rateLimitType === undefined || kind === undefined) return null;
+  const usedPercent =
+    info.utilization === undefined
+      ? info.status === "rejected"
+        ? 100
+        : null
+      : Math.max(0, Math.min(100, info.utilization * 100));
+  if (usedPercent === null) return null;
+  return {
+    windows: [
+      {
+        id: info.rateLimitType,
+        label: kind.label,
+        usedPercent,
+        resetsAt: epochToIso(info.resetsAt),
+        windowMinutes: kind.windowMinutes,
+      },
+    ],
+  };
+}

--- a/apps/server/src/provider/Layers/claudeRateLimits.ts
+++ b/apps/server/src/provider/Layers/claudeRateLimits.ts
@@ -50,6 +50,8 @@ export function normalizeClaudeRateLimit(info: ClaudeRateLimitInfo): UsageLimits
       : Math.max(0, Math.min(100, info.utilization * 100));
   if (usedPercent === null) return null;
   return {
+    // One window per event: everything else is unchanged.
+    complete: false,
     windows: [
       {
         id: info.rateLimitType,

--- a/apps/server/src/provider/Layers/codexAccountClient.ts
+++ b/apps/server/src/provider/Layers/codexAccountClient.ts
@@ -1,0 +1,77 @@
+/**
+ * Short-lived Codex app-server for account-level requests such as rate limits
+ * and reset credits. Nothing thread-bound is needed: the process reads the
+ * configured Codex home, answers, and exits when the scope closes.
+ *
+ * @module provider/Layers/codexAccountClient
+ */
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as CodexClient from "effect-codex-app-server/client";
+import * as CodexErrors from "effect-codex-app-server/errors";
+
+import { expandHomePath } from "../../pathExpansion.ts";
+import { codexAppServerArgs } from "./codexLaunchArgs.ts";
+
+export interface CodexAccountClientOptions {
+  readonly binaryPath: string;
+  readonly homePath?: string | undefined;
+  readonly launchArgs?: string | undefined;
+  readonly environment?: NodeJS.ProcessEnv | undefined;
+  readonly cwd: string;
+}
+
+const FORCE_KILL_AFTER = "2 seconds" as const;
+
+export const withCodexAccountClient = <A, E>(
+  options: CodexAccountClientOptions,
+  use: (client: CodexClient.CodexAppServerClient["Service"]) => Effect.Effect<A, E>,
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      // `~` is not shell-expanded for spawned env vars; mirror the session runtime.
+      const resolvedHomePath = options.homePath ? expandHomePath(options.homePath) : undefined;
+      const env = {
+        ...options.environment,
+        ...(resolvedHomePath ? { CODEX_HOME: resolvedHomePath } : {}),
+      };
+      const extendEnv = options.environment === undefined;
+      const spawnCommand = yield* resolveSpawnCommand(
+        options.binaryPath,
+        codexAppServerArgs(options.launchArgs),
+        { env, extendEnv },
+      );
+      const child = yield* spawner
+        .spawn(
+          ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+            cwd: options.cwd,
+            env,
+            extendEnv,
+            forceKillAfter: FORCE_KILL_AFTER,
+            shell: spawnCommand.shell,
+          }),
+        )
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new CodexErrors.CodexAppServerSpawnError({
+                command: `${options.binaryPath} app-server`,
+                cause,
+              }),
+          ),
+        );
+      const clientContext = yield* Layer.build(CodexClient.layerChildProcess(child));
+      const client = yield* Effect.service(CodexClient.CodexAppServerClient).pipe(
+        Effect.provide(clientContext),
+      );
+      yield* client.request("initialize", {
+        clientInfo: { name: "t3code_desktop", title: "T3 Code Desktop", version: "0.1.0" },
+        capabilities: { experimentalApi: true },
+      });
+      yield* client.notify("initialized", undefined);
+      return yield* use(client);
+    }),
+  );

--- a/apps/server/src/provider/Layers/codexRateLimits.test.ts
+++ b/apps/server/src/provider/Layers/codexRateLimits.test.ts
@@ -4,23 +4,27 @@ import { normalizeCodexRateLimits } from "./codexRateLimits.ts";
 
 describe("normalizeCodexRateLimits", () => {
   it("maps primary and secondary windows with plan and reset credits", () => {
-    const update = normalizeCodexRateLimits({
-      rateLimits: {
-        planType: "pro",
-        primary: { usedPercent: 42, resetsAt: 1_800_000_000, windowDurationMins: 300 },
-        secondary: { usedPercent: 67, resetsAt: 1_800_500_000, windowDurationMins: 10080 },
+    const update = normalizeCodexRateLimits(
+      {
+        rateLimits: {
+          planType: "pro",
+          primary: { usedPercent: 42, resetsAt: 1_800_000_000, windowDurationMins: 300 },
+          secondary: { usedPercent: 67, resetsAt: 1_800_500_000, windowDurationMins: 10080 },
+        },
+        rateLimitResetCredits: {
+          availableCount: 2,
+          credits: [
+            { status: "redeemed", expiresAt: 1_700_000_000 },
+            { status: "available", expiresAt: 1_801_000_000 },
+            { status: "available", expiresAt: 1_800_900_000 },
+          ],
+        },
       },
-      rateLimitResetCredits: {
-        availableCount: 2,
-        credits: [
-          { status: "redeemed", expiresAt: 1_700_000_000 },
-          { status: "available", expiresAt: 1_801_000_000 },
-          { status: "available", expiresAt: 1_800_900_000 },
-        ],
-      },
-    });
+      { complete: true },
+    );
 
     expect(update).toEqual({
+      complete: true,
       plan: "Pro",
       windows: [
         {
@@ -43,11 +47,13 @@ describe("normalizeCodexRateLimits", () => {
   });
 
   it("leaves plan and credits untouched when the payload omits them", () => {
-    const update = normalizeCodexRateLimits({
-      rateLimits: { primary: { usedPercent: 130 } },
-    });
+    const update = normalizeCodexRateLimits(
+      { rateLimits: { primary: { usedPercent: 130 } } },
+      { complete: false },
+    );
 
     expect(update).toEqual({
+      complete: false,
       windows: [
         { id: "primary", label: "5 hour", usedPercent: 100, resetsAt: null, windowMinutes: null },
       ],

--- a/apps/server/src/provider/Layers/codexRateLimits.test.ts
+++ b/apps/server/src/provider/Layers/codexRateLimits.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { normalizeCodexRateLimits } from "./codexRateLimits.ts";
+
+describe("normalizeCodexRateLimits", () => {
+  it("maps primary and secondary windows with plan and reset credits", () => {
+    const update = normalizeCodexRateLimits({
+      rateLimits: {
+        planType: "pro",
+        primary: { usedPercent: 42, resetsAt: 1_800_000_000, windowDurationMins: 300 },
+        secondary: { usedPercent: 67, resetsAt: 1_800_500_000, windowDurationMins: 10080 },
+      },
+      rateLimitResetCredits: {
+        availableCount: 2,
+        credits: [
+          { status: "redeemed", expiresAt: 1_700_000_000 },
+          { status: "available", expiresAt: 1_801_000_000 },
+          { status: "available", expiresAt: 1_800_900_000 },
+        ],
+      },
+    });
+
+    expect(update).toEqual({
+      plan: "Pro",
+      windows: [
+        {
+          id: "primary",
+          label: "5 hour",
+          usedPercent: 42,
+          resetsAt: "2027-01-15T08:00:00.000Z",
+          windowMinutes: 300,
+        },
+        {
+          id: "secondary",
+          label: "Weekly",
+          usedPercent: 67,
+          resetsAt: "2027-01-21T02:53:20.000Z",
+          windowMinutes: 10080,
+        },
+      ],
+      resetCredits: { availableCount: 2, nextExpiresAt: "2027-01-25T18:00:00.000Z" },
+    });
+  });
+
+  it("leaves plan and credits untouched when the payload omits them", () => {
+    const update = normalizeCodexRateLimits({
+      rateLimits: { primary: { usedPercent: 130 } },
+    });
+
+    expect(update).toEqual({
+      windows: [
+        { id: "primary", label: "5 hour", usedPercent: 100, resetsAt: null, windowMinutes: null },
+      ],
+    });
+    expect("plan" in update).toBe(false);
+    expect("resetCredits" in update).toBe(false);
+  });
+});

--- a/apps/server/src/provider/Layers/codexRateLimits.ts
+++ b/apps/server/src/provider/Layers/codexRateLimits.ts
@@ -77,7 +77,15 @@ function planLabel(planType: string): string | null {
     .join(" ");
 }
 
-export function normalizeCodexRateLimits(input: CodexRateLimitsInput): UsageLimitsUpdate {
+/**
+ * `complete` marks a full `account/rateLimits/read` response. The rolling
+ * `account/rateLimits/updated` notification is documented as sparse, so its
+ * missing windows mean "unchanged" rather than "gone".
+ */
+export function normalizeCodexRateLimits(
+  input: CodexRateLimitsInput,
+  options: { readonly complete: boolean },
+): UsageLimitsUpdate {
   const { rateLimits } = input;
   const windows: UsageLimitWindow[] = [];
   if (rateLimits.primary) windows.push(toWindow("primary", "5 hour", rateLimits.primary));
@@ -91,6 +99,7 @@ export function normalizeCodexRateLimits(input: CodexRateLimitsInput): UsageLimi
       .filter((value): value is number => typeof value === "number") ?? [];
 
   return {
+    complete: options.complete,
     windows,
     ...(rateLimits.planType === undefined || rateLimits.planType === null
       ? {}

--- a/apps/server/src/provider/Layers/codexRateLimits.ts
+++ b/apps/server/src/provider/Layers/codexRateLimits.ts
@@ -1,0 +1,110 @@
+/**
+ * Normalises Codex app-server rate-limit payloads into the usage limits
+ * contract. Both the `account/rateLimits/updated` notification and the
+ * `account/rateLimits/read` response carry the same snapshot shape; only the
+ * read response adds banked reset credits.
+ *
+ * @module provider/Layers/codexRateLimits
+ */
+import type { UsageLimitWindow, UsageLimitsUpdate } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+
+interface CodexRateLimitWindow {
+  readonly usedPercent: number;
+  readonly resetsAt?: number | null;
+  readonly windowDurationMins?: number | null;
+}
+
+interface CodexRateLimitSnapshot {
+  readonly planType?: string | null;
+  readonly primary?: CodexRateLimitWindow | null;
+  readonly secondary?: CodexRateLimitWindow | null;
+}
+
+interface CodexResetCredits {
+  readonly availableCount: number;
+  readonly credits?: ReadonlyArray<{
+    readonly expiresAt?: number | null;
+    readonly status: string;
+  }> | null;
+}
+
+export interface CodexRateLimitsInput {
+  readonly rateLimits: CodexRateLimitSnapshot;
+  /** Only the read response carries this; absent means "unchanged". */
+  readonly rateLimitResetCredits?: CodexResetCredits | null;
+}
+
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+const MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
+
+/** Codex timestamps are unix seconds; tolerate milliseconds defensively. */
+export function epochToIso(value: number | null | undefined): string | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) return null;
+  const ms = value > 1e12 ? value : value * 1000;
+  return DateTime.formatIso(DateTime.makeUnsafe(ms));
+}
+
+function windowLabel(minutes: number | null, fallback: string): string {
+  if (minutes === null) return fallback;
+  if (minutes === MINUTES_PER_WEEK) return "Weekly";
+  if (minutes < MINUTES_PER_HOUR) return `${minutes} min`;
+  if (minutes < MINUTES_PER_DAY) return `${Math.round(minutes / MINUTES_PER_HOUR)} hour`;
+  return `${Math.round(minutes / MINUTES_PER_DAY)} day`;
+}
+
+function toWindow(
+  id: string,
+  fallbackLabel: string,
+  window: CodexRateLimitWindow,
+): UsageLimitWindow {
+  const windowMinutes = window.windowDurationMins ?? null;
+  return {
+    id,
+    label: windowLabel(windowMinutes, fallbackLabel),
+    usedPercent: Math.max(0, Math.min(100, window.usedPercent)),
+    resetsAt: epochToIso(window.resetsAt),
+    windowMinutes,
+  };
+}
+
+function planLabel(planType: string): string | null {
+  if (planType === "unknown") return null;
+  return planType
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function normalizeCodexRateLimits(input: CodexRateLimitsInput): UsageLimitsUpdate {
+  const { rateLimits } = input;
+  const windows: UsageLimitWindow[] = [];
+  if (rateLimits.primary) windows.push(toWindow("primary", "5 hour", rateLimits.primary));
+  if (rateLimits.secondary) windows.push(toWindow("secondary", "Weekly", rateLimits.secondary));
+
+  const credits = input.rateLimitResetCredits;
+  const expiries =
+    credits?.credits
+      ?.filter((credit) => credit.status === "available")
+      .map((credit) => credit.expiresAt)
+      .filter((value): value is number => typeof value === "number") ?? [];
+
+  return {
+    windows,
+    ...(rateLimits.planType === undefined || rateLimits.planType === null
+      ? {}
+      : { plan: planLabel(rateLimits.planType) }),
+    ...(credits === undefined
+      ? {}
+      : {
+          resetCredits:
+            credits === null
+              ? null
+              : {
+                  availableCount: Math.max(0, credits.availableCount),
+                  nextExpiresAt: expiries.length === 0 ? null : epochToIso(Math.min(...expiries)),
+                },
+        }),
+  };
+}

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -21,6 +21,8 @@ import type {
   ThreadId,
   ProviderTurnStartResult,
   TurnId,
+  UsageLimitsConsumeResetOutcome,
+  UsageLimitsUpdate,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
 import type * as Stream from "effect/Stream";
@@ -127,6 +129,17 @@ export interface ProviderAdapterShape<TError> {
   readonly uploadFeedback?: (
     input: ProviderUploadFeedbackInput,
   ) => Effect.Effect<ProviderUploadFeedbackResult, TError>;
+
+  /**
+   * Latest account limits the provider can report right now, or null when no
+   * live process can answer. Sparse: windows merge by id downstream.
+   */
+  readonly readAccountLimits?: Effect.Effect<UsageLimitsUpdate | null, TError>;
+
+  /**
+   * Redeem one banked rate-limit reset credit on the signed-in account.
+   */
+  readonly consumeRateLimitResetCredit?: Effect.Effect<UsageLimitsConsumeResetOutcome, TError>;
 
   /**
    * Stop all sessions owned by this adapter.

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -161,6 +161,7 @@ import * as DesktopTelemetryReceiver from "./resourceTelemetry/DesktopTelemetryR
 import * as NativeTelemetryClient from "./resourceTelemetry/NativeTelemetryClient.ts";
 import * as ResourceAttribution from "./resourceTelemetry/ResourceAttribution.ts";
 import * as ResourceTelemetry from "./resourceTelemetry/ResourceTelemetry.ts";
+import * as UsageLimitsService from "./usage/UsageLimitsService.ts";
 import * as UsageService from "./usage/UsageService.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import * as Data from "effect/Data";
@@ -980,6 +981,7 @@ const buildAppUnderTest = (options?: {
     const appLayer = servedRoutesLayer.pipe(
       Layer.provide(resourceTelemetryLayer),
       Layer.provide(UsageService.layerTest),
+      Layer.provide(UsageLimitsService.layerTest),
       Layer.provide(
         Layer.mock(AnalyticsService.AnalyticsService)({
           record: () => Effect.void,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -118,6 +118,7 @@ import * as NativeTelemetryClient from "./resourceTelemetry/NativeTelemetryClien
 import * as ResourceAttribution from "./resourceTelemetry/ResourceAttribution.ts";
 import * as ResourceMonitorBinary from "./resourceTelemetry/ResourceMonitorBinary.ts";
 import * as ResourceTelemetry from "./resourceTelemetry/ResourceTelemetry.ts";
+import * as UsageLimitsService from "./usage/UsageLimitsService.ts";
 import * as UsageService from "./usage/UsageService.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import {
@@ -268,6 +269,7 @@ const PlatformServicesLive = Layer.unwrap(
 const ReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(OrchestrationReactorLive),
   Layer.provideMerge(ProviderRuntimeIngestionLive),
+  Layer.provideMerge(UsageLimitsService.layer),
   Layer.provideMerge(ProviderCommandReactorLive),
   Layer.provideMerge(CheckpointReactorLive),
   Layer.provideMerge(ThreadDeletionReactorLive),
@@ -286,8 +288,10 @@ const ProviderSessionDirectoryLayerLive = ProviderSessionDirectoryLive.pipe(
 // `create()`; `ProviderEventLoggers.layer` owns the shared native/canonical
 // NDJSON writers and is provided at the outer runtime layer so both
 // `ProviderService` and the per-instance drivers read the same logger pair.
+// The registry is merged outward so account-level readers (usage limits) can
+// reach adapters by instance without routing through a thread.
 const ProviderLayerLive = ProviderServiceLive.pipe(
-  Layer.provide(ProviderAdapterRegistryLive),
+  Layer.provideMerge(ProviderAdapterRegistryLive),
   Layer.provideMerge(ProviderSessionDirectoryLayerLive),
 );
 

--- a/apps/server/src/usage/UsageLimitsService.test.ts
+++ b/apps/server/src/usage/UsageLimitsService.test.ts
@@ -21,6 +21,7 @@ describe("UsageLimitsService", () => {
       const events = yield* PubSub.unbounded<ProviderRuntimeEvent>();
       const service = yield* make({
         streamEvents: Stream.fromPubSub(events),
+        instanceChanges: Stream.empty,
         listInstances: Effect.succeed([codexInstance]),
         getInstanceLabel: () => Effect.succeed("Personal"),
         getInstanceIdentity: () => Effect.succeed("codex:home:/home/me/.codex"),
@@ -107,6 +108,7 @@ describe("UsageLimitsService", () => {
     Effect.gen(function* () {
       const service = yield* make({
         streamEvents: Stream.empty,
+        instanceChanges: Stream.empty,
         listInstances: Effect.succeed([]),
         getInstanceLabel: () => Effect.succeed(null),
         getInstanceIdentity: () => Effect.succeed(null),

--- a/apps/server/src/usage/UsageLimitsService.test.ts
+++ b/apps/server/src/usage/UsageLimitsService.test.ts
@@ -23,6 +23,7 @@ describe("UsageLimitsService", () => {
         streamEvents: Stream.fromPubSub(events),
         listInstances: Effect.succeed([codexInstance]),
         getInstanceLabel: () => Effect.succeed("Personal"),
+        getInstanceIdentity: () => Effect.succeed("codex:home:/home/me/.codex"),
         getAdapter: () =>
           Effect.succeed({
             provider: ProviderDriverKind.make("codex"),
@@ -108,6 +109,7 @@ describe("UsageLimitsService", () => {
         streamEvents: Stream.empty,
         listInstances: Effect.succeed([]),
         getInstanceLabel: () => Effect.succeed(null),
+        getInstanceIdentity: () => Effect.succeed(null),
         getAdapter: () => Effect.succeed({ provider: ProviderDriverKind.make("claudeAgent") }),
       });
       const result = yield* service

--- a/apps/server/src/usage/UsageLimitsService.test.ts
+++ b/apps/server/src/usage/UsageLimitsService.test.ts
@@ -16,7 +16,7 @@ import { make } from "./UsageLimitsService.ts";
 const codexInstance = ProviderInstanceId.make("codex");
 
 describe("UsageLimitsService", () => {
-  it.effect("reads adapters on subscribe and merges sparse events by window id", () =>
+  it.effect("reads adapters before the first snapshot and merges sparse events by window id", () =>
     Effect.gen(function* () {
       const events = yield* PubSub.unbounded<ProviderRuntimeEvent>();
       const service = yield* make({
@@ -50,16 +50,16 @@ describe("UsageLimitsService", () => {
       });
 
       const subscription = yield* service.subscribe;
-      assert.deepStrictEqual(subscription.latest.providers, []);
-
-      const afterRead = Option.getOrThrow(yield* Stream.runHead(subscription.changes));
-      const codex = afterRead.providers[0];
+      const codex = subscription.latest.providers[0];
       assert.strictEqual(codex?.plan, "Pro");
       assert.strictEqual(codex?.instanceLabel, "Personal");
       assert.strictEqual(codex?.resetCredits?.availableCount, 2);
       assert.strictEqual(codex?.windows.length, 2);
 
       const next = yield* service.subscribe;
+      // Let the forked ingestion fiber attach to the event stream first.
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* PubSub.publish(events, {
         eventId: EventId.make("evt-1"),
         provider: ProviderDriverKind.make("codex"),

--- a/apps/server/src/usage/UsageLimitsService.test.ts
+++ b/apps/server/src/usage/UsageLimitsService.test.ts
@@ -11,6 +11,7 @@ import * as Option from "effect/Option";
 import * as PubSub from "effect/PubSub";
 import * as Stream from "effect/Stream";
 
+import { ProviderAdapterRequestError } from "../provider/Errors.ts";
 import { make } from "./UsageLimitsService.ts";
 
 const codexInstance = ProviderInstanceId.make("codex");
@@ -29,6 +30,7 @@ describe("UsageLimitsService", () => {
           Effect.succeed({
             provider: ProviderDriverKind.make("codex"),
             readAccountLimits: Effect.succeed({
+              complete: true,
               plan: "Pro",
               windows: [
                 {
@@ -71,6 +73,7 @@ describe("UsageLimitsService", () => {
         type: "account.rate-limits.updated",
         payload: {
           limits: {
+            complete: false,
             windows: [
               {
                 id: "primary",
@@ -118,6 +121,84 @@ describe("UsageLimitsService", () => {
         .consumeReset({ instanceId: ProviderInstanceId.make("claudeAgent") })
         .pipe(Effect.flip);
       assert.strictEqual(result.reason, "unsupported");
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("a complete read drops windows the account no longer reports", () =>
+    Effect.gen(function* () {
+      let windows = [
+        { id: "primary", label: "5 hour", usedPercent: 40, resetsAt: null, windowMinutes: 300 },
+        { id: "secondary", label: "Weekly", usedPercent: 60, resetsAt: null, windowMinutes: 10080 },
+      ];
+      const service = yield* make({
+        streamEvents: Stream.empty,
+        instanceChanges: Stream.empty,
+        listInstances: Effect.succeed([codexInstance]),
+        getInstanceLabel: () => Effect.succeed(null),
+        getInstanceIdentity: () => Effect.succeed("codex:home:x"),
+        getAdapter: () =>
+          Effect.succeed({
+            provider: ProviderDriverKind.make("codex"),
+            readAccountLimits: Effect.sync(() => ({ complete: true, windows })),
+          }),
+      });
+      const first = yield* service.subscribe;
+      assert.deepStrictEqual(
+        first.latest.providers[0]?.windows.map((window) => window.id),
+        ["primary", "secondary"],
+      );
+      windows = windows.slice(0, 1);
+      const second = yield* service.subscribe;
+      assert.deepStrictEqual(
+        second.latest.providers[0]?.windows.map((window) => window.id),
+        ["primary"],
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("a failed read keeps the last good numbers and says so", () =>
+    Effect.gen(function* () {
+      let fail = false;
+      const service = yield* make({
+        streamEvents: Stream.empty,
+        instanceChanges: Stream.empty,
+        listInstances: Effect.succeed([codexInstance]),
+        getInstanceLabel: () => Effect.succeed(null),
+        getInstanceIdentity: () => Effect.succeed("codex:home:x"),
+        getAdapter: () =>
+          Effect.succeed({
+            provider: ProviderDriverKind.make("codex"),
+            readAccountLimits: Effect.suspend(() =>
+              fail
+                ? Effect.fail(
+                    new ProviderAdapterRequestError({
+                      provider: "codex",
+                      method: "account/rateLimits/read",
+                      detail: "Codex could not answer account/rateLimits/read.",
+                    }),
+                  )
+                : Effect.succeed({
+                    complete: true,
+                    windows: [
+                      {
+                        id: "primary",
+                        label: "5 hour",
+                        usedPercent: 40,
+                        resetsAt: null,
+                        windowMinutes: 300,
+                      },
+                    ],
+                  }),
+            ),
+          }),
+      });
+      const good = yield* service.subscribe;
+      assert.strictEqual(good.latest.providers[0]?.readError, null);
+      fail = true;
+      const bad = yield* service.subscribe;
+      const entry = bad.latest.providers[0];
+      assert.strictEqual(entry?.windows[0]?.usedPercent, 40);
+      assert.match(entry?.readError ?? "", /could not answer/);
     }).pipe(Effect.scoped),
   );
 });

--- a/apps/server/src/usage/UsageLimitsService.test.ts
+++ b/apps/server/src/usage/UsageLimitsService.test.ts
@@ -1,0 +1,119 @@
+import { assert, describe, it } from "@effect/vitest";
+import {
+  EventId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ProviderRuntimeEvent,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
+import * as Stream from "effect/Stream";
+
+import { make } from "./UsageLimitsService.ts";
+
+const codexInstance = ProviderInstanceId.make("codex");
+
+describe("UsageLimitsService", () => {
+  it.effect("reads adapters on subscribe and merges sparse events by window id", () =>
+    Effect.gen(function* () {
+      const events = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+      const service = yield* make({
+        streamEvents: Stream.fromPubSub(events),
+        listInstances: Effect.succeed([codexInstance]),
+        getInstanceLabel: () => Effect.succeed("Personal"),
+        getAdapter: () =>
+          Effect.succeed({
+            provider: ProviderDriverKind.make("codex"),
+            readAccountLimits: Effect.succeed({
+              plan: "Pro",
+              windows: [
+                {
+                  id: "primary",
+                  label: "5 hour",
+                  usedPercent: 40,
+                  resetsAt: null,
+                  windowMinutes: 300,
+                },
+                {
+                  id: "secondary",
+                  label: "Weekly",
+                  usedPercent: 60,
+                  resetsAt: null,
+                  windowMinutes: 10080,
+                },
+              ],
+              resetCredits: { availableCount: 2, nextExpiresAt: null },
+            }),
+          }),
+      });
+
+      const subscription = yield* service.subscribe;
+      assert.deepStrictEqual(subscription.latest.providers, []);
+
+      const afterRead = Option.getOrThrow(yield* Stream.runHead(subscription.changes));
+      const codex = afterRead.providers[0];
+      assert.strictEqual(codex?.plan, "Pro");
+      assert.strictEqual(codex?.instanceLabel, "Personal");
+      assert.strictEqual(codex?.resetCredits?.availableCount, 2);
+      assert.strictEqual(codex?.windows.length, 2);
+
+      const next = yield* service.subscribe;
+      yield* PubSub.publish(events, {
+        eventId: EventId.make("evt-1"),
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstance,
+        threadId: ThreadId.make("thread-1"),
+        createdAt: "2026-09-03T08:00:00.000Z",
+        type: "account.rate-limits.updated",
+        payload: {
+          limits: {
+            windows: [
+              {
+                id: "primary",
+                label: "5 hour",
+                usedPercent: 55,
+                resetsAt: null,
+                windowMinutes: 300,
+              },
+            ],
+          },
+        },
+      } satisfies ProviderRuntimeEvent);
+      const merged = Option.getOrThrow(
+        yield* Stream.runHead(
+          next.changes.pipe(
+            Stream.filter((snapshot) =>
+              snapshot.providers.some((entry) =>
+                entry.windows.some((window) => window.usedPercent === 55),
+              ),
+            ),
+          ),
+        ),
+      );
+      const entry = merged.providers[0];
+      assert.strictEqual(entry?.plan, "Pro");
+      assert.strictEqual(
+        entry?.windows.find((window) => window.id === "secondary")?.usedPercent,
+        60,
+      );
+      assert.strictEqual(entry?.windows.find((window) => window.id === "primary")?.usedPercent, 55);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("rejects reset consumption for providers without banked credits", () =>
+    Effect.gen(function* () {
+      const service = yield* make({
+        streamEvents: Stream.empty,
+        listInstances: Effect.succeed([]),
+        getInstanceLabel: () => Effect.succeed(null),
+        getAdapter: () => Effect.succeed({ provider: ProviderDriverKind.make("claudeAgent") }),
+      });
+      const result = yield* service
+        .consumeReset({ instanceId: ProviderInstanceId.make("claudeAgent") })
+        .pipe(Effect.flip);
+      assert.strictEqual(result.reason, "unsupported");
+    }).pipe(Effect.scoped),
+  );
+});

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -39,7 +39,7 @@ import {
 } from "../utils/subscribeBeforeSnapshot.ts";
 
 export interface UsageLimitsServiceShape {
-  /** Latest snapshot plus every later change. Subscribing also triggers a fresh read. */
+  /** Fresh read, then the latest snapshot plus every later change. */
   readonly subscribe: Effect.Effect<SnapshotSubscription<UsageLimitsSnapshot>, never, Scope.Scope>;
   /** Ask every adapter that can answer for its current limits. Never fails. */
   readonly refresh: Effect.Effect<void>;
@@ -146,6 +146,13 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
 
   const refresh: UsageLimitsServiceShape["refresh"] = Effect.gen(function* () {
     const instances = yield* sources.listInstances;
+    // Instances removed from settings take their limits with them.
+    const live = new Set(instances);
+    const pruned = yield* Ref.modify(state, (map) => {
+      const next = new Map([...map].filter(([instanceId]) => live.has(instanceId)));
+      return [next.size !== map.size, next] as const;
+    });
+    if (pruned) yield* PubSub.publish(changes, yield* snapshot);
     yield* Effect.forEach(
       instances,
       (instanceId) =>
@@ -171,10 +178,10 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
   }).pipe(Effect.forkScoped);
 
   const subscribe: UsageLimitsServiceShape["subscribe"] = Effect.gen(function* () {
-    const subscription = yield* subscribeBeforeSnapshotWithoutMutex(changes, snapshot);
-    // Fresh numbers land as a change on the stream the subscriber just opened.
-    yield* Effect.forkScoped(refresh);
-    return subscription;
+    // Read first so the initial snapshot already carries fresh numbers and a
+    // client never mistakes the boot-time empty map for "nothing reported".
+    yield* refresh;
+    return yield* subscribeBeforeSnapshotWithoutMutex(changes, snapshot);
   });
 
   const consumeReset: UsageLimitsServiceShape["consumeReset"] = Effect.fn(

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -21,6 +21,7 @@ import {
   type UsageProviderKind,
   type UsageProviderLimits,
 } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -38,19 +39,21 @@ import {
   subscribeBeforeSnapshotWithoutMutex,
 } from "../utils/subscribeBeforeSnapshot.ts";
 
-export interface UsageLimitsServiceShape {
-  /** Fresh read, then the latest snapshot plus every later change. */
-  readonly subscribe: Effect.Effect<SnapshotSubscription<UsageLimitsSnapshot>, never, Scope.Scope>;
-  /** Ask every adapter that can answer for its current limits. Never fails. */
-  readonly refresh: Effect.Effect<void>;
-  readonly consumeReset: (
-    input: UsageLimitsConsumeResetInput,
-  ) => Effect.Effect<UsageLimitsConsumeResetResult, UsageLimitsError>;
-}
-
 export class UsageLimitsService extends Context.Service<
   UsageLimitsService,
-  UsageLimitsServiceShape
+  {
+    /** Fresh read, then the latest snapshot plus every later change. */
+    readonly subscribe: Effect.Effect<
+      SnapshotSubscription<UsageLimitsSnapshot>,
+      never,
+      Scope.Scope
+    >;
+    /** Ask every adapter that can answer for its current limits. Never fails. */
+    readonly refresh: Effect.Effect<void>;
+    readonly consumeReset: (
+      input: UsageLimitsConsumeResetInput,
+    ) => Effect.Effect<UsageLimitsConsumeResetResult, UsageLimitsError>;
+  }
 >()("t3/usage/UsageLimitsService") {}
 
 /** Adapter surface the service needs; the registry hands back full adapters. */
@@ -91,6 +94,10 @@ function errorDetail(cause: unknown): string {
 
 export const make = Effect.fn("UsageLimitsService.make")(function* (sources: UsageLimitsSources) {
   const state = yield* Ref.make(new Map<ProviderInstanceId, UsageProviderLimits>());
+  /** When each window last changed, so a slow read cannot undo a newer event. */
+  const windowStamps = yield* Ref.make(new Map<string, number>());
+  const stampKey = (instanceId: ProviderInstanceId, windowId: string) =>
+    `${instanceId}:${windowId}`;
   const changes = yield* PubSub.sliding<UsageLimitsSnapshot>(8);
 
   const snapshot: Effect.Effect<UsageLimitsSnapshot> = Ref.get(state).pipe(
@@ -103,18 +110,33 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     })),
   );
 
-  /** Merge a sparse update into one instance's limits and publish the result. */
+  /**
+   * Merge a sparse update into one instance's limits and publish the result.
+   * `since` is when a read began: windows that an event touched after that
+   * moment keep the event's newer numbers.
+   */
   const apply = Effect.fn("UsageLimitsService.apply")(function* (
     instanceId: ProviderInstanceId,
     provider: UsageProviderKind,
     update: UsageLimitsUpdate,
+    since: number,
   ) {
-    const observedAt = DateTime.formatIso(yield* DateTime.now);
+    const nowMs = yield* Clock.currentTimeMillis;
+    const observedAt = DateTime.formatIso(DateTime.makeUnsafe(nowMs));
     const instanceLabel = yield* sources.getInstanceLabel(instanceId);
+    const stamps = yield* Ref.get(windowStamps);
+    const fresh = update.windows.filter(
+      (window) => (stamps.get(stampKey(instanceId, window.id)) ?? 0) <= since,
+    );
+    yield* Ref.update(windowStamps, (map) => {
+      const next = new Map(map);
+      for (const window of fresh) next.set(stampKey(instanceId, window.id), nowMs);
+      return next;
+    });
     yield* Ref.update(state, (map) => {
       const previous = map.get(instanceId);
       const windows = new Map((previous?.windows ?? []).map((window) => [window.id, window]));
-      for (const window of update.windows) windows.set(window.id, window);
+      for (const window of fresh) windows.set(window.id, window);
       const next = new Map(map);
       next.set(instanceId, {
         provider,
@@ -139,12 +161,13 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     const adapter = yield* sources.getAdapter(instanceId);
     const provider = usageProviderFor(adapter.provider);
     if (provider === null || adapter.readAccountLimits === undefined) return;
+    const startedAt = yield* Clock.currentTimeMillis;
     const update = yield* adapter.readAccountLimits;
     if (update === null) return;
-    yield* apply(instanceId, provider, update);
+    yield* apply(instanceId, provider, update, startedAt);
   });
 
-  const refresh: UsageLimitsServiceShape["refresh"] = Effect.gen(function* () {
+  const refresh: UsageLimitsService["Service"]["refresh"] = Effect.gen(function* () {
     const instances = yield* sources.listInstances;
     // Instances removed from settings take their limits with them.
     const live = new Set(instances);
@@ -152,7 +175,16 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
       const next = new Map([...map].filter(([instanceId]) => live.has(instanceId)));
       return [next.size !== map.size, next] as const;
     });
-    if (pruned) yield* PubSub.publish(changes, yield* snapshot);
+    if (pruned) {
+      yield* Ref.update(windowStamps, (map) => {
+        const next = new Map(map);
+        for (const key of next.keys()) {
+          if (!live.has(key.slice(0, key.indexOf(":")) as ProviderInstanceId)) next.delete(key);
+        }
+        return next;
+      });
+      yield* PubSub.publish(changes, yield* snapshot);
+    }
     yield* Effect.forEach(
       instances,
       (instanceId) =>
@@ -174,17 +206,23 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     }
     const provider = usageProviderFor(event.provider);
     if (provider === null) return Effect.void;
-    return apply(event.providerInstanceId, provider, event.payload.limits);
+    const instanceId = event.providerInstanceId;
+    return Effect.gen(function* () {
+      // A session outliving its instance's removal must not resurrect it.
+      const live = yield* sources.listInstances;
+      if (!live.includes(instanceId)) return;
+      yield* apply(instanceId, provider, event.payload.limits, Number.POSITIVE_INFINITY);
+    });
   }).pipe(Effect.forkScoped);
 
-  const subscribe: UsageLimitsServiceShape["subscribe"] = Effect.gen(function* () {
+  const subscribe: UsageLimitsService["Service"]["subscribe"] = Effect.gen(function* () {
     // Read first so the initial snapshot already carries fresh numbers and a
     // client never mistakes the boot-time empty map for "nothing reported".
     yield* refresh;
     return yield* subscribeBeforeSnapshotWithoutMutex(changes, snapshot);
   });
 
-  const consumeReset: UsageLimitsServiceShape["consumeReset"] = Effect.fn(
+  const consumeReset: UsageLimitsService["Service"]["consumeReset"] = Effect.fn(
     "UsageLimitsService.consumeReset",
   )(function* (input) {
     const adapter = yield* sources.getAdapter(input.instanceId);
@@ -199,8 +237,8 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
       Effect.mapError(
         (cause) =>
           new UsageLimitsError({
-            reason: "noSession",
-            detail: errorDetail(cause),
+            reason: "requestFailed",
+            detail: `Provider '${adapter.provider}' could not redeem the reset credit.`,
             cause,
           }),
       ),
@@ -209,7 +247,7 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     return { outcome };
   });
 
-  return { subscribe, refresh, consumeReset } satisfies UsageLimitsServiceShape;
+  return { subscribe, refresh, consumeReset } satisfies UsageLimitsService["Service"];
 });
 
 export const layer = Layer.effect(

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -129,7 +129,9 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     const observedAt = DateTime.formatIso(DateTime.makeUnsafe(nowMs));
     const instanceLabel = yield* sources.getInstanceLabel(instanceId);
     yield* Ref.update(state, (map) => {
-      const previous = map.get(instanceId);
+      // An instance re-pointed at another provider starts from a clean slate.
+      const stored = map.get(instanceId);
+      const previous = stored?.limits.provider === provider ? stored : undefined;
       const fresh = update.windows.filter(
         (window) => (previous?.stamps.get(window.id) ?? 0) <= since,
       );
@@ -167,7 +169,18 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
   ) {
     const adapter = yield* sources.getAdapter(instanceId);
     const provider = usageProviderFor(adapter.provider);
-    if (provider === null || adapter.readAccountLimits === undefined) return;
+    if (provider === null) {
+      // Re-pointed at a provider without limits: drop what the old one left.
+      const dropped = yield* Ref.modify(state, (map) => {
+        if (!map.has(instanceId)) return [false, map] as const;
+        const next = new Map(map);
+        next.delete(instanceId);
+        return [true, next] as const;
+      });
+      if (dropped) yield* PubSub.publish(changes, yield* snapshot);
+      return;
+    }
+    if (adapter.readAccountLimits === undefined) return;
     const startedAt = yield* Clock.currentTimeMillis;
     const update = yield* adapter.readAccountLimits;
     if (update === null) return;

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -92,6 +92,10 @@ function errorDetail(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause);
 }
 
+/** Stamp keys for the account-level fields, beside the window ids. */
+const PLAN_STAMP = "$plan";
+const CREDITS_STAMP = "$resetCredits";
+
 interface InstanceState {
   readonly limits: UsageProviderLimits;
   /** Window id → millis of the last change, so a slow read cannot undo a newer event. */
@@ -132,9 +136,10 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
       // An instance re-pointed at another provider starts from a clean slate.
       const stored = map.get(instanceId);
       const previous = stored?.limits.provider === provider ? stored : undefined;
-      const fresh = update.windows.filter(
-        (window) => (previous?.stamps.get(window.id) ?? 0) <= since,
-      );
+      const isFresh = (key: string) => (previous?.stamps.get(key) ?? 0) <= since;
+      const fresh = update.windows.filter((window) => isFresh(window.id));
+      const plan = update.plan !== undefined && isFresh(PLAN_STAMP);
+      const credits = update.resetCredits !== undefined && isFresh(CREDITS_STAMP);
       const windows = new Map(
         (previous?.limits.windows ?? []).map((window) => [window.id, window]),
       );
@@ -143,18 +148,19 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
         windows.set(window.id, window);
         stamps.set(window.id, nowMs);
       }
+      if (plan) stamps.set(PLAN_STAMP, nowMs);
+      if (credits) stamps.set(CREDITS_STAMP, nowMs);
       const next = new Map(map);
       next.set(instanceId, {
         limits: {
           provider,
           instanceId,
           instanceLabel,
-          plan: update.plan === undefined ? (previous?.limits.plan ?? null) : update.plan,
+          plan: plan ? (update.plan ?? null) : (previous?.limits.plan ?? null),
           windows: Array.from(windows.values()),
-          resetCredits:
-            update.resetCredits === undefined
-              ? (previous?.limits.resetCredits ?? null)
-              : update.resetCredits,
+          resetCredits: credits
+            ? (update.resetCredits ?? null)
+            : (previous?.limits.resetCredits ?? null),
           observedAt,
         },
         stamps,
@@ -163,6 +169,17 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     });
     yield* PubSub.publish(changes, yield* snapshot);
   });
+
+  /** The provider an instance currently resolves to, or null when it is gone or has no limits. */
+  const currentProvider = (instanceId: ProviderInstanceId) =>
+    sources.getAdapter(instanceId).pipe(
+      Effect.flatMap((adapter) =>
+        Effect.map(sources.listInstances, (live) =>
+          live.includes(instanceId) ? usageProviderFor(adapter.provider) : null,
+        ),
+      ),
+      Effect.orElseSucceed(() => null),
+    );
 
   const refreshInstance = Effect.fn("UsageLimitsService.refreshInstance")(function* (
     instanceId: ProviderInstanceId,
@@ -183,6 +200,9 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     const startedAt = yield* Clock.currentTimeMillis;
     const update = yield* adapter.readAccountLimits;
     if (update === null) return;
+    // The instance may have been removed or re-pointed while the read ran.
+    const current = yield* currentProvider(instanceId);
+    if (current !== provider) return;
     yield* apply(instanceId, provider, update, startedAt);
   });
 
@@ -220,10 +240,7 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     return Effect.gen(function* () {
       // A session outliving its instance's removal or re-pointing must not
       // resurrect the old provider's numbers.
-      const current = yield* sources.getAdapter(instanceId).pipe(
-        Effect.map((adapter) => usageProviderFor(adapter.provider)),
-        Effect.orElseSucceed(() => null),
-      );
+      const current = yield* currentProvider(instanceId);
       if (current !== provider) return;
       yield* apply(instanceId, provider, event.payload.limits, Number.POSITIVE_INFINITY);
     });

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -155,6 +155,17 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
         (previous?.limits.windows ?? []).map((window) => [window.id, window]),
       );
       const stamps = new Map(previous?.stamps ?? []);
+      if (update.complete) {
+        // A full account snapshot: windows it no longer lists are gone,
+        // unless an event refreshed them after this read began.
+        const listed = new Set(update.windows.map((window) => window.id));
+        for (const id of windows.keys()) {
+          if (!listed.has(id) && isFresh(id)) {
+            windows.delete(id);
+            stamps.delete(id);
+          }
+        }
+      }
       for (const window of fresh) {
         windows.set(window.id, window);
         stamps.set(window.id, nowMs);
@@ -173,8 +184,47 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
             ? (update.resetCredits ?? null)
             : (previous?.limits.resetCredits ?? null),
           observedAt,
+          readError: null,
         },
         stamps,
+        identity,
+      });
+      return next;
+    });
+    yield* PubSub.publish(changes, yield* snapshot);
+  });
+
+  /**
+   * A failed on-demand read is visible: the entry keeps its last good numbers
+   * and carries the failure, or exists only to carry it when nothing was read yet.
+   */
+  const recordReadError = Effect.fn("UsageLimitsService.recordReadError")(function* (
+    instanceId: ProviderInstanceId,
+    provider: UsageProviderKind,
+    identity: string | null,
+    detail: string,
+  ) {
+    const instanceLabel = yield* sources.getInstanceLabel(instanceId);
+    const observedAt = DateTime.formatIso(yield* DateTime.now);
+    yield* Ref.update(state, (map) => {
+      const stored = map.get(instanceId);
+      const previous =
+        stored?.limits.provider === provider && stored.identity === identity ? stored : undefined;
+      const next = new Map(map);
+      next.set(instanceId, {
+        limits: previous
+          ? { ...previous.limits, readError: detail }
+          : {
+              provider,
+              instanceId,
+              instanceLabel,
+              plan: null,
+              windows: [],
+              resetCredits: null,
+              observedAt,
+              readError: detail,
+            },
+        stamps: previous?.stamps ?? new Map(),
         identity,
       });
       return next;
@@ -216,16 +266,20 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     if (dropped) yield* PubSub.publish(changes, yield* snapshot);
     if (provider === null || adapter.readAccountLimits === undefined) return;
     const startedAt = yield* Clock.currentTimeMillis;
-    const update = yield* adapter.readAccountLimits;
-    if (update === null) return;
+    const read = yield* Effect.result(adapter.readAccountLimits);
     // The instance may have been removed or re-pointed at another provider
-    // or account while the read ran; the numbers would belong to the old one.
+    // or account while the read ran; the result would belong to the old one.
     const current = yield* currentProvider(instanceId);
     const identityNow = yield* sources.getInstanceIdentity(instanceId);
     if (current !== provider || identityNow !== identity) return;
+    if (read._tag === "Failure") {
+      yield* recordReadError(instanceId, provider, identity, read.failure.message);
+      return;
+    }
+    if (read.success === null) return;
     // Filed under the identity the read was made for: if the instance is
     // re-pointed after this point, the next refresh drops the entry.
-    yield* apply(instanceId, provider, update, startedAt, identity);
+    yield* apply(instanceId, provider, read.success, startedAt, identity);
   });
 
   const refresh: UsageLimitsService["Service"]["refresh"] = Effect.gen(function* () {

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -76,6 +76,8 @@ export interface UsageLimitsSources {
   readonly getInstanceLabel: (instanceId: ProviderInstanceId) => Effect.Effect<string | null>;
   /** Stable key for the account an instance points at; changes when its home is reconfigured. */
   readonly getInstanceIdentity: (instanceId: ProviderInstanceId) => Effect.Effect<string | null>;
+  /** Fires whenever instances are added, removed, or rebuilt. */
+  readonly instanceChanges: Stream.Stream<void>;
 }
 
 /** Only subscription providers report limits; everything else is ignored. */
@@ -261,6 +263,10 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     });
   }).pipe(Effect.forkScoped);
 
+  // Settings edits that add, remove, or rebuild an instance re-read straight
+  // away, so a removed provider leaves the snapshot without waiting for a client.
+  yield* Stream.runForEach(sources.instanceChanges, () => refresh).pipe(Effect.forkScoped);
+
   const subscribe: UsageLimitsService["Service"]["subscribe"] = Effect.gen(function* () {
     // Read first so the initial snapshot already carries fresh numbers and a
     // client never mistakes the boot-time empty map for "nothing reported".
@@ -301,8 +307,10 @@ export const layer = Layer.effect(
   Effect.gen(function* () {
     const providerService = yield* ProviderService;
     const registry = yield* ProviderAdapterRegistry;
+    const instanceChanges = yield* registry.subscribeChanges;
     return yield* make({
       streamEvents: providerService.streamEvents,
+      instanceChanges: Stream.fromSubscription(instanceChanges),
       listInstances: registry.listInstances(),
       getInstanceLabel: (instanceId) =>
         registry.getInstanceInfo(instanceId).pipe(
@@ -334,6 +342,7 @@ export const layerTest = Layer.effect(
   UsageLimitsService,
   make({
     streamEvents: Stream.empty,
+    instanceChanges: Stream.empty,
     listInstances: Effect.succeed([]),
     getInstanceLabel: () => Effect.succeed(null),
     getInstanceIdentity: () => Effect.succeed(null),

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -1,0 +1,245 @@
+/**
+ * UsageLimitsService - latest account limits per provider instance.
+ *
+ * Limits are account state, not thread history, so nothing is persisted: the
+ * service folds `account.rate-limits.updated` runtime events into an in-memory
+ * snapshot and asks adapters that can answer on demand (Codex) for a fresh
+ * read whenever a client subscribes.
+ *
+ * @module UsageLimitsService
+ */
+import {
+  type ProviderDriverKind,
+  type ProviderInstanceId,
+  type ProviderRuntimeEvent,
+  type UsageLimitsConsumeResetInput,
+  type UsageLimitsConsumeResetOutcome,
+  type UsageLimitsConsumeResetResult,
+  UsageLimitsError,
+  type UsageLimitsSnapshot,
+  type UsageLimitsUpdate,
+  type UsageProviderKind,
+  type UsageProviderLimits,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as PubSub from "effect/PubSub";
+import * as Ref from "effect/Ref";
+import type * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+
+import type { ProviderAdapterError } from "../provider/Errors.ts";
+import { ProviderAdapterRegistry } from "../provider/Services/ProviderAdapterRegistry.ts";
+import { ProviderService } from "../provider/Services/ProviderService.ts";
+import {
+  type SnapshotSubscription,
+  subscribeBeforeSnapshotWithoutMutex,
+} from "../utils/subscribeBeforeSnapshot.ts";
+
+export interface UsageLimitsServiceShape {
+  /** Latest snapshot plus every later change. Subscribing also triggers a fresh read. */
+  readonly subscribe: Effect.Effect<SnapshotSubscription<UsageLimitsSnapshot>, never, Scope.Scope>;
+  /** Ask every adapter that can answer for its current limits. Never fails. */
+  readonly refresh: Effect.Effect<void>;
+  readonly consumeReset: (
+    input: UsageLimitsConsumeResetInput,
+  ) => Effect.Effect<UsageLimitsConsumeResetResult, UsageLimitsError>;
+}
+
+export class UsageLimitsService extends Context.Service<
+  UsageLimitsService,
+  UsageLimitsServiceShape
+>()("t3/usage/UsageLimitsService") {}
+
+/** Adapter surface the service needs; the registry hands back full adapters. */
+export interface UsageLimitsAdapter {
+  readonly provider: ProviderDriverKind;
+  readonly readAccountLimits?: Effect.Effect<UsageLimitsUpdate | null, ProviderAdapterError>;
+  readonly consumeRateLimitResetCredit?: Effect.Effect<
+    UsageLimitsConsumeResetOutcome,
+    ProviderAdapterError
+  >;
+}
+
+export interface UsageLimitsSources {
+  readonly streamEvents: Stream.Stream<ProviderRuntimeEvent>;
+  readonly listInstances: Effect.Effect<ReadonlyArray<ProviderInstanceId>>;
+  readonly getAdapter: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<UsageLimitsAdapter, UsageLimitsError>;
+  /** Configured display name for an instance, null when it has none. */
+  readonly getInstanceLabel: (instanceId: ProviderInstanceId) => Effect.Effect<string | null>;
+}
+
+/** Only subscription providers report limits; everything else is ignored. */
+function usageProviderFor(driver: ProviderDriverKind): UsageProviderKind | null {
+  switch (driver) {
+    case "codex":
+      return "codex";
+    case "claudeAgent":
+      return "claude";
+    default:
+      return null;
+  }
+}
+
+function errorDetail(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+export const make = Effect.fn("UsageLimitsService.make")(function* (sources: UsageLimitsSources) {
+  const state = yield* Ref.make(new Map<ProviderInstanceId, UsageProviderLimits>());
+  const changes = yield* PubSub.sliding<UsageLimitsSnapshot>(8);
+
+  const snapshot: Effect.Effect<UsageLimitsSnapshot> = Ref.get(state).pipe(
+    Effect.map((map) => ({
+      providers: Array.from(map.values()).toSorted(
+        (left, right) =>
+          left.provider.localeCompare(right.provider) ||
+          left.instanceId.localeCompare(right.instanceId),
+      ),
+    })),
+  );
+
+  /** Merge a sparse update into one instance's limits and publish the result. */
+  const apply = Effect.fn("UsageLimitsService.apply")(function* (
+    instanceId: ProviderInstanceId,
+    provider: UsageProviderKind,
+    update: UsageLimitsUpdate,
+  ) {
+    const observedAt = DateTime.formatIso(yield* DateTime.now);
+    const instanceLabel = yield* sources.getInstanceLabel(instanceId);
+    yield* Ref.update(state, (map) => {
+      const previous = map.get(instanceId);
+      const windows = new Map((previous?.windows ?? []).map((window) => [window.id, window]));
+      for (const window of update.windows) windows.set(window.id, window);
+      const next = new Map(map);
+      next.set(instanceId, {
+        provider,
+        instanceId,
+        instanceLabel,
+        plan: update.plan === undefined ? (previous?.plan ?? null) : update.plan,
+        windows: Array.from(windows.values()),
+        resetCredits:
+          update.resetCredits === undefined
+            ? (previous?.resetCredits ?? null)
+            : update.resetCredits,
+        observedAt,
+      });
+      return next;
+    });
+    yield* PubSub.publish(changes, yield* snapshot);
+  });
+
+  const refreshInstance = Effect.fn("UsageLimitsService.refreshInstance")(function* (
+    instanceId: ProviderInstanceId,
+  ) {
+    const adapter = yield* sources.getAdapter(instanceId);
+    const provider = usageProviderFor(adapter.provider);
+    if (provider === null || adapter.readAccountLimits === undefined) return;
+    const update = yield* adapter.readAccountLimits;
+    if (update === null) return;
+    yield* apply(instanceId, provider, update);
+  });
+
+  const refresh: UsageLimitsServiceShape["refresh"] = Effect.gen(function* () {
+    const instances = yield* sources.listInstances;
+    yield* Effect.forEach(
+      instances,
+      (instanceId) =>
+        refreshInstance(instanceId).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logDebug("usage limits refresh skipped", {
+              instanceId,
+              detail: errorDetail(cause),
+            }),
+          ),
+        ),
+      { concurrency: 4, discard: true },
+    );
+  });
+
+  yield* Stream.runForEach(sources.streamEvents, (event) => {
+    if (event.type !== "account.rate-limits.updated" || event.providerInstanceId === undefined) {
+      return Effect.void;
+    }
+    const provider = usageProviderFor(event.provider);
+    if (provider === null) return Effect.void;
+    return apply(event.providerInstanceId, provider, event.payload.limits);
+  }).pipe(Effect.forkScoped);
+
+  const subscribe: UsageLimitsServiceShape["subscribe"] = Effect.gen(function* () {
+    const subscription = yield* subscribeBeforeSnapshotWithoutMutex(changes, snapshot);
+    // Fresh numbers land as a change on the stream the subscriber just opened.
+    yield* Effect.forkScoped(refresh);
+    return subscription;
+  });
+
+  const consumeReset: UsageLimitsServiceShape["consumeReset"] = Effect.fn(
+    "UsageLimitsService.consumeReset",
+  )(function* (input) {
+    const adapter = yield* sources.getAdapter(input.instanceId);
+    const consume = adapter.consumeRateLimitResetCredit;
+    if (consume === undefined) {
+      return yield* new UsageLimitsError({
+        reason: "unsupported",
+        detail: `Provider '${adapter.provider}' does not bank reset credits.`,
+      });
+    }
+    const outcome = yield* consume.pipe(
+      Effect.mapError(
+        (cause) =>
+          new UsageLimitsError({
+            reason: "noSession",
+            detail: errorDetail(cause),
+            cause,
+          }),
+      ),
+    );
+    yield* refresh;
+    return { outcome };
+  });
+
+  return { subscribe, refresh, consumeReset } satisfies UsageLimitsServiceShape;
+});
+
+export const layer = Layer.effect(
+  UsageLimitsService,
+  Effect.gen(function* () {
+    const providerService = yield* ProviderService;
+    const registry = yield* ProviderAdapterRegistry;
+    return yield* make({
+      streamEvents: providerService.streamEvents,
+      listInstances: registry.listInstances(),
+      getInstanceLabel: (instanceId) =>
+        registry.getInstanceInfo(instanceId).pipe(
+          Effect.map((info) => info.displayName?.trim() || null),
+          Effect.orElseSucceed(() => null),
+        ),
+      getAdapter: (instanceId) =>
+        registry.getByInstance(instanceId).pipe(
+          Effect.mapError(
+            (cause) =>
+              new UsageLimitsError({
+                reason: "requestFailed",
+                detail: `Provider instance '${instanceId}' is not available.`,
+                cause,
+              }),
+          ),
+        ),
+    });
+  }),
+);
+
+/** No adapters and no events: the snapshot stays empty. */
+export const layerTest = Layer.effect(
+  UsageLimitsService,
+  make({
+    streamEvents: Stream.empty,
+    listInstances: Effect.succeed([]),
+    getInstanceLabel: () => Effect.succeed(null),
+    getAdapter: () => Effect.die("UsageLimitsService.layerTest has no adapters"),
+  }),
+);

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -129,9 +129,11 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     update: UsageLimitsUpdate,
     since: number,
   ) {
+    const instanceLabel = yield* sources.getInstanceLabel(instanceId);
+    // Stamp right before the write, after the last yield, so a read that
+    // started while the label lookup ran still counts as older than this.
     const nowMs = yield* Clock.currentTimeMillis;
     const observedAt = DateTime.formatIso(DateTime.makeUnsafe(nowMs));
-    const instanceLabel = yield* sources.getInstanceLabel(instanceId);
     yield* Ref.update(state, (map) => {
       // An instance re-pointed at another provider starts from a clean slate.
       const stored = map.get(instanceId);

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -169,18 +169,17 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
   ) {
     const adapter = yield* sources.getAdapter(instanceId);
     const provider = usageProviderFor(adapter.provider);
-    if (provider === null) {
-      // Re-pointed at a provider without limits: drop what the old one left.
-      const dropped = yield* Ref.modify(state, (map) => {
-        if (!map.has(instanceId)) return [false, map] as const;
-        const next = new Map(map);
-        next.delete(instanceId);
-        return [true, next] as const;
-      });
-      if (dropped) yield* PubSub.publish(changes, yield* snapshot);
-      return;
-    }
-    if (adapter.readAccountLimits === undefined) return;
+    // Re-pointed at another provider, or one without limits: whatever the old
+    // provider left behind goes, even if the new one has nothing to say yet.
+    const dropped = yield* Ref.modify(state, (map) => {
+      const stored = map.get(instanceId);
+      if (stored === undefined || stored.limits.provider === provider) return [false, map] as const;
+      const next = new Map(map);
+      next.delete(instanceId);
+      return [true, next] as const;
+    });
+    if (dropped) yield* PubSub.publish(changes, yield* snapshot);
+    if (provider === null || adapter.readAccountLimits === undefined) return;
     const startedAt = yield* Clock.currentTimeMillis;
     const update = yield* adapter.readAccountLimits;
     if (update === null) return;
@@ -219,9 +218,13 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     if (provider === null) return Effect.void;
     const instanceId = event.providerInstanceId;
     return Effect.gen(function* () {
-      // A session outliving its instance's removal must not resurrect it.
-      const live = yield* sources.listInstances;
-      if (!live.includes(instanceId)) return;
+      // A session outliving its instance's removal or re-pointing must not
+      // resurrect the old provider's numbers.
+      const current = yield* sources.getAdapter(instanceId).pipe(
+        Effect.map((adapter) => usageProviderFor(adapter.provider)),
+        Effect.orElseSucceed(() => null),
+      );
+      if (current !== provider) return;
       yield* apply(instanceId, provider, event.payload.limits, Number.POSITIVE_INFINITY);
     });
   }).pipe(Effect.forkScoped);

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -92,17 +92,20 @@ function errorDetail(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause);
 }
 
+interface InstanceState {
+  readonly limits: UsageProviderLimits;
+  /** Window id → millis of the last change, so a slow read cannot undo a newer event. */
+  readonly stamps: ReadonlyMap<string, number>;
+}
+
 export const make = Effect.fn("UsageLimitsService.make")(function* (sources: UsageLimitsSources) {
-  const state = yield* Ref.make(new Map<ProviderInstanceId, UsageProviderLimits>());
-  /** When each window last changed, so a slow read cannot undo a newer event. */
-  const windowStamps = yield* Ref.make(new Map<string, number>());
-  const stampKey = (instanceId: ProviderInstanceId, windowId: string) =>
-    `${instanceId}:${windowId}`;
+  /** Limits per instance plus when each window last changed, in one Ref so checks and writes are atomic. */
+  const state = yield* Ref.make(new Map<ProviderInstanceId, InstanceState>());
   const changes = yield* PubSub.sliding<UsageLimitsSnapshot>(8);
 
   const snapshot: Effect.Effect<UsageLimitsSnapshot> = Ref.get(state).pipe(
     Effect.map((map) => ({
-      providers: Array.from(map.values()).toSorted(
+      providers: Array.from(map.values(), (entry) => entry.limits).toSorted(
         (left, right) =>
           left.provider.localeCompare(right.provider) ||
           left.instanceId.localeCompare(right.instanceId),
@@ -113,7 +116,8 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
   /**
    * Merge a sparse update into one instance's limits and publish the result.
    * `since` is when a read began: windows that an event touched after that
-   * moment keep the event's newer numbers.
+   * moment keep the event's newer numbers. The stamp check and the write are
+   * one `Ref.update`, so concurrent applies cannot interleave between them.
    */
   const apply = Effect.fn("UsageLimitsService.apply")(function* (
     instanceId: ProviderInstanceId,
@@ -124,31 +128,34 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     const nowMs = yield* Clock.currentTimeMillis;
     const observedAt = DateTime.formatIso(DateTime.makeUnsafe(nowMs));
     const instanceLabel = yield* sources.getInstanceLabel(instanceId);
-    const stamps = yield* Ref.get(windowStamps);
-    const fresh = update.windows.filter(
-      (window) => (stamps.get(stampKey(instanceId, window.id)) ?? 0) <= since,
-    );
-    yield* Ref.update(windowStamps, (map) => {
-      const next = new Map(map);
-      for (const window of fresh) next.set(stampKey(instanceId, window.id), nowMs);
-      return next;
-    });
     yield* Ref.update(state, (map) => {
       const previous = map.get(instanceId);
-      const windows = new Map((previous?.windows ?? []).map((window) => [window.id, window]));
-      for (const window of fresh) windows.set(window.id, window);
+      const fresh = update.windows.filter(
+        (window) => (previous?.stamps.get(window.id) ?? 0) <= since,
+      );
+      const windows = new Map(
+        (previous?.limits.windows ?? []).map((window) => [window.id, window]),
+      );
+      const stamps = new Map(previous?.stamps ?? []);
+      for (const window of fresh) {
+        windows.set(window.id, window);
+        stamps.set(window.id, nowMs);
+      }
       const next = new Map(map);
       next.set(instanceId, {
-        provider,
-        instanceId,
-        instanceLabel,
-        plan: update.plan === undefined ? (previous?.plan ?? null) : update.plan,
-        windows: Array.from(windows.values()),
-        resetCredits:
-          update.resetCredits === undefined
-            ? (previous?.resetCredits ?? null)
-            : update.resetCredits,
-        observedAt,
+        limits: {
+          provider,
+          instanceId,
+          instanceLabel,
+          plan: update.plan === undefined ? (previous?.limits.plan ?? null) : update.plan,
+          windows: Array.from(windows.values()),
+          resetCredits:
+            update.resetCredits === undefined
+              ? (previous?.limits.resetCredits ?? null)
+              : update.resetCredits,
+          observedAt,
+        },
+        stamps,
       });
       return next;
     });
@@ -175,16 +182,7 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
       const next = new Map([...map].filter(([instanceId]) => live.has(instanceId)));
       return [next.size !== map.size, next] as const;
     });
-    if (pruned) {
-      yield* Ref.update(windowStamps, (map) => {
-        const next = new Map(map);
-        for (const key of next.keys()) {
-          if (!live.has(key.slice(0, key.indexOf(":")) as ProviderInstanceId)) next.delete(key);
-        }
-        return next;
-      });
-      yield* PubSub.publish(changes, yield* snapshot);
-    }
+    if (pruned) yield* PubSub.publish(changes, yield* snapshot);
     yield* Effect.forEach(
       instances,
       (instanceId) =>

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -217,9 +217,11 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     const startedAt = yield* Clock.currentTimeMillis;
     const update = yield* adapter.readAccountLimits;
     if (update === null) return;
-    // The instance may have been removed or re-pointed while the read ran.
+    // The instance may have been removed or re-pointed at another provider
+    // or account while the read ran; the numbers would belong to the old one.
     const current = yield* currentProvider(instanceId);
-    if (current !== provider) return;
+    const identityNow = yield* sources.getInstanceIdentity(instanceId);
+    if (current !== provider || identityNow !== identity) return;
     yield* apply(instanceId, provider, update, startedAt);
   });
 

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -74,6 +74,8 @@ export interface UsageLimitsSources {
   ) => Effect.Effect<UsageLimitsAdapter, UsageLimitsError>;
   /** Configured display name for an instance, null when it has none. */
   readonly getInstanceLabel: (instanceId: ProviderInstanceId) => Effect.Effect<string | null>;
+  /** Stable key for the account an instance points at; changes when its home is reconfigured. */
+  readonly getInstanceIdentity: (instanceId: ProviderInstanceId) => Effect.Effect<string | null>;
 }
 
 /** Only subscription providers report limits; everything else is ignored. */
@@ -98,6 +100,8 @@ const CREDITS_STAMP = "$resetCredits";
 
 interface InstanceState {
   readonly limits: UsageProviderLimits;
+  /** Continuation identity at the time of the last write; a change means another account. */
+  readonly identity: string | null;
   /** Window id → millis of the last change, so a slow read cannot undo a newer event. */
   readonly stamps: ReadonlyMap<string, number>;
 }
@@ -130,14 +134,16 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     since: number,
   ) {
     const instanceLabel = yield* sources.getInstanceLabel(instanceId);
+    const identity = yield* sources.getInstanceIdentity(instanceId);
     // Stamp right before the write, after the last yield, so a read that
     // started while the label lookup ran still counts as older than this.
     const nowMs = yield* Clock.currentTimeMillis;
     const observedAt = DateTime.formatIso(DateTime.makeUnsafe(nowMs));
     yield* Ref.update(state, (map) => {
-      // An instance re-pointed at another provider starts from a clean slate.
+      // An instance re-pointed at another provider or account starts from a clean slate.
       const stored = map.get(instanceId);
-      const previous = stored?.limits.provider === provider ? stored : undefined;
+      const previous =
+        stored?.limits.provider === provider && stored.identity === identity ? stored : undefined;
       const isFresh = (key: string) => (previous?.stamps.get(key) ?? 0) <= since;
       const fresh = update.windows.filter((window) => isFresh(window.id));
       const plan = update.plan !== undefined && isFresh(PLAN_STAMP);
@@ -166,6 +172,7 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
           observedAt,
         },
         stamps,
+        identity,
       });
       return next;
     });
@@ -188,11 +195,17 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
   ) {
     const adapter = yield* sources.getAdapter(instanceId);
     const provider = usageProviderFor(adapter.provider);
-    // Re-pointed at another provider, or one without limits: whatever the old
-    // provider left behind goes, even if the new one has nothing to say yet.
+    // Re-pointed at another provider, account, or one without limits: whatever
+    // was there goes, even if the new configuration has nothing to say yet.
+    const identity = yield* sources.getInstanceIdentity(instanceId);
     const dropped = yield* Ref.modify(state, (map) => {
       const stored = map.get(instanceId);
-      if (stored === undefined || stored.limits.provider === provider) return [false, map] as const;
+      if (
+        stored === undefined ||
+        (stored.limits.provider === provider && stored.identity === identity)
+      ) {
+        return [false, map] as const;
+      }
       const next = new Map(map);
       next.delete(instanceId);
       return [true, next] as const;
@@ -296,6 +309,11 @@ export const layer = Layer.effect(
           Effect.map((info) => info.displayName?.trim() || null),
           Effect.orElseSucceed(() => null),
         ),
+      getInstanceIdentity: (instanceId) =>
+        registry.getInstanceInfo(instanceId).pipe(
+          Effect.map((info) => info.continuationIdentity.continuationKey),
+          Effect.orElseSucceed(() => null),
+        ),
       getAdapter: (instanceId) =>
         registry.getByInstance(instanceId).pipe(
           Effect.mapError(
@@ -318,6 +336,7 @@ export const layerTest = Layer.effect(
     streamEvents: Stream.empty,
     listInstances: Effect.succeed([]),
     getInstanceLabel: () => Effect.succeed(null),
+    getInstanceIdentity: () => Effect.succeed(null),
     getAdapter: () => Effect.die("UsageLimitsService.layerTest has no adapters"),
   }),
 );

--- a/apps/server/src/usage/UsageLimitsService.ts
+++ b/apps/server/src/usage/UsageLimitsService.ts
@@ -134,9 +134,10 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     provider: UsageProviderKind,
     update: UsageLimitsUpdate,
     since: number,
+    /** The account the numbers belong to, captured by the caller before its own yields. */
+    identity: string | null,
   ) {
     const instanceLabel = yield* sources.getInstanceLabel(instanceId);
-    const identity = yield* sources.getInstanceIdentity(instanceId);
     // Stamp right before the write, after the last yield, so a read that
     // started while the label lookup ran still counts as older than this.
     const nowMs = yield* Clock.currentTimeMillis;
@@ -222,7 +223,9 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
     const current = yield* currentProvider(instanceId);
     const identityNow = yield* sources.getInstanceIdentity(instanceId);
     if (current !== provider || identityNow !== identity) return;
-    yield* apply(instanceId, provider, update, startedAt);
+    // Filed under the identity the read was made for: if the instance is
+    // re-pointed after this point, the next refresh drops the entry.
+    yield* apply(instanceId, provider, update, startedAt, identity);
   });
 
   const refresh: UsageLimitsService["Service"]["refresh"] = Effect.gen(function* () {
@@ -261,7 +264,8 @@ export const make = Effect.fn("UsageLimitsService.make")(function* (sources: Usa
       // resurrect the old provider's numbers.
       const current = yield* currentProvider(instanceId);
       if (current !== provider) return;
-      yield* apply(instanceId, provider, event.payload.limits, Number.POSITIVE_INFINITY);
+      const identity = yield* sources.getInstanceIdentity(instanceId);
+      yield* apply(instanceId, provider, event.payload.limits, Number.POSITIVE_INFINITY, identity);
     });
   }).pipe(Effect.forkScoped);
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -127,6 +127,7 @@ import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as ResourceTelemetry from "./resourceTelemetry/ResourceTelemetry.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
+import * as UsageLimitsService from "./usage/UsageLimitsService.ts";
 import * as UsageService from "./usage/UsageService.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
@@ -598,6 +599,7 @@ const makeWsRpcLayer = (
       const processResourceMonitor = yield* ProcessResourceMonitor.ProcessResourceMonitor;
       const resourceTelemetry = yield* ResourceTelemetry.ResourceTelemetry;
       const usage = yield* UsageService.UsageService;
+      const usageLimits = yield* UsageLimitsService.UsageLimitsService;
       const relayClient = yield* RelayClient.RelayClient;
       const authorizationError = (requiredScope: AuthEnvironmentScope) =>
         new EnvironmentAuthorizationError({
@@ -1903,6 +1905,12 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.serverRefreshUsageRates, usage.refreshRates, {
             "rpc.aggregate": "server",
           }),
+        [WS_METHODS.serverConsumeUsageLimitReset]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverConsumeUsageLimitReset,
+            usageLimits.consumeReset(input),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverRetryResourceTelemetry]: (_input) =>
           observeRpcEffect(WS_METHODS.serverRetryResourceTelemetry, resourceTelemetry.retry, {
             "rpc.aggregate": "server",
@@ -2665,6 +2673,16 @@ const makeWsRpcLayer = (
             WS_METHODS.subscribeResourceTelemetry,
             Stream.unwrap(
               Effect.map(resourceTelemetry.subscribe, ({ latest, changes }) =>
+                Stream.concat(Stream.make(latest), changes),
+              ),
+            ),
+            { "rpc.aggregate": "server" },
+          ),
+        [WS_METHODS.subscribeUsageLimits]: (_input) =>
+          observeRpcStream(
+            WS_METHODS.subscribeUsageLimits,
+            Stream.unwrap(
+              Effect.map(usageLimits.subscribe, ({ latest, changes }) =>
                 Stream.concat(Stream.make(latest), changes),
               ),
             ),

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -375,8 +375,10 @@ export function UsageLimitsSection({
             </span>
           ))
         : null}
-      {providers.length === 0 && !isPending && failedEnvironments.length === 0 ? (
-        <span className="text-sm text-muted-foreground">No limits reported yet.</span>
+      {providers.length === 0 && failedEnvironments.length === 0 ? (
+        <span className="text-sm text-muted-foreground">
+          {isPending ? "Reading limits…" : "No limits reported yet."}
+        </span>
       ) : null}
       {providers.map((entry) => (
         <section key={entryKey(entry)} className="flex flex-col gap-3">

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -1,0 +1,414 @@
+import type { UsageLimitsConsumeResetOutcome, UsageProviderKind } from "@t3tools/contracts";
+import { GaugeIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react";
+import { Fragment, useState } from "react";
+
+import { cn } from "../../lib/utils";
+import { serverEnvironment } from "../../state/server";
+import type { EnvironmentProviderLimits } from "../../state/usage";
+import { useAtomCommand } from "../../state/use-atom-command";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
+import { Button } from "../ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { PROVIDER_PRESENTATION } from "./usageProviders";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/** `2h 13m`, `3d 4h`, `12m`. */
+function formatDuration(ms: number): string {
+  const remaining = Math.max(0, ms);
+  const days = Math.floor(remaining / DAY);
+  const hours = Math.floor((remaining % DAY) / HOUR);
+  const minutes = Math.floor((remaining % HOUR) / 60000);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function formatUntil(iso: string | null, now: number): string | null {
+  if (iso === null) return null;
+  const at = Date.parse(iso);
+  return Number.isFinite(at) ? formatDuration(at - now) : null;
+}
+
+function formatUsed(percent: number): string {
+  return `${Math.round(percent)}%`;
+}
+
+const RESET_AT = new Intl.DateTimeFormat(undefined, {
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+/** `09/03, 09:40` */
+function formatResetAt(iso: string | null): string | null {
+  if (iso === null) return null;
+  const at = Date.parse(iso);
+  return Number.isFinite(at) ? RESET_AT.format(at) : null;
+}
+
+const OUTCOME_TEXT: Record<UsageLimitsConsumeResetOutcome, string> = {
+  reset: "Reset applied.",
+  nothingToReset: "Nothing to reset right now.",
+  noCredit: "No reset credit left.",
+  alreadyRedeemed: "That credit was already redeemed.",
+};
+
+function ProviderMark({
+  provider,
+  className,
+}: {
+  readonly provider: UsageProviderKind;
+  readonly className?: string;
+}) {
+  const Mark = PROVIDER_PRESENTATION[provider].mark;
+  return <Mark className={cn("shrink-0", className)} aria-hidden />;
+}
+
+/**
+ * Banked Codex reset credits with a confirmed redeem action. Redeeming spends
+ * something on the user's subscription, so it never fires on a bare click.
+ */
+function ResetCredits({
+  entry,
+  now,
+}: {
+  readonly entry: EnvironmentProviderLimits;
+  readonly now: number;
+}) {
+  const credits = entry.resetCredits;
+  const consume = useAtomCommand(serverEnvironment.consumeUsageLimitReset, {
+    reportFailure: false,
+  });
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  if (credits === null || credits.availableCount === 0) return null;
+
+  const expires = formatUntil(credits.nextExpiresAt, now);
+  const summary = `${credits.availableCount} ${credits.availableCount === 1 ? "reset" : "resets"} banked${
+    expires ? ` · next expires in ${expires}` : ""
+  }`;
+
+  const redeem = async () => {
+    setConfirming(false);
+    setBusy(true);
+    setStatus(null);
+    const result = await consume({
+      environmentId: entry.environmentId,
+      input: { instanceId: entry.instanceId },
+    });
+    setBusy(false);
+    if (result._tag === "Success") {
+      setStatus(OUTCOME_TEXT[result.value.outcome]);
+      return;
+    }
+    const failure = result.cause;
+    setStatus(
+      "error" in failure && failure.error instanceof Error
+        ? failure.error.message
+        : "Could not use the reset.",
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+      <span className="tabular-nums">{summary}</span>
+      {credits.availableCount > 0 ? (
+        <Button size="xs" variant="outline" disabled={busy} onClick={() => setConfirming(true)}>
+          {busy ? "Using reset…" : "Use a reset"}
+        </Button>
+      ) : null}
+      {status ? <span className="text-foreground">{status}</span> : null}
+      <AlertDialog open={confirming} onOpenChange={setConfirming}>
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Use a banked reset?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This redeems one reset credit on your Codex account and clears the current rate-limit
+              windows. It cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+            <Button onClick={() => void redeem()}>Use reset</Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </div>
+  );
+}
+
+type LimitWindow = EnvironmentProviderLimits["windows"][number];
+
+function entryKey(entry: EnvironmentProviderLimits): string {
+  return `${entry.environmentId}:${entry.provider}:${entry.instanceId}`;
+}
+
+type SectionProps = {
+  readonly providers: readonly EnvironmentProviderLimits[];
+  readonly now: number;
+  /** Only when two environments report, so a single machine shows no label. */
+  readonly showEnvironment: boolean;
+  /** Only when one environment runs two instances of the same provider. */
+  readonly instanceCounts: ReadonlyMap<string, number>;
+};
+
+/** Qualifier after the provider name: which environment, which instance. */
+function providerQualifier(entry: EnvironmentProviderLimits, props: SectionProps): string | null {
+  const parts: string[] = [];
+  if (props.showEnvironment) parts.push(entry.environmentLabel);
+  if ((props.instanceCounts.get(`${entry.environmentId}:${entry.provider}`) ?? 0) > 1) {
+    parts.push(entry.instanceLabel ?? entry.instanceId);
+  }
+  return parts.length === 0 ? null : parts.join(" · ");
+}
+
+/** Section heading: provider name, tier, and qualifier. */
+function ProviderHeading({
+  entry,
+  props,
+  size = "sm",
+}: {
+  readonly entry: EnvironmentProviderLimits;
+  readonly props: SectionProps;
+  readonly size?: "sm" | "xs";
+}) {
+  const qualifier = providerQualifier(entry, props);
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <h2
+        className={cn(
+          "flex min-w-0 items-center gap-2 font-medium text-foreground",
+          size === "sm" ? "text-sm" : "text-xs",
+        )}
+      >
+        <ProviderMark provider={entry.provider} className={size === "sm" ? "size-4" : "size-3.5"} />
+        <span className="truncate">{PROVIDER_PRESENTATION[entry.provider].label}</span>
+        {qualifier ? (
+          <span className="truncate font-normal text-muted-foreground">{qualifier}</span>
+        ) : null}
+        {entry.plan && size === "sm" ? (
+          <span className="shrink-0 font-normal text-muted-foreground">· {entry.plan}</span>
+        ) : null}
+      </h2>
+    </div>
+  );
+}
+
+function resetMillis(window: LimitWindow): number | null {
+  if (window.resetsAt === null) return null;
+  const at = Date.parse(window.resetsAt);
+  return Number.isFinite(at) ? at : null;
+}
+
+/** Elapsed share of the window, 0..1, or null when the window has no known length. */
+function elapsedShare(window: LimitWindow, now: number): number | null {
+  const resetsAt = resetMillis(window);
+  if (resetsAt === null || window.windowMinutes === null) return null;
+  const length = window.windowMinutes * 60000;
+  return Math.max(0, Math.min(1, (length - (resetsAt - now)) / length));
+}
+
+type Pace = "ahead" | "on" | "under";
+
+/** Usage against the clock: within five points is on pace. */
+function paceOf(window: LimitWindow, now: number): Pace | null {
+  const elapsed = elapsedShare(window, now);
+  if (elapsed === null) return null;
+  const gap = window.usedPercent - elapsed * 100;
+  if (gap > 5) return "ahead";
+  if (gap < -5) return "under";
+  return "on";
+}
+
+const PACE: Record<Pace, { readonly label: string; readonly icon: typeof GaugeIcon }> = {
+  ahead: { label: "Ahead of pace: spending faster than the window elapses", icon: TrendingUpIcon },
+  on: { label: "On pace with the window", icon: GaugeIcon },
+  under: { label: "Under pace: headroom left for the rest of the window", icon: TrendingDownIcon },
+};
+
+/** Pace as a glyph with the words on hover. */
+function PaceIcon({ pace }: { readonly pace: Pace }) {
+  const Icon = PACE[pace].icon;
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            role="img"
+            aria-label={PACE[pace].label}
+            className="inline-flex text-muted-foreground"
+          />
+        }
+      >
+        <Icon className="size-3.5" aria-hidden />
+      </TooltipTrigger>
+      <TooltipPopup side="top">{PACE[pace].label}</TooltipPopup>
+    </Tooltip>
+  );
+}
+
+/**
+ * One window as a full-width bar from the moment it opened to its reset.
+ * Usage fills from the left in the provider's chart colour; the hairline sits
+ * at the elapsed fraction, which is also where even spending would have put
+ * the fill. Hovering explains exactly that.
+ */
+function WindowBar({
+  entry,
+  window,
+  now,
+}: {
+  readonly entry: EnvironmentProviderLimits;
+  readonly window: LimitWindow;
+  readonly now: number;
+}) {
+  const elapsed = elapsedShare(window, now);
+  const used = Math.max(0, Math.min(100, window.usedPercent)) / 100;
+  const at = formatResetAt(window.resetsAt);
+  const until = formatUntil(window.resetsAt, now);
+  return (
+    <Popover>
+      <PopoverTrigger
+        openOnHover
+        delay={150}
+        closeDelay={0}
+        render={<div className="relative h-6 cursor-default outline-none" />}
+      >
+        <div className="absolute inset-x-0 inset-y-1.5 rounded-full bg-muted" />
+        {used > 0 ? (
+          <div
+            className="absolute inset-y-1.5 left-0 rounded-full"
+            style={{
+              width: `${used * 100}%`,
+              // The same series colour the cost chart uses for this provider.
+              backgroundColor: PROVIDER_PRESENTATION[entry.provider].color,
+            }}
+          />
+        ) : null}
+        {elapsed !== null ? (
+          <span
+            aria-hidden
+            className="absolute inset-y-0.5 w-px -translate-x-1/2 bg-foreground/60"
+            style={{ left: `${elapsed * 100}%` }}
+          />
+        ) : null}
+      </PopoverTrigger>
+      <PopoverPopup tooltipStyle side="top" align="center" className="text-xs">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-foreground">
+            {formatUsed(window.usedPercent)} used
+            {elapsed !== null ? ` · ${Math.round(elapsed * 100)}% of the window elapsed` : ""}
+          </span>
+          {elapsed !== null ? (
+            <span className="text-muted-foreground">The line is where even spending would be.</span>
+          ) : null}
+          {at ? (
+            <span className="text-muted-foreground">
+              Resets {at}
+              {until ? ` · in ${until}` : ""}
+            </span>
+          ) : null}
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}
+
+/** One provider's used windows, one bar each. An unused window has nothing to show. */
+function ProviderWindows({
+  entry,
+  now,
+}: {
+  readonly entry: EnvironmentProviderLimits;
+  readonly now: number;
+}) {
+  const windows = entry.windows.filter((window) => window.usedPercent > 0);
+  if (windows.length === 0) {
+    return <span className="text-xs text-muted-foreground">No usage in any window.</span>;
+  }
+  return (
+    <div className="grid grid-cols-[11rem_minmax(0,1fr)_6rem] gap-x-4 gap-y-1">
+      {windows.map((window, index) => {
+        // Windows that reset together show the countdown once.
+        const previous = windows[index - 1];
+        const sharesReset =
+          previous !== undefined &&
+          previous.resetsAt !== null &&
+          previous.resetsAt === window.resetsAt;
+        const pace = paceOf(window, now);
+        return (
+          <Fragment key={window.id}>
+            <span className="flex min-w-0 items-center gap-2 text-xs">
+              <span className="truncate text-muted-foreground">{window.label}</span>
+              <span className="ms-auto shrink-0 font-medium text-foreground tabular-nums">
+                {formatUsed(window.usedPercent)}
+              </span>
+            </span>
+            <WindowBar entry={entry} window={window} now={now} />
+            <span className="flex items-center gap-2 text-xs text-muted-foreground tabular-nums">
+              {pace ? <PaceIcon pace={pace} /> : null}
+              <span className="ms-auto shrink-0">
+                {sharesReset ? "" : (formatUntil(window.resetsAt, now) ?? "")}
+              </span>
+            </span>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Limits tab body: one section per provider with its heading, a bar per
+ * window in use, and banked resets where the provider offers them.
+ */
+export function UsageLimitsSection({
+  providers,
+  now,
+  isPending,
+}: {
+  readonly providers: readonly EnvironmentProviderLimits[];
+  readonly now: number;
+  readonly isPending: boolean;
+}) {
+  const environmentCount = new Set(providers.map((entry) => entry.environmentId)).size;
+  const instanceCounts = new Map<string, number>();
+  for (const entry of providers) {
+    const key = `${entry.environmentId}:${entry.provider}`;
+    instanceCounts.set(key, (instanceCounts.get(key) ?? 0) + 1);
+  }
+  const props: SectionProps = {
+    providers,
+    now,
+    showEnvironment: environmentCount > 1,
+    instanceCounts,
+  };
+  return (
+    <div className="flex flex-col gap-8">
+      {providers.length === 0 && !isPending ? (
+        <span className="text-sm text-muted-foreground">No limits reported yet.</span>
+      ) : null}
+      {providers.map((entry) => (
+        <section key={entryKey(entry)} className="flex flex-col gap-3">
+          <ProviderHeading entry={entry} props={props} />
+          <ProviderWindows entry={entry} now={now} />
+          <ResetCredits entry={entry} now={now} />
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -1,4 +1,4 @@
-import type { UsageLimitsConsumeResetOutcome, UsageProviderKind } from "@t3tools/contracts";
+import type { UsageLimitsConsumeResetOutcome } from "@t3tools/contracts";
 import { GaugeIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react";
 import { Fragment, useState } from "react";
 
@@ -18,7 +18,7 @@ import {
 import { Button } from "../ui/button";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
-import { PROVIDER_PRESENTATION } from "./usageProviders";
+import { PROVIDER_PRESENTATION, ProviderMark } from "./usageProviders";
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
@@ -65,17 +65,6 @@ const OUTCOME_TEXT: Record<UsageLimitsConsumeResetOutcome, string> = {
   noCredit: "No reset credit left.",
   alreadyRedeemed: "That credit was already redeemed.",
 };
-
-function ProviderMark({
-  provider,
-  className,
-}: {
-  readonly provider: UsageProviderKind;
-  readonly className?: string;
-}) {
-  const Mark = PROVIDER_PRESENTATION[provider].mark;
-  return <Mark className={cn("shrink-0", className)} aria-hidden />;
-}
 
 /**
  * Banked Codex reset credits with a confirmed redeem action. Redeeming spends
@@ -378,10 +367,12 @@ function ProviderWindows({
  */
 export function UsageLimitsSection({
   providers,
+  failedEnvironments,
   now,
   isPending,
 }: {
   readonly providers: readonly EnvironmentProviderLimits[];
+  readonly failedEnvironments: readonly string[];
   readonly now: number;
   readonly isPending: boolean;
 }) {
@@ -399,7 +390,12 @@ export function UsageLimitsSection({
   };
   return (
     <div className="flex flex-col gap-8">
-      {providers.length === 0 && !isPending ? (
+      {failedEnvironments.map((label) => (
+        <span key={label} className="text-sm text-muted-foreground">
+          {label} could not report limits.
+        </span>
+      ))}
+      {providers.length === 0 && !isPending && failedEnvironments.length === 0 ? (
         <span className="text-sm text-muted-foreground">No limits reported yet.</span>
       ) : null}
       {providers.map((entry) => (

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -1,4 +1,5 @@
 import type { UsageLimitsConsumeResetOutcome } from "@t3tools/contracts";
+import { elapsedShare, formatDuration, type LimitPace, paceOf } from "@t3tools/shared/usageLimits";
 import { GaugeIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react";
 import { Fragment, useState } from "react";
 
@@ -19,20 +20,6 @@ import { Button } from "../ui/button";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_PRESENTATION, ProviderMark } from "./usageProviders";
-
-const HOUR = 60 * 60 * 1000;
-const DAY = 24 * HOUR;
-
-/** `2h 13m`, `3d 4h`, `12m`. */
-function formatDuration(ms: number): string {
-  const remaining = Math.max(0, ms);
-  const days = Math.floor(remaining / DAY);
-  const hours = Math.floor((remaining % DAY) / HOUR);
-  const minutes = Math.floor((remaining % HOUR) / 60000);
-  if (days > 0) return `${days}d ${hours}h`;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  return `${minutes}m`;
-}
 
 function formatUntil(iso: string | null, now: number): string | null {
   if (iso === null) return null;
@@ -197,40 +184,14 @@ function ProviderHeading({
   );
 }
 
-function resetMillis(window: LimitWindow): number | null {
-  if (window.resetsAt === null) return null;
-  const at = Date.parse(window.resetsAt);
-  return Number.isFinite(at) ? at : null;
-}
-
-/** Elapsed share of the window, 0..1, or null when the window has no known length. */
-function elapsedShare(window: LimitWindow, now: number): number | null {
-  const resetsAt = resetMillis(window);
-  if (resetsAt === null || window.windowMinutes === null) return null;
-  const length = window.windowMinutes * 60000;
-  return Math.max(0, Math.min(1, (length - (resetsAt - now)) / length));
-}
-
-type Pace = "ahead" | "on" | "under";
-
-/** Usage against the clock: within five points is on pace. */
-function paceOf(window: LimitWindow, now: number): Pace | null {
-  const elapsed = elapsedShare(window, now);
-  if (elapsed === null) return null;
-  const gap = window.usedPercent - elapsed * 100;
-  if (gap > 5) return "ahead";
-  if (gap < -5) return "under";
-  return "on";
-}
-
-const PACE: Record<Pace, { readonly label: string; readonly icon: typeof GaugeIcon }> = {
+const PACE: Record<LimitPace, { readonly label: string; readonly icon: typeof GaugeIcon }> = {
   ahead: { label: "Ahead of pace: spending faster than the window elapses", icon: TrendingUpIcon },
   on: { label: "On pace with the window", icon: GaugeIcon },
   under: { label: "Under pace: headroom left for the rest of the window", icon: TrendingDownIcon },
 };
 
 /** Pace as a glyph with the words on hover. */
-function PaceIcon({ pace }: { readonly pace: Pace }) {
+function PaceIcon({ pace }: { readonly pace: LimitPace }) {
   const Icon = PACE[pace].icon;
   return (
     <Tooltip>
@@ -269,13 +230,23 @@ function WindowBar({
   const used = Math.max(0, Math.min(100, window.usedPercent)) / 100;
   const at = formatResetAt(window.resetsAt);
   const until = formatUntil(window.resetsAt, now);
+  const summary = `${window.label}: ${formatUsed(window.usedPercent)} used${
+    elapsed === null ? "" : `, ${Math.round(elapsed * 100)}% of the window elapsed`
+  }${until ? `, resets in ${until}` : ""}`;
   return (
     <Popover>
       <PopoverTrigger
         openOnHover
         delay={150}
         closeDelay={0}
-        render={<div className="relative h-6 cursor-default outline-none" />}
+        render={
+          <div
+            role="img"
+            aria-label={summary}
+            tabIndex={0}
+            className="relative h-6 cursor-default rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          />
+        }
       >
         <div className="absolute inset-x-0 inset-y-1.5 rounded-full bg-muted" />
         {used > 0 ? (
@@ -368,11 +339,13 @@ function ProviderWindows({
 export function UsageLimitsSection({
   providers,
   failedEnvironments,
+  pendingEnvironments,
   now,
   isPending,
 }: {
   readonly providers: readonly EnvironmentProviderLimits[];
   readonly failedEnvironments: readonly string[];
+  readonly pendingEnvironments: readonly string[];
   readonly now: number;
   readonly isPending: boolean;
 }) {
@@ -395,12 +368,27 @@ export function UsageLimitsSection({
           {label} could not report limits.
         </span>
       ))}
+      {providers.length > 0
+        ? pendingEnvironments.map((label) => (
+            <span key={label} className="text-sm text-muted-foreground">
+              {label} is still reading its limits.
+            </span>
+          ))
+        : null}
       {providers.length === 0 && !isPending && failedEnvironments.length === 0 ? (
         <span className="text-sm text-muted-foreground">No limits reported yet.</span>
       ) : null}
       {providers.map((entry) => (
         <section key={entryKey(entry)} className="flex flex-col gap-3">
           <ProviderHeading entry={entry} props={props} />
+          {entry.readError ? (
+            <span className="text-xs text-muted-foreground">
+              Could not read limits.
+              {entry.windows.length > 0
+                ? ` Showing the last report from ${formatDuration(now - Date.parse(entry.observedAt))} ago.`
+                : ""}
+            </span>
+          ) : null}
           <ProviderWindows entry={entry} now={now} />
           <ResetCredits entry={entry} now={now} />
         </section>

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -39,7 +39,13 @@ vi.mock("react", async (importOriginal) => {
 vi.mock("../../env", () => ({ isElectron: false }));
 vi.mock("../../state/usage", () => ({
   useUsage: testState.useUsage,
-  useUsageLimits: () => ({ providers: [], receivedAt: 0, isPending: false, refresh: () => {} }),
+  useUsageLimits: () => ({
+    providers: [],
+    failedEnvironments: [],
+    receivedAt: 0,
+    isPending: false,
+    refresh: () => {},
+  }),
 }));
 vi.mock("./UsageLimits", () => ({ UsageLimitsSection: "section" }));
 vi.mock("../ui/button", () => ({ Button: "button" }));

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -42,6 +42,8 @@ vi.mock("../../state/usage", () => ({
   useUsageLimits: () => ({
     providers: [],
     failedEnvironments: [],
+    pendingEnvironments: [],
+    isRefreshing: false,
     receivedAt: 0,
     isPending: false,
     refresh: () => {},

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -37,7 +37,11 @@ vi.mock("react", async (importOriginal) => {
 });
 
 vi.mock("../../env", () => ({ isElectron: false }));
-vi.mock("../../state/usage", () => ({ useUsage: testState.useUsage }));
+vi.mock("../../state/usage", () => ({
+  useUsage: testState.useUsage,
+  useUsageLimits: () => ({ providers: [], receivedAt: 0, isPending: false, refresh: () => {} }),
+}));
+vi.mock("./UsageLimits", () => ({ UsageLimitsSection: "section" }));
 vi.mock("../ui/button", () => ({ Button: "button" }));
 vi.mock("../ui/scroll-area", () => ({ ScrollArea: "div" }));
 vi.mock("../ui/select", () => ({

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
 
@@ -58,7 +58,9 @@ export function UsagePage() {
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageMetric>("cost");
-  const limits = useUsageLimits();
+  // The limits subscription spawns provider reads, so it only exists while
+  // the Limits tab is mounted; the tab hands its refresh back through a ref.
+  const limitsRefreshRef = useRef<(() => void) | null>(null);
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
   const { days: windowDays, window } = windowSelection;
   const isPast24Hours = windowDays === 1;
@@ -106,7 +108,7 @@ export function UsagePage() {
   };
   const refreshWindow = () => {
     if (metric === "limits") {
-      limits.refresh();
+      limitsRefreshRef.current?.();
       return;
     }
     const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
@@ -234,12 +236,7 @@ export function UsagePage() {
         <ScrollArea className="min-h-0 flex-1">
           <WorkspacePageContainer width="wide">
             {metric === "limits" ? (
-              <UsageLimitsSection
-                providers={limits.providers}
-                failedEnvironments={limits.failedEnvironments}
-                now={limits.receivedAt}
-                isPending={limits.isPending}
-              />
+              <UsageLimitsTab refreshRef={limitsRefreshRef} />
             ) : settling ? (
               <>
                 {environments.length > 1 ? <UsageDeviceStrip environments={environments} /> : null}
@@ -493,6 +490,29 @@ export function UsagePage() {
         </ScrollArea>
       </div>
     </SidebarInset>
+  );
+}
+
+/** Owns the limits subscription so it only runs while the tab is visible. */
+function UsageLimitsTab({
+  refreshRef,
+}: {
+  readonly refreshRef: MutableRefObject<(() => void) | null>;
+}) {
+  const limits = useUsageLimits();
+  useEffect(() => {
+    refreshRef.current = limits.refresh;
+    return () => {
+      refreshRef.current = null;
+    };
+  }, [limits.refresh, refreshRef]);
+  return (
+    <UsageLimitsSection
+      providers={limits.providers}
+      failedEnvironments={limits.failedEnvironments}
+      now={limits.receivedAt}
+      isPending={limits.isPending}
+    />
   );
 }
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -6,7 +6,7 @@ import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
 import { cn } from "../../lib/utils";
-import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
+import { useUsage, useUsageLimits, type EnvironmentUsageStatus } from "../../state/usage";
 import {
   enumerateDays,
   enumerateHourStarts,
@@ -31,6 +31,7 @@ import {
 } from "../WorkspaceBreadcrumb";
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
+import { UsageLimitsSection } from "./UsageLimits";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
@@ -41,12 +42,20 @@ const WINDOW_OPTIONS = [
   { days: 90, label: "90 days" },
 ] as const;
 
+type UsageMetric = UsageChartMetric | "limits";
+const METRIC_LABELS = { cost: "Cost", tokens: "Tokens", limits: "Limits" } as const;
+
+function isUsageMetric(value: string | null | undefined): value is UsageMetric {
+  return value === "cost" || value === "tokens" || value === "limits";
+}
+
 export function UsagePage() {
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: 30,
     window: makeWindow(30),
   }));
-  const [metric, setMetric] = useState<UsageChartMetric>("cost");
+  const [metric, setMetric] = useState<UsageMetric>("cost");
+  const limits = useUsageLimits();
   const [breakdown, setBreakdown] = useState<"model" | "time">("model");
   const { days: windowDays, window } = windowSelection;
   const isPast24Hours = windowDays === 1;
@@ -93,6 +102,10 @@ export function UsagePage() {
     });
   };
   const refreshWindow = () => {
+    if (metric === "limits") {
+      limits.refresh();
+      return;
+    }
     const nextWindow = makeWindow(windowDays, undefined, isPast24Hours ? "hour" : "day");
     if (
       nextWindow.sinceDay === window.sinceDay &&
@@ -115,10 +128,14 @@ export function UsagePage() {
         <WorkspaceBreadcrumbItem current>
           <h1>Usage</h1>
         </WorkspaceBreadcrumbItem>
-        <WorkspaceBreadcrumbSeparator className="hidden md:flex" />
-        <WorkspaceBreadcrumbItem className="hidden min-w-0 shrink md:flex">
-          <span className="truncate">{windowLabel}</span>
-        </WorkspaceBreadcrumbItem>
+        {metric === "limits" ? null : (
+          <>
+            <WorkspaceBreadcrumbSeparator className="hidden md:flex" />
+            <WorkspaceBreadcrumbItem className="hidden min-w-0 shrink md:flex">
+              <span className="truncate">{windowLabel}</span>
+            </WorkspaceBreadcrumbItem>
+          </>
+        )}
       </WorkspaceBreadcrumb>
       <div className="ms-auto hidden min-w-0 items-center justify-end gap-2 lg:flex">
         <ToggleGroup
@@ -127,30 +144,32 @@ export function UsagePage() {
           value={[metric]}
           onValueChange={(next) => {
             const value = next[0];
-            if (value === "cost" || value === "tokens") setMetric(value);
+            if (isUsageMetric(value)) setMetric(value);
           }}
         >
-          {(["cost", "tokens"] as const).map((option) => (
+          {(["cost", "tokens", "limits"] as const).map((option) => (
             <Toggle key={option} value={option}>
-              {option === "cost" ? "Cost" : "Tokens"}
+              {METRIC_LABELS[option]}
             </Toggle>
           ))}
         </ToggleGroup>
-        <ToggleGroup
-          aria-label="Usage period"
-          variant="segmented"
-          value={[String(windowDays)]}
-          onValueChange={(next) => {
-            const value = next[0];
-            if (value) selectWindow(Number(value));
-          }}
-        >
-          {WINDOW_OPTIONS.map((option) => (
-            <Toggle key={option.days} value={String(option.days)}>
-              {option.label}
-            </Toggle>
-          ))}
-        </ToggleGroup>
+        {metric === "limits" ? null : (
+          <ToggleGroup
+            aria-label="Usage period"
+            variant="segmented"
+            value={[String(windowDays)]}
+            onValueChange={(next) => {
+              const value = next[0];
+              if (value) selectWindow(Number(value));
+            }}
+          >
+            {WINDOW_OPTIONS.map((option) => (
+              <Toggle key={option.days} value={String(option.days)}>
+                {option.label}
+              </Toggle>
+            ))}
+          </ToggleGroup>
+        )}
         <Button onClick={refreshWindow} aria-label="Refresh usage" size="icon-sm" variant="ghost">
           <RefreshCwIcon className="size-3.5" />
         </Button>
@@ -159,7 +178,7 @@ export function UsagePage() {
         <Select
           value={metric}
           onValueChange={(value) => {
-            if (value === "cost" || value === "tokens") setMetric(value);
+            if (isUsageMetric(value)) setMetric(value);
           }}
         >
           <SelectTrigger
@@ -168,32 +187,35 @@ export function UsagePage() {
             variant="ghost"
             className="w-auto min-w-0"
           >
-            <SelectValue>{metric === "cost" ? "Cost" : "Tokens"}</SelectValue>
+            <SelectValue>{METRIC_LABELS[metric]}</SelectValue>
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
             <SelectItem value="cost">Cost</SelectItem>
             <SelectItem value="tokens">Tokens</SelectItem>
+            <SelectItem value="limits">Limits</SelectItem>
           </SelectPopup>
         </Select>
-        <Select value={String(windowDays)} onValueChange={(value) => selectWindow(Number(value))}>
-          <SelectTrigger
-            aria-label="Usage period"
-            size="compact"
-            variant="ghost"
-            className="w-auto min-w-0"
-          >
-            <SelectValue>
-              {WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectPopup align="end" alignItemWithTrigger={false}>
-            {WINDOW_OPTIONS.map((option) => (
-              <SelectItem key={option.days} value={String(option.days)}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectPopup>
-        </Select>
+        {metric === "limits" ? null : (
+          <Select value={String(windowDays)} onValueChange={(value) => selectWindow(Number(value))}>
+            <SelectTrigger
+              aria-label="Usage period"
+              size="compact"
+              variant="ghost"
+              className="w-auto min-w-0"
+            >
+              <SelectValue>
+                {WINDOW_OPTIONS.find((option) => option.days === windowDays)?.label}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectPopup align="end" alignItemWithTrigger={false}>
+              {WINDOW_OPTIONS.map((option) => (
+                <SelectItem key={option.days} value={String(option.days)}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+        )}
         <Button onClick={refreshWindow} aria-label="Refresh usage" size="icon-sm" variant="ghost">
           <RefreshCwIcon className="size-3.5" />
         </Button>
@@ -208,7 +230,13 @@ export function UsagePage() {
 
         <ScrollArea className="min-h-0 flex-1">
           <WorkspacePageContainer width="wide">
-            {settling ? (
+            {metric === "limits" ? (
+              <UsageLimitsSection
+                providers={limits.providers}
+                now={limits.receivedAt}
+                isPending={limits.isPending}
+              />
+            ) : settling ? (
               <>
                 {environments.length > 1 ? <UsageDeviceStrip environments={environments} /> : null}
                 <UsageSkeleton />

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -510,6 +510,7 @@ function UsageLimitsTab({
     <UsageLimitsSection
       providers={limits.providers}
       failedEnvironments={limits.failedEnvironments}
+      pendingEnvironments={limits.pendingEnvironments}
       now={limits.receivedAt}
       isPending={limits.isPending}
     />

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -1,11 +1,9 @@
-import type { UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
-import { cn } from "../../lib/utils";
 import { useUsage, useUsageLimits, type EnvironmentUsageStatus } from "../../state/usage";
 import {
   enumerateDays,
@@ -33,7 +31,12 @@ import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageLimitsSection } from "./UsageLimits";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
-import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
+import {
+  PROVIDER_ORDER,
+  PROVIDER_PRESENTATION,
+  ProviderMark,
+  providersWithUsage,
+} from "./usageProviders";
 
 const WINDOW_OPTIONS = [
   { days: 1, label: "Past 24h" },
@@ -233,6 +236,7 @@ export function UsagePage() {
             {metric === "limits" ? (
               <UsageLimitsSection
                 providers={limits.providers}
+                failedEnvironments={limits.failedEnvironments}
                 now={limits.receivedAt}
                 isPending={limits.isPending}
               />
@@ -490,18 +494,6 @@ export function UsagePage() {
       </div>
     </SidebarInset>
   );
-}
-
-/** Brand mark for the harness a row belongs to. */
-function ProviderMark({
-  provider,
-  className,
-}: {
-  readonly provider: UsageProviderKind;
-  readonly className: string;
-}) {
-  const Mark = PROVIDER_PRESENTATION[provider].mark;
-  return <Mark className={cn("shrink-0", className)} aria-hidden />;
 }
 
 function Metric({ label, value }: { readonly label: string; readonly value: string }) {

--- a/apps/web/src/components/usage/usageProviders.tsx
+++ b/apps/web/src/components/usage/usageProviders.tsx
@@ -1,5 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
+import { cn } from "../../lib/utils";
 import { ClaudeAI, GrokIcon, type Icon, OpenAI } from "../Icons";
 
 type UsageProviderPresentation = {
@@ -49,4 +50,16 @@ export function providersWithUsage(
       .map((entry) => entry.provider),
   );
   return PROVIDER_ORDER.filter((provider) => active.has(provider));
+}
+
+/** Brand mark for the harness a row belongs to. */
+export function ProviderMark({
+  provider,
+  className,
+}: {
+  readonly provider: UsageProviderKind;
+  readonly className?: string;
+}) {
+  const Mark = PROVIDER_PRESENTATION[provider].mark;
+  return <Mark className={cn("shrink-0", className)} aria-hidden />;
 }

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -156,6 +156,7 @@ interface EnvironmentLimitsStatus {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly isPending: boolean;
+  readonly failed: boolean;
   readonly providers: readonly UsageProviderLimits[] | null;
 }
 
@@ -173,6 +174,7 @@ const usageLimitsAtom = Atom.make((get) => {
       environmentId,
       label: presentation.entry.target.label,
       isPending: result.waiting && snapshot === null,
+      failed: result._tag === "Failure",
       providers: snapshot?.providers ?? null,
     });
   }
@@ -183,6 +185,8 @@ const usageLimitsAtom = Atom.make((get) => {
 
 export interface UsageLimitsView {
   readonly providers: readonly EnvironmentProviderLimits[];
+  /** Labels of environments whose limits subscription failed. */
+  readonly failedEnvironments: readonly string[];
   /** Wall-clock time of the latest report, for reset countdowns. */
   readonly receivedAt: number;
   /** True until at least one environment has answered. */
@@ -216,8 +220,14 @@ export function useUsageLimits(): UsageLimitsView {
     }
   }, [environments]);
 
+  const failedEnvironments = useMemo(
+    () => environments.filter((environment) => environment.failed).map((e) => e.label),
+    [environments],
+  );
+
   return {
     providers,
+    failedEnvironments,
     receivedAt,
     isPending:
       environments.length > 0 &&

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -173,7 +173,7 @@ const usageLimitsAtom = Atom.make((get) => {
     statuses.push({
       environmentId,
       label: presentation.entry.target.label,
-      isPending: result.waiting && snapshot === null,
+      isPending: result.waiting,
       failed: result._tag === "Failure",
       providers: snapshot?.providers ?? null,
     });
@@ -187,6 +187,10 @@ export interface UsageLimitsView {
   readonly providers: readonly EnvironmentProviderLimits[];
   /** Labels of environments whose limits subscription failed. */
   readonly failedEnvironments: readonly string[];
+  /** Labels of environments that have not answered yet while others have. */
+  readonly pendingEnvironments: readonly string[];
+  /** True while any environment is re-reading after a refresh. */
+  readonly isRefreshing: boolean;
   /** Wall-clock time of the latest report, for reset countdowns. */
   readonly receivedAt: number;
   /** True until at least one environment has answered. */
@@ -225,9 +229,21 @@ export function useUsageLimits(): UsageLimitsView {
     [environments],
   );
 
+  const pendingEnvironments = useMemo(
+    () =>
+      environments
+        .filter((environment) => environment.isPending && !environment.failed)
+        .map((e) => e.label),
+    [environments],
+  );
+
   return {
     providers,
     failedEnvironments,
+    pendingEnvironments,
+    isRefreshing: environments.some(
+      (environment) => environment.providers !== null && environment.isPending,
+    ),
     receivedAt,
     isPending:
       environments.length > 0 &&

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -10,6 +10,7 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   USAGE_CONTRACT_VERSION,
   type EnvironmentId,
+  type UsageProviderLimits,
   type UsageSummary,
   type UsageSummaryInput,
 } from "@t3tools/contracts";
@@ -141,6 +142,87 @@ export function useUsage(input: UsageSummaryInput): UsageView {
     environments,
     isPending: answeredCount === 0 && stillReporting > 0,
     isPartial: answeredCount > 0 && stillReporting > 0,
+    refresh,
+  };
+}
+
+/** One provider instance's limits, tagged with the environment that reported them. */
+export interface EnvironmentProviderLimits extends UsageProviderLimits {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+}
+
+interface EnvironmentLimitsStatus {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly isPending: boolean;
+  readonly providers: readonly UsageProviderLimits[] | null;
+}
+
+/**
+ * Every environment's live limits subscription. Subscribing makes the server
+ * ask its adapters for fresh numbers, so a refresh is a resubscribe.
+ */
+const usageLimitsAtom = Atom.make((get) => {
+  const presentations = get(environmentPresentations.presentationsAtom);
+  const statuses: EnvironmentLimitsStatus[] = [];
+  for (const [environmentId, presentation] of presentations) {
+    const result = get(serverEnvironment.usageLimits({ environmentId, input: {} }));
+    const snapshot = Option.getOrNull(AsyncResult.value(result));
+    statuses.push({
+      environmentId,
+      label: presentation.entry.target.label,
+      isPending: result.waiting && snapshot === null,
+      providers: snapshot?.providers ?? null,
+    });
+  }
+  // Countdowns anchor to the moment a report lands rather than ticking: a
+  // live clock would repaint the page every minute for no decision-changing gain.
+  return { environments: statuses, receivedAt: Date.now() };
+}).pipe(Atom.withLabel("web-usage:limits"));
+
+export interface UsageLimitsView {
+  readonly providers: readonly EnvironmentProviderLimits[];
+  /** Wall-clock time of the latest report, for reset countdowns. */
+  readonly receivedAt: number;
+  /** True until at least one environment has answered. */
+  readonly isPending: boolean;
+  readonly refresh: () => void;
+}
+
+export function useUsageLimits(): UsageLimitsView {
+  const { environments, receivedAt } = useAtomValue(usageLimitsAtom);
+
+  // Every environment is its own machine with its own provider sign-in, so
+  // each report is listed; the page labels the environment when two share a
+  // provider.
+  const providers = useMemo(
+    () =>
+      environments.flatMap((environment) =>
+        (environment.providers ?? []).map((entry) => ({
+          ...entry,
+          environmentId: environment.environmentId,
+          environmentLabel: environment.label,
+        })),
+      ),
+    [environments],
+  );
+
+  const refresh = useCallback(() => {
+    for (const environment of environments) {
+      appAtomRegistry.refresh(
+        serverEnvironment.usageLimits({ environmentId: environment.environmentId, input: {} }),
+      );
+    }
+  }, [environments]);
+
+  return {
+    providers,
+    receivedAt,
+    isPending:
+      environments.length > 0 &&
+      environments.every((environment) => environment.providers === null) &&
+      environments.some((environment) => environment.isPending),
     refresh,
   };
 }

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -121,6 +121,10 @@ A point-in-time view of state. The word is used in multiple layers, including or
 
 The per-driver list of current model slugs that decides which models land in the model picker's legacy section. Bundled at `apps/server/src/provider/model-manifest.json` and refreshed at runtime from the same file on `main`, so classification updates ship as commits instead of releases. See the [provider architecture][16] model manifest section.
 
+#### Limit window
+
+A rolling quota window a subscription provider reports for the signed-in account, such as Codex's 5 hour and weekly windows or Claude Code's five-hour and per-model weekly windows. Adapters normalise native payloads into `UsageLimitsUpdate` in `packages/contracts/src/usageLimits.ts`; `UsageLimitsService` keeps the latest snapshot per provider instance in memory and streams it to clients over `subscribeUsageLimits`. Limits are account state, not thread history, so they are never persisted or event-sourced.
+
 ### Checkpointing
 
 Checkpointing captures workspace state over time so the app can diff turns and restore earlier points. The main pieces are [CheckpointStore.ts][19], [CheckpointDiffQuery.ts][20], and [CheckpointReactor.ts][6].

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -16,9 +16,10 @@ pricing update.
 
 The **Limits** tab shows the rolling quota windows your subscription providers report for the
 signed-in account, across every connected environment. Each window in use is a bar from the moment
-it opened to its reset, filled by how much of the quota is spent. A thin line marks how far into the
-window you are, which is also where even spending would have put the fill, and a small icon says
-whether you are ahead of, on, or under that pace. Hover a bar for the exact figures and the reset
+it opened to its reset, filled by how much of the quota is spent. When the provider reports the
+window's length and reset time, a thin line marks how far into the window you are, which is also
+where even spending would have put the fill, and a small icon says whether you are ahead of, on, or
+under that pace. Windows with nothing used yet are left out until they see use. Hover a bar for the exact figures and the reset
 time. Codex and Claude Code limits are read from the signed-in subscription whenever the tab opens
 or refreshes and update as turns run. Codex accounts with banked reset credits also show how many
 are left, and **Use a reset** redeems one after a confirmation. API key sessions and Grok Build do

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -13,3 +13,13 @@ Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. 
 headline and chart. Refreshing rescans every connected environment and refetches model pricing on
 each of them, so a newly released model that showed $0.00 gets a price without waiting for the daily
 pricing update.
+
+The **Limits** tab shows the rolling quota windows your subscription providers report for the
+signed-in account, across every connected environment. Each window in use is a bar from the moment
+it opened to its reset, filled by how much of the quota is spent. A thin line marks how far into the
+window you are, which is also where even spending would have put the fill, and a small icon says
+whether you are ahead of, on, or under that pace. Hover a bar for the exact figures and the reset
+time. Codex and Claude Code limits are read from the signed-in subscription whenever the tab opens
+or refreshes and update as turns run. Codex accounts with banked reset credits also show how many
+are left, and **Use a reset** redeems one after a confirmation. API key sessions and Grok Build do
+not report limits.

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -52,6 +52,7 @@ export type EnvironmentSubscriptionRpcTag =
   | typeof WS_METHODS.subscribePreviewEvents
   | typeof WS_METHODS.subscribeDiscoveredLocalServers
   | typeof WS_METHODS.subscribeResourceTelemetry
+  | typeof WS_METHODS.subscribeUsageLimits
   | typeof WS_METHODS.previewAutomationConnect
   | typeof WS_METHODS.subscribeVcsStatus
   | typeof WS_METHODS.terminalAttach;

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -881,6 +881,15 @@ export function createServerEnvironmentAtoms<R, E>(
       tag: WS_METHODS.serverGetUsageSummary,
       staleTimeMs: 60_000,
     }),
+    usageLimits: createEnvironmentRpcSubscriptionAtomFamily(runtime, {
+      label: "environment-data:server:usage-limits",
+      tag: WS_METHODS.subscribeUsageLimits,
+      idleTtlMs: 0,
+    }),
+    consumeUsageLimitReset: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:server:consume-usage-limit-reset",
+      tag: WS_METHODS.serverConsumeUsageLimitReset,
+    }),
     configProjection,
     welcome: createEnvironmentRpcSubscriptionAtomFamily(runtime, {
       label: "environment-data:server:welcome",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -34,4 +34,5 @@ export * from "./preview.ts";
 export * from "./previewAutomation.ts";
 export * from "./resourceTelemetry.ts";
 export * from "./usage.ts";
+export * from "./usageLimits.ts";
 export * from "./rpc.ts";

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -14,6 +14,7 @@ import {
   TurnId,
 } from "./baseSchemas.ts";
 import { ProviderInstanceId, ProviderDriverKind } from "./providerInstance.ts";
+import { UsageLimitsUpdate } from "./usageLimits.ts";
 import { ProviderApprovalOption } from "./orchestration.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
@@ -749,8 +750,9 @@ const AccountUpdatedPayload = Schema.Struct({
 });
 export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 
+/** Adapters normalise native rate-limit payloads into a sparse limits update. */
 const AccountRateLimitsUpdatedPayload = Schema.Struct({
-  rateLimits: Schema.Unknown,
+  limits: UsageLimitsUpdate,
 });
 export type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -207,6 +207,12 @@ import {
   ResourceTelemetrySnapshot,
 } from "./resourceTelemetry.ts";
 import { UsagePricing, UsageReadError, UsageSummary, UsageSummaryInput } from "./usage.ts";
+import {
+  UsageLimitsConsumeResetInput,
+  UsageLimitsConsumeResetResult,
+  UsageLimitsError,
+  UsageLimitsSnapshot,
+} from "./usageLimits.ts";
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
 import {
   SourceControlCloneRepositoryInput,
@@ -316,6 +322,7 @@ export const WS_METHODS = {
   serverGetBackgroundPolicy: "server.getBackgroundPolicy",
   serverGetUsageSummary: "server.getUsageSummary",
   serverRefreshUsageRates: "server.refreshUsageRates",
+  serverConsumeUsageLimitReset: "server.consumeUsageLimitReset",
 
   // Cloud environment methods
   cloudGetRelayClientStatus: "cloud.getRelayClientStatus",
@@ -359,6 +366,7 @@ export const WS_METHODS = {
   subscribeAuthAccess: "subscribeAuthAccess",
   subscribeBackgroundPolicy: "subscribeBackgroundPolicy",
   subscribeResourceTelemetry: "subscribeResourceTelemetry",
+  subscribeUsageLimits: "subscribeUsageLimits",
 } as const;
 
 export const WsServerUpsertKeybindingRpc = Rpc.make(WS_METHODS.serverUpsertKeybinding, {
@@ -556,6 +564,12 @@ export const WsServerRefreshUsageRatesRpc = Rpc.make(WS_METHODS.serverRefreshUsa
   payload: Schema.Struct({}),
   success: UsagePricing,
   error: EnvironmentAuthorizationError,
+});
+
+export const WsServerConsumeUsageLimitResetRpc = Rpc.make(WS_METHODS.serverConsumeUsageLimitReset, {
+  payload: UsageLimitsConsumeResetInput,
+  success: UsageLimitsConsumeResetResult,
+  error: Schema.Union([EnvironmentAuthorizationError, UsageLimitsError]),
 });
 
 export const WsServerSignalProcessRpc = Rpc.make(WS_METHODS.serverSignalProcess, {
@@ -1150,6 +1164,13 @@ export const WsSubscribeResourceTelemetryRpc = Rpc.make(WS_METHODS.subscribeReso
   stream: true,
 });
 
+export const WsSubscribeUsageLimitsRpc = Rpc.make(WS_METHODS.subscribeUsageLimits, {
+  payload: Schema.Struct({}),
+  success: UsageLimitsSnapshot,
+  error: EnvironmentAuthorizationError,
+  stream: true,
+});
+
 export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
@@ -1179,6 +1200,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerRetryResourceTelemetryRpc,
   WsServerGetUsageSummaryRpc,
   WsServerRefreshUsageRatesRpc,
+  WsServerConsumeUsageLimitResetRpc,
   WsServerSignalProcessRpc,
   WsServerReportClientActivityRpc,
   WsServerReportHostPowerStateRpc,
@@ -1259,6 +1281,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSubscribeAuthAccessRpc,
   WsSubscribeBackgroundPolicyRpc,
   WsSubscribeResourceTelemetryRpc,
+  WsSubscribeUsageLimitsRpc,
   WsOrchestrationDispatchCommandRpc,
   WsOrchestrationGetWorkflowScriptRpc,
   WsOrchestrationGetTurnDiffRpc,

--- a/packages/contracts/src/usageLimits.ts
+++ b/packages/contracts/src/usageLimits.ts
@@ -82,7 +82,7 @@ export type UsageLimitsConsumeResetResult = typeof UsageLimitsConsumeResetResult
 export class UsageLimitsError extends Schema.TaggedErrorClass<UsageLimitsError>()(
   "UsageLimitsError",
   {
-    reason: Schema.Literals(["unsupported", "noSession", "requestFailed"]),
+    reason: Schema.Literals(["unsupported", "requestFailed"]),
     /** Stable, bounded description. The underlying failure travels in `cause`. */
     detail: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect()),

--- a/packages/contracts/src/usageLimits.ts
+++ b/packages/contracts/src/usageLimits.ts
@@ -1,0 +1,94 @@
+/**
+ * Provider account limits: the rolling quota windows a subscription provider
+ * reports for the signed-in account, plus Codex banked reset credits.
+ *
+ * Limits are account state, not thread history. Adapters normalise their
+ * native payloads at the boundary; the server keeps only the latest snapshot
+ * per provider instance.
+ *
+ * @module usageLimits
+ */
+import * as Schema from "effect/Schema";
+
+import { IsoDateTime, NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { ProviderInstanceId } from "./providerInstance.ts";
+import { UsageProviderKind } from "./usage.ts";
+
+export const UsageLimitWindow = Schema.Struct({
+  /** Stable per provider, e.g. `primary`, `five_hour`. Sparse updates merge on it. */
+  id: TrimmedNonEmptyString,
+  label: TrimmedNonEmptyString,
+  /** 0..100 */
+  usedPercent: Schema.Number,
+  resetsAt: Schema.NullOr(IsoDateTime),
+  windowMinutes: Schema.NullOr(NonNegativeInt),
+});
+export type UsageLimitWindow = typeof UsageLimitWindow.Type;
+
+/** Codex reset credits banked on the account. */
+export const UsageLimitResetCredits = Schema.Struct({
+  availableCount: NonNegativeInt,
+  nextExpiresAt: Schema.NullOr(IsoDateTime),
+});
+export type UsageLimitResetCredits = typeof UsageLimitResetCredits.Type;
+
+/**
+ * Sparse update from one provider event or read. Windows replace by id, the
+ * other fields only when present.
+ */
+export const UsageLimitsUpdate = Schema.Struct({
+  plan: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  windows: Schema.Array(UsageLimitWindow),
+  resetCredits: Schema.optional(Schema.NullOr(UsageLimitResetCredits)),
+});
+export type UsageLimitsUpdate = typeof UsageLimitsUpdate.Type;
+
+export const UsageProviderLimits = Schema.Struct({
+  provider: UsageProviderKind,
+  instanceId: ProviderInstanceId,
+  /** The instance's configured display name, for telling two Codex homes apart. */
+  instanceLabel: Schema.NullOr(TrimmedNonEmptyString),
+  plan: Schema.NullOr(TrimmedNonEmptyString),
+  windows: Schema.Array(UsageLimitWindow),
+  resetCredits: Schema.NullOr(UsageLimitResetCredits),
+  /** When the provider last reported any of these numbers. */
+  observedAt: IsoDateTime,
+});
+export type UsageProviderLimits = typeof UsageProviderLimits.Type;
+
+export const UsageLimitsSnapshot = Schema.Struct({
+  providers: Schema.Array(UsageProviderLimits),
+});
+export type UsageLimitsSnapshot = typeof UsageLimitsSnapshot.Type;
+
+export const UsageLimitsConsumeResetInput = Schema.Struct({
+  instanceId: ProviderInstanceId,
+});
+export type UsageLimitsConsumeResetInput = typeof UsageLimitsConsumeResetInput.Type;
+
+export const UsageLimitsConsumeResetOutcome = Schema.Literals([
+  "reset",
+  "nothingToReset",
+  "noCredit",
+  "alreadyRedeemed",
+]);
+export type UsageLimitsConsumeResetOutcome = typeof UsageLimitsConsumeResetOutcome.Type;
+
+export const UsageLimitsConsumeResetResult = Schema.Struct({
+  outcome: UsageLimitsConsumeResetOutcome,
+});
+export type UsageLimitsConsumeResetResult = typeof UsageLimitsConsumeResetResult.Type;
+
+export class UsageLimitsError extends Schema.TaggedErrorClass<UsageLimitsError>()(
+  "UsageLimitsError",
+  {
+    reason: Schema.Literals(["unsupported", "noSession", "requestFailed"]),
+    /** Stable, bounded description. The underlying failure travels in `cause`. */
+    detail: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Usage limits request failed (${this.reason}): ${this.detail}`;
+  }
+}

--- a/packages/contracts/src/usageLimits.ts
+++ b/packages/contracts/src/usageLimits.ts
@@ -33,10 +33,12 @@ export const UsageLimitResetCredits = Schema.Struct({
 export type UsageLimitResetCredits = typeof UsageLimitResetCredits.Type;
 
 /**
- * Sparse update from one provider event or read. Windows replace by id, the
- * other fields only when present.
+ * One provider event or read. Windows replace by id and the other fields only
+ * when present. A complete update is the account's whole window set, so
+ * windows it omits are gone; a sparse one only touches what it carries.
  */
 export const UsageLimitsUpdate = Schema.Struct({
+  complete: Schema.Boolean,
   plan: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   windows: Schema.Array(UsageLimitWindow),
   resetCredits: Schema.optional(Schema.NullOr(UsageLimitResetCredits)),
@@ -53,6 +55,8 @@ export const UsageProviderLimits = Schema.Struct({
   resetCredits: Schema.NullOr(UsageLimitResetCredits),
   /** When the provider last reported any of these numbers. */
   observedAt: IsoDateTime,
+  /** Set when the latest on-demand read failed; the numbers above are the last good report. */
+  readError: Schema.NullOr(TrimmedNonEmptyString),
 });
 export type UsageProviderLimits = typeof UsageProviderLimits.Type;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -243,6 +243,10 @@
       "types": "./src/usageFormat.ts",
       "import": "./src/usageFormat.ts"
     },
+    "./usageLimits": {
+      "types": "./src/usageLimits.ts",
+      "import": "./src/usageLimits.ts"
+    },
     "./desktopAppControl": {
       "types": "./src/desktopAppControl.ts",
       "import": "./src/desktopAppControl.ts"

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import * as DateTime from "effect/DateTime";
+
+import { elapsedShare, formatDuration, paceOf } from "./usageLimits.ts";
+
+const now = Date.parse("2026-09-03T12:00:00.000Z");
+const weekly = (usedPercent: number, resetsInHours: number) => ({
+  id: "seven_day",
+  label: "Weekly",
+  usedPercent,
+  resetsAt: DateTime.formatIso(DateTime.makeUnsafe(now + resetsInHours * 3_600_000)),
+  windowMinutes: 7 * 24 * 60,
+});
+
+describe("usage limit pace", () => {
+  it("measures how far into the window we are", () => {
+    // Resets in 84 hours of a 168 hour window: half elapsed.
+    expect(elapsedShare(weekly(0, 84), now)).toBeCloseTo(0.5);
+    expect(elapsedShare({ ...weekly(0, 84), windowMinutes: null }, now)).toBeNull();
+    expect(elapsedShare({ ...weekly(0, 84), resetsAt: null }, now)).toBeNull();
+  });
+
+  it("compares usage against the clock with a five point band", () => {
+    expect(paceOf(weekly(56, 84), now)).toBe("ahead");
+    expect(paceOf(weekly(52, 84), now)).toBe("on");
+    expect(paceOf(weekly(44, 84), now)).toBe("under");
+    expect(paceOf({ ...weekly(44, 84), windowMinutes: null }, now)).toBeNull();
+  });
+
+  it("formats countdowns at the coarsest useful unit", () => {
+    expect(formatDuration(3 * 86_400_000 + 4 * 3_600_000)).toBe("3d 4h");
+    expect(formatDuration(2 * 3_600_000 + 13 * 60_000)).toBe("2h 13m");
+    expect(formatDuration(12 * 60_000)).toBe("12m");
+    expect(formatDuration(-5)).toBe("0m");
+  });
+});

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -1,0 +1,51 @@
+/**
+ * Pace maths for provider limit windows, shared by the web and mobile Limits
+ * views so both agree on what "ahead of pace" means.
+ *
+ * @module usageLimits
+ */
+import type { UsageLimitWindow } from "@t3tools/contracts";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/** `2h 13m`, `3d 4h`, `12m`. */
+export function formatDuration(ms: number): string {
+  const remaining = Math.max(0, ms);
+  const days = Math.floor(remaining / DAY);
+  const hours = Math.floor((remaining % DAY) / HOUR);
+  const minutes = Math.floor((remaining % HOUR) / 60000);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+export function resetMillis(window: UsageLimitWindow): number | null {
+  if (window.resetsAt === null) return null;
+  const at = Date.parse(window.resetsAt);
+  return Number.isFinite(at) ? at : null;
+}
+
+/** Elapsed share of the window, 0..1, or null when the window has no known length or reset. */
+export function elapsedShare(window: UsageLimitWindow, now: number): number | null {
+  const resetsAt = resetMillis(window);
+  if (resetsAt === null || window.windowMinutes === null) return null;
+  const length = window.windowMinutes * 60000;
+  return Math.max(0, Math.min(1, (length - (resetsAt - now)) / length));
+}
+
+export type LimitPace = "ahead" | "on" | "under";
+
+/**
+ * Usage against the clock. The window's bar is its whole span, so the elapsed
+ * share is also where even spending would have put the fill; within five
+ * points of it counts as on pace.
+ */
+export function paceOf(window: UsageLimitWindow, now: number): LimitPace | null {
+  const elapsed = elapsedShare(window, now);
+  if (elapsed === null) return null;
+  const gap = window.usedPercent - elapsed * 100;
+  if (gap > 5) return "ahead";
+  if (gap < -5) return "under";
+  return "on";
+}


### PR DESCRIPTION
Users on Codex or Claude Code subscriptions had no way to see how much of their quota was left or when it resets without leaving T3 Code. Both providers already emit a rate-limits event during turns, but its payload was untyped and the server dropped it on the floor.

This adds a **Limits** tab to the Usage page, next to Cost and Tokens. Each connected environment reports the account limits its providers know about, and the page shows one section per provider: a bar per window in use, filled by the share of quota spent, with a marker at how far into the window you are. Because the bar is the whole window, that marker is also where even spending would have put the fill, so a pace icon says whether you are ahead of, on, or under pace. Hovering a bar gives the exact figures and the reset time. Codex accounts with banked reset credits show the count with a confirmed **Use a reset** action.

## How it works

- Adapters normalise their native payloads at the boundary into a typed `UsageLimitsUpdate`. Codex maps `account/rateLimits/updated`, Claude Code maps `rate_limit_event`, and both keep window ids stable so turn-driven updates merge onto the same rows.
- Codex is also read on demand: through a live session's app-server when one exists, otherwise through a short-lived `codex app-server` process, so limits never need an open thread. Reads may retry on a fresh process after a session failure; a redemption never does. Redemption is single-flight per instance and keeps one idempotency key until Codex reports an outcome.
- Claude Code has no on-demand call in the SDK, so the driver reads the claude.ai usage endpoint that the CLI's own `/usage` dialog uses, with the OAuth token Claude Code stored on disk. The token never leaves the server. It reads the endpoint's structured `limits` array, which is where model-scoped weekly buckets such as Fable carry their real names, and falls back to the legacy named keys. On macOS the credentials live in the Keychain and reading them from another process triggers a prompt on every refresh, so macOS relies on turn events until that becomes an explicit opt-in.
- A small in-memory `UsageLimitsService` keeps the latest snapshot per provider instance, folds in runtime events, refreshes on every subscribe and on every provider instance change, and streams changes over a new `subscribeUsageLimits` RPC. Full account reads replace the window set; sparse turn events merge by id. A failed read is recorded on the snapshot beside the last good numbers. Limits are account state rather than thread history, so nothing is persisted or event-sourced.
- The web client subscribes per environment only while the Limits tab is mounted, and lists every report, labelling the environment and the instance only when two share a provider.
- Mobile gets the same data as a Limits card on the usage screen: a bar per window in use, the elapsed marker, the pace against the clock, and the reset countdown. Redeeming a reset stays web-only for now.

## Verification

- New tests for both mappers, the Claude endpoint mapper and tier derivation, and the limits service merge and subscribe behaviour. Existing adapter, driver, and usage page suites pass.
- Typecheck and lint clean on contracts, client-runtime, server, and web.
- Exercised against real Pro and Max accounts on a dev environment, including the standalone Codex read with no thread open.

## Not in this PR

- Persisting snapshots across server restarts. Cost and Tokens rescan on every open too, and Limits already re-read from the providers on every open, so a stored snapshot would only add a second source of truth.
- Android screenshots. The machine that built this has no Android SDK, so the mobile card was verified by typecheck and lint only.

## After

Light:

![Limits tab](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/7dcef987-35cd-4945-ab48-a6cb303dec22/t3code-usage-limits-tab.png)

Dark:

![Limits tab, dark](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/f48ca11e-97d5-4557-b36e-0135b4b2b670/t3code-usage-limits-tab-dark.png)

Built with Claude Fable 5.1 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider adapters, OAuth token reads for Claude limits, and Codex reset consumption with idempotency; incorrect merge on complete reads could briefly drop windows, though stamps protect newer turn events.
> 
> **Overview**
> Adds **subscription quota visibility** on Usage via a new **Limits** metric alongside Cost and Tokens (web tab + mobile card). Clients subscribe per environment only while Limits is open; pull-to-refresh also re-fetches limits.
> 
> **Server:** Introduces typed `usageLimits` contracts, `UsageLimitsService` (in-memory snapshots, merge by window id, refresh on subscribe/instance changes), and WebSocket **`subscribeUsageLimits`** plus **`serverConsumeUsageLimitReset`**. Codex and Claude adapters now emit normalised `UsageLimitsUpdate` from turn events and optional **on-demand reads** (Codex via live or short-lived app-server; Claude via claude.ai usage API with stored OAuth, skipping macOS file creds to avoid Keychain prompts). Codex reset redemption is single-flight with stable idempotency keys.
> 
> **UI:** Bars per active window with elapsed marker, pace vs. even spend, reset countdowns, and web-only confirmed **Use a reset** for banked Codex credits. Shared `@t3tools/shared/usageLimits` keeps pace math consistent across web and mobile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e02d2e1de8939d213d489a0651e99f02f49507e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Limits tab with provider quota windows and Codex banked resets
> - Adds the `UsageLimitsService` backend in [UsageLimitsService.ts](https://github.com/pingdotgg/t3code/pull/9421/files#diff-f157a426439ca3beb0ef4c73c3c29d31f96326f249d08a82a754c0030ddd46f9). It reads account limits from Codex and Claude adapters, merges sparse runtime events, and serves snapshots over WebSocket.
> - Adds normalization layers for Codex and Claude. These convert native rate-limit payloads into the shared `UsageLimitsUpdate` schema with windows, percentages, reset timestamps, and plan labels.
> - Adds a "Limits" tab to the web and mobile usage pages. It shows usage bars, pace indicators, reset countdowns, and a confirmation dialog to redeem Codex banked reset credits.
> - Adds shared utilities in [usageLimits.ts](https://github.com/pingdotgg/t3code/pull/9421/files#diff-68cfbbd2d613fbb904208024425af193a1c663fa233b1c58b58735a924530b7f) for formatting countdowns, calculating elapsed window share, and classifying usage pace.
> - Risk: `UsageLimitsService.make` stores state in memory. The `make.apply` merge operation removes stale windows during complete adapter reads unless a newer runtime event touched them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e02d2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->