### PR TITLE
feat(web): add usage page keybinding

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -443,6 +443,28 @@ export function CommandPalette({ children }: { children: ReactNode }) {
   }, [state.mode, state.open, toggleMode]);
 
   useEffect(() => {
+    // Claim navigation before the composer's underline shortcut consumes mod+u.
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: {
+          terminalFocus: isTerminalFocused(),
+          terminalOpen,
+          previewFocus: isPreviewFocused(),
+          previewOpen,
+        },
+      });
+      if (command !== "usage.open") return;
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+      void navigate({ to: "/usage" });
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [keybindings, navigate, previewOpen, setOpen, terminalOpen]);
+
+  useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.defaultPrevented) return;
       // Resolve with the complete shortcut context so customized bindings
@@ -455,13 +477,6 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           previewOpen,
         },
       });
-      if (command === "usage.open") {
-        event.preventDefault();
-        event.stopPropagation();
-        setOpen(false);
-        void navigate({ to: "/usage" });
-        return;
-      }
       if (command === "themeEditor.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -484,10 +499,8 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [
     keybindings,
-    navigate,
     previewOpen,
     resolvedTheme,
-    setOpen,
     terminalOpen,
     theme,
     themeHalves,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -96,6 +96,7 @@ import {
 } from "../lib/projectPaths";
 import { onOpenCommandPalette } from "../commandPaletteBus";
 import { isPreviewFocused } from "../lib/previewFocus";
+import { isModelPickerOpen } from "../modelPickerVisibility";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { getLatestThreadForProject, sortThreads } from "../lib/threadSort";
@@ -452,6 +453,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           terminalOpen,
           previewFocus: isPreviewFocused(),
           previewOpen,
+          modelPickerOpen: isModelPickerOpen(),
         },
       });
       if (command !== "usage.open") return;
@@ -475,6 +477,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           terminalOpen,
           previewFocus: isPreviewFocused(),
           previewOpen,
+          modelPickerOpen: isModelPickerOpen(),
         },
       });
       if (command === "themeEditor.toggle") {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -497,15 +497,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [
-    keybindings,
-    previewOpen,
-    resolvedTheme,
-    terminalOpen,
-    theme,
-    themeHalves,
-    toggleMode,
-  ]);
+  }, [keybindings, previewOpen, resolvedTheme, terminalOpen, theme, themeHalves, toggleMode]);
 
   useEffect(
     () =>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -397,6 +397,7 @@ function overlayModeForCommand(command: string | null): SearchOverlayMode | null
 }
 
 export function CommandPalette({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
   const [state, dispatch] = useReducer(reduceCommandPaletteUiState, {
     open: false,
     mode: "command",
@@ -454,6 +455,13 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           previewOpen,
         },
       });
+      if (command === "usage.open") {
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(false);
+        void navigate({ to: "/usage" });
+        return;
+      }
       if (command === "themeEditor.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -474,7 +482,17 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keybindings, previewOpen, resolvedTheme, terminalOpen, theme, themeHalves, toggleMode]);
+  }, [
+    keybindings,
+    navigate,
+    previewOpen,
+    resolvedTheme,
+    setOpen,
+    terminalOpen,
+    theme,
+    themeHalves,
+    toggleMode,
+  ]);
 
   useEffect(
     () =>

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -165,7 +165,12 @@ describe("KeybindingsSettings.logic", () => {
     ] satisfies ResolvedKeybindingsConfig);
 
     expect(options).toEqual(
-      expect.arrayContaining(["chat.new", "rightPanel.toggleMaximized", "script.setup-db.run"]),
+      expect.arrayContaining([
+        "chat.new",
+        "rightPanel.toggleMaximized",
+        "usage.open",
+        "script.setup-db.run",
+      ]),
     );
   });
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -131,6 +131,11 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("u"),
+    command: "usage.open",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("t", { altKey: true, shiftKey: true }),
     command: "themeEditor.toggle",
   },
@@ -634,6 +639,22 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
       "projectSearch.toggle",
+    );
+  });
+
+  it("matches usage.open outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "u", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "usage.open",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "u", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: true },
+      }),
     );
   });
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -53,6 +53,9 @@ a shortcut.
 
 ## Commands with special behavior
 
+`usage.open` opens the Usage page and defaults to `mod+u`. It does not run while
+the terminal has focus.
+
 `chat.new` may ask you to choose a project when there is more than one.
 `chat.newLocal` skips that chooser. Both use your
 [new-thread defaults](./thread-sidebar.md#start-a-thread).

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,5 +1,8 @@
 # Usage and limits
 
+Open **Usage** from the sidebar, or press `mod+u` on web and desktop when the terminal
+is not focused. Customize `usage.open` in **Settings → Keybindings**.
+
 ## Understand your usage
 
 **Usage** combines Codex, Claude Code, and Grok Build session history from your connected

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -78,6 +78,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedProjectSearch.command, "projectSearch.toggle");
 
+    const parsedUsageOpen = yield* decode(KeybindingRule, {
+      key: "mod+u",
+      command: "usage.open",
+    });
+    assert.strictEqual(parsedUsageOpen.command, "usage.open");
+
     const parsedThemeEditor = yield* decode(KeybindingRule, {
       key: "mod+alt+shift+t",
       command: "themeEditor.toggle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -70,6 +70,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "commandPalette.toggle",
   "filePicker.toggle",
   "projectSearch.toggle",
+  "usage.open",
   "themeEditor.toggle",
   "composer.stash",
   "chat.new",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -38,6 +38,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+k", command: "commandPalette.toggle", when: "!terminalFocus" },
   { key: "mod+p", command: "filePicker.toggle", when: "!terminalFocus" },
   { key: "mod+shift+f", command: "projectSearch.toggle", when: "!terminalFocus" },
+  { key: "mod+u", command: "usage.open", when: "!terminalFocus" },
   { key: "mod+alt+shift+t", command: "themeEditor.toggle" },
   { key: "mod+s", command: "composer.stash", when: "!terminalFocus" },
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },


### PR DESCRIPTION
### NOTE FROM HUMAN

This PR is much more useful in conjunction with https://github.com/pingdotgg/t3code/pull/9263 - I added this PR because if provider limits are there, its something I find myself checking frequently.

### The rest of this was AI generated

Opening the Usage page currently requires using the sidebar. This adds a configurable `usage.open` command that defaults to `mod+u` and stays inactive while the terminal has focus.

The existing global keybinding dispatcher now navigates to `/usage`, so web and desktop share the behavior without another event listener or navigation path. The keybinding contract, default synchronization, focused tests, and user docs are updated with it.

Validation:
- `vp test run packages/contracts/src/keybindings.test.ts apps/server/src/keybindings.test.ts apps/web/src/keybindings.test.ts apps/web/src/components/settings/KeybindingsSettings.logic.test.ts`
- `vp run -F @t3tools/contracts -F @t3tools/shared -F @t3tools/web -F t3 typecheck`
- focused `vp lint`
- focused `vp fmt --check`

No visual changes.

Generated with gpt-5.6-sol in T3 Code using the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `usage.open` keybinding with default modifier-plus-U shortcut
> - Registers `usage.open` as a static keybinding command and maps it to modifier-plus-U (outside terminal focus) in the default bindings
> - Implements a global keydown handler in `CommandPalette` that resolves the shortcut, closes the palette, and navigates to `/usage`; the binding is skipped when the event is already prevented or composing
> - Extends the shortcut-resolution context with `modelPickerOpen` so other bindings also receive the current model-picker visibility state
> - Updates tests for command options, default bindings, and rule parsing; documents the shortcut in keybindings and usage docs
> - Risk: existing consumers of the `CommandPalette` shortcut-resolution context now receive an additional `modelPickerOpen` field — check [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/9434/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) for any resolver that does not tolerate the extra field
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7629026.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UX addition; outside terminal focus the app now captures `mod+u`, which could conflict with any other in-app use of that chord.
> 
> **Overview**
> Adds a configurable **`usage.open`** command (default **`mod+u`**, inactive while the terminal has focus) so the Usage page is reachable from the keyboard instead of only the sidebar.
> 
> The command is registered in the keybinding contract and shared defaults, wired in the global shortcut listener in `CommandPalette` to close overlays and navigate to `/usage`, and covered by contract/server/web tests plus user docs for keybindings and usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7eedca6d99a7630bf2e76b4c4da028f12f6da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default `Mod+U` shortcut to open the Usage page when the terminal is not focused.
  * The shortcut works across web and desktop and can be customized in **Settings → Keybindings**.
  * Shortcut handling now opens Usage directly, including when another command palette is active.

* **Documentation**
  * Updated keybinding and Usage documentation with the new shortcut and customization details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->