### PR TITLE
fix(web): keep opencode icon hollow in collapsed composer

### DIFF
--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -653,9 +653,19 @@ export const AntigravityIcon: Icon = (props) => (
 export const OpenCodeIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g clipPath="url(#opencode__clip0_1311_94969)">
-      <path data-opencode-hole="true" className="dark:hidden" d="M24 32H8V16H24V32Z" fill="#CFCECD" />
+      <path
+        data-opencode-hole="true"
+        className="dark:hidden"
+        d="M24 32H8V16H24V32Z"
+        fill="#CFCECD"
+      />
       <path className="dark:hidden" d="M24 8H8V32H24V8ZM32 40H0V0H32V40Z" fill="#211E1E" />
-      <path data-opencode-hole="true" className="hidden dark:block" d="M24 32H8V16H24V32Z" fill="#4B4646" />
+      <path
+        data-opencode-hole="true"
+        className="hidden dark:block"
+        d="M24 32H8V16H24V32Z"
+        fill="#4B4646"
+      />
       <path className="hidden dark:block" d="M24 8H8V32H24V8ZM32 40H0V0H32V40Z" fill="#F1ECEC" />
     </g>
     <defs>

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -653,9 +653,9 @@ export const AntigravityIcon: Icon = (props) => (
 export const OpenCodeIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g clipPath="url(#opencode__clip0_1311_94969)">
-      <path className="dark:hidden" d="M24 32H8V16H24V32Z" fill="#CFCECD" />
+      <path data-opencode-hole="true" className="dark:hidden" d="M24 32H8V16H24V32Z" fill="#CFCECD" />
       <path className="dark:hidden" d="M24 8H8V32H24V8ZM32 40H0V0H32V40Z" fill="#211E1E" />
-      <path className="hidden dark:block" d="M24 32H8V16H24V32Z" fill="#4B4646" />
+      <path data-opencode-hole="true" className="hidden dark:block" d="M24 32H8V16H24V32Z" fill="#4B4646" />
       <path className="hidden dark:block" d="M24 8H8V32H24V8ZM32 40H0V0H32V40Z" fill="#F1ECEC" />
     </g>
     <defs>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3808,7 +3808,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               activeProviderIconClassName: cn(
                 composerProviderState.modelPickerIconClassName,
                 composerControlsInStrip &&
-                  "fill-muted-foreground/70! text-muted-foreground/70! [&_path]:fill-muted-foreground/70! [&_rect]:fill-muted-foreground/70!",
+                  "fill-muted-foreground/70! text-muted-foreground/70! [&_path]:fill-muted-foreground/70! [&_rect]:fill-muted-foreground/70! [&_[data-opencode-hole]]:fill-transparent!",
               ),
             }
           : {})}


### PR DESCRIPTION
Collapsed composer tints the provider icon to muted-foreground by forcing every svg path to that color. The OpenCode glyph paints its middle as a second solid path, so the tint stacked two translucent layers and filled the hole with a darker blob. The inner paths are now tagged data-opencode-hole and the collapsed tint keeps them transparent, so the ring keeps the preferred color while the middle stays hollow.

Before (middle filled, darker overlap visible at 16px real size and zoomed, dark and light):
![collapsed opencode icon before fix, middle filled in](https://uploads-production-47e4.up.railway.app/files/ffb785cb-f5c9-4812-9d94-39af853073f0/before.png)

After (same muted ring, hollow middle showing the strip through):
![collapsed opencode icon after fix, hollow middle](https://uploads-production-47e4.up.railway.app/files/d1c5a36c-7b85-4989-b13c-105b5ad7ef65/after.png)

Verified with headless-chrome renders of the exact svg paths and tint values at real size plus zoomed views. Full typecheck, lint, and tests run in CI.

Built with opencode + muse-spark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/icon styling change with no auth, data, or API impact.
> 
> **Overview**
> Fixes the **OpenCode** provider glyph looking filled in the collapsed composer strip when the model picker tints all SVG paths to muted foreground.
> 
> The inner “hole” paths in `OpenCodeIcon` are tagged with `data-opencode-hole`, and the compact strip’s `activeProviderIconClassName` now forces those paths to **transparent fill** so they are not double-tinted over the outer ring. The ring keeps the muted color; the center stays hollow and shows the strip behind it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 771f7c623fbc0c7dd9d0d2c0bf5aa203694c7865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OpenCodeIcon` losing hollow fill in collapsed composer
> - Adds a `data-opencode-hole` marker to the inner paths of the `OpenCodeIcon` in [Icons.tsx](https://github.com/pingdotgg/t3code/pull/9492/files#diff-d19962a9c1cb0bc3363e0d837062d1bd60923e4ea67f675a9f9fc3ec7f7e3442)
> - Updates [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/9492/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to target that marker and set its fill to transparent, preventing the composer strip from incorrectly filling the icon's hole
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 771f7c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->