### PR TITLE
fix(composer): mute fast icon when collapsed

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -592,7 +592,11 @@ export const TraitsPicker = memo(function TraitsPicker({
         size={size}
         className={cn(
           "fill-current opacity-80",
-          provider === "claudeAgent" ? "text-[#d97757]" : "text-foreground",
+          size === "xs"
+            ? "text-current"
+            : provider === "claudeAgent"
+              ? "text-[#d97757]"
+              : "text-foreground",
         )}
       />
       <span className="sr-only">Fast mode on</span>


### PR DESCRIPTION
The fast-mode bolt in the collapsed composer forced the foreground color; it now inherits the resting control color while preserving the expanded Codex and Claude treatments.

Verified with targeted web typecheck, lint, formatting, and dark/light browser checks; the focused existing test files remain blocked before collection by the current Vite+ runner TypeError.

Before

![collapsed composer before, with bright fast-mode bolt](https://uploads-production-47e4.up.railway.app/files/d42d2b85-4028-4502-83b2-c71ecd26c69a/t3-fast-icon-before.png)

After

![collapsed composer after, with muted fast-mode bolt](https://uploads-production-47e4.up.railway.app/files/fdfc5397-f64c-4691-8639-ed75518abf20/t3-fast-icon-after.png)

Built by `gpt-5.6-sol` in the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5da6f5d87703f42a71d6185fe9490ced56c126ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fast-mode Zap icon color in `TraitsPicker` when collapsed
> Changes the fast-mode icon class selection so `xs`-sized controls use the inherited current text color. Other sizes keep their existing provider-specific color.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5da6f5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->