### PR TITLE
fix(web): unify skeleton loading animations on one pulse

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
@@ -3,11 +3,9 @@
  * and a detail panel opening — use bars in the geometry of the content they stand for, pulsing
  * on one composited layer. Diff loading uses the shared diff-panel skeleton instead.
  *
- * Deliberately not the app's shimmer skeleton. The sweep is a `transform` animation per bar —
- * compositor-safe, but a layer for every bar on screen — and its white highlight over the
- * near-white `muted` base all but disappears in light mode. Here one `animate-ghost-pulse` on the
- * container is a single opacity animation however many bars sit under it, and the bars take
- * their tone from `muted-foreground` at low alpha, which reads on both themes.
+ * The bars share the app-wide `Skeleton` tone (`muted-foreground` at low alpha, which reads on
+ * both themes) and the single `animate-skeleton` pulse, applied once on the container so any
+ * number of bars costs one opacity animation.
  */
 import { cn } from "~/lib/utils";
 
@@ -32,7 +30,7 @@ export function PullRequestListGhost({
     <div
       role="status"
       aria-label={caption ?? "Loading pull requests"}
-      className="animate-ghost-pulse space-y-0.5"
+      className="motion-safe:animate-skeleton space-y-0.5"
     >
       {caption ? (
         <p className="px-3 pb-1 text-xs font-medium text-muted-foreground/70">{caption}</p>
@@ -67,7 +65,7 @@ export function PullRequestDetailGhost() {
     <div
       role="status"
       aria-label="Loading pull request"
-      className="animate-ghost-pulse flex h-full min-h-0 flex-col overflow-hidden bg-background"
+      className="motion-safe:animate-skeleton flex h-full min-h-0 flex-col overflow-hidden bg-background"
     >
       <div className="shrink-0 border-b border-border/60">
         <div className="flex h-7 items-center justify-between gap-3 px-4">
@@ -160,7 +158,11 @@ export function PullRequestDetailGhost() {
 /** People-shaped: an avatar and a name, in the reviewer picker's own row height. */
 export function PullRequestPeopleGhost({ rows = 4 }: { rows?: number }) {
   return (
-    <div role="status" aria-label="Loading people" className="animate-ghost-pulse space-y-1 p-1">
+    <div
+      role="status"
+      aria-label="Loading people"
+      className="motion-safe:animate-skeleton space-y-1 p-1"
+    >
       {Array.from({ length: rows }, (_, index) => (
         <div key={index} className="flex h-7 items-center gap-2 rounded-md px-2">
           <GhostBar className="size-4 rounded-full" />
@@ -174,7 +176,11 @@ export function PullRequestPeopleGhost({ rows = 4 }: { rows?: number }) {
 /** The timeline's own shape: dots on the rail, a line and a date to each. */
 export function PullRequestTimelineGhost({ rows = 6 }: { rows?: number }) {
   return (
-    <div role="status" aria-label="Loading timeline" className="animate-ghost-pulse px-4 py-5">
+    <div
+      role="status"
+      aria-label="Loading timeline"
+      className="motion-safe:animate-skeleton px-4 py-5"
+    >
       <div className="relative ml-2 border-l border-border/70 pl-5">
         {Array.from({ length: rows }, (_, index) => (
           <div key={index} className="relative pb-5">
@@ -194,7 +200,7 @@ export function PullRequestConversationGhost({ rows = 3 }: { rows?: number }) {
     <div
       role="status"
       aria-label="Loading pull request conversation"
-      className="animate-ghost-pulse space-y-4 py-2"
+      className="motion-safe:animate-skeleton space-y-4 py-2"
     >
       {Array.from({ length: rows }, (_, index) => (
         <div key={index} className="flex items-start gap-2">

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -3,10 +3,7 @@ import { cn } from "~/lib/utils";
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn(
-        "relative overflow-hidden rounded-sm bg-muted [--skeleton-highlight:--alpha(var(--color-white)/64%)] after:absolute after:inset-0 after:animate-skeleton after:bg-[linear-gradient(120deg,transparent_40%,var(--skeleton-highlight),transparent_60%)] motion-reduce:after:content-none dark:[--skeleton-highlight:--alpha(var(--color-white)/4%)]",
-        className,
-      )}
+      className={cn("rounded-sm bg-muted-foreground/15 motion-safe:animate-skeleton", className)}
       data-slot="skeleton"
       {...props}
     />

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -23,6 +23,7 @@ import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { SidebarInset } from "../ui/sidebar";
+import { Skeleton } from "../ui/skeleton";
 import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import {
   WorkspaceBreadcrumb,
@@ -585,8 +586,9 @@ function UsageDeviceStrip({
 }
 
 /**
- * Static stand-in with the loaded page's shape. No shimmer; blocks fill in
- * exactly once when the last device answers.
+ * Stand-in with the loaded page's shape, using the shared `Skeleton` bars so it
+ * breathes with the same `animate-skeleton` pulse as every other loading state.
+ * Blocks fill in exactly once when the last device answers.
  */
 function UsageSkeleton() {
   return (
@@ -594,29 +596,29 @@ function UsageSkeleton() {
       <section className="grid gap-6 lg:grid-cols-[minmax(0,18rem)_minmax(0,1fr)]">
         <div className="flex flex-col gap-5">
           <div className="flex flex-col gap-1">
-            <div className="h-10 w-36 rounded-sm bg-muted" />
-            <div className="h-4 w-32 rounded-sm bg-muted" />
+            <Skeleton className="h-10 w-36" />
+            <Skeleton className="h-4 w-32" />
           </div>
           {PROVIDER_ORDER.map((provider) => (
             <div key={provider} className="flex flex-col gap-1">
               <div className="flex min-h-5 items-center justify-between gap-4">
                 <span className="flex items-center gap-2">
-                  <span className="size-2 shrink-0 rounded-full bg-muted" />
-                  <span className="size-4 shrink-0 rounded-full bg-muted" />
-                  <div className="h-3.5 w-20 rounded-sm bg-muted" />
+                  <Skeleton className="size-2 shrink-0 rounded-full" />
+                  <Skeleton className="size-4 shrink-0 rounded-full" />
+                  <Skeleton className="h-3.5 w-20" />
                 </span>
-                <div className="h-3.5 w-14 rounded-sm bg-muted" />
+                <Skeleton className="h-3.5 w-14" />
               </div>
-              <div className="h-4 w-36 rounded-sm bg-muted" />
+              <Skeleton className="h-4 w-36" />
             </div>
           ))}
         </div>
 
         <div className="flex flex-col gap-3">
-          <div className="h-5 w-24 rounded-sm bg-muted" />
+          <Skeleton className="h-5 w-24" />
           <div className="flex flex-col gap-1">
-            <div className="ml-16 h-56 rounded-sm bg-muted/35" />
-            <div className="ml-16 h-4 rounded-sm bg-muted/35" />
+            <Skeleton className="ml-16 h-56 bg-muted-foreground/10" />
+            <Skeleton className="ml-16 h-4 bg-muted-foreground/10" />
           </div>
         </div>
       </section>
@@ -628,7 +630,7 @@ function UsageSkeleton() {
             (label) => (
               <div key={label} className="flex flex-col gap-0.5">
                 <span className="text-xs text-muted-foreground">{label}</span>
-                <div className="h-6 w-16 rounded-sm bg-muted" />
+                <Skeleton className="h-6 w-16" />
               </div>
             ),
           )}
@@ -638,9 +640,9 @@ function UsageSkeleton() {
       <section className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-sm font-medium text-foreground">Breakdown</h2>
-          <div className="h-7 w-28 rounded-lg bg-input/40" />
+          <Skeleton className="h-7 w-28 rounded-lg" />
         </div>
-        <div className="h-44 rounded-sm bg-muted/35" />
+        <Skeleton className="h-44 bg-muted-foreground/10" />
       </section>
     </>
   );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -145,11 +145,10 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
 
 @theme inline {
   --color-zinc-25: oklch(99.2% 0 0);
-  --animate-skeleton: skeleton 2s infinite linear;
+  --animate-skeleton: skeleton 2.4s infinite;
   /* Duty-cycled indicator animations: long holds with stepped ramps, so the
      compositor updates discrete frames instead of every vsync. */
   --animate-status-pulse: status-pulse 2s infinite;
-  --animate-ghost-pulse: ghost-pulse 2.4s infinite;
   --animate-status-ping: status-ping 2s infinite;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
@@ -207,20 +206,10 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   @keyframes skeleton {
-    /* Transform-only so the highlight sweep stays on the compositor, then a
-       long hold with the band parked off-screen instead of a constant shimmer. */
-    0% {
-      transform: translateX(-100%);
-    }
-    60%,
-    100% {
-      transform: translateX(100%);
-    }
-  }
-  @keyframes ghost-pulse {
-    /* The loading ghosts' breath. Stepped like the status indicators, so however many bars a
-       ghost holds, the compositor draws a handful of discrete frames per cycle rather than one
-       per vsync — which on a 120Hz display is the difference between ~14 and ~288 updates. */
+    /* The single loading-bar breath used by every skeleton: one opacity pulse
+       per container, stepped so however many bars sit under it, the compositor
+       draws a handful of discrete frames per cycle rather than one per vsync —
+       which on a 120Hz display is the difference between ~14 and ~288 updates. */
     0%,
     42% {
       opacity: 1;


### PR DESCRIPTION
Unifies the three skeleton loading animations on a single pulse. The shimmer sweep on Skeleton and the static usage placeholders now share the muted-foreground/15 tone and stepped animate-skeleton opacity pulse the PR ghosts already used; the animate-ghost-pulse token is gone. Spinners, status dots, and the mobile live-row shimmer are untouched as activity indicators, not placeholders.

Verified with tsgo --noEmit (clean); vp test run fails identically on a clean tree (pre-existing vitest runner issue).

Before:
![](https://uploads-production-47e4.up.railway.app/files/957a42a7-3f21-40ed-bbd5-99c94b428c63/before.png)
![](https://uploads-production-47e4.up.railway.app/files/2afff62e-766e-4b1e-9271-ed55018ee3a7/before.webm)

After:
![](https://uploads-production-47e4.up.railway.app/files/d6002ba7-38a6-432b-9327-36001b5991dd/after.png)
![](https://uploads-production-47e4.up.railway.app/files/3e72e1cc-e757-40c0-832c-216cf17932b4/after.webm)

Built with muse-spark via OpenCode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only loading UI with no auth, data, or API changes; reduced-motion behavior is explicitly gated with `motion-safe`.
> 
> **Overview**
> **Unifies placeholder loading visuals** so PR ghosts, the shared `Skeleton` component, and the usage page all use the same stepped **opacity pulse** (`motion-safe:animate-skeleton`) instead of mixing a gradient shimmer, static blocks, and a separate ghost animation.
> 
> The **`Skeleton`** component drops the `::after` highlight sweep and `bg-muted` stack in favor of `bg-muted-foreground/15` plus the shared pulse. **`PullRequest*Ghost`** containers switch from `animate-ghost-pulse` to `motion-safe:animate-skeleton` (bar geometry unchanged). **`UsageSkeleton`** replaces hand-rolled `bg-muted` divs with **`Skeleton`** so usage loading animates like the rest of the app.
> 
> In **`index.css`**, `ghost-pulse` and its token are removed; the **`skeleton`** keyframes are rewritten from a transform-based shimmer to the stepped opacity cycle (1 ↔ 0.55 over **2.4s**). Users who prefer reduced motion get static placeholders via **`motion-safe`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1428efd8d0481f150528018ad8a224065d145a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `ghost-pulse` and shimmer with shared `animate-skeleton` pulse across web loading states
> - Replaces the `ghost-pulse` class on pull-request loading components (`PullRequestListGhost`, `PullRequestDetailGhost`, `PullRequestPeopleGhost`, `PullRequestTimelineGhost`, `PullRequestConversationGhost`) with `motion-safe animate-skeleton`.
> - Rewrites [skeleton.tsx](https://github.com/pingdotgg/t3code/pull/9448/files#diff-4f60b26bc3ce3cbd8ae6ecef8e7d99925e323c55c7755ca53565e6a0ce534544) to drop the gradient shimmer and render muted-foreground bars with an opacity pulse.
> - Adopts the shared `Skeleton` component in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/9448/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) for provider summaries, charts, totals, and breakdowns.
> - Updates [index.css](https://github.com/pingdotgg/t3code/pull/9448/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to redefine `animate-skeleton` as a 2.4s stepped opacity pulse and removes the `animate-ghost-pulse` token and keyframes.
> - Behavioral Change: all loading states now pulse opacity rather than sweep horizontally; animation is suppressed under reduced-motion preferences. The `ghost-pulse` CSS token and keyframes are removed, so any remaining references to `animate-ghost-pulse` outside these components will no longer animate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1428ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->