### PR TITLE
fix(shared): resolve multi-account SSH alias hosts to the real provider host

### DIFF
--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -36,6 +36,7 @@ import {
   detectSourceControlProviderFromGitRemoteUrl,
   mergeGitStatusParts,
   normalizeGitRemoteUrl,
+  parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
   resolveAutoFeatureBranchName,
   sanitizeBranchFragment,
   sanitizeFeatureBranchName,
@@ -233,20 +234,6 @@ function resolvePullRequestWorktreeLocalBranchName(
   const sanitizedHeadBranch = sanitizeBranchFragment(pullRequest.headBranch).trim();
   const suffix = sanitizedHeadBranch.length > 0 ? sanitizedHeadBranch : "head";
   return `t3code/pr-${pullRequest.number}/${suffix}`;
-}
-
-function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string | null {
-  const trimmed = url?.trim() ?? "";
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
-      trimmed,
-    );
-  const repositoryNameWithOwner = match?.[1]?.trim() ?? "";
-  return repositoryNameWithOwner.length > 0 ? repositoryNameWithOwner : null;
 }
 
 function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null {

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -172,3 +172,35 @@ describe("applyGitStatusStreamEvent", () => {
     });
   });
 });
+
+describe("SSH host aliases", () => {
+  it("canonicalizes multi-account SSH alias hosts to the real provider host", () => {
+    expect(normalizeGitRemoteUrl("git@github.com-work:T3Tools/T3Code.git")).toBe(
+      "github.com/t3tools/t3code",
+    );
+    expect(normalizeGitRemoteUrl("ssh://git@github.com-work/T3Tools/T3Code.git")).toBe(
+      "github.com/t3tools/t3code",
+    );
+    expect(normalizeGitRemoteUrl("git@gitlab.com-personal:group/project.git")).toBe(
+      "gitlab.com/group/project",
+    );
+  });
+
+  it("leaves non-SSH remotes and unrelated hosts alone", () => {
+    expect(normalizeGitRemoteUrl("https://github.com-work/T3Tools/T3Code.git")).toBe(
+      "github.com-work/t3tools/t3code",
+    );
+    expect(normalizeGitRemoteUrl("git@github.company.com:T3Tools/T3Code.git")).toBe(
+      "github.company.com/t3tools/t3code",
+    );
+  });
+
+  it("parses owner and repo through a GitHub SSH alias", () => {
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("git@github.com-work:owner/repo.git"),
+    ).toBe("owner/repo");
+    expect(
+      parseGitHubRepositoryNameWithOwnerFromRemoteUrl("ssh://git@github.com-work/owner/repo"),
+    ).toBe("owner/repo");
+  });
+});

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -8,7 +8,10 @@ import type {
 } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
-import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
+import {
+  canonicalizeSshRemoteHostname,
+  detectSourceControlProviderFromRemoteUrl,
+} from "./sourceControl.ts";
 
 export const WORKTREE_BRANCH_PREFIX = "t3code";
 // Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
@@ -126,7 +129,9 @@ export function normalizeGitRemoteUrl(value: string): string {
         .filter((segment) => segment.length > 0)
         .join("/");
       if (url.hostname && repositoryPath.includes("/")) {
-        return `${url.hostname}/${repositoryPath}`;
+        const hostname =
+          url.protocol === "ssh:" ? canonicalizeSshRemoteHostname(url.hostname) : url.hostname;
+        return `${hostname}/${repositoryPath}`;
       }
     } catch {
       return normalized;
@@ -137,7 +142,7 @@ export function normalizeGitRemoteUrl(value: string): string {
     normalized,
   );
   if (scpStyleHostAndPath?.[1] && scpStyleHostAndPath[2]) {
-    return `${scpStyleHostAndPath[1]}/${scpStyleHostAndPath[2]}`;
+    return `${canonicalizeSshRemoteHostname(scpStyleHostAndPath[1])}/${scpStyleHostAndPath[2]}`;
   }
 
   return normalized;
@@ -152,8 +157,9 @@ export function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | nu
     return null;
   }
 
+  // SSH shapes tolerate a multi-account alias suffix such as `github.com-work`.
   const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
+    /^(?:git@github\.com(?:-[^./:\s]+)?:|ssh:\/\/git@github\.com(?:-[^./\s]+)?\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
       trimmed,
     );
   const repositoryNameWithOwner = match?.[1]?.trim() ?? "";

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -160,3 +160,30 @@ describe("isSshRemoteUrl", () => {
     expect(isSshRemoteUrl("deploy@github.com/project/repo")).toBe(false);
   });
 });
+
+describe("SSH host aliases", () => {
+  it("resolves multi-account SSH alias hosts to the real provider", () => {
+    expect(detectSourceControlProviderFromRemoteUrl("git@github.com-work:owner/repo.git")).toEqual({
+      kind: "github",
+      name: "GitHub",
+      baseUrl: "https://github.com",
+    });
+    expect(
+      detectSourceControlProviderFromRemoteUrl("ssh://git@gitlab.com-personal/group/repo.git"),
+    ).toEqual({
+      kind: "gitlab",
+      name: "GitLab",
+      baseUrl: "https://gitlab.com",
+    });
+  });
+
+  it("keeps literal hosts for non-SSH remotes that merely resemble aliases", () => {
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://github.com-work/owner/repo.git"),
+    ).toEqual({
+      kind: "github",
+      name: "GitHub Self-Hosted",
+      baseUrl: "https://github.com-work",
+    });
+  });
+});

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -170,6 +170,15 @@ function toBaseUrl(host: string): string {
   return `https://${host}`;
 }
 
+// Multi-account ~/.ssh/config setups follow the documented convention of
+// suffixing the real host in the alias, e.g. `Host github.com-work`. The alias
+// only exists for SSH, so HTTPS remotes keep their literal host.
+const SSH_ALIAS_HOSTNAME_PATTERN = /^(github\.com|gitlab\.com|bitbucket\.org)-[^./]+$/;
+
+export function canonicalizeSshRemoteHostname(hostname: string): string {
+  return SSH_ALIAS_HOSTNAME_PATTERN.exec(hostname)?.[1] ?? hostname;
+}
+
 function hasDnsLabel(host: string, label: string): boolean {
   return host.split(".").includes(label);
 }
@@ -201,11 +210,17 @@ function isBitbucketHost(host: string): boolean {
 export function detectSourceControlProviderFromRemoteUrl(
   remoteUrl: string,
 ): SourceControlProviderInfo | null {
-  const host = parseRemoteHost(remoteUrl);
-  if (!host) {
+  const parsedHost = parseRemoteHost(remoteUrl);
+  if (!parsedHost) {
     return null;
   }
-  const hostname = parseHostName(host);
+  const parsedHostname = parseHostName(parsedHost);
+  const hostname = isSshRemoteUrl(remoteUrl)
+    ? canonicalizeSshRemoteHostname(parsedHostname)
+    : parsedHostname;
+  // Stripping the alias suffix drops any port, but SSH ports never belong in
+  // the https base URL anyway; unaliased hosts keep their port as before.
+  const host = hostname === parsedHostname ? parsedHost : hostname;
 
   if (isGitHubHost(hostname)) {
     return {


### PR DESCRIPTION
A remote like `git@github.com-work:org/repo.git`, the documented `~/.ssh/config` convention for multiple GitHub accounts on one machine, leaks the alias into everything derived from the remote: the provider base URL becomes `https://github.com-work` (the invalid domain from the issue), the normalized identity key keeps the alias so PR URLs never match the project, and the GitHub `owner/repo` parser returns null.

SSH remotes now canonicalize an aliased `github.com`, `gitlab.com`, or `bitbucket.org` host back to the real one before deriving the base URL, the identity key, and `owner/repo`. HTTPS remotes keep their literal host, since only SSH goes through `~/.ssh/config` aliasing. GitManager's private copy of the owner/repo parser was byte-identical to the shared one, so it now imports it instead.

Covered by tests for all three derivations; each fails without the fix.

Fixes #9458.

Implemented with Claude Code (Claude Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow URL-parsing fix with tests; affects remote identity and PR association for SSH aliases but does not change auth or git execution.
> 
> **Overview**
> Fixes broken provider detection, normalized remote identity keys, and GitHub `owner/repo` parsing when remotes use common `~/.ssh/config` SSH host aliases (e.g. `git@github.com-work:org/repo.git`).
> 
> **Shared layer:** Adds `canonicalizeSshRemoteHostname` for `github.com`, `gitlab.com`, and `bitbucket.org` alias suffixes, applied only for SSH remotes in provider detection and in `normalizeGitRemoteUrl` (URL and SCP forms). Extends the GitHub owner/repo parser regex for aliased SSH hosts. HTTPS remotes still use the literal hostname (e.g. self-hosted `github.com-work`).
> 
> **Server:** `GitManager` drops its duplicate GitHub parser and imports `parseGitHubRepositoryNameWithOwnerFromRemoteUrl` from shared so behavior stays in sync.
> 
> New unit tests cover alias canonicalization, non-SSH hosts left unchanged, and parsing through aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f21017c647992af7829f0de04731211f17be569. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve multi-account SSH alias hosts to canonical provider host in shared git utils
> - Adds `canonicalizeSshRemoteHostname` in [sourceControl.ts](https://github.com/pingdotgg/t3code/pull/9497/files#diff-cb400671e313566c053c016f281d8ebad90db5adcec2fee1dea13d296d8b789d) to map recognized SSH aliases for GitHub, GitLab, and Bitbucket to their canonical public hostnames; other hostnames pass through unchanged.
> - Updates `detectSourceControlProviderFromRemoteUrl` and `normalizeGitRemoteUrl` in [git.ts](https://github.com/pingdotgg/t3code/pull/9497/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) to canonicalize the hostname only for SSH remotes, so HTTPS hosts that resemble aliases stay literal.
> - Expands `parseGitHubRepositoryNameWithOwnerFromRemoteUrl` to accept SSH host alias suffixes for both SCP-style and SSH-URL remotes; HTTPS and git-protocol forms still require the canonical GitHub host.
> - Replaces the local GitHub remote parser in [GitManager.ts](https://github.com/pingdotgg/t3code/pull/9497/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337) with the shared shared git utility.
> - Risk: `canonicalizeSshRemoteHostname` only recognizes a fixed set of alias hosts; SSH remotes using custom or future alias schemes will not be canonicalized and may be misclassified as self-hosted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f21017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->