### PR TITLE
fix(web): banner buttons no longer expand the resting composer

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -60,6 +60,7 @@ import {
 } from "./composerMentionDrag";
 import {
   composerFloatingLayerProps,
+  isInsideCollapsedComposerControls,
   isInsideComposerFloatingLayer,
   isInsideRestingComposerControlScope,
 } from "./composerEventScope";
@@ -4542,6 +4543,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       onPointerDownCapture={(event) => {
         const target = event.target;
         if (isInsideRestingComposerControlScope(target)) return;
+        if (isInsideCollapsedComposerControls(target)) return;
         if (!(target instanceof Element)) return;
         const isInteractive = Boolean(
           target.closest('button, a, input, select, [role="button"], [role="menuitem"]'),
@@ -4564,11 +4566,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         if (composerControlsInStrip && isInsideRestingComposerControlScope(activeElement)) {
           return;
         }
-        if (
-          isComposerCollapsedMobile &&
-          activeElement instanceof HTMLElement &&
-          activeElement.closest('[data-chat-composer-collapsed-controls="true"]')
-        ) {
+        if (isInsideCollapsedComposerControls(activeElement)) {
           return;
         }
         // Focus returning from another window or tab lands on the element

--- a/apps/web/src/components/chat/composerEventScope.test.ts
+++ b/apps/web/src/components/chat/composerEventScope.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  isInsideCollapsedComposerControls,
   isInsideComposerFloatingLayer,
   isInsideRestingComposerControlScope,
 } from "./composerEventScope";
@@ -57,5 +58,16 @@ describe("composer event scopes", () => {
     const target = new FakeElement(null);
     expect(isInsideRestingComposerControlScope(target as unknown as EventTarget)).toBe(false);
     expect(isInsideRestingComposerControlScope(null)).toBe(false);
+  });
+
+  it("recognizes banner and drawer controls docked above the surface", () => {
+    vi.stubGlobal("Element", FakeElement);
+
+    const target = new FakeElement('[data-chat-composer-collapsed-controls="true"]');
+    expect(isInsideCollapsedComposerControls(target as unknown as EventTarget)).toBe(true);
+    expect(isInsideCollapsedComposerControls(new FakeElement(null) as unknown as EventTarget)).toBe(
+      false,
+    );
+    expect(isInsideCollapsedComposerControls(null)).toBe(false);
   });
 });

--- a/apps/web/src/components/chat/composerEventScope.ts
+++ b/apps/web/src/components/chat/composerEventScope.ts
@@ -11,6 +11,16 @@ export function isInsideComposerFloatingLayer(target: EventTarget | null): boole
   return target instanceof Element && target.closest(COMPOSER_FLOATING_LAYER_SELECTOR) !== null;
 }
 
+// Banners, the approval row, and the tasks badge dock above the surface. A
+// pointer or focus landing on one of them acts on that control and must not
+// expand a resting or collapsed composer.
+export function isInsideCollapsedComposerControls(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest('[data-chat-composer-collapsed-controls="true"]') !== null
+  );
+}
+
 export function isInsideRestingComposerControlScope(target: EventTarget | null): boolean {
   return (
     target instanceof Element &&


### PR DESCRIPTION
## Problem

With the composer resting (blurred, desktop) and a banner docked above it, clicking a button on the banner — "Un-settle", "Wake now", "Restore branch", dismiss, etc. — expanded the composer instead of running the button. The banner stack renders inside the composer `<form>`, so the button taking focus fired the form's `onFocusCapture`, which treated it as a request to expand. The surface grew under the pointer and the `click` never landed on the button.

## Fix

The `data-chat-composer-collapsed-controls` scope was already exempt from that focus capture, but only when the composer was collapsed on mobile. `isInsideCollapsedComposerControls` in `composerEventScope.ts` now applies that exemption on every viewport, and the form's `onPointerDownCapture` skips the same scope so pressing a banner does not steal focus into the editor either. Banners, the approval row, pending-input panel, and the tasks badge all already carry the marker.

Web/desktop only; mobile has its own composer.

## Demo

Resting composer on a settled thread, real pointer click on **Un-settle**.

Before — the composer expands and the thread stays settled:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d7ee41ed34918b89/before-banner-click-expands-composer.mp4

After — the thread un-settles, the banner leaves, the composer stays at rest:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2a719c16f1d047dc/after-banner-click-unsettles.mp4

## Verification

- `vp test run apps/web/src/components/chat/composerEventScope.test.ts`
- lint on the touched files, `vpr typecheck` in `apps/web`
- Browser pass against a snapshot of real data, recorded above

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized composer event-guard change with tests; no auth, data, or API impact.
> 
> **Overview**
> Fixes a desktop bug where clicking **banner** actions (e.g. Un-settle, Wake now) on a **resting** composer expanded the input instead of running the control, because those elements sit inside the composer `<form>` and triggered expand-on-focus/pointer handlers.
> 
> Adds shared **`isInsideCollapsedComposerControls`** in `composerEventScope.ts` for targets under `data-chat-composer-collapsed-controls` (banners, approval row, pending-input chrome, tasks badge). **`ChatComposer`** now skips scroll-collapse and resting expansion on **pointer down** and **focus capture** for that scope on **all viewports**, replacing the previous mobile-collapsed-only focus check. Unit tests cover the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe1108d09edcbb04b71a4faeb6a4a0e11f47ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix banner buttons expanding the resting `ChatComposer`
> - Adds `isInsideCollapsedComposerControls` helper in [composerEventScope.ts](https://github.com/pingdotgg/t3code/pull/9452/files#diff-1d19fa94b2a00867c7373b907feaca2849867ffcb27e9710885cd0af8d97433d) to detect event targets inside elements marked with the collapsed-controls data attribute
> - Updates pointer-down and focus capture handlers in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/9452/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to ignore events from that scope so the composer no longer expands or clears scroll-collapse state
> - Adds test coverage for the new helper in [composerEventScope.test.ts](https://github.com/pingdotgg/t3code/pull/9452/files#diff-0c546e3ba134405208e4a5e2fc2985d0b1e4434af56ed624938e66538dd7cf07)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfe1108.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->