### PR TITLE
fix(web): copy an update command that matches how the server is installed

### DIFF
--- a/apps/server/src/cli/invocation.test.ts
+++ b/apps/server/src/cli/invocation.test.ts
@@ -1,6 +1,6 @@
 import { assert, it } from "@effect/vitest";
 
-import { formatCliCommand } from "./invocation.ts";
+import { detectServerInstall, formatCliCommand } from "./invocation.ts";
 
 it("formats package runner commands from their cache entry paths", () => {
   for (const [entryPath, expected] of [
@@ -40,6 +40,33 @@ it("treats stable installs as direct invocations", () => {
       formatCliCommand({ subcommand: "serve", entryPath, version: "0.0.31" }),
       "t3 serve",
     );
+  }
+});
+
+it("tells package runners, global installs, and everything else apart", () => {
+  for (const [entryPath, expected] of [
+    ["/home/theo/.npm/_npx/abc123/node_modules/t3/dist/bin.mjs", "npx"],
+    ["/home/theo/.cache/pnpm/dlx/abc/node_modules/t3/dist/bin.mjs", "pnpm-dlx"],
+    ["/tmp/bunx-1000-t3@latest/node_modules/t3/dist/bin.mjs", "bunx"],
+    ["/usr/local/lib/node_modules/t3/dist/bin.mjs", "npm-global"],
+    ["/home/theo/.nvm/versions/node/v24.13.1/lib/node_modules/t3/dist/bin.mjs", "npm-global"],
+    ["C:\\Users\\theo\\AppData\\Roaming\\npm\\node_modules\\t3\\dist\\bin.mjs", "npm-global"],
+    [
+      "/home/theo/.local/share/pnpm/global/5/.pnpm/t3@0.0.35/node_modules/t3/dist/bin.mjs",
+      "pnpm-global",
+    ],
+    ["/home/theo/.bun/install/global/node_modules/t3/dist/bin.mjs", "bun-global"],
+  ] as const) {
+    assert.equal(detectServerInstall(entryPath), expected);
+  }
+  // Nothing global updates these, so no command is suggested.
+  for (const entryPath of [
+    "/srv/project/node_modules/t3/dist/bin.mjs",
+    "/home/theo/.t3/runtime/0.0.31/node_modules/t3/dist/bin.mjs",
+    "/home/theo/Code/work/t3code/apps/server/dist/bin.mjs",
+    "",
+  ]) {
+    assert.isNull(detectServerInstall(entryPath));
   }
 });
 

--- a/apps/server/src/cli/invocation.ts
+++ b/apps/server/src/cli/invocation.ts
@@ -1,3 +1,4 @@
+import type { ServerInstallKind } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 
 import { HostProcessArguments } from "@t3tools/shared/hostProcess";
@@ -32,6 +33,46 @@ function detectCliRunner(entryPath: string): CliRunner | null {
   }
   if (path.includes("/.bun/install/cache/") || path.includes("/bunx-")) {
     return "bunx";
+  }
+  return null;
+}
+
+const SERVER_INSTALL_BY_RUNNER: Record<CliRunner, ServerInstallKind> = {
+  npx: "npx",
+  "pnpm dlx": "pnpm-dlx",
+  bunx: "bunx",
+};
+
+/**
+ * How the CLI is installed, for clients that must tell the user how to update
+ * it by hand. Package runners are recognised as above. Global installs are
+ * recognised by each package manager's own layout, so the suggested command
+ * is the one that manages that install:
+ *
+ *   npm   <prefix>/lib/node_modules/t3/... (system node, nvm, fnm, volta,
+ *         Homebrew), or %APPDATA%/npm/node_modules/t3/... on Windows
+ *   pnpm  <pnpm home>/global/<n>/...
+ *   bun   ~/.bun/install/global/...
+ *
+ * Pass the resolved entry script: the bin a global install runs is usually a
+ * symlink into the package. Anything else (repo checkouts, project-local
+ * installs, the pinned service runtime) returns null, since no global
+ * command would update the executable that gets restarted.
+ */
+export function detectServerInstall(entryPath: string): ServerInstallKind | null {
+  const runner = detectCliRunner(entryPath);
+  if (runner !== null) {
+    return SERVER_INSTALL_BY_RUNNER[runner];
+  }
+  const path = entryPath.replaceAll("\\", "/");
+  if (path.includes("/pnpm/global/")) {
+    return "pnpm-global";
+  }
+  if (path.includes("/.bun/install/global/")) {
+    return "bun-global";
+  }
+  if (path.includes("/lib/node_modules/") || path.includes("/npm/node_modules/")) {
+    return "npm-global";
   }
   return null;
 }

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -1,5 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
+import { HostProcessArguments } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -257,6 +258,56 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
 
       const web = yield* describeWith({ mode: "web", desktopTelemetryControlFd: 5 });
       expect(web.capabilities.desktopAppUpdate).toBeUndefined();
+    }),
+  );
+
+  it.effect("reports how the server is installed only when it cannot update itself", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-environment-install-test-",
+      });
+      const serverConfig = yield* makeServerConfig(baseDir);
+      yield* fileSystem.makeDirectory(serverConfig.stateDir, { recursive: true });
+
+      const describeWith = (
+        overrides: Partial<ServerConfig.ServerConfig["Service"]>,
+        entryPath: string,
+      ) =>
+        Effect.gen(function* () {
+          const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
+          return yield* serverEnvironment.getDescriptor;
+        }).pipe(
+          Effect.provide(
+            ServerEnvironment.layer.pipe(
+              Layer.provide(ServerSecretStore.layer),
+              Layer.provide(ServerConfig.layer({ ...serverConfig, ...overrides })),
+              Layer.provide(Layer.succeed(HostProcessArguments, ["/usr/bin/node", entryPath])),
+            ),
+          ),
+        );
+
+      const npx = yield* describeWith({}, "/home/theo/.npm/_npx/abc/node_modules/t3/dist/bin.mjs");
+      expect(npx.capabilities.serverSelfUpdate).toBeUndefined();
+      expect(npx.capabilities.serverInstall).toBe("npx");
+
+      // A global install runs through a bin symlink; the install is read off
+      // the package it points into.
+      const packageDir = `${baseDir}/lib/node_modules/t3/dist`;
+      yield* fileSystem.makeDirectory(packageDir, { recursive: true });
+      yield* fileSystem.writeFileString(`${packageDir}/bin.mjs`, "");
+      yield* fileSystem.makeDirectory(`${baseDir}/bin`, { recursive: true });
+      yield* fileSystem.symlink(`${packageDir}/bin.mjs`, `${baseDir}/bin/t3`);
+      const global = yield* describeWith({}, `${baseDir}/bin/t3`);
+      expect(global.capabilities.serverInstall).toBe("npm-global");
+
+      const checkout = yield* describeWith({}, "/home/theo/Code/t3code/apps/server/src/bin.ts");
+      expect(checkout.capabilities.serverInstall).toBeUndefined();
+
+      // A desktop-managed server updates through the app, so it never hands out a command.
+      const desktop = yield* describeWith({ mode: "desktop" }, `${baseDir}/bin/t3`);
+      expect(desktop.capabilities.serverSelfUpdate).toBe("desktop-managed");
+      expect(desktop.capabilities.serverInstall).toBeUndefined();
     }),
   );
 

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -3,7 +3,11 @@ import {
   PROVIDER_SEND_TURN_MAX_FILE_BYTES,
   type ExecutionEnvironmentDescriptor,
 } from "@t3tools/contracts";
-import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import {
+  HostProcessArchitecture,
+  HostProcessArguments,
+  HostProcessPlatform,
+} from "@t3tools/shared/hostProcess";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
@@ -14,6 +18,7 @@ import * as Schema from "effect/Schema";
 
 import packageJson from "../../package.json" with { type: "json" };
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import { detectServerInstall } from "../cli/invocation.ts";
 import { readAgentActivityPublishingActive } from "../cloud/config.ts";
 import { resolveServerSelfUpdateCapability } from "../cloud/selfUpdate.ts";
 import { resolveServiceLauncherMode } from "../cloud/serviceLauncherClient.ts";
@@ -182,11 +187,13 @@ const makeIdentity = Effect.gen(function* () {
 /** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
+  const fileSystem = yield* FileSystem.FileSystem;
   const serverConfig = yield* ServerConfig.ServerConfig;
   const secrets = yield* ServerSecretStore.ServerSecretStore;
   const identity = yield* ServerEnvironmentIdentity;
   const hostPlatform = yield* HostProcessPlatform;
   const hostArchitecture = yield* HostProcessArchitecture;
+  const processArguments = yield* HostProcessArguments;
   const environmentId = yield* identity.getEnvironmentId;
   const cwdBaseName = path.basename(serverConfig.cwd).trim();
   const label = yield* resolveServerEnvironmentLabel({ cwdBaseName });
@@ -202,6 +209,16 @@ export const make = Effect.gen(function* () {
   // the fd and correctly do not advertise.
   const desktopAppUpdate =
     serverSelfUpdate === "desktop-managed" && serverConfig.desktopTelemetryControlFd !== undefined;
+  // Only a server with no self-update path hands the user a command, so only
+  // that server needs to say which command will land on its install. The bin
+  // a global install runs is a symlink into the package, so resolve it first.
+  const entryPath = processArguments[1] ?? "";
+  const serverInstall =
+    serverSelfUpdate === null
+      ? detectServerInstall(
+          yield* fileSystem.realPath(entryPath).pipe(Effect.orElseSucceed(() => entryPath)),
+        )
+      : null;
 
   const descriptor: ExecutionEnvironmentDescriptor = {
     environmentId,
@@ -235,6 +252,7 @@ export const make = Effect.gen(function* () {
       threadPullRequestLinking: true,
       environmentIcon: true,
       ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
+      ...(serverInstall === null ? {} : { serverInstall }),
       ...(serverSelfUpdate === "boot-service" || desktopAppUpdate
         ? {
             serverSelfUpdateProgress: true,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -471,6 +471,7 @@ import {
   isServerUpdateFailureDismissed,
   isVersionMismatchDismissed,
   resolveServerConfigVersionMismatch,
+  resolveServerInstall,
   resolveServerSelfUpdateCapability,
   serverUpdateGuidance,
   supportsDesktopAppUpdate,
@@ -2395,6 +2396,7 @@ export default function ChatView(props: ChatViewProps) {
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
   const versionMismatchDesktopAppUpdate = supportsDesktopAppUpdate(serverConfig);
   const versionMismatchThreadContinuation = supportsServerUpdateThreadContinuation(serverConfig);
+  const versionMismatchInstall = resolveServerInstall(serverConfig);
   const serverUpdateState = useAtomValue(
     serverEnvironment.updateStateAtom(serverUpdateEnvironmentId),
   );
@@ -2535,6 +2537,7 @@ export default function ChatView(props: ChatViewProps) {
               selfUpdate={versionMismatchSelfUpdate}
               desktopAppUpdate={versionMismatchDesktopAppUpdate}
               threadContinuation={versionMismatchThreadContinuation}
+              install={versionMismatchInstall}
               targetVersion={versionMismatch.clientVersion}
               label={updateFailed ? "Retry" : "Update"}
               variant="ghost"

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -1,4 +1,8 @@
-import type { EnvironmentId, ServerSelfUpdateCapability } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  ServerInstallKind,
+  ServerSelfUpdateCapability,
+} from "@t3tools/contracts";
 import type { ServerUpdateStage, ServerUpdateState } from "@t3tools/client-runtime/state/server";
 import {
   isAtomCommandInterrupted,
@@ -40,6 +44,9 @@ export interface ServerUpdateTarget {
   readonly selfUpdate: ServerSelfUpdateCapability | null;
   readonly desktopAppUpdate?: boolean;
   readonly threadContinuation?: boolean;
+  /** How the server is installed (capabilities.serverInstall), which picks
+      the manual update command when it cannot update itself. */
+  readonly install?: ServerInstallKind | undefined;
   readonly targetVersion: string;
   readonly continueThreadsAfterServerUpdate?: boolean;
 }
@@ -187,6 +194,7 @@ export function ServerUpdateAction({
   selfUpdate,
   desktopAppUpdate = false,
   threadContinuation = false,
+  install,
   targetVersion,
   label = "Update",
   variant = "outline",
@@ -252,7 +260,7 @@ export function ServerUpdateAction({
   }
 
   if (selfUpdate === null) {
-    const command = manualServerUpdateCommand(targetVersion);
+    const command = manualServerUpdateCommand(targetVersion, install);
     return (
       <Button size={size} variant={variant} onClick={() => copyToClipboard(command, { command })}>
         Copy update command

--- a/apps/web/src/components/chat/useAutoBalanceUpdateBanner.tsx
+++ b/apps/web/src/components/chat/useAutoBalanceUpdateBanner.tsx
@@ -12,6 +12,7 @@ import {
   isServerUpdateFailureDismissed,
   isVersionMismatchDismissed,
   resolveServerConfigVersionMismatch,
+  resolveServerInstall,
   resolveServerSelfUpdateCapability,
   supportsDesktopAppUpdate,
   supportsServerUpdateThreadContinuation,
@@ -65,6 +66,7 @@ export function useAutoBalanceUpdateBanner(
         selfUpdate,
         desktopAppUpdate,
         threadContinuation: supportsServerUpdateThreadContinuation(environment.serverConfig),
+        install: resolveServerInstall(environment.serverConfig),
         continueThreadsAfterServerUpdate:
           environment.serverConfig?.settings.continueThreadsAfterServerUpdate ?? false,
         targetVersion: state.status === "idle" ? mismatch!.clientVersion : state.targetVersion,

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -121,6 +121,7 @@ import { isDesktopLocalConnectionTarget } from "~/connection/desktopLocal";
 import { useUiStateStore } from "~/uiStateStore";
 import {
   resolveServerConfigVersionMismatch,
+  resolveServerInstall,
   resolveServerSelfUpdateCapability,
   supportsDesktopAppUpdate,
   supportsServerUpdateThreadContinuation,
@@ -1552,6 +1553,7 @@ function SavedBackendListRow({
               selfUpdate={resolveServerSelfUpdateCapability(environment.serverConfig)}
               desktopAppUpdate={supportsDesktopAppUpdate(environment.serverConfig)}
               threadContinuation={supportsServerUpdateThreadContinuation(environment.serverConfig)}
+              install={resolveServerInstall(environment.serverConfig)}
               targetVersion={versionMismatch.clientVersion}
               label={serverUpdateState.status === "failed" ? "Retry" : "Update"}
             />
@@ -3177,6 +3179,7 @@ export function ConnectionsSettings() {
                       threadContinuation={supportsServerUpdateThreadContinuation(
                         primaryServerConfig,
                       )}
+                      install={resolveServerInstall(primaryServerConfig)}
                       targetVersion={primaryVersionMismatch.clientVersion}
                       label={primaryServerUpdateState.status === "failed" ? "Retry" : "Update"}
                     />

--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -14,6 +14,7 @@ import {
   dismissVersionMismatch,
   isServerUpdateFailureDismissed,
   isVersionMismatchDismissed,
+  manualServerUpdateCommand,
   resolveServerConfigVersionMismatch,
   resolveServerSelfUpdateCapability,
   resolveVersionMismatch,
@@ -27,6 +28,17 @@ const MISMATCH_HINT =
 describe("versionSkew", () => {
   beforeEach(() => {
     branding.APP_VERSION = "0.0.34";
+  });
+
+  it("hands out the update command that matches the server install", () => {
+    expect(manualServerUpdateCommand("0.0.35", "npm-global")).toBe("npm i -g t3@0.0.35");
+    expect(manualServerUpdateCommand("0.0.35", "pnpm-global")).toBe("pnpm add -g t3@0.0.35");
+    expect(manualServerUpdateCommand("0.0.35", "bun-global")).toBe("bun add -g t3@0.0.35");
+    expect(manualServerUpdateCommand("0.0.35", "npx")).toBe("npx t3@0.0.35");
+    expect(manualServerUpdateCommand("0.0.35", "pnpm-dlx")).toBe("pnpm dlx t3@0.0.35");
+    expect(manualServerUpdateCommand("0.0.35", "bunx")).toBe("bunx t3@0.0.35");
+    // Older servers and dev checkouts report no install; the relaunch stays.
+    expect(manualServerUpdateCommand("0.0.35", undefined)).toBe("npx t3@0.0.35");
   });
 
   it("dismisses only the current failed attempt without clearing its retry state", () => {

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -1,4 +1,9 @@
-import type { EnvironmentId, ServerConfig, ServerSelfUpdateCapability } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  ServerConfig,
+  ServerInstallKind,
+  ServerSelfUpdateCapability,
+} from "@t3tools/contracts";
 import type { ServerUpdateState } from "@t3tools/client-runtime/state/server";
 import { compareSemverVersions, parseSemver } from "@t3tools/shared/semver";
 import * as Schema from "effect/Schema";
@@ -114,9 +119,37 @@ export function supportsServerUpdateThreadContinuation(
   return serverConfig?.environment.capabilities.serverUpdateThreadContinuation === true;
 }
 
-/** The command to hand users whose server cannot update itself. */
-export function manualServerUpdateCommand(targetVersion: string): string {
-  return `npx t3@${targetVersion}`;
+/** How the connected server is installed, when it says. Older servers and
+    dev checkouts do not. */
+export function resolveServerInstall(
+  serverConfig: Pick<ServerConfig, "environment"> | null | undefined,
+): ServerInstallKind | undefined {
+  return serverConfig?.environment.capabilities.serverInstall;
+}
+
+/** The command to hand users whose server cannot update itself. A global
+    install is upgraded in place; a server started through a package runner
+    is relaunched at the target version. Servers that do not report their
+    install keep the npx relaunch. */
+export function manualServerUpdateCommand(
+  targetVersion: string,
+  install: ServerInstallKind | undefined,
+): string {
+  switch (install) {
+    case "npm-global":
+      return `npm i -g t3@${targetVersion}`;
+    case "pnpm-global":
+      return `pnpm add -g t3@${targetVersion}`;
+    case "bun-global":
+      return `bun add -g t3@${targetVersion}`;
+    case "pnpm-dlx":
+      return `pnpm dlx t3@${targetVersion}`;
+    case "bunx":
+      return `bunx t3@${targetVersion}`;
+    case "npx":
+    case undefined:
+      return `npx t3@${targetVersion}`;
+  }
 }
 
 export function serverUpdateGuidance(capability: ServerSelfUpdateCapability): string {

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -25,11 +25,11 @@ to allow recovery without a connected client.
 
 The offered action depends on how the server runs:
 
-| Action                     | What to do                                                                                                                                                                                      |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Update server**          | Keep the client open while it installs and reconnects. Supported background services update remotely. For a desktop-hosted server, this also closes and relaunches the desktop app on the host. |
-| **Update the desktop app** | Update the desktop app on the machine running the server, then reopen it if needed.                                                                                                             |
-| **Copy update command**    | Stop the command-line server on its host and relaunch with the copied command, keeping your usual startup options.                                                                              |
+| Action                     | What to do                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Update server**          | Keep the client open while it installs and reconnects. Supported background services update remotely. For a desktop-hosted server, this also closes and relaunches the desktop app on the host.                                                                                                                                             |
+| **Update the desktop app** | Update the desktop app on the machine running the server, then reopen it if needed.                                                                                                                                                                                                                                                         |
+| **Copy update command**    | Stop the command-line server on its host first, then run the copied command. It matches how that server was installed: a global npm, pnpm, or bun install is upgraded in place and started again as usual, while a server started through `npx`, `pnpm dlx`, or `bunx` is relaunched by the command itself with your usual startup options. |
 
 For a background service, run the matching version's CLI on the host:
 
@@ -42,7 +42,13 @@ Replace `<client-version>` with the version shown in the notice. Using
 service launcher may require this local update before it supports remote updates
 and rollback.
 
-For a foreground server, the copied command is `npx t3@<client-version>`. Add
+For a foreground server, the copied command matches how it was installed. A
+global install gets its package manager's upgrade command, such as
+`npm i -g t3@<client-version>`, `pnpm add -g t3@<client-version>`, or
+`bun add -g t3@<client-version>`: run it, then start the server again as usual.
+A server started through a package runner gets that runner again,
+`npx t3@<client-version>`, `pnpm dlx t3@<client-version>`, or
+`bunx t3@<client-version>`, which relaunches it at the matching version. Add
 `serve` if you normally run without a browser, and preserve options such as
 `--host` or `--tailscale-serve`. See
 [background services](./background-service.md) for service management.
@@ -54,7 +60,8 @@ update can roll back to the previous version. If the update still fails:
 
 1. Retry the offered action once.
 2. Check that you updated the server's machine, not only the device you are using.
-3. For a command-line server, stop it and relaunch the exact version shown in the notice.
+3. For a command-line server, stop it, run the copied update command, and make sure it is running
+   again on the exact version shown in the notice.
 
 ## Mobile updates
 

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -75,6 +75,19 @@ export const ServerSelfUpdateCapability = Schema.Literals([
 ]);
 export type ServerSelfUpdateCapability = typeof ServerSelfUpdateCapability.Type;
 
+/** How the server's CLI is installed, judged by where its entry script lives:
+    run out of a package runner's cache, or installed globally by npm, pnpm,
+    or bun. */
+export const ServerInstallKind = Schema.Literals([
+  "npx",
+  "pnpm-dlx",
+  "bunx",
+  "npm-global",
+  "pnpm-global",
+  "bun-global",
+]);
+export type ServerInstallKind = typeof ServerInstallKind.Type;
+
 export const ExecutionEnvironmentCapabilities = Schema.Struct({
   repositoryIdentity: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   connectionProbe: Schema.optionalKey(Schema.Boolean),
@@ -135,6 +148,13 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
       servers that must be relaunched manually (dev checkouts, Windows
       foreground runs, pre-update servers). */
   serverSelfUpdate: Schema.optionalKey(ServerSelfUpdateCapability),
+  /** How the server's CLI is installed, so the manual update command a
+      client hands out lands on the running install: package runners re-run
+      the pinned version, a global install is upgraded in place. Only sent
+      when serverSelfUpdate is absent. Older servers and dev checkouts leave
+      it out, and a kind this build does not know decodes as absent; either
+      way clients fall back to the npx relaunch. */
+  serverInstall: ForwardCompatibleOptional(ServerInstallKind),
   /** Server can stream self-update progress before acknowledging the
       restart. Clients fall back to server.updateServer when absent. */
   serverSelfUpdateProgress: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
## What Changed

`packages/contracts/src/environment.ts`: a new optional capability, `serverInstall`, says how the server's CLI is installed: run out of a package runner's cache (`npx`, `pnpm-dlx`, `bunx`) or installed globally by a package manager (`npm-global`, `pnpm-global`, `bun-global`). It is declared with `ForwardCompatibleOptional`, like `platform.machine`, so a kind an older client does not know decodes as absent instead of failing the descriptor.

`apps/server/src/cli/invocation.ts`: `detectServerInstall` builds on the existing `detectCliRunner` entry-path check and recognises global installs by each package manager's own layout: npm's `<prefix>/lib/node_modules/` (system node, nvm, fnm, volta, Homebrew) or `%APPDATA%/npm/node_modules/` on Windows, pnpm's `/pnpm/global/`, bun's `/.bun/install/global/`. Repo checkouts, project-local installs, and the pinned service runtime return `null`, since no global command would update the executable that gets restarted.

`apps/server/src/environment/ServerEnvironment.ts`: the descriptor carries `serverInstall` only when `serverSelfUpdate` is absent, since that is the only server whose clients hand out a command. The entry path is resolved first because a global install's bin is a symlink into the package.

`apps/web/src/versionSkew.ts`: `manualServerUpdateCommand` picks the command from it: `npm i -g` / `pnpm add -g` / `bun add -g t3@<version>` for a global install, `npx` / `pnpm dlx` / `bunx t3@<version>` for a package runner, and the unchanged `npx t3@<version>` when the server does not say (older servers, dev checkouts). `ServerUpdateAction` takes the install as a prop; its three call sites (chat banner, Connections row, Connections primary card) pass it.

`docs/user/updating.md`: the Copy update command description now matches.

Tests: `detectServerInstall` per layout, the descriptor advertising `serverInstall` only for a server that cannot update itself (through a real bin symlink), and the command per install kind.

## Why

Fixes #9370.

**Copy update command** always produced `npx t3@<version>`. For a server started with `npx` that relaunches it at the right version, but for a server installed with `npm i -g` it runs a throwaway copy out of the npx cache and never touches the installed CLI. The next `t3 start`, systemd unit, or shell alias comes back on the old version and the banner reappears, even though the user did exactly what the toast asked.

The server already knows how it was launched (`detectCliRunner` powers the `npx t3 serve` suggestions), so this reports that over the existing capabilities channel and lets the client format the command that will actually land. Nothing changes for servers that self-update, and older servers keep the current behaviour because the field is optional.

Model and harness: Claude Fable 5.1 in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show update command matching server install type instead of npx fallback
> - Adds `ServerInstallKind` and an optional `serverInstall` capability to [environment.ts](https://github.com/pingdotgg/t3code/pull/9489/files#diff-b65c7cdf3624689c7649437c1a0f4c45f1ce579724f52098249d43ccf0aa7203) so the server can report whether it runs via npx, pnpm dlx, bunx, or npm/pnpm/bun global.
> - [invocation.ts](https://github.com/pingdotgg/t3code/pull/9489/files#diff-f66315c334f5c48011ca39453770f9f79309c92830faf9f19f96bf162b7ae089) detects the install kind from the entry script path; [ServerEnvironment.ts](https://github.com/pingdotgg/t3code/pull/9489/files#diff-28d9690cbe59a84cd86ea9e149972794d5eec454e166270a91c12f5b656ecfd6) advertises `serverInstall` only for manually-updateable installs.
> - [versionSkew.ts](https://github.com/pingdotgg/t3code/pull/9489/files#diff-783a2e421405ef3af3e1f17f70b8b5d18abf1081be90640034de054f22e85caa) builds global upgrade commands for global installs, relaunch commands for package-runner installs, and keeps the npx fallback when no kind is reported.
> - Wires the install kind through [ServerUpdateAction.tsx](https://github.com/pingdotgg/t3code/pull/9489/files#diff-c763cea5fd019df67ff03a8c988bc9ea2af55b7f10b5fa6fe8557bd1f92471a3), [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/9489/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), and [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/9489/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9); updates [updating.md](https://github.com/pingdotgg/t3code/pull/9489/files#diff-346e6eee50c69757c87a85fb4c1982569f3a2ad9c76d019f9d3f5d8fb61e427a).
> - Risk: older or unrecognized servers omit `serverInstall`, so the web client falls back to the npx command — this is intentional but may not match the actual install.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 290522b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server update commands now match the server’s installation method, including npm, pnpm, Bun, npx, pnpm dlx, and bunx.
  * Global installations are updated in place and restarted, while package-runner installations are relaunched with the appropriate command.
  * Unknown installation methods continue to use the npx update command as a fallback.

* **Documentation**
  * Updated server update instructions to explain installation-specific commands and recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->