### PR TITLE
fix(mobile): show loading and syncing in the working pill

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -110,12 +110,6 @@ export interface ThreadComposerProps {
   readonly connectionState: RemoteClientConnectionState;
   readonly connectionError: string | null;
   readonly environmentLabel: string | null;
-  /**
-   * Message sync phase for the selected thread (drives the status pill):
-   * "loading" = first fetch, nothing to show yet; "syncing" = cached messages
-   * are on screen while they reconcile with the server.
-   */
-  readonly threadSyncPhase?: "loading" | "syncing" | null;
   readonly selectedThread: OrchestrationThreadShell;
   readonly serverConfig: T3ServerConfig | null;
   readonly queueCount: number;
@@ -225,7 +219,7 @@ export function ComposerSurface(props: {
 }
 
 type ComposerStatusPillState = {
-  readonly kind: "unavailable" | "reconnecting" | "syncing";
+  readonly kind: "unavailable" | "reconnecting";
   readonly label: string;
 };
 
@@ -233,7 +227,6 @@ function composerConnectionStatus(input: {
   readonly connectionError: string | null;
   readonly connectionState: RemoteClientConnectionState;
   readonly environmentLabel: string | null;
-  readonly threadSyncPhase?: "loading" | "syncing" | null;
 }): ComposerStatusPillState | null {
   const environmentLabel = input.environmentLabel ?? "Environment";
 
@@ -259,18 +252,6 @@ function composerConnectionStatus(input: {
     case "available":
       return { kind: "unavailable", label: `${environmentLabel} is not connected` };
     case "connected":
-      break;
-  }
-
-  // Connected: the pill is the single loading/sync indicator. One stable
-  // label per open — "Loading" when starting from scratch, "Syncing" when
-  // cached messages are already visible.
-  switch (input.threadSyncPhase) {
-    case "loading":
-      return { kind: "syncing", label: "Loading messages..." };
-    case "syncing":
-      return { kind: "syncing", label: "Syncing messages..." };
-    default:
       return null;
   }
 }
@@ -279,7 +260,7 @@ const ComposerConnectionStatusPill = memo(function ComposerConnectionStatusPill(
   readonly onPress: () => void;
   readonly status: ComposerStatusPillState;
 }) {
-  const isReconnecting = props.status.kind !== "unavailable";
+  const isReconnecting = props.status.kind === "reconnecting";
   return (
     <Animated.View
       className="absolute inset-x-0 bottom-full items-center pb-2"
@@ -344,7 +325,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     connectionError: props.connectionError,
     connectionState: props.connectionState,
     environmentLabel: props.environmentLabel,
-    threadSyncPhase: props.threadSyncPhase,
   });
   const selectedProviderStatus = useMemo(() => {
     if (!props.serverConfig) return null;

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -74,6 +74,7 @@ import { PendingUserInputCard } from "./PendingUserInputCard";
 import {
   FLOATING_WORKING_CONTROL_COVERAGE,
   FloatingWorkingControl,
+  type FloatingWorkingStatus,
 } from "./floating-working-control";
 import {
   derivePendingUserInputMaxHeight,
@@ -301,27 +302,38 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   // The raw sync status enters "synchronizing" on every full fetch, cached or
   // not. Whether messages are already on screen decides the pill label: no
   // data yet → "Loading messages", cached data reconciling → "Syncing".
-  const threadSyncPhase = (() => {
+  const threadSyncLabel = (() => {
     switch (props.threadSyncStatus) {
       case "empty":
       case "cached":
       case "synchronizing":
         if (contentPresentationKind === "ready") {
-          return "syncing" as const;
+          return "Syncing messages...";
         }
-        return contentPresentationKind === "loading" ? ("loading" as const) : null;
+        return contentPresentationKind === "loading" ? "Loading messages..." : null;
       default:
         return null;
     }
   })();
-  const showWorkingControl =
-    props.activeWorkStartedAt !== null &&
-    contentPresentationKind === "ready" &&
-    threadSyncPhase === null &&
-    props.connectionStateLabel === "connected" &&
-    props.activePendingApproval === null &&
-    props.activePendingUserInput === null;
-  const floatingWorkingStartedAt = showWorkingControl ? props.activeWorkStartedAt : null;
+  // One floating pill above the composer: it reads the sync state while
+  // messages load, then the working timer once the feed is settled.
+  const floatingStatus = ((): FloatingWorkingStatus | null => {
+    if (
+      props.connectionStateLabel !== "connected" ||
+      props.activePendingApproval !== null ||
+      props.activePendingUserInput !== null
+    ) {
+      return null;
+    }
+    if (threadSyncLabel !== null) {
+      return { kind: "syncing", label: threadSyncLabel };
+    }
+    if (props.activeWorkStartedAt !== null && contentPresentationKind === "ready") {
+      return { kind: "working", startedAt: props.activeWorkStartedAt };
+    }
+    return null;
+  })();
+  const showWorkingControl = floatingStatus !== null;
   const selectedThreadFeed = props.selectedThreadFeed;
   const composerChrome = composerExpanded ? COMPOSER_EXPANDED_CHROME : COMPOSER_COLLAPSED_CHROME;
   const composerOverlapHeight = composerChrome + composerBottomInset;
@@ -748,7 +760,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             <View ref={composerOverlayRef} onLayout={onComposerLayout} className="w-full">
               <FloatingWorkingControl
                 colorScheme={isDarkMode ? "dark" : "light"}
-                startedAt={floatingWorkingStartedAt}
+                status={floatingStatus}
                 showScrollToEnd={showScrollToEndButton}
                 onScrollToEnd={handleScrollToEnd}
               />
@@ -807,7 +819,6 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                   connectionState={props.connectionStateLabel}
                   connectionError={props.connectionError}
                   environmentLabel={props.environmentLabel}
-                  threadSyncPhase={threadSyncPhase}
                   selectedThread={props.selectedThread}
                   serverConfig={props.serverConfig}
                   queueCount={props.selectedThreadQueueCount}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -157,8 +157,9 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
 
   // Render the full thread chrome (header, feed, composer) as soon as the
   // thread SHELL is known — no blocking on message detail. The feed shows a
-  // loading placeholder while messages fetch, and the composer's connection
-  // pill reports connecting/reconnecting/syncing status.
+  // loading placeholder while messages fetch, the floating pill above the
+  // composer reports loading/syncing, and the composer's connection pill
+  // reports connecting/reconnecting status.
   if (selectedThread !== null && selectedThreadKey === routeThreadKey) {
     return <ThreadRouteContent {...props} selectedThreadDetailState={selectedThreadDetailState} />;
   }

--- a/apps/mobile/src/features/threads/floating-working-control.tsx
+++ b/apps/mobile/src/features/threads/floating-working-control.tsx
@@ -1,6 +1,6 @@
 import { GlassContainer, GlassView } from "expo-glass-effect";
 import { useEffect, useState } from "react";
-import { Text as SystemText, View } from "react-native";
+import { ActivityIndicator, Text as SystemText, View } from "react-native";
 import Animated, {
   Easing,
   FadeIn,
@@ -40,9 +40,17 @@ const AnimatedGlassView = Animated.createAnimatedComponent(UniwindGlassView);
 
 export const FLOATING_WORKING_CONTROL_COVERAGE = CONTROL_HEIGHT + CONTROL_COMPOSER_GAP;
 
+/**
+ * What the floating pill says. Syncing and working share one element so the
+ * label swaps in place instead of one pill fading out for another.
+ */
+export type FloatingWorkingStatus =
+  | { readonly kind: "working"; readonly startedAt: string }
+  | { readonly kind: "syncing"; readonly label: string };
+
 export function FloatingWorkingControl(props: {
   readonly colorScheme: "light" | "dark";
-  readonly startedAt: string | null;
+  readonly status: FloatingWorkingStatus | null;
   readonly showScrollToEnd: boolean;
   readonly onScrollToEnd: () => void;
 }) {
@@ -62,7 +70,7 @@ export function FloatingWorkingControl(props: {
     opacity: separationProgress.value,
   }));
 
-  if (props.startedAt === null && !props.showScrollToEnd) {
+  if (props.status === null && !props.showScrollToEnd) {
     return null;
   }
 
@@ -74,7 +82,7 @@ export function FloatingWorkingControl(props: {
       entering={NATIVE_LIQUID_GLASS_SUPPORTED ? undefined : CONTROL_ENTERING}
       exiting={NATIVE_LIQUID_GLASS_SUPPORTED ? undefined : CONTROL_EXITING}
     >
-      {props.startedAt !== null && NATIVE_LIQUID_GLASS_SUPPORTED ? (
+      {props.status !== null && NATIVE_LIQUID_GLASS_SUPPORTED ? (
         <UniwindGlassContainer
           spacing={GLASS_MERGE_SPACING}
           pointerEvents="box-none"
@@ -87,7 +95,7 @@ export function FloatingWorkingControl(props: {
             className="h-11 justify-center overflow-hidden rounded-full"
             style={timerStyle}
           >
-            <WorkingDuration startedAt={props.startedAt} />
+            <FloatingStatusLabel status={props.status} />
           </AnimatedGlassView>
 
           <AnimatedGlassView
@@ -105,14 +113,14 @@ export function FloatingWorkingControl(props: {
             </Animated.View>
           </AnimatedGlassView>
         </UniwindGlassContainer>
-      ) : props.startedAt !== null ? (
+      ) : props.status !== null ? (
         <View pointerEvents="box-none" className="flex-row items-center gap-4">
           <Animated.View
             pointerEvents="none"
             className="h-11 justify-center rounded-full border border-border bg-card shadow-md shadow-black/10"
             style={timerStyle}
           >
-            <WorkingDuration startedAt={props.startedAt} />
+            <FloatingStatusLabel status={props.status} />
           </Animated.View>
 
           <Animated.View
@@ -151,6 +159,22 @@ export function FloatingWorkingControl(props: {
       )}
     </Animated.View>
   );
+}
+
+function FloatingStatusLabel(props: { readonly status: FloatingWorkingStatus }) {
+  if (props.status.kind === "syncing") {
+    return (
+      <View
+        accessible
+        accessibilityLabel={props.status.label}
+        className="h-11 flex-row items-center gap-2 px-4"
+      >
+        <ActivityIndicator size="small" colorClassName="accent-icon-muted" />
+        <Text className="font-t3-medium text-xs text-foreground">{props.status.label}</Text>
+      </View>
+    );
+  }
+  return <WorkingDuration startedAt={props.status.startedAt} />;
 }
 
 function WorkingDuration(props: { readonly startedAt: string }) {


### PR DESCRIPTION
Mobile drew two different pills above the composer: the composer's own "Loading messages…" / "Syncing messages…" pill (bold text, tappable, no glass) and the floating "Working for …" timer pill (glass, merges with the scroll-to-end button). Opening a thread that was already working faded one out and the other in, with a different shape and font each time.

The floating working control now takes a `status` of either `syncing` (spinner + label) or `working` (timer), so both states render in the same element and the label just swaps in place. `ThreadDetailScreen` derives that status from the thread sync state and the active turn, with syncing taking priority. The composer's status pill now only reports connection problems (reconnecting, offline, error, not connected). The old sync pill's tap called reconnect, but since it only ever showed while already connected, nothing is lost by making the new one non-interactive.

Same gating as the timer had: hidden while disconnected or while an approval/user-input card owns the composer slot. The feed's bottom inset already keyed off the pill's presence, so it now reserves space during loading/syncing too.

## Before / after

Loading a thread (left: before, right: after):

![loading](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0dd5c1f8bb3ad057/mobile-pill-loading-before-after.png)

Working timer, unchanged (left: before, right: after):

![working](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/420602746d22e539/mobile-pill-working-before-after.png)

Load transition on the new build (server delayed 3s locally to make it visible):

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6c62066b94880475/mobile-pill-loading-after.mp4

Verified on iOS Simulator (iPhone 17 Pro, iOS 26.5) against a disposable environment seeded from real data. `vp run typecheck` in `apps/mobile` passes; lint shows only pre-existing warnings.

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile thread UI and status presentation only; no auth, data, or API changes. Feed inset logic already keyed off floating pill visibility, now extended to loading/syncing.
> 
> **Overview**
> **Thread loading and syncing** now show in the same glass **floating pill** above the composer as the “Working for …” timer, instead of a separate bold composer status pill.
> 
> `FloatingWorkingControl` takes a `status` of `syncing` (spinner + “Loading/Syncing messages…”) or `working` (elapsed timer) so the label swaps in place without a second pill fading in. `ThreadDetailScreen` builds that status from thread sync + feed presentation, with syncing ahead of active work, and still hides the pill when disconnected or when approval/user-input owns the composer.
> 
> **`ThreadComposer`** drops `threadSyncPhase` and limits its status pill to connection problems (reconnecting, offline, error, not connected); when connected it shows nothing for sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2317bdd62252e5c50ede779e3e27c5ff63308607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show loading and syncing status in the floating working pill
> - Moves message loading and synchronization status display from the composer connection pill to the floating working control pill on the thread detail screen.
> - [ThreadDetailScreen](apps/mobile/src/features/threads/ThreadDetailScreen.tsx) derives a `floatingStatus` from sync and content state, and passes it to `FloatingWorkingControl`. The floating pill now shows the sync label (with activity indicator) before showing the active-work timer.
> - [ThreadComposer](apps/mobile/src/features/threads/ThreadComposer.tsx) and `composerConnectionStatus` no longer accept or produce a syncing status; the composer pill now reports only connection/retry states.
> - Risk: `ThreadComposerProps.threadSyncPhase` is removed; any caller still passing it will get a type error. `FloatingWorkingControl` API changes from a nullable `startedAt` value to a nullable `status` object, requiring all callers to migrate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2317bdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->