### PR TITLE
fix(web): move workflow approval beside checks

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -2120,22 +2120,7 @@ export function PullRequestDetailPanel({
               ))}
             </ToggleGroup>
             {tab === "summary" ? (
-              <span className="ml-auto inline-flex shrink-0 items-center gap-2">
-                <span
-                  className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
-                  aria-label={checksSummary ? `Checks: ${checksSummary}` : "Checks"}
-                >
-                  {checksState !== null ? (
-                    <PullRequestChecksPopover
-                      checks={detail.checks}
-                      checksState={checksState}
-                      threadRef={threadRef}
-                    />
-                  ) : (
-                    <CircleDotIcon aria-hidden className="size-3.5" />
-                  )}
-                  {checksSummary}
-                </span>
+              <span className="ml-auto inline-flex shrink-0 items-center">
                 {workflowApprovalsRequired > 0 && can("approve-workflows") ? (
                   <Tooltip>
                     <TooltipTrigger
@@ -2155,7 +2140,7 @@ export function PullRequestDetailPanel({
                             }
                           >
                             <PlayIcon aria-hidden className="size-3.5" />
-                            <span className="@max-[40rem]/pr-header:hidden">
+                            <span>
                               {pendingAction === "approve-workflows"
                                 ? "Approving..."
                                 : "Approve workflows to run"}
@@ -2170,7 +2155,23 @@ export function PullRequestDetailPanel({
                         : "Approve workflows to run"}
                     </TooltipPopup>
                   </Tooltip>
-                ) : null}
+                ) : (
+                  <span
+                    className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+                    aria-label={checksSummary ? `Checks: ${checksSummary}` : "Checks"}
+                  >
+                    {checksState !== null ? (
+                      <PullRequestChecksPopover
+                        checks={detail.checks}
+                        checksState={checksState}
+                        threadRef={threadRef}
+                      />
+                    ) : (
+                      <CircleDotIcon aria-hidden className="size-3.5" />
+                    )}
+                    {checksSummary}
+                  </span>
+                )}
               </span>
             ) : tab === "timeline" ? (
               <div className="ml-auto flex shrink-0 items-center gap-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1468,41 +1468,6 @@ export function PullRequestDetailPanel({
                   </MenuPopup>
                 </Menu>
               ) : null}
-              {workflowApprovalsRequired > 0 && can("approve-workflows") ? (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <span className="inline-flex shrink-0">
-                        <Button
-                          size="xs"
-                          variant="warning-outline"
-                          disabled={actionPending}
-                          onClick={() =>
-                            setConfirmation({ open: true, action: "approve-workflows" })
-                          }
-                          aria-label={
-                            pendingAction === "approve-workflows"
-                              ? "Approving..."
-                              : "Approve workflows to run"
-                          }
-                        >
-                          <PlayIcon aria-hidden className="size-3.5" />
-                          <span className="@max-[40rem]/pr-header:hidden">
-                            {pendingAction === "approve-workflows"
-                              ? "Approving..."
-                              : "Approve workflows to run"}
-                          </span>
-                        </Button>
-                      </span>
-                    }
-                  />
-                  <TooltipPopup side="top">
-                    {pendingAction === "approve-workflows"
-                      ? "Approving..."
-                      : "Approve workflows to run"}
-                  </TooltipPopup>
-                </Tooltip>
-              ) : null}
               {/* Said where the Merge button is, because it is the answer to why nobody has
                   pressed it: the merge is already asked for, and the host is holding it. */}
               {autoMergeArmed && primaryAction !== "auto-merge-armed" ? (
@@ -2155,20 +2120,57 @@ export function PullRequestDetailPanel({
               ))}
             </ToggleGroup>
             {tab === "summary" ? (
-              <span
-                className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
-                aria-label={checksSummary ? `Checks: ${checksSummary}` : "Checks"}
-              >
-                {checksState !== null ? (
-                  <PullRequestChecksPopover
-                    checks={detail.checks}
-                    checksState={checksState}
-                    threadRef={threadRef}
-                  />
-                ) : (
-                  <CircleDotIcon aria-hidden className="size-3.5" />
-                )}
-                {checksSummary}
+              <span className="ml-auto inline-flex shrink-0 items-center gap-2">
+                <span
+                  className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+                  aria-label={checksSummary ? `Checks: ${checksSummary}` : "Checks"}
+                >
+                  {checksState !== null ? (
+                    <PullRequestChecksPopover
+                      checks={detail.checks}
+                      checksState={checksState}
+                      threadRef={threadRef}
+                    />
+                  ) : (
+                    <CircleDotIcon aria-hidden className="size-3.5" />
+                  )}
+                  {checksSummary}
+                </span>
+                {workflowApprovalsRequired > 0 && can("approve-workflows") ? (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <span className="inline-flex shrink-0">
+                          <Button
+                            size="xs"
+                            variant="warning-outline"
+                            disabled={actionPending}
+                            onClick={() =>
+                              setConfirmation({ open: true, action: "approve-workflows" })
+                            }
+                            aria-label={
+                              pendingAction === "approve-workflows"
+                                ? "Approving..."
+                                : "Approve workflows to run"
+                            }
+                          >
+                            <PlayIcon aria-hidden className="size-3.5" />
+                            <span className="@max-[40rem]/pr-header:hidden">
+                              {pendingAction === "approve-workflows"
+                                ? "Approving..."
+                                : "Approve workflows to run"}
+                            </span>
+                          </Button>
+                        </span>
+                      }
+                    />
+                    <TooltipPopup side="top">
+                      {pendingAction === "approve-workflows"
+                        ? "Approving..."
+                        : "Approve workflows to run"}
+                    </TooltipPopup>
+                  </Tooltip>
+                ) : null}
               </span>
             ) : tab === "timeline" ? (
               <div className="ml-auto flex shrink-0 items-center gap-2 text-xs text-muted-foreground">


### PR DESCRIPTION
when workflows require approval, users who can approve them see only the approval button in the checks slot. users without that permission keep the read-only awaiting-approval status, and after approval removes the gate, the normal checks status returns. the existing host capability gate, pending state, confirmation, and github action are unchanged. verified with web typecheck, focused lint and format checks, the existing pull request checks test, and both live ui states in the real app.

![before: workflow approval button in the header](https://uploads-production-47e4.up.railway.app/files/bd3b4093-9201-4f29-addb-d7868ecb39f6/t3-pr-workflow-before-final.png)

![after: approval button replaces the awaiting-approval checks status](https://uploads-production-47e4.up.railway.app/files/3bd8b5b5-2442-43ba-9a18-8753f84b79c1/t3-pr-workflow-after-corrected.png)

model: gpt-5.6-sol. harness: codex in t3 code.