### PR TITLE
fix(web): keep ref picker steady when opening

### DIFF
--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -774,7 +774,9 @@ export function BranchToolbarBranchSelector({
         >
           <ComboboxTrigger
             render={<Button variant="ghost" size="xs" />}
-            className="min-w-0 max-w-full font-normal text-muted-foreground/70 text-xs! hover:text-foreground/80"
+            // No press-scale: the popup aligns live to this trigger, so a
+            // momentary 0.97 shrink would drag the open popup ~3px sideways.
+            className="min-w-0 max-w-full font-normal text-muted-foreground/70 text-xs! hover:text-foreground/80 active:scale-100"
             disabled={isInitialBranchesLoadPending || isBranchActionPending}
           >
             <GitBranchIcon className="size-3 shrink-0 opacity-70" />

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -154,8 +154,8 @@ function ComboboxPopup({
   side?: ComboboxPrimitive.Positioner.Props["side"];
   anchor?: ComboboxPrimitive.Positioner.Props["anchor"];
 }) {
-  const { chipsRef } = React.use(ComboboxContext);
-  const anchor = anchorProp ?? chipsRef;
+  const { chipsRef, multiple } = React.use(ComboboxContext);
+  const anchor = anchorProp ?? (multiple ? chipsRef : undefined);
 
   return (
     <ComboboxPrimitive.Portal>


### PR DESCRIPTION
## What Changed

Single-select comboboxes now use their trigger as the positioning anchor from the first frame. The branch picker trigger also stays at full scale while pressed.

## Why

The old empty chips anchor caused a second positioning pass, and the trigger's press scale moved the live popup anchor a few pixels. Together these made the ref picker jump as it opened.

The composer-focus portion of the original PR is no longer needed after `main` stopped collapsing the desktop composer on focus loss in #10437, so it was dropped during the rebase.

## UI Changes

### Before

https://github.com/user-attachments/assets/96e54ad1-a90e-4616-9f19-6b9e5d820ddc

### After

https://github.com/user-attachments/assets/4c66c86a-ac66-42f2-8eef-759c25dd44fa

## Validation

- `vp test run apps/web/src/components/chat/composerEventScope.test.ts` (7 tests passed)
- `git diff --check`
- Clean merge-tree against current `main`
- Fresh CI triggered for the rebased head

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after UI evidence
- [x] I included video for the interaction change

Built with GPT-5.6 Sol in the Codex harness.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop composer expand/collapse focus rules and global single-select combobox popup anchoring, so regressions could show up outside the branch picker if other comboboxes relied on the old implicit anchor.
> 
> **Overview**
> Fixes the branch/ref picker **jumping sideways** when opened from the expanded thread composer. Focus moving into the portaled combobox was treated as leaving the composer, which collapsed the surface and re-anchored the popup mid-open.
> 
> **Composer focus scope** now treats context toolbar controls (via `data-chat-composer-focus-scope`) and existing composer floating layers as in-composer for blur and desktop focus tracking. `resolveDesktopComposerFocus` keeps an **already expanded** composer focused across branch-picker focus transitions but does **not** expand a resting composer when only the picker receives focus.
> 
> **Branch picker UI:** the selector wrapper is marked as a composer focus scope, and the combobox trigger uses **`active:scale-100`** so press-scale does not shrink the anchor while the popup is aligned to it.
> 
> **Combobox positioning:** `ComboboxPopup` only falls back to `chipsRef` as the positioner anchor when **`multiple`** is true; single-select popups use the default trigger anchor from the first frame, avoiding a second layout pass that used an empty chips anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41740263b57f7c15c3d9dceafbe1391c86a8f7a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ref picker popup shift by disabling trigger scale and restricting chips anchor
> - Prevents the `BranchToolbarBranchSelector` trigger from applying a scale transform while pressed, which stops the popup anchor from shifting.
> - Restricts the implicit `chips` anchor reference to multi-select comboboxes only in `ComboboxPopup`.
> - Behavioral Change: Single-select combobox popups no longer use the `chips` reference as their implicit positioner anchor unless an explicit anchor is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a862ba8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch selector button behavior while its popup is open.
  * Corrected popup positioning for single-select and multi-select comboboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->