### PR TITLE
fix(web): let the PR reviewer and label search boxes take keystrokes

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
@@ -2,12 +2,15 @@
  * The menu shell the reviewer and label pickers share: an icon trigger, a search box, and a
  * scrolling body that says when the list is loading, could not be read, is empty, or is not all
  * of it. The rows and the words are the caller's; the frame is the same either way.
+ *
+ * Built on a popover and the command list rather than a menu: a menu's typeahead claims every
+ * keypress to jump between rows, which is exactly what a search box cannot share.
  */
 import type { ReactNode } from "react";
 
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
+import { Command, CommandInput, CommandItem, CommandList } from "../ui/command";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PullRequestPeopleGhost } from "./PullRequestGhosts";
 
@@ -79,58 +82,63 @@ export function PullRequestCandidatePicker<T>({
   }
 
   return (
-    <Menu open={open} onOpenChange={onOpenChange}>
-      <MenuTrigger
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger
         render={
           <Button size="icon-xs" variant="ghost" aria-label={label}>
             {icon}
           </Button>
         }
       />
-      <MenuPopup align="start" side="bottom" className="w-72 p-0">
-        <div className="border-b border-border/60 p-2">
-          <Input
-            autoFocus
-            value={query}
-            onChange={(event) => onQueryChange(event.currentTarget.value)}
+      <PopoverPopup
+        align="start"
+        side="bottom"
+        className="w-72 before:hidden [--viewport-inline-padding:0]"
+        viewportClassName="overflow-hidden p-0"
+      >
+        {/* The caller narrows the list, so the command does no filtering of its own. */}
+        <Command mode="none" value={query} onValueChange={onQueryChange}>
+          <CommandInput
+            wrapperClassName="border-b border-border/60 px-2 py-2 [&_[data-slot=autocomplete-start-addon]]:ps-2"
+            className="*:data-[slot=autocomplete-input]:ps-8!"
             placeholder={searchLabel}
             aria-label={searchLabel}
-            size="compact"
+            size="sm"
           />
-        </div>
-        <div className="max-h-72 overflow-y-auto p-1">
-          {isPending ? (
-            <PullRequestPeopleGhost rows={4} />
-          ) : error !== null ? (
-            <p className="p-2 text-xs text-muted-foreground">
-              {errorLabel} {error}
-            </p>
-          ) : candidates.length === 0 ? (
-            <p className="p-2 text-xs text-muted-foreground">
-              {query.length > 0 ? noMatchLabel : emptyLabel}
-            </p>
-          ) : (
-            candidates.map((candidate) => (
-              // Stays open on press: a change is confirmed by the row's own check turning over,
-              // and a second label or reviewer is usually wanted right after the first.
-              <MenuItem
-                key={candidateKey(candidate)}
-                closeOnClick={false}
-                disabled={disabled}
-                onClick={() => onSelect(candidate)}
-                className="min-h-0 py-1.5 text-xs sm:min-h-0 sm:text-xs"
-              >
-                {children(candidate)}
-              </MenuItem>
-            ))
-          )}
-          {truncated ? (
-            // Typing filters what arrived; it does not ask the host again, so this says what the
-            // list is rather than offering a search that would find nothing further.
-            <p className="px-2 py-1.5 text-xs text-muted-foreground">{truncatedLabel}</p>
-          ) : null}
-        </div>
-      </MenuPopup>
-    </Menu>
+          <CommandList className="max-h-72 not-empty:p-1">
+            {isPending ? (
+              <PullRequestPeopleGhost rows={4} />
+            ) : error !== null ? (
+              <p className="p-2 text-xs text-muted-foreground">
+                {errorLabel} {error}
+              </p>
+            ) : candidates.length === 0 ? (
+              <p className="p-2 text-xs text-muted-foreground">
+                {query.length > 0 ? noMatchLabel : emptyLabel}
+              </p>
+            ) : (
+              candidates.map((candidate) => (
+                // Stays open on press: a change is confirmed by the row's own check turning over,
+                // and a second label or reviewer is usually wanted right after the first.
+                <CommandItem
+                  key={candidateKey(candidate)}
+                  value={candidateKey(candidate)}
+                  disabled={disabled}
+                  onClick={() => onSelect(candidate)}
+                  className="min-h-0 cursor-pointer gap-2 py-1.5 text-xs sm:min-h-0 sm:text-xs"
+                >
+                  {children(candidate)}
+                </CommandItem>
+              ))
+            )}
+            {truncated ? (
+              // Typing filters what arrived; it does not ask the host again, so this says what the
+              // list is rather than offering a search that would find nothing further.
+              <p className="px-2 py-1.5 text-xs text-muted-foreground">{truncatedLabel}</p>
+            ) : null}
+          </CommandList>
+        </Command>
+      </PopoverPopup>
+    </Popover>
   );
 }

--- a/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
@@ -3,14 +3,21 @@
  * scrolling body that says when the list is loading, could not be read, is empty, or is not all
  * of it. The rows and the words are the caller's; the frame is the same either way.
  *
- * Built on a popover and the command list rather than a menu: a menu's typeahead claims every
- * keypress to jump between rows, which is exactly what a search box cannot share.
+ * The same combobox as the project and branch pickers, and dressed the same, rather than a menu:
+ * a menu's typeahead claims every keypress to jump between rows, which a search box cannot share.
  */
+import { SearchIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Button } from "../ui/button";
-import { Command, CommandInput, CommandItem, CommandList } from "../ui/command";
-import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPopup,
+  ComboboxTrigger,
+} from "../ui/combobox";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PullRequestPeopleGhost } from "./PullRequestGhosts";
 
@@ -81,64 +88,88 @@ export function PullRequestCandidatePicker<T>({
     );
   }
 
+  const keys = candidates.map(candidateKey);
+
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverTrigger
+    <Combobox
+      items={keys}
+      // The caller narrows the list, so the combobox does no filtering of its own.
+      filteredItems={keys}
+      filter={null}
+      autoHighlight
+      value={null}
+      onValueChange={(key) => {
+        const candidate = candidates.find((entry) => candidateKey(entry) === key);
+        if (candidate) onSelect(candidate);
+      }}
+      open={open}
+      onOpenChange={(nextOpen, details) => {
+        // Stays open on a pick: a change is confirmed by the row's own check turning over, and a
+        // second label or reviewer is usually wanted right after the first.
+        if (!nextOpen && details.reason === "item-press") return;
+        onOpenChange(nextOpen);
+      }}
+    >
+      <ComboboxTrigger
         render={
           <Button size="icon-xs" variant="ghost" aria-label={label}>
             {icon}
           </Button>
         }
       />
-      <PopoverPopup
-        align="start"
-        side="bottom"
-        className="w-72 before:hidden [--viewport-inline-padding:0]"
-        viewportClassName="overflow-hidden p-0"
-      >
-        {/* The caller narrows the list, so the command does no filtering of its own. */}
-        <Command mode="none" value={query} onValueChange={onQueryChange}>
-          <CommandInput
-            wrapperClassName="border-b border-border/60 px-2 py-2 [&_[data-slot=autocomplete-start-addon]]:ps-2"
-            className="*:data-[slot=autocomplete-input]:ps-8!"
-            placeholder={searchLabel}
-            aria-label={searchLabel}
-            size="sm"
-          />
-          <CommandList className="max-h-72 not-empty:p-1">
-            {isPending ? (
-              <PullRequestPeopleGhost rows={4} />
-            ) : error !== null ? (
-              <p className="p-2 text-xs text-muted-foreground">
-                {errorLabel} {error}
-              </p>
-            ) : candidates.length === 0 ? (
-              <p className="p-2 text-xs text-muted-foreground">
-                {query.length > 0 ? noMatchLabel : emptyLabel}
-              </p>
-            ) : (
-              candidates.map((candidate) => (
-                // Stays open on press: a change is confirmed by the row's own check turning over,
-                // and a second label or reviewer is usually wanted right after the first.
-                <CommandItem
-                  key={candidateKey(candidate)}
-                  value={candidateKey(candidate)}
-                  disabled={disabled}
-                  onClick={() => onSelect(candidate)}
-                  className="min-h-0 cursor-pointer gap-2 py-1.5 text-xs sm:min-h-0 sm:text-xs"
-                >
-                  {children(candidate)}
-                </CommandItem>
-              ))
-            )}
-            {truncated ? (
-              // Typing filters what arrived; it does not ask the host again, so this says what the
-              // list is rather than offering a search that would find nothing further.
-              <p className="px-2 py-1.5 text-xs text-muted-foreground">{truncatedLabel}</p>
-            ) : null}
-          </CommandList>
-        </Command>
-      </PopoverPopup>
-    </Popover>
+      <ComboboxPopup align="start" side="bottom" className="w-72">
+        <div className="shrink-0 px-3 pt-2.5">
+          <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
+            <SearchIcon
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1.5 left-0 size-4 shrink-0 text-muted-foreground/55"
+            />
+            <ComboboxInput
+              aria-label={searchLabel}
+              className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
+              inputClassName="rounded-none bg-transparent text-sm"
+              placeholder={searchLabel}
+              showTrigger={false}
+              size="sm"
+              unstyled
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+            />
+          </div>
+        </div>
+        <ComboboxList className="max-h-72">
+          {isPending ? (
+            <PullRequestPeopleGhost rows={4} />
+          ) : error !== null ? (
+            <p className="p-2 text-xs text-muted-foreground">
+              {errorLabel} {error}
+            </p>
+          ) : candidates.length === 0 ? (
+            <p className="p-2 text-xs text-muted-foreground">
+              {query.length > 0 ? noMatchLabel : emptyLabel}
+            </p>
+          ) : (
+            candidates.map((candidate, index) => (
+              <ComboboxItem
+                key={keys[index]}
+                hideIndicator
+                index={index}
+                value={keys[index]}
+                disabled={disabled}
+                className="min-h-0 py-1.5 text-xs sm:min-h-0 sm:text-xs"
+                contentClassName="flex min-w-0 items-center gap-2"
+              >
+                {children(candidate)}
+              </ComboboxItem>
+            ))
+          )}
+          {truncated ? (
+            // Typing filters what arrived; it does not ask the host again, so this says what the
+            // list is rather than offering a search that would find nothing further.
+            <p className="px-2 py-1.5 text-xs text-muted-foreground">{truncatedLabel}</p>
+          ) : null}
+        </ComboboxList>
+      </ComboboxPopup>
+    </Combobox>
   );
 }

--- a/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
@@ -105,8 +105,13 @@ export function PullRequestCandidatePicker<T>({
       open={open}
       onOpenChange={(nextOpen, details) => {
         // Stays open on a pick: a change is confirmed by the row's own check turning over, and a
-        // second label or reviewer is usually wanted right after the first.
-        if (!nextOpen && details.reason === "item-press") return;
+        // second label or reviewer is usually wanted right after the first. Cancelled rather than
+        // ignored, so the combobox also skips its own close work: freezing the query and returning
+        // focus to the trigger, either of which would take the next keystroke away from the box.
+        if (!nextOpen && details.reason === "item-press") {
+          details.cancel();
+          return;
+        }
         onOpenChange(nextOpen);
       }}
     >


### PR DESCRIPTION
The reviewer and label pickers on the PR summary were built on a Base UI \`Menu\`, whose typeahead claims every printable key to jump between rows. Typing into the search box never reached the input: pressing \`t\` highlighted \`t3dotgg\` instead of filtering.

The shared picker shell now sits on the same \`Combobox\` wrapper the sidebar project picker and the branch picker use, with the same search-box treatment, so the three read as one control. The input owns typing, arrow keys and Enter still walk and pick rows, the popover stays open after a pick so a second reviewer or label can follow, and the loading, error, empty, and truncated states are unchanged. Both the reviewer picker and the label picker share this shell, so one change fixes both.

| Before (pressed \`t\`, \`3\`) | After (opened) | After (pressed \`t\`, \`3\`) |
| --- | --- | --- |
| ![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/01115586a0de7869/before.png) | ![after open](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/002f3637d059a5a0/after-open.png) | ![after typed](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f93507a8aba5707f/after.png) |

Verified in a local dev environment against a real PR: the input takes focus on open, typing filters the list, backspacing widens it again, and the labels picker filters the same way.

Made with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI primitive swap in a shared picker shell with no auth or data-layer changes; main risk is combobox keyboard/focus edge cases in reviewer and label pickers.
> 
> **Overview**
> **Replaces the shared PR reviewer/label picker shell** (`PullRequestCandidatePicker`) from a `Menu` + plain `Input` to the same `Combobox` stack used by the project and branch pickers, with a search-icon input styling that matches those controls.
> 
> **Search now works:** menu typeahead no longer steals printable keys, so filtering goes through the caller-controlled `query` while arrow keys/Enter still navigate rows. The combobox is configured with `filter={null}` and caller-supplied `filteredItems` so filtering behavior stays unchanged.
> 
> **Selection UX:** picking a row still calls `onSelect`, but closes from `item-press` are **cancelled** so the popover stays open (and focus/query behavior stays in the search box) for adding multiple reviewers or labels. Loading, error, empty, and truncated messaging are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fc9a91702a37468277378a9c15708494ac8aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PR reviewer and label search boxes to accept keystrokes
> Replaces the menu-based picker in `PullRequestCandidatePicker` with shared combobox primitives so the search input receives keyboard focus and typing. Candidate filtering stays with the caller; combobox-owned filtering is disabled. Selecting a candidate no longer closes the picker, while other open-state changes still propagate through `onOpenChange`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12fc9a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->