### PR TITLE
feat(web): add a setting to keep the composer from collapsing at rest

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -47,6 +47,7 @@ const clientSettings: ClientSettings = {
   planModeEnabled: false,
   proactivePanelsEnabled: true,
   showSkillsInSlashMenu: false,
+  composerAutoCollapse: false,
   providerModelPreferences: {},
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3540,6 +3540,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     providerInputSubmissionError !== null ||
     hasImageAttachmentAttention;
   const isComposerResting = shouldUseRestingComposerLayout({
+    autoCollapseEnabled: settings.composerAutoCollapse,
     isExistingThread: routeKind === "server" && activeThreadId !== null,
     isMobileViewport,
     isFocused: isComposerFocused && !isComposerScrollCollapsed,
@@ -3613,7 +3614,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     onComposerOverlayHeightChange,
   );
   const canTrackComposerScrollGesture =
-    routeKind === "server" && activeThreadId !== null && !isMobileViewport;
+    settings.composerAutoCollapse &&
+    routeKind === "server" &&
+    activeThreadId !== null &&
+    !isMobileViewport;
   const canScrollCollapseComposer =
     canTrackComposerScrollGesture && !composerHasExpandedChrome && !showInlineTasksBadge;
   composerScrollCollapseEligibleRef.current = canScrollCollapseComposer;

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -76,6 +76,7 @@ describe("shouldUseCompactComposerPrimaryActions", () => {
 
 describe("shouldUseRestingComposerLayout", () => {
   const resting = {
+    autoCollapseEnabled: true,
     isExistingThread: true,
     isMobileViewport: false,
     isFocused: false,
@@ -84,6 +85,10 @@ describe("shouldUseRestingComposerLayout", () => {
 
   it("uses the resting layout for an unfocused desktop composer", () => {
     expect(shouldUseRestingComposerLayout(resting)).toBe(true);
+  });
+
+  it("keeps the composer expanded when auto-collapse is turned off", () => {
+    expect(shouldUseRestingComposerLayout({ ...resting, autoCollapseEnabled: false })).toBe(false);
   });
 
   it("keeps new-thread composers expanded", () => {

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -24,6 +24,7 @@ export function shouldUseCompactComposerFooter(
 }
 
 export function shouldUseRestingComposerLayout(input: {
+  autoCollapseEnabled: boolean;
   isExistingThread: boolean;
   isMobileViewport: boolean;
   isFocused: boolean;
@@ -38,6 +39,7 @@ export function shouldUseRestingComposerLayout(input: {
   // desktop width, and where the strip is missing or too narrow the controls
   // simply return when the composer is focused.
   return (
+    input.autoCollapseEnabled &&
     input.isExistingThread &&
     !input.isMobileViewport &&
     !input.isFocused &&

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -542,6 +542,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.showSkillsInSlashMenu !== DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu
         ? ["Show skills in slash menu"]
         : []),
+      ...(settings.composerAutoCollapse !== DEFAULT_UNIFIED_SETTINGS.composerAutoCollapse
+        ? ["Collapse the composer at rest"]
+        : []),
       ...(settings.contextWindowMeterEnabled !== DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled
         ? ["Context window indicator"]
         : []),
@@ -625,6 +628,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.showSkillsInSlashMenu,
+      settings.composerAutoCollapse,
       settings.timestampFormat,
       settings.wordWrap,
       followSystem,
@@ -703,6 +707,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       diffLayout: DEFAULT_UNIFIED_SETTINGS.diffLayout,
       proactivePanelsEnabled: DEFAULT_UNIFIED_SETTINGS.proactivePanelsEnabled,
       showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
+      composerAutoCollapse: DEFAULT_UNIFIED_SETTINGS.composerAutoCollapse,
       contextWindowMeterEnabled: DEFAULT_UNIFIED_SETTINGS.contextWindowMeterEnabled,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
@@ -2330,6 +2335,32 @@ export function GeneralSettingsPanel() {
                 updateSettings({ showSkillsInSlashMenu: Boolean(checked) })
               }
               aria-label="Show skills in slash menu"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("composer-auto-collapse")}
+          description="Shrink the composer to a single line when it loses focus or you scroll the conversation. Turn off to keep the full composer visible."
+          resetAction={
+            settings.composerAutoCollapse !== DEFAULT_UNIFIED_SETTINGS.composerAutoCollapse ? (
+              <SettingResetButton
+                label="composer collapse"
+                onClick={() =>
+                  updateSettings({
+                    composerAutoCollapse: DEFAULT_UNIFIED_SETTINGS.composerAutoCollapse,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.composerAutoCollapse}
+              onCheckedChange={(checked) =>
+                updateSettings({ composerAutoCollapse: Boolean(checked) })
+              }
+              aria-label="Collapse the composer at rest"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -203,6 +203,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["command menu dollar $ slash /"],
   },
   {
+    id: "composer-auto-collapse",
+    title: "Collapse the composer at rest",
+    to: "/settings/general",
+    searchTerms: ["chat input shrink resting auto collapse expand focus scroll"],
+  },
+  {
     id: "provider-update-checks",
     title: "Provider update checks",
     to: "/settings/general",

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -56,7 +56,8 @@ the composer loses focus. At wider sizes, scrolling the conversation also rests 
 except when scrolling toward the end while already there. When the thread-context strip has room,
 the model and mode controls stay available beside the thread context; otherwise they return when the
 composer is focused. Focus the composer or start typing to expand it again. New-thread layouts keep
-the full composer.
+the full composer. To keep the full composer visible on existing threads too, turn off **Collapse
+the composer at rest** in **Settings → General**.
 
 At phone-sized web or desktop window widths, existing threads animate between their compact and
 expanded layouts. Up to three image attachments remain visible in either resting layout, followed

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -321,6 +321,10 @@ export const ClientSettingsSchema = Schema.Struct({
   contextWindowMeterEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   proactivePanelsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   showSkillsInSlashMenu: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  // Whether an existing thread's composer settles into the single-line
+  // resting layout when it loses focus or the conversation scrolls. Off keeps
+  // the full composer visible at all times on web and desktop.
+  composerAutoCollapse: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   // Legacy sidebar (the original per-project tree). Deliberately a fresh key
   // (was `sidebarV2Enabled` + `sidebarV2ConfiguredByUser`): decoding drops the
   // old keys, so everyone, including prior beta opt-outs, resets to the new
@@ -1167,6 +1171,7 @@ export const ClientSettingsPatch = Schema.Struct({
   contextWindowMeterEnabled: Schema.optionalKey(Schema.Boolean),
   proactivePanelsEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
+  composerAutoCollapse: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(


### PR DESCRIPTION
## Problem

The resting composer from #7855 shrinks the chat input to a single line whenever it loses focus or the conversation scrolls. On a large display that reclaimed space is not needed, and the constant shrink/expand is disruptive. There was no way to opt out.

## Fix

Adds a client setting **Collapse the composer at rest** (on by default) under **Settings → General**, next to the other composer toggles. Turning it off:

- keeps the full composer on existing threads instead of settling into the resting layout
- disables the scroll-to-collapse gesture, so scrolling the timeline never collapses a focused composer

The gate lives in `shouldUseRestingComposerLayout`, so the resting/expanded transition, relocated controls, and inline image previews all follow from that single decision. New-thread and phone-width layouts are unchanged.

Surfaces walked: contracts schema + patch, Settings panel row with reset and "restore defaults" wiring, settings search entry, desktop client-settings fixture, user docs. Mobile is unaffected since the resting layout is desktop/web only.

Verified with the touched unit tests (`composerFooterLayout`, `settingsSearch`, `settingsLayout`, `DesktopClientSettings`) and typechecks for contracts, web, and desktop.

Built with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `composerAutoCollapse` setting to keep composer expanded at rest
> - Adds the `composerAutoCollapse` boolean to `ClientSettingsSchema` and `ClientSettingsPatch`, defaulting to enabled when absent.
> - Wires the setting into `shouldUseRestingComposerLayout` and the desktop scroll-collapse tracking in `ChatComposer`, so disabling it keeps the full composer visible on existing threads.
> - Adds a searchable General Settings toggle and search entry, plus docs in [composer.md](https://github.com/pingdotgg/t3code/pull/9470/files#diff-6c496fed927e1ba2296273bdfca78fd482921ebd76a32bb9d0c534f7bda35b63).
> - Risk: the `shouldUseRestingComposerLayout` predicate now requires `autoCollapseEnabled` as input, so any caller not updated in [composerFooterLayout.ts](https://github.com/pingdotgg/t3code/pull/9470/files#diff-f2c45cfa4b4b1e011f20b2464141c82ddc1b7023b5d2707e33b4ab4504c747f8) will fail to compile; mobile collapse behavior is unchanged and governed by its existing path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f55612c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->