### PR TITLE
fix(web): settled banner un-settles threads again

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -4564,13 +4564,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         if (composerControlsInStrip && isInsideRestingComposerControlScope(activeElement)) {
           return;
         }
-        if (
-          isComposerCollapsedMobile &&
-          activeElement instanceof HTMLElement &&
-          activeElement.closest('[data-chat-composer-collapsed-controls="true"]')
-        ) {
-          return;
-        }
         // Focus returning from another window or tab lands on the element
         // that already held it, which is not a request to expand a
         // scroll-collapsed composer.

--- a/apps/web/src/components/chat/composerEventScope.test.ts
+++ b/apps/web/src/components/chat/composerEventScope.test.ts
@@ -35,6 +35,13 @@ describe("composer event scopes", () => {
     expect(isInsideRestingComposerControlScope(target as unknown as EventTarget)).toBe(true);
   });
 
+  it("keeps collapsed banner actions from expanding the resting composer", () => {
+    vi.stubGlobal("Element", FakeElement);
+
+    const target = new FakeElement('[data-chat-composer-collapsed-controls="true"]');
+    expect(isInsideRestingComposerControlScope(target as unknown as EventTarget)).toBe(true);
+  });
+
   it("includes composer-owned floating layers in the resting control scope", () => {
     vi.stubGlobal("Element", FakeElement);
 

--- a/apps/web/src/components/chat/composerEventScope.ts
+++ b/apps/web/src/components/chat/composerEventScope.ts
@@ -16,6 +16,7 @@ export function isInsideRestingComposerControlScope(target: EventTarget | null):
     target instanceof Element &&
     (target.closest('[data-chat-composer-resting-controls="true"]') !== null ||
       target.closest('[data-chat-composer-resting-images="true"]') !== null ||
+      target.closest('[data-chat-composer-collapsed-controls="true"]') !== null ||
       isInsideComposerFloatingLayer(target))
   );
 }


### PR DESCRIPTION
Clicking `Un-settle` in the banner above a resting composer only expanded the composer. The thread stayed settled and the button remained visible, even though the same action worked from the sidebar and thread menu.

The banner button receives focus during pointer-down. On desktop, the resting composer treated that focus as an intent to start typing, expanded synchronously, and moved the button before the click could finish. The banner already marks its controls as safe to use while the composer is collapsed. This change includes that marker in the shared resting-control event scope, so focus stays on the action and its click dispatches `thread.unsettle`.

This keeps the existing mobile behavior while replacing its one-off check with the shared rule. The same rule covers `Wake now` in the snoozed-thread banner, which had the same focus race. The thread command and settlement state handling are unchanged.

Tests: 6 focused tests, web typecheck, targeted lint, formatting.

## Screenshot

The highlighted `Un-settle` action is the banner control affected by the pointer and focus race.

<img width="823" alt="Un-settle action in the settled-thread banner" src="https://github.com/user-attachments/assets/9b86623e-6402-44fb-aa55-59e784908c41" />

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.
