### PR TITLE
fix(usage): keep the largest output count in a Claude dedupe group

### DIFF
--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -349,10 +349,10 @@ export const make = Effect.gen(function* () {
 
       // Stored already de-duplicated within the file, which is 99% of all
       // duplicates. The aggregator still runs the cross-file dedupe pass. One
-      // seen set spans the cached base, the new lines, and the tail so a
+      // seen map spans the cached base, the new lines, and the tail so a
       // resumed parse dedupes exactly like a full one.
       const base = parsed.resumed && cached !== undefined ? cached.records : [];
-      const seen = new Set<string>();
+      const seen = new Map<string, UsageRecord>();
       const records = dedupeWithinFile([...base, ...parsed.records], seen);
       const tailRecords = dedupeWithinFile(parsed.tailRecords, seen);
 

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -281,15 +281,47 @@ describe("pruneScanCache with an unwalked root", () => {
 });
 
 describe("dedupeWithinFile", () => {
-  it("keeps the first record per dedupe key", () => {
+  it("keeps the record with the largest output per dedupe key", () => {
+    // Claude Code can report progressive usage across the content blocks of
+    // one message: the thinking block says 1, the final tool_use block says
+    // the real total. The group must resolve to the final count.
     const kept = dedupeWithinFile([
       record({ totals: { ...record().totals, outputTokens: 1 } }),
-      record({ totals: { ...record().totals, outputTokens: 999 } }),
+      record({ totals: { ...record().totals, outputTokens: 398 } }),
       record({ dedupeKey: "msg_2:" }),
     ]);
 
     expect(kept).toHaveLength(2);
-    expect(kept[0]?.totals.outputTokens).toBe(1);
+    expect(kept[0]?.totals.outputTokens).toBe(398);
+    expect(kept[0]?.totals.cachedInputTokens).toBe(record().totals.cachedInputTokens);
+  });
+
+  it("keeps the first record when a repeat does not grow the output", () => {
+    const first = record({ totals: { ...record().totals, outputTokens: 398 } });
+    const kept = dedupeWithinFile([
+      first,
+      record({ totals: { ...record().totals, outputTokens: 398 } }),
+      record({ totals: { ...record().totals, outputTokens: 5 } }),
+    ]);
+
+    expect(kept).toHaveLength(1);
+    expect(kept[0]).toBe(first);
+  });
+
+  it("does not resurrect a key already settled by an earlier batch", () => {
+    const seen = new Map<string, UsageRecord>();
+    const head = dedupeWithinFile(
+      [record({ totals: { ...record().totals, outputTokens: 1 } })],
+      seen,
+    );
+    const tail = dedupeWithinFile(
+      [record({ totals: { ...record().totals, outputTokens: 398 } })],
+      seen,
+    );
+
+    expect(head).toHaveLength(1);
+    expect(tail).toHaveLength(0);
+    expect(seen.get(record().dedupeKey ?? "")?.totals.outputTokens).toBe(398);
   });
 
   it("keeps every record that has no dedupe key", () => {

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -26,7 +26,7 @@ import type { CodexScanState, UsageRecord } from "./usageTranscripts.ts";
 // entries would keep serving double-counted records forever.
 // v3: entries carry the parse position and reducer state so a grown file
 // re-parses only its appended bytes instead of starting over.
-export const USAGE_SCAN_CACHE_VERSION = 3 as const;
+export const USAGE_SCAN_CACHE_VERSION = 4 as const;
 
 export interface CachedFile {
   readonly size: number;
@@ -346,21 +346,43 @@ export function pruneScanCache(cache: ScanCache, options: PruneOptions): number 
 /**
  * Within-file de-duplication, applied before an entry is cached.
  *
- * Callers stitching an incremental parse together pass one `seen` set across
+ * A dedupe group resolves to the record with the largest `outputTokens`.
+ * Claude Code sometimes writes progressive usage across the content-block
+ * records of one message, where the first block carries a partial output
+ * count and the last carries the final one; keeping the first record
+ * undercounted output by about a third on a real workload. Input and cache
+ * buckets are identical across the group, so the choice only affects output.
+ *
+ * Callers stitching an incremental parse together pass one `seen` map across
  * the line and tail record batches so the whole file stays deduplicated as a
- * unit; the set is mutated in place.
+ * unit; the map is mutated in place. A larger record whose earlier sibling
+ * landed in a previous batch cannot be reached from here and is dropped; the
+ * next parse of the file sees both in one batch and settles it.
  */
 export function dedupeWithinFile(
   records: readonly UsageRecord[],
-  seen: Set<string> = new Set(),
+  seen: Map<string, UsageRecord> = new Map(),
 ): readonly UsageRecord[] {
   const kept: UsageRecord[] = [];
+  const keptIndex = new Map<string, number>();
   for (const record of records) {
-    if (record.dedupeKey !== null) {
-      if (seen.has(record.dedupeKey)) continue;
-      seen.add(record.dedupeKey);
+    const key = record.dedupeKey;
+    if (key === null) {
+      kept.push(record);
+      continue;
     }
-    kept.push(record);
+    const prior = seen.get(key);
+    if (prior === undefined) {
+      seen.set(key, record);
+      keptIndex.set(key, kept.length);
+      kept.push(record);
+      continue;
+    }
+    if (record.totals.outputTokens > prior.totals.outputTokens) {
+      seen.set(key, record);
+      const index = keptIndex.get(key);
+      if (index !== undefined) kept[index] = record;
+    }
   }
   return kept;
 }

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -91,10 +91,13 @@ export function grokCostTicksToUsd(ticks: unknown): number | null {
 /**
  * Parses one line of a Claude Code transcript.
  *
- * T3 Code writes one record per assistant *content block*, and every one of
- * those records repeats the same complete `usage` object for the parent
- * message. Summing them overcounts by roughly 2.4x on a real workload, so the
- * caller must drop repeats by `dedupeKey` and keep the first.
+ * Claude Code writes one record per assistant *content block*, each carrying
+ * a `usage` object for the parent message. Summing them overcounts by roughly
+ * 2.4x on a real workload, so the caller must collapse repeats by `dedupeKey`.
+ * The records are not always identical: some transcripts report progressive
+ * usage, where an early block holds a partial `output_tokens` and the last
+ * block holds the final count, so the caller must keep the record with the
+ * largest output rather than the first.
  */
 export function parseClaudeLine(line: string): UsageRecord | null {
   let parsed: unknown;


### PR DESCRIPTION
## What Changed

`dedupeWithinFile` in the usage scanner now resolves each message id + request id group to the record with the largest `output_tokens`, instead of keeping whichever record came first. `USAGE_SCAN_CACHE_VERSION` goes 3 to 4 so entries that cached the partial record get re-parsed. The doc comment on `parseClaudeLine` no longer claims that every split record repeats the same usage object, because that is the assumption that produced the bug.

Tests: the existing dedupe test now expects the larger record, plus two new ones covering a repeat that does not grow output (first record stays) and a key already settled by an earlier batch (the tail does not resurrect it).

Four files, about 70 lines.

## Why

Claude Code writes one transcript line per assistant content block. Usually every line carries the same finished `usage` object, and first-wins dedupe is fine. Some transcripts do not do that. The thinking block reports `output_tokens: 1`, the tool_use block that follows reports the real total, same message id, same request id. First-wins keeps the 1.

On a week of my own transcripts (28 Aug to 3 Sep) that came out to 5.26M output tokens reported against 8.14M actual, so roughly a third missing. Input, cache read and cache write totals were untouched, because those fields are identical across the group. That is why the token totals on the usage page looked right while the output column looked low. ccusage and cc-browse read the same files and both land on 8.14M.

Picking the largest output rather than the last record makes the result independent of file order. Cross-file dedupe in `UsageAggregator` is unchanged: once each file is internally correct, the first file the aggregator sees already holds the right value.

One known limit, documented in the function comment: if the partial record was in a previous batch (cached base) and the final one is in the tail, the tail record is dropped for that scan. The next parse of the file sees both in one batch and settles it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (no UI change)
- [ ] I included a video for animation/interaction changes (none)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage accounting logic and invalidates scan cache v3; miscount risk is limited to within-file Claude dedupe, but reported output totals can shift materially for affected transcripts.
> 
> **Overview**
> Fixes **under-reported Claude output tokens** when transcripts emit progressive usage across multiple content-block lines for the same message (partial `output_tokens` on an early block, final count on a later one).
> 
> **`dedupeWithinFile`** now collapses each `dedupeKey` to the record with the **highest `outputTokens`**, replacing first-wins dedupe. Incremental parsing passes a shared **`Map<string, UsageRecord>`** (not a `Set`) across cached base, new lines, and tail batches so resumed scans stay consistent. **`USAGE_SCAN_CACHE_VERSION`** is bumped **3 → 4** so on-disk entries that cached the partial record are cold-re-parsed.
> 
> Docs on **`parseClaudeLine`** and **`dedupeWithinFile`** describe progressive usage and the edge case where a larger sibling in a later batch cannot replace an already-kept smaller record until the next full parse. Tests cover max-output wins, ties keeping the first instance, and cross-batch `seen` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f9a4f2b61d7e382d39ebd60b6beab2bcde6f8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `dedupeWithinFile` to keep largest output count in Claude dedupe groups
> - Changes shared dedupe state from `Set<string>` to `Map<string, UsageRecord>` so records can be compared by `outputTokens` across cached base, newly parsed, and tail batches.
> - A later duplicate replaces the retained record only when its `outputTokens` is larger; equal or smaller repeats are discarded and the original record object stays.
> - Increments `USAGE_SCAN_CACHE_VERSION` from 3 to 4.
> - Risk: bumping `USAGE_SCAN_CACHE_VERSION` invalidates existing caches; any out-of-tree consumer expecting version 3 will see stale caches discarded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74f9a4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->