### PR TITLE
fix(server): open stable Zed when a prerelease Zed is first on PATH

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -159,6 +159,52 @@ it.effect("launches an installed editor with platform-safe arguments", () =>
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
+it.effect("launches stable Zed when a nightly install comes first on PATH", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-zed-" });
+    const nightlyDir = path.join(root, "Zed Nightly", "bin");
+    const stableDir = path.join(root, "Zed", "bin");
+    yield* fileSystem.makeDirectory(nightlyDir, { recursive: true });
+    yield* fileSystem.makeDirectory(stableDir, { recursive: true });
+    yield* fileSystem.writeFileString(path.join(nightlyDir, "zed.EXE"), "");
+    yield* fileSystem.writeFileString(path.join(stableDir, "zed.EXE"), "");
+    const env = { PATH: `${nightlyDir};${stableDir}`, PATHEXT: ".COM;.EXE;.BAT;.CMD" };
+
+    const launchZed = Effect.gen(function* () {
+      let spawned: ChildProcess.StandardCommand | undefined;
+      yield* Effect.gen(function* () {
+        const launcher = yield* ExternalLauncher.ExternalLauncher;
+        yield* launcher.launchEditor({ editor: "zed", cwd: "C:\\workspace" });
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            platform: "win32",
+            env,
+            onSpawn: (command) => {
+              spawned = command;
+            },
+          }),
+        ),
+      );
+      assert.ok(spawned);
+      return spawned;
+    });
+
+    const preferred = yield* launchZed;
+    assert.equal(preferred.command, path.join(stableDir, "zed.EXE"));
+    assert.deepEqual(preferred.args, ["C:\\workspace"]);
+    assert.equal(preferred.options.shell, false);
+
+    // With only a nightly install left, PATH order is already right and the
+    // bare command is kept.
+    yield* fileSystem.remove(path.join(stableDir, "zed.EXE"));
+    const fallback = yield* launchZed;
+    assert.equal(fallback.command, "zed");
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 it.effect.skipIf(windowsHost)("reveals a file in Finder with open -R on macOS", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -205,6 +205,25 @@ it.effect("launches stable Zed when a nightly install comes first on PATH", () =
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
+it("recognizes prerelease Zed installs by their own folder name only", () => {
+  for (const prerelease of [
+    "C:\\Users\\me\\AppData\\Local\\Programs\\Zed Preview\\bin\\zed.exe",
+    "C:\\Users\\me\\AppData\\Local\\Programs\\Zed Nightly\\bin\\zed.exe",
+    "/Applications/Zed Nightly.app/Contents/MacOS/cli",
+    "/home/me/.local/zed-preview.app/bin/zed",
+  ]) {
+    assert.equal(ExternalLauncher.isPrereleaseZedPath(prerelease), true, prerelease);
+  }
+  for (const stable of [
+    "C:\\Users\\preview-user\\AppData\\Local\\Programs\\Zed\\bin\\zed.exe",
+    "C:\\nightly-builds\\Zed\\bin\\zed.exe",
+    "/Applications/Zed.app/Contents/MacOS/cli",
+    "/home/me/.local/zed.app/bin/zed",
+  ]) {
+    assert.equal(ExternalLauncher.isPrereleaseZedPath(stable), false, stable);
+  }
+});
+
 it.effect.skipIf(windowsHost)("reveals a file in Finder with open -R on macOS", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -183,9 +183,18 @@ const resolveAvailableCommand = Effect.fn("externalLauncher.resolveAvailableComm
 // PATH order alone can open a prerelease build when the user picked "Zed".
 // Prefer the first install whose location does not name a prerelease channel
 // and, when that is not the first on PATH, launch it by absolute path.
-function isPrereleaseZedPath(filePath: string): boolean {
-  const normalized = filePath.toLowerCase();
-  return normalized.includes("nightly") || normalized.includes("preview");
+// A prerelease install is recognized by a single path component that names
+// both Zed and the channel (`Zed Preview`, `Zed Nightly.app`,
+// `zed-nightly.app`), so a user or folder called "preview" elsewhere in the
+// path does not count.
+export function isPrereleaseZedPath(filePath: string): boolean {
+  return filePath.split(/[\\/]/).some((component) => {
+    const normalized = component.toLowerCase();
+    return (
+      normalized.includes("zed") &&
+      (normalized.includes("nightly") || normalized.includes("preview"))
+    );
+  });
 }
 
 const resolveZedCommand = Effect.fn("externalLauncher.resolveZedCommand")(function* (

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -19,7 +19,11 @@ import {
   type LaunchEditorInput,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
-import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
+import {
+  isCommandAvailable,
+  resolveCommandPaths,
+  resolveSpawnCommand,
+} from "@t3tools/shared/shell";
 import * as Clock from "effect/Clock";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
@@ -173,6 +177,31 @@ const resolveAvailableCommand = Effect.fn("externalLauncher.resolveAvailableComm
     }
   }
   return Option.none();
+});
+
+// Zed's stable, preview, and nightly channels each install a `zed` CLI, so
+// PATH order alone can open a prerelease build when the user picked "Zed".
+// Prefer the first install whose location does not name a prerelease channel
+// and, when that is not the first on PATH, launch it by absolute path.
+function isPrereleaseZedPath(filePath: string): boolean {
+  const normalized = filePath.toLowerCase();
+  return normalized.includes("nightly") || normalized.includes("preview");
+}
+
+const resolveZedCommand = Effect.fn("externalLauncher.resolveZedCommand")(function* (
+  commands: ReadonlyArray<string>,
+  env: NodeJS.ProcessEnv,
+): Effect.fn.Return<Option.Option<string>, never, FileSystem.FileSystem | Path.Path> {
+  const installs: Array<{ readonly command: string; readonly path: string }> = [];
+  for (const command of commands) {
+    for (const resolvedPath of yield* resolveCommandPaths(command, { env })) {
+      installs.push({ command, path: resolvedPath });
+    }
+  }
+  const first = installs[0];
+  if (!first) return Option.none();
+  const preferred = installs.find((install) => !isPrereleaseZedPath(install.path)) ?? first;
+  return Option.some(preferred === first ? first.command : preferred.path);
 });
 
 function encodeUtf16LeBase64(input: string): string {
@@ -540,7 +569,9 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
 
   if (editorDef.commands) {
     const command = Option.getOrElse(
-      yield* resolveAvailableCommand(editorDef.commands, env),
+      editorDef.id === "zed"
+        ? yield* resolveZedCommand(editorDef.commands, env)
+        : yield* resolveAvailableCommand(editorDef.commands, env),
       () => editorDef.commands[0],
     );
     return {

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -20,6 +20,7 @@ import {
   readPathFromLaunchctl,
   readPathFromLoginShell,
   resolveCommandPath,
+  resolveCommandPaths,
   resolveKnownWindowsCliDirs,
   resolveSpawnCommand,
   resolveWindowsEnvironment,
@@ -343,6 +344,43 @@ effectIt.layer(NodeServices.layer)("isCommandAvailable", (it) => {
         }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
       ).toBe(false);
     }),
+  );
+});
+
+effectIt.layer(NodeServices.layer)("resolveCommandPaths", (it) => {
+  it.effect("lists every PATH match in order and yields nothing for an empty PATH", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-command-paths-" });
+      const firstDir = path.join(root, "first");
+      const secondDir = path.join(root, "second");
+      const emptyDir = path.join(root, "empty");
+      yield* fileSystem.makeDirectory(firstDir, { recursive: true });
+      yield* fileSystem.makeDirectory(secondDir, { recursive: true });
+      yield* fileSystem.makeDirectory(emptyDir, { recursive: true });
+      yield* fileSystem.writeFileString(path.join(firstDir, "zed.CMD"), "@echo off\r\n");
+      yield* fileSystem.writeFileString(path.join(secondDir, "zed.EXE"), "");
+      const env = {
+        PATH: [firstDir, emptyDir, secondDir].join(";"),
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      };
+
+      const resolved = yield* resolveCommandPaths("zed", { env }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+      );
+      expect(resolved).toEqual([path.join(firstDir, "zed.CMD"), path.join(secondDir, "zed.EXE")]);
+
+      const explicit = yield* resolveCommandPaths(path.join(secondDir, "zed.EXE"), { env }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+      );
+      expect(explicit).toEqual([path.join(secondDir, "zed.EXE")]);
+
+      const none = yield* resolveCommandPaths("zed", { env: { PATH: "" } }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+      );
+      expect(none).toEqual([]);
+    }).pipe(Effect.scoped),
   );
 });
 

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -626,6 +626,54 @@ export const resolveCommandPath = Effect.fn("shell.resolveCommandPath")(function
   });
 });
 
+/**
+ * Every executable on PATH that `command` could resolve to, in PATH order.
+ * Callers that must choose between same-named installs (for example stable
+ * and nightly Zed both shipping a `zed` CLI) use this instead of the
+ * first-match `resolveCommandPath`. Explicit paths yield at most one entry.
+ * Never cached and never fails: an empty PATH yields an empty list.
+ */
+export const resolveCommandPaths = Effect.fn("shell.resolveCommandPaths")(function* (
+  command: string,
+  options: CommandAvailabilityOptions = {},
+): Effect.fn.Return<ReadonlyArray<string>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const platform = yield* HostProcessPlatform;
+  const env = options.env ?? (yield* HostProcessEnvironment);
+  const windowsPathExtensions = platform === "win32" ? resolveWindowsPathExtensions(env) : [];
+  const commandCandidates = resolveCommandCandidates(
+    command,
+    platform,
+    windowsPathExtensions,
+    path.extname,
+  );
+
+  if (command.includes("/") || command.includes("\\")) {
+    for (const candidate of commandCandidates) {
+      if (yield* isExecutableFile(candidate, platform, windowsPathExtensions)) {
+        return [candidate];
+      }
+    }
+    return [];
+  }
+
+  const resolvedPaths: string[] = [];
+  for (const entry of resolvePathEnvironmentVariable(env).split(
+    pathDelimiterForPlatform(platform),
+  )) {
+    const pathEntry = stripWrappingQuotes(entry.trim());
+    if (pathEntry.length === 0) continue;
+    for (const candidate of commandCandidates) {
+      const candidatePath = path.join(pathEntry, candidate);
+      if (yield* isExecutableFile(candidatePath, platform, windowsPathExtensions)) {
+        resolvedPaths.push(candidatePath);
+        break;
+      }
+    }
+  }
+  return resolvedPaths;
+});
+
 export const resolveSpawnCommand = Effect.fn("shell.resolveSpawnCommand")(function* (
   command: string,
   args: ReadonlyArray<string>,


### PR DESCRIPTION
## What Changed

Zed's stable, preview, and nightly channels each install their own `zed` CLI. The editor launcher in `externalLauncher.ts` took the first `zed` found on PATH, so on a machine where a prerelease channel sits earlier on PATH, choosing "Zed" opened Zed Nightly or Zed Preview.

- `packages/shared/src/shell.ts` gains `resolveCommandPaths`, which lists every PATH match for a command in order, reusing the existing PATHEXT handling and quote stripping. It never fails and is not cached.
- The launcher uses it only for Zed: it prefers the first install whose location does not name a prerelease channel (`nightly` or `preview`) and, when that install is not the first on PATH, launches it by absolute path. A single install or an already correct PATH order keeps the bare command, so nothing changes for those users.
- No environment or PATH rewriting, which is what the earlier attempt in #2066 was flagged for.

Tests: a launcher test puts a nightly `zed.EXE` ahead of a stable one on PATH and asserts stable launches by absolute path, then removes stable and asserts the bare command is kept. A shared test covers `resolveCommandPaths` ordering, explicit paths, and an empty PATH.

## Why

Fixes #1978. The bug reproduces on Windows with Zed 1.18.0 stable and Zed Preview 1.19.0 installed side by side, both at `%LOCALAPPDATA%\Programs\<channel>\bin\zed.exe`, with the Preview `bin` first on PATH. Verified by launching through the real `ExternalLauncher` and checking which Zed process received the workspace:

| PATH order | Before | After |
|---|---|---|
| Preview `bin` before stable `bin` | Zed Preview opened the project | Zed stable opened the project |

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (not applicable)
- [ ] I included a video for animation/interaction changes (not applicable)

## Validation

- `vp test run apps/server/src/process/externalLauncher.test.ts` (23 passed)
- `vp test run packages/shared/src/shell.test.ts` (31 passed)
- `vp lint` and `vp fmt --check` on the four changed files
- `vp run --filter @t3tools/shared --filter t3 typecheck`

Model: Claude Fable 5.1. Harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Zed editor launch resolution with no PATH or env mutation; wrong heuristics could pick the wrong Zed binary on unusual install layouts.
> 
> **Overview**
> When several Zed channels each expose a `zed` CLI, choosing **Zed** no longer always uses the first PATH hit (often Preview/Nightly).
> 
> **`resolveCommandPaths`** in shared shell code returns every executable match for a bare command in PATH order (Windows PATHEXT and quoting unchanged); it never fails and returns `[]` on an empty PATH. **`resolveZedCommand`** uses that only for the Zed editor: it picks the first install whose path is not treated as prerelease (`isPrereleaseZedPath` — a path segment must include both `zed` and `nightly` or `preview`). If that stable binary is not first on PATH, launch uses its **absolute path**; if stable is already first or only prerelease exists, behavior stays the bare `zed` command. Other editors still use first-available resolution. PATH is not rewritten.
> 
> Tests cover PATH ordering, nightly-only fallback, prerelease path classification, and `resolveCommandPaths` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36c424ada4c95d9a3ee40ec2673f87982af1db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveEditorLaunch` to pick stable Zed over prerelease on PATH
> - Adds `resolveCommandPaths` in [shell.ts](https://github.com/pingdotgg/t3code/pull/9501/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) to return every executable match in PATH order instead of just the first.
> - Adds `isPrereleaseZedPath` and `resolveZedCommand` in [externalLauncher.ts](https://github.com/pingdotgg/t3code/pull/9501/files#diff-157ca66b5181820e0a628ef443d244577cda2329dd1d88fe5f2aff441da05e56) to classify Zed paths as prerelease (Nightly/Preview) and prefer the first stable match, using its absolute path when it is not first on PATH.
> - Only the `zed` editor definition uses the new resolver; all other command-based editors keep their existing first-available-command behavior.
> - Risk: `resolveZedCommand` returns no resolved command when no PATH match is found, falling back to the bare configured command via the existing fallback in `resolveEditorLaunch`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c4d469.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->