### PR TITLE
fix(web): thread error banner no longer shifts the chat

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7607,14 +7607,6 @@ function ChatViewContent(props: ChatViewProps) {
           />
         </WorkspacePageHeader>
 
-        <ThreadErrorBanner
-          error={visibleThreadError}
-          onDismiss={() => {
-            setThreadError(activeThread.id, null);
-            dismissThreadErrorBannerForSession(threadErrorBannerKey);
-            setThreadErrorBannerDismissTick((tick) => tick + 1);
-          }}
-        />
         {/* Main content area with optional plan sidebar */}
         <div className="flex min-h-0 min-w-0 flex-1">
           {/* Chat column */}
@@ -7640,12 +7632,20 @@ function ChatViewContent(props: ChatViewProps) {
                 </div>
               </div>
             ) : null}
-            {/* Provider status overlays the timeline without changing its content height. */}
-            <div className="pointer-events-none absolute inset-x-0 top-0 z-20">
+            {/* Banners overlay the timeline without changing its content height. */}
+            <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex flex-col">
               <ProviderStatusBanner
                 status={visibleProviderStatus}
                 onDismiss={() => setDismissedProviderStatusBannerKey(providerStatusBannerKey)}
                 onOpenProviderSetup={openProviderSetup}
+              />
+              <ThreadErrorBanner
+                error={visibleThreadError}
+                onDismiss={() => {
+                  setThreadError(activeThread.id, null);
+                  dismissThreadErrorBannerForSession(threadErrorBannerKey);
+                  setThreadErrorBannerDismissTick((tick) => tick + 1);
+                }}
               />
             </div>
             {/* Messages Wrapper */}

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -42,8 +42,13 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
 }) {
   if (!error) return null;
   return (
-    <div className="mx-auto w-fit max-w-[min(48rem,calc(100%-2rem))] pt-3">
-      <Alert variant="error" controlAlignment="first-line">
+    <div className="pointer-events-auto mx-auto w-fit max-w-[min(48rem,calc(100%-2rem))] pt-3">
+      <Alert
+        variant="error"
+        controlAlignment="first-line"
+        className="alert-glass"
+        data-variant="error"
+      >
         <CircleAlertIcon />
         <AlertDescription>
           <Tooltip>


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Fable 5.1 on behalf of Oliver**

## Problem

`ThreadErrorBanner` rendered in normal flow between the workspace header and the timeline. When a thread error appeared, the whole chat column shifted down by the banner's height, and shifted back on dismiss. Any thread error triggers it; it's most noticeable with long-lived errors like a provider auth failure.

## Fix

The banner now lives in the same absolutely positioned, `pointer-events-none` overlay at the top of the chat column that `ProviderStatusBanner` already uses, so the timeline keeps its height. The container stacks the two banners vertically when both are visible. The banner re-enables pointer events on its wrapper and uses the existing `alert-glass` surface with `data-variant="error"` for the tint, matching the provider banner.

Like the provider banner, the overlay covers the top of the timeline instead of pushing it down. That is the same tradeoff the provider status banner already makes.

Mobile has no equivalent thread error banner, so nothing changes there.

## UI Changes

### Before
<img width="2880" height="1800" alt="before-dark-error" src="https://github.com/user-attachments/assets/7e0ec5fa-e2bf-45bf-add0-597fab5b76e9" />
<img width="2880" height="1800" alt="before-light-error" src="https://github.com/user-attachments/assets/9d6471ae-cfc6-4fa6-a542-8784ce042815" />
<img width="2880" height="1800" alt="before-light-no-error" src="https://github.com/user-attachments/assets/76b5df02-911c-45c0-b778-0002c76e1628" />

### After
<img width="2880" height="1800" alt="after-dark-error" src="https://github.com/user-attachments/assets/787cf008-7084-45f3-8706-8452ece6adb3" />
<img width="2880" height="1800" alt="after-light-error" src="https://github.com/user-attachments/assets/ca23a61e-7e12-4ff8-9d36-f324107d8898" />
<img width="2880" height="1800" alt="after-light-no-error" src="https://github.com/user-attachments/assets/b75ba8c0-9382-4bf1-bb77-92cb76bf75d0" />

---

Changes made by Fable 5.1 running in Claude Code via T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread error banner shifting chat in `ChatViewContent`
> Moves the thread error banner into the existing top-of-timeline overlay in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9473/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e). The overlay now uses a vertical flex layout so the provider-status and thread-error banners stack without reserving layout height above the chat content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e662ad0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->