### PR TITLE
fix(desktop): restore second-press quit fallback

### DIFF
--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -368,14 +368,14 @@ describe("makeQuitShortcutHandler", () => {
     expect(harness.notifications).toEqual([DOUBLE_CLICK_DOWN, UP, DOUBLE_CLICK_DOWN]);
   });
 
-  it("does not treat two quick presses as a quit in hold mode", async () => {
+  it("quits on a quick second press in hold mode", async () => {
     const harness = makeHarness();
     await harness.send(makeInput({}));
     await harness.send(makeInput({ type: "keyUp" }));
     vi.advanceTimersByTime(QUIT_DOUBLE_PRESS_MS - 100);
     await harness.send(makeInput({}));
-    expect(harness.quit).not.toHaveBeenCalled();
-    expect(harness.notifications).toEqual([HOLD_DOWN, UP, HOLD_DOWN]);
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+    expect(harness.notifications).toEqual([HOLD_DOWN, UP]);
   });
 
   it("cancels the hold when another key interrupts it", async () => {

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -181,11 +181,9 @@ export function makeQuitShortcutHandler(
           quitNow();
           return;
         }
-        if (
-          resolvedMode === "double-click" &&
-          previousPressAt !== 0 &&
-          now - previousPressAt <= QUIT_DOUBLE_PRESS_MS
-        ) {
+        // Keep a second press as an escape hatch when macOS misses the events
+        // that would complete a hold.
+        if (previousPressAt !== 0 && now - previousPressAt <= QUIT_DOUBLE_PRESS_MS) {
           quitNow();
           return;
         }


### PR DESCRIPTION
Hold mode lost its quick second-press escape hatch when quit confirmation modes were split, so retrying Cmd/Ctrl+Q could only start another hold. This restores the existing 500 ms second-press path in hold mode while keeping direct and dedicated double-press modes unchanged. Verified with all 25 quit-handler tests, desktop typecheck, and targeted lint and formatting. Implemented with gpt-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to desktop quit shortcut handling with updated unit tests; restores prior user-facing behavior rather than new quit paths.
> 
> **Overview**
> **Hold mode** again treats a second Cmd/Ctrl+Q within **500 ms** as quit, not only when confirmation mode is `double-click`. That path was the escape hatch when macOS drops key events and a hold never completes.
> 
> In `QuitHold.ts`, the quick second-press check runs for any non-`direct` mode after settings resolve; `direct` still quits on the first press. Dedicated double-click behavior (hints, slow presses as separate attempts) stays covered by existing tests; one hold-mode test now expects quit on a quick second press.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18a9e40fbdcff3104f226cef2ca1052e27fa101b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore second-press quit fallback for hold mode in `makeQuitShortcutHandler`
> Removes the restriction in `makeQuitShortcutHandler` that limited the quick-second-press quit path to double-click mode. A second press within `QUIT_DOUBLE_PRESS_MS` now quits regardless of the resolved confirmation mode, including hold mode. This handles missed completion events on macOS. Test in [QuitHold.test.ts](https://github.com/pingdotgg/t3code/pull/9485/files#diff-3352b14e4b42d743f79eda4760f7b22ed6975e03d915be0dcb0ea1f78fc11534) updated to expect a quit call without a second hold notification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18a9e40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->