### PR TITLE
fix(web): pull request panel polls go around the server's hold

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -707,22 +707,27 @@ export function PullRequestDetailPanel({
       state: resolvedCoreDetail.state,
     });
   }, [onStateChange, resolvedCoreDetail]);
+  // Both reads below go around the server's cache rather than through it. An ordinary read is
+  // answered from what the server already holds while it refreshes behind the answer, which is
+  // right for a reopen and wrong for a poll: the point of a poll is what that refresh brings back,
+  // and nothing pushes it to a panel already told the old answer, so a poll served from the hold
+  // shows the previous poll's data for good. The invalidation goes first so the re-reads miss
+  // that cache; if it fails, the reads still run and at worst answer from it.
+  const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
   // Core detail is cheap enough to re-read while this stays open. Activity is heavier, so the
   // revision effect above reads it only after this same pull request reports a change. Keyed by
   // the pull request rather than by the panel, because this one panel shows a different pull
   // request every time it is opened.
-  useLiveRefresh(
-    () => {
-      detailQuery.refresh();
-      setRefreshToken((token) => token + 1);
-    },
-    { key: `pull-request:${reference.projectId}:${reference.repository}#${reference.number}` },
-  );
-  // The button, on the other hand, goes around the server's cache rather than through it: it is
-  // the answer for a reader who can see that what they are looking at is behind. The
-  // invalidation goes first so the re-reads miss that cache; if it fails, the reads still run
-  // and at worst answer from it.
-  const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
+  const refreshDetailFromHost = useCallback(async () => {
+    await invalidate({ environmentId, input: { reference } });
+    detailQuery.refresh();
+    setRefreshToken((token) => token + 1);
+  }, [detailQuery.refresh, environmentId, invalidate, reference]);
+  useLiveRefresh(() => void refreshDetailFromHost(), {
+    key: `pull-request:${reference.projectId}:${reference.repository}#${reference.number}`,
+  });
+  // The button is the answer for a reader who can see that what they are looking at is behind,
+  // so it reads everything: the detail, the activity, and through the refresh token, the diff.
   const refreshFromHost = useCallback(async () => {
     await invalidate({ environmentId, input: { reference } });
     refreshDetail();


### PR DESCRIPTION
## What Changed

`apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx`: the panel's automatic refresh (the five-minute interval, and the read on returning to the window) now invalidates the pull request on the server before re-reading its detail, the same way the **Refresh** menu action already does. The invalidation is scoped to that one pull request (`bumpRefEpoch`), so no listing, viewer, or other pull request is dropped with it. The poll still bumps the diff token that #9496 added, so the code tab re-reads with it.

Rebased on `main` over #9496, which restructured this block. #9496 refreshes when an agent turn ends; this is the other case #8640 describes: a change arriving from outside a turn (a push from another machine, a check finishing) while the panel sits open, which still reads through the hold.

## Why

Fixes #8640.

The server answers an ordinary detail read from what it already holds and refreshes behind the answer (`lastGoodDetail.serveHeld(..., "revalidate")`). That suits reopening a panel, but a poll exists for what the refresh brings back, and nothing pushes that value to a panel already told the old one. So each automatic read showed the previous read's data, and because polling stops after six idle minutes, a person passively watching CI after a push never got a second read: the panel stayed on the old title or check state until they pressed Refresh. That matches the reporter's reproduction, where the automatic request receives the changed detail and the heading keeps the original title.

The cache comment in `PullRequestService` states the rule: reads that must not be answered from the hold go through `invalidate` rather than a flag on the read. The panel's poll is such a read, so it now takes that path. The cost is what the interval already intends to spend, one host read per open panel per tick, and the ten-second minimum interval still bounds the arrival reads.

## Verification

Web typecheck and lint on the file. The change is wiring on top of the existing manual-refresh path, so it adds no test of its own.

Then the reporter's reproduction, on today's `main` and on this branch, in an isolated dev server whose `gh` is wrapped by a shim that delegates to the real CLI and rewrites `title` in `gh pr view --json` answers. The poll is fired by the panel's own live-refresh handler (the return-to-window read); the shim log shows what the host answered, the DOM shows what the panel kept.

| panel file | host title changed | poll reaches host | host answers | panel heading after the poll |
|---|---|---|---|---|
| `main` | 10:47:12 | 10:53:09 | new title, 10:53:12 | **old title** at 10:53:16 |
| `main`, again from a manual Refresh | 10:57:57 | 10:58:38 | new title, 10:58:39 | **previous title** at 10:58:45 |
| this branch | 10:55:06 | 10:55:25 | new title, 10:55:27 | **new title** at 10:55:31 |

The two `main` rows are the issue's log line for line: the automatic request reaches the host and gets the changed detail, the heading keeps the earlier one. The branch row is the same poll answering with what the host just said.

Model and harness: Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side wiring change to refresh semantics for one panel; invalidation is scoped to a single PR reference and reuses the existing manual-refresh command.
> 
> **Overview**
> **Automatic pull request panel refresh** (interval + return-to-window via `useLiveRefresh`) now **invalidates that PR on the server** before re-fetching detail, matching the manual **Refresh** path instead of calling `detailQuery.refresh()` alone.
> 
> Ordinary detail reads can be answered from the server’s held snapshot while a background refresh runs, which left passive viewers stuck on stale titles/checks until they hit Refresh. Polls are wired through a new `refreshDetailFromHost` callback (`invalidate` then detail refresh); the menu refresh still invalidates and refreshes detail, activity, and diff via the existing token path. Comments were updated to document poll vs manual behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf9cf649ab9ea95245f3899b64d0e07755db4a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `PullRequestDetailPanel` polling to invalidate cached PR data before refresh
> The live-refresh (polling) callback in [PullRequestDetailPanel.tsx](https://github.com/pingdotgg/t3code/pull/9491/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a) now invalidates the pull-request data for the current environment and reference before re-fetching the detail query. Previously, polling read the existing cached response directly, which kept it stuck on the server's held data. The manual refresh path was already doing this and is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cf9cf6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
