### PR TITLE
fix(antigravity): forward Google sign-in URLs from browser helper

### DIFF
--- a/apps/server/src/provider/AntigravityAuth.test.ts
+++ b/apps/server/src/provider/AntigravityAuth.test.ts
@@ -54,6 +54,7 @@ const phase = (auth: AntigravityAuth, value: ProviderAuthState["phase"], session
 const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
   options: {
     readonly interactive?: boolean;
+    readonly authorizationUrls?: ReadonlyArray<string>;
     readonly supportsLogout?: boolean;
     readonly forwardCallback?: Effect.Effect<void, ProviderSetupError>;
   } = {},
@@ -87,7 +88,9 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
             Effect.gen(function* () {
               events.push("authenticate");
               if (options.interactive !== false && input.onAuthorizationUrl) {
-                yield* input.onAuthorizationUrl(authorizationUrl);
+                for (const url of options.authorizationUrls ?? [authorizationUrl]) {
+                  yield* input.onAuthorizationUrl(url);
+                }
               }
               yield* Deferred.await(authenticated);
               events.push("session-new");
@@ -128,6 +131,34 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
 });
 
 it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
+  it.effect("accepts the same authorization URL from stderr and stdout", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        authorizationUrls: [authorizationUrl, authorizationUrl],
+      });
+      yield* harness.auth.controller.start(owner);
+      const waiting = yield* phase(harness.auth, "waiting");
+      assert.equal(waiting.authorizationUrl, authorizationUrl);
+
+      yield* Deferred.succeed(harness.authenticated, undefined);
+      yield* Deferred.succeed(harness.discovered, undefined);
+      yield* phase(harness.auth, "succeeded");
+    }),
+  );
+
+  it.effect("rejects a different second authorization URL", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        authorizationUrls: [authorizationUrl, `${authorizationUrl}&scope=another-request`],
+      });
+      yield* harness.auth.controller.start(owner);
+
+      const failed = yield* phase(harness.auth, "failed");
+      assert.isNull(failed.authorizationUrl);
+      assert.deepEqual(harness.catalog(), ["previous-account-model"]);
+    }),
+  );
+
   it.effect("keeps a remote flow private and waits for native auth and catalog discovery", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness();

--- a/apps/server/src/provider/AntigravityAuth.test.ts
+++ b/apps/server/src/provider/AntigravityAuth.test.ts
@@ -63,12 +63,16 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
   const discovered = yield* Deferred.make<void>();
   const closed = yield* Deferred.make<void>();
   const events: string[] = [];
+  let receiveAuthorizationUrl:
+    | ((url: string) => Effect.Effect<void, AcpErrors.AcpError>)
+    | undefined;
   let forwarded = 0;
   let catalog = ["previous-account-model"];
   const auth = yield* makeAntigravityAuth({
     instanceId,
     makeRuntime: (input) =>
       Effect.gen(function* () {
+        receiveAuthorizationUrl = input.onAuthorizationUrl;
         events.push("process-open");
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
@@ -127,6 +131,12 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
     events,
     catalog: () => catalog,
     forwarded: () => forwarded,
+    receiveAuthorizationUrl: (url: string) =>
+      Effect.suspend(() =>
+        receiveAuthorizationUrl
+          ? receiveAuthorizationUrl(url)
+          : Effect.die("Authorization URL receiver is not ready."),
+      ),
   };
 });
 
@@ -139,6 +149,24 @@ it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
       yield* harness.auth.controller.start(owner);
       const waiting = yield* phase(harness.auth, "waiting");
       assert.equal(waiting.authorizationUrl, authorizationUrl);
+
+      yield* Deferred.succeed(harness.authenticated, undefined);
+      yield* Deferred.succeed(harness.discovered, undefined);
+      yield* phase(harness.auth, "succeeded");
+    }),
+  );
+
+  it.effect("accepts a delayed duplicate after callback completion starts", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const state = yield* harness.auth.controller.start(owner);
+      yield* phase(harness.auth, "waiting");
+      yield* harness.auth.controller.complete(owner, {
+        flowId: state.flowId!,
+        callbackUrl,
+      });
+
+      yield* harness.receiveAuthorizationUrl(authorizationUrl);
 
       yield* Deferred.succeed(harness.authenticated, undefined);
       yield* Deferred.succeed(harness.discovered, undefined);

--- a/apps/server/src/provider/AntigravityAuth.ts
+++ b/apps/server/src/provider/AntigravityAuth.ts
@@ -20,11 +20,13 @@ import * as SubscriptionRef from "effect/SubscriptionRef";
 import * as AcpErrors from "effect-acp/errors";
 
 import type { AcpSessionRuntime, AcpSessionRuntimeStartResult } from "./acp/AcpSessionRuntime.ts";
-import { parseAntigravityAuthorizationUrl } from "./antigravityAuthSupport.ts";
+import {
+  parseAntigravityAuthorizationUrl,
+  type AntigravityAuthorizationUrl,
+} from "./antigravityAuthSupport.ts";
 import {
   forwardAntigravityCallback,
   validateAntigravityCallbackUrl,
-  type AntigravityPendingCallback,
 } from "./antigravityCallback.ts";
 import type { ProviderAuthController } from "./Services/ProviderAuthService.ts";
 
@@ -43,7 +45,7 @@ interface AuthFlow {
   readonly ownerSessionId: string;
   readonly expiresAtMillis: number;
   state: ProviderAuthState;
-  pending: AntigravityPendingCallback | undefined;
+  pending: AntigravityAuthorizationUrl | undefined;
   callbackSent: boolean;
   fiber: Fiber.Fiber<void> | undefined;
   forwarding: Fiber.Fiber<void, ProviderSetupError> | undefined;
@@ -239,7 +241,7 @@ export const makeAntigravityAuth = Effect.fn("makeAntigravityAuth")(function* <
           Effect.gen(function* () {
             if (activeFlow !== flow || operation !== "auth") return;
             if (flow.pending) {
-              if (flow.state.authorizationUrl === authorization.authorizationUrl) return;
+              if (flow.pending.authorizationUrl === authorization.authorizationUrl) return;
               return yield* new AcpErrors.AcpTransportError({
                 detail: "Antigravity started more than one Google sign-in request.",
                 cause: undefined,

--- a/apps/server/src/provider/AntigravityAuth.ts
+++ b/apps/server/src/provider/AntigravityAuth.ts
@@ -239,6 +239,7 @@ export const makeAntigravityAuth = Effect.fn("makeAntigravityAuth")(function* <
           Effect.gen(function* () {
             if (activeFlow !== flow || operation !== "auth") return;
             if (flow.pending) {
+              if (flow.state.authorizationUrl === authorization.authorizationUrl) return;
               return yield* new AcpErrors.AcpTransportError({
                 detail: "Antigravity started more than one Google sign-in request.",
                 cause: undefined,

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -13,6 +13,7 @@ import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
@@ -407,6 +408,27 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
         expect(snapshot.models).toEqual(buildAntigravityModelsFromSession(sessionSetupResult));
         expect(snapshot.slashCommands).toEqual(commands);
         expect(snapshot.workspaceSnapshots?.[0]?.cwd).toBe("/workspace");
+      }),
+    ),
+  );
+
+  it.effect("allows a slow packaged runtime health check to finish", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        yield* harness.initialize;
+        yield* Ref.set(harness.probe, Effect.sleep("20 seconds").pipe(Effect.as(initializeResult)));
+
+        const refresh = yield* harness.provider.snapshot.refresh.pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust("20 seconds");
+        const snapshot = yield* Fiber.join(refresh);
+
+        expect(snapshot).toMatchObject({
+          installed: true,
+          status: "warning",
+          auth: { status: "unknown" },
+        });
       }),
     ),
   );

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -32,6 +32,7 @@ import {
 
 const EMPTY_MODEL_CAPABILITIES = createModelCapabilities({ optionDescriptors: [] });
 const MAX_WORKSPACE_SNAPSHOTS = 32;
+const HEALTH_CHECK_TIMEOUT = "45 seconds";
 const SIGN_IN_MESSAGE = "Sign in with Google to use Antigravity.";
 const AUTH_UNCHECKED_MESSAGE =
   "Antigravity is installed. Google account access is not checked yet.";
@@ -166,7 +167,10 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
   const checkProvider = Effect.fn("checkAntigravityProvider")(function* () {
     if (!settings.enabled) return yield* getSnapshot;
     const before = yield* SubscriptionRef.get(metadata);
-    const result = yield* options.probe.pipe(Effect.timeoutOption("15 seconds"), Effect.result);
+    const result = yield* options.probe.pipe(
+      Effect.timeoutOption(HEALTH_CHECK_TIMEOUT),
+      Effect.result,
+    );
     const initialized =
       Result.isSuccess(result) && Option.isSome(result.success) ? result.success.value : undefined;
     const failure = Result.isFailure(result) ? result.failure : undefined;
@@ -180,7 +184,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
             ? "Antigravity is not installed or its executable could not be found."
             : failure
               ? "Antigravity could not complete its local health check."
-              : "Antigravity did not respond to its local health check within 15 seconds.";
+              : `Antigravity did not respond to its local health check within ${HEALTH_CHECK_TIMEOUT}.`;
     const supportsTextGeneration =
       initialized !== undefined ? yield* options.supportsTextGeneration : false;
     const updatedAt = DateTime.formatIso(yield* DateTime.now);

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -327,7 +327,7 @@ describe("AcpSessionRuntime", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
-  it.effect("drains large stderr output and bounds optional logging chunks", () =>
+  it.effect("drains large stderr output and keeps auth-sized logging chunks", () =>
     Effect.gen(function* () {
       const lengths: Array<number> = [];
       for (const logStderr of [false, true]) {
@@ -348,7 +348,8 @@ describe("AcpSessionRuntime", () => {
         }).pipe(Effect.scoped);
       }
       expect(lengths.length).toBeGreaterThan(0);
-      expect(Math.max(...lengths)).toBeLessThanOrEqual(8_192);
+      expect(Math.max(...lengths)).toBeGreaterThanOrEqual(16_384);
+      expect(Math.max(...lengths)).toBeLessThanOrEqual(32_768);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -66,7 +66,8 @@ const defaultSessionLoadTimeout = Duration.seconds(90);
 const defaultSessionLoadReplayIdleGap = Duration.seconds(2);
 const defaultCancelTimeout = Duration.seconds(15);
 const maxStartupMetadataUpdates = 32;
-const maxStderrChunkLength = 8_192;
+// Antigravity can emit an accepted 16 KiB Google authorization URL on stderr.
+const maxStderrChunkLength = 32_768;
 
 export interface AcpSpawnInput {
   readonly command: string;

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -19,7 +19,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import {
-  drainAntigravityStderr,
+  makeAntigravityStderrHandler,
   makeAntigravityStdoutTransform,
 } from "../antigravityAuthSupport.ts";
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
@@ -73,7 +73,13 @@ export const makeAntigravityAcpRuntime = Effect.fn("makeAntigravityAcpRuntime")(
       transformStdout: makeAntigravityStdoutTransform(
         input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
       ),
-      onStderr: drainAntigravityStderr,
+      ...(input.onAuthorizationUrl
+        ? {
+            onStderr: makeAntigravityStderrHandler({
+              onAuthorizationUrl: input.onAuthorizationUrl,
+            }),
+          }
+        : {}),
       transformSessionUpdate: normalizeAntigravitySessionUpdate,
     }).pipe(
       Layer.provide(

--- a/apps/server/src/provider/antigravityAuthSupport.test.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.test.ts
@@ -391,6 +391,23 @@ describe("Antigravity stdout compatibility", () => {
 });
 
 describe("Antigravity stderr compatibility", () => {
+  it.effect("forwards an accepted browser-helper URL larger than 8 KiB", () =>
+    Effect.gen(function* () {
+      const urls: string[] = [];
+      const longAuthorizationUrl = `${authorizationUrl}&scope=${"a".repeat(9_000)}`;
+      const handleStderr = makeAntigravityStderrHandler({
+        onAuthorizationUrl: (url) => Effect.sync(() => void urls.push(url)),
+      });
+
+      expect(longAuthorizationUrl.length).toBeGreaterThan(8_192);
+      yield* handleStderr(
+        `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeUnknownJson(longAuthorizationUrl)}\n`,
+      );
+
+      expect(urls).toEqual([longAuthorizationUrl]);
+    }),
+  );
+
   it.effect("forwards a fragmented browser-helper URL without exposing other stderr", () =>
     Effect.gen(function* () {
       const urls: string[] = [];

--- a/apps/server/src/provider/antigravityAuthSupport.test.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.test.ts
@@ -17,6 +17,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as AcpErrors from "effect-acp/errors";
 
 import {
+  ANTIGRAVITY_AUTH_BROWSER_MARKER,
   ANTIGRAVITY_AUTH_STDOUT_PREFIX,
   ANTIGRAVITY_PERSONAL_AUTH,
   ANTIGRAVITY_SIGN_IN_REQUIRED_MESSAGE,
@@ -26,6 +27,7 @@ import {
   antigravityProfileSettings,
   buildAntigravityAcpSpawnInput,
   isAntigravitySignInRequiredError,
+  makeAntigravityStderrHandler,
   makeAntigravityStdoutTransform,
   parseAntigravityAuthorizationUrl,
   prepareAntigravityProfile,
@@ -384,6 +386,43 @@ describe("Antigravity stdout compatibility", () => {
         _tag: "AcpTransportError",
         detail: "Antigravity sent a protocol line that is too large.",
       });
+    }),
+  );
+});
+
+describe("Antigravity stderr compatibility", () => {
+  it.effect("forwards a fragmented browser-helper URL without exposing other stderr", () =>
+    Effect.gen(function* () {
+      const urls: string[] = [];
+      const markerLine = `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeUnknownJson(authorizationUrl)}\n`;
+      const handleStderr = makeAntigravityStderrHandler({
+        onAuthorizationUrl: (url) => Effect.sync(() => void urls.push(url)),
+      });
+
+      yield* handleStderr(`native log\n${markerLine.slice(0, 12)}`);
+      yield* handleStderr(markerLine.slice(12, 70));
+      yield* handleStderr(`${markerLine.slice(70)}another native log\n`);
+
+      expect(urls).toEqual([authorizationUrl]);
+    }),
+  );
+
+  it.effect("ignores malformed and similar browser-helper messages", () =>
+    Effect.gen(function* () {
+      const urls: string[] = [];
+      const handleStderr = makeAntigravityStderrHandler({
+        onAuthorizationUrl: (url) => Effect.sync(() => void urls.push(url)),
+      });
+
+      yield* handleStderr(
+        ` ${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeUnknownJson(authorizationUrl)}\n`,
+      );
+      yield* handleStderr(`${ANTIGRAVITY_AUTH_BROWSER_MARKER}${authorizationUrl}\n`);
+      yield* handleStderr(
+        `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeUnknownJson("https://example.com")}\n`,
+      );
+
+      expect(urls).toEqual([]);
     }),
   );
 });

--- a/apps/server/src/provider/antigravityAuthSupport.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.ts
@@ -24,9 +24,12 @@ export const ANTIGRAVITY_SIGN_IN_REQUIRED_MESSAGE =
   "Sign in to Antigravity in Settings before you continue.";
 
 const maxAuthorizationUrlLength = 16_384;
+const maxBrowserHelperLineLength =
+  ANTIGRAVITY_AUTH_BROWSER_MARKER.length + maxAuthorizationUrlLength + 2;
 const maxStdoutLineBytes = 16 * 1024 * 1024;
 const authPrefixBytes = new TextEncoder().encode(ANTIGRAVITY_AUTH_STDOUT_PREFIX);
 const decodeUrl = Schema.decodeUnknownEffect(Schema.URLFromString);
+const decodeBrowserHelperUrl = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.String));
 const ProfileSettingsFile = Schema.Struct({
   auth: Schema.Struct({ type: Schema.String }),
   gcp: Schema.optional(
@@ -455,5 +458,32 @@ export function makeAntigravityStdoutTransform(
     });
 }
 
-/** Upstream stderr can contain OAuth URLs, states, and redirect codes. */
-export const drainAntigravityStderr = (_text: string): Effect.Effect<void> => Effect.void;
+/** Receives the URL emitted by T3's no-browser helper on stderr. */
+export function makeAntigravityStderrHandler(input: {
+  readonly onAuthorizationUrl: (
+    authorizationUrl: string,
+  ) => Effect.Effect<void, AcpErrors.AcpError>;
+}) {
+  let pending = "";
+  const handleLine = (line: string) => {
+    const message = line.endsWith("\r") ? line.slice(0, -1) : line;
+    if (
+      message.length > maxBrowserHelperLineLength ||
+      !message.startsWith(ANTIGRAVITY_AUTH_BROWSER_MARKER)
+    ) {
+      return Effect.void;
+    }
+    return decodeBrowserHelperUrl(message.slice(ANTIGRAVITY_AUTH_BROWSER_MARKER.length)).pipe(
+      Effect.flatMap(parseAntigravityAuthorizationUrl),
+      Effect.flatMap((request) => input.onAuthorizationUrl(request.authorizationUrl)),
+      Effect.ignore,
+    );
+  };
+
+  return Effect.fn("antigravityAuthSupport.handleStderr")(function* (text: string) {
+    const lines = `${pending}${text}`.split("\n");
+    pending = lines.pop() ?? "";
+    if (pending.length > maxBrowserHelperLineLength) pending = "";
+    yield* Effect.forEach(lines, handleLine, { discard: true });
+  });
+}


### PR DESCRIPTION
On Windows, Antigravity Google sign-in could stay on "Starting Google sign-in" without ever showing the browser link. The provider also appeared unavailable when its packaged runtime took longer than the 15-second health-check limit to initialize.

Cause: T3's no-browser helper writes its controlled OAuth marker to stderr on Windows, but the ACP runtime discarded all Antigravity stderr. The packaged runtime took 17-27 seconds to initialize in repeated Windows probes.

## Fix

- Read only T3's exact browser-helper marker from stderr, decode and validate the Google authorization URL, and forward it to the existing auth flow without logging other stderr.
- Increase the Antigravity health-check limit to 45 seconds so the packaged Windows runtime can finish initialization.

## Tests

- Added coverage for fragmented helper output, malformed markers, and non-Google URLs.
- Added regressions for URLs over 8 KiB, duplicate stderr/stdout delivery, and delayed duplicate delivery.
- Added a fake-clock test for a valid 20-second runtime startup.
- Focused server suites: 97 tests passed.
- Targeted lint and the server typecheck passed.

**Before** - the Windows runtime times out and Google sign-in stays on its starting state:

![Antigravity unavailable after the 15-second health check while Google sign-in remains in the starting state](https://github.com/user-attachments/assets/1cfc9fe0-a18b-4461-9a3c-b3dc46984aa1)

**After** - the local dev build completes Google sign-in and loads the Antigravity models:

![Antigravity authenticated with Google and showing 11 models in the local dev build](https://github.com/user-attachments/assets/af5fec88-fb92-4007-b0c7-321574c459a6)

Closes #9405

Built with GPT-5.6 Sol in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth URL handling and auth state machine behavior; changes are scoped with validation and tests, but mis-parsed stderr could still affect sign-in reliability.
> 
> **Overview**
> Fixes Windows Antigravity Google sign-in stuck on **"Starting Google sign-in"** and false **unavailable** when the packaged runtime is slow to start.
> 
> **Stderr browser-helper URLs:** Replaces discarding all Antigravity stderr with `makeAntigravityStderrHandler`, which buffers lines, recognizes T3?s `__T3_ANTIGRAVITY_AUTH_URL__` marker, JSON-decodes and validates the Google OAuth URL, and forwards it into the existing auth flow?without surfacing other stderr. The handler is wired in `makeAntigravityAcpRuntime` only when an authorization callback is configured.
> 
> **Supporting limits:** Raises ACP `maxStderrChunkLength` from 8 KiB to 32 KiB so ~16 KiB authorization URLs fit in one chunk. Extends the Antigravity provider health-check timeout from **15s to 45s** and updates the timeout message accordingly.
> 
> **Auth deduplication:** `receiveAuthorizationUrl` now ignores a second delivery of the **same** URL (e.g. stdout + stderr) but still fails the flow if a **different** second URL arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee980670830a5e280d080f8effac5e25993279b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward Google sign-in URLs from Antigravity browser-helper stderr
> - `makeAntigravityAcpRuntime` now installs a stderr handler that parses browser-helper marker lines, reconstructs URLs split across chunks, and forwards valid authorization URLs to the auth callback; non-auth runtimes skip this handler.
> - Raises `AcpSessionRuntime` max stderr chunk from 8,192 to 32,768 characters so 16 KiB auth URLs are not truncated.
> - `makeAntigravityAuth.receiveAuthorizationUrl` now succeeds when it receives the same parsed URL twice instead of failing; a different second URL still fails.
> - Increases `checkAntigravityProvider` health-check timeout from 15s to 45s.
> - Risk: the stderr parser in [antigravityAuthSupport.ts](https://github.com/pingdotgg/t3code/pull/9425/files#diff-5eda6c48a8418e5891186bdfb6405818b8c5f7e03da0f36c3ac0f88226fff600) only recognizes exact marker lines within the length limit; malformed or oversized lines are silently discarded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee98067.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
