### PR TITLE
fix(web): stop clipping the traits chevron on long Codex effort labels

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -623,11 +623,10 @@ export const TraitsPicker = memo(function TraitsPicker({
         }
       >
         {isCodexStyle ? (
+          // The label truncates itself; clipping the wrapper too would cut off
+          // the chevron, whose negative end margin overhangs the wrapper edge.
           <span
-            className={cn(
-              "flex min-w-0 w-full items-center overflow-hidden",
-              size === "xs" ? "gap-1" : "gap-1.5",
-            )}
+            className={cn("flex min-w-0 w-full items-center", size === "xs" ? "gap-1" : "gap-1.5")}
           >
             {fastModeIcon}
             <span className="min-w-0 truncate">{triggerLabel}</span>


### PR DESCRIPTION
With a Codex model and a long effort label (Extra High / Very High), the traits trigger's chevron gets clipped on its right edge. The Codex-style trigger wraps its content in a span with `overflow-hidden`, and `ComposerControlChevron` carries a negative end margin (`-me-1` in the resting strip, `-mx-0.5` in the expanded footer) that pulls its box past the wrapper's edge. Short labels leave slack so nothing shows; once the label fills the trigger, the chevron lands flush against the wrapper and loses those pixels.

The label already truncates itself via `truncate`, so the wrapper's `overflow-hidden` was only clipping the icon. Dropped it; the button's own padding absorbs the chevron overhang as it does for every other composer control.

```diff
-"flex min-w-0 w-full items-center overflow-hidden"
+"flex min-w-0 w-full items-center"
```

Before:

![before](https://raw.githubusercontent.com/zortos293/t3code/assets/pr-traits-chevron-clip/before.png)

After:

<img width="812" height="121" alt="image" src="https://github.com/user-attachments/assets/a38591da-6462-478c-a88d-0a0e715258b3" />

Claude Fable 5.1 via Cursor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class CSS tweak in the Codex traits trigger layout with no auth, data, or API impact.
> 
> **Overview**
> Fixes a visual bug where the **traits picker chevron** was clipped on the right when using Codex with long effort labels (e.g. Extra High / Very High).
> 
> For Codex-style triggers, the inner content wrapper no longer uses `overflow-hidden`. Long labels still truncate via the inner `truncate` span; removing wrapper clipping lets `ComposerControlChevron`’s negative end margin overhang without being cut off. A short comment documents the rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce3ac125b4b8bcec64337cbc1fd02b1a79c5987. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chevron clipping on long Codex effort labels in `TraitsPicker`
> Removes overflow clipping from the flex wrapper in the Codex-style trigger layout in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/9433/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45). The trigger-label span keeps its truncation, while the chevron can extend past the wrapper via its negative end margin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ce3ac1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->