### PR TITLE
fix(mobile): show checkout branch for phone-created threads

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -1007,6 +1007,10 @@ export function HomeScreen(props: HomeScreenProps) {
               onNewThreadOnBranch={props.onNewThreadOnBranch}
               variant="compact"
               thread={thread}
+              projectCwd={
+                projectByKey.get(scopedProjectKey(thread.environmentId, thread.projectId))
+                  ?.workspaceRoot ?? null
+              }
               hasQueuedMessages={queuedThreadKeys.has(`${thread.environmentId}:${thread.id}`)}
               environmentLabel={
                 props.savedConnectionsById[thread.environmentId]?.environmentLabel ?? null
@@ -1047,6 +1051,7 @@ export function HomeScreen(props: HomeScreenProps) {
       handleSwipeableWillOpen,
       handleRegenerateThreadTitle,
       machineByEnvironmentId,
+      projectByKey,
       queuedThreadKeys,
       props.onArchiveThread,
       props.onDeletePendingTask,

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -957,11 +957,12 @@ export function HomeScreen(props: HomeScreenProps) {
 
   const extraData = useMemo(
     () => ({
+      projectByKey,
       savedConnectionsById: props.savedConnectionsById,
       searchQuery: props.searchQuery,
       threadSearchMatchByKey,
     }),
-    [props.savedConnectionsById, props.searchQuery, threadSearchMatchByKey],
+    [projectByKey, props.savedConnectionsById, props.searchQuery, threadSearchMatchByKey],
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -1029,6 +1029,10 @@ function ThreadNavigationSidebarPane(
               onNewThreadOnBranch={props.onNewThreadOnBranch}
               variant="sidebar"
               thread={thread}
+              projectCwd={
+                projectByKey.get(scopedProjectKey(thread.environmentId, thread.projectId))
+                  ?.workspaceRoot ?? null
+              }
               hasQueuedMessages={queuedThreadKeys.has(`${thread.environmentId}:${thread.id}`)}
               environmentLabel={
                 savedConnectionsById[thread.environmentId]?.environmentLabel ?? null

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -23,6 +23,7 @@ import { relativeTime } from "../../lib/time";
 import { themeColorWithAlpha } from "../../lib/mobileTheme";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
+import { useThreadDisplayBranch } from "../../state/use-thread-display-branch";
 import { useThreadPr, type ThreadPrPresentation } from "../../state/use-thread-pr";
 import type { HomeGroupDisplayAction } from "../home/homeListItems";
 import { ThreadSwipeable } from "../home/thread-swipe-actions";
@@ -441,6 +442,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   readonly thread: EnvironmentThreadShell;
   readonly environmentLabel: string | null;
   readonly environmentMachine?: EnvironmentMachineKind;
+  readonly projectCwd: string | null;
   /** A message for this thread is waiting in the outbox. */
   readonly hasQueuedMessages?: boolean;
   readonly searchMatch?: EnvironmentThreadSearchMatch;
@@ -487,6 +489,9 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   } = props;
   const status = resolveThreadStatus(thread);
   const pr = useThreadPr(thread);
+  // Same live-checkout fallback as the v2 rows: phone-created local threads
+  // can persist branch=null, and should still read like PC rows.
+  const displayBranch = useThreadDisplayBranch(thread, props.projectCwd);
   const timestamp = relativeTime(
     thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt,
   );
@@ -497,7 +502,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   ]
     .filter(Boolean)
     .join(", ");
-  const subtitleParts = [props.environmentLabel, thread.branch].filter((part): part is string =>
+  const subtitleParts = [props.environmentLabel, displayBranch].filter((part): part is string =>
     Boolean(part),
   );
 

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -21,6 +21,7 @@ import { cn } from "../../lib/cn";
 import { relativeTime } from "../../lib/time";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
+import { useThreadDisplayBranch } from "../../state/use-thread-display-branch";
 import { useThreadPr } from "../../state/use-thread-pr";
 import { ThreadSwipeable } from "../home/thread-swipe-actions";
 import { buildThreadTitleRegenerationMenuItems } from "./thread-title-regeneration-menu";
@@ -427,6 +428,9 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   const pinnedRow = props.pinned === true;
 
   const pr = useThreadPr(thread);
+  // Local threads created before the checkout was known persist branch=null;
+  // fall back to the live checkout so a phone-created row reads like PC.
+  const displayBranch = useThreadDisplayBranch(thread, props.project?.workspaceRoot ?? null);
 
   const theme = useUniwindTheme();
   const screenColor = theme["--color-screen"];
@@ -765,7 +769,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
           >
             {thread.session.lastError}
           </Text>
-        ) : thread.branch || props.environmentLabel ? (
+        ) : displayBranch || props.environmentLabel ? (
           /* "branch · machine" share one truncating line. The machine sits
              last so a tight fit cuts the repetitive label, not the branch —
              and machine-only fills the row for non-git projects. The glyph
@@ -780,7 +784,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
               )}
               numberOfLines={1}
             >
-              {thread.branch ? (
+              {displayBranch ? (
                 <Text
                   className={cn(
                     "text-xs",
@@ -788,10 +792,10 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
                   )}
                   style={{ fontFamily: MONO_FONT }}
                 >
-                  {thread.branch}
+                  {displayBranch}
                 </Text>
               ) : null}
-              {thread.branch && props.environmentLabel ? "  ·  " : null}
+              {displayBranch && props.environmentLabel ? "  ·  " : null}
               {props.environmentLabel ? (
                 <Text
                   className={cn(

--- a/apps/mobile/src/state/thread-display-branch.test.ts
+++ b/apps/mobile/src/state/thread-display-branch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveThreadDisplayBranch } from "./thread-display-branch";
+
+describe("resolveThreadDisplayBranch", () => {
+  it("prefers the stored branch over the live checkout", () => {
+    expect(
+      resolveThreadDisplayBranch({
+        branch: "feature/phone-thread",
+        worktreePath: null,
+        liveCheckoutBranch: "main",
+      }),
+    ).toBe("feature/phone-thread");
+  });
+
+  it("falls back to the live checkout for local threads with no stored branch", () => {
+    expect(
+      resolveThreadDisplayBranch({
+        branch: null,
+        worktreePath: null,
+        liveCheckoutBranch: "main",
+      }),
+    ).toBe("main");
+  });
+
+  it("stays blank for local threads while the checkout is unknown", () => {
+    expect(
+      resolveThreadDisplayBranch({
+        branch: null,
+        worktreePath: null,
+        liveCheckoutBranch: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("never falls back for worktree threads", () => {
+    expect(
+      resolveThreadDisplayBranch({
+        branch: null,
+        worktreePath: "/repo/.t3/worktrees/feature",
+        liveCheckoutBranch: "main",
+      }),
+    ).toBeNull();
+  });
+
+  it("treats blank strings as missing", () => {
+    expect(
+      resolveThreadDisplayBranch({ branch: "  ", worktreePath: null, liveCheckoutBranch: "main" }),
+    ).toBe("main");
+    expect(
+      resolveThreadDisplayBranch({ branch: null, worktreePath: null, liveCheckoutBranch: "  " }),
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/src/state/thread-display-branch.ts
+++ b/apps/mobile/src/state/thread-display-branch.ts
@@ -1,0 +1,25 @@
+/**
+ * Branch shown on a thread list row. The stored `thread.branch` always wins:
+ * it is the ref the thread was created against and the value the PR badge
+ * compares. A local thread (`worktreePath == null`) with a null branch was
+ * created before the live checkout was known (status pending, detached HEAD,
+ * non-repo, or offline queue) — the server never backfills that null, so the
+ * row falls back to the live checkout, mirroring web's header
+ * (`resolveBranchToolbarValue`). Worktree threads never fall back: their cwd
+ * is isolated and its checkout may be a temporary `t3-*` placeholder.
+ */
+export function resolveThreadDisplayBranch(input: {
+  readonly branch: string | null;
+  readonly worktreePath: string | null;
+  readonly liveCheckoutBranch: string | null;
+}): string | null {
+  const stored = input.branch?.trim();
+  if (stored) {
+    return stored;
+  }
+  if (input.worktreePath !== null) {
+    return null;
+  }
+  const live = input.liveCheckoutBranch?.trim();
+  return live ? live : null;
+}

--- a/apps/mobile/src/state/use-thread-display-branch.ts
+++ b/apps/mobile/src/state/use-thread-display-branch.ts
@@ -6,7 +6,7 @@ import { vcsEnvironment } from "./vcs";
 
 /**
  * Branch label for a thread list row. Stored `thread.branch` needs no fetch;
- * the live status stream is only subscribed for local null-branch threads,
+ * the live status stream is only subscribed for local missing-branch threads,
  * where it is the same deduplicated per-(environmentId, cwd) stream the PR
  * badge and the new-task composer already share — so rows on one project
  * root share one subscription, and virtualization keeps it to visible rows.
@@ -16,7 +16,7 @@ export function useThreadDisplayBranch(
   projectCwd: string | null,
 ): string | null {
   const cwd = thread.worktreePath ?? projectCwd;
-  const needsLiveBranch = thread.branch === null && thread.worktreePath === null && cwd !== null;
+  const needsLiveBranch = !thread.branch?.trim() && thread.worktreePath === null && cwd !== null;
   const liveStatus = useEnvironmentQuery(
     needsLiveBranch
       ? vcsEnvironment.status({

--- a/apps/mobile/src/state/use-thread-display-branch.ts
+++ b/apps/mobile/src/state/use-thread-display-branch.ts
@@ -1,0 +1,33 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+
+import { useEnvironmentQuery } from "./query";
+import { resolveThreadDisplayBranch } from "./thread-display-branch";
+import { vcsEnvironment } from "./vcs";
+
+/**
+ * Branch label for a thread list row. Stored `thread.branch` needs no fetch;
+ * the live status stream is only subscribed for local null-branch threads,
+ * where it is the same deduplicated per-(environmentId, cwd) stream the PR
+ * badge and the new-task composer already share — so rows on one project
+ * root share one subscription, and virtualization keeps it to visible rows.
+ */
+export function useThreadDisplayBranch(
+  thread: EnvironmentThreadShell,
+  projectCwd: string | null,
+): string | null {
+  const cwd = thread.worktreePath ?? projectCwd;
+  const needsLiveBranch = thread.branch === null && thread.worktreePath === null && cwd !== null;
+  const liveStatus = useEnvironmentQuery(
+    needsLiveBranch
+      ? vcsEnvironment.status({
+          environmentId: thread.environmentId,
+          input: { cwd },
+        })
+      : null,
+  );
+  return resolveThreadDisplayBranch({
+    branch: thread.branch,
+    worktreePath: thread.worktreePath,
+    liveCheckoutBranch: liveStatus.data?.refName ?? null,
+  });
+}


### PR DESCRIPTION
## Summary

Threads created from mobile can persist without a branch while VCS status is still loading, leaving the branch line blank even though the environment has a checked-out branch.

## Changes

- Keep the stored thread branch authoritative when present.
- For local null-branch threads, reuse the deduplicated live VCS status stream to display the current checkout branch.
- Apply the fallback to both mobile thread-list implementations; worktree threads remain excluded from the fallback.

## Before:
<img width="314" height="76" alt="image" src="https://github.com/user-attachments/assets/b951bcc2-4040-441e-b850-270f98c1215c" />

## After:
<img width="405" height="92" alt="image" src="https://github.com/user-attachments/assets/fe564fdb-91fe-429e-8da4-9e5e2b738b06" />


## Testing

- `vp test run apps/mobile/src/state/thread-display-branch.test.ts` (5 passed)
- `vp run --filter @t3tools/mobile typecheck`
- Targeted lint on the five changed files (passes with two pre-existing memo dependency warnings outside the diff)
- Android Emulator (`T3_Pixel_API_36`) against a disposable local server and a thread fixture with `branch = NULL` and `worktree_path = NULL`

Built with GPT-5.6 Codex in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display logic with conditional VCS subscriptions; stored branch and worktree behavior are unchanged aside from filling in missing labels for local threads.
> 
> **Overview**
> Fixes mobile thread list rows that stayed blank on the branch line when a phone-created local thread was saved with `branch: null` while VCS status was still unknown.
> 
> Adds **`resolveThreadDisplayBranch`** and **`useThreadDisplayBranch`**: stored `thread.branch` stays authoritative; only **local** threads (`worktreePath == null`) with no stored branch use the live checkout from the existing deduplicated `vcsEnvironment.status` query (same stream as PR badges). **Worktree** threads never fall back.
> 
> **`ThreadListRow`** and **`ThreadListV2Row`** render the resolved branch in subtitles instead of `thread.branch` directly. Unit tests cover precedence, fallback, worktree exclusion, and blank strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a96d1d0760d7e097badf4f8659dcb141644cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show live checkout branch for phone-created threads in mobile thread rows
> - Adds `resolveThreadDisplayBranch` utility in [thread-display-branch.ts](https://github.com/pingdotgg/t3code/pull/9475/files#diff-6fbc653d0b0f17768d45be03afa3e10c41716beee971518d6717463d12400cd4) that returns a trimmed stored branch when present, falls back to a live checkout branch for local threads, and returns null for worktree threads
> - Adds `useThreadDisplayBranch` hook in [use-thread-display-branch.ts](https://github.com/pingdotgg/t3code/pull/9475/files#diff-8f79b23ab668779466bc94520bb1ef1113edf49234476554c92f5c3e955007b4) that subscribes to VCS status only for local threads with a blank stored branch and a known cwd
> - Updates `ThreadListRow` in [thread-list-items.tsx](https://github.com/pingdotgg/t3code/pull/9475/files#diff-d7cca5a410b8a14057731c4f49de8786310bd38ded01b09dd02b4da1e3d01808) and `ThreadListV2Row` in [thread-list-v2-items.tsx](https://github.com/pingdotgg/t3code/pull/9475/files#diff-2cea439fc4533a1bdf479cb7688682b3833ed6dbb1ce83c425862cd1af610fb2) to display the resolved branch instead of `thread.branch`
> - `HomeScreen` and `ThreadNavigationSidebarPane` pass the project workspace root to each thread row via the new `projectCwd` prop
> - Risk: `ThreadListRow.projectCwd` is now a required prop; any caller not passing it will fail to compile
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40dbed9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Thread lists now display the appropriate branch for locally created threads, including when no branch was saved.
  - Local threads can fall back to the current checkout branch when available.
  - Worktree threads continue to display their stored branch information.
  - Branch labels handle missing or blank values more reliably, preventing misleading or empty display text.
  - Thread rows now refresh when project workspace information changes, keeping branch labels up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->