### PR TITLE
fix(web): invisible toggles and focus rings from imported themes

### DIFF
--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -156,6 +156,19 @@ describe("VS Code theme import", () => {
     expect(contrastRatio(vitesse.colors.focus, vitesse.colors.canvas)).toBeGreaterThanOrEqual(1.1);
   });
 
+  it("skips a transparent button background for the action color", () => {
+    const theme = parseVsCodeThemeFile({
+      name: "Transparent button",
+      type: "dark",
+      colors: {
+        "editor.background": "#121212",
+        focusBorder: "#4d9375",
+        "button.background": "#00000000",
+      },
+    });
+    expect(asHex(theme.colors.messageAction)).toBe("#4d9375");
+  });
+
   it("uses a visible default accent when the file has no usable accent key", () => {
     const theme = parseVsCodeThemeFile({
       name: "No accent",

--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -112,6 +112,89 @@ describe("VS Code theme import", () => {
     );
   });
 
+  it("prefers a visible input background over a transparent border", () => {
+    const catppuccin = parseVsCodeThemeFile({
+      name: "Catppuccin Mocha",
+      type: "dark",
+      colors: {
+        "editor.background": "#1e1e2e",
+        "input.border": "#00000000",
+        "input.background": "#313244",
+      },
+    });
+    expect(asHex(catppuccin.colors.input)).toBe("#313244");
+  });
+
+  it("keeps unchecked inputs distinct from the checked action color", () => {
+    const gruvbox = parseVsCodeThemeFile({
+      name: "Gruvbox Light Soft",
+      type: "light",
+      colors: {
+        "editor.background": "#f2e5bc",
+        "button.background": "#45858880",
+        "input.background": "#45858880",
+        "input.border": "#928374",
+      },
+    });
+    expect(
+      contrastRatio(gruvbox.colors.input, gruvbox.colors.messageAction),
+    ).toBeGreaterThanOrEqual(1.1);
+  });
+
+  it("skips a transparent focus border for a visible accent key", () => {
+    const vitesse = parseVsCodeThemeFile({
+      name: "Vitesse Dark",
+      type: "dark",
+      colors: {
+        "editor.background": "#121212",
+        focusBorder: "#00000000",
+        "button.background": "#4d9375",
+      },
+    });
+    expect(asHex(vitesse.colors.accent)).toBe("#4d9375");
+    expect(asHex(vitesse.colors.focus)).toBe("#4d9375");
+    expect(contrastRatio(vitesse.colors.focus, vitesse.colors.canvas)).toBeGreaterThanOrEqual(1.1);
+  });
+
+  it("uses a visible default accent when the file has no usable accent key", () => {
+    const theme = parseVsCodeThemeFile({
+      name: "No accent",
+      type: "dark",
+      colors: { "editor.background": "#121212", focusBorder: "#121212" },
+    });
+    expect(contrastRatio(theme.colors.focus, theme.colors.canvas)).toBeGreaterThanOrEqual(1.1);
+  });
+
+  it("validates placeholders against the resolved raised surface", () => {
+    const lightPlus = parseVsCodeThemeFile({
+      name: "Light Plus Shape",
+      type: "light",
+      colors: {
+        "editor.background": "#eaeff3",
+        "editor.foreground": "#1f1f1f",
+        "editorWidget.background": "#ffffff",
+        "input.placeholderForeground": "#767676",
+      },
+    });
+    expect(
+      contrastRatio(lightPlus.colors.placeholder, lightPlus.colors.surfaceRaised),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrastRatio(lightPlus.colors.placeholder, lightPlus.colors.surfaceRaised),
+    ).toBeLessThan(contrastRatio(lightPlus.colors.text, lightPlus.colors.surfaceRaised));
+  });
+
+  it("moves reserved VS Code names to a non-reserved id", () => {
+    const darkPlus = parseVsCodeThemeFile({
+      name: "Dark+",
+      type: "dark",
+      colors: { "editor.background": "#1e1e1e" },
+    });
+    expect(darkPlus.label).toBe("Dark+");
+    expect(darkPlus.id).not.toBe("dark");
+    expect(darkPlus.id).toBe("dark-vscode");
+  });
+
   it("fills every role the file omits with a readable derived value", () => {
     const theme = parseVsCodeThemeFile(VSCODE_DARK);
     const colors = getThemeColorsForMode(theme, "dark")!;

--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -141,6 +141,25 @@ describe("VS Code theme import", () => {
     ).toBeGreaterThanOrEqual(1.1);
   });
 
+  it("keeps the derived input distinct when a button reuses it", () => {
+    const theme = parseVsCodeThemeFile({
+      name: "Derived input collision",
+      type: "dark",
+      colors: {
+        "editor.background": "#1e1e2e",
+        focusBorder: "#89b4fa",
+        "button.background": "#525661",
+      },
+    });
+
+    expect(asHex(theme.colors.messageAction)).toBe("#525661");
+    expect(asHex(theme.colors.input)).not.toBe("#525661");
+    expect(contrastRatio(theme.colors.input, theme.colors.canvas)).toBeGreaterThanOrEqual(1.1);
+    expect(contrastRatio(theme.colors.input, theme.colors.messageAction)).toBeGreaterThanOrEqual(
+      1.1,
+    );
+  });
+
   it("skips a transparent focus border for a visible accent key", () => {
     const vitesse = parseVsCodeThemeFile({
       name: "Vitesse Dark",

--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -156,6 +156,23 @@ describe("VS Code theme import", () => {
     expect(contrastRatio(vitesse.colors.focus, vitesse.colors.canvas)).toBeGreaterThanOrEqual(1.1);
   });
 
+  it("keeps focus visible against an explicit raised surface", () => {
+    const theme = parseVsCodeThemeFile({
+      name: "Raised focus",
+      type: "dark",
+      colors: {
+        "editor.background": "#000000",
+        focusBorder: "#111111",
+        "editorWidget.background": "#111111",
+        "button.background": "#4d9375",
+      },
+    });
+    expect(contrastRatio(theme.colors.focus, theme.colors.surfaceRaised)).toBeGreaterThanOrEqual(
+      1.1,
+    );
+    expect(asHex(theme.colors.focus)).toBe("#4d9375");
+  });
+
   it("skips a transparent button background for the action color", () => {
     const theme = parseVsCodeThemeFile({
       name: "Transparent button",

--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -173,6 +173,22 @@ describe("VS Code theme import", () => {
     expect(asHex(theme.colors.focus)).toBe("#4d9375");
   });
 
+  it("keeps the fallback focus visible against an explicit raised surface", () => {
+    const theme = parseVsCodeThemeFile({
+      name: "Raised fallback focus",
+      type: "dark",
+      colors: {
+        "editor.background": "#121212",
+        "editorWidget.background": "#346bf1",
+      },
+    });
+    expect(asHex(theme.colors.focus)).toBe("#ffffff");
+    expect(contrastRatio(theme.colors.focus, theme.colors.canvas)).toBeGreaterThanOrEqual(1.1);
+    expect(contrastRatio(theme.colors.focus, theme.colors.surfaceRaised)).toBeGreaterThanOrEqual(
+      1.1,
+    );
+  });
+
   it("skips a transparent button background for the action color", () => {
     const theme = parseVsCodeThemeFile({
       name: "Transparent button",

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -283,7 +283,8 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
     solidOver(canvas, "editorWidget.background", "dropdown.background") ?? derived.surfaceRaised;
   // The checked switch track maps to messageAction, so resolve it before
   // choosing the input role used by the unchecked track.
-  const actionHex = solidOver(canvas, "button.background") ?? accentHex;
+  const buttonHex = solidOver(canvas, "button.background");
+  const actionHex = buttonHex && standsApart(buttonHex, canvasHex) ? buttonHex : accentHex;
   let inputHex = derived.input;
   for (const key of ["input.background", "input.border"]) {
     const candidate = solidOver(canvas, key);

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -1,8 +1,11 @@
 import {
   createVividThemeColors,
+  getStandardThemeColors,
   getThemeModes,
+  isReservedThemeId,
   parseThemeFile,
   themeColorToHex,
+  themeIdFromName,
   THEME_FILE_VERSION,
   type ThemeAppearance,
   type ThemeColorRole,
@@ -14,10 +17,10 @@ import {
  *
  * VS Code themes describe editor chrome, not an app palette: they carry a few
  * hundred workbench keys, leave most of them unset, and freely use 8-digit
- * hex with alpha for overlays. So the conversion derives a complete, contrast
- * -solved palette from the theme's editor background and accent, then layers
- * the workbench colors it did specify on top. Anything the file omits keeps
- * the derived value instead of falling back to an unrelated palette.
+ * hex with alpha for overlays. The conversion derives a complete palette from
+ * a visible accent and the editor background, then layers usable workbench
+ * colors on top. Foregrounds must remain readable, while authored focus and
+ * control candidates must remain distinct from adjacent surfaces and states.
  */
 
 type VsCodeRgba = { r: number; g: number; b: number; a: number };
@@ -210,26 +213,46 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
   const canvas = { r: canvasColor.r, g: canvasColor.g, b: canvasColor.b };
   const appearance = resolveAppearance(value, canvas);
 
-  const accentColor = pick(
+  const canvasHex = toHex(canvas);
+
+  /** Accent and control candidates must clear this small separation floor
+   * from every adjacent surface or state checked by the importer. */
+  const standsApart = (first: string, second: string) =>
+    contrastRatio(hexToRgb(first), hexToRgb(second)) >= 1.1;
+
+  let accentColor: VsCodeRgba | null = null;
+  let accentHex: string | null = null;
+  for (const key of [
     "focusBorder",
     "button.background",
     "textLink.foreground",
     "activityBarBadge.background",
     "progressBar.background",
     "badge.background",
-  );
-  const canvasHex = toHex(canvas);
-  const accentHex = accentColor ? flattenOver(accentColor, canvas) : null;
+  ]) {
+    const candidate = parseVsCodeColor(colors[key]);
+    if (!candidate) continue;
+    const candidateHex = flattenOver(candidate, canvas);
+    if (!standsApart(candidateHex, canvasHex)) continue;
+    accentColor = candidate;
+    accentHex = candidateHex;
+    break;
+  }
+  if (!accentColor || !accentHex) {
+    accentHex = themeColorToHex(getStandardThemeColors(appearance).accent)!;
+    accentColor = parseVsCodeColor(accentHex)!;
+  }
 
   // The derived palette is the floor: every role starts contrast-solved, then
   // the theme's own workbench colors replace what it actually specified. The
   // floor derives from a muted accent -- the vivid engine carries the accent
   // hue into every surface, which washes an imported neutral palette (a gray
   // theme with a blue focusBorder would get blue code and text surfaces).
-  const mutedAccentHex = accentColor
-    ? flattenOver({ r: accentColor.r, g: accentColor.g, b: accentColor.b, a: 0.2 }, canvas)
-    : null;
-  const derived = createVividThemeColors(appearance, canvasHex, mutedAccentHex ?? canvasHex);
+  const mutedAccentHex = flattenOver(
+    { r: accentColor.r, g: accentColor.g, b: accentColor.b, a: 0.2 },
+    canvas,
+  );
+  const derived = createVividThemeColors(appearance, canvasHex, mutedAccentHex);
   const sidebarHex =
     solidOver(canvas, "sideBar.background", "activityBar.background") ?? derived.sidebar;
   const sidebar = hexToRgb(sidebarHex);
@@ -256,6 +279,20 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
     return relativeLuminance(surfaceRgb) < 0.179 ? "#ffffff" : "#000000";
   };
 
+  const surfaceRaisedHex =
+    solidOver(canvas, "editorWidget.background", "dropdown.background") ?? derived.surfaceRaised;
+  // The checked switch track maps to messageAction, so resolve it before
+  // choosing the input role used by the unchecked track.
+  const actionHex = solidOver(canvas, "button.background") ?? accentHex;
+  let inputHex = derived.input;
+  for (const key of ["input.background", "input.border"]) {
+    const candidate = solidOver(canvas, key);
+    if (candidate && standsApart(candidate, canvasHex) && standsApart(candidate, actionHex)) {
+      inputHex = candidate;
+      break;
+    }
+  }
+
   const overrides: Partial<Record<ThemeColorRole, string>> = {
     canvas: canvasHex,
     text: readableOn(canvasHex, derived.text, "editor.foreground", "foreground"),
@@ -266,15 +303,14 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
       "disabledForeground",
     ),
     surface: solidOver(canvas, "editorWidget.background") ?? derived.surface,
-    surfaceRaised:
-      solidOver(canvas, "editorWidget.background", "dropdown.background") ?? derived.surfaceRaised,
+    surfaceRaised: surfaceRaisedHex,
     surfaceOverlay:
       solidOver(canvas, "menu.background", "quickInput.background", "dropdown.background") ??
       derived.surfaceOverlay,
     border:
       solidOver(canvas, "panel.border", "editorGroup.border", "contrastBorder") ?? derived.border,
-    input: solidOver(canvas, "input.border", "dropdown.border") ?? derived.input,
-    placeholder: readableOn(canvasHex, derived.placeholder, "input.placeholderForeground"),
+    input: inputHex,
+    placeholder: readableOn(surfaceRaisedHex, derived.placeholder, "input.placeholderForeground"),
     error: readableOn(canvasHex, derived.error, "editorError.foreground", "errorForeground"),
     warning: readableOn(canvasHex, derived.warning, "editorWarning.foreground"),
     accentSurface:
@@ -301,29 +337,24 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
     terminalScrollbar:
       solidOver(terminal, "scrollbarSlider.background") ?? derived.terminalScrollbar,
   };
-  if (accentHex) {
-    overrides.accent = accentHex;
-    overrides.focus = accentHex;
-    // The button pair is the closest thing VS Code has to our action color.
-    const actionHex = solidOver(canvas, "button.background") ?? accentHex;
-    overrides.messageAction = actionHex;
-    overrides.messageActionForeground = readableOn(
-      actionHex,
-      derived.messageActionForeground,
-      "button.foreground",
-    );
-    overrides.accentForeground = readableOn(
-      accentHex,
-      derived.accentForeground,
-      "button.foreground",
-    );
-  }
+  overrides.accent = accentHex;
+  overrides.focus = accentHex;
+  overrides.messageAction = actionHex;
+  overrides.messageActionForeground = readableOn(
+    actionHex,
+    derived.messageActionForeground,
+    "button.foreground",
+  );
+  overrides.accentForeground = readableOn(accentHex, derived.accentForeground, "button.foreground");
 
   // Reuse the theme-file parser so ids, names, and color values go through the
   // same validation as a hand-written file.
+  const name = resolveName(value);
+  const generatedId = themeIdFromName(name);
   return parseThemeFile({
     version: THEME_FILE_VERSION,
-    name: resolveName(value),
+    ...(isReservedThemeId(generatedId) ? { id: `${generatedId}-vscode` } : {}),
+    name,
     appearance,
     colors: { ...derived, ...overrides },
   });

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -248,7 +248,13 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
     break;
   }
   if (!accentColor || !accentHex) {
-    accentHex = themeColorToHex(getStandardThemeColors(appearance).accent)!;
+    const standardAccentHex = themeColorToHex(getStandardThemeColors(appearance).accent)!;
+    accentHex =
+      [standardAccentHex, "#ffffff", "#000000"].find(
+        (candidate) =>
+          standsApart(candidate, canvasHex) &&
+          (raisedSurfaceCandidateHex === null || standsApart(candidate, raisedSurfaceCandidateHex)),
+      ) ?? standardAccentHex;
     accentColor = parseVsCodeColor(accentHex)!;
   }
 

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -299,7 +299,18 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
   // choosing the input role used by the unchecked track.
   const buttonHex = solidOver(canvas, "button.background");
   const actionHex = buttonHex && standsApart(buttonHex, canvasHex) ? buttonHex : accentHex;
-  let inputHex = derived.input;
+  const inputCandidates = [
+    derived.input,
+    derived.surfaceRaised,
+    getStandardThemeColors(appearance).input,
+    "#000000",
+    "#ffffff",
+    "#808080",
+  ];
+  let inputHex =
+    inputCandidates.find(
+      (candidate) => standsApart(candidate, canvasHex) && standsApart(candidate, actionHex),
+    ) ?? "#808080";
   for (const key of ["input.background", "input.border"]) {
     const candidate = solidOver(canvas, key);
     if (candidate && standsApart(candidate, canvasHex) && standsApart(candidate, actionHex)) {

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -214,6 +214,11 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
   const appearance = resolveAppearance(value, canvas);
 
   const canvasHex = toHex(canvas);
+  const raisedSurfaceCandidateHex = solidOver(
+    canvas,
+    "editorWidget.background",
+    "dropdown.background",
+  );
 
   /** Accent and control candidates must clear this small separation floor
    * from every adjacent surface or state checked by the importer. */
@@ -233,7 +238,11 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
     const candidate = parseVsCodeColor(colors[key]);
     if (!candidate) continue;
     const candidateHex = flattenOver(candidate, canvas);
-    if (!standsApart(candidateHex, canvasHex)) continue;
+    if (
+      !standsApart(candidateHex, canvasHex) ||
+      (raisedSurfaceCandidateHex !== null && !standsApart(candidateHex, raisedSurfaceCandidateHex))
+    )
+      continue;
     accentColor = candidate;
     accentHex = candidateHex;
     break;
@@ -279,8 +288,7 @@ export function parseVsCodeThemeFile(value: unknown): ThemeDefinition {
     return relativeLuminance(surfaceRgb) < 0.179 ? "#ffffff" : "#000000";
   };
 
-  const surfaceRaisedHex =
-    solidOver(canvas, "editorWidget.background", "dropdown.background") ?? derived.surfaceRaised;
+  const surfaceRaisedHex = raisedSurfaceCandidateHex ?? derived.surfaceRaised;
   // The checked switch track maps to messageAction, so resolve it before
   // choosing the input role used by the unchecked track.
   const buttonHex = solidOver(canvas, "button.background");


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-5.6 Sol on behalf of Oliver**

## Problem

As an example, importing Catppuccin Mocha made every toggle in Settings disappear. The theme sets `input.border` to fully transparent, which the importer flattened onto the editor background, so the `input` role became the canvas color. That role is the unchecked switch track and the border of every text input.

An audit of 47 published themes and the VS Code defaults found three more cases of the same shape: a transparent or canvas-colored `focusBorder` yields an invisible focus ring and accent (all five Vitesse themes, One Dark Pro Flat), the placeholder color was validated against the canvas instead of the raised surface inputs render on (Light+), and names that slug to `dark` or `light` (Dark+, Light+) hit a reserved id and fail to import at all.

## Fix

The importer now treats a workbench color as usable only when it does the job the role needs:

- The `input` role tries `input.background` first, then `input.border`, and accepts a candidate only if it stands apart from both the canvas and the checked-switch color. Otherwise it keeps the derived value. `dropdown.border` is no longer a candidate; it turns an edge color into a fill.
- The accent seed skips a `focusBorder` that flattens into the canvas and moves on to the next accent key, falling back to the standard palette accent instead of the canvas.
- Placeholder readability is checked against the resolved raised surface.
- A generated id that collides with a reserved id gets a `-vscode` suffix. The label is unchanged.

Built-in themes and the CSS token mapping are untouched. Already imported themes keep their stored colors, so a re-import is needed to pick up the change.

## UI changes

### Before

<!-- Add before image here: Catppuccin Mocha Settings toggles -->
<img width="857" height="202" alt="SCR-20260904-bgcq" src="https://github.com/user-attachments/assets/c4b80c9b-ac84-4fe3-a31f-53eb5fa64413" />



### After

<!-- Add after image here: Catppuccin Mocha Settings toggles -->
<img width="870" height="214" alt="SCR-20260904-birb" src="https://github.com/user-attachments/assets/98a8724b-1edb-40e6-b504-95ccb6edcf83" />

### Focus ring before
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/02f3985c-7089-484d-844b-120d78039a3e" />


### Focus ring after
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/f51333db-34ff-46ff-8dc7-caac3c787d29" />


## Verification

- Added 6 focused cases for input candidate selection, checked-state separation, transparent focus borders, placeholder readability on the raised surface, and reserved ids
- `vp test run apps/web/src/vscodeThemeImport.test.ts`, 22 tests passed
- `vp lint <changed files> --report-unused-disable-directives`
- `vp fmt --check <changed files>`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check origin/main...HEAD`

Changes prepared by Claude Fable 5.1 through Claude Code in T3 Code, with a GPT-5.6 Sol subagent auditing the theme corpus and implementing the importer changes to spec.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invisible toggles and focus rings in imported VS Code themes
> Hardens the VS Code theme import logic so imported themes no longer produce invisible or low-contrast UI elements.
>
> - Skips transparent input borders and selects a visible input background instead
> - Ensures derived input colors stay contrast-distinct from message action and button colors, even when source inputs are translucent
> - Replaces focus borders that are transparent or too close to a raised surface with a button-derived focus color; falls back to a canvas-distinct color when no usable accent exists
> - Ignores transparent button backgrounds for the message action role, using the visible focus border instead
> - Preserves labels for reserved theme names like `Dark+` while assigning non-reserved identifiers
> - Adds regression tests in [vscodeThemeImport.test.ts](https://github.com/pingdotgg/t3code/pull/9477/files#diff-d690b716e49037069fdbd1c1dbd75556f04ec3c7ed6b8e46ab0f9a7e9cda82ad) covering all above cases
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 016f831.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved VS Code theme imports with more readable accent, input, button, and focus colors.
  - Transparent or low-contrast colors are skipped in favor of visible alternatives.
  - Focus colors remain distinguishable against raised surfaces.
  - Placeholder text readability is improved against raised surfaces.
  - Imported themes use a standard accent when no suitable accent is available.
  - Reserved theme names are automatically adjusted to prevent naming conflicts.
  - Unchecked inputs remain visually distinct from checked action colors.
  - Input colors remain distinct from canvas and action colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

