### PR TITLE
fix(server): keep a/ and b/ prefixes in rendered git patches

### DIFF
--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -147,6 +147,37 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
       }),
     );
 
+    it.effect("keeps a/ and b/ patch prefixes when the repository disables them", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        yield* git(tmp, ["config", "diff.noprefix", "true"]);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const threadId = ThreadId.make("thread-checkpoint-store-noprefix");
+        const fromCheckpointRef = checkpointRefForThreadTurn(threadId, 0);
+        const toCheckpointRef = checkpointRefForThreadTurn(threadId, 1);
+
+        yield* checkpointStore.captureCheckpoint({
+          cwd: tmp,
+          checkpointRef: fromCheckpointRef,
+        });
+        yield* writeTextFile(NodePath.join(tmp, "README.md"), "# changed\n");
+        yield* checkpointStore.captureCheckpoint({
+          cwd: tmp,
+          checkpointRef: toCheckpointRef,
+        });
+
+        const diff = yield* checkpointStore.diffCheckpoints({
+          cwd: tmp,
+          fromCheckpointRef,
+          toCheckpointRef,
+          ignoreWhitespace: false,
+        });
+
+        expect(diff).toContain("diff --git a/README.md b/README.md");
+      }),
+    );
+
     it.effect("can hide indentation churn when changes wrap existing lines", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -30,7 +30,11 @@ import {
   type VcsStatusInput,
   type VcsStatusResult,
 } from "@t3tools/contracts";
-import { makeGitVcsDriverCore, splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
+import {
+  makeGitVcsDriverCore,
+  PATCH_RENDER_PREFIX_ARGS,
+  splitNullSeparatedGitStdoutPaths,
+} from "./GitVcsDriverCore.ts";
 import * as VcsDriver from "./VcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
 
@@ -869,6 +873,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
           "--no-color",
           "--no-ext-diff",
           "--no-textconv",
+          ...PATCH_RENDER_PREFIX_ARGS,
           ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
           `${fromRevision}^{commit}`,
           `${input.toCheckpointRef}^{commit}`,

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -819,6 +819,34 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("keeps a/ and b/ patch prefixes when the repository disables them", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* git(cwd, ["config", "diff.noprefix", "true"]);
+        yield* git(cwd, ["config", "diff.mnemonicPrefix", "true"]);
+        yield* git(cwd, ["checkout", "-b", "feature/noprefix"]);
+        yield* writeTextFile(cwd, "README.md", "# committed change\n");
+        yield* git(cwd, ["add", "README.md"]);
+        yield* git(cwd, ["commit", "-m", "committed change"]);
+        yield* writeTextFile(cwd, "README.md", "# dirty change\n");
+        yield* writeTextFile(cwd, "untracked.txt", "untracked\n");
+
+        const preview = yield* driver.getReviewDiffPreview({
+          cwd,
+          baseRef: initialBranch,
+          ignoreWhitespace: false,
+        });
+
+        const workingTree = preview.sources.find((source) => source.kind === "working-tree")?.diff;
+        const branchRange = preview.sources.find((source) => source.kind === "branch-range")?.diff;
+        assert.include(workingTree, "diff --git a/README.md b/README.md");
+        assert.include(workingTree, "+++ b/untracked.txt");
+        assert.include(branchRange, "diff --git a/README.md b/README.md");
+      }),
+    );
+
     it.effect("loads full file contents for working-tree diff expansion", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -52,6 +52,10 @@ const RANGE_DIFF_PATCH_MAX_OUTPUT_BYTES = 59_000;
 const REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES = 120_000;
 const REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES = 80_000;
 const REVIEW_DIFF_FILE_MAX_OUTPUT_BYTES = 1024 * 1024;
+// Patches the clients render are parsed against git's default a/ and b/ path
+// prefixes. A repository or global diff.noprefix or diff.mnemonicPrefix would
+// otherwise leak into the patch and leave every parsed file unnamed.
+export const PATCH_RENDER_PREFIX_ARGS = ["--src-prefix=a/", "--dst-prefix=b/"] as const;
 const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 120_000;
 const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
@@ -2205,6 +2209,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             "--no-ext-diff",
             "--no-textconv",
             "--minimal",
+            ...PATCH_RENDER_PREFIX_ARGS,
             "--",
             "/dev/null",
             relativePath,
@@ -2257,6 +2262,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         "--no-ext-diff",
         "--no-textconv",
         "--minimal",
+        ...PATCH_RENDER_PREFIX_ARGS,
         ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
         "HEAD",
         "--",
@@ -2293,6 +2299,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
               "--no-ext-diff",
               "--no-textconv",
               "--minimal",
+              ...PATCH_RENDER_PREFIX_ARGS,
               ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
               `${baseRef}...HEAD`,
             ],


### PR DESCRIPTION
When the user's git config sets `diff.noprefix` or `diff.mnemonicPrefix`, the patches the server hands to the clients lose their `a/` and `b/` path prefixes. The diff renderer only recognizes the default prefixes, so every file in such a patch parses with an empty name, and opening the diff panel crashes with `CodeView.addItem: duplicate id ""` as soon as the diff contains two files. Reloading crashes again immediately because the panel reopens into the same state.

The review preview, untracked, and checkpoint diff commands now pin the prefixes with `--src-prefix=a/ --dst-prefix=b/`, which wins over the user's config on every git version I could test. Patches that only feed text generation are left alone.

Covered by tests that run the real driver against a repository configured with `diff.noprefix=true`; both fail without the fix.

Fixes #9427.

Implemented with Claude Code (Claude Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized VCS diff flag change with regression tests; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes broken diff UI when a repo’s Git config sets **`diff.noprefix`** or **`diff.mnemonicPrefix`**, which strips the default `a/` / `b/` path prefixes from patches. The client parser only recognizes those prefixes, so files end up with empty names and the diff panel can crash on multi-file diffs.
> 
> Server-side **`git diff`** calls that feed the review preview, untracked diffs, and checkpoint diffs now pass **`--src-prefix=a/`** and **`--dst-prefix=b/`** via shared **`PATCH_RENDER_PREFIX_ARGS`**, overriding user config. Diffs used only for text summaries (e.g. staged commit context) are unchanged.
> 
> Integration tests configure **`diff.noprefix`** (and mnemonic prefix in the driver test) and assert patches still contain **`diff --git a/... b/...`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6691bc3ea47317ecf61e31e2fabdf6679e67672a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `GitVcsDriver` patch rendering to keep `a/` and `b/` prefixes
> Git config options like `diff.noprefix` or `diff.mnemonicPrefix` could strip or alter the standard `a/`/`b/` path prefixes in rendered patches, breaking parsers that expect them.
>
> - Adds the shared constant `PATCH_RENDER_PREFIX_ARGS` in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/9438/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) and applies it to checkpoint diffs, working-tree review diffs, branch-range review diffs, and untracked-file (`--no-index`) review diffs
> - Adds integration tests in [CheckpointStore.test.ts](https://github.com/pingdotgg/t3code/pull/9438/files#diff-5c6b84e1253064afcb0e87b5fb9fc47454c34943dbf86fce3979b722b85881eb) and [GitVcsDriverCore.test.ts](https://github.com/pingdotgg/t3code/pull/9438/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) covering `diff.noprefix` and `diff.mnemonicPrefix` scenarios
> - Behavioral Change: all rendered checkpoint and review patches now emit standard `a/`/`b/` prefixes regardless of repository or global git diff settings
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6691bc3. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/vcs/GitVcsDriverCore.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 58](https://github.com/pingdotgg/t3code/blob/6691bc3ea47317ecf61e31e2fabdf6679e67672a/apps/server/src/vcs/GitVcsDriverCore.ts#L58): `PATCH_RENDER_PREFIX_ARGS` does not disable `diff.mnemonicPrefix`. Git's documented `--default-prefix` option is the one that overrides `diff.mnemonicPrefix`; supplying only custom source/destination prefixes leaves that configuration enabled. Consequently, repositories with `diff.mnemonicPrefix=true` still emit prefixes such as `i/`, `w/`, `c/`, or `o/`, which the client parser does not recognize, so a multi-file review/checkpoint patch can again create duplicate empty file IDs and crash the diff panel. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->