### PR TITLE
fix: link PRs from non-Git workspaces

### DIFF
--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -76,6 +76,7 @@ export function useThreadPr(
             projectId: thread.linkedPullRequest.projectId,
             repository: thread.linkedPullRequest.repository,
             number: thread.linkedPullRequest.number,
+            url: thread.linkedPullRequest.url,
           },
         }),
   );

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -168,6 +168,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.pullRequests).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
+      expect(second.capabilities.threadPullRequestUrlLinking).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);
     }),
   );

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -225,6 +225,7 @@ export const make = Effect.gen(function* () {
       threadPinReorder: true,
       threadTitleRegeneration: true,
       threadPullRequestLinking: true,
+      threadPullRequestUrlLinking: true,
       environmentIcon: true,
       ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
       ...(serverSelfUpdate === "boot-service" || desktopAppUpdate

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -156,6 +156,7 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
       readonly projectId: ProjectId;
       readonly repository: string;
       readonly number: number;
+      readonly url?: string | undefined;
     }>
   >([]);
   const summaryRecovery = yield* Ref.make<ReadonlyArray<boolean | undefined>>([]);
@@ -338,7 +339,12 @@ describe("ThreadSettlementReactor", () => {
             { cwd: "/workspace/project", branch: "inactive-feature" },
           ]);
           assert.deepStrictEqual(yield* Ref.get(fixture.summaryCalls), [
-            { projectId: LINKED_PROJECT_ID, repository: "owner/repository", number: 42 },
+            {
+              projectId: LINKED_PROJECT_ID,
+              repository: "owner/repository",
+              number: 42,
+              url: "https://example.test/owner/repository/pull/42",
+            },
           ]);
           assert.deepStrictEqual(yield* Ref.get(fixture.summaryRecovery), [false]);
         }).pipe(Effect.provide(fixture.layer));
@@ -581,7 +587,12 @@ describe("ThreadSettlementReactor", () => {
 
           assert.deepStrictEqual(yield* Ref.get(fixture.commands), []);
           assert.deepStrictEqual(yield* Ref.get(fixture.summaryCalls), [
-            { projectId: LINKED_PROJECT_ID, repository: "owner/repository", number: 10 },
+            {
+              projectId: LINKED_PROJECT_ID,
+              repository: "owner/repository",
+              number: 10,
+              url: "https://example.test/owner/repository/pull/10",
+            },
           ]);
           assert.deepStrictEqual(yield* Ref.get(fixture.branchCalls), []);
         }).pipe(Effect.provide(fixture.layer));
@@ -631,7 +642,12 @@ describe("ThreadSettlementReactor", () => {
             { cwd: "/workspace/project-root", branch: "saved-feature" },
           ]);
           assert.deepStrictEqual(yield* Ref.get(fixture.summaryCalls), [
-            { projectId: LINKED_PROJECT_ID, repository: "owner/repository", number: 77 },
+            {
+              projectId: LINKED_PROJECT_ID,
+              repository: "owner/repository",
+              number: 77,
+              url: "https://example.test/owner/repository/pull/77",
+            },
           ]);
           assert.deepStrictEqual(
             new Set((yield* Ref.get(fixture.commands)).map((command) => command.threadId)),

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -61,6 +61,7 @@ export const make = Effect.gen(function* () {
           thread.linkedPullRequest.projectId,
           thread.linkedPullRequest.repository,
           thread.linkedPullRequest.number,
+          thread.linkedPullRequest.url,
         ]);
       }
       if (thread.branch === null) return JSON.stringify(["none", thread.id]);
@@ -91,6 +92,7 @@ export const make = Effect.gen(function* () {
             projectId: thread.linkedPullRequest.projectId,
             repository: thread.linkedPullRequest.repository,
             number: thread.linkedPullRequest.number,
+            url: thread.linkedPullRequest.url,
           },
           { recoverTransientFailure: false },
         );

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3172,6 +3172,75 @@ it.effect("shares linked summaries and reuses them for display without asking th
   }),
 );
 
+it.effect("reads a linked pull request URL from a non-Git project", () =>
+  Effect.gen(function* () {
+    const requests: Array<{
+      readonly cwd: string;
+      readonly host: string;
+      readonly repository: string;
+      readonly number: number;
+    }> = [];
+    const service = yield* makeService({
+      projects: [project({ id: "parent", title: "work", workspaceRoot: "/work" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequestSummary: (input) => {
+            requests.push(input);
+            return Effect.succeed(changeRequest(9435, "2026-09-03T00:00:00Z"));
+          },
+        }),
+      ],
+    });
+
+    const summary = yield* service.summary({
+      projectId: "parent" as ProjectId,
+      repository: "pingdotgg/t3code",
+      number: 9435,
+      url: "https://github.com/pingdotgg/t3code/pull/9435",
+    });
+
+    assert.deepStrictEqual(requests, [
+      {
+        cwd: "/work",
+        host: "github.com",
+        repository: "pingdotgg/t3code",
+        number: 9435,
+      },
+    ]);
+    assert.strictEqual(summary.projectId, "parent");
+    assert.strictEqual(summary.number, 9435);
+  }),
+);
+
+it.effect("refuses a URL-only summary whose repository does not match the URL", () =>
+  Effect.gen(function* () {
+    let calls = 0;
+    const service = yield* makeService({
+      projects: [project({ id: "parent", title: "work", workspaceRoot: "/work" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequestSummary: () => {
+            calls += 1;
+            return Effect.succeed(changeRequest(9435, "2026-09-03T00:00:00Z"));
+          },
+        }),
+      ],
+    });
+
+    const error = yield* Effect.flip(
+      service.summary({
+        projectId: "parent" as ProjectId,
+        repository: "other/repository",
+        number: 9435,
+        url: "https://github.com/pingdotgg/t3code/pull/9435",
+      }),
+    );
+
+    assert.strictEqual(error._tag, "PullRequestOperationError");
+    assert.strictEqual(calls, 0);
+  }),
+);
+
 it.effect("answers a known pull request immediately while the host refreshes", () =>
   Effect.gen(function* () {
     const gate = yield* Deferred.make<void>();

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3118,10 +3118,6 @@ it.effect("shares linked summaries and reuses them for display without asking th
     let calls = 0;
     let failing = false;
     const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
-    const linkedReference = {
-      ...reference,
-      url: "https://github.com/acme/web/pull/1",
-    };
     const service = yield* makeService({
       projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
       providers: [
@@ -3151,8 +3147,8 @@ it.effect("shares linked summaries and reuses them for display without asking th
 
     yield* Effect.all(
       [
-        service.summary(linkedReference, { recoverTransientFailure: false }),
-        service.summary(linkedReference, { recoverTransientFailure: false }),
+        service.summary(reference, { recoverTransientFailure: false }),
+        service.summary(reference, { recoverTransientFailure: false }),
       ],
       { concurrency: "unbounded" },
     );
@@ -3161,7 +3157,7 @@ it.effect("shares linked summaries and reuses them for display without asking th
     yield* TestClock.adjust("61 seconds");
     failing = true;
     const strict = yield* Effect.flip(
-      service.summary(linkedReference, { recoverTransientFailure: false }),
+      service.summary(reference, { recoverTransientFailure: false }),
     );
     assert.strictEqual(strict._tag, "PullRequestOperationError");
 
@@ -3216,6 +3212,43 @@ it.effect("reads a linked pull request URL from a non-Git project", () =>
   }),
 );
 
+it.effect("keeps URL-only summaries on different hosts separate", () =>
+  Effect.gen(function* () {
+    let githubCalls = 0;
+    let bitbucketCalls = 0;
+    const service = yield* makeService({
+      projects: [project({ id: "parent", title: "work", workspaceRoot: "/work" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequestSummary: () => {
+            githubCalls += 1;
+            return Effect.succeed(changeRequest(7, "2026-09-03T00:00:00Z"));
+          },
+        }),
+        fakeProvider("bitbucket", {
+          getChangeRequestSummary: () => {
+            bitbucketCalls += 1;
+            return Effect.succeed(changeRequest(7, "2026-09-03T00:00:00Z"));
+          },
+        }),
+      ],
+    });
+    const reference = {
+      projectId: "parent" as ProjectId,
+      repository: "acme/web",
+      number: 7,
+    };
+
+    yield* service.summary({ ...reference, url: "https://github.com/acme/web/pull/7" });
+    yield* service.summary({
+      ...reference,
+      url: "https://bitbucket.org/acme/web/pull-requests/7",
+    });
+
+    assert.deepStrictEqual([githubCalls, bitbucketCalls], [1, 1]);
+  }),
+);
+
 it.effect("does not use providers that cannot resolve URL-only summary hosts", () =>
   Effect.gen(function* () {
     for (const testCase of [
@@ -3233,6 +3266,11 @@ it.effect("does not use providers that cannot resolve URL-only summary hosts", (
         provider: "bitbucket" as const,
         repository: "pingdotgg/t3code",
         url: "https://bitbucket.acme.test/pingdotgg/t3code/pull-requests/9435",
+      },
+      {
+        provider: "github" as const,
+        repository: "pingdotgg/t3code",
+        url: "https://github.acme.test/pingdotgg/t3code/pull/9435",
       },
     ]) {
       const service = yield* makeService({

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3118,6 +3118,10 @@ it.effect("shares linked summaries and reuses them for display without asking th
     let calls = 0;
     let failing = false;
     const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const linkedReference = {
+      ...reference,
+      url: "https://github.com/acme/web/pull/1",
+    };
     const service = yield* makeService({
       projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
       providers: [
@@ -3147,8 +3151,8 @@ it.effect("shares linked summaries and reuses them for display without asking th
 
     yield* Effect.all(
       [
-        service.summary(reference, { recoverTransientFailure: false }),
-        service.summary(reference, { recoverTransientFailure: false }),
+        service.summary(linkedReference, { recoverTransientFailure: false }),
+        service.summary(linkedReference, { recoverTransientFailure: false }),
       ],
       { concurrency: "unbounded" },
     );
@@ -3157,7 +3161,7 @@ it.effect("shares linked summaries and reuses them for display without asking th
     yield* TestClock.adjust("61 seconds");
     failing = true;
     const strict = yield* Effect.flip(
-      service.summary(reference, { recoverTransientFailure: false }),
+      service.summary(linkedReference, { recoverTransientFailure: false }),
     );
     assert.strictEqual(strict._tag, "PullRequestOperationError");
 
@@ -3209,6 +3213,48 @@ it.effect("reads a linked pull request URL from a non-Git project", () =>
     ]);
     assert.strictEqual(summary.projectId, "parent");
     assert.strictEqual(summary.number, 9435);
+  }),
+);
+
+it.effect("does not use providers that cannot resolve URL-only summary hosts", () =>
+  Effect.gen(function* () {
+    for (const testCase of [
+      {
+        provider: "gitlab" as const,
+        repository: "pingdotgg/t3code",
+        url: "https://gitlab.com/pingdotgg/t3code/-/merge_requests/9435",
+      },
+      {
+        provider: "azure-devops" as const,
+        repository: "pingdotgg/t3code/_git/t3code",
+        url: "https://dev.azure.com/pingdotgg/t3code/_git/t3code/pullrequest/9435",
+      },
+      {
+        provider: "bitbucket" as const,
+        repository: "pingdotgg/t3code",
+        url: "https://bitbucket.acme.test/pingdotgg/t3code/pull-requests/9435",
+      },
+    ]) {
+      const service = yield* makeService({
+        projects: [project({ id: "parent", title: "work", workspaceRoot: "/work" })],
+        providers: [
+          fakeProvider(testCase.provider, {
+            getChangeRequest: () => Effect.die("unsupported URL-only provider was called"),
+          }),
+        ],
+      });
+
+      const error = yield* Effect.flip(
+        service.summary({
+          projectId: "parent" as ProjectId,
+          repository: testCase.repository,
+          number: 9435,
+          url: testCase.url,
+        }),
+      );
+
+      assert.strictEqual(error._tag, "PullRequestUnavailableError");
+    }
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3409,6 +3409,43 @@ it.effect("reuses an observed merged state for strict settlement reads", () =>
   }),
 );
 
+it.effect("shares detail updates with a registered project's linked summary", () =>
+  Effect.gen(function* () {
+    let summaryCalls = 0;
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const linkedReference = {
+      ...reference,
+      url: "https://github.com/acme/web/pull/1",
+    };
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequest: () =>
+            Effect.succeed({
+              ...hostedChangeRequest("merged body", 4),
+              url: linkedReference.url,
+              state: "merged",
+              updatedAt: "2026-07-03T00:00:00Z",
+            }),
+          getChangeRequestSummary: () => {
+            summaryCalls += 1;
+            return Effect.succeed({
+              ...changeRequest(1, "2026-07-02T00:00:00Z"),
+              url: linkedReference.url,
+            });
+          },
+        }),
+      ],
+    });
+
+    assert.strictEqual((yield* service.summary(linkedReference)).state, "open");
+    yield* service.detail(reference);
+    assert.strictEqual((yield* service.summary(linkedReference)).state, "merged");
+    assert.strictEqual(summaryCalls, 1);
+  }),
+);
+
 it.effect("does not let a stale detail reopen overwrite a fresher linked summary", () =>
   Effect.gen(function* () {
     const gate = yield* Deferred.make<void>();

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2179,6 +2179,27 @@ export const make = Effect.gen(function* () {
     ref.url === undefined
       ? refCacheKey(ref)
       : JSON.stringify([refEpoch(ref), ref.projectId, ref.repository, ref.number, ref.url]);
+  const heldSummaryCacheKey = (ref: PullRequestRef) => {
+    if (ref.url === undefined) return refCacheKey(ref);
+    const parsed = parseChangeRequestUrl(ref.url);
+    return parsed === null
+      ? summaryCacheKey(ref)
+      : JSON.stringify([
+          refEpoch(ref),
+          ref.projectId,
+          ref.repository,
+          ref.number,
+          parsed.provider,
+          parsed.host,
+        ]);
+  };
+  const recordHeldSummary = (key: string, next: PullRequestSummary) => {
+    const current = lastGoodSummary.peek(key);
+    if (current?.state === "merged" && next.state !== "merged") return Effect.void;
+    return current === undefined || next.updatedAt >= current.updatedAt
+      ? lastGoodSummary.record(key, next)
+      : Effect.void;
+  };
   const bumpRefEpoch = (ref: PullRequestRef) => {
     const scope = refScope(ref);
     if (!refEpochs.has(scope) && refEpochs.size >= REF_EPOCH_CAPACITY) {
@@ -2227,8 +2248,15 @@ export const make = Effect.gen(function* () {
     },
   );
   const summary: PullRequestService["Service"]["summary"] = (input, options) => {
-    const key = summaryCacheKey(input);
-    const cached = Cache.get(summaryCache, key);
+    const cacheKey = summaryCacheKey(input);
+    const key = heldSummaryCacheKey(input);
+    const cached = Cache.get(summaryCache, cacheKey).pipe(
+      Effect.tap((value) =>
+        input.url === undefined
+          ? recordHeldSummary(heldSummaryCacheKey({ ...input, url: value.url }), value)
+          : Effect.void,
+      ),
+    );
     if (options?.recoverTransientFailure !== false) {
       return lastGoodSummary.serveHeld(key, cached, "reuse");
     }
@@ -2337,12 +2365,6 @@ export const make = Effect.gen(function* () {
     baseBranch: detail.baseBranch,
     updatedAt: detail.updatedAt,
   });
-  const shouldReplaceHeldSummary = (key: string, next: PullRequestSummary) => {
-    const current = lastGoodSummary.peek(key);
-    if (current === undefined) return true;
-    if (current.state === "merged" && next.state !== "merged") return false;
-    return next.updatedAt >= current.updatedAt;
-  };
   const detail: PullRequestService["Service"]["detail"] = (input) => {
     const key = refCacheKey(input);
     // Record the summary from a host or cache read, not the stale value
@@ -2354,9 +2376,13 @@ export const make = Effect.gen(function* () {
       Cache.get(detailCache, key).pipe(
         Effect.tap((value) => {
           const summary = summaryFromDetail(value);
-          return shouldReplaceHeldSummary(key, summary)
-            ? lastGoodSummary.record(key, summary)
-            : Effect.void;
+          return Effect.all(
+            [
+              recordHeldSummary(key, summary),
+              recordHeldSummary(heldSummaryCacheKey({ ...input, url: summary.url }), summary),
+            ],
+            { discard: true },
+          );
         }),
       ),
       "revalidate",

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -55,6 +55,7 @@ import {
   type SourceControlProviderKind,
 } from "@t3tools/contracts";
 import {
+  canReadChangeRequestSummaryWithoutCheckout,
   detectSourceControlProviderFromRemoteUrl,
   parseChangeRequestUrl,
 } from "@t3tools/shared/sourceControl";
@@ -700,7 +701,9 @@ export const make = Effect.gen(function* () {
                   }),
                 );
               }
-              const api = registry.get(parsed.provider);
+              const api = canReadChangeRequestSummaryWithoutCheckout(parsed)
+                ? registry.get(parsed.provider)
+                : null;
               if (api !== null) {
                 return Effect.succeed({
                   project: selectedProject,
@@ -2224,8 +2227,8 @@ export const make = Effect.gen(function* () {
     },
   );
   const summary: PullRequestService["Service"]["summary"] = (input, options) => {
-    const key = summaryCacheKey(input);
-    const cached = Cache.get(summaryCache, key);
+    const key = refCacheKey(input);
+    const cached = Cache.get(summaryCache, summaryCacheKey(input));
     if (options?.recoverTransientFailure !== false) {
       return lastGoodSummary.serveHeld(key, cached, "reuse");
     }

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2227,8 +2227,8 @@ export const make = Effect.gen(function* () {
     },
   );
   const summary: PullRequestService["Service"]["summary"] = (input, options) => {
-    const key = refCacheKey(input);
-    const cached = Cache.get(summaryCache, summaryCacheKey(input));
+    const key = summaryCacheKey(input);
+    const cached = Cache.get(summaryCache, key);
     if (options?.recoverTransientFailure !== false) {
       return lastGoodSummary.serveHeld(key, cached, "reuse");
     }

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -54,7 +54,10 @@ import {
   type SourceControlProviderInfo,
   type SourceControlProviderKind,
 } from "@t3tools/contracts";
-import { detectSourceControlProviderFromRemoteUrl } from "@t3tools/shared/sourceControl";
+import {
+  detectSourceControlProviderFromRemoteUrl,
+  parseChangeRequestUrl,
+} from "@t3tools/shared/sourceControl";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
@@ -252,6 +255,7 @@ interface SupportedProject {
  */
 interface WorkspaceProjects {
   readonly supported: ReadonlyArray<SupportedProject>;
+  readonly selectedProject: OrchestrationProjectShell | undefined;
   /** Keyed by host, as the readable ones are: an unimplemented host is its own switcher entry. */
   readonly unimplemented: ReadonlyMap<
     string,
@@ -659,29 +663,68 @@ export const make = Effect.gen(function* () {
             host,
           });
         }
-        return { supported, unimplemented, viewerRoots };
+        return {
+          supported,
+          selectedProject: snapshot.projects.find((project) => project.id === filter.projectId),
+          unimplemented,
+          viewerRoots,
+        };
       }),
     );
 
-  const requireProject = (ref: PullRequestRef): Effect.Effect<SupportedProject, PullRequestError> =>
+  const requireProject = (
+    ref: PullRequestRef,
+    options?: { readonly allowUrlReference?: boolean },
+  ): Effect.Effect<SupportedProject, PullRequestError> =>
     listWorkspaceProjects({ projectId: ref.projectId }).pipe(
-      Effect.flatMap(({ supported }): Effect.Effect<SupportedProject, PullRequestError> => {
-        const match = supported[0];
-        if (!match) {
-          return Effect.fail(new PullRequestUnavailableError({ reason: "provider-unsupported" }));
-        }
-        // The repository travels through the client, so it is checked against the project's
-        // own remote rather than being handed to a provider verbatim.
-        if (match.repository.toLowerCase() !== ref.repository.trim().toLowerCase()) {
-          return Effect.fail(
-            new PullRequestOperationError({
-              operation: "resolveRepository",
-              detail: "The change request does not belong to the selected project.",
-            }),
-          );
-        }
-        return Effect.succeed(match);
-      }),
+      Effect.flatMap(
+        ({ selectedProject, supported }): Effect.Effect<SupportedProject, PullRequestError> => {
+          const match = supported[0];
+          if (!match) {
+            if (
+              options?.allowUrlReference === true &&
+              selectedProject !== undefined &&
+              selectedProject.repositoryIdentity == null &&
+              ref.url !== undefined
+            ) {
+              const parsed = parseChangeRequestUrl(ref.url);
+              if (
+                parsed === null ||
+                parsed.repository !== ref.repository.trim().toLowerCase() ||
+                parsed.number !== ref.number
+              ) {
+                return Effect.fail(
+                  new PullRequestOperationError({
+                    operation: "resolveRepository",
+                    detail: "The linked change request does not match its URL.",
+                  }),
+                );
+              }
+              const api = registry.get(parsed.provider);
+              if (api !== null) {
+                return Effect.succeed({
+                  project: selectedProject,
+                  api: withRateLimitBackoff(api, parsed.host, rateLimits),
+                  repository: parsed.repository,
+                  host: parsed.host,
+                });
+              }
+            }
+            return Effect.fail(new PullRequestUnavailableError({ reason: "provider-unsupported" }));
+          }
+          // The repository travels through the client, so it is checked against the project's
+          // own remote rather than being handed to a provider verbatim.
+          if (match.repository.toLowerCase() !== ref.repository.trim().toLowerCase()) {
+            return Effect.fail(
+              new PullRequestOperationError({
+                operation: "resolveRepository",
+                detail: "The change request does not belong to the selected project.",
+              }),
+            );
+          }
+          return Effect.succeed(match);
+        },
+      ),
     );
 
   /**
@@ -1228,7 +1271,7 @@ export const make = Effect.gen(function* () {
     resolveViewers([project], new Map()).pipe(Effect.map(([resolved]) => resolved?.viewer ?? null));
 
   const summaryUncached: PullRequestService["Service"]["summary"] = (input) =>
-    requireProject(input).pipe(
+    requireProject(input, { allowUrlReference: true }).pipe(
       Effect.flatMap((project) => {
         const providerInput = {
           cwd: project.project.workspaceRoot,
@@ -2129,6 +2172,10 @@ export const make = Effect.gen(function* () {
   const refEpoch = (ref: PullRequestRef) => refEpochs.get(refScope(ref)) ?? 0;
   const refCacheKey = (ref: PullRequestRef) =>
     JSON.stringify([refEpoch(ref), ref.projectId, ref.repository, ref.number]);
+  const summaryCacheKey = (ref: PullRequestRef) =>
+    ref.url === undefined
+      ? refCacheKey(ref)
+      : JSON.stringify([refEpoch(ref), ref.projectId, ref.repository, ref.number, ref.url]);
   const bumpRefEpoch = (ref: PullRequestRef) => {
     const scope = refScope(ref);
     if (!refEpochs.has(scope) && refEpochs.size >= REF_EPOCH_CAPACITY) {
@@ -2157,8 +2204,19 @@ export const make = Effect.gen(function* () {
 
   const summaryCache = yield* Cache.makeWith(
     (key: string) => {
-      const [, projectId, repository, number] = JSON.parse(key) as [number, string, string, number];
-      return summaryUncached({ projectId, repository, number } as PullRequestRef);
+      const [, projectId, repository, number, url] = JSON.parse(key) as [
+        number,
+        string,
+        string,
+        number,
+        string | undefined,
+      ];
+      return summaryUncached({
+        projectId,
+        repository,
+        number,
+        ...(url ? { url } : {}),
+      } as PullRequestRef);
     },
     {
       capacity: DETAIL_CACHE_CAPACITY,
@@ -2166,7 +2224,7 @@ export const make = Effect.gen(function* () {
     },
   );
   const summary: PullRequestService["Service"]["summary"] = (input, options) => {
-    const key = refCacheKey(input);
+    const key = summaryCacheKey(input);
     const cached = Cache.get(summaryCache, key);
     if (options?.recoverTransientFailure !== false) {
       return lastGoodSummary.serveHeld(key, cached, "reuse");

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -22,9 +22,8 @@ vi.mock("../editorPreferences", () => ({
   usePreferredEditor: () => [null, vi.fn()],
 }));
 vi.mock("~/lib/openPullRequestLink", () => ({
-  findProjectForChangeRequest: () => undefined,
   matchesLinkedPullRequestUrl: () => false,
-  parseChangeRequestUrl: () => null,
+  resolveThreadPullRequestLink: () => null,
   useOpenChangeRequestLink: () => vi.fn(),
 }));
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -26,7 +26,6 @@ import type {
   EnvironmentId,
   ScopedThreadRef,
   ServerProviderSkill,
-  ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
@@ -159,9 +158,8 @@ import {
   WORKSPACE_BASENAME_LOOKUP_LIMIT,
 } from "../workspaceBasenameLookup";
 import {
-  findProjectForChangeRequest,
   matchesLinkedPullRequestUrl,
-  parseChangeRequestUrl,
+  resolveThreadPullRequestLink,
   useOpenChangeRequestLink,
 } from "~/lib/openPullRequestLink";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
@@ -2126,27 +2124,21 @@ function ChatMarkdown({
   // makes a persisted "app" apply once settings hydrate after launch.
   const linkTargetPreference = useClientSettings((settings) => settings.browserLinkTarget);
   const resolveThreadPullRequest = useCallback(
-    (href: string): ThreadLinkedPullRequest | null => {
+    (href: string) => {
+      const thread = threadRef === undefined ? null : readThreadShell(threadRef);
       if (
         threadRef === undefined ||
-        readThreadShell(threadRef) === null ||
+        thread === null ||
         threadServerConfig?.environment.capabilities.threadPullRequestLinking !== true
       ) {
         return null;
       }
-      const parsed = parseChangeRequestUrl(href);
-      if (parsed === null) return null;
-      const project = findProjectForChangeRequest(
+      return resolveThreadPullRequestLink(
         projects.filter((candidate) => candidate.environmentId === threadRef.environmentId),
-        parsed,
+        thread.projectId,
+        href,
+        threadServerConfig.environment.capabilities.threadPullRequestUrlLinking === true,
       );
-      if (project === undefined) return null;
-      return {
-        projectId: project.id,
-        repository: project.repositoryIdentity?.displayName ?? parsed.repository,
-        number: parsed.number,
-        url: href,
-      };
     },
     [projects, threadRef, threadServerConfig],
   );

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -36,9 +36,8 @@ vi.mock("../editorPreferences", () => ({
   usePreferredEditor: () => [null, vi.fn()],
 }));
 vi.mock("~/lib/openPullRequestLink", () => ({
-  findProjectForChangeRequest: () => undefined,
   matchesLinkedPullRequestUrl: () => false,
-  parseChangeRequestUrl: () => null,
+  resolveThreadPullRequestLink: () => null,
   useOpenChangeRequestLink: () => vi.fn(),
 }));
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -948,6 +948,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     linkedPullRequestStatus,
   });
   const prStatus = prStatusIndicator(pr, prProvider);
+  const prLinkUrl = pr?.url ?? thread.linkedPullRequest?.url ?? null;
+  const prLinkNumber = pr?.number ?? thread.linkedPullRequest?.number ?? null;
   const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
   useEffect(() => {
     const nextSnapshot = nextThreadChangeRequestSnapshot({
@@ -1132,17 +1134,24 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   }, [showSnoozeButton]);
   const handlePrClick = useCallback(
     (event: ReactMouseEvent<HTMLAnchorElement>) => {
-      if (!pr?.url) return;
+      if (prLinkUrl === null) return;
       const openedInRightPanel = openPrLink(
         event,
-        pr.url,
+        prLinkUrl,
         openPullRequestsInRightPanel ? threadRef : undefined,
       );
       if (openedInRightPanel && openPullRequestsInRightPanel && !props.isActive) {
         onThreadActivate(threadRef);
       }
     },
-    [onThreadActivate, openPrLink, openPullRequestsInRightPanel, pr, props.isActive, threadRef],
+    [
+      onThreadActivate,
+      openPrLink,
+      openPullRequestsInRightPanel,
+      prLinkUrl,
+      props.isActive,
+      threadRef,
+    ],
   );
 
   // All sidebar rows share one surface model. Live threads used to look
@@ -1211,9 +1220,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // A real link so cmd/ctrl+click and middle-click open the host in the
   // browser. A plain click still opens T3's pull request view.
   const prBadge =
-    prStatus && pr ? (
+    prLinkUrl !== null && prLinkNumber !== null ? (
       <a
-        href={pr.url}
+        href={prLinkUrl}
         target="_blank"
         rel="noopener noreferrer"
         onPointerDown={(event) => event.stopPropagation()}
@@ -1226,11 +1235,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             ? props.isActive
               ? "text-secondary-label"
               : cn("text-secondary-label transition-colors", settledPrHoverClass)
-            : prStatus.colorClass,
+            : (prStatus?.colorClass ?? "text-secondary-label"),
         )}
-        aria-label={prStatus.tooltip}
+        aria-label={prStatus?.tooltip ?? `Change request #${prLinkNumber}`}
       >
-        #{pr.number}
+        #{prLinkNumber}
       </a>
     ) : null;
   const terminalStatusIcon = terminalStatus ? (

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -63,6 +63,7 @@ export function useLinkedThreadPullRequest(
             projectId: linkedPullRequest.projectId,
             repository: linkedPullRequest.repository,
             number: linkedPullRequest.number,
+            url: linkedPullRequest.url,
           },
         }),
   ).data;

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -8,6 +8,7 @@ import {
   openPullRequestLink,
   parseChangeRequestUrl,
   PullRequestLinkOpenError,
+  resolveThreadPullRequestLink,
   shouldOpenPullRequestExternally,
 } from "./openPullRequestLink";
 import { ProjectId, type RepositoryIdentity } from "@t3tools/contracts";
@@ -204,6 +205,7 @@ describe("parseChangeRequestUrl", () => {
       host: "github.com",
       repository: "t3tools/t3code",
       number: 123,
+      provider: "github",
     });
   });
 
@@ -212,6 +214,7 @@ describe("parseChangeRequestUrl", () => {
       host: "github.acme.test",
       repository: "platform/api",
       number: 7,
+      provider: "github",
     });
   });
 
@@ -222,6 +225,7 @@ describe("parseChangeRequestUrl", () => {
       host: "gitlab.com",
       repository: "t3tools/platform/t3code",
       number: 42,
+      provider: "gitlab",
     });
   });
 
@@ -231,6 +235,7 @@ describe("parseChangeRequestUrl", () => {
         host: "code.acme.test",
         repository: "team/project",
         number: 9,
+        provider: "gitlab",
       },
     );
   });
@@ -240,6 +245,7 @@ describe("parseChangeRequestUrl", () => {
       host: "bitbucket.org",
       repository: "workspace/repo",
       number: 5,
+      provider: "bitbucket",
     });
   });
 
@@ -250,6 +256,7 @@ describe("parseChangeRequestUrl", () => {
       host: "dev.azure.com",
       repository: "acme/platform/_git/t3code",
       number: 17,
+      provider: "azure-devops",
     });
     expect(
       parseChangeRequestUrl("https://acme.visualstudio.com/platform/_git/t3code/pullrequest/17"),
@@ -257,6 +264,7 @@ describe("parseChangeRequestUrl", () => {
       host: "acme.visualstudio.com",
       repository: "platform/_git/t3code",
       number: 17,
+      provider: "azure-devops",
     });
   });
 
@@ -265,17 +273,29 @@ describe("parseChangeRequestUrl", () => {
       host: "github.com",
       repository: "t3tools/t3code",
       number: 123,
+      provider: "github",
     });
     expect(
       parseChangeRequestUrl("https://gitlab.com/team/project/-/merge_requests/42/diffs#note_1"),
-    ).toEqual({ host: "gitlab.com", repository: "team/project", number: 42 });
+    ).toEqual({
+      host: "gitlab.com",
+      repository: "team/project",
+      number: 42,
+      provider: "gitlab",
+    });
     expect(
       parseChangeRequestUrl("https://bitbucket.org/team/repo/pull-requests/5/commits"),
-    ).toEqual({ host: "bitbucket.org", repository: "team/repo", number: 5 });
+    ).toEqual({
+      host: "bitbucket.org",
+      repository: "team/repo",
+      number: 5,
+      provider: "bitbucket",
+    });
     expect(parseChangeRequestUrl("https://github.com/t3tools/t3code/pull/123/")).toEqual({
       host: "github.com",
       repository: "t3tools/t3code",
       number: 123,
+      provider: "github",
     });
   });
 
@@ -297,6 +317,41 @@ describe("parseChangeRequestUrl", () => {
     ]) {
       expect(parseChangeRequestUrl(link), link).toBeNull();
     }
+  });
+});
+
+describe("resolveThreadPullRequestLink", () => {
+  const parentProjectId = ProjectId.make("parent");
+  const parentProject = {
+    id: parentProjectId,
+    repositoryIdentity: null,
+  } as never;
+
+  it("uses a non-Git parent as the context for a URL-only link", () => {
+    expect(
+      resolveThreadPullRequestLink(
+        [parentProject],
+        parentProjectId,
+        "https://github.com/pingdotgg/t3code/pull/9435",
+        true,
+      ),
+    ).toEqual({
+      projectId: parentProjectId,
+      repository: "pingdotgg/t3code",
+      number: 9435,
+      url: "https://github.com/pingdotgg/t3code/pull/9435",
+    });
+  });
+
+  it("keeps URL-only linking behind its server capability", () => {
+    expect(
+      resolveThreadPullRequestLink(
+        [parentProject],
+        parentProjectId,
+        "https://github.com/pingdotgg/t3code/pull/9435",
+        false,
+      ),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -216,6 +216,12 @@ describe("parseChangeRequestUrl", () => {
       number: 7,
       provider: "github",
     });
+    expect(parseChangeRequestUrl("https://github.acme.test:8443/platform/api/pull/7")).toEqual({
+      host: "github.acme.test:8443",
+      repository: "platform/api",
+      number: 7,
+      provider: "github",
+    });
   });
 
   it("reads a GitLab merge request, nested groups and all", () => {
@@ -352,6 +358,14 @@ describe("resolveThreadPullRequestLink", () => {
         false,
       ),
     ).toBeNull();
+  });
+
+  it.each([
+    "https://gitlab.com/pingdotgg/t3code/-/merge_requests/9435",
+    "https://dev.azure.com/pingdotgg/t3code/_git/t3code/pullrequest/9435",
+    "https://bitbucket.acme.test/pingdotgg/t3code/pull-requests/9435",
+  ])("does not offer URL-only linking when the provider cannot resolve the host", (url) => {
+    expect(resolveThreadPullRequestLink([parentProject], parentProjectId, url, true)).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -217,7 +217,7 @@ describe("parseChangeRequestUrl", () => {
       provider: "github",
     });
     expect(parseChangeRequestUrl("https://github.acme.test:8443/platform/api/pull/7")).toEqual({
-      host: "github.acme.test:8443",
+      host: "github.acme.test",
       repository: "platform/api",
       number: 7,
       provider: "github",
@@ -364,6 +364,7 @@ describe("resolveThreadPullRequestLink", () => {
     "https://gitlab.com/pingdotgg/t3code/-/merge_requests/9435",
     "https://dev.azure.com/pingdotgg/t3code/_git/t3code/pullrequest/9435",
     "https://bitbucket.acme.test/pingdotgg/t3code/pull-requests/9435",
+    "https://github.acme.test/pingdotgg/t3code/pull/9435",
   ])("does not offer URL-only linking when the provider cannot resolve the host", (url) => {
     expect(resolveThreadPullRequestLink([parentProject], parentProjectId, url, true)).toBeNull();
   });
@@ -372,6 +373,18 @@ describe("resolveThreadPullRequestLink", () => {
 describe("findProjectForChangeRequest", () => {
   const project = (identity: Record<string, unknown>) =>
     ({ id: "p1", repositoryIdentity: identity }) as never;
+
+  it("matches a custom-port link by its canonical hostname", () => {
+    const candidate = project({
+      canonicalKey: "github.acme.test/platform/api",
+      provider: "github",
+      displayName: "platform/api",
+    });
+    const link = parseChangeRequestUrl("https://github.acme.test:8443/platform/api/pull/7");
+
+    if (link === null) throw new Error("expected a GitHub Enterprise pull request");
+    expect(findProjectForChangeRequest([candidate], link)).toBe(candidate);
+  });
 
   it("matches a nested GitLab group by the whole path below the host", () => {
     // The server identifies a repository by `displayName`, which keeps every group segment; the

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -6,6 +6,7 @@ import type {
   ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
 import { useNavigate } from "@tanstack/react-router";
+import { parseChangeRequestUrl, type ChangeRequestLink } from "@t3tools/shared/sourceControl";
 import * as Schema from "effect/Schema";
 import { type MouseEvent, useCallback } from "react";
 
@@ -18,6 +19,9 @@ import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 
 import { useProjects, useServerConfigs } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
+
+export { parseChangeRequestUrl } from "@t3tools/shared/sourceControl";
+export type { ChangeRequestLink } from "@t3tools/shared/sourceControl";
 
 export class PullRequestLinkOpenError extends Schema.TaggedErrorClass<PullRequestLinkOpenError>()(
   "PullRequestLinkOpenError",
@@ -90,76 +94,6 @@ export function gitHubPullRequestBrowserUrl(
   }
 }
 
-/**
- * A change request the page can open, named the way the page names one: the host below which the
- * repository is addressed, the repository path as that host writes it, and the number.
- *
- * The two strings are what `pullRequestHostOf` and the project's `repositoryIdentity` produce
- * from a git remote — lower case, no port, the full path below the host — because the page matches
- * a link against those. Anything else opens nothing.
- */
-export interface ChangeRequestLink {
-  readonly host: string;
-  readonly repository: string;
-  readonly number: number;
-}
-
-/** The host itself, one of its subdomains, or an install named after the provider. */
-function isHostOf(hostname: string, apex: string, label?: string): boolean {
-  if (hostname === apex || hostname.endsWith(`.${apex}`)) return true;
-  return label !== undefined && hostname.startsWith(`${label}.`);
-}
-
-/**
- * The repository and number behind a change request URL on a host the page can read, or null for
- * anything else — an issue, a commit, a repository root, a host this cannot tell apart from an
- * ordinary link. Null means the system browser, so a doubtful match is worse than no match: it
- * takes the reader out of their browser and into a page that cannot find the change request.
- *
- * Each host is recognised by the path shape it alone uses, guarded by a hostname it could
- * plausibly be served from, since self-hosted installs are named whatever their admin chose:
- * GitLab's `/-/` marker is unique enough to trust on any hostname, while `/pull/` is generic
- * enough that it is only believed from a GitHub-ish host.
- */
-export function parseChangeRequestUrl(targetUrl: string): ChangeRequestLink | null {
-  let url: URL;
-  try {
-    url = new URL(targetUrl);
-  } catch {
-    return null;
-  }
-  // `javascript:`, `mailto:` and friends have no host to speak of and nothing to open.
-  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-  // Nothing here tries to tell a lookalike hostname from a real one — `github.com.evil.test`,
-  // `github.com-evil.test` and the rest are an open set, and blocking spellings of it costs real
-  // hosts (`gitlab.com.br` is a registrable domain, not a disguise). What a claim is worth is
-  // decided where it is used: only a link matching a repository this workspace has checked out
-  // opens the page, and everything else stays the ordinary link it was.
-  const host = url.hostname.toLowerCase();
-
-  // GitHub, and any Enterprise install: /{owner}/{repo}/pull/{n}
-  if (isHostOf(host, "github.com", "github")) {
-    const match = /^\/([^/]+\/[^/]+)\/pull\/(\d+)(?:\/|$)/u.exec(url.pathname);
-    return claim(host, match);
-  }
-  // GitLab, self-hosted included: /{group}/[{subgroup}/...]{repo}/-/merge_requests/{n}. The `/-/`
-  // separator is GitLab's own, so the hostname is not asked about.
-  const gitlab = /^\/([^/]+(?:\/[^/]+)+)\/-\/merge_requests\/(\d+)(?:\/|$)/u.exec(url.pathname);
-  if (gitlab) return claim(host, gitlab);
-  // Bitbucket Cloud: /{workspace}/{repo}/pull-requests/{n}
-  if (isHostOf(host, "bitbucket.org", "bitbucket")) {
-    const match = /^\/([^/]+\/[^/]+)\/pull-requests\/(\d+)(?:\/|$)/u.exec(url.pathname);
-    return claim(host, match);
-  }
-  // Azure DevOps, both the current host and the per-organisation one it replaced. `_git` is part
-  // of the repository path there, as it is in the remote URL the identity is read from.
-  if (isHostOf(host, "dev.azure.com") || host.endsWith(".visualstudio.com")) {
-    const match = /^\/((?:[^/]+\/)*_git\/[^/]+)\/pullrequest\/(\d+)(?:\/|$)/u.exec(url.pathname);
-    return claim(host, match);
-  }
-  return null;
-}
-
 /** Match a stored PR without requiring its project to remain available. */
 export function matchesLinkedPullRequestUrl(
   linkedPullRequest: ThreadLinkedPullRequest,
@@ -193,14 +127,6 @@ export function changeRequestRepositoryUrl(targetUrl: string): string | null {
   return url.toString();
 }
 
-function claim(host: string, match: RegExpExecArray | null): ChangeRequestLink | null {
-  const repository = match?.[1];
-  const number = Number(match?.[2]);
-  return repository && Number.isSafeInteger(number) && number > 0
-    ? { host, repository: repository.toLowerCase(), number }
-    : null;
-}
-
 /**
  * Returns a click handler that opens a pull request URL in the system browser.
  *
@@ -232,6 +158,26 @@ export function findProjectForChangeRequest(
       pullRequestHostOf(identity, kind) === link.host.toLowerCase()
     );
   });
+}
+
+export function resolveThreadPullRequestLink(
+  projects: ReadonlyArray<EnvironmentProject>,
+  threadProjectId: EnvironmentProject["id"],
+  targetUrl: string,
+  allowUrlOnly: boolean,
+): ThreadLinkedPullRequest | null {
+  const parsed = parseChangeRequestUrl(targetUrl);
+  if (parsed === null) return null;
+  const matchedProject = findProjectForChangeRequest(projects, parsed);
+  const project = matchedProject ?? projects.find((candidate) => candidate.id === threadProjectId);
+  if (project === undefined || (matchedProject === undefined && !allowUrlOnly)) return null;
+  if (matchedProject === undefined && project.repositoryIdentity != null) return null;
+  return {
+    projectId: project.id,
+    repository: matchedProject?.repositoryIdentity?.displayName ?? parsed.repository,
+    number: parsed.number,
+    url: targetUrl,
+  };
 }
 
 /**

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -6,7 +6,11 @@ import type {
   ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
 import { useNavigate } from "@tanstack/react-router";
-import { parseChangeRequestUrl, type ChangeRequestLink } from "@t3tools/shared/sourceControl";
+import {
+  canReadChangeRequestSummaryWithoutCheckout,
+  parseChangeRequestUrl,
+  type ChangeRequestLink,
+} from "@t3tools/shared/sourceControl";
 import * as Schema from "effect/Schema";
 import { type MouseEvent, useCallback } from "react";
 
@@ -171,7 +175,12 @@ export function resolveThreadPullRequestLink(
   const matchedProject = findProjectForChangeRequest(projects, parsed);
   const project = matchedProject ?? projects.find((candidate) => candidate.id === threadProjectId);
   if (project === undefined || (matchedProject === undefined && !allowUrlOnly)) return null;
-  if (matchedProject === undefined && project.repositoryIdentity != null) return null;
+  if (
+    matchedProject === undefined &&
+    (project.repositoryIdentity != null || !canReadChangeRequestSummaryWithoutCheckout(parsed))
+  ) {
+    return null;
+  }
   return {
     projectId: project.id,
     repository: matchedProject?.repositoryIdentity?.displayName ?? parsed.repository,

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -58,6 +58,7 @@ export function useSharedPullRequestSummary(
           reference.projectId,
           reference.repository.toLowerCase(),
           reference.number,
+          reference.url ?? null,
         ]);
   const atom = observedPullRequestSummaryAtom(key);
   const observed = useAtomValue(atom);

--- a/apps/web/src/state/pullRequests.ts
+++ b/apps/web/src/state/pullRequests.ts
@@ -58,7 +58,7 @@ export function useSharedPullRequestSummary(
           reference.projectId,
           reference.repository.toLowerCase(),
           reference.number,
-          reference.url ?? null,
+          current?.url ?? reference.url ?? null,
         ]);
   const atom = observedPullRequestSummaryAtom(key);
   const observed = useAtomValue(atom);

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -113,6 +113,8 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   threadTitleRegeneration: Schema.optionalKey(Schema.Boolean),
   /** Server persists a pull request reference on thread.meta.update. */
   threadPullRequestLinking: Schema.optionalKey(Schema.Boolean),
+  /** Server can resolve a linked pull request from its URL without a Git project. */
+  threadPullRequestUrlLinking: Schema.optionalKey(Schema.Boolean),
   /** The update path clients should offer for this server. Absent on
       servers that must be relaunched manually (dev checkouts, Windows
       foreground runs, pre-update servers). */

--- a/packages/contracts/src/pullRequest.test.ts
+++ b/packages/contracts/src/pullRequest.test.ts
@@ -6,6 +6,7 @@ import {
   PullRequestCapabilities,
   PullRequestListInput,
   PullRequestListResult,
+  PullRequestRef,
   PullRequestReviewerRequestInput,
   resolvePullRequestAuthorFilter,
 } from "./pullRequest.ts";
@@ -14,6 +15,7 @@ const decodeListResult = Schema.decodeUnknownSync(PullRequestListResult);
 const decodeListInput = Schema.decodeUnknownSync(PullRequestListInput);
 const decodeReviewerRequest = Schema.decodeUnknownSync(PullRequestReviewerRequestInput);
 const decodeAction = Schema.decodeUnknownSync(PullRequestActionInput);
+const decodeRef = Schema.decodeUnknownSync(PullRequestRef);
 
 const LIST_RESULT: PullRequestListResult = {
   viewers: { "github.com": "bilal", "gitlab.com": "bilal.hassan" },
@@ -63,6 +65,14 @@ const LIST_RESULT: PullRequestListResult = {
   truncated: false,
   nextCursors: { "github.com pingdotgg/t3code": "2026-07-02T00:00:00Z|1|1" },
 };
+
+it("keeps the URL that identifies a linked pull request without a Git project", () => {
+  const url = "https://github.com/pingdotgg/t3code/pull/9435";
+
+  expect(
+    decodeRef({ projectId: "parent", repository: "pingdotgg/t3code", number: 9435, url }).url,
+  ).toBe(url);
+});
 
 describe("PullRequestListResult", () => {
   /**

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -619,6 +619,7 @@ export const PullRequestRef = Schema.Struct({
   projectId: ProjectId,
   repository: TrimmedNonEmptyString,
   number: PositiveInt,
+  url: Schema.optional(TrimmedNonEmptyString),
 });
 export type PullRequestRef = typeof PullRequestRef.Type;
 

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -29,7 +29,8 @@ export interface ParsedChangeRequestLink extends ChangeRequestLink {
 /** Providers whose linked-thread summary can be read without repository checkout context. */
 export function canReadChangeRequestSummaryWithoutCheckout(link: ParsedChangeRequestLink): boolean {
   return (
-    link.provider === "github" || (link.provider === "bitbucket" && link.host === "bitbucket.org")
+    (link.provider === "github" && link.host === "github.com") ||
+    (link.provider === "bitbucket" && link.host === "bitbucket.org")
   );
 }
 
@@ -59,22 +60,21 @@ export function parseChangeRequestUrl(targetUrl: string): ParsedChangeRequestLin
     return null;
   }
   if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-  const hostname = url.hostname.toLowerCase();
-  const host = url.host.toLowerCase();
+  const host = url.hostname.toLowerCase();
 
-  if (isHostOf(hostname, "github.com", "github")) {
+  if (isHostOf(host, "github.com", "github")) {
     return claim(host, "github", /^\/([^/]+\/[^/]+)\/pull\/(\d+)(?:\/|$)/u.exec(url.pathname));
   }
   const gitlab = /^\/([^/]+(?:\/[^/]+)+)\/-\/merge_requests\/(\d+)(?:\/|$)/u.exec(url.pathname);
   if (gitlab) return claim(host, "gitlab", gitlab);
-  if (isHostOf(hostname, "bitbucket.org", "bitbucket")) {
+  if (isHostOf(host, "bitbucket.org", "bitbucket")) {
     return claim(
       host,
       "bitbucket",
       /^\/([^/]+\/[^/]+)\/pull-requests\/(\d+)(?:\/|$)/u.exec(url.pathname),
     );
   }
-  if (isHostOf(hostname, "dev.azure.com") || hostname.endsWith(".visualstudio.com")) {
+  if (isHostOf(host, "dev.azure.com") || host.endsWith(".visualstudio.com")) {
     return claim(
       host,
       "azure-devops",

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -26,6 +26,13 @@ export interface ParsedChangeRequestLink extends ChangeRequestLink {
   readonly provider: Exclude<SourceControlProviderKind, "unknown">;
 }
 
+/** Providers whose linked-thread summary can be read without repository checkout context. */
+export function canReadChangeRequestSummaryWithoutCheckout(link: ParsedChangeRequestLink): boolean {
+  return (
+    link.provider === "github" || (link.provider === "bitbucket" && link.host === "bitbucket.org")
+  );
+}
+
 function isHostOf(hostname: string, apex: string, label?: string): boolean {
   if (hostname === apex || hostname.endsWith(`.${apex}`)) return true;
   return label !== undefined && hostname.startsWith(`${label}.`);
@@ -52,21 +59,22 @@ export function parseChangeRequestUrl(targetUrl: string): ParsedChangeRequestLin
     return null;
   }
   if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-  const host = url.hostname.toLowerCase();
+  const hostname = url.hostname.toLowerCase();
+  const host = url.host.toLowerCase();
 
-  if (isHostOf(host, "github.com", "github")) {
+  if (isHostOf(hostname, "github.com", "github")) {
     return claim(host, "github", /^\/([^/]+\/[^/]+)\/pull\/(\d+)(?:\/|$)/u.exec(url.pathname));
   }
   const gitlab = /^\/([^/]+(?:\/[^/]+)+)\/-\/merge_requests\/(\d+)(?:\/|$)/u.exec(url.pathname);
   if (gitlab) return claim(host, "gitlab", gitlab);
-  if (isHostOf(host, "bitbucket.org", "bitbucket")) {
+  if (isHostOf(hostname, "bitbucket.org", "bitbucket")) {
     return claim(
       host,
       "bitbucket",
       /^\/([^/]+\/[^/]+)\/pull-requests\/(\d+)(?:\/|$)/u.exec(url.pathname),
     );
   }
-  if (isHostOf(host, "dev.azure.com") || host.endsWith(".visualstudio.com")) {
+  if (isHostOf(hostname, "dev.azure.com") || hostname.endsWith(".visualstudio.com")) {
     return claim(
       host,
       "azure-devops",

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -16,6 +16,66 @@ export interface ChangeRequestTerminology {
   readonly singular: string;
 }
 
+export interface ChangeRequestLink {
+  readonly host: string;
+  readonly repository: string;
+  readonly number: number;
+}
+
+export interface ParsedChangeRequestLink extends ChangeRequestLink {
+  readonly provider: Exclude<SourceControlProviderKind, "unknown">;
+}
+
+function isHostOf(hostname: string, apex: string, label?: string): boolean {
+  if (hostname === apex || hostname.endsWith(`.${apex}`)) return true;
+  return label !== undefined && hostname.startsWith(`${label}.`);
+}
+
+function claim(
+  host: string,
+  provider: ParsedChangeRequestLink["provider"],
+  match: RegExpExecArray | null,
+): ParsedChangeRequestLink | null {
+  const repository = match?.[1];
+  const number = Number(match?.[2]);
+  return repository && Number.isSafeInteger(number) && number > 0
+    ? { host, repository: repository.toLowerCase(), number, provider }
+    : null;
+}
+
+/** A supported source-control change request parsed from its browser URL. */
+export function parseChangeRequestUrl(targetUrl: string): ParsedChangeRequestLink | null {
+  let url: URL;
+  try {
+    url = new URL(targetUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  const host = url.hostname.toLowerCase();
+
+  if (isHostOf(host, "github.com", "github")) {
+    return claim(host, "github", /^\/([^/]+\/[^/]+)\/pull\/(\d+)(?:\/|$)/u.exec(url.pathname));
+  }
+  const gitlab = /^\/([^/]+(?:\/[^/]+)+)\/-\/merge_requests\/(\d+)(?:\/|$)/u.exec(url.pathname);
+  if (gitlab) return claim(host, "gitlab", gitlab);
+  if (isHostOf(host, "bitbucket.org", "bitbucket")) {
+    return claim(
+      host,
+      "bitbucket",
+      /^\/([^/]+\/[^/]+)\/pull-requests\/(\d+)(?:\/|$)/u.exec(url.pathname),
+    );
+  }
+  if (isHostOf(host, "dev.azure.com") || host.endsWith(".visualstudio.com")) {
+    return claim(
+      host,
+      "azure-devops",
+      /^\/((?:[^/]+\/)*_git\/[^/]+)\/pullrequest\/(\d+)(?:\/|$)/u.exec(url.pathname),
+    );
+  }
+  return null;
+}
+
 export const DEFAULT_CHANGE_REQUEST_TERMINOLOGY: ChangeRequestTerminology = {
   shortLabel: "PR",
   singular: "pull request",


### PR DESCRIPTION
A thread under a non-Git parent workspace could not link a child repository PR because the client required every URL to match a registered Git project. The sidebar also hid the persisted PR number until a live summary loaded.

This keeps the existing project-backed path and lets capable servers use a non-Git thread project as read-only provider context. The server re-parses and validates the URL before fetching a summary; PR mutations remain restricted to registered Git projects. The sidebar now renders the persisted PR number immediately.

## Verification

- Reproduced on `origin/main`: issue #9435 parsed correctly but had no matching project, so the link action was omitted
- `vp test run packages/contracts/src/pullRequest.test.ts apps/web/src/lib/openPullRequestLink.test.ts apps/web/src/components/ChatMarkdown.test.tsx apps/web/src/components/ChatMarkdown.workspace-images.test.tsx apps/web/src/components/ThreadStatusIndicators.test.ts apps/server/src/environment/ServerEnvironment.test.ts apps/server/src/pullRequest/PullRequestService.test.ts apps/server/src/orchestration/ThreadSettlementReactor.test.ts` (277 tests)
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter t3 typecheck`
- Targeted lint on all changed files (no errors)

Fixes #9435

Implemented with GPT-5.6 Sol via Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR resolution, caching, and thread linking across server and clients; URL-only reads are restricted to public GitHub/Bitbucket hosts, so self-hosted or enterprise URLs remain unavailable by design.
> 
> **Overview**
> Threads in **non-Git parent workspaces** can now link a change request from a pasted URL when the server advertises **`threadPullRequestUrlLinking`**. The client no longer requires a matching checked-out Git project; it uses **`resolveThreadPullRequestLink`** (with the existing project-match path unchanged) and gates URL-only linking on that capability.
> 
> **Contracts and plumbing:** `PullRequestRef` gains an optional **`url`**, and mobile/web/settlement paths forward it into PR detail and summary queries. Settlement dedupe keys include the URL so linked lookups stay distinct.
> 
> **Server:** `PullRequestService.summary` can resolve references for projects **without `repositoryIdentity`** by re-parsing the URL, validating repo/number against the ref, and calling a provider only when **`canReadChangeRequestSummaryWithoutCheckout`** allows it (**`github.com`** and **`bitbucket.org`** today). Summary/detail held-cache keys incorporate URL/provider/host so different links do not share state; detail refreshes can update URL-keyed summaries.
> 
> **Shared parsing:** Change-request URL parsing (with **provider** metadata) moves to **`@t3tools/shared/sourceControl`** for web and server.
> 
> **UI:** The sidebar shows the **persisted PR number and link** from `thread.linkedPullRequest` before live summary loads; chat markdown uses the centralized resolver instead of inline project matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dad1010c5e166ad32853fd497320c9185a777a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PR linking from non-Git workspaces via URL-only references
> - Adds a shared change-request URL parser with provider metadata and `canReadChangeRequestSummaryWithoutCheckout` to [sourceControl.ts](https://github.com/pingdotgg/t3code/pull/9440/files#diff-cb400671e313566c053c016f281d8ebad90db5adcec2fee1dea13d296d8b789d); only public GitHub and Bitbucket hosts qualify for checkout-independent summary reads
> - `PullRequestService.requireProject` gains an opt-in URL-reference path: when no supported project match exists, it validates the parsed URL, requires a selected project without repository identity, and resolves the provider by parsed kind
> - Summary cache keys and held-summary recorders now distinguish URL-bearing references while sharing compatible results between URL-less and URL-bearing refs for the same parsed provider and host
> - New `threadPullRequestUrlLinking` capability in [environment.ts](https://github.com/pingdotgg/t3code/pull/9440/files#diff-b65c7cdf3624689c7649437c1a0f4c45f1ce579724f52098249d43ccf0aa7203) gates the feature server-side; web and mobile clients pass the stored URL into linked-PR detail queries and resolve URL-only links for eligible non-Git projects
> - Risk: unsupported URL-only hosts (GitLab, Azure DevOps, self-hosted Bitbucket, GitHub Enterprise) return `PullRequestUnavailableError`; URL-sensitive cache keys in [PullRequestService.ts](https://github.com/pingdotgg/t3code/pull/9440/files#diff-6dc74968ebcf535ce84fea9f44369080aa5246f4a8c9d10824bf988651c4f0bf) mean existing URL-less cached summaries will not be reused for URL-bearing lookups
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dad101.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->