### PR TITLE
fix(web): make project icons the default

### DIFF
--- a/apps/web/src/components/ProjectFavicon.test.tsx
+++ b/apps/web/src/components/ProjectFavicon.test.tsx
@@ -115,28 +115,40 @@ describe("ProjectFavicon", () => {
     testState.faviconUrl = "https://environment.test/api/assets/token-a/v1-20-favicon.svg";
   });
 
-  it("shows a project-name emoji when no favicon exists", () => {
+  it("shows a project-name icon when no favicon exists", () => {
     testState.faviconUrl = `https://environment.test/api/assets/token/${PROJECT_FAVICON_FALLBACK_MARKER}`;
 
     const element = ProjectFavicon({
       environmentId: "environment-test" as EnvironmentId,
       cwd: "/workspace/analytics-db",
       projectName: "analytics-db",
-    }) as ReactElement<{ readonly emoji?: string }>;
+    }) as ReactElement<{
+      readonly colorClassName?: string;
+      readonly emoji?: string;
+      readonly icon?: ComponentType<{ className?: string }>;
+    }>;
 
-    expect(element.props.emoji).toBe("🗄️");
+    expect(element.props.icon).toBeDefined();
+    expect(element.props.emoji).toBeUndefined();
+    expect(element.props.colorClassName).toContain("text-cyan-600");
   });
 
-  it("chooses a deterministic semantic emoji", () => {
+  it("chooses a deterministic semantic icon", () => {
     testState.faviconUrl = `https://environment.test/api/assets/token/${PROJECT_FAVICON_FALLBACK_MARKER}`;
 
     const element = ProjectFavicon({
       environmentId: "environment-test" as EnvironmentId,
       cwd: "/workspace/agent-runtime",
       projectName: "agent-runtime",
-    }) as ReactElement<{ readonly emoji?: string }>;
+    }) as ReactElement<{
+      readonly colorClassName?: string;
+      readonly emoji?: string;
+      readonly icon?: ComponentType<{ className?: string }>;
+    }>;
 
-    expect(element.props.emoji).toBe("🤖");
+    expect(element.props.icon).toBeDefined();
+    expect(element.props.emoji).toBeUndefined();
+    expect(element.props.colorClassName).toContain("text-violet-600");
   });
 
   it("renders a saved Lucide icon and color ahead of an uploaded favicon", () => {

--- a/apps/web/src/components/settings/ProjectIconPickerDialog.test.tsx
+++ b/apps/web/src/components/settings/ProjectIconPickerDialog.test.tsx
@@ -46,6 +46,6 @@ describe("ProjectIconPickerDialog", () => {
 
     expect(markup).toContain('data-current="lucide"');
     expect(markup.indexOf(">Icons<")).toBeLessThan(markup.indexOf(">Emoji<"));
-    expect(markup).toContain("Search all Lucide icons");
+    expect(markup).toContain('aria-label="Icon color"');
   });
 });

--- a/apps/web/src/components/settings/ProjectIconPickerDialog.test.tsx
+++ b/apps/web/src/components/settings/ProjectIconPickerDialog.test.tsx
@@ -39,13 +39,13 @@ vi.mock("../ui/toggle-group", () => ({
 import { ProjectIconPickerDialog } from "./ProjectIconPickerDialog";
 
 describe("ProjectIconPickerDialog", () => {
-  it("shows emoji first and selects it for an automatic project", () => {
+  it("shows icons first and selects them for an automatic project", () => {
     const markup = renderToStaticMarkup(
       <ProjectIconPickerDialog current={null} open onOpenChange={() => {}} onSelect={() => {}} />,
     );
 
-    expect(markup).toContain('data-current="emoji"');
-    expect(markup.indexOf(">Emoji<")).toBeLessThan(markup.indexOf(">Icons<"));
-    expect(markup).toContain("Or paste any emoji");
+    expect(markup).toContain('data-current="lucide"');
+    expect(markup.indexOf(">Icons<")).toBeLessThan(markup.indexOf(">Emoji<"));
+    expect(markup).toContain("Search all Lucide icons");
   });
 });

--- a/apps/web/src/components/settings/ProjectIconPickerDialog.tsx
+++ b/apps/web/src/components/settings/ProjectIconPickerDialog.tsx
@@ -45,7 +45,7 @@ export function ProjectIconPickerDialog({
   readonly onSelect: (icon: ProjectIconOverride) => void;
 }) {
   const [mode, setMode] = useState<"lucide" | "emoji">(
-    current?.kind === "lucide" ? "lucide" : "emoji",
+    current?.kind === "emoji" ? "emoji" : "lucide",
   );
   const [iconName, setIconName] = useState<IconName>(
     current?.kind === "lucide" ? (current.name as IconName) : DEFAULT_ICON,
@@ -60,7 +60,7 @@ export function ProjectIconPickerDialog({
 
   useEffect(() => {
     if (open && !previousOpenRef.current) {
-      setMode(current?.kind === "lucide" ? "lucide" : "emoji");
+      setMode(current?.kind === "emoji" ? "emoji" : "lucide");
       setIconName(current?.kind === "lucide" ? (current.name as IconName) : DEFAULT_ICON);
       setColor(current?.kind === "lucide" ? current.color : DEFAULT_COLOR);
       setEmoji(current?.kind === "emoji" ? current.emoji : "💻");
@@ -84,7 +84,7 @@ export function ProjectIconPickerDialog({
       <DialogPopup className="w-full sm:w-[32rem]">
         <DialogHeader>
           <DialogTitle>Choose project icon</DialogTitle>
-          <DialogDescription>Pick an emoji, or choose any Lucide icon and color.</DialogDescription>
+          <DialogDescription>Pick any Lucide icon and color, or use an emoji.</DialogDescription>
         </DialogHeader>
         <DialogPanel className="flex min-h-0 flex-col gap-4">
           <ToggleGroup
@@ -96,8 +96,8 @@ export function ProjectIconPickerDialog({
               if (value === "lucide" || value === "emoji") setMode(value);
             }}
           >
-            <Toggle value="emoji">Emoji</Toggle>
             <Toggle value="lucide">Icons</Toggle>
+            <Toggle value="emoji">Emoji</Toggle>
           </ToggleGroup>
 
           {mode === "lucide" ? (

--- a/apps/web/src/projectIconModel.test.ts
+++ b/apps/web/src/projectIconModel.test.ts
@@ -19,18 +19,17 @@ describe("selectProjectIcon", () => {
     expect(selectProjectIcon("", "C:\\work\\mobile-app").icon).toBe("mobile");
   });
 
-  it("uses emoji for automatic project icons", () => {
+  it("uses Lucide icons for automatic project icons", () => {
     expect(selectProjectIcon("agent-runtime", "/workspace/agent-runtime")).toEqual({
-      kind: "emoji",
+      kind: "lucide",
       icon: "ai",
-      emoji: "🤖",
     });
   });
 
   it("gives unknown names a stable generic icon", () => {
     const icon = selectProjectIcon("mercury", "/workspace/mercury");
 
-    expect(icon.kind).toBe("emoji");
+    expect(icon.kind).toBe("lucide");
     expect(PROJECT_ICON_NAMES).toContain(icon.icon);
     expect(selectProjectIcon("mercury", "/elsewhere/mercury")).toEqual(icon);
   });

--- a/apps/web/src/projectIconModel.ts
+++ b/apps/web/src/projectIconModel.ts
@@ -131,31 +131,6 @@ const GENERIC_PROJECT_ICONS: ReadonlyArray<ProjectIconName> = [
   "layers",
 ];
 
-const PROJECT_ICON_EMOJIS: Record<ProjectIconName, string> = {
-  ai: "🤖",
-  book: "📚",
-  braces: "🧩",
-  circuit: "⚡",
-  cloud: "☁️",
-  code: "💻",
-  database: "🗄️",
-  desktop: "🖥️",
-  "folder-code": "🛠️",
-  game: "🎮",
-  image: "🖼️",
-  layers: "✨",
-  mobile: "📱",
-  music: "🎵",
-  package: "📦",
-  security: "🔒",
-  server: "⚙️",
-  shopping: "🛍️",
-  terminal: "⌨️",
-  test: "🧪",
-  video: "🎬",
-  web: "🌐",
-};
-
 const projectIconCache = new Map<string, ProjectIconSelection>();
 
 function projectNameTokens(value: string): ReadonlyArray<string> {
@@ -211,11 +186,7 @@ export function selectProjectIcon(
 
   const iconName =
     bestIcon ?? GENERIC_PROJECT_ICONS[stableIndex(cacheKey, GENERIC_PROJECT_ICONS.length)]!;
-  const icon: ProjectIconSelection = {
-    kind: "emoji",
-    icon: iconName,
-    emoji: PROJECT_ICON_EMOJIS[iconName],
-  };
+  const icon: ProjectIconSelection = { kind: "lucide", icon: iconName };
   projectIconCache.set(cacheKey, icon);
   return icon;
 }

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -2,7 +2,7 @@
 
 T3 Code selects a project icon automatically. It checks `t3.json`, common favicon and app icon
 paths, and icon links in project HTML files. If it does not find an image, it chooses a built-in
-emoji from the project name.
+icon from the project name.
 
 To choose a different icon or emoji:
 


### PR DESCRIPTION
Automatic project fallbacks now use deterministic colored Lucide icons, while detected or uploaded images and saved emoji or icon overrides are unchanged. The picker opens on Icons, preserves each saved mode, and still supports Lucide search and color plus curated or pasted emoji selection. Verified with web typecheck, targeted lint, a production build, and browser e2e at desktop and 390px in light and dark; the three targeted tests are currently blocked before execution by Vite+ 0.3's `undefined.config` runner failure. Built by `gpt-5.6-sol` in T3 Code through the Codex harness.

### evidence

before: automatic emoji fallback

![automatic project fallback rendered as an emoji on the base commit](https://uploads-production-47e4.up.railway.app/files/d8012f3d-635f-4f9f-ac59-f845a807e815/t3-icons-base-automatic.png)

after: automatic Lucide fallback

![automatic project fallback rendered as a colored Lucide icon on this branch](https://uploads-production-47e4.up.railway.app/files/e6d0263c-78b7-485c-8fe4-72e0e78ce285/t3-icons-branch-automatic.png)

before: picker defaults to emoji

![project icon picker defaulting to emoji on the base commit](https://uploads-production-47e4.up.railway.app/files/cb536de7-0fcc-4aea-b3a0-9c17bcfc2870/t3-icons-base-picker.png)

after: picker defaults to icons

![project icon picker defaulting to Lucide icons on this branch](https://uploads-production-47e4.up.railway.app/files/f329ed5c-0e33-405b-905c-ea3a32d8e9dc/t3-icons-branch-picker.png)

browser e2e: icon search, green selection, save and reopen, custom emoji save and reopen, then reset

![browser e2e for the icon and emoji selector](https://uploads-production-47e4.up.railway.app/files/8a396fd6-53c5-47a0-832e-6b6f0521ac9c/t3-icons-e2e.mp4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only default change for automatic icons and picker state; no auth, data, or API behavior changes.
> 
> **Overview**
> **Automatic project icon fallbacks** no longer map classified names to emojis. `selectProjectIcon` now returns `{ kind: "lucide", icon }` only, and the emoji lookup table was removed. Name-based classification and stable generic icons are unchanged; saved emoji/Lucide overrides and uploaded favicons are unaffected.
> 
> The **Choose project icon** dialog defaults to **Icons** (Lucide + color) for new/automatic projects, puts the Icons toggle before Emoji, and updates the helper copy. Tests and user docs were updated to match icon-first behavior and `ProjectFavicon` fallback expectations (icon component + color class instead of emoji props).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac018613c5b7bc4a4c149c7efa5f16ec297b2ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Lucide project icons the default instead of emojis
> - Changes `selectProjectIcon` in [projectIconModel.ts](https://github.com/pingdotgg/t3code/pull/9457/files#diff-3cd5e5b7038ddb58114c43e05ab9878262097e72484423fc4bd5fa90b4e623c2) to return Lucide icon selections for classified and generic project names, removing the `PROJECT_ICON_EMOJIS` lookup table.
> - Updates `ProjectIconPickerDialog` in [ProjectIconPickerDialog.tsx](https://github.com/pingdotgg/t3code/pull/9457/files#diff-7e19f23415e77ba2b4c299ef2280f55fbc96b6ad115a9cdd2873edf8f2074533) to open in Icons mode by default (unless an emoji override exists), reorder mode toggles to show Icons first, and revise the description text.
> - Updates tests and [project-settings.md](https://github.com/pingdotgg/t3code/pull/9457/files#diff-ef2f94e4f2f246b11ca5a23fea9246251f37b46baa59397ca8f3590905c64463) to expect icon-based fallbacks.
> - Behavioral Change: existing projects without an explicit emoji override will now display a Lucide icon instead of an automatically-assigned emoji.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eac0186.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->