### PR TITLE
perf(client-runtime): batch terminal input writes

### DIFF
--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -161,6 +161,7 @@ type ThreadTerminalRouteScreenProps = StaticScreenProps<{
 export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps) {
   const navigation = useNavigation();
   const writeTerminal = useAtomCommand(terminalEnvironment.write, "terminal write");
+  const writeTerminalInput = useAtomCommand(terminalEnvironment.input, "terminal input");
   const resizeTerminal = useAtomCommand(terminalEnvironment.resize, "terminal resize");
   const clearTerminal = useAtomCommand(terminalEnvironment.clear, "terminal clear");
   const closeTerminal = useAtomCommand(terminalEnvironment.close, "terminal close");
@@ -699,7 +700,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         return;
       }
 
-      void writeTerminal({
+      void writeTerminalInput({
         environmentId: selectedThread.environmentId,
         input: {
           threadId: selectedThread.id,
@@ -708,7 +709,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         },
       });
     },
-    [isRunning, selectedThread, terminalId, writeTerminal],
+    [isRunning, selectedThread, terminalId, writeTerminalInput],
   );
 
   const handleInput = useCallback(

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -322,7 +322,7 @@ export function TerminalViewport({
   const openPreview = useAtomCommand(previewEnvironment.open, {
     reportFailure: false,
   });
-  const runTerminalWrite = useAtomCommand(terminalEnvironment.write, {
+  const runTerminalWrite = useAtomCommand(terminalEnvironment.input, {
     reportFailure: false,
   });
   const runTerminalResize = useAtomCommand(terminalEnvironment.resize, {

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -145,6 +145,32 @@ export const request = Effect.fn("EnvironmentRpc.request")(function* <
   return yield* method(input).pipe(Effect.ensuring(completeObservation));
 });
 
+/**
+ * Sends a unary RPC without waiting for a response frame. This is reserved for
+ * ordered, ephemeral traffic where replay would be unsafe and the caller has a
+ * separate authoritative stream for observing the resulting state.
+ */
+export const requestDiscard = Effect.fn("EnvironmentRpc.requestDiscard")(function* <
+  TTag extends EnvironmentUnaryRpcTag,
+>(tag: TTag, input: EnvironmentRpcInput<TTag>) {
+  const supervisor = yield* EnvironmentSupervisor;
+  yield* Effect.annotateCurrentSpan({
+    "environment.id": supervisor.target.environmentId,
+    "rpc.method": tag,
+  });
+  const session = yield* currentSession();
+  const observer = yield* EnvironmentRpcRequestObserver;
+  const method = session.client[tag] as (
+    input: EnvironmentRpcInput<TTag>,
+    options: { readonly discard: true },
+  ) => Effect.Effect<void, RpcClientError.RpcClientError>;
+  const completeObservation = yield* observer.observe({
+    environmentId: supervisor.target.environmentId,
+    method: tag,
+  });
+  return yield* method(input, { discard: true }).pipe(Effect.ensuring(completeObservation));
+});
+
 export function runStream<TTag extends EnvironmentStreamCommandRpcTag>(
   tag: TTag,
   input: EnvironmentRpcInput<TTag>,

--- a/packages/client-runtime/src/state/terminal.ts
+++ b/packages/client-runtime/src/state/terminal.ts
@@ -1,15 +1,20 @@
 import { type TerminalSummary, WS_METHODS } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
-import { Atom } from "effect/unstable/reactivity";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import {
   createAtomCommandScheduler,
+  createEnvironmentCommand,
   createEnvironmentRpcCommand,
   createEnvironmentRpcSubscriptionAtomFamily,
   createEnvironmentSubscriptionAtomFamily,
+  runInEnvironment,
+  settleAsyncResult,
 } from "./runtime.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
-import { subscribe, type EnvironmentRpcInput } from "../rpc/client.ts";
+import { requestDiscard, subscribe, type EnvironmentRpcInput } from "../rpc/client.ts";
+import { createTerminalInputCommand } from "./terminalInput.ts";
 import {
   applyTerminalAttachStreamEvent,
   applyTerminalMetadataStreamEvent,
@@ -36,6 +41,28 @@ export function createTerminalEnvironmentAtoms<R, E>(
     readonly input: { readonly threadId: string; readonly terminalId?: string | undefined };
   }) => JSON.stringify([environmentId, input.threadId, input.terminalId ?? null]);
   const lifecycleConcurrency = { mode: "serial" as const, key: terminalThreadKey };
+  const sendTerminalInputFallback = createEnvironmentCommand(runtime, {
+    label: "environment-data:terminal:input:send",
+    execute: (input: EnvironmentRpcInput<typeof WS_METHODS.terminalWrite>) =>
+      requestDiscard(WS_METHODS.terminalWrite, input),
+  });
+  const sendTerminalInput: typeof sendTerminalInputFallback = {
+    label: sendTerminalInputFallback.label,
+    run: (registry, target) => {
+      const runtimeContext = registry.get(runtime);
+      if (!AsyncResult.isSuccess(runtimeContext)) {
+        return sendTerminalInputFallback.run(registry, target);
+      }
+      return settleAsyncResult(() =>
+        Effect.runPromiseExitWith(runtimeContext.value)(
+          runInEnvironment(
+            target.environmentId,
+            requestDiscard(WS_METHODS.terminalWrite, target.input),
+          ),
+        ),
+      );
+    },
+  };
   return {
     attach: createEnvironmentSubscriptionAtomFamily(runtime, {
       label: "environment-data:terminal:attach",
@@ -65,6 +92,7 @@ export function createTerminalEnvironmentAtoms<R, E>(
       label: "environment-data:terminal:write",
       tag: WS_METHODS.terminalWrite,
     }),
+    input: createTerminalInputCommand(sendTerminalInput),
     resize: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:terminal:resize",
       tag: WS_METHODS.terminalResize,
@@ -93,3 +121,4 @@ export function createTerminalEnvironmentAtoms<R, E>(
 }
 
 export * from "./terminalSession.ts";
+export * from "./terminalInput.ts";

--- a/packages/client-runtime/src/state/terminalInput.test.ts
+++ b/packages/client-runtime/src/state/terminalInput.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { AtomRegistry } from "effect/unstable/reactivity";
+
+import {
+  createTerminalInputCommand,
+  TerminalInputBackpressureError,
+  type TerminalInputTarget,
+} from "./terminalInput.ts";
+import type { AtomCommand } from "./runtime.ts";
+
+const target = (data: string, terminalId = "term-1"): TerminalInputTarget => ({
+  environmentId: EnvironmentId.make("environment-1"),
+  input: {
+    threadId: ThreadId.make("thread-1"),
+    terminalId,
+    data,
+  },
+});
+
+describe("terminal input command", () => {
+  it("coalesces same-task input and preserves its order", async () => {
+    const sent: string[] = [];
+    const send: AtomCommand<TerminalInputTarget, void, never> = {
+      label: "send",
+      run: async (_registry, input) => {
+        sent.push(input.input.data);
+        return AsyncResult.success(undefined);
+      },
+    };
+    const input = createTerminalInputCommand(send);
+    const registry = AtomRegistry.make();
+
+    const results = await Promise.all([
+      input.run(registry, target("a")),
+      input.run(registry, target("b")),
+      input.run(registry, target("c")),
+    ]);
+
+    expect(sent).toEqual(["abc"]);
+    expect(results.every(AsyncResult.isSuccess)).toBe(true);
+    registry.dispose();
+  });
+
+  it("keeps independent terminal lanes separate", async () => {
+    const sent: Array<{ terminalId: string; data: string }> = [];
+    const send: AtomCommand<TerminalInputTarget, void, never> = {
+      label: "send",
+      run: async (_registry, input) => {
+        sent.push({ terminalId: input.input.terminalId, data: input.input.data });
+        return AsyncResult.success(undefined);
+      },
+    };
+    const input = createTerminalInputCommand(send);
+    const registry = AtomRegistry.make();
+
+    await Promise.all([
+      input.run(registry, target("a", "term-1")),
+      input.run(registry, target("b", "term-2")),
+    ]);
+
+    expect(sent).toEqual([
+      { terminalId: "term-1", data: "a" },
+      { terminalId: "term-2", data: "b" },
+    ]);
+    registry.dispose();
+  });
+
+  it("splits queued input into ordered batches at the configured size", async () => {
+    const sent: string[] = [];
+    const send: AtomCommand<TerminalInputTarget, void, never> = {
+      label: "send",
+      run: async (_registry, input) => {
+        sent.push(input.input.data);
+        return AsyncResult.success(undefined);
+      },
+    };
+    const input = createTerminalInputCommand(send, { maxBatchChars: 3 });
+    const registry = AtomRegistry.make();
+
+    const results = await Promise.all([
+      input.run(registry, target("ab")),
+      input.run(registry, target("cd")),
+      input.run(registry, target("e")),
+    ]);
+
+    expect(sent).toEqual(["ab", "cde"]);
+    expect(results.every(AsyncResult.isSuccess)).toBe(true);
+    registry.dispose();
+  });
+
+  it("splits a single oversized input into legal ordered writes", async () => {
+    const sent: string[] = [];
+    const data = `${"a".repeat(65_535)}😀b`;
+    const send: AtomCommand<TerminalInputTarget, void, never> = {
+      label: "send",
+      run: async (_registry, input) => {
+        sent.push(input.input.data);
+        return AsyncResult.success(undefined);
+      },
+    };
+    const input = createTerminalInputCommand(send);
+    const registry = AtomRegistry.make();
+
+    const result = await input.run(registry, target(data));
+
+    expect(sent.map((chunk) => chunk.length)).toEqual([65_535, 3]);
+    expect(sent.join("")).toBe(data);
+    expect(result._tag).toBe("Success");
+    registry.dispose();
+  });
+
+  it("preserves surrounding input order when splitting an oversized entry", async () => {
+    const sent: string[] = [];
+    const send: AtomCommand<TerminalInputTarget, void, never> = {
+      label: "send",
+      run: async (_registry, input) => {
+        sent.push(input.input.data);
+        return AsyncResult.success(undefined);
+      },
+    };
+    const input = createTerminalInputCommand(send, { maxBatchChars: 4 });
+    const registry = AtomRegistry.make();
+
+    await Promise.all([
+      input.run(registry, target("ab")),
+      input.run(registry, target("cdefgh")),
+      input.run(registry, target("ij")),
+    ]);
+
+    expect(sent).toEqual(["ab", "cdef", "gh", "ij"]);
+    expect(sent.join("")).toBe("abcdefghij");
+    registry.dispose();
+  });
+
+  it("reports a failed chunk after sending the rest of an oversized input", async () => {
+    const sent: string[] = [];
+    const send: AtomCommand<TerminalInputTarget, void, string> = {
+      label: "send",
+      run: async (_registry, input) => {
+        sent.push(input.input.data);
+        return input.input.data === "efgh"
+          ? AsyncResult.failure(Cause.fail("chunk failed"))
+          : AsyncResult.success(undefined);
+      },
+    };
+    const input = createTerminalInputCommand(send, { maxBatchChars: 4 });
+    const registry = AtomRegistry.make();
+
+    const result = await input.run(registry, target("abcdefghij"));
+
+    expect(sent).toEqual(["abcd", "efgh", "ij"]);
+    expect(result._tag).toBe("Failure");
+    registry.dispose();
+  });
+
+  it("fails new input when the bounded lane is full", async () => {
+    let releaseSend!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    const send: AtomCommand<TerminalInputTarget, void, never> = {
+      label: "send",
+      run: async () => {
+        await blocked;
+        return AsyncResult.success(undefined);
+      },
+    };
+    const input = createTerminalInputCommand(send, { maxBufferedChars: 2 });
+    const registry = AtomRegistry.make();
+
+    const accepted = input.run(registry, target("ab"));
+    await Promise.resolve();
+    const rejected = await input.run(registry, target("c"));
+
+    expect(rejected._tag).toBe("Failure");
+    if (rejected._tag === "Failure") {
+      expect(rejected.cause.reasons[0]).toMatchObject({
+        _tag: "Fail",
+        error: expect.any(TerminalInputBackpressureError),
+      });
+    }
+    releaseSend();
+    await accepted;
+    registry.dispose();
+  });
+});

--- a/packages/client-runtime/src/state/terminalInput.ts
+++ b/packages/client-runtime/src/state/terminalInput.ts
@@ -1,0 +1,173 @@
+import type { EnvironmentId, TerminalWriteInput } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import type * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry";
+
+import type { AtomCommand, AtomCommandResult } from "./runtime.ts";
+
+export const TERMINAL_INPUT_MAX_BATCH_CHARS = 65_536;
+export const TERMINAL_INPUT_MAX_BUFFERED_CHARS = 512 * 1024;
+
+export interface TerminalInputTarget {
+  readonly environmentId: EnvironmentId;
+  readonly input: TerminalWriteInput;
+}
+
+export class TerminalInputBackpressureError extends Error {
+  readonly _tag = "TerminalInputBackpressureError";
+  readonly maxBufferedChars: number;
+
+  constructor(maxBufferedChars: number) {
+    super(
+      `Terminal input is arriving faster than it can be sent (${maxBufferedChars} characters buffered).`,
+    );
+    this.maxBufferedChars = maxBufferedChars;
+  }
+}
+
+interface PendingInput<A, E> {
+  readonly target: TerminalInputTarget;
+  readonly resolve: (result: AtomCommandResult<A, E | TerminalInputBackpressureError>) => void;
+}
+
+interface InputLane<A, E> {
+  pending: Array<PendingInput<A, E>>;
+  bufferedChars: number;
+  flushScheduled: boolean;
+  tail: Promise<void>;
+}
+
+function terminalInputKey(target: TerminalInputTarget): string {
+  return JSON.stringify([target.environmentId, target.input.threadId, target.input.terminalId]);
+}
+
+/**
+ * Keeps one ordered writer lane per terminal. Input produced in the same task
+ * is coalesced into the fewest legal RPC payloads, while discard-mode sends
+ * keep the lane moving without waiting for a round trip.
+ */
+export function createTerminalInputCommand<A, E>(
+  send: AtomCommand<TerminalInputTarget, A, E>,
+  options: {
+    readonly maxBatchChars?: number;
+    readonly maxBufferedChars?: number;
+  } = {},
+): AtomCommand<TerminalInputTarget, A, E | TerminalInputBackpressureError> {
+  const maxBatchChars = options.maxBatchChars ?? TERMINAL_INPUT_MAX_BATCH_CHARS;
+  const maxBufferedChars = options.maxBufferedChars ?? TERMINAL_INPUT_MAX_BUFFERED_CHARS;
+  const registryLanes = new WeakMap<AtomRegistry.AtomRegistry, Map<string, InputLane<A, E>>>();
+
+  const lanesFor = (registry: AtomRegistry.AtomRegistry) => {
+    const existing = registryLanes.get(registry);
+    if (existing !== undefined) return existing;
+    const lanes = new Map<string, InputLane<A, E>>();
+    registryLanes.set(registry, lanes);
+    return lanes;
+  };
+
+  const flush = (
+    registry: AtomRegistry.AtomRegistry,
+    lanes: Map<string, InputLane<A, E>>,
+    key: string,
+    lane: InputLane<A, E>,
+  ) => {
+    lane.flushScheduled = false;
+    const pending = lane.pending;
+    lane.pending = [];
+
+    let group: Array<PendingInput<A, E>> = [];
+    let groupChars = 0;
+    const sendGroup = () => {
+      if (group.length === 0) return;
+      const currentGroup = group;
+      const data = currentGroup.map((entry) => entry.target.input.data).join("");
+      const target = currentGroup[0]!.target;
+      group = [];
+      groupChars = 0;
+      lane.tail = lane.tail.then(async () => {
+        const result = await send.run(registry, {
+          environmentId: target.environmentId,
+          input: { ...target.input, data },
+        });
+        lane.bufferedChars -= data.length;
+        for (const entry of currentGroup) entry.resolve(result);
+        if (lane.bufferedChars === 0 && lane.pending.length === 0 && lanes.get(key) === lane) {
+          lanes.delete(key);
+        }
+      });
+    };
+
+    const sendOversizedEntry = (entry: PendingInput<A, E>) => {
+      const { target } = entry;
+      lane.tail = lane.tail.then(async () => {
+        let result: AtomCommandResult<A, E> | undefined;
+        for (let offset = 0; offset < target.input.data.length; ) {
+          let end = Math.min(offset + maxBatchChars, target.input.data.length);
+          const splitsSurrogatePair =
+            end - offset > 1 &&
+            end < target.input.data.length &&
+            target.input.data.charCodeAt(end - 1) >= 0xd800 &&
+            target.input.data.charCodeAt(end - 1) <= 0xdbff &&
+            target.input.data.charCodeAt(end) >= 0xdc00 &&
+            target.input.data.charCodeAt(end) <= 0xdfff;
+          if (splitsSurrogatePair) end -= 1;
+          const data = target.input.data.slice(offset, end);
+          const chunkResult = await send.run(registry, {
+            environmentId: target.environmentId,
+            input: { ...target.input, data },
+          });
+          result = result?._tag === "Failure" ? result : chunkResult;
+          lane.bufferedChars -= data.length;
+          offset = end;
+        }
+        entry.resolve(result!);
+        if (lane.bufferedChars === 0 && lane.pending.length === 0 && lanes.get(key) === lane) {
+          lanes.delete(key);
+        }
+      });
+    };
+
+    for (const entry of pending) {
+      const chars = entry.target.input.data.length;
+      if (chars > maxBatchChars) {
+        sendGroup();
+        sendOversizedEntry(entry);
+        continue;
+      }
+      if (groupChars > 0 && groupChars + chars > maxBatchChars) sendGroup();
+      group.push(entry);
+      groupChars += chars;
+      if (groupChars >= maxBatchChars) sendGroup();
+    }
+    sendGroup();
+  };
+
+  return {
+    label: "environment-data:terminal:input",
+    run: (registry, target) => {
+      const lanes = lanesFor(registry);
+      const key = terminalInputKey(target);
+      let lane = lanes.get(key);
+      if (lane === undefined) {
+        lane = { pending: [], bufferedChars: 0, flushScheduled: false, tail: Promise.resolve() };
+        lanes.set(key, lane);
+      }
+
+      if (lane.bufferedChars + target.input.data.length > maxBufferedChars) {
+        return Promise.resolve(
+          AsyncResult.failure(Cause.fail(new TerminalInputBackpressureError(maxBufferedChars))),
+        );
+      }
+
+      lane.bufferedChars += target.input.data.length;
+      const result = new Promise<AtomCommandResult<A, E | TerminalInputBackpressureError>>(
+        (resolve) => lane!.pending.push({ target, resolve }),
+      );
+      if (!lane.flushScheduled) {
+        lane.flushScheduled = true;
+        queueMicrotask(() => flush(registry, lanes, key, lane!));
+      }
+      return result;
+    },
+  };
+}


### PR DESCRIPTION
Interactive terminal input currently sends every terminal-emulator callback through a separate unary request/response lifecycle. Rapid typing, escape sequences, and paste bursts can create many small RPCs, adding avoidable transport and bookkeeping overhead—especially for remote environments.

This adds a bounded, ordered input lane per environment/thread/terminal. Input queued in the same JavaScript task is coalesced into batches of up to 65,536 characters, batches are sent serially without waiting for response frames, and each lane rejects new input after 512 KiB is buffered. Web/Desktop and Mobile interactive terminal surfaces use the batched command; the existing direct write command remains available for one-off launch input.

Verification:
- `vp test run packages/client-runtime/src/state/terminalInput.test.ts` — 4 passed
- client-runtime, web, and mobile typechecks passed
- targeted lint passed with pre-existing warnings in the two terminal components
- targeted format check passed

Model: GPT-5.6 Sol
Harness: Sovereign / Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how terminal input reaches remote PTYs (ordering, batching, backpressure failures, discard RPCs); mistakes could drop or reorder keystrokes under load.
> 
> **Overview**
> Interactive terminal keystrokes and pastes no longer trigger one unary RPC per emulator callback. The PR adds **`terminalEnvironment.input`**, which batches and serializes writes per environment/thread/terminal while sending them in **discard mode** so the client does not wait on response frames.
> 
> **Client runtime:** `createTerminalInputCommand` coalesces input queued in the same microtask, splits payloads over 65 KiB (UTF-16 surrogate-safe), enforces a 512 KiB per-lane buffer with `TerminalInputBackpressureError` when exceeded, and chains sends on a per-terminal promise tail. **`requestDiscard`** is the new RPC helper used for these fire-and-forget `terminalWrite` calls. **`terminalEnvironment.write`** stays for one-off writes (e.g. mobile launch `initialInput`, chat-driven writes).
> 
> **UI:** Web `ThreadTerminalDrawer` and mobile `ThreadTerminalRouteScreen` route live keyboard/toolbar input through **`input`** instead of **`write`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bab8fd1b6e9674aaedc7ecdd137129f21816835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch terminal input writes through `terminalEnvironment.input`
> - Adds a per-terminal input scheduler in [terminalInput.ts](https://github.com/pingdotgg/t3code/pull/9456/files#diff-466e43aa7c49fb660723fae51a964fc99affedf2ce55591a922b5917d99c7d2a) that buffers concurrent input, coalesces compatible entries up to 65,536 characters, splits oversized payloads into ordered chunks (without breaking surrogate pairs), and sends them serially within each lane.
> - Adds `requestDiscard` in [client.ts](https://github.com/pingdotgg/t3code/pull/9456/files#diff-f60493a8e60511194714ca2543e1d58cfb8198eb71d2bf0c9655acdc93220c38) — a unary RPC helper that fires the request in discard mode without waiting for a response frame.
> - Wires `terminalEnvironment.input` into [terminal.ts](https://github.com/pingdotgg/t3code/pull/9456/files#diff-28e99dfccf29308e09cf5f289f71b20aaffad6230e9e1c58ce165a60191da6d7) and switches the mobile ([ThreadTerminalRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/9456/files#diff-0815b7fd5b544c4241d321358e819d5904da641dfefcb502e256ad3173f71df2)) and web ([ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/9456/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636)) terminal writers from `write` to `input`.
> - Lanes exceeding 512 KiB of buffered input reject new requests with `TerminalInputBackpressureError`.
> - Risk: terminal input now uses discard-mode RPCs, so failed sends no longer surface a response frame error to the UI in the same way as the previous `write` path; failure reporting in the web drawer was already disabled and remains so.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bab8fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->