### PR TITLE
fix(web): render transparent previews on white

### DIFF
--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -315,7 +315,7 @@ export function HostedBrowserWebview(props: {
           }
           aria-hidden={active ? undefined : true}
           className={cn(
-            "absolute flex overflow-hidden bg-background",
+            "absolute flex overflow-hidden bg-white",
             active && !layout.fillsPanel && "ring-1 ring-border/70 shadow-sm",
           )}
           style={{


### PR DESCRIPTION
## What Changed

Changed the embedded preview webview backing surface from the T3 theme background to white.

## Why

Transparent top-level documents currently inherit the selected T3 application theme because the webview is composited over the app background. In dark themes this renders otherwise unstyled pages black and changes how semi-transparent page backgrounds appear.

Using a white backing surface matches the default canvas users see when opening the same page in a regular browser. Explicit page backgrounds continue to render unchanged.

## UI Changes

Before:
T3 Code is on the right
<img width="843" height="482" alt="Screenshot 2026-09-03 123216" src="https://github.com/user-attachments/assets/57626886-e1d7-4b34-8af2-6330b1891525" />
<img width="1695" height="987" alt="image" src="https://github.com/user-attachments/assets/5c7a64bb-7bbb-4f99-b388-ead549899807" />

After:
<img width="831" height="1078" alt="image" src="https://github.com/user-attachments/assets/06408b9e-b799-4b2f-815e-1e1b2279abb6" />
<img width="657" height="615" alt="image" src="https://github.com/user-attachments/assets/c645c028-430a-49a8-9c85-9b1bcb159df8" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable)

Verification:
- vp fmt --check apps/web/src/browser/HostedBrowserWebview.tsx
- vp lint apps/web/src/browser/HostedBrowserWebview.tsx
- vp run --filter @t3tools/web typecheck

Created with GPT-5.6 in the Codex harness.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single visual styling change on the preview webview container with no auth, data, or routing impact.
> 
> **Overview**
> Sets the hosted preview **webview** backing layer to a fixed **white** (`bg-white`) instead of the theme **`bg-background`**, so transparent or unstyled pages no longer pick up the app theme (especially dark mode) behind the guest content.
> 
> Active-tab ring/shadow and other preview chrome are unchanged; only the compositing surface behind the embedded page matches a normal browser canvas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e42800aaa3d4b6f1e99c43f0859afb2cd042091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render transparent previews on white in `HostedBrowserWebview`
> Changes the webview container background from the theme background color to a fixed white so transparent previews display correctly. Active-tab ring and shadow styling remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e42800.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->