### PR TITLE
fix(web): keep the composer open while selecting timeline text

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -206,6 +206,7 @@ import {
   resetComposerScrollGesture,
   suppressActiveComposerScrollGesture,
 } from "./composerScrollGesture";
+import { selectionHoldsComposerOpen } from "./composerSelectionHold";
 import { prepareVideoFirstFrame } from "../../lib/videoFirstFrame";
 
 function ComposerVideoThumbnail({ file }: { file: File }) {
@@ -4293,9 +4294,42 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       ) {
         return;
       }
+      if (
+        !isMobileViewport &&
+        selectionHoldsComposerOpen(window.getSelection(), getTimelineScrollableNode())
+      ) {
+        // The check runs again once the selection clears.
+        return;
+      }
       setIsComposerFocused(false);
     });
-  }, [isMobileViewport]);
+  }, [getTimelineScrollableNode, isMobileViewport]);
+
+  // A held collapse settles when the selection goes away, whether the user
+  // clicked elsewhere, pressed Escape, or used the selection toolbar.
+  useEffect(() => {
+    if (isMobileViewport || !isComposerFocused) return;
+    let wasHolding = false;
+    const handleSelectionChange = () => {
+      const holding = selectionHoldsComposerOpen(
+        window.getSelection(),
+        getTimelineScrollableNode(),
+      );
+      if (wasHolding && !holding) {
+        scheduleComposerCollapseCheck();
+      }
+      wasHolding = holding;
+    };
+    document.addEventListener("selectionchange", handleSelectionChange);
+    return () => {
+      document.removeEventListener("selectionchange", handleSelectionChange);
+    };
+  }, [
+    getTimelineScrollableNode,
+    isComposerFocused,
+    isMobileViewport,
+    scheduleComposerCollapseCheck,
+  ]);
 
   useEffect(() => {
     if (isMobileViewport || !isComposerFocused) return;

--- a/apps/web/src/components/chat/composerSelectionHold.test.ts
+++ b/apps/web/src/components/chat/composerSelectionHold.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { selectionHoldsComposerOpen } from "./composerSelectionHold";
+
+function node(parent: Node | null = null) {
+  const self = {
+    parent,
+    contains(other: Node | null): boolean {
+      let cursor: { parent: Node | null } | null = other as unknown as { parent: Node | null };
+      while (cursor) {
+        if (cursor === (self as unknown)) return true;
+        cursor = cursor.parent as { parent: Node | null } | null;
+      }
+      return false;
+    },
+  };
+  return self as unknown as Node;
+}
+
+function selection(anchor: Node, collapsed = false) {
+  return {
+    isCollapsed: collapsed,
+    rangeCount: 1,
+    getRangeAt: () => ({ commonAncestorContainer: anchor }) as Range,
+  };
+}
+
+describe("selectionHoldsComposerOpen", () => {
+  const timeline = node();
+  const message = node(timeline);
+  const elsewhere = node();
+
+  it("holds for a range inside the timeline", () => {
+    expect(selectionHoldsComposerOpen(selection(message), timeline)).toBe(true);
+  });
+
+  it("ignores a caret with nothing selected", () => {
+    expect(selectionHoldsComposerOpen(selection(message, true), timeline)).toBe(false);
+  });
+
+  it("ignores selections outside the timeline", () => {
+    expect(selectionHoldsComposerOpen(selection(elsewhere), timeline)).toBe(false);
+  });
+
+  it("ignores an empty or missing selection", () => {
+    expect(selectionHoldsComposerOpen(null, timeline)).toBe(false);
+    expect(
+      selectionHoldsComposerOpen(
+        { isCollapsed: false, rangeCount: 0, getRangeAt: () => ({}) as Range },
+        timeline,
+      ),
+    ).toBe(false);
+    expect(selectionHoldsComposerOpen(selection(message), null)).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/composerSelectionHold.ts
+++ b/apps/web/src/components/chat/composerSelectionHold.ts
@@ -1,0 +1,15 @@
+/**
+ * Whether a live text selection inside the timeline should hold the composer
+ * open. A drag-select in the conversation blurs the composer, and letting it
+ * rest mid-gesture reflows the timeline, which dismisses the selection
+ * toolbar the user was about to use.
+ */
+export function selectionHoldsComposerOpen(
+  selection: Pick<Selection, "isCollapsed" | "rangeCount" | "getRangeAt"> | null,
+  timeline: Node | null,
+): boolean {
+  if (!timeline || !selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return false;
+  }
+  return timeline.contains(selection.getRangeAt(0).commonAncestorContainer);
+}


### PR DESCRIPTION
Raised on [#7855](https://github.com/pingdotgg/t3code/pull/7855) with a video: drag-selecting an assistant response while the composer is expanded makes the **Cite** button flash and vanish. The selection blurs the composer, the composer rests, the timeline reflows under it, and the selection toolbar dismisses on that scroll.

The blur check now holds while a non-collapsed selection lives inside the timeline, and a `selectionchange` listener re-runs it once the selection clears (click elsewhere, Escape, or using Cite). The rest still happens; it just waits until the user is done with the text. Desktop only; the phone collapse is focus-driven and unaffected.

Stacked on [#9498](https://github.com/pingdotgg/t3code/pull/9498) (paste-to-focus); this layer's diff is independent of it.

## Before

Drag-select with the composer expanded: composer rests (84px), no Cite button.

![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/778c1370ad8176c5/before-select.png)

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4239771dd51fcfde/before-select.mp4

## After

Composer stays expanded through the selection, Cite is usable, and the citation lands in the draft. Once the selection clears the composer rests as before.

| Selection held | Cite used |
| --- | --- |
| ![after select](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ecbd00206908a364/after-select.png) | ![after cite](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bf0cb35063d155b3/after-cite.png) |

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4a53b1968522ead9/after-select.mp4

## Verification

- `vp test run` on the new `composerSelectionHold.test.ts` (4 passing).
- `tsgo --noEmit` in web, lint clean on the touched files.
- Manual pass in the web app: held at 178px with Cite visible → clear selection → rests at 84px.

Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `ChatComposer` open while selecting timeline text on desktop
> - Adds `selectionHoldsComposerOpen` predicate that returns true only for a non-collapsed selection whose range ancestor is inside the timeline node
> - Updates the desktop blur/collapse check in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/9499/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to skip clearing focus while a timeline selection is active, and adds a `selectionchange` listener that schedules a collapse check when the selection ends
> - Adds unit tests in [composerSelectionHold.test.ts](https://github.com/pingdotgg/t3code/pull/9499/files#diff-f2dbf1792408eadeb3921dcb9e1cfa549b69a47c9d03ca6d51f306fc754ae5ea) covering active, collapsed, external, empty, and missing-node cases
> - Behavioral Change: mobile is excluded from both new paths; desktop composer will no longer auto-collapse during an active timeline selection
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4557997.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->