### PR TITLE
fix(web): settle the resting composer layout with a pixel of slack

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -876,7 +876,11 @@ function useRestingComposerControlsLayout(host: HTMLDivElement | null) {
     const hostWidth = currentHost.clientWidth;
 
     setLayout((current) => {
-      const next = resolveRestingComposerControlsLayout({ ...measurement, hostWidth });
+      const next = resolveRestingComposerControlsLayout({
+        ...measurement,
+        hostWidth,
+        previous: current,
+      });
       return next.hiddenCount === current.hiddenCount && next.visible === current.visible
         ? current
         : next;

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -277,3 +277,82 @@ describe("context strip labels and resting composer controls", () => {
     ).toEqual({ hiddenCount: 2, visible: true });
   });
 });
+
+describe("resolveRestingComposerControlsLayout hysteresis", () => {
+  // Same cluster as above: picker 140 natural / 96 minimum plus a 9px
+  // separator, traits 60, mode 140, overflow 24, gap 4.
+  const base = {
+    gap: 4,
+    naturalFixedWidth: 149,
+    minimumFixedWidth: 105,
+    blockWidths: [60, 140],
+    overflowWidth: 24,
+  };
+
+  it("keeps a block in overflow when re-showing it would leave no slack", () => {
+    // 149 + 60 + 140 + 4 * 2 = 357 fills the host exactly.
+    expect(
+      resolveRestingComposerControlsLayout({
+        ...base,
+        hostWidth: 357,
+        previous: { hiddenCount: 1, visible: true },
+      }),
+    ).toEqual({ hiddenCount: 1, visible: true });
+  });
+
+  it("re-shows a block once the host clears the slack margin", () => {
+    expect(
+      resolveRestingComposerControlsLayout({
+        ...base,
+        hostWidth: 358,
+        previous: { hiddenCount: 1, visible: true },
+      }),
+    ).toEqual({ hiddenCount: 0, visible: true });
+  });
+
+  it("still resolves from scratch when there is no previous layout", () => {
+    expect(resolveRestingComposerControlsLayout({ ...base, hostWidth: 357 })).toEqual({
+      hiddenCount: 0,
+      visible: true,
+    });
+  });
+
+  it("settles when the measured picker width jitters below a pixel", () => {
+    // Regression guard for React error #185 ("Maximum update depth
+    // exceeded"). The composer re-measures on every render, so the picker's
+    // recovered natural width can land a fraction of a pixel apart between
+    // renders. Without hysteresis that flips hiddenCount forever.
+    let layout = { hiddenCount: 0, visible: true };
+    const settled: string[] = [];
+    for (let index = 0; index < 10; index += 1) {
+      layout = resolveRestingComposerControlsLayout({
+        ...base,
+        // The picker's recovered natural width lands a half pixel apart
+        // between renders.
+        naturalFixedWidth: index % 2 === 0 ? 149 : 149.5,
+        hostWidth: 357,
+        previous: layout,
+      });
+      if (index >= 2) settled.push(`${layout.hiddenCount}:${layout.visible}`);
+    }
+    expect(new Set(settled).size).toBe(1);
+  });
+
+  it("keeps the cluster hidden until its minimum width clears the slack", () => {
+    // 105 + 24 + 4 = 133 is the exact minimum for the hidden cluster.
+    expect(
+      resolveRestingComposerControlsLayout({
+        ...base,
+        hostWidth: 133,
+        previous: { hiddenCount: 2, visible: false },
+      }),
+    ).toEqual({ hiddenCount: 2, visible: false });
+    expect(
+      resolveRestingComposerControlsLayout({
+        ...base,
+        hostWidth: 134,
+        previous: { hiddenCount: 2, visible: false },
+      }),
+    ).toEqual({ hiddenCount: 2, visible: true });
+  });
+});

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -108,10 +108,15 @@ export function resolveRestingComposerControlsNaturalWidth(
  * the overflow menu, the picker may contract to its minimum readable width;
  * below that the whole cluster hides rather than clipping.
  */
+const RESTING_CONTROLS_SLACK_PX = 1;
+
 export function resolveRestingComposerControlsLayout(
-  input: RestingComposerControlsMeasurement & { hostWidth: number },
+  input: RestingComposerControlsMeasurement & {
+    hostWidth: number;
+    previous?: { hiddenCount: number; visible: boolean };
+  },
 ): { hiddenCount: number; visible: boolean } {
-  const { blockWidths, hostWidth } = input;
+  const { blockWidths, hostWidth, previous } = input;
   let hiddenCount = 0;
   while (
     hiddenCount < blockWidths.length &&
@@ -119,7 +124,22 @@ export function resolveRestingComposerControlsLayout(
   ) {
     hiddenCount += 1;
   }
+  // Growing the overflow menu is unconditional, or the controls would clip.
+  // Shrinking it has to earn a pixel of slack first: the picker is flexible,
+  // so its natural width is recovered from a truncated label whose
+  // scrollWidth is integral while the rendered box is fractional. The
+  // composer re-measures on every render, so without that margin a host
+  // sitting exactly on a threshold flips a block in and out until React
+  // gives up with "Maximum update depth exceeded".
+  if (previous && hiddenCount < previous.hiddenCount) {
+    if (restingComposerControlsWidth(input, hiddenCount) > hostWidth - RESTING_CONTROLS_SLACK_PX) {
+      hiddenCount = Math.min(previous.hiddenCount, blockWidths.length);
+    }
+  }
+  const minimumWidth = restingComposerControlsWidth(input, hiddenCount, input.minimumFixedWidth);
   const visible =
-    restingComposerControlsWidth(input, hiddenCount, input.minimumFixedWidth) <= hostWidth;
+    previous && !previous.visible
+      ? minimumWidth <= hostWidth - RESTING_CONTROLS_SLACK_PX
+      : minimumWidth <= hostWidth;
   return { hiddenCount, visible };
 }


### PR DESCRIPTION
## What Changed

`resolveRestingComposerControlsLayout` takes an optional `previous` layout and applies 1px of hysteresis in the *re-showing* direction only. Hiding a block stays unconditional — the controls would clip otherwise. `ChatComposer` passes the current layout through.

3 files, +107/-4.

## Why

The composer re-measures its resting controls on every render (`useLayoutEffect(measure)`, no dependency array), and the model picker's natural width is recovered from a truncated label whose `scrollWidth` is integral while the rendered box is fractional. With the host sitting exactly on a threshold, that sub-pixel difference flipped a block in and out of the overflow menu on every render until React gave up with "Maximum update depth exceeded" (error #185) while opening a thread.

Requiring real slack before a block comes back makes that noise unable to drive the layout.

Follow-up to #9393, which removed the strip-reservation feedback path but left this one — it runs entirely inside the composer's own measure -> resolve -> render cycle.

Fixes #9481.

The new test `settles when the measured picker width jitters below a pixel` feeds alternating 149 / 149.5 measurements and asserts the layout converges: 2 distinct layouts before the fix, 1 after. The existing threshold tests call the resolver without `previous` and are unchanged.

## UI Changes

None visible. A block now needs 1px more room before it leaves the overflow menu.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (no visual change)
- [ ] I included a video for animation/interaction changes (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout math and state threading in the composer measure loop; behavior change is a 1px margin when controls leave overflow, with no auth or data impact.
> 
> **Overview**
> Fixes an infinite re-render loop when opening a thread by stabilizing **resting composer** overflow layout against sub-pixel measurement jitter.
> 
> `resolveRestingComposerControlsLayout` now accepts an optional **`previous`** layout. **Hiding** controls into overflow stays immediate (to avoid clipping). **Bringing blocks back** from overflow—or making the cluster visible again—requires about **1px of slack** (`RESTING_CONTROLS_SLACK_PX`) so threshold flicker from the model picker’s fractional vs integral width does not flip `hiddenCount` every render.
> 
> `ChatComposer` passes the current layout into the resolver on each measure. New unit tests cover hysteresis thresholds, no-`previous` behavior, sub-pixel jitter convergence, and cluster visibility slack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec1d9c1458098cd1276b474512dd4ed3e1b3b12c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 1px slack hysteresis to `resolveRestingComposerControlsLayout` to prevent control oscillation
> - Introduces `RESTING_CONTROLS_SLACK_PX` (1px) in [composerFooterLayout.ts](https://github.com/pingdotgg/t3code/pull/9482/files#diff-f2c45cfa4b4b1e011f20b2464141c82ddc1b7023b5d2707e33b4ab4504c747f8); the resolver now requires one pixel of spare host width before restoring previously overflowed blocks or re-showing a previously hidden cluster.
> - `resolveRestingComposerControlsLayout` accepts an optional previous layout and retains the prior hidden count when the newly expanded layout does not clear the slack margin. Calls without previous state use the original width check.
> - [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/9482/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) passes the hook's current layout as `previous` into each measurement, guarded by the existing state-change check.
> - Adds hysteresis tests in [composerFooterLayout.test.ts](https://github.com/pingdotgg/t3code/pull/9482/files#diff-94d220fe67d6c22a11f1c4e0e72c01ddd034bf9b8ec6ca204e848e90a5f64da9) covering exact-fit retention, 1px re-show, scratch resolution, fractional-width stabilization, and cluster visibility.
> - Behavioral Change: controls that were hidden now stay hidden until host width exceeds their minimum by at least 1px; reviewers should verify the `previous` param threading in `useRestingComposerControlsLayout` does not cause stale layouts during rapid resize.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec1d9c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->