### PR TITLE
fix(server): look up GitLab repositories pasted as a URL

### DIFF
--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -186,14 +186,12 @@ layer("GitLabCli.layer", (it) => {
 
   it.effect("looks repositories up by the host and project path a URL names", () =>
     Effect.gen(function* () {
-      const repositoryJson =
-        // @effect-diagnostics-next-line preferSchemaOverJson:off
-        JSON.stringify({
-          path_with_namespace: "group/subgroup/project",
-          web_url: "https://sourcecontrol.example.com/group/subgroup/project",
-          http_url_to_repo: "https://sourcecontrol.example.com/group/subgroup/project.git",
-          ssh_url_to_repo: "git@sourcecontrol.example.com:group/subgroup/project.git",
-        });
+      const repositoryJson = `{
+        "path_with_namespace": "group/subgroup/project",
+        "web_url": "https://sourcecontrol.example.com/group/subgroup/project",
+        "http_url_to_repo": "https://sourcecontrol.example.com/group/subgroup/project.git",
+        "ssh_url_to_repo": "git@sourcecontrol.example.com:group/subgroup/project.git"
+      }`;
       const onHost = [
         "--hostname",
         "sourcecontrol.example.com",
@@ -212,6 +210,16 @@ layer("GitLabCli.layer", (it) => {
         [
           "https://sourcecontrol.example.com:8443/group/subgroup/project",
           ["--hostname", "sourcecontrol.example.com:8443", "projects/group%2Fsubgroup%2Fproject"],
+        ],
+        // A pasted URL arrives percent-encoded, so the path is decoded before it is encoded again.
+        [
+          "https://sourcecontrol.example.com/group/subgroup/pro%2Dject",
+          ["--hostname", "sourcecontrol.example.com", "projects/group%2Fsubgroup%2Fpro-ject"],
+        ],
+        // Malformed escapes name no project, so the raw path stands rather than throwing.
+        [
+          "https://sourcecontrol.example.com/group/pro%ZZject",
+          ["--hostname", "sourcecontrol.example.com", "projects/group%2Fpro%25ZZject"],
         ],
         // A bare path names no host, so `glab` keeps resolving it against its own default.
         ["group/subgroup/project", ["projects/group%2Fsubgroup%2Fproject"]],

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -29,8 +29,6 @@ function processOutput(stdout: string): VcsProcess.VcsProcessOutput {
   };
 }
 
-// A URL lookup reads the host's relative URL root before it asks for the project, so both
-// answers are dispatched on the subcommand rather than queued in order.
 function mockRepository(
   repositoryJson: string,
   config: { readonly subfolder?: string; readonly host?: string } = {},
@@ -200,12 +198,14 @@ layer("GitLabCli.layer", (it) => {
 
   it.effect("reduces a repository given as a URL to the project path it names", () =>
     Effect.gen(function* () {
-      const repositoryJson = `{
-        "path_with_namespace": "group/subgroup/project",
-        "web_url": "https://sourcecontrol.example.com/group/subgroup/project",
-        "http_url_to_repo": "https://sourcecontrol.example.com/group/subgroup/project.git",
-        "ssh_url_to_repo": "git@sourcecontrol.example.com:group/subgroup/project.git"
-      }`;
+      const repositoryJson =
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/subgroup/project",
+          web_url: "https://sourcecontrol.example.com/group/subgroup/project",
+          http_url_to_repo: "https://sourcecontrol.example.com/group/subgroup/project.git",
+          ssh_url_to_repo: "git@sourcecontrol.example.com:group/subgroup/project.git",
+        });
       const project = "projects/group%2Fsubgroup%2Fproject";
 
       const cases: ReadonlyArray<readonly [string, string]> = [
@@ -216,17 +216,14 @@ layer("GitLabCli.layer", (it) => {
         ["git@sourcecontrol.example.com:group/subgroup/project.git", project],
         ["sourcecontrol.example.com:group/subgroup/project.git", project],
         ["ssh://git@sourcecontrol.example.com:22/group/subgroup/project.git", project],
-        // A pasted URL arrives percent-encoded, so the path is decoded before it is encoded again.
         [
           "https://sourcecontrol.example.com/group/subgroup/pro%2Dject",
           "projects/group%2Fsubgroup%2Fpro-ject",
         ],
-        // Malformed escapes name no project, so the raw path stands rather than throwing.
         ["https://sourcecontrol.example.com/group/pro%ZZject", "projects/group%2Fpro%25ZZject"],
         ["group/subgroup/project", project],
       ];
 
-      // No relative URL root configured, so the path is asked for as it was parsed.
       mockRepository(repositoryJson);
 
       const sent: Array<readonly [string, ReadonlyArray<string> | undefined]> = [];
@@ -246,12 +243,13 @@ layer("GitLabCli.layer", (it) => {
   it.effect("drops the relative URL root of an instance hosted under a subfolder", () =>
     Effect.gen(function* () {
       mockRepository(
-        `{
-          "path_with_namespace": "group/project",
-          "web_url": "https://example.com/gitlab/group/project",
-          "http_url_to_repo": "https://example.com/gitlab/group/project.git",
-          "ssh_url_to_repo": "git@example.com:group/project.git"
-        }`,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://example.com/gitlab/group/project",
+          http_url_to_repo: "https://example.com/gitlab/group/project.git",
+          ssh_url_to_repo: "git@example.com:group/project.git",
+        }),
         { subfolder: "gitlab" },
       );
 
@@ -278,16 +276,15 @@ layer("GitLabCli.layer", (it) => {
 
   it.effect("reads the relative URL root from a host configured with or without a scheme", () =>
     Effect.gen(function* () {
-      // `glab config get host` answers with whatever was configured: a bare host and root, or the
-      // whole URL, as `GITLAB_HOST=https://example.com/gitlab` gives.
       for (const host of ["example.com/gitlab", "https://example.com/gitlab"]) {
         mockRepository(
-          `{
-            "path_with_namespace": "group/subgroup/project",
-            "web_url": "https://example.com/gitlab/group/subgroup/project",
-            "http_url_to_repo": "https://example.com/gitlab/group/subgroup/project.git",
-            "ssh_url_to_repo": "git@example.com:group/subgroup/project.git"
-          }`,
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
+          JSON.stringify({
+            path_with_namespace: "group/subgroup/project",
+            web_url: "https://example.com/gitlab/group/subgroup/project",
+            http_url_to_repo: "https://example.com/gitlab/group/subgroup/project.git",
+            ssh_url_to_repo: "git@example.com:group/subgroup/project.git",
+          }),
           { host },
         );
 
@@ -310,12 +307,13 @@ layer("GitLabCli.layer", (it) => {
   it.effect("reads the relative URL root under the port the instance is served on", () =>
     Effect.gen(function* () {
       mockRepository(
-        `{
-          "path_with_namespace": "group/project",
-          "web_url": "https://example.com:8443/gitlab/group/project",
-          "http_url_to_repo": "https://example.com:8443/gitlab/group/project.git",
-          "ssh_url_to_repo": "git@example.com:group/project.git"
-        }`,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://example.com:8443/gitlab/group/project",
+          http_url_to_repo: "https://example.com:8443/gitlab/group/project.git",
+          ssh_url_to_repo: "git@example.com:group/project.git",
+        }),
         { subfolder: "gitlab" },
       );
 
@@ -325,7 +323,6 @@ layer("GitLabCli.layer", (it) => {
         repository: "https://example.com:8443/gitlab/group/project",
       });
 
-      // `glab` keys per-host settings by the configured address, so the port belongs in the ask.
       assert.deepStrictEqual(mockedRun.mock.calls[0]?.[0].args, [
         "config",
         "get",
@@ -343,13 +340,13 @@ layer("GitLabCli.layer", (it) => {
   it.effect("keeps a leading segment when the configured root belongs to another host", () =>
     Effect.gen(function* () {
       mockRepository(
-        `{
-          "path_with_namespace": "gitlab/group/project",
-          "web_url": "https://gitlab.com/gitlab/group/project",
-          "http_url_to_repo": "https://gitlab.com/gitlab/group/project.git",
-          "ssh_url_to_repo": "git@gitlab.com:gitlab/group/project.git"
-        }`,
-        // The relative root belongs to example.com, so a gitlab.com path keeps its own `gitlab/`.
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "gitlab/group/project",
+          web_url: "https://gitlab.com/gitlab/group/project",
+          http_url_to_repo: "https://gitlab.com/gitlab/group/project.git",
+          ssh_url_to_repo: "git@gitlab.com:gitlab/group/project.git",
+        }),
         { host: "https://example.com/gitlab" },
       );
 
@@ -370,13 +367,13 @@ layer("GitLabCli.layer", (it) => {
   it.effect("keeps a root that would leave a project without its namespace", () =>
     Effect.gen(function* () {
       mockRepository(
-        `{
-          "path_with_namespace": "group/project",
-          "web_url": "https://example.com/group/project",
-          "http_url_to_repo": "https://example.com/group/project.git",
-          "ssh_url_to_repo": "git@example.com:group/project.git"
-        }`,
-        // `group` is the project's own namespace here, not an install root.
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://example.com/group/project",
+          http_url_to_repo: "https://example.com/group/project.git",
+          ssh_url_to_repo: "git@example.com:group/project.git",
+        }),
         { subfolder: "group" },
       );
 
@@ -395,12 +392,15 @@ layer("GitLabCli.layer", (it) => {
 
   it.effect("asks for a bare project path without reading any config", () =>
     Effect.gen(function* () {
-      mockRepository(`{
-        "path_with_namespace": "group/subgroup/project",
-        "web_url": "https://gitlab.com/group/subgroup/project",
-        "http_url_to_repo": "https://gitlab.com/group/subgroup/project.git",
-        "ssh_url_to_repo": "git@gitlab.com:group/subgroup/project.git"
-      }`);
+      mockRepository(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/subgroup/project",
+          web_url: "https://gitlab.com/group/subgroup/project",
+          http_url_to_repo: "https://gitlab.com/group/subgroup/project.git",
+          ssh_url_to_repo: "git@gitlab.com:group/subgroup/project.git",
+        }),
+      );
 
       const glab = yield* GitLabCli.GitLabCli;
       yield* glab.getRepositoryCloneUrls({ cwd: "/repo", repository: "group/subgroup/project" });
@@ -414,17 +414,19 @@ layer("GitLabCli.layer", (it) => {
 
   it.effect("accepts a project served on a non-default port", () =>
     Effect.gen(function* () {
-      mockRepository(`{
-            "path_with_namespace": "group/project",
-            "web_url": "https://sourcecontrol.example.com:8443/group/project",
-            "http_url_to_repo": "https://sourcecontrol.example.com:8443/group/project.git",
-            "ssh_url_to_repo": "git@sourcecontrol.example.com:group/project.git"
-          }`);
+      mockRepository(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://sourcecontrol.example.com:8443/group/project",
+          http_url_to_repo: "https://sourcecontrol.example.com:8443/group/project.git",
+          ssh_url_to_repo: "git@sourcecontrol.example.com:group/project.git",
+        }),
+      );
 
       const glab = yield* GitLabCli.GitLabCli;
       const urls = yield* glab.getRepositoryCloneUrls({
         cwd: "/repo",
-        // An ssh remote never carries the web port, so the check has to compare without it.
         repository: "git@sourcecontrol.example.com:group/project.git",
       });
 
@@ -434,12 +436,15 @@ layer("GitLabCli.layer", (it) => {
 
   it.effect("refuses a project served on a different port than the URL named", () =>
     Effect.gen(function* () {
-      mockRepository(`{
-        "path_with_namespace": "group/project",
-        "web_url": "https://sourcecontrol.example.com/group/project",
-        "http_url_to_repo": "https://sourcecontrol.example.com/group/project.git",
-        "ssh_url_to_repo": "git@sourcecontrol.example.com:group/project.git"
-      }`);
+      mockRepository(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://sourcecontrol.example.com/group/project",
+          http_url_to_repo: "https://sourcecontrol.example.com/group/project.git",
+          ssh_url_to_repo: "git@sourcecontrol.example.com:group/project.git",
+        }),
+      );
 
       const error = yield* Effect.gen(function* () {
         const glab = yield* GitLabCli.GitLabCli;
@@ -456,12 +461,15 @@ layer("GitLabCli.layer", (it) => {
 
   it.effect("refuses a project resolved on a host the URL did not name", () =>
     Effect.gen(function* () {
-      mockRepository(`{
-            "path_with_namespace": "group/project",
-            "web_url": "https://gitlab.com/group/project",
-            "http_url_to_repo": "https://gitlab.com/group/project.git",
-            "ssh_url_to_repo": "git@gitlab.com:group/project.git"
-          }`);
+      mockRepository(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://gitlab.com/group/project",
+          http_url_to_repo: "https://gitlab.com/group/project.git",
+          ssh_url_to_repo: "git@gitlab.com:group/project.git",
+        }),
+      );
 
       const error = yield* Effect.gen(function* () {
         const glab = yield* GitLabCli.GitLabCli;

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -304,6 +304,32 @@ layer("GitLabCli.layer", (it) => {
     }),
   );
 
+  it.effect("strips an installation root whose lowercase spelling changes length", () =>
+    Effect.gen(function* () {
+      mockRepository(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://example.com/İ/group/project",
+          http_url_to_repo: "https://example.com/İ/group/project.git",
+          ssh_url_to_repo: "git@example.com:group/project.git",
+        }),
+        { subfolder: "İ" },
+      );
+
+      const glab = yield* GitLabCli.GitLabCli;
+      yield* glab.getRepositoryCloneUrls({
+        cwd: "/repo",
+        repository: "https://example.com/İ/group/project",
+      });
+
+      assert.deepStrictEqual(mockedRun.mock.lastCall?.[0].args, [
+        "api",
+        "projects/group%2Fproject",
+      ]);
+    }),
+  );
+
   it.effect("reads the relative URL root under the port the instance is served on", () =>
     Effect.gen(function* () {
       mockRepository(

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -184,7 +184,7 @@ layer("GitLabCli.layer", (it) => {
     }),
   );
 
-  it.effect("looks repositories up by the host and project path a URL names", () =>
+  it.effect("reduces a repository given as a URL to the project path it names", () =>
     Effect.gen(function* () {
       const repositoryJson = `{
         "path_with_namespace": "group/subgroup/project",
@@ -192,37 +192,24 @@ layer("GitLabCli.layer", (it) => {
         "http_url_to_repo": "https://sourcecontrol.example.com/group/subgroup/project.git",
         "ssh_url_to_repo": "git@sourcecontrol.example.com:group/subgroup/project.git"
       }`;
-      const onHost = [
-        "--hostname",
-        "sourcecontrol.example.com",
-        "projects/group%2Fsubgroup%2Fproject",
-      ];
+      const project = "projects/group%2Fsubgroup%2Fproject";
 
-      const cases: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
-        ["https://sourcecontrol.example.com/group/subgroup/project", onHost],
-        ["https://sourcecontrol.example.com/group/subgroup/project.git", onHost],
-        ["https://sourcecontrol.example.com/group/subgroup/project/-/tree/main", onHost],
-        ["https://sourcecontrol.example.com/group/subgroup/project?ref_type=heads", onHost],
-        ["git@sourcecontrol.example.com:group/subgroup/project.git", onHost],
-        ["sourcecontrol.example.com:group/subgroup/project.git", onHost],
-        // The ssh port is not the API's, so it is dropped; a web port is kept.
-        ["ssh://git@sourcecontrol.example.com:22/group/subgroup/project.git", onHost],
-        [
-          "https://sourcecontrol.example.com:8443/group/subgroup/project",
-          ["--hostname", "sourcecontrol.example.com:8443", "projects/group%2Fsubgroup%2Fproject"],
-        ],
+      const cases: ReadonlyArray<readonly [string, string]> = [
+        ["https://sourcecontrol.example.com/group/subgroup/project", project],
+        ["https://sourcecontrol.example.com/group/subgroup/project.git", project],
+        ["https://sourcecontrol.example.com/group/subgroup/project/-/tree/main", project],
+        ["https://sourcecontrol.example.com/group/subgroup/project?ref_type=heads", project],
+        ["git@sourcecontrol.example.com:group/subgroup/project.git", project],
+        ["sourcecontrol.example.com:group/subgroup/project.git", project],
+        ["ssh://git@sourcecontrol.example.com:22/group/subgroup/project.git", project],
         // A pasted URL arrives percent-encoded, so the path is decoded before it is encoded again.
         [
           "https://sourcecontrol.example.com/group/subgroup/pro%2Dject",
-          ["--hostname", "sourcecontrol.example.com", "projects/group%2Fsubgroup%2Fpro-ject"],
+          "projects/group%2Fsubgroup%2Fpro-ject",
         ],
         // Malformed escapes name no project, so the raw path stands rather than throwing.
-        [
-          "https://sourcecontrol.example.com/group/pro%ZZject",
-          ["--hostname", "sourcecontrol.example.com", "projects/group%2Fpro%25ZZject"],
-        ],
-        // A bare path names no host, so `glab` keeps resolving it against its own default.
-        ["group/subgroup/project", ["projects/group%2Fsubgroup%2Fproject"]],
+        ["https://sourcecontrol.example.com/group/pro%ZZject", "projects/group%2Fpro%25ZZject"],
+        ["group/subgroup/project", project],
       ];
 
       const sent: Array<readonly [string, ReadonlyArray<string> | undefined]> = [];
@@ -236,8 +223,35 @@ layer("GitLabCli.layer", (it) => {
 
       assert.deepStrictEqual(
         sent,
-        cases.map(([repository, expectedArgs]) => [repository, ["api", ...expectedArgs]]),
+        cases.map(([repository, path]) => [repository, ["api", path]]),
       );
+    }),
+  );
+
+  it.effect("refuses a project resolved on a host the URL did not name", () =>
+    Effect.gen(function* () {
+      mockedRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(`{
+            "path_with_namespace": "group/project",
+            "web_url": "https://gitlab.com/group/project",
+            "http_url_to_repo": "https://gitlab.com/group/project.git",
+            "ssh_url_to_repo": "git@gitlab.com:group/project.git"
+          }`),
+        ),
+      );
+
+      const error = yield* Effect.gen(function* () {
+        const glab = yield* GitLabCli.GitLabCli;
+        return yield* glab.getRepositoryCloneUrls({
+          cwd: "/repo",
+          repository: "https://sourcecontrol.example.com/group/project",
+        });
+      }).pipe(Effect.flip);
+
+      assert.strictEqual(error._tag, "GitLabRepositoryHostMismatchError");
+      assert.equal(error.detail.includes("sourcecontrol.example.com"), true);
+      assert.equal(error.detail.includes("gitlab.com"), true);
     }),
   );
 

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -29,6 +29,14 @@ function processOutput(stdout: string): VcsProcess.VcsProcessOutput {
   };
 }
 
+// A URL lookup reads the host's relative URL root before it asks for the project, so both
+// answers are dispatched on the subcommand rather than queued in order.
+function mockRepository(repositoryJson: string, subfolder = "") {
+  mockedRun.mockImplementation((run) =>
+    Effect.succeed(processOutput(run.args[0] === "config" ? subfolder : repositoryJson)),
+  );
+}
+
 afterEach(() => {
   mockedRun.mockReset();
 });
@@ -212,10 +220,13 @@ layer("GitLabCli.layer", (it) => {
         ["group/subgroup/project", project],
       ];
 
+      // No relative URL root configured, so the path is asked for as it was parsed.
+      mockedRun.mockImplementation((run) =>
+        Effect.succeed(processOutput(run.args[0] === "config" ? "" : repositoryJson)),
+      );
+
       const sent: Array<readonly [string, ReadonlyArray<string> | undefined]> = [];
       for (const [repository] of cases) {
-        mockedRun.mockReturnValueOnce(Effect.succeed(processOutput(repositoryJson)));
-
         const glab = yield* GitLabCli.GitLabCli;
         yield* glab.getRepositoryCloneUrls({ cwd: "/repo", repository });
         sent.push([repository, mockedRun.mock.lastCall?.[0].args]);
@@ -228,18 +239,67 @@ layer("GitLabCli.layer", (it) => {
     }),
   );
 
+  it.effect("drops the relative URL root of an instance hosted under a subfolder", () =>
+    Effect.gen(function* () {
+      mockRepository(
+        `{
+          "path_with_namespace": "group/project",
+          "web_url": "https://example.com/gitlab/group/project",
+          "http_url_to_repo": "https://example.com/gitlab/group/project.git",
+          "ssh_url_to_repo": "git@example.com:group/project.git"
+        }`,
+        "gitlab",
+      );
+
+      const glab = yield* GitLabCli.GitLabCli;
+      const urls = yield* glab.getRepositoryCloneUrls({
+        cwd: "/repo",
+        repository: "https://example.com/gitlab/group/project",
+      });
+
+      assert.deepStrictEqual(mockedRun.mock.calls[0]?.[0].args, [
+        "config",
+        "get",
+        "subfolder",
+        "--host",
+        "example.com",
+      ]);
+      assert.deepStrictEqual(mockedRun.mock.lastCall?.[0].args, [
+        "api",
+        "projects/group%2Fproject",
+      ]);
+      assert.strictEqual(urls.nameWithOwner, "group/project");
+    }),
+  );
+
+  it.effect("accepts a project served on a non-default port", () =>
+    Effect.gen(function* () {
+      mockRepository(`{
+            "path_with_namespace": "group/project",
+            "web_url": "https://sourcecontrol.example.com:8443/group/project",
+            "http_url_to_repo": "https://sourcecontrol.example.com:8443/group/project.git",
+            "ssh_url_to_repo": "git@sourcecontrol.example.com:group/project.git"
+          }`);
+
+      const glab = yield* GitLabCli.GitLabCli;
+      const urls = yield* glab.getRepositoryCloneUrls({
+        cwd: "/repo",
+        // An ssh remote never carries the web port, so the check has to compare without it.
+        repository: "git@sourcecontrol.example.com:group/project.git",
+      });
+
+      assert.strictEqual(urls.nameWithOwner, "group/project");
+    }),
+  );
+
   it.effect("refuses a project resolved on a host the URL did not name", () =>
     Effect.gen(function* () {
-      mockedRun.mockReturnValueOnce(
-        Effect.succeed(
-          processOutput(`{
+      mockRepository(`{
             "path_with_namespace": "group/project",
             "web_url": "https://gitlab.com/group/project",
             "http_url_to_repo": "https://gitlab.com/group/project.git",
             "ssh_url_to_repo": "git@gitlab.com:group/project.git"
-          }`),
-        ),
-      );
+          }`);
 
       const error = yield* Effect.gen(function* () {
         const glab = yield* GitLabCli.GitLabCli;

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -184,6 +184,54 @@ layer("GitLabCli.layer", (it) => {
     }),
   );
 
+  it.effect("looks repositories up by the host and project path a URL names", () =>
+    Effect.gen(function* () {
+      const repositoryJson =
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/subgroup/project",
+          web_url: "https://sourcecontrol.example.com/group/subgroup/project",
+          http_url_to_repo: "https://sourcecontrol.example.com/group/subgroup/project.git",
+          ssh_url_to_repo: "git@sourcecontrol.example.com:group/subgroup/project.git",
+        });
+      const onHost = [
+        "--hostname",
+        "sourcecontrol.example.com",
+        "projects/group%2Fsubgroup%2Fproject",
+      ];
+
+      const cases: ReadonlyArray<readonly [string, ReadonlyArray<string>]> = [
+        ["https://sourcecontrol.example.com/group/subgroup/project", onHost],
+        ["https://sourcecontrol.example.com/group/subgroup/project.git", onHost],
+        ["https://sourcecontrol.example.com/group/subgroup/project/-/tree/main", onHost],
+        ["https://sourcecontrol.example.com/group/subgroup/project?ref_type=heads", onHost],
+        ["git@sourcecontrol.example.com:group/subgroup/project.git", onHost],
+        // The ssh port is not the API's, so it is dropped; a web port is kept.
+        ["ssh://git@sourcecontrol.example.com:22/group/subgroup/project.git", onHost],
+        [
+          "https://sourcecontrol.example.com:8443/group/subgroup/project",
+          ["--hostname", "sourcecontrol.example.com:8443", "projects/group%2Fsubgroup%2Fproject"],
+        ],
+        // A bare path names no host, so `glab` keeps resolving it against its own default.
+        ["group/subgroup/project", ["projects/group%2Fsubgroup%2Fproject"]],
+      ];
+
+      const sent: Array<readonly [string, ReadonlyArray<string> | undefined]> = [];
+      for (const [repository] of cases) {
+        mockedRun.mockReturnValueOnce(Effect.succeed(processOutput(repositoryJson)));
+
+        const glab = yield* GitLabCli.GitLabCli;
+        yield* glab.getRepositoryCloneUrls({ cwd: "/repo", repository });
+        sent.push([repository, mockedRun.mock.lastCall?.[0].args]);
+      }
+
+      assert.deepStrictEqual(
+        sent,
+        cases.map(([repository, expectedArgs]) => [repository, ["api", ...expectedArgs]]),
+      );
+    }),
+  );
+
   it.effect("creates merge requests through the GitLab API without placing the body in argv", () =>
     Effect.gen(function* () {
       mockedRun.mockReturnValueOnce(Effect.succeed(processOutput("{}")));

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -340,6 +340,59 @@ layer("GitLabCli.layer", (it) => {
     }),
   );
 
+  it.effect("keeps a leading segment when the configured root belongs to another host", () =>
+    Effect.gen(function* () {
+      mockRepository(
+        `{
+          "path_with_namespace": "gitlab/group/project",
+          "web_url": "https://gitlab.com/gitlab/group/project",
+          "http_url_to_repo": "https://gitlab.com/gitlab/group/project.git",
+          "ssh_url_to_repo": "git@gitlab.com:gitlab/group/project.git"
+        }`,
+        // The relative root belongs to example.com, so a gitlab.com path keeps its own `gitlab/`.
+        { host: "https://example.com/gitlab" },
+      );
+
+      const glab = yield* GitLabCli.GitLabCli;
+      const urls = yield* glab.getRepositoryCloneUrls({
+        cwd: "/repo",
+        repository: "https://gitlab.com/gitlab/group/project",
+      });
+
+      assert.deepStrictEqual(mockedRun.mock.lastCall?.[0].args, [
+        "api",
+        "projects/gitlab%2Fgroup%2Fproject",
+      ]);
+      assert.strictEqual(urls.nameWithOwner, "gitlab/group/project");
+    }),
+  );
+
+  it.effect("keeps a root that would leave a project without its namespace", () =>
+    Effect.gen(function* () {
+      mockRepository(
+        `{
+          "path_with_namespace": "group/project",
+          "web_url": "https://example.com/group/project",
+          "http_url_to_repo": "https://example.com/group/project.git",
+          "ssh_url_to_repo": "git@example.com:group/project.git"
+        }`,
+        // `group` is the project's own namespace here, not an install root.
+        { subfolder: "group" },
+      );
+
+      const glab = yield* GitLabCli.GitLabCli;
+      yield* glab.getRepositoryCloneUrls({
+        cwd: "/repo",
+        repository: "https://example.com/group/project",
+      });
+
+      assert.deepStrictEqual(mockedRun.mock.lastCall?.[0].args, [
+        "api",
+        "projects/group%2Fproject",
+      ]);
+    }),
+  );
+
   it.effect("asks for a bare project path without reading any config", () =>
     Effect.gen(function* () {
       mockRepository(`{

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -31,10 +31,16 @@ function processOutput(stdout: string): VcsProcess.VcsProcessOutput {
 
 // A URL lookup reads the host's relative URL root before it asks for the project, so both
 // answers are dispatched on the subcommand rather than queued in order.
-function mockRepository(repositoryJson: string, subfolder = "") {
-  mockedRun.mockImplementation((run) =>
-    Effect.succeed(processOutput(run.args[0] === "config" ? subfolder : repositoryJson)),
-  );
+function mockRepository(
+  repositoryJson: string,
+  config: { readonly subfolder?: string; readonly host?: string } = {},
+) {
+  mockedRun.mockImplementation((run) => {
+    if (run.args[0] !== "config") return Effect.succeed(processOutput(repositoryJson));
+    return Effect.succeed(
+      processOutput(run.args[2] === "subfolder" ? (config.subfolder ?? "") : (config.host ?? "")),
+    );
+  });
 }
 
 afterEach(() => {
@@ -221,9 +227,7 @@ layer("GitLabCli.layer", (it) => {
       ];
 
       // No relative URL root configured, so the path is asked for as it was parsed.
-      mockedRun.mockImplementation((run) =>
-        Effect.succeed(processOutput(run.args[0] === "config" ? "" : repositoryJson)),
-      );
+      mockRepository(repositoryJson);
 
       const sent: Array<readonly [string, ReadonlyArray<string> | undefined]> = [];
       for (const [repository] of cases) {
@@ -248,7 +252,7 @@ layer("GitLabCli.layer", (it) => {
           "http_url_to_repo": "https://example.com/gitlab/group/project.git",
           "ssh_url_to_repo": "git@example.com:group/project.git"
         }`,
-        "gitlab",
+        { subfolder: "gitlab" },
       );
 
       const glab = yield* GitLabCli.GitLabCli;
@@ -272,6 +276,89 @@ layer("GitLabCli.layer", (it) => {
     }),
   );
 
+  it.effect("reads the relative URL root from a host configured with or without a scheme", () =>
+    Effect.gen(function* () {
+      // `glab config get host` answers with whatever was configured: a bare host and root, or the
+      // whole URL, as `GITLAB_HOST=https://example.com/gitlab` gives.
+      for (const host of ["example.com/gitlab", "https://example.com/gitlab"]) {
+        mockRepository(
+          `{
+            "path_with_namespace": "group/subgroup/project",
+            "web_url": "https://example.com/gitlab/group/subgroup/project",
+            "http_url_to_repo": "https://example.com/gitlab/group/subgroup/project.git",
+            "ssh_url_to_repo": "git@example.com:group/subgroup/project.git"
+          }`,
+          { host },
+        );
+
+        const glab = yield* GitLabCli.GitLabCli;
+        const urls = yield* glab.getRepositoryCloneUrls({
+          cwd: "/repo",
+          repository: "https://example.com/gitlab/group/subgroup/project.git",
+        });
+
+        assert.deepStrictEqual(
+          mockedRun.mock.lastCall?.[0].args,
+          ["api", "projects/group%2Fsubgroup%2Fproject"],
+          host,
+        );
+        assert.strictEqual(urls.nameWithOwner, "group/subgroup/project");
+      }
+    }),
+  );
+
+  it.effect("reads the relative URL root under the port the instance is served on", () =>
+    Effect.gen(function* () {
+      mockRepository(
+        `{
+          "path_with_namespace": "group/project",
+          "web_url": "https://example.com:8443/gitlab/group/project",
+          "http_url_to_repo": "https://example.com:8443/gitlab/group/project.git",
+          "ssh_url_to_repo": "git@example.com:group/project.git"
+        }`,
+        { subfolder: "gitlab" },
+      );
+
+      const glab = yield* GitLabCli.GitLabCli;
+      yield* glab.getRepositoryCloneUrls({
+        cwd: "/repo",
+        repository: "https://example.com:8443/gitlab/group/project",
+      });
+
+      // `glab` keys per-host settings by the configured address, so the port belongs in the ask.
+      assert.deepStrictEqual(mockedRun.mock.calls[0]?.[0].args, [
+        "config",
+        "get",
+        "subfolder",
+        "--host",
+        "example.com:8443",
+      ]);
+      assert.deepStrictEqual(mockedRun.mock.lastCall?.[0].args, [
+        "api",
+        "projects/group%2Fproject",
+      ]);
+    }),
+  );
+
+  it.effect("asks for a bare project path without reading any config", () =>
+    Effect.gen(function* () {
+      mockRepository(`{
+        "path_with_namespace": "group/subgroup/project",
+        "web_url": "https://gitlab.com/group/subgroup/project",
+        "http_url_to_repo": "https://gitlab.com/group/subgroup/project.git",
+        "ssh_url_to_repo": "git@gitlab.com:group/subgroup/project.git"
+      }`);
+
+      const glab = yield* GitLabCli.GitLabCli;
+      yield* glab.getRepositoryCloneUrls({ cwd: "/repo", repository: "group/subgroup/project" });
+
+      assert.deepStrictEqual(
+        mockedRun.mock.calls.map((call) => call[0].args),
+        [["api", "projects/group%2Fsubgroup%2Fproject"]],
+      );
+    }),
+  );
+
   it.effect("accepts a project served on a non-default port", () =>
     Effect.gen(function* () {
       mockRepository(`{
@@ -289,6 +376,28 @@ layer("GitLabCli.layer", (it) => {
       });
 
       assert.strictEqual(urls.nameWithOwner, "group/project");
+    }),
+  );
+
+  it.effect("refuses a project served on a different port than the URL named", () =>
+    Effect.gen(function* () {
+      mockRepository(`{
+        "path_with_namespace": "group/project",
+        "web_url": "https://sourcecontrol.example.com/group/project",
+        "http_url_to_repo": "https://sourcecontrol.example.com/group/project.git",
+        "ssh_url_to_repo": "git@sourcecontrol.example.com:group/project.git"
+      }`);
+
+      const error = yield* Effect.gen(function* () {
+        const glab = yield* GitLabCli.GitLabCli;
+        return yield* glab.getRepositoryCloneUrls({
+          cwd: "/repo",
+          repository: "https://sourcecontrol.example.com:8443/group/project",
+        });
+      }).pipe(Effect.flip);
+
+      assert.strictEqual(error._tag, "GitLabRepositoryHostMismatchError");
+      assert.equal(error.detail.includes("sourcecontrol.example.com:8443"), true);
     }),
   );
 

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -459,6 +459,31 @@ layer("GitLabCli.layer", (it) => {
     }),
   );
 
+  it.effect.each([
+    "https://sourcecontrol.example.com/group/project",
+    "https://sourcecontrol.example.com:443/group/project",
+  ])("does not treat the default web port as a wildcard: %s", (repository) =>
+    Effect.gen(function* () {
+      mockRepository(
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          path_with_namespace: "group/project",
+          web_url: "https://sourcecontrol.example.com:8443/group/project",
+          http_url_to_repo: "https://sourcecontrol.example.com:8443/group/project.git",
+          ssh_url_to_repo: "git@sourcecontrol.example.com:group/project.git",
+        }),
+      );
+
+      const error = yield* Effect.gen(function* () {
+        const glab = yield* GitLabCli.GitLabCli;
+        return yield* glab.getRepositoryCloneUrls({ cwd: "/repo", repository });
+      }).pipe(Effect.flip);
+
+      assert.strictEqual(error._tag, "GitLabRepositoryHostMismatchError");
+      assert.equal(error.detail.includes("sourcecontrol.example.com:8443"), true);
+    }),
+  );
+
   it.effect("refuses a project resolved on a host the URL did not name", () =>
     Effect.gen(function* () {
       mockRepository(

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -206,6 +206,7 @@ layer("GitLabCli.layer", (it) => {
         ["https://sourcecontrol.example.com/group/subgroup/project/-/tree/main", onHost],
         ["https://sourcecontrol.example.com/group/subgroup/project?ref_type=heads", onHost],
         ["git@sourcecontrol.example.com:group/subgroup/project.git", onHost],
+        ["sourcecontrol.example.com:group/subgroup/project.git", onHost],
         // The ssh port is not the API's, so it is dropped; a web port is kept.
         ["ssh://git@sourcecontrol.example.com:22/group/subgroup/project.git", onHost],
         [

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -420,9 +420,20 @@ function decodePathname(pathname: string): string {
   }
 }
 
-function hostOf(url: string): string | null {
+// A GitLab installed under a relative URL root serves its projects below that prefix, so the
+// prefix is part of the pasted URL but not part of the project path the API takes.
+function stripSubfolder(path: string, subfolder: string): string {
+  if (subfolder.length === 0) return path;
+
+  const prefix = `${subfolder.toLowerCase()}/`;
+  return path.toLowerCase().startsWith(prefix) && path.length > prefix.length
+    ? path.slice(prefix.length)
+    : path;
+}
+
+function hostnameOf(url: string): string | null {
   try {
-    return new URL(url).host.toLowerCase();
+    return new URL(url).hostname.toLowerCase();
   } catch {
     return null;
   }
@@ -442,11 +453,9 @@ function parseProjectTarget(repository: string): {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
     try {
       const url = new URL(trimmed);
-      // Port kept for web URLs, where it is part of the address, and dropped for ssh, where it
-      // belongs to the ssh endpoint rather than the one the project is served from.
-      host = (
-        url.protocol === "http:" || url.protocol === "https:" ? url.host : url.hostname
-      ).toLowerCase();
+      // Compared without the port, which an ssh remote never carries and a web URL may, so the
+      // two shapes of the same instance still agree.
+      host = url.hostname.toLowerCase();
       // `pathname` is percent-encoded, and the caller encodes the path it gets back, so decoding
       // here keeps a pasted URL from being encoded twice.
       path = decodePathname(url.pathname);
@@ -599,10 +608,26 @@ export const make = Effect.gen(function* () {
       ),
     getRepositoryCloneUrls: (input) => {
       const target = parseProjectTarget(input.repository);
-      return execute({
-        cwd: input.cwd,
-        args: ["api", `projects/${encodeURIComponent(target.path)}`],
-      }).pipe(
+      // Only a URL can carry the prefix, and reading it is a local config lookup rather than a
+      // request, so a bare path skips it.
+      const subfolder =
+        target.host === null
+          ? Effect.succeed("")
+          : execute({
+              cwd: input.cwd,
+              args: ["config", "get", "subfolder", "--host", target.host],
+            }).pipe(
+              Effect.map((result) => result.stdout.trim().replace(/^\/+|\/+$/g, "")),
+              Effect.orElseSucceed(() => ""),
+            );
+
+      return subfolder.pipe(
+        Effect.flatMap((prefix) =>
+          execute({
+            cwd: input.cwd,
+            args: ["api", `projects/${encodeURIComponent(stripSubfolder(target.path, prefix))}`],
+          }),
+        ),
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
           decodeGitLabRepositoryCloneUrls(raw).pipe(
@@ -622,7 +647,7 @@ export const make = Effect.gen(function* () {
         // The lookup runs on whichever host `glab` is signed in to, so a URL naming another
         // instance would otherwise resolve a same-named project on the wrong one.
         Effect.tap((urls) => {
-          const resolvedHost = hostOf(urls.url);
+          const resolvedHost = hostnameOf(urls.url);
           if (target.host === null || resolvedHost === null || resolvedHost === target.host) {
             return Effect.void;
           }

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -422,8 +422,8 @@ function decodePathname(pathname: string): string {
 function stripSubfolder(path: string, subfolder: string): string {
   if (subfolder.length === 0) return path;
 
-  const prefix = `${subfolder.toLowerCase()}/`;
-  if (!path.toLowerCase().startsWith(prefix)) return path;
+  const prefix = `${subfolder}/`;
+  if (!path.toLowerCase().startsWith(prefix.toLowerCase())) return path;
 
   const stripped = path.slice(prefix.length);
   return stripped.includes("/") ? stripped : path;

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -414,7 +414,8 @@ function parseProjectTarget(repository: string): {
       path = trimmed;
     }
   } else {
-    const scpStyle = /^[^/@\s]+@([^:/\s]+):(.+)$/.exec(trimmed);
+    // scp-style, where the user is optional the way `git clone host:group/project.git` allows.
+    const scpStyle = /^(?:[^/@\s]+@)?([^:/\s]+):(.+)$/.exec(trimmed);
     if (scpStyle?.[1] !== undefined && scpStyle[2] !== undefined) {
       host = scpStyle[1];
       path = scpStyle[2];

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -431,9 +431,29 @@ function stripSubfolder(path: string, subfolder: string): string {
     : path;
 }
 
-function hostnameOf(url: string): string | null {
+// `glab config get host` answers with whatever the user configured, which may be a bare hostname,
+// or a URL carrying the scheme and the relative root, as `GITLAB_HOST=https://example.com/gitlab`
+// does. Only the path part names the root.
+function relativeRootOf(configuredHost: string): string {
+  const value = configuredHost.trim();
+  if (value.length === 0) return "";
+
+  const addressed = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `https://${value}`;
   try {
-    return new URL(url).hostname.toLowerCase();
+    return new URL(addressed).pathname.replace(/^\/+|\/+$/g, "");
+  } catch {
+    return "";
+  }
+}
+
+function withPort(hostname: string, port: string): string {
+  return port === "" ? hostname : `${hostname}:${port}`;
+}
+
+function webAddressOf(url: string): { readonly hostname: string; readonly port: string } | null {
+  try {
+    const parsed = new URL(url);
+    return { hostname: parsed.hostname.toLowerCase(), port: parsed.port };
   } catch {
     return null;
   }
@@ -444,18 +464,21 @@ function hostnameOf(url: string): string | null {
 // resolved project can be checked against it; a bare path names no host and needs no check.
 function parseProjectTarget(repository: string): {
   readonly host: string | null;
+  readonly port: string;
   readonly path: string;
 } {
   const trimmed = repository.trim();
   let host: string | null = null;
+  let port = "";
   let path = trimmed;
 
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
     try {
       const url = new URL(trimmed);
-      // Compared without the port, which an ssh remote never carries and a web URL may, so the
-      // two shapes of the same instance still agree.
       host = url.hostname.toLowerCase();
+      // Only a web URL states the port the project is served from. An ssh remote's port belongs
+      // to its own endpoint, so it is left out rather than compared against the API's.
+      port = url.protocol === "http:" || url.protocol === "https:" ? url.port : "";
       // `pathname` is percent-encoded, and the caller encodes the path it gets back, so decoding
       // here keeps a pasted URL from being encoded twice.
       path = decodePathname(url.pathname);
@@ -477,7 +500,9 @@ function parseProjectTarget(repository: string): {
   const normalized = (beforeProjectContent ?? path)
     .replace(/^\/+|\/+$/g, "")
     .replace(/\.git$/i, "");
-  return normalized.length > 0 ? { host, path: normalized } : { host: null, path: trimmed };
+  return normalized.length > 0
+    ? { host, port, path: normalized }
+    : { host: null, port: "", path: trimmed };
 }
 
 function parseRepositoryPath(repository: string): {
@@ -610,15 +635,25 @@ export const make = Effect.gen(function* () {
       const target = parseProjectTarget(input.repository);
       // Only a URL can carry the prefix, and reading it is a local config lookup rather than a
       // request, so a bare path skips it.
+      const readConfig = (args: ReadonlyArray<string>) =>
+        execute({ cwd: input.cwd, args: ["config", "get", ...args] }).pipe(
+          Effect.map((result) => result.stdout.trim()),
+          Effect.orElseSucceed(() => ""),
+        );
       const subfolder =
         target.host === null
           ? Effect.succeed("")
-          : execute({
-              cwd: input.cwd,
-              args: ["config", "get", "subfolder", "--host", target.host],
-            }).pipe(
-              Effect.map((result) => result.stdout.trim().replace(/^\/+|\/+$/g, "")),
-              Effect.orElseSucceed(() => ""),
+          : // Per-host settings are keyed by the address as configured, port included, so an
+            // instance on a non-default port is asked for under that same address.
+            readConfig(["subfolder", "--host", withPort(target.host, target.port)]).pipe(
+              Effect.map((configured) => configured.replace(/^\/+|\/+$/g, "")),
+              // The key is only set when `glab auth login` was told about the root. A host given
+              // as a URL carries it in the path instead, so that is where it is read from next.
+              Effect.flatMap((configured) =>
+                configured.length > 0
+                  ? Effect.succeed(configured)
+                  : readConfig(["host"]).pipe(Effect.map(relativeRootOf)),
+              ),
             );
 
       return subfolder.pipe(
@@ -647,18 +682,22 @@ export const make = Effect.gen(function* () {
         // The lookup runs on whichever host `glab` is signed in to, so a URL naming another
         // instance would otherwise resolve a same-named project on the wrong one.
         Effect.tap((urls) => {
-          const resolvedHost = hostnameOf(urls.url);
-          if (target.host === null || resolvedHost === null || resolvedHost === target.host) {
-            return Effect.void;
-          }
+          const resolved = webAddressOf(urls.url);
+          if (target.host === null || resolved === null) return Effect.void;
+          // A stated port names one server among several a hostname may serve, so it is compared
+          // when the URL gave one and ignored when it did not.
+          const sameServer =
+            resolved.hostname === target.host &&
+            (target.port === "" || target.port === resolved.port);
+          if (sameServer) return Effect.void;
 
           return Effect.fail(
             new GitLabRepositoryHostMismatchError({
               command: "glab",
               cwd: input.cwd,
               operation: "getRepositoryCloneUrls",
-              requestedHost: target.host,
-              resolvedHost,
+              requestedHost: withPort(target.host, target.port),
+              resolvedHost: withPort(resolved.hostname, resolved.port),
             }),
           );
         }),

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -415,29 +415,20 @@ function decodePathname(pathname: string): string {
   try {
     return decodeURIComponent(pathname);
   } catch {
-    // Malformed escapes are not a project path either way, so the raw pathname stands.
     return pathname;
   }
 }
 
-// A GitLab installed under a relative URL root serves its projects below that prefix, so the
-// prefix is part of the pasted URL but not part of the project path the API takes.
 function stripSubfolder(path: string, subfolder: string): string {
   if (subfolder.length === 0) return path;
 
   const prefix = `${subfolder.toLowerCase()}/`;
   if (!path.toLowerCase().startsWith(prefix)) return path;
 
-  // A project path is a namespace and a project at the least, so a prefix that would leave one
-  // segment is naming that project's own group rather than an install root.
   const stripped = path.slice(prefix.length);
   return stripped.includes("/") ? stripped : path;
 }
 
-// `glab config get host` answers with whatever the user configured, which may be a bare hostname,
-// or a URL carrying the scheme and the relative root, as `GITLAB_HOST=https://example.com/gitlab`
-// does. Only the path part names the root, and it names it for that host alone, so a URL pointing
-// somewhere else keeps its own leading segment.
 function relativeRootOf(configuredHost: string, address: string): string {
   const value = configuredHost.trim();
   if (value.length === 0) return "";
@@ -465,9 +456,6 @@ function webAddressOf(url: string): { readonly hostname: string; readonly port: 
   }
 }
 
-// `glab api projects/:path` addresses a project by its namespace path, so a repository pasted as a
-// web or clone URL has to be reduced to that path first. The host the URL named is kept so the
-// resolved project can be checked against it; a bare path names no host and needs no check.
 function parseProjectTarget(repository: string): {
   readonly host: string | null;
   readonly port: string;
@@ -482,18 +470,13 @@ function parseProjectTarget(repository: string): {
     try {
       const url = new URL(trimmed);
       host = url.hostname.toLowerCase();
-      // Only a web URL states the port the project is served from. An ssh remote's port belongs
-      // to its own endpoint, so it is left out rather than compared against the API's.
       port = url.protocol === "http:" || url.protocol === "https:" ? url.port : "";
-      // `pathname` is percent-encoded, and the caller encodes the path it gets back, so decoding
-      // here keeps a pasted URL from being encoded twice.
       path = decodePathname(url.pathname);
     } catch {
       host = null;
       path = trimmed;
     }
   } else {
-    // scp-style, where the user is optional the way `git clone host:group/project.git` allows.
     const scpStyle = /^(?:[^/@\s]+@)?([^:/\s]+):(.+)$/.exec(trimmed);
     if (scpStyle?.[1] !== undefined && scpStyle[2] !== undefined) {
       host = scpStyle[1].toLowerCase();
@@ -501,7 +484,6 @@ function parseProjectTarget(repository: string): {
     }
   }
 
-  // GitLab hangs everything below a project off `/-/`, so a deeper URL still names its project.
   const [beforeProjectContent] = path.split("/-/");
   const normalized = (beforeProjectContent ?? path)
     .replace(/^\/+|\/+$/g, "")
@@ -639,23 +621,17 @@ export const make = Effect.gen(function* () {
       ),
     getRepositoryCloneUrls: (input) => {
       const target = parseProjectTarget(input.repository);
-      // Only a URL can carry the prefix, and reading it is a local config lookup rather than a
-      // request, so a bare path skips it.
       const readConfig = (args: ReadonlyArray<string>) =>
         execute({ cwd: input.cwd, args: ["config", "get", ...args] }).pipe(
           Effect.map((result) => result.stdout.trim()),
           Effect.orElseSucceed(() => ""),
         );
-      // Per-host settings are keyed by the address as configured, port included, so an instance
-      // on a non-default port is asked for under that same address.
       const address = target.host === null ? "" : withPort(target.host, target.port);
       const subfolder =
         target.host === null
           ? Effect.succeed("")
           : readConfig(["subfolder", "--host", address]).pipe(
               Effect.map((configured) => configured.replace(/^\/+|\/+$/g, "")),
-              // The key is only set when `glab auth login` was told about the root. A host given
-              // as a URL carries it in the path instead, so that is where it is read from next.
               Effect.flatMap((configured) =>
                 configured.length > 0
                   ? Effect.succeed(configured)
@@ -688,13 +664,9 @@ export const make = Effect.gen(function* () {
           ),
         ),
         Effect.map(normalizeRepositoryCloneUrls),
-        // The lookup runs on whichever host `glab` is signed in to, so a URL naming another
-        // instance would otherwise resolve a same-named project on the wrong one.
         Effect.tap((urls) => {
           const resolved = webAddressOf(urls.url);
           if (target.host === null || resolved === null) return Effect.void;
-          // A stated port names one server among several a hostname may serve, so it is compared
-          // when the URL gave one and ignored when it did not.
           const sameServer =
             resolved.hostname === target.host &&
             (target.port === "" || target.port === resolved.port);

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -225,6 +225,25 @@ export class GitLabNamespaceDecodeError extends Schema.TaggedErrorClass<GitLabNa
   }
 }
 
+export class GitLabRepositoryHostMismatchError extends Schema.TaggedErrorClass<GitLabRepositoryHostMismatchError>()(
+  "GitLabRepositoryHostMismatchError",
+  {
+    command: Schema.Literal("glab"),
+    cwd: Schema.String,
+    operation: Schema.Literal("getRepositoryCloneUrls"),
+    requestedHost: Schema.String,
+    resolvedHost: Schema.String,
+  },
+) {
+  get detail(): string {
+    return `This URL names ${this.requestedHost}, but GitLab CLI resolved the project on ${this.resolvedHost}. Run \`glab config set host ${this.requestedHost}\` and retry, or enter the project path to use ${this.resolvedHost}.`;
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
 export const GitLabCliError = Schema.Union([
   GitLabCliUnavailableError,
   GitLabCliAuthenticationError,
@@ -235,6 +254,7 @@ export const GitLabCliError = Schema.Union([
   GitLabMergeRequestDecodeError,
   GitLabRepositoryDecodeError,
   GitLabNamespaceDecodeError,
+  GitLabRepositoryHostMismatchError,
 ]);
 export type GitLabCliError = typeof GitLabCliError.Type;
 export const isGitLabCliError = Schema.is(GitLabCliError);
@@ -400,10 +420,17 @@ function decodePathname(pathname: string): string {
   }
 }
 
-// `glab api projects/:path` addresses a project by its namespace path on one host, so a repository
-// pasted as a web or clone URL has to be split into both first. Without the host the path alone
-// would be looked up on whichever host `glab` defaults to, which can resolve a same-named project
-// on the wrong instance. A bare path carries no host and keeps that default.
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+// `glab api projects/:path` addresses a project by its namespace path, so a repository pasted as a
+// web or clone URL has to be reduced to that path first. The host the URL named is kept so the
+// resolved project can be checked against it; a bare path names no host and needs no check.
 function parseProjectTarget(repository: string): {
   readonly host: string | null;
   readonly path: string;
@@ -415,8 +442,11 @@ function parseProjectTarget(repository: string): {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
     try {
       const url = new URL(trimmed);
-      // Port kept for web URLs, where it belongs to the API, and dropped for ssh, where it does not.
-      host = url.protocol === "http:" || url.protocol === "https:" ? url.host : url.hostname;
+      // Port kept for web URLs, where it is part of the address, and dropped for ssh, where it
+      // belongs to the ssh endpoint rather than the one the project is served from.
+      host = (
+        url.protocol === "http:" || url.protocol === "https:" ? url.host : url.hostname
+      ).toLowerCase();
       // `pathname` is percent-encoded, and the caller encodes the path it gets back, so decoding
       // here keeps a pasted URL from being encoded twice.
       path = decodePathname(url.pathname);
@@ -428,7 +458,7 @@ function parseProjectTarget(repository: string): {
     // scp-style, where the user is optional the way `git clone host:group/project.git` allows.
     const scpStyle = /^(?:[^/@\s]+@)?([^:/\s]+):(.+)$/.exec(trimmed);
     if (scpStyle?.[1] !== undefined && scpStyle[2] !== undefined) {
-      host = scpStyle[1];
+      host = scpStyle[1].toLowerCase();
       path = scpStyle[2];
     }
   }
@@ -571,11 +601,7 @@ export const make = Effect.gen(function* () {
       const target = parseProjectTarget(input.repository);
       return execute({
         cwd: input.cwd,
-        args: [
-          "api",
-          ...(target.host === null ? [] : ["--hostname", target.host]),
-          `projects/${encodeURIComponent(target.path)}`,
-        ],
+        args: ["api", `projects/${encodeURIComponent(target.path)}`],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
@@ -593,6 +619,24 @@ export const make = Effect.gen(function* () {
           ),
         ),
         Effect.map(normalizeRepositoryCloneUrls),
+        // The lookup runs on whichever host `glab` is signed in to, so a URL naming another
+        // instance would otherwise resolve a same-named project on the wrong one.
+        Effect.tap((urls) => {
+          const resolvedHost = hostOf(urls.url);
+          if (target.host === null || resolvedHost === null || resolvedHost === target.host) {
+            return Effect.void;
+          }
+
+          return Effect.fail(
+            new GitLabRepositoryHostMismatchError({
+              command: "glab",
+              cwd: input.cwd,
+              operation: "getRepositoryCloneUrls",
+              requestedHost: target.host,
+              resolvedHost,
+            }),
+          );
+        }),
       );
     },
     createRepository: (input) => {

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -391,6 +391,15 @@ function toSummaryWithOptionalUpdatedAt(
   return Option.isSome(updatedAt) ? { ...summary, updatedAt } : summary;
 }
 
+function decodePathname(pathname: string): string {
+  try {
+    return decodeURIComponent(pathname);
+  } catch {
+    // Malformed escapes are not a project path either way, so the raw pathname stands.
+    return pathname;
+  }
+}
+
 // `glab api projects/:path` addresses a project by its namespace path on one host, so a repository
 // pasted as a web or clone URL has to be split into both first. Without the host the path alone
 // would be looked up on whichever host `glab` defaults to, which can resolve a same-named project
@@ -408,7 +417,9 @@ function parseProjectTarget(repository: string): {
       const url = new URL(trimmed);
       // Port kept for web URLs, where it belongs to the API, and dropped for ssh, where it does not.
       host = url.protocol === "http:" || url.protocol === "https:" ? url.host : url.hostname;
-      path = url.pathname;
+      // `pathname` is percent-encoded, and the caller encodes the path it gets back, so decoding
+      // here keeps a pasted URL from being encoded twice.
+      path = decodePathname(url.pathname);
     } catch {
       host = null;
       path = trimmed;

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -426,21 +426,27 @@ function stripSubfolder(path: string, subfolder: string): string {
   if (subfolder.length === 0) return path;
 
   const prefix = `${subfolder.toLowerCase()}/`;
-  return path.toLowerCase().startsWith(prefix) && path.length > prefix.length
-    ? path.slice(prefix.length)
-    : path;
+  if (!path.toLowerCase().startsWith(prefix)) return path;
+
+  // A project path is a namespace and a project at the least, so a prefix that would leave one
+  // segment is naming that project's own group rather than an install root.
+  const stripped = path.slice(prefix.length);
+  return stripped.includes("/") ? stripped : path;
 }
 
 // `glab config get host` answers with whatever the user configured, which may be a bare hostname,
 // or a URL carrying the scheme and the relative root, as `GITLAB_HOST=https://example.com/gitlab`
-// does. Only the path part names the root.
-function relativeRootOf(configuredHost: string): string {
+// does. Only the path part names the root, and it names it for that host alone, so a URL pointing
+// somewhere else keeps its own leading segment.
+function relativeRootOf(configuredHost: string, address: string): string {
   const value = configuredHost.trim();
   if (value.length === 0) return "";
 
   const addressed = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `https://${value}`;
   try {
-    return new URL(addressed).pathname.replace(/^\/+|\/+$/g, "");
+    const url = new URL(addressed);
+    if (withPort(url.hostname.toLowerCase(), url.port) !== address) return "";
+    return url.pathname.replace(/^\/+|\/+$/g, "");
   } catch {
     return "";
   }
@@ -640,19 +646,22 @@ export const make = Effect.gen(function* () {
           Effect.map((result) => result.stdout.trim()),
           Effect.orElseSucceed(() => ""),
         );
+      // Per-host settings are keyed by the address as configured, port included, so an instance
+      // on a non-default port is asked for under that same address.
+      const address = target.host === null ? "" : withPort(target.host, target.port);
       const subfolder =
         target.host === null
           ? Effect.succeed("")
-          : // Per-host settings are keyed by the address as configured, port included, so an
-            // instance on a non-default port is asked for under that same address.
-            readConfig(["subfolder", "--host", withPort(target.host, target.port)]).pipe(
+          : readConfig(["subfolder", "--host", address]).pipe(
               Effect.map((configured) => configured.replace(/^\/+|\/+$/g, "")),
               // The key is only set when `glab auth login` was told about the root. A host given
               // as a URL carries it in the path instead, so that is where it is read from next.
               Effect.flatMap((configured) =>
                 configured.length > 0
                   ? Effect.succeed(configured)
-                  : readConfig(["host"]).pipe(Effect.map(relativeRootOf)),
+                  : readConfig(["host"]).pipe(
+                      Effect.map((configured) => relativeRootOf(configured, address)),
+                    ),
               ),
             );
 

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -458,19 +458,19 @@ function webAddressOf(url: string): { readonly hostname: string; readonly port: 
 
 function parseProjectTarget(repository: string): {
   readonly host: string | null;
-  readonly port: string;
+  readonly port: string | null;
   readonly path: string;
 } {
   const trimmed = repository.trim();
   let host: string | null = null;
-  let port = "";
+  let port: string | null = null;
   let path = trimmed;
 
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
     try {
       const url = new URL(trimmed);
       host = url.hostname.toLowerCase();
-      port = url.protocol === "http:" || url.protocol === "https:" ? url.port : "";
+      port = url.protocol === "http:" || url.protocol === "https:" ? url.port : null;
       path = decodePathname(url.pathname);
     } catch {
       host = null;
@@ -490,7 +490,7 @@ function parseProjectTarget(repository: string): {
     .replace(/\.git$/i, "");
   return normalized.length > 0
     ? { host, port, path: normalized }
-    : { host: null, port: "", path: trimmed };
+    : { host: null, port: null, path: trimmed };
 }
 
 function parseRepositoryPath(repository: string): {
@@ -626,7 +626,7 @@ export const make = Effect.gen(function* () {
           Effect.map((result) => result.stdout.trim()),
           Effect.orElseSucceed(() => ""),
         );
-      const address = target.host === null ? "" : withPort(target.host, target.port);
+      const address = target.host === null ? "" : withPort(target.host, target.port ?? "");
       const subfolder =
         target.host === null
           ? Effect.succeed("")
@@ -669,7 +669,7 @@ export const make = Effect.gen(function* () {
           if (target.host === null || resolved === null) return Effect.void;
           const sameServer =
             resolved.hostname === target.host &&
-            (target.port === "" || target.port === resolved.port);
+            (target.port === null || target.port === resolved.port);
           if (sameServer) return Effect.void;
 
           return Effect.fail(
@@ -677,7 +677,7 @@ export const make = Effect.gen(function* () {
               command: "glab",
               cwd: input.cwd,
               operation: "getRepositoryCloneUrls",
-              requestedHost: withPort(target.host, target.port),
+              requestedHost: withPort(target.host, target.port ?? ""),
               resolvedHost: withPort(resolved.hostname, resolved.port),
             }),
           );

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -391,6 +391,44 @@ function toSummaryWithOptionalUpdatedAt(
   return Option.isSome(updatedAt) ? { ...summary, updatedAt } : summary;
 }
 
+// `glab api projects/:path` addresses a project by its namespace path on one host, so a repository
+// pasted as a web or clone URL has to be split into both first. Without the host the path alone
+// would be looked up on whichever host `glab` defaults to, which can resolve a same-named project
+// on the wrong instance. A bare path carries no host and keeps that default.
+function parseProjectTarget(repository: string): {
+  readonly host: string | null;
+  readonly path: string;
+} {
+  const trimmed = repository.trim();
+  let host: string | null = null;
+  let path = trimmed;
+
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      // Port kept for web URLs, where it belongs to the API, and dropped for ssh, where it does not.
+      host = url.protocol === "http:" || url.protocol === "https:" ? url.host : url.hostname;
+      path = url.pathname;
+    } catch {
+      host = null;
+      path = trimmed;
+    }
+  } else {
+    const scpStyle = /^[^/@\s]+@([^:/\s]+):(.+)$/.exec(trimmed);
+    if (scpStyle?.[1] !== undefined && scpStyle[2] !== undefined) {
+      host = scpStyle[1];
+      path = scpStyle[2];
+    }
+  }
+
+  // GitLab hangs everything below a project off `/-/`, so a deeper URL still names its project.
+  const [beforeProjectContent] = path.split("/-/");
+  const normalized = (beforeProjectContent ?? path)
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\.git$/i, "");
+  return normalized.length > 0 ? { host, path: normalized } : { host: null, path: trimmed };
+}
+
 function parseRepositoryPath(repository: string): {
   readonly namespacePath: string | null;
   readonly projectPath: string;
@@ -517,10 +555,15 @@ export const make = Effect.gen(function* () {
           ),
         ),
       ),
-    getRepositoryCloneUrls: (input) =>
-      execute({
+    getRepositoryCloneUrls: (input) => {
+      const target = parseProjectTarget(input.repository);
+      return execute({
         cwd: input.cwd,
-        args: ["api", `projects/${encodeURIComponent(input.repository)}`],
+        args: [
+          "api",
+          ...(target.host === null ? [] : ["--hostname", target.host]),
+          `projects/${encodeURIComponent(target.path)}`,
+        ],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
@@ -538,7 +581,8 @@ export const make = Effect.gen(function* () {
           ),
         ),
         Effect.map(normalizeRepositoryCloneUrls),
-      ),
+      );
+    },
     createRepository: (input) => {
       const { namespacePath, projectPath } = parseRepositoryPath(input.repository);
       const namespaceId: Effect.Effect<number | null, GitLabCliError> = namespacePath


### PR DESCRIPTION
GitLab repository lookup encodes a pasted Git URL as the API project ID, producing requests such as `projects/https%3A%2F%2F...` instead of `projects/group%2Fproject`.

Normalize web, clone, SSH, scp-style, and project-content links to the namespace/project path. Read the configured relative installation root when present, preserve nested namespaces, and leave bare project paths unchanged. The API call still uses glab's existing host selection. It does not send authentication to an arbitrary pasted hostname.

Check the returned project's web host and the requested web port before returning clone URLs. SSH remotes do not identify a web port, so they retain the existing host-only check. During preparation, two regressions exposed a default-port bug in the original patch: web URLs with an omitted port or explicit 443 accepted a result from 8443. The fix distinguishes an unknown SSH web port from a known default web port.

Addresses [#7849](https://github.com/pingdotgg/t3code/issues/7849). Carries the relative-install-root cases requested from [#7944](https://github.com/pingdotgg/t3code/pull/7944).

Verification rebased onto main [82f64cd8](https://github.com/pingdotgg/t3code/commit/82f64cd8d046ab4ee8588f7bcbc1e66a4a0c80fe):

- The normalization regression fails against the unchanged production implementation. Full URLs and SSH remotes are encoded into the project ID; the bare project-path control remains correct.
- The two new default-port controls fail on the original PR and pass after the fix. The existing SSH-to-nondefault-web-port control still passes.
- A review follow-up reproduced a Unicode installation root being sliced at the length of its lowercased spelling: `İ/group/project` became `roup/project`. Preserve the original prefix for slicing; the focused regression fails before and passes after this fix.
- `vp test run apps/server/src/sourceControl/GitLabCli.test.ts apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts apps/server/src/sourceControl/SourceControlRepositoryService.test.ts --maxWorkers=2`: 36 tests pass. Targeted lint/format and the server typecheck pass.

Human review is required for host selection and installation-root behavior. Legitimate deployments with different SSH and web hostnames still fail the returned-web-host check; deciding how to trust or map those aliases remains unresolved. A live authenticated self-hosted GitLab check is also missing. These are explicit remaining gates, not claims of completed support. Leave this PR unmerged.

Refreshed September 5 onto main [ce4712d](https://github.com/pingdotgg/t3code/commit/ce4712d5b04fb998f79fe132245289191147e5d5), which fixes the Ubuntu CI mirror transport upstream. Both changed source/test files are byte-identical to the previously reviewed candidate. All 36 focused tests, the server typecheck and targeted lint/format pass again. Current-head CI and Bugbot pass at [1116c2ed](https://github.com/pingdotgg/t3code/commit/1116c2ed2c2cd2cbfaeed290acdc707b5a692c83). All ten review threads are resolved, with no active change requests. The earlier approvability rejection and the stated human decisions remain; passing CI does not waive them. The previous [CI run 33935585794](https://github.com/pingdotgg/t3code/actions/runs/33935585794) exhausted its one retry on the old HTTP mirror failure; it is not counted as passing. This PR adds no workflow changes or bypasses. The stated human and live-account gates remain, so it is not merge-ready.

The verification uses production services with a recorded process boundary, not a live account. Screenshots cannot establish request arguments and no visual change is claimed.

Original implementation by StefNef. Port regression fix and updated verification by GPT 6 Astra via Codex in T3 Code.

