### PR TITLE
feat(settings): add a worktree directory setting

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -648,11 +648,13 @@ function makeManager(input?: {
         Layer.provideMerge(VcsProcess.layer),
         Layer.provideMerge(NodeServices.layer),
         Layer.provideMerge(serverConfigLayer),
+        Layer.provide(serverSettingsLayer),
       )
     : GitVcsDriver.layer.pipe(
         Layer.provideMerge(VcsProcess.layer),
         Layer.provideMerge(NodeServices.layer),
         Layer.provideMerge(serverConfigLayer),
+        Layer.provide(serverSettingsLayer),
       );
   const sourceControlRegistryLayer = Layer.effect(
     SourceControlProviderRegistry.SourceControlProviderRegistry,
@@ -693,7 +695,12 @@ function makeManager(input?: {
 const asThreadId = (threadId: string) => threadId as ThreadId;
 
 const GitManagerTestLayer = GitVcsDriver.layer.pipe(
-  Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-git-manager-test-" })),
+  Layer.provide(
+    Layer.mergeAll(
+      ServerConfig.layerTest(process.cwd(), { prefix: "t3-git-manager-test-" }),
+      ServerSettings.layerTest(),
+    ),
+  ),
   Layer.provideMerge(VcsProcess.layer),
   Layer.provideMerge(NodeServices.layer),
 );

--- a/apps/server/src/sourceControl/PrTemplateDetection.test.ts
+++ b/apps/server/src/sourceControl/PrTemplateDetection.test.ts
@@ -7,6 +7,7 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 
 import { ServerConfig } from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import { detectPrTemplate } from "./PrTemplateDetection.ts";
@@ -28,9 +29,12 @@ const TEMPLATE_DIRECTORIES = [
 
 const PrTemplateDetectionTestLayer = GitVcsDriver.layer.pipe(
   Layer.provide(
-    ServerConfig.layerTest(process.cwd(), {
-      prefix: "t3-pr-template-test-",
-    }),
+    Layer.mergeAll(
+      ServerConfig.layerTest(process.cwd(), {
+        prefix: "t3-pr-template-test-",
+      }),
+      ServerSettings.layerTest(),
+    ),
   ),
   Layer.provideMerge(VcsProcess.layer),
   Layer.provideMerge(NodeServices.layer),

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -9,6 +9,7 @@ import { assert, it } from "@effect/vitest";
 
 import { GitCommandError } from "@t3tools/contracts";
 import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
 import { runVcsDriverContractSuite } from "./testing/VcsDriverContractHarness.ts";
@@ -17,7 +18,7 @@ const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-git-vcs-contract-",
 });
 const GitContractLayer = Layer.mergeAll(GitVcsDriver.vcsLayer, GitVcsDriver.layer).pipe(
-  Layer.provide(ServerConfigLayer),
+  Layer.provide(Layer.mergeAll(ServerConfigLayer, Layer.orDie(ServerSettings.layerTest()))),
   Layer.provideMerge(VcsProcess.layer),
   Layer.provideMerge(NodeServices.layer),
 );

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1,3 +1,5 @@
+import * as NodeOS from "node:os";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it, describe } from "@effect/vitest";
 import * as Deferred from "effect/Deferred";
@@ -16,14 +18,20 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError, type ReviewDiffFileContentsInput } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
-import { makeGitVcsDriverCore, splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
+import * as ServerSettings from "../serverSettings.ts";
+import {
+  makeGitVcsDriverCore,
+  resolveWorktreesRoot,
+  splitNullSeparatedGitStdoutPaths,
+} from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-git-vcs-driver-test-",
 });
+const CoreDepsLayer = Layer.mergeAll(ServerConfigLayer, ServerSettings.layerTest());
 const TestLayer = GitVcsDriver.layer.pipe(
-  Layer.provide(ServerConfigLayer),
+  Layer.provide(CoreDepsLayer),
   Layer.provideMerge(NodeServices.layer),
 );
 
@@ -147,7 +155,7 @@ it.effect("uses stable diagnostics for every parsed non-repository command", () 
     Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
   );
   const layer = GitVcsDriver.layer.pipe(
-    Layer.provide(ServerConfigLayer),
+    Layer.provide(CoreDepsLayer),
     Layer.provideMerge(nodeServicesLayer),
   );
 
@@ -321,7 +329,7 @@ it.effect("coalesces concurrent ref pages into one repository snapshot", () =>
         2,
       );
     }),
-  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+  ).pipe(Effect.provide(CoreDepsLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );
 
 it.effect("retries an in-flight ref snapshot invalidated by a mutation", () =>
@@ -380,7 +388,7 @@ it.effect("retries an in-flight ref snapshot invalidated by a mutation", () =>
       assert.isTrue(refs.refs.some((ref) => ref.name === "feature/during-refresh"));
       assert.equal(yield* Ref.get(refScans), 2);
     }),
-  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+  ).pipe(Effect.provide(CoreDepsLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );
 
 it.effect("invalidates a ref snapshot when a mutation fails after changing Git", () =>
@@ -412,7 +420,7 @@ it.effect("invalidates a ref snapshot when a mutation fails after changing Git",
       const refs = yield* driver.listRefs({ cwd });
       assert.isTrue(refs.refs.some((ref) => ref.name === "feature/partial-failure"));
     }),
-  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+  ).pipe(Effect.provide(CoreDepsLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );
 
 it.effect("fails a ref snapshot when for-each-ref exits unsuccessfully", () =>
@@ -448,7 +456,7 @@ it.effect("fails a ref snapshot when for-each-ref exits unsuccessfully", () =>
       });
       assert.equal(yield* Ref.get(snapshotAttempts), 1);
     }),
-  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+  ).pipe(Effect.provide(CoreDepsLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );
 
 it.effect("marks the current branch when worktree metadata is unavailable", () =>
@@ -483,7 +491,7 @@ it.effect("marks the current branch when worktree metadata is unavailable", () =
       assert.isTrue(refs.isRepo);
       assert.isTrue(refs.refs.find((ref) => ref.name === initialBranch)?.current);
     }),
-  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+  ).pipe(Effect.provide(CoreDepsLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );
 
 it.effect("ignores worktree metadata for directories that no longer exist", () =>
@@ -519,7 +527,7 @@ it.effect("ignores worktree metadata for directories that no longer exist", () =
 
       assert.equal(refs.refs.find((ref) => ref.name === "stale-worktree")?.worktreePath, null);
     }),
-  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+  ).pipe(Effect.provide(CoreDepsLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );
 
 it.effect("refreshes the current branch after an external checkout", () =>
@@ -632,7 +640,101 @@ it.effect("backs off failed upstream refreshes across linked worktrees", () =>
       yield* driver.statusDetailsRemote(cwd);
       assert.equal(yield* Ref.get(fetchAttempts), 3);
     }),
-  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+  ).pipe(Effect.provide(CoreDepsLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+);
+
+describe("resolveWorktreesRoot", () => {
+  const withPathService = (
+    body: (pathService: Path.Path) => void,
+  ): Effect.Effect<void, never, never> =>
+    Effect.gen(function* () {
+      body(yield* Path.Path);
+    }).pipe(Effect.provide(NodeServices.layer));
+
+  it.effect("keeps the fallback when nothing is configured", () =>
+    withPathService((pathService) => {
+      assert.equal(
+        resolveWorktreesRoot(
+          { configured: "  ", fallback: "/t3/worktrees", projectCwd: "/repos/app" },
+          pathService,
+        ),
+        "/t3/worktrees",
+      );
+    }),
+  );
+
+  it.effect("expands a leading tilde to the home directory", () =>
+    withPathService((pathService) => {
+      assert.equal(
+        resolveWorktreesRoot(
+          { configured: "~/worktrees", fallback: "/t3/worktrees", projectCwd: "/repos/app" },
+          pathService,
+        ),
+        pathService.join(NodeOS.homedir(), "worktrees"),
+      );
+    }),
+  );
+
+  it.effect("resolves a relative directory from the project root", () =>
+    withPathService((pathService) => {
+      assert.equal(
+        resolveWorktreesRoot(
+          { configured: "../trees", fallback: "/t3/worktrees", projectCwd: "/repos/app" },
+          pathService,
+        ),
+        pathService.resolve("/repos", "trees"),
+      );
+    }),
+  );
+
+  it.effect("keeps an absolute directory as written", () =>
+    withPathService((pathService) => {
+      assert.equal(
+        resolveWorktreesRoot(
+          { configured: "/mnt/trees", fallback: "/t3/worktrees", projectCwd: "/repos/app" },
+          pathService,
+        ),
+        "/mnt/trees",
+      );
+    }),
+  );
+});
+
+it.effect("creates worktrees under the configured worktree directory", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const pathService = yield* Path.Path;
+      const configuredRoot = yield* makeTmpDir("git-vcs-driver-configured-worktrees-");
+      const driver = yield* makeGitVcsDriverCore().pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ServerConfigLayer,
+            ServerSettings.layerTest({ worktreeDirectory: configuredRoot }),
+          ),
+        ),
+      );
+      const cwd = yield* makeTmpDir();
+      const { initialBranch } = yield* initRepoWithCommit(cwd).pipe(
+        Effect.provideService(GitVcsDriver.GitVcsDriver, driver),
+      );
+
+      const created = yield* driver.createWorktree({
+        cwd,
+        path: null,
+        refName: initialBranch,
+        newRefName: "feature/configured-root",
+      });
+
+      const expected = pathService.join(
+        configuredRoot,
+        pathService.basename(cwd),
+        "feature-configured-root",
+      );
+      assert.equal(created.worktree.path, expected);
+      assert.equal(yield* fileSystem.exists(expected), true);
+    }),
+  ).pipe(Effect.provide(NodeServices.layer)),
 );
 
 it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
@@ -1781,7 +1883,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         );
         const driver = yield* makeGitVcsDriverCore().pipe(
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, delayedPushSpawner),
-          Effect.provide(ServerConfigLayer),
+          Effect.provide(CoreDepsLayer),
         );
         const cwd = yield* makeTmpDir();
         const remote = yield* makeTmpDir("git-remote-");

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -37,6 +37,8 @@ import {
   parseRemoteRefWithRemoteNames,
 } from "../git/remoteRefs.ts";
 import { ServerConfig } from "../config.ts";
+import { expandHomePathWith } from "../pathExpansion.ts";
+import * as ServerSettings from "../serverSettings.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 // `git worktree add` checks out the full tree, so on large repositories it can
@@ -716,11 +718,36 @@ const collectOutput = Effect.fnUntraced(function* (
   };
 });
 
+/**
+ * Resolve the directory that holds generated worktrees. An empty `configured`
+ * value keeps the built-in `<t3 home>/worktrees` fallback, a leading `~`
+ * expands to the home directory, and anything else resolves against the
+ * project root so a relative setting follows each project.
+ */
+export function resolveWorktreesRoot(
+  input: {
+    readonly configured: string;
+    readonly fallback: string;
+    readonly projectCwd: string;
+  },
+  path: Path.Path,
+): string {
+  const configured = input.configured.trim();
+  if (configured === "") {
+    return input.fallback;
+  }
+  if (configured.startsWith("~")) {
+    return expandHomePathWith(configured, path);
+  }
+  return path.resolve(input.projectCwd, configured);
+}
+
 export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const { worktreesDir } = yield* ServerConfig;
+  const serverSettings = yield* ServerSettings.ServerSettingsService;
   const crypto = yield* Crypto.Crypto;
 
   const executeRaw: GitVcsDriver.GitVcsDriver["Service"]["execute"] = Effect.fnUntraced(
@@ -2823,13 +2850,40 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     },
   );
 
+  const readSettingsForWorktree = (cwd: string) =>
+    serverSettings.getSettings.pipe(
+      Effect.mapError(
+        (cause) =>
+          new GitCommandError({
+            operation: "GitVcsDriver.createWorktree",
+            command: "git",
+            cwd,
+            detail: "Failed to read server settings.",
+            cause,
+          }),
+      ),
+    );
+
   const createWorktree: GitVcsDriver.GitVcsDriver["Service"]["createWorktree"] = Effect.fn(
     "createWorktree",
   )(function* (input) {
     const targetBranch = input.newRefName ?? input.refName;
     const sanitizedBranch = targetBranch.replace(/\//g, "-");
     const repoName = path.basename(input.cwd);
-    const worktreePath = input.path ?? path.join(worktreesDir, repoName, sanitizedBranch);
+    const worktreePath =
+      input.path ??
+      path.join(
+        resolveWorktreesRoot(
+          {
+            configured: (yield* readSettingsForWorktree(input.cwd)).worktreeDirectory,
+            fallback: worktreesDir,
+            projectCwd: input.cwd,
+          },
+          path,
+        ),
+        repoName,
+        sanitizedBranch,
+      );
     const args = input.newRefName
       ? ["worktree", "add", "-b", input.newRefName, worktreePath, input.refName]
       : ["worktree", "add", worktreePath, input.refName];

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -565,6 +565,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeDirectory !== DEFAULT_UNIFIED_SETTINGS.worktreeDirectory
+        ? ["Worktree directory"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -600,6 +603,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadDelete,
       settings.confirmThreadUnpin,
       settings.addProjectBaseDirectory,
+      settings.worktreeDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -720,6 +724,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeDirectory: DEFAULT_UNIFIED_SETTINGS.worktreeDirectory,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2555,6 +2560,35 @@ export function GeneralSettingsPanel() {
             }
           />
         ) : null}
+
+        <SettingsRow
+          serverScoped
+          {...searchableSetting("worktree-directory")}
+          description="Leave empty to keep worktrees inside the T3 data folder. A relative path resolves from the project root."
+          resetAction={
+            settings.worktreeDirectory !== DEFAULT_UNIFIED_SETTINGS.worktreeDirectory ? (
+              <SettingResetButton
+                label="worktree directory"
+                onClick={() =>
+                  updateSettings({
+                    worktreeDirectory: DEFAULT_UNIFIED_SETTINGS.worktreeDirectory,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              size="sm"
+              className="w-full sm:w-72"
+              value={settings.worktreeDirectory}
+              onCommit={(next) => updateSettings({ worktreeDirectory: next })}
+              placeholder="~/worktrees"
+              spellCheck={false}
+              aria-label="Worktree directory"
+            />
+          }
+        />
 
         <SettingsRow
           serverScoped

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -236,6 +236,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["new worktrees latest matching remote branch local"],
   },
   {
+    id: "worktree-directory",
+    title: "Worktree directory",
+    to: "/settings/general",
+    searchTerms: ["worktree folder path location directory"],
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -27,7 +27,7 @@ The root filesystem path for a project. In [the orchestration model][1], it is t
 
 #### Worktree
 
-A Git worktree used as an isolated workspace for a thread. If a thread has a `worktreePath` in [the contracts][1], it runs there instead of in the main working tree. Git operations live behind the VCS driver contract in `apps/server/src/vcs/VcsDriver.ts`, implemented by [GitVcsDriverCore.ts][3].
+A Git worktree used as an isolated workspace for a thread. If a thread has a `worktreePath` in [the contracts][1], it runs there instead of in the main working tree. Generated worktrees land in `<t3 home>/worktrees/<repo>/<branch>` unless the `worktreeDirectory` server setting names another root, which may be absolute, `~`-prefixed, or relative to the project root. Git operations live behind the VCS driver contract in `apps/server/src/vcs/VcsDriver.ts`, implemented by [GitVcsDriverCore.ts][3].
 
 ### Thread timeline
 

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -230,3 +230,8 @@ On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the
 thread that started. The new thread keeps the selected workspace mode and base branch. If **New
 worktree** is selected, each background thread creates its own worktree.
+
+Worktrees live inside the T3 Code data folder by default. To keep them somewhere else, set
+**Settings → General → Worktree directory**. A leading `~` expands to your home folder, and a
+relative path resolves from the project root, so each project keeps its worktrees beside itself.
+Worktrees that already exist stay where they are.

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -860,6 +860,7 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  worktreeDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -1079,6 +1080,7 @@ export const ServerSettingsPatch = Schema.Struct({
   environmentIcon: Schema.optionalKey(Schema.NullOr(EnvironmentMachineKind)),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeDirectory: Schema.optionalKey(TrimmedString),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(


### PR DESCRIPTION
## Problem

Every worktree lands in `<T3 home>/worktrees`. There is no way to put them somewhere else.

## Fix

A new server setting, `worktreeDirectory`, names the root for new worktrees. Empty keeps the built-in location. A leading `~` expands to the home folder. A relative path resolves from the project root, so `../trees` puts worktrees next to each repo. The layout under the root stays `<repo>/<branch>` and existing worktrees do not move.

The git driver reads the setting only when a caller gives no explicit path, so no caller changed. The setting is per machine and does not sync to other environments, like the add-project base directory.

Settings → General gets a **Worktree directory** row, searchable from the settings search. Mobile has no editor for these server keys and is unchanged. Desktop wraps web.

## Tests

- Unit tests for the four path rules (empty, `~`, relative, absolute).
- A real git run with a configured root asserts the worktree directory exists on disk.
- `vp run --filter t3 typecheck`, `vp fmt --check`, and the touched server test files pass.

No screenshot yet. The row is wired the same way as the add-project base directory row directly below it.

Built with Claude Fable 5.1 in Claude Code.

https://claude.ai/code/session_0136unQ6tTxfabuDkvQxCX93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default filesystem paths for new worktrees based on server settings; behavior is bounded by empty/default fallback and explicit paths, but misconfiguration could put worktrees in unexpected locations.
> 
> **Overview**
> Adds a server-scoped **`worktreeDirectory`** setting so **new** auto-generated worktrees can live outside the default `<t3 home>/worktrees` layout. Empty keeps the existing fallback; `~` expands to home; relative paths resolve from the project root; absolute paths are used as-is. **`createWorktree`** still honors an explicit `path`—only the default root changes.
> 
> **`GitVcsDriverCore`** loads the setting when building the default worktree path and surfaces a **`GitCommandError`** if settings cannot be read. **`resolveWorktreesRoot`** is exported and covered by unit tests, plus an integration test that checks the worktree exists under a configured root.
> 
> **Settings → General** gets a **Worktree directory** field (dirty-state, reset, search). Contracts gain **`worktreeDirectory`** on unified settings. Git-related test layers now merge **`ServerSettings.layerTest()`** so the driver compiles. Glossary and composer docs note the new behavior; existing worktrees are not relocated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8036b028a53ae93b99d39f4e1be0c382f9e232fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `worktreeDirectory` server setting for Git worktree creation
> - Adds `worktreeDirectory` to the `ServerSettings` and `ServerSettingsPatch` schemas in [settings.ts](https://github.com/pingdotgg/t3code/pull/9503/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), defaulting to an empty string.
> - Adds `resolveWorktreesRoot` in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/9503/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) which trims the configured value, falls back to `ServerConfig` default when empty, expands `~` to the user home, and resolves relative paths against the project cwd. `GitVcsDriver.createWorktree` uses this when no explicit path is given.
> - Adds a Worktree directory row to the General settings panel in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/9503/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) with reset and search support.
> - Documents the setting and path forms in [glossary.md](https://github.com/pingdotgg/t3code/pull/9503/files#diff-e0c866441aac1f3881c959ca81446787f1dd3961a8788864576676854e841da3) and [composer.md](https://github.com/pingdotgg/t3code/pull/9503/files#diff-6c496fed927e1ba2296273bdfca78fd482921ebd76a32bb9d0c534f7bda35b63).
> - Risk: `makeGitVcsDriverCore` now requires `ServerSettings` as a factory dependency; settings read failures during `createWorktree` path generation are returned as `GitCommandError` values instead of being silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8036b02. 6 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->