### PR TITLE
feat(web): animate pins without moving sidebar scroll

### DIFF
--- a/apps/web/src/components/Sidebar.motion.test.ts
+++ b/apps/web/src/components/Sidebar.motion.test.ts
@@ -39,6 +39,9 @@ class TestRow {
   getBoundingClientRect() {
     return { top: this.offsetTop + this.dragTranslate, height: this.offsetHeight };
   }
+  getAttribute(name: string) {
+    return this.attributes.find((attribute) => attribute.name === name)?.value ?? null;
+  }
   setAttribute(name: string, value: string) {
     this.removeAttribute(name);
     this.attributes.push({ name, value });
@@ -96,7 +99,10 @@ function fixture(rows: TestRow[]) {
 
 function expectMove(row: TestRow, offset: number) {
   expect(row.animate).toHaveBeenLastCalledWith(
-    [{ transform: `translateY(${offset}px)` }, { transform: "translateY(0px)" }],
+    [
+      { transform: `translate(0px, ${offset}px)`, offset: 0 },
+      { transform: "translate(0px, 0px)", offset: 1 },
+    ],
     { duration: 150, easing: "ease-out" },
   );
 }
@@ -397,5 +403,88 @@ describe("sidebar list motion", () => {
     motion.update(true);
     expectMove(a, 83);
     expectMove(b, -83);
+  });
+});
+
+describe("pinning motion", () => {
+  it("retargets a pin from its curved XY position during another layout change", () => {
+    const first = new TestRow("first");
+    const pin = new TestRow("pin");
+    const inserted = new TestRow("inserted");
+    const { motion, layout } = fixture([first, pin]);
+    motion.update(true);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, first]);
+    motion.update(true);
+    const frames = pin.animate.mock.lastCall![0];
+    // The first curve finishes at the 6px dip and 7.68px horizontal bow.
+    pin.animations[0]!.progress = Number(frames[80]!.offset);
+    layout([inserted, pin, first]);
+    motion.update(true);
+    expect(pin.animate.mock.lastCall![0][0]).toEqual({
+      transform: "translate(7.68px, 6px)",
+      offset: 0,
+      zIndex: 20,
+      backgroundColor: "var(--sidebar)",
+    });
+    expect(pin.animate.mock.lastCall![1].duration).toBe(150);
+    expect(pin.animations[0]!.cancel).toHaveBeenCalledOnce();
+    // A second interruption retains the X carried into the ordinary glide.
+    pin.animations[1]!.progress = 0.5;
+    layout([pin, inserted, first]);
+    motion.update(true);
+    expect(pin.animate.mock.lastCall![0][0]).toEqual({
+      transform: "translate(3.84px, 86px)",
+      offset: 0,
+      zIndex: 20,
+      backgroundColor: "var(--sidebar)",
+    });
+  });
+
+  it("fades a removed pin from its curved position instead of its linear estimate", () => {
+    const first = new TestRow("first");
+    const pin = new TestRow("pin");
+    const { motion, layout } = fixture([first, pin]);
+    motion.update(true);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, first]);
+    motion.update(true);
+    pin.animations[0]!.progress = Number(pin.animate.mock.lastCall![0][80]!.offset);
+    layout([first]);
+    motion.update(true);
+    expect(pin.clones[0]!.style.top).toBe("97px");
+    expect(pin.clones[0]!.style.left).toBe("11.68px");
+  });
+
+  it("flies a newly pinned row from its old location into the pinned slot", () => {
+    const first = new TestRow("first");
+    const pinned = new TestRow("pinned");
+    const { motion, layout } = fixture([first, pinned]);
+    motion.update(false);
+    pinned.setAttribute("data-thread-pinned", "true");
+    layout([pinned, first]);
+    motion.update(true);
+    const [frames, timing] = pinned.animate.mock.lastCall!;
+    expect(timing.duration).toBe(550);
+    expect(frames[0]?.transform).toBe("translate(0px, 83px)");
+    expect(frames.at(-1)?.transform).toBe("translate(0px, 0px)");
+    expectMove(first, -83);
+    pinned.animations[0]!.finish();
+    pinned.setAttribute("data-thread-pinned", "false");
+    layout([first, pinned]);
+    motion.update(true);
+    expectMove(pinned, -83);
+  });
+
+  it("does not fly pins when reduced motion is enabled", () => {
+    const first = new TestRow("first");
+    const pinned = new TestRow("pinned");
+    const { motion, layout, media } = fixture([first, pinned]);
+    motion.update(false);
+    media.matches = true;
+    pinned.setAttribute("data-thread-pinned", "true");
+    layout([pinned, first]);
+    motion.update(true);
+    expect(pinned.animate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/Sidebar.motion.test.ts
+++ b/apps/web/src/components/Sidebar.motion.test.ts
@@ -37,7 +37,11 @@ class TestRow {
     public offsetHeight = 82,
   ) {}
   getBoundingClientRect() {
-    return { top: this.offsetTop + this.dragTranslate, height: this.offsetHeight };
+    return {
+      top: this.offsetTop + this.dragTranslate,
+      bottom: this.offsetTop + this.dragTranslate + this.offsetHeight,
+      height: this.offsetHeight,
+    };
   }
   getAttribute(name: string) {
     return this.attributes.find((attribute) => attribute.name === name)?.value ?? null;
@@ -68,10 +72,12 @@ class TestRow {
   });
 }
 
-function fixture(rows: TestRow[]) {
+function fixture(rows: TestRow[], viewportTop = 0) {
   const media = { matches: false };
+  const viewport = { getBoundingClientRect: () => ({ top: viewportTop }), clientTop: 0 };
   const parent = {
     children: rows,
+    closest: () => viewport,
     ownerDocument: { defaultView: { matchMedia: () => media } },
     getBoundingClientRect: () => ({ top: 0 }),
     append(node: TestRow) {
@@ -407,6 +413,59 @@ describe("sidebar list motion", () => {
 });
 
 describe("pinning motion", () => {
+  it("finishes an offscreen pin at the top clipping edge instead of rushing through the viewport", () => {
+    const rows = Array.from({ length: 16 }, (_, index) => new TestRow(String(index)));
+    const pin = rows.at(-1)!;
+    const { motion, layout } = fixture(rows, 1000);
+    motion.update(false);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, ...rows.slice(0, -1)]);
+    motion.update(true);
+    const [frames, timing] = pin.animate.mock.lastCall!;
+    expect(timing.duration).toBe(550);
+    expect(frames[0]?.transform).toBe("translate(0px, 1245px)");
+    // The row's bottom reaches 1000; removing the transform then lands it
+    // in the real pinned slot, entirely outside the viewport.
+    expect(frames.at(-1)?.transform).toBe("translate(0px, 910px)");
+  });
+
+  it("keeps the real destination when the pinned row is partly visible", () => {
+    const [first, pin] = [new TestRow("first"), new TestRow("pin")];
+    const { motion, layout } = fixture([first, pin], 50);
+    motion.update(false);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, first]);
+    motion.update(true);
+    expect(pin.animate.mock.lastCall![0].at(-1)?.transform).toBe("translate(0px, 0px)");
+  });
+
+  it("keeps an interrupted offscreen pin aimed at the clipping edge", () => {
+    const rows = Array.from({ length: 16 }, (_, index) => new TestRow(String(index)));
+    const pin = rows.at(-1)!;
+    const inserted = new TestRow("inserted");
+    const { motion, layout } = fixture(rows, 1000);
+    motion.update(false);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, ...rows.slice(0, -1)]);
+    motion.update(true);
+    pin.animations[0]!.progress = Number(pin.animate.mock.lastCall![0][80]!.offset);
+    layout([inserted, pin, ...rows.slice(0, -1)]);
+    motion.update(true);
+    const frames = pin.animate.mock.lastCall![0];
+    expect(frames[0]?.transform).toBe("translate(7.68px, 1168px)");
+    expect(frames.at(-1)?.transform).toBe("translate(0px, 827px)");
+  });
+
+  it("does not fly a pin whose entire journey is already above the viewport", () => {
+    const [first, pin] = [new TestRow("first"), new TestRow("pin")];
+    const { motion, layout } = fixture([first, pin], 1000);
+    motion.update(false);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, first]);
+    motion.update(true);
+    expect(pin.animate).not.toHaveBeenCalled();
+  });
+
   it("retargets a pin from its curved XY position during another layout change", () => {
     const first = new TestRow("first");
     const pin = new TestRow("pin");

--- a/apps/web/src/components/Sidebar.motion.test.ts
+++ b/apps/web/src/components/Sidebar.motion.test.ts
@@ -40,6 +40,7 @@ class TestRow {
     return {
       top: this.offsetTop + this.dragTranslate,
       bottom: this.offsetTop + this.dragTranslate + this.offsetHeight,
+      right: this.offsetLeft + this.offsetWidth,
       height: this.offsetHeight,
     };
   }
@@ -74,7 +75,13 @@ class TestRow {
 
 function fixture(rows: TestRow[], viewportTop = 0) {
   const media = { matches: false };
-  const viewport = { getBoundingClientRect: () => ({ top: viewportTop }), clientTop: 0 };
+  const viewport = Object.assign(new EventTarget(), {
+    top: viewportTop,
+    clientTop: 0,
+    clientLeft: 0,
+    clientWidth: 280,
+    getBoundingClientRect: () => ({ top: viewport.top, left: 0 }),
+  });
   const parent = {
     children: rows,
     closest: () => viewport,
@@ -100,7 +107,7 @@ function fixture(rows: TestRow[], viewportTop = 0) {
   }
   layout(rows);
   const motion = createSidebarListMotion(parent as unknown as HTMLUListElement);
-  return { motion, layout, media, parent };
+  return { motion, layout, media, parent, viewport };
 }
 
 function expectMove(row: TestRow, offset: number) {
@@ -413,6 +420,47 @@ describe("sidebar list motion", () => {
 });
 
 describe("pinning motion", () => {
+  it("retargets a clipped flight when scrolling exposes its old endpoint", () => {
+    const rows = Array.from({ length: 16 }, (_, index) => new TestRow(String(index)));
+    const pin = rows.at(-1)!;
+    const { motion, layout, viewport } = fixture(rows, 1000);
+    motion.update(false);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, ...rows.slice(0, -1)]);
+    motion.update(true);
+    const first = pin.animations[0]!;
+    first.progress = Number(pin.animate.mock.lastCall![0][80]!.offset);
+    viewport.top = 600;
+    viewport.dispatchEvent(new Event("scroll"));
+    expect(first.cancel).toHaveBeenCalledOnce();
+    expect(pin.animate.mock.lastCall![0][0]?.transform).toBe("translate(7.68px, 1251px)");
+    expect(pin.animate.mock.lastCall![0].at(-1)?.transform).toBe("translate(0px, 510px)");
+    // Scrolling all the way back reveals the actual pinned slot.
+    pin.animations[1]!.progress = 0.5;
+    viewport.top = 0;
+    viewport.dispatchEvent(new Event("scroll"));
+    expect(pin.animate.mock.lastCall![0][0]?.transform).toBe("translate(3.84px, 880.5px)");
+    expect(pin.animate.mock.lastCall![0].at(-1)?.transform).toBe("translate(0px, 0px)");
+    motion.dispose();
+    viewport.dispatchEvent(new Event("scroll"));
+    expect(pin.animate).toHaveBeenCalledTimes(3);
+  });
+
+  it("fits the bow inside the viewport's available right inset", () => {
+    const [first, pin] = [new TestRow("first"), new TestRow("pin")];
+    const { motion, layout, viewport } = fixture([first, pin]);
+    viewport.clientWidth = 272;
+    motion.update(false);
+    pin.setAttribute("data-thread-pinned", "true");
+    layout([pin, first]);
+    motion.update(true);
+    const xs = pin.animate.mock.lastCall![0].map((frame) =>
+      Number(String(frame.transform).match(/translate\(([^p]+)px/)![1]),
+    );
+    expect(Math.max(...xs)).toBe(8);
+    expect(Math.min(...xs)).toBe(0);
+  });
+
   it("does not replay pinning when an already pinned slim row returns to the pinned section", () => {
     const first = new TestRow("first");
     const pin = new TestRow("settled pin", 36);

--- a/apps/web/src/components/Sidebar.motion.test.ts
+++ b/apps/web/src/components/Sidebar.motion.test.ts
@@ -413,6 +413,20 @@ describe("sidebar list motion", () => {
 });
 
 describe("pinning motion", () => {
+  it("does not replay pinning when an already pinned slim row returns to the pinned section", () => {
+    const first = new TestRow("first");
+    const pin = new TestRow("settled pin", 36);
+    const { motion, layout } = fixture([first, pin]);
+    motion.update(false);
+    pin.setAttribute("data-thread-pinned", "true");
+    motion.update(true);
+    expect(pin.animate).not.toHaveBeenCalled();
+    pin.offsetHeight = 82;
+    layout([pin, first]);
+    motion.update(true);
+    expectMove(pin, 83);
+  });
+
   it("finishes an offscreen pin at the top clipping edge instead of rushing through the viewport", () => {
     const rows = Array.from({ length: 16 }, (_, index) => new TestRow(String(index)));
     const pin = rows.at(-1)!;

--- a/apps/web/src/components/Sidebar.motion.ts
+++ b/apps/web/src/components/Sidebar.motion.ts
@@ -1,3 +1,5 @@
+import { sidebarPinPath } from "../sidebarPinPath";
+
 const motionTiming = { duration: 150, easing: "ease-out" };
 // A project filter change or a bulk snooze swaps a large part of the list at
 // once. Fades are the expensive part: every removed row gets a deep clone and
@@ -6,7 +8,7 @@ const motionTiming = { duration: 150, easing: "ease-out" };
 // so only the fade count decides whether an update animates.
 const MAX_FADED_ROWS_PER_UPDATE = 40;
 
-type RowPosition = { top: number; left: number; width: number; height: number };
+type RowPosition = { top: number; left: number; width: number; height: number; pinned: boolean };
 
 function progress(animation: Animation) {
   return animation.playState === "finished"
@@ -22,7 +24,14 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
   const reducedMotion = parent.ownerDocument.defaultView?.matchMedia(
     "(prefers-reduced-motion: reduce)",
   );
-  const running = new Map<HTMLElement, { animation: Animation; offset: number }>();
+  const running = new Map<
+    HTMLElement,
+    {
+      animation: Animation;
+      path: { x: number; y: number; offset: number }[];
+      pinVisual: boolean;
+    }
+  >();
   const entering = new Map<HTMLElement, Animation>();
   const exiting = new Map<HTMLElement, Animation>();
   // Visual tops at drag release, relative to the list, so the release
@@ -31,7 +40,19 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
 
   const remainingOffset = (node: HTMLElement) => {
     const current = running.get(node);
-    return current ? current.offset * (1 - progress(current.animation)) : 0;
+    if (!current) return { x: 0, y: 0 };
+    const elapsed = progress(current.animation);
+    const afterIndex = current.path.findIndex((point) => point.offset >= elapsed);
+    const after = current.path[afterIndex === -1 ? current.path.length - 1 : afterIndex]!;
+    const before = current.path[Math.max(0, afterIndex - 1)]!;
+    const fraction =
+      after.offset === before.offset
+        ? 0
+        : (elapsed - before.offset) / (after.offset - before.offset);
+    return {
+      x: before.x + (after.x - before.x) * fraction,
+      y: before.y + (after.y - before.y) * fraction,
+    };
   };
   const clearFades = () => {
     for (const animation of [...entering.values(), ...exiting.values()]) animation.cancel();
@@ -57,10 +78,11 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
     }
     clone.setAttribute("aria-hidden", "true");
     clone.inert = true;
+    const offset = remainingOffset(node);
     Object.assign(clone.style, {
       position: "absolute",
-      top: `${position.top + remainingOffset(node)}px`,
-      left: `${position.left}px`,
+      top: `${position.top + offset.y}px`,
+      left: `${position.left + offset.x}px`,
       width: `${position.width}px`,
       height: `${position.height}px`,
       margin: "0",
@@ -97,14 +119,26 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
     positions = null;
     released = null;
   };
-  const move = (node: HTMLElement, offset: number) => {
+  const move = (node: HTMLElement, offset: number, pinning = false, offsetX = 0) => {
+    const pinVisual = pinning || (running.get(node)?.pinVisual ?? false);
     cancel(node);
-    if (offset === 0) return;
+    if (offset === 0 && offsetX === 0) return;
+    const path = pinning
+      ? sidebarPinPath(offsetX, offset)
+      : [
+          { x: offsetX, y: offset, offset: 0 },
+          { x: 0, y: 0, offset: 1 },
+        ];
+    // A pinning row stays opaque and above its neighbours until it settles.
     const animation = node.animate(
-      [{ transform: `translateY(${offset}px)` }, { transform: "translateY(0px)" }],
-      motionTiming,
+      path.map(({ x, y, offset }) => ({
+        transform: `translate(${x}px, ${y}px)`,
+        offset,
+        ...(pinVisual ? { zIndex: 20, backgroundColor: "var(--sidebar)" } : {}),
+      })),
+      pinning ? { duration: 550, easing: "cubic-bezier(.32,0,.18,1)" } : motionTiming,
     );
-    running.set(node, { animation, offset });
+    running.set(node, { animation, path, pinVisual });
     animation.addEventListener(
       "finish",
       () => {
@@ -127,6 +161,7 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
               left: node.offsetLeft,
               width: node.offsetWidth,
               height: node.offsetHeight,
+              pinned: node.getAttribute("data-thread-pinned") === "true",
             },
           ]),
       );
@@ -177,9 +212,16 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
             continue;
           }
           if (previousTop === position.top) continue;
-          // Computed progress includes the effect's easing. Only our own
-          // translate is carried forward; dnd-kit's transforms are never read.
-          move(node, previousTop + remainingOffset(node) - position.top);
+          // Interpolate our sampled path at the effect's eased progress, so
+          // an interrupted pin preserves its curved XY position, not a linear Y.
+          // dnd-kit's transforms are never read.
+          const offset = remainingOffset(node);
+          move(
+            node,
+            previousTop + offset.y - position.top,
+            position.pinned && !positions?.get(node)?.pinned,
+            offset.x,
+          );
         }
       }
       if (released !== null) {

--- a/apps/web/src/components/Sidebar.motion.ts
+++ b/apps/web/src/components/Sidebar.motion.ts
@@ -126,18 +126,27 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
     if (offset === 0 && offsetX === 0) return;
     // Spend the flight on the visible journey. Once the whole row clears the
     // scrollport, removing its transform lands it in the real offscreen slot.
+    const viewportRect = pinVisual ? viewport?.getBoundingClientRect() : undefined;
+    const rowRect = viewportRect ? node.getBoundingClientRect() : undefined;
     const targetY =
-      pinVisual && viewport
-        ? Math.max(
-            0,
-            viewport.getBoundingClientRect().top +
-              viewport.clientTop -
-              node.getBoundingClientRect().bottom,
-          )
+      viewport && viewportRect && rowRect
+        ? Math.max(0, viewportRect.top + viewport.clientTop - rowRect.bottom)
         : 0;
     if (targetY > 0 && offset <= targetY) return;
+    // Transformed rows contribute to scrollable overflow. Keep the bow within
+    // the existing inset so it cannot introduce horizontal scrolling or fades.
+    const bow =
+      viewport && viewportRect && rowRect
+        ? Math.max(
+            0,
+            Math.min(
+              16,
+              viewportRect.left + viewport.clientLeft + viewport.clientWidth - rowRect.right,
+            ),
+          )
+        : 16;
     const path = pinning
-      ? sidebarPinPath(offsetX, offset - targetY).map((point) => ({
+      ? sidebarPinPath(offsetX, offset - targetY, bow).map((point) => ({
           ...point,
           y: point.y + targetY,
         }))
@@ -163,6 +172,17 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
       { once: true },
     );
   };
+
+  // A scroll can reveal a clipped endpoint. Retarget from the current visual
+  // position so the row still clears the edge before its transform disappears.
+  const onScroll = () => {
+    for (const [node, { pinVisual }] of Array.from(running)) {
+      if (!pinVisual) continue;
+      const offset = remainingOffset(node);
+      move(node, offset.y, false, offset.x);
+    }
+  };
+  viewport?.addEventListener("scroll", onScroll, { passive: true });
 
   return {
     update(animate: boolean) {
@@ -267,6 +287,7 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
     suspend,
     dispose() {
       suspend();
+      viewport?.removeEventListener("scroll", onScroll);
       disposed = true;
     },
   };

--- a/apps/web/src/components/Sidebar.motion.ts
+++ b/apps/web/src/components/Sidebar.motion.ts
@@ -19,6 +19,7 @@ function progress(animation: Animation) {
 /** Animate rows between their layout positions. The list must be
  * positioned so every direct child's offsetTop has the same origin. */
 export function createSidebarListMotion(parent: HTMLUListElement) {
+  const viewport = parent.closest<HTMLElement>('[data-slot="scroll-area-viewport"]');
   let positions: Map<HTMLElement, RowPosition> | null = null;
   let disposed = false;
   const reducedMotion = parent.ownerDocument.defaultView?.matchMedia(
@@ -123,11 +124,26 @@ export function createSidebarListMotion(parent: HTMLUListElement) {
     const pinVisual = pinning || (running.get(node)?.pinVisual ?? false);
     cancel(node);
     if (offset === 0 && offsetX === 0) return;
+    // Spend the flight on the visible journey. Once the whole row clears the
+    // scrollport, removing its transform lands it in the real offscreen slot.
+    const targetY =
+      pinVisual && viewport
+        ? Math.max(
+            0,
+            viewport.getBoundingClientRect().top +
+              viewport.clientTop -
+              node.getBoundingClientRect().bottom,
+          )
+        : 0;
+    if (targetY > 0 && offset <= targetY) return;
     const path = pinning
-      ? sidebarPinPath(offsetX, offset)
+      ? sidebarPinPath(offsetX, offset - targetY).map((point) => ({
+          ...point,
+          y: point.y + targetY,
+        }))
       : [
           { x: offsetX, y: offset, offset: 0 },
-          { x: 0, y: 0, offset: 1 },
+          { x: 0, y: targetY, offset: 1 },
         ];
     // A pinning row stays opaque and above its neighbours until it settles.
     const animation = node.animate(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1714,12 +1714,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   return (
     <li
       data-thread-item
+      data-thread-pinned={props.isPinned}
       {...sortableRootProps}
       {...(fileDropHandlers ?? {})}
       className={cn(
         // Matches the h-[4.875rem] content box; the py-0.5 padding is added on top.
-        "list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_78px]",
-        sortable?.isDragging && "relative z-20",
+        "relative list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_78px]",
+        sortable?.isDragging && "z-20",
       )}
     >
       <Tooltip disabled={snoozeMenuOpen || sortable?.isDragging}>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1561,6 +1561,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     return (
       <li
         data-thread-item
+        data-thread-pinned={props.isPinned}
         {...sortableRootProps}
         {...(fileDropHandlers ?? {})}
         className={cn(

--- a/apps/web/src/sidebarPinPath.test.ts
+++ b/apps/web/src/sidebarPinPath.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { sidebarPinPath } from "./sidebarPinPath";
+
+describe("sidebar pin path", () => {
+  it.each([48, 280, 1200])("keeps a small rounded dip and arc over a %i px journey", (fromY) => {
+    const path = sidebarPinPath(0, fromY);
+    expect(path[0]).toEqual({ x: 0, y: fromY, offset: 0 });
+    expect(path.at(-1)).toEqual({ x: 0, y: 0, offset: 1 });
+    expect(Math.max(...path.map((point) => point.x))).toBe(16);
+    expect(Math.max(...path.map((point) => point.y))).toBe(fromY + 6);
+    expect(Math.min(...path.map((point) => point.y))).toBe(0);
+    const lowest = path.findIndex((point) => point.y === fromY + 6);
+    expect(path.slice(lowest + 1).every((point, i) => point.y <= path[lowest + i]!.y)).toBe(true);
+    expect(path.slice(1).every((point, i) => point.offset > path[i]!.offset)).toBe(true);
+  });
+
+  it.each([
+    [12, 280],
+    [-12, 48],
+    [0, 0],
+  ])("starts at (%i, %i) and lands exactly in the slot with finite frames", (fromX, fromY) => {
+    const path = sidebarPinPath(fromX, fromY);
+    expect(path[0]).toEqual({ x: fromX, y: fromY, offset: 0 });
+    expect(path.at(-1)).toEqual({ x: 0, y: 0, offset: 1 });
+    expect(path.every((point) => Object.values(point).every(Number.isFinite))).toBe(true);
+  });
+});

--- a/apps/web/src/sidebarPinPath.ts
+++ b/apps/web/src/sidebarPinPath.ts
@@ -1,0 +1,50 @@
+/**
+ * Traces a small teardrop from a row's old offset into the pinned slot at (0, 0),
+ * at constant speed along each curve.
+ */
+export function sidebarPinPath(fromX: number, fromY: number) {
+  const bow = 16;
+  const dip = 6;
+  const y = -fromY;
+  const segments = [
+    [
+      [0, 0],
+      [0, dip * 0.68],
+      [bow * 0.18, dip],
+      [bow * 0.48, dip],
+    ],
+    [
+      [bow * 0.48, dip],
+      [bow * 0.82, dip],
+      [bow, y * 0.08],
+      [bow, y * 0.22],
+    ],
+    [
+      [bow, y * 0.22],
+      [bow, y * 0.58],
+      [bow * 0.16, y * 0.96],
+      [0, y],
+    ],
+  ] as const;
+  let previous = { x: 0, y: 0, distance: 0 };
+  const points = [previous];
+  for (const [p0, p1, p2, p3] of segments) {
+    for (let step = 1; step <= 80; step++) {
+      const t = step / 80;
+      const u = 1 - t;
+      const px = u ** 3 * p0[0] + 3 * u ** 2 * t * p1[0] + 3 * u * t ** 2 * p2[0] + t ** 3 * p3[0];
+      const py = u ** 3 * p0[1] + 3 * u ** 2 * t * p1[1] + 3 * u * t ** 2 * p2[1] + t ** 3 * p3[1];
+      previous = {
+        x: px,
+        y: py,
+        distance: previous.distance + Math.hypot(px - previous.x, py - previous.y),
+      };
+      points.push(previous);
+    }
+  }
+  // Distance-based offsets keep velocity continuous where the curve segments join.
+  return points.map((point) => {
+    const offset = point.distance / previous.distance;
+    return { x: point.x + fromX * (1 - offset), y: point.y + fromY, offset };
+  });
+}

--- a/apps/web/src/sidebarPinPath.ts
+++ b/apps/web/src/sidebarPinPath.ts
@@ -2,8 +2,7 @@
  * Traces a small teardrop from a row's old offset into the pinned slot at (0, 0),
  * at constant speed along each curve.
  */
-export function sidebarPinPath(fromX: number, fromY: number) {
-  const bow = 16;
+export function sidebarPinPath(fromX: number, fromY: number, bow = 16) {
   const dip = 6;
   const y = -fromY;
   const segments = [


### PR DESCRIPTION
## What Changed

Pinning a thread now follows a subtle 550 ms curved path into Pinned. When the destination is above the scrolled sidebar, the row travels only far enough to clear the list’s top edge, then settles into its real offscreen slot. The list keeps its scroll position.

## Why

The previous curve covered the entire distance to the hidden pinned slot in 550 ms. In the long-list reproduction, most of that distance was offscreen: the visible row left the viewport in about 100 ms. The endpoint now uses the scrollport edge and the row’s full height, so the whole row leaves through the list boundary. Partly visible destinations retain their actual landing position.

The existing list-motion engine retains the current XY position during interruptions. Scroll gestures retarget a running flight to the new clipping edge or visible pinned slot. The curve also fits within the row’s right inset, preventing transient horizontal overflow. Unpinning uses the ordinary glide; reduced motion skips the flight. Both card and slim rows expose pinned state. This branch includes upstream’s scroll-anchoring fix from #10757.

## UI Changes

Full web client, dark theme, 1280×800 viewport, disposable Harbor project with 60 threads. The scrolled case pins task 35 at `scrollTop = 2600`: every measured frame and the settled result retained **2600 px**. GIFs show the complete sidebar and menu; exports run at 30 fps and original speed. Refreshed candidate clips include a one-second hold on the settled result. The full-frame MP4s preserve the surrounding app. Relative age labels advance between recordings.

**Before this fix: the previous PR curve rushes toward the distant offscreen slot.**

![Before: task 35 leaves the visible list too quickly](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-before-offscreen.gif)

**After: the complete row follows the curve through the top edge; the list stays still.**

![After: task 35 flies through the top edge without scrolling](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-after-offscreen.gif)

[Before recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-before-offscreen.mp4) · [After recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-after-offscreen.mp4)

<details>
<summary>Visible destination: upstream base and candidate</summary>

**Before: upstream’s straight 150 ms movement.**

![Base: straight pin movement](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-before-main.gif)

**After: the subtle curved path lands in the visible pinned slot.**

![Candidate: curved pin movement](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-after-visible.gif)

[Base recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-before-main.mp4) · [Candidate recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-after-visible.mp4)

</details>

<details>
<summary>Interrupted flight and reduced motion</summary>

A second pin starts while the first flight is running; both settle correctly. The second action is dispatched through the real menu handler at a measured point during the first animation.

![Two overlapping pins settle without a stale flying row](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-interrupted.gif)

[Interruption recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-interrupted.mp4)

With a simulated reduced-motion media preference, pinning changes the list immediately and starts zero row animations.

![Reduced motion: immediate pin with unchanged scroll position](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-reduced-motion.gif)

[Reduced-motion recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-reduced-motion.mp4)

</details>

<details>
<summary>Scrolling during a flight</summary>

The test scrolls upward by 400 px while the pin is moving. The flight retargets from its current XY position to the new clipping edge, then settles without a visible jump. Scroll width stays at 255 px.

![Scroll during flight: the pin retargets to the new list edge](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-scroll-during-flight.gif)

[Scroll-during-flight recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-scroll-during-flight.mp4)

</details>

<details>
<summary>Updated before/after screenshots</summary>

**Before pinning**

![Before pinning: task 05 in the active list](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-before-main-start.png)

**After pinning**

![After pinning: task 05 in Pinned](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-after-visible-end.png)

[Scrolled start](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-before-offscreen-start.png) · [Scrolled result](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/9431-20260913-final-after-offscreen-end.png)

</details>

The upstream baseline is `0c5771d60a`; the offscreen “before” uses the unchanged `f39bd81739` motion engine on that baseline. Candidate captures match head `b48a17f973`, including scroll retargeting and the constrained bow.

## Verification

- `cd apps/web && vp test run src/components/Sidebar.motion.test.ts src/sidebarPinPath.test.ts src/components/Sidebar.logic.test.ts`: **190 passed**. The offscreen, scroll-retarget, and horizontal-overflow regressions fail before their respective fixes and pass afterward.
- Web typecheck, scoped lint and formatting pass (existing warnings/suggestions only).
- Live checks: visible and offscreen landing, unchanged scroll, unpin, overlapping pins, scrolling during flight, and simulated reduced motion. The list’s scroll width also remained 255 px throughout the new recordings. No owned row animation remained after settling; the pin was confirmed in the isolated database.
- Electron uses this shared sidebar. The Electron native context menu, grouped sidebar, mobile clients, and remote connections were not separately exercised. Mobile keeps its existing native presentation; this is a shared web/Electron visual change. No native shell, provider, or wire contract changes.
- Direct independent Claude Fable 5 high review completed with exit **0** on `7abe5e5de6`. Two confirmed findings (scroll-during-flight clipping and horizontal overflow) were fixed and regression-tested. A fresh review of the final diff also exited **0**. Its timing concern was disproved by a Chromium 150 check: at 500 ms of the 1000 ms timing probe, both computed progress and rendered opacity were 0.802669. The final diff has no unresolved actionable findings after verification. Launcher: `claude -p --model claude-fable-5 --effort high --tools '' --no-session-persistence --output-format stream-json --verbose`. The result reports actual model `claude-fable-5`. Review context included `CODING_STANDARDS.md`, frozen hash `144fbf46af335d8d18a95c8d4b4f2e9e0207fa2e`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Updated and verified by GPT-6 in the Codex harness (T3 Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Sidebar thread rows now follow smooth, curved paths when moving into the pinned section.
  - Pinning animations adapt to each row’s position within the scroll area and remain aligned during scrolling.
  - Pinning transitions keep rows within the visible viewport and use improved layering.
  - Rows already aligned with the pinned section avoid unnecessary animation.
  - Unpinning and other sidebar movements now provide smoother positioning and fade-out behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->