### PR TITLE
fix(web): keep agent images collapsed

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3049,16 +3049,17 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const previewText = displayLabel ?? workEntryDisplayLabel(workEntry, workspaceRoot);
   const displayText =
     !toolPresentation && expanded && workEntry.command?.trim() ? "Command" : previewText;
+  const viewedImagePath = workEntryViewedImagePath(workEntry);
   const canExpand =
     (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
     Boolean(
       workEntryRawCommand(workEntry) ||
       workEntry.command?.trim() ||
       workEntry.detail?.trim() ||
-      workEntry.changedFiles?.length,
+      workEntry.changedFiles?.length ||
+      viewedImagePath,
     );
   const expandedBody = expanded ? buildToolCallExpandedBody(workEntry, workspaceRoot) : null;
-  const viewedImagePath = workEntryViewedImagePath(workEntry);
   const viewedImage =
     viewedImagePath && threadRef
       ? resolveViewedImageAsset(viewedImagePath, {
@@ -3159,7 +3160,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           </span>
         </div>
       </div>
-      {viewedImage && threadRef ? (
+      {expanded && viewedImage && threadRef ? (
         <div
           className="mt-1 ms-7 cursor-default"
           onClick={stopRowToggle}


### PR DESCRIPTION
Agent-produced image previews were rendered while their activity row reported aria-expanded=false. This was introduced when image rendering moved outside the disclosure condition; singleton tool-call grouping is unrelated.

This keeps viewed images behind the existing row disclosure and lets image-only activities participate in expansion. The existing click and full-size preview behavior are unchanged.

### Before

![](https://uploads-production-47e4.up.railway.app/files/f4cbaf6f-932f-4e07-9301-102a429eea0c/t3-image-autofold-before-final.png)

### After

![](https://uploads-production-47e4.up.railway.app/files/6b26fb22-eae1-4bfa-afb4-55b4d663fb34/t3-image-autofold-after-collapsed.png)

### Verification

- 38 MessagesTimeline tests pass
- web typecheck passes
- targeted lint and format checks pass
- collapsed and expanded states verified in dark and light at 1280×800
- expanded image preview action verified

Built by gpt-5.6-sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only disclosure logic in the chat timeline; no auth, data, or API changes.
> 
> **Overview**
> Fixes a mismatch where **agent “viewed image” previews** could render on collapsed activity rows (`aria-expanded=false`) after image rendering was decoupled from row expansion.
> 
> **Viewed-image previews** now render only when the work entry row is **expanded**. **`canExpand`** treats a resolved viewed-image path like other expandable content (command, detail, changed files), so **image-only** activities show the disclosure chevron and can be toggled. Click-to-expand and full-size preview behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee95d2cfed9fcd0fb5e325b023597a4aa143250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent viewed images to stay collapsed in `PlainWorkEntryRow`
> Moves the viewed-image path calculation before the expandability check in `PlainWorkEntryRow` so rows with only a viewed image become expandable. The viewed image now renders only while the row is expanded, keeping agent images collapsed by default. Changes are in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/9460/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ee95d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->