### PR TITLE
fix(web): open proactive panels in compact threads

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3851,8 +3851,7 @@ function ChatViewContent(props: ChatViewProps) {
     })
       ? settledTurnId
       : null;
-    const eligibleCompletion =
-      settings.proactivePanelsEnabled && !shouldUseRightPanelSheet && newlyCompletedTurnId !== null;
+    const eligibleCompletion = settings.proactivePanelsEnabled && newlyCompletedTurnId !== null;
     const checkpointReady =
       eligibleCompletion &&
       activeThread?.checkpoints.some((checkpoint) => checkpoint.turnId === newlyCompletedTurnId) ===
@@ -3882,7 +3881,6 @@ function ChatViewContent(props: ChatViewProps) {
     latestTurnSettled,
     onDiffPanelOpen,
     settings.proactivePanelsEnabled,
-    shouldUseRightPanelSheet,
     threadDetailLoading,
   ]);
 
@@ -3902,8 +3900,7 @@ function ChatViewContent(props: ChatViewProps) {
       previousTargetKey,
       linkedThreadPullRequestKey,
     );
-    const eligibleLink =
-      settings.proactivePanelsEnabled && !shouldUseRightPanelSheet && newlyLinkedPullRequest;
+    const eligibleLink = settings.proactivePanelsEnabled && newlyLinkedPullRequest;
     const shouldOpenLink =
       eligibleLink &&
       pullRequestsCapabilityKnown &&
@@ -3926,7 +3923,6 @@ function ChatViewContent(props: ChatViewProps) {
     linkedThreadPullRequestKey,
     pullRequestsCapabilityKnown,
     settings.proactivePanelsEnabled,
-    shouldUseRightPanelSheet,
     supportsPullRequests,
     threadDetailLoading,
   ]);


### PR DESCRIPTION
> [!NOTE]
> Written by `gpt-5.6-sol` on behalf of Maria

Proactive panels were suppressed in compact thread layouts, so completed-turn diffs and newly linked pull requests stayed closed in the normal thread view. This removes the responsive-layout guard while retaining the existing right-side sheet and inline panel rendering. Verified with 96 focused ChatView logic tests, the web typecheck, targeted lint, and a real 900x800 turn completion; implemented by `gpt-5.6-sol` through T3 Code.

![completed turn automatically opened its latest diff in the right-side sheet](https://uploads-production-47e4.up.railway.app/files/27a2aa52-718a-4b73-ae79-f41fb88827ea/proactive-panel-right-side-final.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX fix in ChatView effect eligibility with no auth or data changes; behavior is covered by existing focused tests.
> 
> **Overview**
> **Proactive right-panel behavior** no longer skips turn-diff and linked-PR auto-open when the thread uses the compact **right-panel sheet** layout (`shouldUseRightPanelSheet`).
> 
> `eligibleCompletion` and `eligibleLink` now depend only on `settings.proactivePanelsEnabled` and the turn/PR signals, so completed turns and newly linked PRs can open proactively in narrow viewports instead of staying closed. The sheet vs inline rendering path is unchanged; only the guard that blocked proactive open in sheet mode was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60022b3b44f540c442b40a464449c35d8a17592c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open proactive panels in compact threads in `ChatViewContent`
> Removes the `shouldUseRightPanelSheet` guard from proactive turn-diff and linked pull-request eligibility checks in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9462/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e). Proactive panels now open when the proactive-panels setting is enabled, regardless of right-panel sheet mode. Existing checkpoint, repository, and capability checks remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60022b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->