### PR TITLE
fix(server): reuse pr state when settling threads

### DIFF
--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -17,6 +17,7 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Crypto from "effect/Crypto";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as PubSub from "effect/PubSub";
 import * as Queue from "effect/Queue";
@@ -134,6 +135,7 @@ interface HarnessOptions {
   readonly settings?: ServerSettings;
   readonly branchPullRequest?: GitManager["Service"]["branchPullRequest"];
   readonly pullRequestSummary?: PullRequestService["Service"]["summary"];
+  readonly existingWorktreePaths?: ReadonlyArray<string>;
   readonly onDispatch?: (
     command: AutoSettleCommand,
   ) => Effect.Effect<void, OrchestrationCommandInvariantError>;
@@ -235,6 +237,9 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
     Layer.succeed(ServerSettingsService, serverSettings),
     Layer.succeed(ServerActivation, Deferred.await(activation)),
     Layer.succeed(Crypto.Crypto, testCrypto),
+    FileSystem.layerNoop({
+      exists: (path) => Effect.succeed(options.existingWorktreePaths?.includes(path) ?? false),
+    }),
   );
 
   return {
@@ -640,6 +645,43 @@ describe("ThreadSettlementReactor", () => {
               ThreadId.make("branch-two"),
               ThreadId.make("linked-one"),
               ThreadId.make("linked-two"),
+            ]),
+          );
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
+  it.effect("looks up the branch pull request from a thread's live worktree", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const fixture = yield* makeHarness({
+          snapshot: makeSnapshot(
+            [
+              makeThread("live-worktree", {
+                branch: "feature/live",
+                worktreePath: "/workspace/project-root/.worktrees/live",
+              }),
+              makeThread("deleted-worktree", {
+                branch: "feature/deleted",
+                worktreePath: "/workspace/project-root/.worktrees/deleted",
+              }),
+            ],
+            [makeProject(PROJECT_ID, "/workspace/project-root")],
+          ),
+          existingWorktreePaths: ["/workspace/project-root/.worktrees/live"],
+        });
+
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+
+          assert.deepStrictEqual(
+            new Set(yield* Ref.get(fixture.branchCalls)),
+            new Set([
+              { cwd: "/workspace/project-root/.worktrees/live", branch: "feature/live" },
+              { cwd: "/workspace/project-root", branch: "feature/deleted" },
             ]),
           );
         }).pipe(Effect.provide(fixture.layer));

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -5,6 +5,7 @@ import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
 import type * as Scope from "effect/Scope";
@@ -37,6 +38,7 @@ export const make = Effect.gen(function* () {
   const git = yield* GitManager.GitManager;
   const pullRequests = yield* PullRequestService.PullRequestService;
   const crypto = yield* Crypto.Crypto;
+  const fileSystem = yield* FileSystem.FileSystem;
 
   const sweep = Effect.fn("ThreadSettlementReactor.sweep")(function* (
     mergedPullRequest: PullRequestService.PullRequestMergeEvent | null,
@@ -54,6 +56,26 @@ export const make = Effect.gen(function* () {
               mergedPullRequest.repository.toLowerCase() &&
             thread.linkedPullRequest.number === mergedPullRequest.number)),
     );
+    // Use the same cwd as the sidebar so both paths share GitManager's PR cache.
+    const lookupCwdByThreadId = new Map<string, string>();
+    yield* Effect.forEach(
+      candidates,
+      (thread) =>
+        Effect.gen(function* () {
+          const project = projects.get(thread.projectId);
+          if (project === undefined || thread.linkedPullRequest != null) return;
+          const worktreeExists =
+            thread.worktreePath !== null &&
+            (yield* fileSystem.exists(thread.worktreePath).pipe(Effect.orElseSucceed(() => false)));
+          lookupCwdByThreadId.set(
+            thread.id,
+            worktreeExists && thread.worktreePath !== null
+              ? thread.worktreePath
+              : project.workspaceRoot,
+          );
+        }),
+      { concurrency: 8, discard: true },
+    );
     const lookupKey = (thread: (typeof candidates)[number]) => {
       if (thread.linkedPullRequest != null) {
         return JSON.stringify([
@@ -64,11 +86,9 @@ export const make = Effect.gen(function* () {
         ]);
       }
       if (thread.branch === null) return JSON.stringify(["none", thread.id]);
-      const project = projects.get(thread.projectId);
+      const cwd = lookupCwdByThreadId.get(thread.id);
       return JSON.stringify(
-        project === undefined
-          ? ["missing-project", thread.id]
-          : ["branch", project.workspaceRoot, thread.branch],
+        cwd === undefined ? ["missing-project", thread.id] : ["branch", cwd, thread.branch],
       );
     };
     const groups = Map.groupBy(candidates, lookupKey);
@@ -100,11 +120,11 @@ export const make = Effect.gen(function* () {
         } satisfies SettlementPullRequest;
       }
       if (thread.branch === null) return null;
-      const project = projects.get(thread.projectId);
-      if (project === undefined) {
+      const cwd = lookupCwdByThreadId.get(thread.id);
+      if (cwd === undefined) {
         return yield* Effect.die(new Error("thread project not found"));
       }
-      return yield* git.branchPullRequest({ cwd: project.workspaceRoot, branch: thread.branch });
+      return yield* git.branchPullRequest({ cwd, branch: thread.branch });
     });
 
     yield* Effect.forEach(


### PR DESCRIPTION
Merged threads could remain active for about two minutes because automatic settlement looked up PR state from the project root while the sidebar refreshed the same branch from its worktree. Since GitManager caches PR lookups by cwd for two minutes, those paths held independent state. This reuses the live worktree for settlement, falls back to the project root after deletion, and is verified by 9 focused reactor tests plus the server typecheck.

Built by `gpt-5.6-sol` in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to cwd selection for existing settlement PR lookups, with filesystem existence checks and fallback to the prior root path.
> 
> **Overview**
> Fixes delayed auto-settlement when a thread’s PR was already merged but the sidebar had fresher state: **branch PR lookups during settlement sweeps now use the thread’s live worktree path when it still exists**, matching the sidebar, so both paths share **GitManager’s cwd-keyed PR cache** (2-minute TTL). If the worktree path is missing on disk, settlement **falls back to the project workspace root** as before.
> 
> Lookup grouping and `git.branchPullRequest` calls use this per-thread cwd instead of always using `project.workspaceRoot`. Tests add a **FileSystem** noop layer and a case that asserts live vs deleted worktrees get the expected `cwd` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3612d8814bd6e966b1b846cf80f8e05377820048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ThreadSettlementReactor` to use existing worktree path for branch PR lookups
> - `ThreadSettlementReactor.make` now depends on a `FileSystem` service and checks whether each eligible thread's worktree path exists before running branch pull-request lookups
> - Existing worktree paths are preferred as the lookup cwd; when the worktree is absent or the existence check fails, the project workspace root is used as before
> - Existence checks run concurrently up to 8 at a time, with filesystem failures treated as non-existent paths
> - Test harness gains a mocked `FileSystem` layer controlled by `existingWorktreePaths`, and a new test verifies cwd selection for both existing and missing worktrees in [ThreadSettlementReactor.test.ts](https://github.com/pingdotgg/t3code/pull/9459/files#diff-799740a1e201215c3aa843f4fbb2dc375971633b640c627e33df611654fa7f9e)
> - Risk: `GitManager.branchPullRequest` calls now receive per-thread cwd values instead of always the project workspace root; any callers relying on the old fixed cwd behavior in [ThreadSettlementReactor.ts](https://github.com/pingdotgg/t3code/pull/9459/files#diff-d1d0434f1c82cb762eac14e3238e44d97e93fde6be3f5120c34057a355a0b6fb) should verify grouping still works correctly
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3612d88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->