### PR TITLE
fix(mobile): keep the machine glyph next to the environment label

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -746,49 +746,54 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         ) : thread.branch || props.environmentLabel ? (
           /* "branch · machine" share one truncating line. The machine sits
              last so a tight fit cuts the repetitive label, not the branch —
-             and machine-only fills the row for non-git projects. */
-          <Text
-            className={cn(
-              "flex-1 text-xs",
-              selected ? "text-user-bubble-foreground-muted" : "text-foreground-muted",
-            )}
-            numberOfLines={1}
-          >
-            {thread.branch ? (
-              <Text
-                className={cn(
-                  "text-xs",
-                  selected ? "text-user-bubble-foreground-muted" : "text-foreground-muted",
-                )}
-                style={{ fontFamily: MONO_FONT }}
-              >
-                {thread.branch}
-              </Text>
+             and machine-only fills the row for non-git projects. The glyph
+             hugs the label (it cannot live inside the Text without breaking
+             truncation), and the wrapper takes the slack so the trailers
+             stay pinned right. */
+          <View className="min-w-0 flex-1 flex-row items-center gap-1">
+            <Text
+              className={cn(
+                "shrink text-xs",
+                selected ? "text-user-bubble-foreground-muted" : "text-foreground-muted",
+              )}
+              numberOfLines={1}
+            >
+              {thread.branch ? (
+                <Text
+                  className={cn(
+                    "text-xs",
+                    selected ? "text-user-bubble-foreground-muted" : "text-foreground-muted",
+                  )}
+                  style={{ fontFamily: MONO_FONT }}
+                >
+                  {thread.branch}
+                </Text>
+              ) : null}
+              {thread.branch && props.environmentLabel ? "  ·  " : null}
+              {props.environmentLabel ? (
+                <Text
+                  className={cn(
+                    "text-xs",
+                    selected ? "text-user-bubble-foreground-muted" : "text-foreground-tertiary",
+                  )}
+                >
+                  {props.environmentLabel}
+                </Text>
+              ) : null}
+            </Text>
+            {props.environmentLabel && props.environmentMachine ? (
+              <EnvironmentMachineSymbol
+                kind={props.environmentMachine}
+                size={11}
+                tintColorClassName={
+                  selected ? "accent-user-bubble-foreground-muted" : "accent-foreground-tertiary"
+                }
+              />
             ) : null}
-            {thread.branch && props.environmentLabel ? "  ·  " : null}
-            {props.environmentLabel ? (
-              <Text
-                className={cn(
-                  "text-xs",
-                  selected ? "text-user-bubble-foreground-muted" : "text-foreground-tertiary",
-                )}
-              >
-                {props.environmentLabel}
-              </Text>
-            ) : null}
-          </Text>
+          </View>
         ) : (
           <View className="flex-1" />
         )}
-        {status !== "failed" && props.environmentLabel && props.environmentMachine ? (
-          <EnvironmentMachineSymbol
-            kind={props.environmentMachine}
-            size={11}
-            tintColorClassName={
-              selected ? "accent-user-bubble-foreground-muted" : "accent-foreground-tertiary"
-            }
-          />
-        ) : null}
         {pr ? (
           <Text
             accessibilityLabel={pr.accessibilityLabel}


### PR DESCRIPTION
## Problem

On the mobile thread list, the machine glyph that [#9299](https://github.com/pingdotgg/t3code/pull/9299) added lands at the far right of the subtitle row, next to the PR number and provider icon, instead of after the environment name it describes. The subtitle `Text` was `flex-1`, so it swallowed the horizontal slack and pushed the glyph away from `nucbox-1`.

## Fix

The text now shrinks inside a `flex-1` wrapper that takes the slack, so the row reads `main · nucbox-1 ▭` with the glyph hugging the label, and the PR and provider trailers stay pinned right. Only the v2 thread row needed this; the pending row and the v1 rows already placed the glyph beside the label.

The glyph can't live inside the `Text` itself without breaking single-line truncation, which is why it sits as a sibling.

## Before / after

| Before | After |
| --- | --- |
| ![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/02c28a21962b37a3/mobile-glyph-before-v2.png) | ![after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9e84d1fe31d5e9a1/mobile-glyph-after-v2.png) |

Rows with a branch, environment label, and linked PR, where the slack between label and trailers is widest. Before, the glyph sat with the PR number; after, it follows the label. iPhone 17 Pro simulator, dev client on this branch against a disposable backend seeded from real data.

## Verification

Mobile typecheck and lint pass. Layout-only change.

Built with Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change in the mobile thread list subtitle row; no API, auth, or data handling impact.
> 
> **Overview**
> Fixes **v2 thread list** subtitle layout so `EnvironmentMachineSymbol` sits immediately after the branch/environment text (`main · nucbox-1 ▭`) instead of at the far right beside the PR and provider icons.
> 
> The branch/label line is wrapped in a `flex-1` row: truncating `Text` uses **`shrink`** (not `flex-1`), and the glyph is a **sibling** inside that wrapper so single-line ellipsis still works. The old row-level glyph (shown when not failed) is **removed** in favor of the in-wrapper placement when both `environmentLabel` and `environmentMachine` are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36dec6d65be1e54beffe34a21418a8ceb5b2dc06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep machine glyph next to environment label in `ThreadListV2Row`
> Reworks the branch/environment metadata row into a flexible horizontal wrapper that truncates the text while keeping the machine symbol adjacent to the environment label. The PR and provider trailers remain positioned after the flexible metadata area, and the machine symbol stays suppressed for failed rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 36dec6d. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
