### PR TITLE
fix(shared): resolve SSH config host aliases in git remote URLs

### DIFF
--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -242,7 +242,7 @@ function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): st
   }
 
   const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
+    /^(?:git@github\.com(?:-[^:/\s]+)?:|ssh:\/\/git@github\.com(?:-[^/\s]+)?\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
       trimmed,
     );
   const repositoryNameWithOwner = match?.[1]?.trim() ?? "";

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -23,6 +23,18 @@ describe("normalizeGitRemoteUrl", () => {
     );
   });
 
+  it("resolves SSH config host aliases to the host they extend", () => {
+    expect(normalizeGitRemoteUrl("git@github.com-work:T3Tools/T3Code.git")).toBe(
+      "github.com/t3tools/t3code",
+    );
+    expect(normalizeGitRemoteUrl("ssh://git@github.com-work/T3Tools/T3Code")).toBe(
+      "github.com/t3tools/t3code",
+    );
+    expect(normalizeGitRemoteUrl("https://github.com-work/T3Tools/T3Code")).toBe(
+      "github.com-work/t3tools/t3code",
+    );
+  });
+
   it("preserves nested group paths for providers like GitLab", () => {
     expect(normalizeGitRemoteUrl("git@gitlab.com:T3Tools/platform/T3Code.git")).toBe(
       "gitlab.com/t3tools/platform/t3code",
@@ -52,6 +64,15 @@ describe("normalizeGitRemoteUrl", () => {
 });
 
 describe("parseGitHubRepositoryNameWithOwnerFromRemoteUrl", () => {
+  it("accepts SSH config host aliases on the GitHub host", () => {
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("git@github.com-work:owner/repo.git"),
+    ).toBe("owner/repo");
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("ssh://git@github.com-work/owner/repo.git"),
+    ).toBe("owner/repo");
+  });
+
   it("extracts the owner and repository from common GitHub remote shapes", () => {
     expect(
       parseGitHubRepositoryNameWithOwnerFromRemoteUrl("git@github.com:T3Tools/T3Code.git"),

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -8,7 +8,7 @@ import type {
 } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
-import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
+import { detectSourceControlProviderFromRemoteUrl, stripSshHostAlias } from "./sourceControl.ts";
 
 export const WORKTREE_BRANCH_PREFIX = "t3code";
 // Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
@@ -126,7 +126,8 @@ export function normalizeGitRemoteUrl(value: string): string {
         .filter((segment) => segment.length > 0)
         .join("/");
       if (url.hostname && repositoryPath.includes("/")) {
-        return `${url.hostname}/${repositoryPath}`;
+        const hostname = url.protocol === "ssh:" ? stripSshHostAlias(url.hostname) : url.hostname;
+        return `${hostname}/${repositoryPath}`;
       }
     } catch {
       return normalized;
@@ -137,7 +138,7 @@ export function normalizeGitRemoteUrl(value: string): string {
     normalized,
   );
   if (scpStyleHostAndPath?.[1] && scpStyleHostAndPath[2]) {
-    return `${scpStyleHostAndPath[1]}/${scpStyleHostAndPath[2]}`;
+    return `${stripSshHostAlias(scpStyleHostAndPath[1])}/${scpStyleHostAndPath[2]}`;
   }
 
   return normalized;
@@ -153,7 +154,7 @@ export function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | nu
   }
 
   const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
+    /^(?:git@github\.com(?:-[^:/\s]+)?:|ssh:\/\/git@github\.com(?:-[^/\s]+)?\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
       trimmed,
     );
   const repositoryNameWithOwner = match?.[1]?.trim() ?? "";

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -147,14 +147,16 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
       baseUrl: "https://github.com",
     });
     expect(
-      detectSourceControlProviderFromRemoteUrl(
-        "ssh://git@gitlab.company.com-personal:2222/team/repo.git",
-      ),
+      detectSourceControlProviderFromRemoteUrl("ssh://git@gitlab.com-personal:2222/team/repo.git"),
     ).toEqual({
       kind: "gitlab",
-      name: "GitLab Self-Hosted",
-      baseUrl: "https://gitlab.company.com:2222",
+      name: "GitLab",
+      baseUrl: "https://gitlab.com:2222",
     });
+    expect(
+      detectSourceControlProviderFromRemoteUrl("git@ssh.dev.azure.com-work:v3/org/project/repo")
+        ?.baseUrl,
+    ).toBe("https://ssh.dev.azure.com");
     // HTTPS never consults the SSH config, so its host is taken literally.
     expect(
       detectSourceControlProviderFromRemoteUrl("https://github.com-work/owner/repo.git")?.baseUrl,
@@ -163,13 +165,15 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
 });
 
 describe("stripSshHostAlias", () => {
-  it("drops the alias suffix only from the last DNS label", () => {
+  it("drops the alias suffix only behind a hosted provider domain", () => {
     expect(stripSshHostAlias("github.com-work")).toBe("github.com");
+    expect(stripSshHostAlias("bitbucket.org-personal")).toBe("bitbucket.org");
+    // Self-hosted and internal names are taken as written, hyphens included.
+    expect(stripSshHostAlias("github.example-corp")).toBe("github.example-corp");
+    expect(stripSshHostAlias("gitlab.company.com-personal")).toBe("gitlab.company.com-personal");
     expect(stripSshHostAlias("gitlab.my-corp.com")).toBe("gitlab.my-corp.com");
-    expect(stripSshHostAlias("my-server.local")).toBe("my-server.local");
-    expect(stripSshHostAlias("git-server")).toBe("git-server");
-    expect(stripSshHostAlias("example.xn--p1ai")).toBe("example.xn--p1ai");
-    expect(stripSshHostAlias("192.168.1.10")).toBe("192.168.1.10");
+    expect(stripSshHostAlias("github.com")).toBe("github.com");
+    expect(stripSshHostAlias("github.community")).toBe("github.community");
   });
 });
 

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -5,6 +5,7 @@ import {
   getChangeRequestTerminologyForKind,
   isSshRemoteUrl,
   resolveChangeRequestPresentation,
+  stripSshHostAlias,
 } from "./sourceControl.ts";
 
 describe("source control presentation", () => {
@@ -136,6 +137,39 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
     expect(
       detectSourceControlProviderFromRemoteUrl("git@bitbucket.org:workspace/repo.git")?.kind,
     ).toBe("bitbucket");
+  });
+
+  it("resolves SSH config host aliases to the host they extend", () => {
+    // `Host github.com-work` in ~/.ssh/config is the common multi-account setup.
+    expect(detectSourceControlProviderFromRemoteUrl("git@github.com-work:owner/repo.git")).toEqual({
+      kind: "github",
+      name: "GitHub",
+      baseUrl: "https://github.com",
+    });
+    expect(
+      detectSourceControlProviderFromRemoteUrl(
+        "ssh://git@gitlab.company.com-personal:2222/team/repo.git",
+      ),
+    ).toEqual({
+      kind: "gitlab",
+      name: "GitLab Self-Hosted",
+      baseUrl: "https://gitlab.company.com:2222",
+    });
+    // HTTPS never consults the SSH config, so its host is taken literally.
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://github.com-work/owner/repo.git")?.baseUrl,
+    ).toBe("https://github.com-work");
+  });
+});
+
+describe("stripSshHostAlias", () => {
+  it("drops the alias suffix only from the last DNS label", () => {
+    expect(stripSshHostAlias("github.com-work")).toBe("github.com");
+    expect(stripSshHostAlias("gitlab.my-corp.com")).toBe("gitlab.my-corp.com");
+    expect(stripSshHostAlias("my-server.local")).toBe("my-server.local");
+    expect(stripSshHostAlias("git-server")).toBe("git-server");
+    expect(stripSshHostAlias("example.xn--p1ai")).toBe("example.xn--p1ai");
+    expect(stripSshHostAlias("192.168.1.10")).toBe("192.168.1.10");
   });
 });
 

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -140,26 +140,20 @@ export function isSshRemoteUrl(remoteUrl: string): boolean {
   return SCP_SSH_REMOTE_PATTERN.test(trimmed) || trimmed.toLowerCase().startsWith("ssh://");
 }
 
+// The hosted providers whose SSH host commonly carries a `-<alias>` suffix.
+const SSH_ALIAS_HOSTS = ["github.com", "gitlab.com", "bitbucket.org", "ssh.dev.azure.com"];
+
 /**
- * SSH remotes often name a `~/.ssh/config` alias instead of the real host, and
- * the common multi-account convention appends the alias to it:
- * `git@github.com-work:org/repo.git`. No public host carries a hyphen in its
- * last DNS label (IDN `xn--` labels aside), so one there marks where the real
- * host ends. Only SSH transports consult the SSH config, so callers apply this
- * to SSH hosts alone and leave HTTPS hosts untouched.
+ * SSH remotes often name a `~/.ssh/config` alias instead of the real host. The
+ * common multi-account convention appends the alias to the hosted provider's
+ * domain, `git@github.com-work:org/repo.git`, so a hyphen right after one of
+ * those domains marks the alias. Only those domains are recognised: a
+ * self-hosted name is taken as written, since an internal zone may
+ * legitimately carry a hyphen there. Only SSH transports consult the SSH
+ * config, so callers apply this to SSH hosts alone and leave HTTPS untouched.
  */
 export function stripSshHostAlias(host: string): string {
-  const labels = host.split(".");
-  const lastLabel = labels.at(-1);
-  if (labels.length < 2 || lastLabel === undefined || lastLabel.startsWith("xn--")) {
-    return host;
-  }
-  const aliasStart = lastLabel.indexOf("-");
-  if (aliasStart <= 0) {
-    return host;
-  }
-  labels[labels.length - 1] = lastLabel.slice(0, aliasStart);
-  return labels.join(".");
+  return SSH_ALIAS_HOSTS.find((known) => host.startsWith(`${known}-`)) ?? host;
 }
 
 function parseRemoteHost(remoteUrl: string): string | null {

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -140,6 +140,28 @@ export function isSshRemoteUrl(remoteUrl: string): boolean {
   return SCP_SSH_REMOTE_PATTERN.test(trimmed) || trimmed.toLowerCase().startsWith("ssh://");
 }
 
+/**
+ * SSH remotes often name a `~/.ssh/config` alias instead of the real host, and
+ * the common multi-account convention appends the alias to it:
+ * `git@github.com-work:org/repo.git`. No public host carries a hyphen in its
+ * last DNS label (IDN `xn--` labels aside), so one there marks where the real
+ * host ends. Only SSH transports consult the SSH config, so callers apply this
+ * to SSH hosts alone and leave HTTPS hosts untouched.
+ */
+export function stripSshHostAlias(host: string): string {
+  const labels = host.split(".");
+  const lastLabel = labels.at(-1);
+  if (labels.length < 2 || lastLabel === undefined || lastLabel.startsWith("xn--")) {
+    return host;
+  }
+  const aliasStart = lastLabel.indexOf("-");
+  if (aliasStart <= 0) {
+    return host;
+  }
+  labels[labels.length - 1] = lastLabel.slice(0, aliasStart);
+  return labels.join(".");
+}
+
 function parseRemoteHost(remoteUrl: string): string | null {
   const trimmed = remoteUrl.trim();
   if (trimmed.length === 0) {
@@ -148,11 +170,16 @@ function parseRemoteHost(remoteUrl: string): string | null {
 
   const scpMatch = SCP_SSH_REMOTE_PATTERN.exec(trimmed);
   if (scpMatch?.[1]) {
-    return scpMatch[1].toLowerCase();
+    return stripSshHostAlias(scpMatch[1].toLowerCase());
   }
 
   try {
-    return new URL(trimmed).host.toLowerCase();
+    const url = new URL(trimmed);
+    if (url.protocol !== "ssh:") {
+      return url.host.toLowerCase();
+    }
+    const hostname = stripSshHostAlias(url.hostname.toLowerCase());
+    return url.port ? `${hostname}:${url.port}` : hostname;
   } catch {
     return null;
   }


### PR DESCRIPTION
## What Changed

`packages/shared/src/sourceControl.ts`: `parseRemoteHost` strips an SSH config alias suffix from SSH hosts before provider detection, so `git@github.com-work:org/repo.git` now yields `baseUrl: "https://github.com"` instead of `https://github.com-work`. The rule lives in a new `stripSshHostAlias` helper.

`packages/shared/src/git.ts`: `normalizeGitRemoteUrl` canonicalizes the same way, so the repository identity key (and every host the app derives from it: the pull request host, the browser link, the list de-duplication key) reads `github.com/org/repo`. `parseGitHubRepositoryNameWithOwnerFromRemoteUrl` accepts the aliased host.

`apps/server/src/git/GitManager.ts`: the same one-token regex change on its local copy of that parser, so PR lookups resolve `owner/repo` for aliased remotes.

Focused tests for each: the alias forms, ports on `ssh://` URLs, and the hosts that must stay as written (self-hosted and internal names, HTTPS remotes).

## Why

Fixes #9458.

A `Host github.com-work` entry in `~/.ssh/config` is the standard way to drive several GitHub accounts from one machine, and the remote then reads `git@github.com-work:org/repo.git`. T3 Code took that alias host literally: it became the identity's canonical key, the provider base URL, and the pull request URL, so reading a PR hit `https://github.com-work/org/repo/pull/123` and failed on DNS.

The rule is deliberately narrow. Only SSH transports consult the SSH config, so HTTPS hosts are never touched. Only the hosted provider domains this module already special-cases (`github.com`, `gitlab.com`, `bitbucket.org`, `ssh.dev.azure.com`) followed by `-` are treated as an alias; a self-hosted or internal name such as `github.example-corp` is taken as written, since an internal zone may legitimately carry a hyphen there. Aliases that do not embed the real host at all (`Host work`) would need `ssh -G` resolution and are out of scope for this fix.

Existing projects pick up the corrected identity the next time it is resolved; nothing is migrated.

Model and harness: Claude Fable 5.1 in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseGitHubRepositoryNameWithOwnerFromRemoteUrl` to accept SSH config host aliases
> Extends the GitHub SSH URL pattern in `parseGitHubRepositoryNameWithOwnerFromRemoteUrl` to match hostnames like `github.com-work` for both SCP-style and `ssh://` remotes. This lets the parser extract `owner/repo` from remotes that use SSH config host aliases (e.g. `git@github.com-work:owner/repo.git`). HTTPS and `git://` patterns are unchanged.
> - Risk: the broader SSH hostname pattern could match non-GitHub hosts that happen to use a `github.com-*` alias; verify no such remotes are expected in practice.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de7462b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->