### PR TITLE
fix(web): reuse pull request list data while loading

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -4,6 +4,7 @@ import {
   type EnvironmentId,
   type PullRequestAction,
   type PullRequestMergeMethod,
+  type PullRequestListEntry,
   type PullRequestUpdateMethod,
   type PullRequestRef,
   type PullRequestState,
@@ -447,6 +448,7 @@ export function PullRequestDetailPanel({
   environmentId,
   threadRef = null,
   reference,
+  listEntry = null,
   refreshToken: forcedRefreshToken = 0,
   onActed,
   onClose,
@@ -463,6 +465,8 @@ export function PullRequestDetailPanel({
    */
   threadRef?: ScopedThreadRef | null;
   reference: PullRequestRef;
+  /** Row fields already loaded by the pull-request list, used while richer detail arrives. */
+  listEntry?: PullRequestListEntry | null;
   /**
    * Bumped by whatever holds the panel when a reader asks for everything on screen to be read
    * again. The panel owns its own reads, so the page cannot refresh them for it — it says when,
@@ -491,6 +495,12 @@ export function PullRequestDetailPanel({
   composerDraftTarget?: ScopedThreadRef | DraftId;
 }) {
   const pullRequestKey = `${reference.projectId}:${reference.repository}#${reference.number}`;
+  const matchingListEntry =
+    listEntry?.projectId === reference.projectId &&
+    listEntry.repository.toLowerCase() === reference.repository.toLowerCase() &&
+    listEntry.number === reference.number
+      ? listEntry
+      : null;
   const [tab, setTab] = useState<DetailTab>("summary");
   const [timelineOrder, setTimelineOrder] = useState<"newest" | "oldest">("newest");
   const [codeCommitScope, setCodeCommitScope] = useState<{
@@ -1296,10 +1306,10 @@ export function PullRequestDetailPanel({
         ).length
       : 0;
 
-  // A reopen already has last time's title, author, and counts. Keep them on screen
-  // and let the live read replace fields — especially the diff counts — in place.
+  // The list already has the pull request's identity and summary. Keep them on screen
+  // and let the richer detail read replace the remaining placeholders in place.
   if (detailQuery.isPending && !detail) {
-    return <PullRequestDetailGhost />;
+    return <PullRequestDetailGhost seed={matchingListEntry} />;
   }
 
   return (

--- a/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
@@ -7,7 +7,19 @@
  * both themes) and the single `animate-skeleton` pulse, applied once on the container so any
  * number of bars costs one opacity animation.
  */
+import type { PullRequestListEntry } from "@t3tools/contracts";
+import { ArrowLeftIcon } from "lucide-react";
+
 import { cn } from "~/lib/utils";
+import { formatRelativeTimeLabel } from "~/timestampFormat";
+
+import { pullRequestLabelColor } from "./pullRequestList.logic";
+import {
+  PullRequestActorLabel,
+  PullRequestDiffStat,
+  pullRequestChecksStatePresentation,
+  resolvePullRequestState,
+} from "./pullRequestPresentation";
 
 function GhostBar({ className }: { className?: string | undefined }) {
   return <div aria-hidden className={cn("h-3 rounded bg-muted-foreground/15", className)} />;
@@ -60,18 +72,48 @@ export function PullRequestListGhost({
  * boundaries in the ghost prevents the loaded pull request from replacing one layout with
  * another a moment later.
  */
-export function PullRequestDetailGhost() {
+export function PullRequestDetailGhost({ seed }: { seed?: PullRequestListEntry | null }) {
+  const statePresentation = seed
+    ? resolvePullRequestState({
+        state: seed.state,
+        isDraft: seed.isDraft,
+        mergeability: seed.mergeability,
+        baseBranch: seed.baseBranch,
+      })
+    : null;
+  const checksPresentation = seed?.checksState
+    ? pullRequestChecksStatePresentation(seed.checksState)
+    : null;
+
   return (
     <div
       role="status"
       aria-label="Loading pull request"
-      className="motion-safe:animate-skeleton flex h-full min-h-0 flex-col overflow-hidden bg-background"
+      className={cn(
+        "flex h-full min-h-0 flex-col overflow-hidden bg-background",
+        !seed && "motion-safe:animate-skeleton",
+      )}
     >
       <div className="shrink-0 border-b border-border/60">
         <div className="flex h-7 items-center justify-between gap-3 px-4">
           <div className="flex min-w-0 flex-1 items-center gap-1.5">
-            <GhostBar className="w-24" />
-            <GhostBar className="w-9" />
+            {seed && statePresentation ? (
+              <>
+                <span className="min-w-0 truncate text-xs font-medium text-muted-foreground">
+                  {seed.repository}
+                </span>
+                <span
+                  className={cn("shrink-0 text-xs font-medium", statePresentation.toneClassName)}
+                >
+                  #{seed.number}
+                </span>
+              </>
+            ) : (
+              <>
+                <GhostBar className="w-24" />
+                <GhostBar className="w-9" />
+              </>
+            )}
           </div>
           <div className="flex shrink-0 items-center gap-1">
             <GhostBar className="h-5 w-16 rounded-md" />
@@ -80,18 +122,58 @@ export function PullRequestDetailGhost() {
         </div>
 
         <div className="px-4 pb-4 pt-1">
-          <GhostBar className="h-5 w-4/5 max-w-md" />
+          {seed ? (
+            <h1 className="truncate text-base font-semibold leading-snug">{seed.title}</h1>
+          ) : (
+            <GhostBar className="h-5 w-4/5 max-w-md" />
+          )}
           <div className="mt-2 flex items-center gap-1.5">
-            <GhostBar className="size-4 rounded-full" />
-            <GhostBar className="w-24" />
+            {seed ? (
+              <>
+                <PullRequestActorLabel
+                  actor={seed.author}
+                  className="font-medium"
+                  tooltip={false}
+                />
+                <span className="text-xs text-muted-foreground">
+                  updated {formatRelativeTimeLabel(seed.updatedAt)}
+                </span>
+              </>
+            ) : (
+              <>
+                <GhostBar className="size-4 rounded-full" />
+                <GhostBar className="w-24" />
+              </>
+            )}
           </div>
           <div className="mt-4 flex min-w-0 items-center gap-2">
-            <GhostBar className="h-6 w-24 rounded-md" />
-            <GhostBar className="size-3 rounded-full" />
-            <GhostBar className="h-6 w-32 rounded-md" />
+            {seed ? (
+              <span className="flex min-w-0 flex-1 items-center gap-1.5 font-mono text-xs text-muted-foreground/70">
+                <code className="min-w-0 max-w-[40%] shrink-0 truncate">{seed.baseBranch}</code>
+                <ArrowLeftIcon
+                  aria-label="receives changes from"
+                  className="size-3.5 shrink-0 opacity-60"
+                />
+                <code className="min-w-0 flex-1 truncate">{seed.headBranch}</code>
+              </span>
+            ) : (
+              <>
+                <GhostBar className="h-6 w-24 rounded-md" />
+                <GhostBar className="size-3 rounded-full" />
+                <GhostBar className="h-6 w-32 rounded-md" />
+              </>
+            )}
             <div className="ml-auto flex shrink-0 items-center gap-2">
               <GhostBar className="w-10" />
-              <GhostBar className="w-20" />
+              {seed ? (
+                <PullRequestDiffStat
+                  additions={seed.additions}
+                  deletions={seed.deletions}
+                  className="font-mono text-xs"
+                />
+              ) : (
+                <GhostBar className="w-20" />
+              )}
             </div>
           </div>
         </div>
@@ -102,7 +184,19 @@ export function PullRequestDetailGhost() {
             <GhostBar className="h-6 w-16 rounded-md" />
             <GhostBar className="h-6 w-12 rounded-md" />
           </div>
-          <GhostBar className="w-20" />
+          {checksPresentation ? (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1.5 text-xs",
+                checksPresentation.toneClassName,
+              )}
+            >
+              <checksPresentation.Icon aria-hidden className="size-3.5" />
+              {checksPresentation.label}
+            </span>
+          ) : (
+            <GhostBar className="w-20" />
+          )}
         </div>
       </div>
 
@@ -125,8 +219,29 @@ export function PullRequestDetailGhost() {
               <GhostBar className="w-10" />
             </div>
             <div className="flex items-center gap-1">
-              <GhostBar className="h-5 w-24 rounded-full" />
-              <GhostBar className="h-5 w-20 rounded-full" />
+              {seed ? (
+                seed.labels.slice(0, 3).map((label) => {
+                  const color = pullRequestLabelColor(label.color);
+                  return (
+                    <span
+                      key={label.name}
+                      className="inline-flex h-5 max-w-32 items-center gap-1 truncate rounded-full border border-border/70 bg-muted/40 px-2 text-[10px] text-muted-foreground"
+                    >
+                      <span
+                        aria-hidden
+                        className="size-2 shrink-0 rounded-full bg-muted-foreground"
+                        {...(color ? { style: { backgroundColor: color } } : {})}
+                      />
+                      <span className="truncate">{label.name}</span>
+                    </span>
+                  );
+                })
+              ) : (
+                <>
+                  <GhostBar className="h-5 w-24 rounded-full" />
+                  <GhostBar className="h-5 w-20 rounded-full" />
+                </>
+              )}
             </div>
           </div>
           <div className="grid min-h-8 grid-cols-[6rem_minmax(0,1fr)] items-center gap-2">

--- a/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
@@ -77,8 +77,6 @@ export function PullRequestDetailGhost({ seed }: { seed?: PullRequestListEntry |
     ? resolvePullRequestState({
         state: seed.state,
         isDraft: seed.isDraft,
-        mergeability: seed.mergeability,
-        baseBranch: seed.baseBranch,
       })
     : null;
   const checksPresentation = seed?.checksState

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1436,6 +1436,15 @@ function PullRequestsRouteView() {
         entry.additions + entry.deletions > 0 || statsByRow.has(pullRequestDiffStatKey(entry)),
     );
   }, [groups, sort, statsByRow, typedParsed.text]);
+  const listedPullRequestsBySurface = useMemo(
+    () =>
+      new Map(
+        displayGroups.flatMap((group) =>
+          group.entries.map((entry) => [pullRequestSurfaceId(entry), entry] as const),
+        ),
+      ),
+    [displayGroups],
+  );
 
   const linkedSelection = useMemo(
     () =>
@@ -1939,6 +1948,7 @@ function PullRequestsRouteView() {
                 repository: renderedPullRequestSurface.repository,
                 number: renderedPullRequestSurface.number,
               }}
+              listEntry={listedPullRequestsBySurface.get(renderedPullRequestSurface.id) ?? null}
               refreshToken={detailRefreshToken}
               // Merging, closing or reopening changes the row this panel was opened from, so
               // the list behind it is out of date the moment the host takes the action.

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -220,6 +220,9 @@ const EMPTY_TERMINAL_LABELS = new Map<string, string>();
 const EMPTY_PENDING_SURFACES = new Set<string>();
 const MAX_SEARCH_LABEL_CANDIDATES = 100;
 
+const pullRequestListEntryId = (target: Parameters<typeof pullRequestSurfaceId>[0]) =>
+  pullRequestSurfaceId({ ...target, repository: target.repository.toLowerCase() });
+
 function pullRequestSearchLabels(raw: unknown): Partial<Pick<PullRequestsSearch, "labels">> {
   const values = (Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : []).slice(
     0,
@@ -1440,7 +1443,7 @@ function PullRequestsRouteView() {
     () =>
       new Map(
         displayGroups.flatMap((group) =>
-          group.entries.map((entry) => [pullRequestSurfaceId(entry), entry] as const),
+          group.entries.map((entry) => [pullRequestListEntryId(entry), entry] as const),
         ),
       ),
     [displayGroups],
@@ -1948,7 +1951,11 @@ function PullRequestsRouteView() {
                 repository: renderedPullRequestSurface.repository,
                 number: renderedPullRequestSurface.number,
               }}
-              listEntry={listedPullRequestsBySurface.get(renderedPullRequestSurface.id) ?? null}
+              listEntry={
+                listedPullRequestsBySurface.get(
+                  pullRequestListEntryId(renderedPullRequestSurface),
+                ) ?? null
+              }
               refreshToken={detailRefreshToken}
               // Merging, closing or reopening changes the row this panel was opened from, so
               // the list behind it is out of date the moment the host takes the action.


### PR DESCRIPTION
Opening a loaded pull request discarded its row metadata and replaced the panel with a full skeleton while the richer detail request ran. This reuses the matching list entry immediately while retaining the detail request only for fields absent from the list. Verified with the web typecheck, targeted lint, diff checks, and the exact list-to-detail browser transition.

Before

![](https://uploads-production-47e4.up.railway.app/files/b0c3d3f8-0a5b-469f-96e9-3011bf0d7f99/pr-before.gif)

[play the before video](https://uploads-production-47e4.up.railway.app/files/e206f3fa-0fac-4219-9b96-f4111379090d/pr-list-detail-before.mp4)

After

![](https://uploads-production-47e4.up.railway.app/files/6fb0253a-71b8-437c-a5de-87100e5d807b/pr-after.gif)

[play the after video](https://uploads-production-47e4.up.railway.app/files/0e34576a-3a81-4145-a965-684be6bcac18/pr-list-detail-after.mp4)

Built by gpt-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only loading UX; no changes to fetch logic, actions, or security-sensitive paths.
> 
> **Overview**
> Opening a pull request from the list no longer swaps the detail panel to a **full skeleton** while the richer detail request runs. The pull-requests page now passes the matching **list row** into `PullRequestDetailPanel`, which only accepts it when project, repository (case-insensitive), and number align with the panel reference.
> 
> While detail is still pending, `PullRequestDetailGhost` can take that row as a **seed** and render real header/summary fields—title, author, branches, diff stats, checks, labels, and similar—instead of placeholder bars, and it **skips the skeleton pulse** when seeded. Areas that still need detail (e.g. description body, lower sections) keep ghost bars until load completes.
> 
> Deep links or opens without a list row behave as before: an unseeded ghost with the animated skeleton.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1df036b896b834d2a3e7508c4a138b05240121c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse pull request list data while loading `PullRequestDetailPanel`
> Adds an optional pull-request list entry prop to `PullRequestDetailPanel`. The component validates that the entry matches the requested project, repository, and number (repository names compared case-insensitively), then seeds the loading ghost with the list row's identity and summary data while the full detail is pending.
> - Risk: mismatched entries fall back to the previous unseeded ghost, so no data corruption occurs, but reviewers should verify the match logic in [PullRequestDetailPanel.tsx](https://github.com/pingdotgg/t3code/pull/9467/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a) covers all list-vs-detail key combinations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1df036.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->