### PR TITLE
feat(web): let users turn off composer collapse on blur and scroll

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -28,6 +28,8 @@ const clientSettings: ClientSettings = {
   confirmThreadUnpin: false,
   continueThreadsAfterServerUpdate: true,
   contextWindowMeterEnabled: false,
+  composerCollapseOnBlur: false,
+  composerCollapseOnScroll: true,
   dismissedProviderUpdateNotificationKeys: [],
   diffIgnoreWhitespace: true,
   diffLayout: "stacked",

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3621,7 +3621,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     settings.composerCollapseOnScroll &&
     !composerHasExpandedChrome &&
     !showInlineTasksBadge;
-  composerScrollCollapseEligibleRef.current = canScrollCollapseComposer;
+  // Scrolling only has something to collapse while the composer is expanded.
+  // With blur collapse off that includes an unfocused composer, so the wheel
+  // handler keys off this rather than editor focus.
+  composerScrollCollapseEligibleRef.current = canScrollCollapseComposer && !isComposerResting;
 
   useEffect(() => {
     if (!canScrollCollapseComposer) {
@@ -3662,11 +3665,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       resetComposerScrollGesture(composerScrollGestureRef.current);
     };
     const handleTimelineWheel = (event: WheelEvent) => {
-      const activeElement = document.activeElement;
-      const isPromptEditorFocused =
-        activeElement instanceof HTMLElement &&
-        activeElement.isContentEditable &&
-        composerFormRef.current?.contains(activeElement) === true;
       if (event.ctrlKey || !(event.target instanceof Element)) {
         return;
       }
@@ -3700,8 +3698,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         now: window.performance.now(),
         deltaPx,
         collapseThresholdPx: COMPOSER_SCROLL_COLLAPSE_THRESHOLD_PX,
-        collapseEligible:
-          targetsTimeline && composerScrollCollapseEligibleRef.current && isPromptEditorFocused,
+        collapseEligible: targetsTimeline && composerScrollCollapseEligibleRef.current,
         canScrollInGestureDirection,
         scrollsTowardLogicalEnd: event.deltaY > 0 && isTimelineAtLogicalEnd(),
       });

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3542,8 +3542,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const isComposerResting = shouldUseRestingComposerLayout({
     isExistingThread: routeKind === "server" && activeThreadId !== null,
     isMobileViewport,
-    isFocused: isComposerFocused && !isComposerScrollCollapsed,
+    isFocused: isComposerFocused,
+    isScrollCollapsed: isComposerScrollCollapsed,
     hasExpandedChrome: composerHasExpandedChrome,
+    collapseOnBlur: settings.composerCollapseOnBlur,
   });
   // The relocated controls live in the context strip whenever the composer is
   // collapsed for any reason, the desktop resting layout or the phone
@@ -3615,7 +3617,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const canTrackComposerScrollGesture =
     routeKind === "server" && activeThreadId !== null && !isMobileViewport;
   const canScrollCollapseComposer =
-    canTrackComposerScrollGesture && !composerHasExpandedChrome && !showInlineTasksBadge;
+    canTrackComposerScrollGesture &&
+    settings.composerCollapseOnScroll &&
+    !composerHasExpandedChrome &&
+    !showInlineTasksBadge;
   composerScrollCollapseEligibleRef.current = canScrollCollapseComposer;
 
   useEffect(() => {

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -79,11 +79,34 @@ describe("shouldUseRestingComposerLayout", () => {
     isExistingThread: true,
     isMobileViewport: false,
     isFocused: false,
+    isScrollCollapsed: false,
     hasExpandedChrome: false,
+    collapseOnBlur: true,
   };
 
   it("uses the resting layout for an unfocused desktop composer", () => {
     expect(shouldUseRestingComposerLayout(resting)).toBe(true);
+  });
+
+  it("keeps an unfocused composer expanded when blur collapse is off", () => {
+    expect(shouldUseRestingComposerLayout({ ...resting, collapseOnBlur: false })).toBe(false);
+  });
+
+  it("rests a scroll-collapsed composer even while focused", () => {
+    expect(
+      shouldUseRestingComposerLayout({ ...resting, isFocused: true, isScrollCollapsed: true }),
+    ).toBe(true);
+  });
+
+  it("rests a scroll-collapsed composer regardless of the blur preference", () => {
+    expect(
+      shouldUseRestingComposerLayout({
+        ...resting,
+        isFocused: true,
+        isScrollCollapsed: true,
+        collapseOnBlur: false,
+      }),
+    ).toBe(true);
   });
 
   it("keeps new-thread composers expanded", () => {

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -27,7 +27,9 @@ export function shouldUseRestingComposerLayout(input: {
   isExistingThread: boolean;
   isMobileViewport: boolean;
   isFocused: boolean;
+  isScrollCollapsed: boolean;
   hasExpandedChrome: boolean;
+  collapseOnBlur: boolean;
 }): boolean {
   // Passive draft content is deliberately absent here. Resting only clamps
   // the prompt row and overlays its actions; non-image attachment and context
@@ -37,12 +39,13 @@ export function shouldUseRestingComposerLayout(input: {
   // deliberately absent here: resting reclaims vertical space at every
   // desktop width, and where the strip is missing or too narrow the controls
   // simply return when the composer is focused.
-  return (
-    input.isExistingThread &&
-    !input.isMobileViewport &&
-    !input.isFocused &&
-    !input.hasExpandedChrome
-  );
+  //
+  // A scroll collapse rests the composer regardless of the blur preference:
+  // the user asked for it with the gesture, and it lifts on the next
+  // composer interaction. With blur collapse off, losing focus alone never
+  // rests the composer.
+  const collapsed = input.isScrollCollapsed || (input.collapseOnBlur && !input.isFocused);
+  return input.isExistingThread && !input.isMobileViewport && collapsed && !input.hasExpandedChrome;
 }
 
 export function shouldAnimateComposerRestingTransition(input: {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -173,7 +173,7 @@ const TIMESTAMP_FORMAT_LABELS = {
 } as const;
 
 const COMPOSER_COLLAPSE_TRIGGER_LABELS = {
-  blur: "On blur",
+  blur: "On unfocus",
   scroll: "On scroll",
 } as const;
 type ComposerCollapseTrigger = keyof typeof COMPOSER_COLLAPSE_TRIGGER_LABELS;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -128,7 +128,6 @@ import {
 } from "../ui/number-field";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
-import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ThemeLibrary } from "./ThemeSettings";
@@ -172,6 +171,12 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const COMPOSER_COLLAPSE_TRIGGER_LABELS = {
+  blur: "On blur",
+  scroll: "On scroll",
+} as const;
+type ComposerCollapseTrigger = keyof typeof COMPOSER_COLLAPSE_TRIGGER_LABELS;
 
 const DIFF_LAYOUT_LABELS: Record<DiffLayout, string> = {
   stacked: "Stacked",
@@ -2019,6 +2024,13 @@ export function GeneralSettingsPanel() {
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const supportsAutoSettlement =
     useAtomValue(primaryServerConfigAtom)?.environment.capabilities.threadAutoSettlement === true;
+  const composerCollapseTriggers = useMemo<ComposerCollapseTrigger[]>(
+    () => [
+      ...(settings.composerCollapseOnBlur ? (["blur"] as const) : []),
+      ...(settings.composerCollapseOnScroll ? (["scroll"] as const) : []),
+    ],
+    [settings.composerCollapseOnBlur, settings.composerCollapseOnScroll],
+  );
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
@@ -2345,7 +2357,7 @@ export function GeneralSettingsPanel() {
 
         <SettingsRow
           {...searchableSetting("composer-collapse")}
-          description="Rest the composer of an existing thread into a single line when it loses focus, when you scroll the conversation, or both. Deselect both to keep it expanded."
+          description="Rest the composer of an existing thread into a single line when it loses focus, when you scroll the conversation, or both. Pick neither to keep it expanded."
           resetAction={
             settings.composerCollapseOnBlur !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur ||
             settings.composerCollapseOnScroll !==
@@ -2362,14 +2374,9 @@ export function GeneralSettingsPanel() {
             ) : null
           }
           control={
-            <ToggleGroup
+            <Select
               multiple
-              aria-label="Collapse composer"
-              variant="segmented"
-              value={[
-                ...(settings.composerCollapseOnBlur ? ["blur"] : []),
-                ...(settings.composerCollapseOnScroll ? ["scroll"] : []),
-              ]}
+              value={composerCollapseTriggers}
               onValueChange={(next) =>
                 updateSettings({
                   composerCollapseOnBlur: next.includes("blur"),
@@ -2377,9 +2384,24 @@ export function GeneralSettingsPanel() {
                 })
               }
             >
-              <Toggle value="blur">On blur</Toggle>
-              <Toggle value="scroll">On scroll</Toggle>
-            </ToggleGroup>
+              <SelectTrigger size="sm" className="w-full sm:w-40" aria-label="Collapse composer">
+                <SelectValue>
+                  {composerCollapseTriggers.length === 0
+                    ? "Never"
+                    : composerCollapseTriggers
+                        .map((trigger) => COMPOSER_COLLAPSE_TRIGGER_LABELS[trigger])
+                        .join(", ")}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem showCheck value="blur">
+                  {COMPOSER_COLLAPSE_TRIGGER_LABELS.blur}
+                </SelectItem>
+                <SelectItem showCheck value="scroll">
+                  {COMPOSER_COLLAPSE_TRIGGER_LABELS.scroll}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -542,6 +542,12 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.showSkillsInSlashMenu !== DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu
         ? ["Show skills in slash menu"]
         : []),
+      ...(settings.composerCollapseOnBlur !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur
+        ? ["Collapse composer when it loses focus"]
+        : []),
+      ...(settings.composerCollapseOnScroll !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll
+        ? ["Collapse composer when scrolling"]
+        : []),
       ...(settings.contextWindowMeterEnabled !== DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled
         ? ["Context window indicator"]
         : []),
@@ -599,6 +605,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.confirmThreadUnpin,
+      settings.composerCollapseOnBlur,
+      settings.composerCollapseOnScroll,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
@@ -703,6 +711,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       diffLayout: DEFAULT_UNIFIED_SETTINGS.diffLayout,
       proactivePanelsEnabled: DEFAULT_UNIFIED_SETTINGS.proactivePanelsEnabled,
       showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
+      composerCollapseOnBlur: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur,
+      composerCollapseOnScroll: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll,
       contextWindowMeterEnabled: DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
@@ -2330,6 +2340,59 @@ export function GeneralSettingsPanel() {
                 updateSettings({ showSkillsInSlashMenu: Boolean(checked) })
               }
               aria-label="Show skills in slash menu"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("composer-collapse-on-blur")}
+          description="Rest the composer of an existing thread into a single line when you click or tab away from it."
+          resetAction={
+            settings.composerCollapseOnBlur !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur ? (
+              <SettingResetButton
+                label="collapse composer on blur"
+                onClick={() =>
+                  updateSettings({
+                    composerCollapseOnBlur: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.composerCollapseOnBlur}
+              onCheckedChange={(checked) =>
+                updateSettings({ composerCollapseOnBlur: Boolean(checked) })
+              }
+              aria-label="Collapse composer when it loses focus"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("composer-collapse-on-scroll")}
+          description="Rest a focused composer when you scroll the conversation. Scrolling toward the end while already there never collapses it."
+          resetAction={
+            settings.composerCollapseOnScroll !==
+            DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll ? (
+              <SettingResetButton
+                label="collapse composer on scroll"
+                onClick={() =>
+                  updateSettings({
+                    composerCollapseOnScroll: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.composerCollapseOnScroll}
+              onCheckedChange={(checked) =>
+                updateSettings({ composerCollapseOnScroll: Boolean(checked) })
+              }
+              aria-label="Collapse composer when scrolling"
             />
           }
         />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -128,6 +128,7 @@ import {
 } from "../ui/number-field";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
+import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ThemeLibrary } from "./ThemeSettings";
@@ -542,11 +543,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.showSkillsInSlashMenu !== DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu
         ? ["Show skills in slash menu"]
         : []),
-      ...(settings.composerCollapseOnBlur !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur
-        ? ["Collapse composer when it loses focus"]
-        : []),
-      ...(settings.composerCollapseOnScroll !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll
-        ? ["Collapse composer when scrolling"]
+      ...(settings.composerCollapseOnBlur !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur ||
+      settings.composerCollapseOnScroll !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll
+        ? ["Collapse composer"]
         : []),
       ...(settings.contextWindowMeterEnabled !== DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled
         ? ["Context window indicator"]
@@ -2345,41 +2344,17 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
-          {...searchableSetting("composer-collapse-on-blur")}
-          description="Rest the composer of an existing thread into a single line when you click or tab away from it."
+          {...searchableSetting("composer-collapse")}
+          description="Rest the composer of an existing thread into a single line when it loses focus, when you scroll the conversation, or both. Deselect both to keep it expanded."
           resetAction={
-            settings.composerCollapseOnBlur !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur ? (
+            settings.composerCollapseOnBlur !== DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur ||
+            settings.composerCollapseOnScroll !==
+              DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll ? (
               <SettingResetButton
-                label="collapse composer on blur"
+                label="collapse composer"
                 onClick={() =>
                   updateSettings({
                     composerCollapseOnBlur: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnBlur,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.composerCollapseOnBlur}
-              onCheckedChange={(checked) =>
-                updateSettings({ composerCollapseOnBlur: Boolean(checked) })
-              }
-              aria-label="Collapse composer when it loses focus"
-            />
-          }
-        />
-
-        <SettingsRow
-          {...searchableSetting("composer-collapse-on-scroll")}
-          description="Rest a focused composer when you scroll the conversation. Scrolling toward the end while already there never collapses it."
-          resetAction={
-            settings.composerCollapseOnScroll !==
-            DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll ? (
-              <SettingResetButton
-                label="collapse composer on scroll"
-                onClick={() =>
-                  updateSettings({
                     composerCollapseOnScroll: DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll,
                   })
                 }
@@ -2387,13 +2362,24 @@ export function GeneralSettingsPanel() {
             ) : null
           }
           control={
-            <Switch
-              checked={settings.composerCollapseOnScroll}
-              onCheckedChange={(checked) =>
-                updateSettings({ composerCollapseOnScroll: Boolean(checked) })
+            <ToggleGroup
+              multiple
+              aria-label="Collapse composer"
+              variant="segmented"
+              value={[
+                ...(settings.composerCollapseOnBlur ? ["blur"] : []),
+                ...(settings.composerCollapseOnScroll ? ["scroll"] : []),
+              ]}
+              onValueChange={(next) =>
+                updateSettings({
+                  composerCollapseOnBlur: next.includes("blur"),
+                  composerCollapseOnScroll: next.includes("scroll"),
+                })
               }
-              aria-label="Collapse composer when scrolling"
-            />
+            >
+              <Toggle value="blur">On blur</Toggle>
+              <Toggle value="scroll">On scroll</Toggle>
+            </ToggleGroup>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -203,16 +203,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["command menu dollar $ slash /"],
   },
   {
-    id: "composer-collapse-on-blur",
-    title: "Collapse composer when it loses focus",
+    id: "composer-collapse",
+    title: "Collapse composer",
     to: "/settings/general",
-    searchTerms: ["composer rest resting collapse blur focus click away shrink minimize"],
-  },
-  {
-    id: "composer-collapse-on-scroll",
-    title: "Collapse composer when scrolling",
-    to: "/settings/general",
-    searchTerms: ["composer rest resting collapse scroll wheel conversation timeline shrink"],
+    searchTerms: [
+      "composer rest resting blur focus click away scroll wheel conversation timeline shrink minimize",
+    ],
   },
   {
     id: "provider-update-checks",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -203,6 +203,18 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["command menu dollar $ slash /"],
   },
   {
+    id: "composer-collapse-on-blur",
+    title: "Collapse composer when it loses focus",
+    to: "/settings/general",
+    searchTerms: ["composer rest resting collapse blur focus click away shrink minimize"],
+  },
+  {
+    id: "composer-collapse-on-scroll",
+    title: "Collapse composer when scrolling",
+    to: "/settings/general",
+    searchTerms: ["composer rest resting collapse scroll wheel conversation timeline shrink"],
+  },
+  {
     id: "provider-update-checks",
     title: "Provider update checks",
     to: "/settings/general",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -207,7 +207,7 @@ export const SETTINGS_SEARCH_ITEMS = [
     title: "Collapse composer",
     to: "/settings/general",
     searchTerms: [
-      "composer rest resting blur focus click away scroll wheel conversation timeline shrink minimize",
+      "composer rest resting unfocus blur focus click away scroll wheel conversation timeline shrink minimize",
     ],
   },
   {

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -4,7 +4,7 @@ import { mergeProps } from "@base-ui/react/merge-props";
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ChevronDownIcon, ChevronsUpDownIcon, ChevronUpIcon } from "lucide-react";
+import { CheckIcon, ChevronDownIcon, ChevronsUpDownIcon, ChevronUpIcon } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "~/lib/utils";
@@ -180,19 +180,32 @@ function SelectItem({
   className,
   children,
   hideIndicator: _hideIndicator = false,
+  showCheck = false,
   ...props
 }: SelectPrimitive.Item.Props & {
   hideIndicator?: boolean;
+  /** Render a check mark on selected items. Multi-selects use it so every chosen item is visible at once. */
+  showCheck?: boolean;
 }) {
   return (
     <SelectPrimitive.Item
       className={cn(
         "flex min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-pointer items-center rounded-sm px-2 py-1 text-base outline-none data-selected:bg-foreground/[0.08] data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        showCheck && "gap-2",
         className,
       )}
       data-slot="select-item"
       {...props}
     >
+      {showCheck ? (
+        <SelectPrimitive.ItemIndicator
+          className="flex w-4 shrink-0 items-center justify-center"
+          data-slot="select-item-indicator"
+          keepMounted
+        >
+          <CheckIcon className="in-data-[selected]:opacity-100 opacity-0" />
+        </SelectPrimitive.ItemIndicator>
+      ) : null}
       <SelectPrimitive.ItemText
         className="min-w-0 flex-1 [&_svg:not([class*='text-'])]:text-muted-foreground"
         data-slot="select-item-text"

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -56,7 +56,9 @@ the composer loses focus. At wider sizes, scrolling the conversation also rests 
 except when scrolling toward the end while already there. When the thread-context strip has room,
 the model and mode controls stay available beside the thread context; otherwise they return when the
 composer is focused. Focus the composer or start typing to expand it again. New-thread layouts keep
-the full composer.
+the full composer. Both triggers are optional: turn off **Settings → General → Collapse composer
+when it loses focus** to keep the composer expanded until you scroll, or **Collapse composer when
+scrolling** to rest it only when it loses focus. Turn off both and the composer stays expanded.
 
 At phone-sized web or desktop window widths, existing threads animate between their compact and
 expanded layouts. Up to three image attachments remain visible in either resting layout, followed

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -56,9 +56,8 @@ the composer loses focus. At wider sizes, scrolling the conversation also rests 
 except when scrolling toward the end while already there. When the thread-context strip has room,
 the model and mode controls stay available beside the thread context; otherwise they return when the
 composer is focused. Focus the composer or start typing to expand it again. New-thread layouts keep
-the full composer. Both triggers are optional: turn off **Settings → General → Collapse composer
-when it loses focus** to keep the composer expanded until you scroll, or **Collapse composer when
-scrolling** to rest it only when it loses focus. Turn off both and the composer stays expanded.
+the full composer. **Settings → General → Collapse composer** chooses which triggers rest it:
+**On blur**, **On scroll**, both, or neither. Deselect both and the composer stays expanded.
 
 At phone-sized web or desktop window widths, existing threads animate between their compact and
 expanded layouts. Up to three image attachments remain visible in either resting layout, followed

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -57,7 +57,7 @@ except when scrolling toward the end while already there. When the thread-contex
 the model and mode controls stay available beside the thread context; otherwise they return when the
 composer is focused. Focus the composer or start typing to expand it again. New-thread layouts keep
 the full composer. **Settings → General → Collapse composer** chooses which triggers rest it:
-**On blur**, **On scroll**, both, or neither. Deselect both and the composer stays expanded.
+**On blur**, **On scroll**, both, or neither. With neither selected the composer stays expanded.
 
 At phone-sized web or desktop window widths, existing threads animate between their compact and
 expanded layouts. Up to three image attachments remain visible in either resting layout, followed

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -57,7 +57,7 @@ except when scrolling toward the end while already there. When the thread-contex
 the model and mode controls stay available beside the thread context; otherwise they return when the
 composer is focused. Focus the composer or start typing to expand it again. New-thread layouts keep
 the full composer. **Settings → General → Collapse composer** chooses which triggers rest it:
-**On blur**, **On scroll**, both, or neither. With neither selected the composer stays expanded.
+**On unfocus**, **On scroll**, both, or neither. With neither selected the composer stays expanded.
 
 At phone-sized web or desktop window widths, existing threads animate between their compact and
 expanded layouts. Up to three image attachments remain visible in either resting layout, followed

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -228,6 +228,22 @@ describe("ClientSettings context window meter", () => {
   });
 });
 
+describe("ClientSettings composer collapse", () => {
+  it("collapses on blur and scroll by default and accepts opting out of each", () => {
+    const defaults = decodeClientSettings({});
+    expect(defaults.composerCollapseOnBlur).toBe(true);
+    expect(defaults.composerCollapseOnScroll).toBe(true);
+
+    const blurOff = decodeClientSettings({ composerCollapseOnBlur: false });
+    expect(blurOff.composerCollapseOnBlur).toBe(false);
+    expect(blurOff.composerCollapseOnScroll).toBe(true);
+
+    expect(
+      decodeClientSettingsPatch({ composerCollapseOnScroll: false }).composerCollapseOnScroll,
+    ).toBe(false);
+  });
+});
+
 describe("ServerSettings thread settlement", () => {
   it("defaults merge settlement on and inactivity settlement to three days", () => {
     const settings = decodeServerSettings({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -319,6 +319,10 @@ export const ClientSettingsSchema = Schema.Struct({
   // Legacy context window meter. The composer hides it by default; users who
   // still want the old usage indicator can restore it from Settings.
   contextWindowMeterEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  // Desktop resting composer. Each trigger that settles an existing thread's
+  // composer into its single-line layout can be turned off on its own.
+  composerCollapseOnBlur: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  composerCollapseOnScroll: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   proactivePanelsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   showSkillsInSlashMenu: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   // Legacy sidebar (the original per-project tree). Deliberately a fresh key
@@ -1165,6 +1169,8 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   contextWindowMeterEnabled: Schema.optionalKey(Schema.Boolean),
+  composerCollapseOnBlur: Schema.optionalKey(Schema.Boolean),
+  composerCollapseOnScroll: Schema.optionalKey(Schema.Boolean),
   proactivePanelsEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
On web and desktop, an existing thread's composer rests into a single line whenever it loses focus or the conversation is scrolled. Some users want it to stay expanded, and there was no way to opt out of either trigger.

A **Settings → General → Collapse composer** row now offers a multi-select dropdown of **On unfocus** / **On scroll**, backed by two client settings (`composerCollapseOnBlur`, `composerCollapseOnScroll`). Both default on, so behavior is unchanged unless a user deselects one. The trigger summarises the selection ("On unfocus, On scroll" / "On scroll" / "Never"). With blur collapse off, losing focus never rests the composer; scrolling still does whenever the composer is expanded, focused or not, and lifts on the next composer interaction. With scroll collapse off, the wheel gesture is never eligible. Both off keeps the composer expanded.

The change lives in `shouldUseRestingComposerLayout`, which now takes the scroll-collapsed flag and the blur preference as separate inputs instead of folding the scroll state into `isFocused`. The wheel handler used to require editor focus as a proxy for "expanded"; it now keys off the resting state directly, so scroll can rest an unfocused-but-expanded composer. The settings row, search entry, changed-settings list, restore-defaults, and the user docs follow. `SelectItem` gains an opt-in `showCheck` so multi-select popups can show every chosen item; single-select callers are untouched.

## Settings

| Defaults | Open | Neither selected (reset arrow appears) |
| --- | --- | --- |
| ![settings defaults](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2469162850004d42/20-select-default.png) | ![settings open](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/32f52d60013e6795/21-select-open.png) | ![settings never](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/641c581ee505237c/23-select-never.png) |

## Before (defaults, unchanged)

Click away from a focused composer → rests into a single line.

![before: blur collapses](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b6a3475a75686a2c/02-default-blur-collapsed.png)

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c3fdd7b5b652ba2d/demo-before.mp4

## After

**Blur off, scroll on.** Clicking away keeps it expanded; scrolling the conversation still rests it.

| Click away | Scroll up |
| --- | --- |
| ![blur off stays expanded](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/815e037bec759c2f/05-blur-off-stays-expanded.png) | ![blur off scroll collapses](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/cc511c43cc6e5fd1/06-blur-off-scroll-collapses.png) |

**Both off.** Neither scrolling nor clicking away collapses it.

| Scroll up | Click away |
| --- | --- |
| ![both off scroll stays expanded](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/55b9ad3164846205/08-both-off-scroll-stays-expanded.png) | ![both off blur stays expanded](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/931db6395c0eec32/09-both-off-blur-stays-expanded.png) |

Demo: toggling both off in Settings, then typing, scrolling up, and clicking away in a thread. (Recorded with an earlier two-switch layout of the row; the control is now the multi-select dropdown above and the composer behavior is identical.)

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e76f183fb7494c0c/demo-after.mp4

## Surfaces

- Web and desktop share this path. Mobile has its own focus-driven collapse and is unaffected; both new keys are client settings, so they are per-device.
- The Settings → General row, settings search, the changed-settings summary, and Restore defaults all know about the new keys.
- Docs: `docs/user/composer.md`.

## Verification

- `vp test run` on `composerFooterLayout.test.ts`, `settings.test.ts`, `DesktopClientSettings.test.ts` (111 passing).
- `tsgo --noEmit` in contracts, web, desktop.
- Manual pass in the web app against a copy of real data for all four setting combinations (screenshots above).

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI preference with defaults preserving current behavior; scope is composer layout and settings, not auth or data.
> 
> **Overview**
> Adds **Settings → General → Collapse composer**, a multi-select for **On unfocus** and **On scroll**, backed by client settings `composerCollapseOnBlur` and `composerCollapseOnScroll` (both default **on**, so existing behavior is unchanged until the user opts out).
> 
> **Resting layout logic** in `shouldUseRestingComposerLayout` now treats blur and scroll as separate inputs: scroll collapse can rest the composer even while it is focused; with blur collapse off, unfocus alone never rests it. **Scroll collapse** in `ChatComposer` respects `composerCollapseOnScroll`, only runs while the composer is expanded (not already resting), and no longer requires the prompt editor to be focused for wheel gestures.
> 
> Also adds settings search/reset/changed-settings wiring, contract decode tests, user docs, and an opt-in `showCheck` on `SelectItem` for the multi-select UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0d5723c4a1de3e1bf7ce78a8a210e5de0ae458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add user settings to toggle composer collapse on blur and scroll
> - Adds `composerCollapseOnBlur` and `composerCollapseOnScroll` boolean client settings, both defaulting to `true` when absent, with independent patch fields in `ClientSettingsPatch` ([settings.ts](https://github.com/pingdotgg/t3code/pull/9469/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c)).
> - Adds a searchable General settings multi-select row for choosing unfocus, scroll, both, or neither as collapse triggers ([SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/9469/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18)).
> - Updates `shouldUseRestingComposerLayout` to honor the new preferences: an existing desktop composer rests when scroll-collapsed (even while focused), and unfocus alone rests only when blur collapse is enabled ([composerFooterLayout.ts](https://github.com/pingdotgg/t3code/pull/9469/files#diff-f2c45cfa4b4b1e011f20b2464141c82ddc1b7023b5d2707e33b4ab4504c747f8)).
> - Adds a `showCheck` prop to `SelectItem` so multiple selected options display a check icon ([select.tsx](https://github.com/pingdotgg/t3code/pull/9469/files#diff-f8dc315356af4a3938a8bfea44f5cb369e197db435ab6b932a79253ad2844789)).
> - Behavioral Change: disabling blur collapse means an unfocused expanded composer no longer rests on its own; it can still rest after an eligible scroll gesture if scroll collapse remains enabled. Disabling scroll collapse clears the scroll-collapsed state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a0d572.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->