### PR TITLE
fix(web): dont collapse composer when interacting with bottom row

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -40,6 +40,7 @@ import {
 } from "./ui/menu";
 import { Separator } from "./ui/separator";
 import { ComposerSurface } from "./chat/ComposerSurface";
+import { composerFloatingLayerProps } from "./chat/composerEventScope";
 import { measureRestingComposerControls } from "./chat/restingComposerControlsMeasurement";
 import { resolveRestingComposerControlsNaturalWidth } from "./composerFooterLayout";
 import { cn } from "~/lib/utils";
@@ -160,7 +161,7 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
         {triggerContent}
         <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
       </MenuTrigger>
-      <MenuPopup align="start" side="top" className="w-64">
+      <MenuPopup align="start" side="top" className="w-64" {...composerFloatingLayerProps}>
         {showEnvironmentPicker && availableEnvironments && onEnvironmentChange ? (
           <>
             <MenuGroup>

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -34,6 +34,7 @@ import { vcsEnvironment } from "../state/vcs";
 import { cn } from "../lib/utils";
 import { parsePullRequestReference } from "../pullRequestReference";
 import { getSourceControlPresentation } from "../sourceControlPresentation";
+import { composerFloatingLayerProps } from "./chat/composerEventScope";
 import {
   deriveLocalBranchNameFromRemoteRef,
   resolveBranchTriggerLabel,
@@ -788,7 +789,12 @@ export function BranchToolbarBranchSelector({
           </ComboboxTrigger>
         </span>
       </div>
-      <ComboboxPopup align="end" side="top" className="flex w-80 flex-col">
+      <ComboboxPopup
+        align="end"
+        side="top"
+        className="flex w-80 flex-col"
+        {...composerFloatingLayerProps}
+      >
         <div className="shrink-0 px-3 pt-2.5">
           <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
             <SearchIcon

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -7,6 +7,7 @@ import {
   resolveLockedWorkspaceLabel,
   type EnvMode,
 } from "./BranchToolbar.logic";
+import { composerFloatingLayerProps } from "./chat/composerEventScope";
 import {
   Select,
   SelectGroup,
@@ -113,7 +114,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
           </span>
         </span>
       </SelectTrigger>
-      <SelectPopup>
+      <SelectPopup {...composerFloatingLayerProps}>
         <SelectGroup>
           <SelectGroupLabel>Workspace</SelectGroupLabel>
           <SelectItem value="local">

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo } from "react";
 
 import type { EnvironmentOption } from "./BranchToolbar.logic";
 import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
+import { composerFloatingLayerProps } from "./chat/composerEventScope";
 import {
   Select,
   SelectGroup,
@@ -101,7 +102,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
           </span>
         </span>
       </SelectTrigger>
-      <SelectPopup>
+      <SelectPopup {...composerFloatingLayerProps}>
         <SelectGroup>
           <SelectGroupLabel>Run on</SelectGroupLabel>
           {availableEnvironments.map((env) => (

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -4283,7 +4283,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       const composerSurface = composerSurfaceRef.current;
       const composerForm = composerFormRef.current;
       const activeElement = document.activeElement;
-      if (activeElement instanceof Element && isInsideComposerFloatingLayer(activeElement)) {
+      if (isInsideRestingComposerControlScope(activeElement)) {
         return;
       }
       if (
@@ -4303,8 +4303,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const isInsideDesktopComposerFocusScope = (target: EventTarget | null) =>
       Boolean(
         target instanceof Node &&
-        (composerFormRef.current?.contains(target) ||
-          (target instanceof Element && isInsideComposerFloatingLayer(target))),
+        (composerFormRef.current?.contains(target) || isInsideRestingComposerControlScope(target)),
       );
     const handleFocusIn = (event: FocusEvent) => {
       if (!isInsideDesktopComposerFocusScope(event.target)) {

--- a/apps/web/src/components/chat/composerEventScope.test.ts
+++ b/apps/web/src/components/chat/composerEventScope.test.ts
@@ -29,6 +29,13 @@ describe("composer event scopes", () => {
     expect(isInsideRestingComposerControlScope(target as unknown as EventTarget)).toBe(true);
   });
 
+  it("recognizes events from the composer context strip controls", () => {
+    vi.stubGlobal("Element", FakeElement);
+
+    const target = new FakeElement("[data-composer-context-control]");
+    expect(isInsideRestingComposerControlScope(target as unknown as EventTarget)).toBe(true);
+  });
+
   it("keeps resting image previews focused without expanding their subtree", () => {
     vi.stubGlobal("Element", FakeElement);
 

--- a/apps/web/src/components/chat/composerEventScope.ts
+++ b/apps/web/src/components/chat/composerEventScope.ts
@@ -26,6 +26,7 @@ export function isInsideRestingComposerControlScope(target: EventTarget | null):
     target instanceof Element &&
     (target.closest('[data-chat-composer-resting-controls="true"]') !== null ||
       target.closest('[data-chat-composer-resting-images="true"]') !== null ||
+      target.closest("[data-composer-context-control]") !== null ||
       isInsideComposerFloatingLayer(target))
   );
 }


### PR DESCRIPTION
## What Changed

Keep the composer open while interacting with branch and environment controls in the bottom row, including their portaled popups.

## Why

Those controls render outside the composer DOM and were treated as outside interactions, so the composer collapsed during the interaction. The controls and their floating layers now participate in the composer event scope, with a focused regression test.

## UI Changes

Before:

https://github.com/user-attachments/assets/c2409e9f-9552-47ae-88bf-b59fb50fd8ab

After:

https://github.com/user-attachments/assets/e1cc28c3-180c-4e96-905a-550b5c9dafd1

## Tests

- `vp test run src/components/chat/composerEventScope.test.ts src/components/composerFooterLayout.test.ts src/components/BranchToolbar.logic.test.ts --project unit` (101 passed)
- `vp run --filter @t3tools/web typecheck`

Model: 5.6
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused composer focus/blur UX change in the web app with a targeted regression test; no auth, data, or API impact.
> 
> **Overview**
> Fixes the chat composer collapsing while users interact with **branch, environment, and workspace** controls on the bottom context strip, including their **portaled** menus and dropdowns.
> 
> Those controls sit outside the composer DOM, so blur/focus handling treated them as outside clicks. **`isInsideRestingComposerControlScope`** now treats `[data-composer-context-control]` as in-scope, and branch toolbar **Select/Menu/Combobox** popups spread **`composerFloatingLayerProps`** so portaled layers count too. **`ChatComposer`** uses the unified scope helper instead of only **`isInsideComposerFloatingLayer`**. A unit test covers context-strip controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a81045f09aec5ded2ba8e5500ac00f441ffc18c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer closing on focus of bottom-row `BranchToolbar` controls
> - Marks the run-context, branch-reference, environment-mode, and environment-select popups in `BranchToolbar` as composer-owned floating layers by passing shared composer floating-layer props to each popup.
> - Updates `ChatComposer` desktop blur cleanup and focus-in containment checks to use the broader resting composer control scope instead of checking only for composer-owned floating layers.
> - Extends `composerEventScope.isInsideRestingComposerControlScope` to recognize composer context-control elements, so focus stays in the composer when interacting with context-strip controls, resting images, or floating layers.
> - Adds a unit test verifying that composer context-control elements belong to the resting composer control scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a81045f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->