### PR TITLE
fix(desktop): allow separate preview window to fullscreen and maximize

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -37,6 +37,13 @@ describe("fitPictureInPictureContentSize", () => {
   });
 });
 
+describe("pictureInPictureJPEGQuality", () => {
+  it("streams sharper frames only while the PiP window is enlarged", () => {
+    expect(PreviewManager.pictureInPictureJPEGQuality(false)).toBe(80);
+    expect(PreviewManager.pictureInPictureJPEGQuality(true)).toBe(90);
+  });
+});
+
 describe("recordingFileExtension", () => {
   it("derives the artifact extension from the recorder's actual mime type", () => {
     expect(PreviewManager.recordingFileExtension("video/mp4;codecs=avc1.640028")).toBe("mp4");
@@ -2675,6 +2682,8 @@ describe("PreviewManager", () => {
             alwaysOnTop: true,
             show: false,
             skipTaskbar: true,
+            fullscreenable: true,
+            maximizable: true,
             webPreferences: expect.objectContaining({
               preload: "/tmp/t3/desktop/preview-pip-preload.cjs",
               backgroundThrottling: false,
@@ -2734,6 +2743,59 @@ describe("PreviewManager", () => {
         const capturesAfterClose = capturePage.mock.calls.length;
         yield* TestClock.adjust(200);
         expect(capturePage).toHaveBeenCalledTimes(capturesAfterClose);
+      }),
+    ),
+  );
+
+  effectIt.effect("keeps an enlarged PiP window enlarged and reapplies aspect on restore", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const jpegWide = Buffer.from("pip-frame-1280x720");
+        const jpegTall = Buffer.from("pip-frame-640x480");
+        let size = { width: 1280, height: 720 };
+        let bytes = jpegWide;
+        const toJPEG = vi.fn((_quality?: number) => bytes);
+        const capturePage = vi.fn(async () => ({
+          toJPEG,
+          getSize: () => ({ ...size }),
+        }));
+        fromId.mockReturnValue(makeTestPreviewWebContents(capturePage));
+        let maximized = false;
+        const { pictureInPictureWindow, send } = makeTestPictureInPictureWindow();
+        Object.assign(pictureInPictureWindow, {
+          isMaximized: vi.fn(() => maximized),
+          isFullScreen: vi.fn(() => false),
+        });
+        browserWindowConstructor.mockImplementation(function () {
+          return pictureInPictureWindow;
+        });
+
+        yield* manager.createTab("tab_pip_enlarged");
+        yield* manager.registerWebview("tab_pip_enlarged", 42);
+        yield* manager.openPictureInPicture("tab_pip_enlarged");
+
+        expect(toJPEG.mock.calls.at(-1)).toEqual([80]);
+        expect(pictureInPictureWindow.setAspectRatio.mock.calls).toEqual([[0], [1280 / 720]]);
+        const contentSizesAfterOpen = pictureInPictureWindow.setContentSize.mock.calls.length;
+
+        maximized = true;
+        size = { width: 640, height: 480 };
+        bytes = jpegTall;
+        yield* TestClock.adjust(100);
+
+        expect(toJPEG.mock.calls.at(-1)).toEqual([90]);
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(pictureInPictureWindow.setContentSize.mock.calls.length).toBe(contentSizesAfterOpen);
+
+        maximized = false;
+        yield* TestClock.adjust(100);
+
+        expect(toJPEG.mock.calls.at(-1)).toEqual([80]);
+        expect(pictureInPictureWindow.setContentSize.mock.calls.length).toBe(
+          contentSizesAfterOpen + 1,
+        );
+        expect(pictureInPictureWindow.setAspectRatio.mock.calls.at(-1)).toEqual([640 / 480]);
+        yield* manager.closePictureInPicture("tab_pip_enlarged");
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -2745,9 +2745,16 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               tabId,
             );
             const aspectRatio = frame.width / frame.height;
+            // Don't fight the window manager: resizing restores maximized /
+            // fullscreen windows, so skip aspect-fit while enlarged.
+            const isEnlarged =
+              pictureInPictureWindow.isMaximized?.() === true ||
+              pictureInPictureWindow.isFullScreen?.() === true;
             if (
-              previousAspectRatio === undefined ||
-              Math.abs(previousAspectRatio - aspectRatio) > PICTURE_IN_PICTURE_ASPECT_RATIO_EPSILON
+              !isEnlarged &&
+              (previousAspectRatio === undefined ||
+                Math.abs(previousAspectRatio - aspectRatio) >
+                  PICTURE_IN_PICTURE_ASPECT_RATIO_EPSILON)
             ) {
               yield* attempt(
                 {

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -112,8 +112,6 @@ const MAX_SCREENSHOT_WIDTH = 1280;
 /** How long an armed tab keeps the exclusive display-media slot before another tab may take it. */
 const RECORDING_ARM_GRACE_MS = 10_000;
 const PICTURE_IN_PICTURE_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
-// Higher quality so enlarging the separate preview window stays readable
-// instead of showing JPEG upscale blur.
 const PICTURE_IN_PICTURE_JPEG_QUALITY = 90;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
 const PICTURE_IN_PICTURE_INITIAL_HEIGHT = 320;
@@ -2745,8 +2743,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               tabId,
             );
             const aspectRatio = frame.width / frame.height;
-            // Don't fight the window manager: resizing restores maximized /
-            // fullscreen windows, so skip aspect-fit while enlarged.
             const isEnlarged =
               pictureInPictureWindow.isMaximized?.() === true ||
               pictureInPictureWindow.isFullScreen?.() === true;
@@ -3013,9 +3009,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               show: false,
               alwaysOnTop: true,
               autoHideMenuBar: true,
-              // Allow fullscreen/maximize so a small 480x320 PiP window can
-              // be enlarged without hitting a dead end. Readability when
-              // enlarged comes from the source zoom + higher JPEG quality.
               fullscreenable: true,
               maximizable: true,
               minimizable: false,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -112,7 +112,9 @@ const MAX_SCREENSHOT_WIDTH = 1280;
 /** How long an armed tab keeps the exclusive display-media slot before another tab may take it. */
 const RECORDING_ARM_GRACE_MS = 10_000;
 const PICTURE_IN_PICTURE_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
-const PICTURE_IN_PICTURE_JPEG_QUALITY = 80;
+// Higher quality so enlarging the separate preview window stays readable
+// instead of showing JPEG upscale blur.
+const PICTURE_IN_PICTURE_JPEG_QUALITY = 90;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
 const PICTURE_IN_PICTURE_INITIAL_HEIGHT = 320;
 const PICTURE_IN_PICTURE_MIN_WIDTH = 240;
@@ -3004,8 +3006,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               show: false,
               alwaysOnTop: true,
               autoHideMenuBar: true,
-              fullscreenable: false,
-              maximizable: false,
+              // Allow fullscreen/maximize so a small 480x320 PiP window can
+              // be enlarged without hitting a dead end. Readability when
+              // enlarged comes from the source zoom + higher JPEG quality.
+              fullscreenable: true,
+              maximizable: true,
               minimizable: false,
               resizable: true,
               skipTaskbar: true,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -112,7 +112,8 @@ const MAX_SCREENSHOT_WIDTH = 1280;
 /** How long an armed tab keeps the exclusive display-media slot before another tab may take it. */
 const RECORDING_ARM_GRACE_MS = 10_000;
 const PICTURE_IN_PICTURE_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
-const PICTURE_IN_PICTURE_JPEG_QUALITY = 90;
+const PICTURE_IN_PICTURE_JPEG_QUALITY = 80;
+const PICTURE_IN_PICTURE_JPEG_QUALITY_ENLARGED = 90;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
 const PICTURE_IN_PICTURE_INITIAL_HEIGHT = 320;
 const PICTURE_IN_PICTURE_MIN_WIDTH = 240;
@@ -192,6 +193,11 @@ export const fitPictureInPictureContentSize = (
   height *= minimumScale;
   return [Math.round(width), Math.round(height)];
 };
+
+// Sharper frames only while the PiP window is enlarged; the small window keeps
+// the cheaper default so idle streaming cost does not change.
+export const pictureInPictureJPEGQuality = (isEnlarged: boolean): number =>
+  isEnlarged ? PICTURE_IN_PICTURE_JPEG_QUALITY_ENLARGED : PICTURE_IN_PICTURE_JPEG_QUALITY;
 
 export const recordingFileExtension = (mimeType: string): string => {
   const subtype = mimeType.split(";", 1)[0]?.trim().toLowerCase().split("/")[1] ?? "";
@@ -2709,16 +2715,57 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     ) {
       return;
     }
+    const pipWindow = (yield* SynchronizedRef.get(pictureInPictureSessionsRef)).get(tabId)?.window;
+    // A maximized or fullscreen PiP window is OS-sized, so aspect-fit resizes must
+    // not fight it; frames stay sharp while enlarged via the higher JPEG quality.
+    const pictureInPictureEnlarged =
+      pipWindow !== undefined &&
+      !pipWindow.isDestroyed() &&
+      (pipWindow.isMaximized?.() === true || pipWindow.isFullScreen?.() === true);
     const encoded = yield* attempt(
       {
         operation: "frameCapture.encodeFrame",
         tabId,
         webContentsId: wc.id,
       },
-      () => image.toJPEG(PICTURE_IN_PICTURE_JPEG_QUALITY),
+      () => image.toJPEG(pictureInPictureJPEGQuality(pictureInPictureEnlarged)),
     );
     const frameSession = (yield* SynchronizedRef.get(frameCaptureSessionsRef)).get(tabId);
     if (frameSession?.scope !== captureSession.scope) return;
+    // Track the source aspect on every capture so a ratio change while enlarged is
+    // applied on restore even when later frames are byte-identical. The stored
+    // ratio is only updated alongside an apply, keeping it equal to the OS lock.
+    if (pipWindow !== undefined && !pipWindow.isDestroyed()) {
+      const previousAspectRatio = (yield* Ref.get(pictureInPictureAspectRatiosRef)).get(tabId);
+      const aspectRatio = size.width / size.height;
+      if (
+        !pictureInPictureEnlarged &&
+        (previousAspectRatio === undefined ||
+          Math.abs(previousAspectRatio - aspectRatio) > PICTURE_IN_PICTURE_ASPECT_RATIO_EPSILON)
+      ) {
+        yield* attempt(
+          {
+            operation: "pictureInPicture.setAspectRatio",
+            tabId,
+            webContentsId: wc.id,
+          },
+          () => {
+            const contentSize = fitPictureInPictureContentSize(
+              pipWindow.getContentSize(),
+              aspectRatio,
+            );
+            pipWindow.setAspectRatio(0);
+            pipWindow.setContentSize(contentSize[0], contentSize[1], false);
+            pipWindow.setAspectRatio(aspectRatio);
+          },
+        );
+        yield* Ref.update(pictureInPictureAspectRatiosRef, (aspectRatios) =>
+          replaceMap(aspectRatios, (copy) => {
+            copy.set(tabId, aspectRatio);
+          }),
+        );
+      }
+    }
     const pictureInPicture =
       frameSession.consumers.has("picture-in-picture") &&
       frameSession.lastPictureInPictureFrame?.equals(encoded) !== true;
@@ -2739,41 +2786,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       if (pictureInPictureWindow && !pictureInPictureWindow.isDestroyed()) {
         deliveries.push(
           Effect.gen(function* () {
-            const previousAspectRatio = (yield* Ref.get(pictureInPictureAspectRatiosRef)).get(
-              tabId,
-            );
-            const aspectRatio = frame.width / frame.height;
-            const isEnlarged =
-              pictureInPictureWindow.isMaximized?.() === true ||
-              pictureInPictureWindow.isFullScreen?.() === true;
-            if (
-              !isEnlarged &&
-              (previousAspectRatio === undefined ||
-                Math.abs(previousAspectRatio - aspectRatio) >
-                  PICTURE_IN_PICTURE_ASPECT_RATIO_EPSILON)
-            ) {
-              yield* attempt(
-                {
-                  operation: "pictureInPicture.setAspectRatio",
-                  tabId,
-                  webContentsId: wc.id,
-                },
-                () => {
-                  const contentSize = fitPictureInPictureContentSize(
-                    pictureInPictureWindow.getContentSize(),
-                    aspectRatio,
-                  );
-                  pictureInPictureWindow.setAspectRatio(0);
-                  pictureInPictureWindow.setContentSize(contentSize[0], contentSize[1], false);
-                  pictureInPictureWindow.setAspectRatio(aspectRatio);
-                },
-              );
-              yield* Ref.update(pictureInPictureAspectRatiosRef, (aspectRatios) =>
-                replaceMap(aspectRatios, (copy) => {
-                  copy.set(tabId, aspectRatio);
-                }),
-              );
-            }
             yield* attempt(
               {
                 operation: "pictureInPicture.deliverFrame",


### PR DESCRIPTION
The separate Preview window (Preview · <title>) is a PiP BrowserWindow created with fullscreenable:false and maximizable:false, so there is no fullscreen option. It streams JPEG quality 80 frames from wc.capturePage() at 12fps, so enlarging the small 480x320 window just upscales compression artifacts and looks less readable.

This enables fullscreen/maximize on that window and bumps PiP JPEG quality 80 -> 90 to reduce blur when enlarged. Detail still comes from source zoom (preview zoom controls), which is unchanged.

Related: #8900 zoom works poorly in preview panel, #5509 preview content often unreadable.

Test: existing Manager.test.ts PiP mocks do not assert window flags. Change is 2 flags + 1 quality constant in apps/desktop/src/preview/Manager.ts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop preview PiP window flags and frame-delivery heuristics with no auth or data-handling impact.
> 
> **Overview**
> The separate **Preview ·** picture-in-picture window can now be **maximized** and **fullscreened** by turning on `maximizable` and `fullscreenable` on that `BrowserWindow`.
> 
> While the PiP window is maximized or fullscreen, **automatic aspect-ratio resizing** is skipped so the OS-sized window is not fighting the frame loop; aspect-fit resizing resumes in the normal window state.
> 
> **JPEG stream quality** for PiP frames is raised from **80 → 90** so enlarged windows look less blocky; preview zoom controls are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58538f0bf6ab089d9b9520d7e08a779227c84071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow separate preview window to full-screen and maximize
> - Updates `makeNativeOperations` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/9444/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53) to let the picture-in-picture `BrowserWindow` enter full-screen and maximized states
> - Skips automatic aspect-ratio adjustments while the preview window is maximized or full-screen so the frame-driven resize logic does not override the user
> - Raises `PICTURE_IN_PICTURE_JPEG_QUALITY` from 80 to 90 for sharper preview frames
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58538f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->