### PR TITLE
fix(shared): preserve hyphens inside semver prerelease identifiers

### DIFF
--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -72,6 +72,19 @@ describe("semver helpers", () => {
     expect(normalizeSemverVersion("1.2.3+build.1")).toBe("1.2.3");
   });
 
+  it("keeps build metadata unparseable when normalization would repair it", () => {
+    // Regression (Codex + Bugbot reviews): normalize drops empty dot
+    // segments, which must not launder a malformed suffix into a valid one.
+    expect(parseSemver("1.2.3+foo.")).toBeNull();
+    expect(parseSemver("1.2.3+foo..bar")).toBeNull();
+  });
+
+  it("rejects empty prerelease identifiers", () => {
+    // Regression (CodeRabbit review): 1.2.3-+build normalized into 1.2.3.
+    expect(parseSemver("1.2.3-+build")).toBeNull();
+    expect(parseSemver("1.2.3-")).toBeNull();
+  });
+
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);
   });

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -46,6 +46,15 @@ describe("semver helpers", () => {
     expect(compareSemverVersions("2.1.111-beta.1", "2.1.111")).toBeLessThan(0);
   });
 
+  it("preserves hyphens inside prerelease identifiers", () => {
+    // Regression: split("-", 2) discarded everything after a second hyphen,
+    // so "1.2.3-alpha-1" normalized to "1.2.3-alpha".
+    expect(normalizeSemverVersion("1.2.3-alpha-1")).toBe("1.2.3-alpha-1");
+    expect(normalizeSemverVersion("1.0.0-beta.2-extra")).toBe("1.0.0-beta.2-extra");
+    expect(parseSemver("1.2.3-alpha-1")?.prerelease).toEqual(["alpha-1"]);
+    expect(compareSemverVersions("1.2.3-alpha", "1.2.3-alpha-1")).not.toBe(0);
+  });
+
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);
   });

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -85,6 +85,13 @@ describe("semver helpers", () => {
     expect(parseSemver("1.2.3-")).toBeNull();
   });
 
+  it("compares prerelease identifiers in ASCII order", () => {
+    // Regression (Codex review on this PR): semver identifiers with letters
+    // or hyphens compare lexically in ASCII order, so Z precedes a.
+    expect(compareSemverVersions("1.2.3-alpha-Z", "1.2.3-alpha-a")).toBeLessThan(0);
+    expect(compareSemverVersions("1.2.3-alpha", "1.2.3-alpha")).toBe(0);
+  });
+
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);
   });

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -55,6 +55,14 @@ describe("semver helpers", () => {
     expect(compareSemverVersions("1.2.3-alpha", "1.2.3-alpha-1")).not.toBe(0);
   });
 
+  it("ignores build metadata in precedence", () => {
+    // Regression (Codex review on this PR): build metadata must not affect
+    // precedence, matching compareExactServiceVersions in serviceProtocol.ts.
+    expect(normalizeSemverVersion("1.2.3-alpha-1+build")).toBe("1.2.3-alpha-1");
+    expect(parseSemver("1.2.3-alpha-1+build")?.prerelease).toEqual(["alpha-1"]);
+    expect(compareSemverVersions("1.2.3-alpha-1+one", "1.2.3-alpha-1+two")).toBe(0);
+  });
+
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);
   });

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -61,6 +61,15 @@ describe("semver helpers", () => {
     expect(normalizeSemverVersion("1.2.3-alpha-1+build")).toBe("1.2.3-alpha-1");
     expect(parseSemver("1.2.3-alpha-1+build")?.prerelease).toEqual(["alpha-1"]);
     expect(compareSemverVersions("1.2.3-alpha-1+one", "1.2.3-alpha-1+two")).toBe(0);
+    expect(compareSemverVersions("1.0.0+build.1", "1.0.0")).toBe(0);
+  });
+
+  it("keeps malformed build metadata unparseable", () => {
+    // Regression (Codex review on this PR): only a nonempty dot-separated
+    // sequence of valid identifiers may be ignored for precedence.
+    expect(parseSemver("1.2.3+")).toBeNull();
+    expect(parseSemver("1.2.3+not valid")).toBeNull();
+    expect(normalizeSemverVersion("1.2.3+build.1")).toBe("1.2.3");
   });
 
   it("falls back to lexical comparison for malformed numeric segments", () => {

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -120,7 +120,9 @@ function comparePrereleaseIdentifier(left: string, right: string): number {
   if (rightNumeric) {
     return 1;
   }
-  return left.localeCompare(right);
+  // Semver identifiers compare lexically in ASCII order, not locale
+  // collation: "Z" precedes "a". Matches compareExactServiceVersions.
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 export function compareSemverVersions(left: string, right: string): number {

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -22,11 +22,22 @@ function splitMainPrerelease(version: string): [main: string, prerelease: string
   if (dash < 0) {
     return [core, undefined];
   }
+  if (dash === core.length - 1) {
+    // An empty prerelease ("1.2.3-...") is invalid: keep the version
+    // unparseable instead of normalizing into the core version.
+    return [version, undefined];
+  }
   return [core.slice(0, dash), core.slice(dash + 1)];
 }
 
 export function normalizeSemverVersion(version: string): string {
-  const [main, prerelease] = splitMainPrerelease(version.trim());
+  const trimmed = version.trim();
+  const [main, prerelease] = splitMainPrerelease(trimmed);
+  // A malformed build suffix stays unparseable: pass it through untouched so
+  // empty-segment filtering below cannot repair it into a valid suffix.
+  if (main.includes("+")) {
+    return trimmed;
+  }
   const segments: string[] = [];
   for (const segment of (main ?? "").split(".")) {
     const trimmed = segment.trim();

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -9,12 +9,15 @@ const SEMVER_NUMBER_SEGMENT = /^\d+$/;
 
 // Split on the first hyphen only: prerelease identifiers may themselves
 // contain hyphens ("1.2.3-alpha-1"), which split("-", 2) would discard.
+// Build metadata ("+...") never affects precedence, so strip it first,
+// matching compareExactServiceVersions in serviceProtocol.ts.
 function splitMainPrerelease(version: string): [main: string, prerelease: string | undefined] {
-  const dash = version.indexOf("-");
+  const withoutBuild = version.split("+", 1)[0] ?? version;
+  const dash = withoutBuild.indexOf("-");
   if (dash < 0) {
-    return [version, undefined];
+    return [withoutBuild, undefined];
   }
-  return [version.slice(0, dash), version.slice(dash + 1)];
+  return [withoutBuild.slice(0, dash), withoutBuild.slice(dash + 1)];
 }
 
 export function normalizeSemverVersion(version: string): string {

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -7,8 +7,18 @@ interface ParsedSemver {
 
 const SEMVER_NUMBER_SEGMENT = /^\d+$/;
 
+// Split on the first hyphen only: prerelease identifiers may themselves
+// contain hyphens ("1.2.3-alpha-1"), which split("-", 2) would discard.
+function splitMainPrerelease(version: string): [main: string, prerelease: string | undefined] {
+  const dash = version.indexOf("-");
+  if (dash < 0) {
+    return [version, undefined];
+  }
+  return [version.slice(0, dash), version.slice(dash + 1)];
+}
+
 export function normalizeSemverVersion(version: string): string {
-  const [main, prerelease] = version.trim().split("-", 2);
+  const [main, prerelease] = splitMainPrerelease(version.trim());
   const segments: string[] = [];
   for (const segment of (main ?? "").split(".")) {
     const trimmed = segment.trim();
@@ -31,7 +41,7 @@ export function normalizeSemverVersion(version: string): string {
 
 export function parseSemver(value: string): ParsedSemver | null {
   const normalized = normalizeSemverVersion(value).replace(/^v/, "");
-  const [main = "", prerelease] = normalized.split("-", 2);
+  const [main = "", prerelease] = splitMainPrerelease(normalized);
   const segments = main.split(".");
   if (segments.length !== 3) {
     return null;

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -7,17 +7,22 @@ interface ParsedSemver {
 
 const SEMVER_NUMBER_SEGMENT = /^\d+$/;
 
-// Split on the first hyphen only: prerelease identifiers may themselves
-// contain hyphens ("1.2.3-alpha-1"), which split("-", 2) would discard.
-// Build metadata ("+...") never affects precedence, so strip it first,
-// matching compareExactServiceVersions in serviceProtocol.ts.
+// Build metadata ("+...") never affects precedence. Strip it when it is a
+// nonempty dot-separated sequence of valid identifiers; a malformed suffix
+// keeps the version unparseable downstream, as before.
+const SEMVER_BUILD_IDENTIFIER = /^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$/;
+
 function splitMainPrerelease(version: string): [main: string, prerelease: string | undefined] {
-  const withoutBuild = version.split("+", 1)[0] ?? version;
-  const dash = withoutBuild.indexOf("-");
-  if (dash < 0) {
-    return [withoutBuild, undefined];
+  const plus = version.indexOf("+");
+  if (plus >= 0 && !SEMVER_BUILD_IDENTIFIER.test(version.slice(plus + 1))) {
+    return [version, undefined];
   }
-  return [withoutBuild.slice(0, dash), withoutBuild.slice(dash + 1)];
+  const core = plus < 0 ? version : version.slice(0, plus);
+  const dash = core.indexOf("-");
+  if (dash < 0) {
+    return [core, undefined];
+  }
+  return [core.slice(0, dash), core.slice(dash + 1)];
 }
 
 export function normalizeSemverVersion(version: string): string {


### PR DESCRIPTION
## What Changed

- packages/shared/src/semver.ts: replaced split("-", 2) with a shared splitMainPrerelease helper that splits on the first hyphen only and strips + build metadata before splitting, matching compareExactServiceVersions in serviceProtocol.ts. Malformed + suffixes pass through normalize untouched so empty-segment filtering cannot repair them, empty prereleases stay unparseable, and non-numeric identifiers compare in ASCII order instead of locale collation.
- packages/shared/src/semver.test.ts: regression tests for hyphenated prereleases (1.2.3-alpha-1), build-metadata precedence (1.2.3-alpha-1+one vs +two compare equal), malformed build metadata (1.2.3+, 1.2.3+not valid, 1.2.3+foo. stay null), empty prereleases (1.2.3-+build, 1.2.3- stay null) and ASCII ordering (1.2.3-alpha-Z precedes 1.2.3-alpha-a).

## Why

String.split with a limit discards the remainder, so normalizeSemverVersion("1.2.3-alpha-1") returned "1.2.3-alpha" and two distinct prereleases compared equal. That feeds version gates (version skew, model manifests, runtime minimums), so precedence must be exact. Build metadata must not affect precedence per semver.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes (screenshots N/A)
- [x] No animation/interaction changes (video N/A)

Built with Muse Spark via OpenCode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter parsing may reject inputs that previously normalized into valid versions, affecting any caller that relied on that leniency for version gates.
> 
> **Overview**
> Fixes **semver parsing and comparison** in `packages/shared/src/semver.ts` so version gates (skew checks, manifests, runtime minimums) treat prerelease strings correctly.
> 
> **Hyphenated prereleases:** `normalizeSemverVersion` and `parseSemver` no longer use `split("-", 2)`, which truncated values like `1.2.3-alpha-1` to `1.2.3-alpha`. A shared `splitMainPrerelease` splits only on the first prerelease hyphen and keeps the rest of the identifier intact.
> 
> **Build metadata:** Valid `+...` suffixes are stripped for normalization and ignored when comparing equal cores; malformed build metadata (empty, spaces, trailing dots) stays unparseable instead of being “repaired” by dot-segment filtering. Empty prereleases (`1.2.3-`, `1.2.3-+build`) now return null rather than collapsing to the stable version.
> 
> **Comparison:** Prerelease identifier tie-breaks use **ASCII lexical order** (not `localeCompare`), so ordering matches service version comparison behavior.
> 
> Regression tests in `semver.test.ts` cover the above edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ad8bfcf267ce48d914da68b0ec8585d5e7b206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve hyphens inside semver prerelease identifiers in `parseSemver` and `normalizeSemverVersion`
> - Adds `splitMainPrerelease` helper to split the core version from prerelease data at the first hyphen, so hyphens inside prerelease identifiers are retained rather than treated as separators.
> - Valid build metadata (dot-separated nonempty identifiers) is now stripped during normalization and excluded from parsed precedence data; malformed build metadata and empty prerelease identifiers cause parsing to fail.
> - `comparePrereleaseIdentifier` replaces locale-based comparison with direct ASCII lexical ordering for nonnumeric prerelease identifiers.
> - Behavioral Change: versions with malformed build metadata (empty segments, trailing or repeated separators) or empty prerelease identifiers that may have been accepted before now return `null` from `parseSemver`; normalized output no longer repairs these suffixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5ad8bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->