### PR TITLE
perf(threads): reuse derived state while loading activity

### DIFF
--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -15,16 +15,15 @@ import type {
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 import {
   commandDetailRepeatsCommand,
-  createToolGroupSummaryAccumulator,
   extractCommandOutputText,
   isWorktreeSetupActivity,
   liveActivityToolStatus,
   normalizeCompactToolLabel,
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
-  summarizeToolGroupAccumulator,
+  summarizeToolGroup,
   toolGroupAction,
-  toolGroupSummaryKindFromAccumulator,
+  toolGroupSummaryKind,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
 import { extractToolActivityPresentation } from "@t3tools/client-runtime/work-log/tool-presentation";
@@ -382,7 +381,7 @@ function isAgentInternalActivity(activity: OrchestrationThreadActivity): boolean
 function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): DerivedWorkLogEntry[] {
-  const ordered = sortThreadActivities(activities);
+  const ordered = Arr.sort(activities, activityOrder);
   const entries: DerivedWorkLogEntry[] = [];
   for (const activity of ordered) {
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
@@ -1239,34 +1238,6 @@ const activityOrder = Order.combineAll<OrchestrationThreadActivity>([
   Order.mapInput(Order.String, (activity) => activity.id),
 ]);
 
-const sortedActivitiesCache = new WeakMap<
-  ReadonlyArray<OrchestrationThreadActivity>,
-  ReadonlyArray<OrchestrationThreadActivity>
->();
-
-function sortActivitiesIfNeeded(
-  activities: ReadonlyArray<OrchestrationThreadActivity>,
-): ReadonlyArray<OrchestrationThreadActivity> {
-  const cached = sortedActivitiesCache.get(activities);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  let isOrdered = true;
-  for (let index = 1; index < activities.length; index += 1) {
-    const previous = activities[index - 1];
-    const current = activities[index];
-    if (previous && current && activityOrder(previous, current) > 0) {
-      isOrdered = false;
-      break;
-    }
-  }
-
-  const sorted = isOrdered ? activities : Arr.sort(activities, activityOrder);
-  sortedActivitiesCache.set(activities, sorted);
-  return sorted;
-}
-
 function isEmptyMessage(entry: RawThreadFeedEntry): boolean {
   if (entry.type !== "message") {
     return false;
@@ -1607,10 +1578,6 @@ function appendToolGroupRows(
   const live = activeTail || active;
   const latestActivity = latestActiveActivity ?? activities.at(-1)!;
   const singleActivity = activities.length === 1 ? latestActivity : null;
-  const summaryEntries = (live ? [latestActivity] : activities).map(
-    (activity) => activity.workEntry,
-  );
-  const summaryAccumulator = createToolGroupSummaryAccumulator(summaryEntries);
   const summary = live
     ? liveToolActivitySummary(latestActivity, live)
     : singleActivity !== null &&
@@ -1619,7 +1586,7 @@ function appendToolGroupRows(
       ? singleToolCallLabel(singleActivity)
       : singleActivity !== null && !singleActivity.toolLike
         ? singleActivity.workEntry.label
-        : summarizeToolGroupAccumulator(summaryAccumulator);
+        : summarizeToolGroup(activities.map((activity) => activity.workEntry));
   const primarySourceActivity = activities.find(
     (activity) => activity.workEntry.toolSource !== undefined,
   );
@@ -1657,7 +1624,9 @@ function appendToolGroupRows(
     hiddenCount: activities.length,
     expanded,
     summary,
-    summaryKind: toolGroupSummaryKindFromAccumulator(summaryAccumulator),
+    summaryKind: toolGroupSummaryKind(
+      (live ? [latestActivity] : activities).map((activity) => activity.workEntry),
+    ),
     ...(groupToolSurface ? { toolSurface: groupToolSurface } : {}),
     ...(groupToolIcon ? { toolIcon: groupToolIcon } : {}),
     ...(summaryToolIcon ? { summaryToolIcon } : {}),
@@ -1719,7 +1688,7 @@ function liveToolActivitySummary(activity: ThreadFeedActivity, presentTense: boo
 export function sortThreadActivities(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): ReadonlyArray<OrchestrationThreadActivity> {
-  return sortActivitiesIfNeeded(activities);
+  return Arr.sort(activities, activityOrder);
 }
 
 export function derivePendingApprovals(

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -15,15 +15,16 @@ import type {
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 import {
   commandDetailRepeatsCommand,
+  createToolGroupSummaryAccumulator,
   extractCommandOutputText,
   isWorktreeSetupActivity,
   liveActivityToolStatus,
   normalizeCompactToolLabel,
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
-  summarizeToolGroup,
+  summarizeToolGroupAccumulator,
   toolGroupAction,
-  toolGroupSummaryKind,
+  toolGroupSummaryKindFromAccumulator,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
 import { extractToolActivityPresentation } from "@t3tools/client-runtime/work-log/tool-presentation";
@@ -381,7 +382,7 @@ function isAgentInternalActivity(activity: OrchestrationThreadActivity): boolean
 function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): DerivedWorkLogEntry[] {
-  const ordered = Arr.sort(activities, activityOrder);
+  const ordered = sortThreadActivities(activities);
   const entries: DerivedWorkLogEntry[] = [];
   for (const activity of ordered) {
     if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
@@ -1238,6 +1239,34 @@ const activityOrder = Order.combineAll<OrchestrationThreadActivity>([
   Order.mapInput(Order.String, (activity) => activity.id),
 ]);
 
+const sortedActivitiesCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  ReadonlyArray<OrchestrationThreadActivity>
+>();
+
+function sortActivitiesIfNeeded(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ReadonlyArray<OrchestrationThreadActivity> {
+  const cached = sortedActivitiesCache.get(activities);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let isOrdered = true;
+  for (let index = 1; index < activities.length; index += 1) {
+    const previous = activities[index - 1];
+    const current = activities[index];
+    if (previous && current && activityOrder(previous, current) > 0) {
+      isOrdered = false;
+      break;
+    }
+  }
+
+  const sorted = isOrdered ? activities : Arr.sort(activities, activityOrder);
+  sortedActivitiesCache.set(activities, sorted);
+  return sorted;
+}
+
 function isEmptyMessage(entry: RawThreadFeedEntry): boolean {
   if (entry.type !== "message") {
     return false;
@@ -1578,6 +1607,10 @@ function appendToolGroupRows(
   const live = activeTail || active;
   const latestActivity = latestActiveActivity ?? activities.at(-1)!;
   const singleActivity = activities.length === 1 ? latestActivity : null;
+  const summaryEntries = (live ? [latestActivity] : activities).map(
+    (activity) => activity.workEntry,
+  );
+  const summaryAccumulator = createToolGroupSummaryAccumulator(summaryEntries);
   const summary = live
     ? liveToolActivitySummary(latestActivity, live)
     : singleActivity !== null &&
@@ -1586,7 +1619,7 @@ function appendToolGroupRows(
       ? singleToolCallLabel(singleActivity)
       : singleActivity !== null && !singleActivity.toolLike
         ? singleActivity.workEntry.label
-        : summarizeToolGroup(activities.map((activity) => activity.workEntry));
+        : summarizeToolGroupAccumulator(summaryAccumulator);
   const primarySourceActivity = activities.find(
     (activity) => activity.workEntry.toolSource !== undefined,
   );
@@ -1624,9 +1657,7 @@ function appendToolGroupRows(
     hiddenCount: activities.length,
     expanded,
     summary,
-    summaryKind: toolGroupSummaryKind(
-      (live ? [latestActivity] : activities).map((activity) => activity.workEntry),
-    ),
+    summaryKind: toolGroupSummaryKindFromAccumulator(summaryAccumulator),
     ...(groupToolSurface ? { toolSurface: groupToolSurface } : {}),
     ...(groupToolIcon ? { toolIcon: groupToolIcon } : {}),
     ...(summaryToolIcon ? { summaryToolIcon } : {}),
@@ -1688,7 +1719,7 @@ function liveToolActivitySummary(activity: ThreadFeedActivity, presentTense: boo
 export function sortThreadActivities(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): ReadonlyArray<OrchestrationThreadActivity> {
-  return Arr.sort(activities, activityOrder);
+  return sortActivitiesIfNeeded(activities);
 }
 
 export function derivePendingApprovals(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -96,11 +96,13 @@ import {
   derivePendingApprovals,
   derivePendingUserInputs,
   derivePhase,
-  deriveTimelineEntries,
+  deriveTimelineEntriesWithState,
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
   findLatestProposedPlan,
-  deriveWorkLogEntries,
+  deriveWorkLogEntriesWithState,
+  type TimelineEntriesProjection,
+  type WorkLogEntriesProjection,
   hasActionableProposedPlan,
   isLatestTurnSettled,
 } from "../session-logic";
@@ -2476,7 +2478,16 @@ function ChatViewContent(props: ChatViewProps) {
     () => deriveLatestContextWindowSnapshot(threadActivities),
     [threadActivities],
   );
-  const workLogEntries = useMemo(() => deriveWorkLogEntries(threadActivities), [threadActivities]);
+  const workLogProjectionRef = useRef<WorkLogEntriesProjection | null>(null);
+  const timelineProjectionRef = useRef<TimelineEntriesProjection | null>(null);
+  const workLogEntries = useMemo(() => {
+    const projection = deriveWorkLogEntriesWithState(
+      threadActivities,
+      workLogProjectionRef.current,
+    );
+    workLogProjectionRef.current = projection;
+    return projection.entries;
+  }, [threadActivities]);
   // Native subagent fold: memoized by activity-list identity, shared by the
   // Agents surface, live strip, and workflow cards. v2Projection is null
   // until orchestration-v2 lands (source precedence lives in the derive).
@@ -2868,11 +2879,16 @@ function ChatViewContent(props: ChatViewProps) {
     feedbackSubmissions,
     optimisticUserMessages,
   ]);
-  const timelineEntries = useMemo(
-    () =>
-      deriveTimelineEntries(timelineMessages, activeThread?.proposedPlans ?? [], workLogEntries),
-    [activeThread?.proposedPlans, timelineMessages, workLogEntries],
-  );
+  const timelineEntries = useMemo(() => {
+    const projection = deriveTimelineEntriesWithState(
+      timelineMessages,
+      activeThread?.proposedPlans ?? [],
+      workLogEntries,
+      timelineProjectionRef.current,
+    );
+    timelineProjectionRef.current = projection;
+    return projection.entries;
+  }, [activeThread?.proposedPlans, timelineMessages, workLogEntries]);
   const [dockedDraftHeroThreadKey, setDockedDraftHeroThreadKey] = useState<string | null>(null);
   const draftHeroDockRequested =
     activeThreadKey !== null && dockedDraftHeroThreadKey === activeThreadKey;

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -2447,4 +2447,60 @@ describe("computeStableMessagesTimelineRows", () => {
     expect(reordered).not.toBe(initial);
     expect(reordered.result).toEqual([initial.result[1], initial.result[0]]);
   });
+
+  it("keeps expanded group snapshots immutable across appended work", () => {
+    const firstEntry = {
+      id: "work-append-1",
+      createdAt: "2026-01-01T00:00:01Z",
+      label: "Ran command",
+      command: "git status",
+      tone: "tool" as const,
+      toolLifecycleStatus: "completed" as const,
+    };
+    const secondEntry = {
+      ...firstEntry,
+      id: "work-append-2",
+      command: "git diff",
+    };
+    const baseInput = {
+      isWorking: false,
+      expandedWorkGroupIds: new Set(["work-group:work-append-1"]),
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    };
+    const initial = deriveMessagesTimelineRows({
+      ...baseInput,
+      timelineEntries: [
+        {
+          id: firstEntry.id,
+          kind: "work" as const,
+          createdAt: firstEntry.createdAt,
+          entry: firstEntry,
+        },
+      ],
+    });
+    const updated = deriveMessagesTimelineRows({
+      ...baseInput,
+      timelineEntries: [
+        {
+          id: firstEntry.id,
+          kind: "work" as const,
+          createdAt: firstEntry.createdAt,
+          entry: firstEntry,
+        },
+        {
+          id: secondEntry.id,
+          kind: "work" as const,
+          createdAt: secondEntry.createdAt,
+          entry: secondEntry,
+        },
+      ],
+    });
+    const initialDetails = initial.find((row) => row.kind === "work");
+    const updatedDetails = updated.find((row) => row.kind === "work");
+
+    expect(initialDetails?.groupedEntries).toHaveLength(1);
+    expect(updatedDetails?.groupedEntries).toHaveLength(2);
+  });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -10,6 +10,7 @@ import {
   resolveWorkGroupScrollIndex,
   shouldFollowWorkGroupAppend,
   shouldPreserveAssistantLineBreaks,
+  type ActiveTimelineScanRef,
   type MessagesTimelineRow,
   workEntryDisplayLabel,
   workEntryIsVisibleInGroup,
@@ -1292,6 +1293,92 @@ describe("deriveMessagesTimelineRows", () => {
       "assistant-thought-entry",
       "live-activity-row",
     ]);
+  });
+
+  it("keeps active scan state isolated to its timeline owner", () => {
+    const turnId = "turn-1" as never;
+    const startedAt = "2026-01-01T00:00:00Z";
+    const userEntry = {
+      id: "user-entry",
+      kind: "message" as const,
+      createdAt: startedAt,
+      message: {
+        id: "user-1" as never,
+        role: "user" as const,
+        text: "Run the tools",
+        turnId: null,
+        createdAt: startedAt,
+        updatedAt: startedAt,
+        streaming: false,
+      },
+    };
+    const firstWorkEntry = {
+      id: "work-entry-1",
+      kind: "work" as const,
+      createdAt: "2026-01-01T00:00:01Z",
+      entry: {
+        id: "work-1",
+        createdAt: "2026-01-01T00:00:01Z",
+        turnId,
+        label: "Ran status",
+        command: "git status",
+        tone: "tool" as const,
+      },
+    };
+    const secondWorkEntry = {
+      id: "work-entry-2",
+      kind: "work" as const,
+      createdAt: "2026-01-01T00:00:02Z",
+      entry: {
+        ...firstWorkEntry.entry,
+        id: "work-2",
+        createdAt: "2026-01-01T00:00:02Z",
+        label: "Ran diff",
+        command: "git diff",
+      },
+    };
+    const firstRef: ActiveTimelineScanRef = { current: null };
+    const secondRef: ActiveTimelineScanRef = { current: null };
+    const baseInput = {
+      latestTurn: {
+        turnId,
+        state: "running" as const,
+        startedAt,
+        completedAt: null,
+      },
+      runningTurnId: turnId,
+      activeTurnStartedAt: startedAt,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    };
+    const firstTimeline = [userEntry, firstWorkEntry];
+
+    deriveMessagesTimelineRows({
+      ...baseInput,
+      timelineEntries: firstTimeline,
+      isWorking: true,
+      activeTimelineScanRef: firstRef,
+    });
+    deriveMessagesTimelineRows({
+      ...baseInput,
+      timelineEntries: firstTimeline,
+      isWorking: false,
+      activeTimelineScanRef: secondRef,
+    });
+
+    const appendedTimeline = [...firstTimeline, secondWorkEntry];
+    const rows = deriveMessagesTimelineRows({
+      ...baseInput,
+      timelineEntries: appendedTimeline,
+      isWorking: true,
+      activeTimelineScanRef: firstRef,
+    });
+
+    expect(firstRef.current?.timelineEntries).toBe(appendedTimeline);
+    expect(secondRef.current).toBeNull();
+    expect(rows.find((row) => row.kind === "work-live")).toMatchObject({
+      groupedEntries: [{ id: "work-1" }, { id: "work-2" }],
+    });
   });
 
   it("keeps an actually running tool in the shared activity row", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -7,9 +7,13 @@ import {
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
   summarizeToolGroup,
+  appendToolGroupSummaryEntry,
+  createToolGroupSummaryAccumulator,
+  summarizeToolGroupAccumulator,
+  toolGroupSummaryKindFromAccumulator,
   toolGroupAction,
-  toolGroupSummaryKind,
   workEntryViewedImagePath,
+  type ToolGroupSummaryAccumulator,
   type ToolGroupSummaryKind,
 } from "@t3tools/client-runtime/work-log/presentation";
 export {
@@ -417,6 +421,336 @@ function expandedWorkGroupRow(
   };
 }
 
+interface WorkGroupPresentationState {
+  rawEntries: ReadonlyArray<WorkLogEntry>;
+  activeTurnId: TurnId | null;
+  visibleEntries: WorkLogEntry[];
+  activeEntries: WorkLogEntry[];
+  summary: ToolGroupSummaryAccumulator;
+  latestToolEntry: WorkLogEntry | undefined;
+  hasStatuslessLifecycleMarker: boolean;
+}
+
+const workGroupPresentationByAnchor = new WeakMap<WorkLogEntry, WorkGroupPresentationState>();
+
+function isStatuslessLifecycleMarker(entry: WorkLogEntry): boolean {
+  return (
+    entry.toolCallId === undefined &&
+    entry.toolLifecycleStatus === undefined &&
+    (entry.sourceActivityKind === "tool.started" || entry.sourceActivityKind === "tool.updated")
+  );
+}
+
+function isTerminalLifecycleEntry(entry: WorkLogEntry): boolean {
+  return (
+    entry.sourceActivityKind === "tool.completed" ||
+    (entry.toolLifecycleStatus !== undefined && entry.toolLifecycleStatus !== "inProgress")
+  );
+}
+
+function workEntryIsInActiveRunForTurn(entry: WorkLogEntry, activeTurnId: TurnId | null): boolean {
+  return (
+    activeTurnId !== null &&
+    entry.toolLifecycleStatus === "inProgress" &&
+    entry.turnId === activeTurnId
+  );
+}
+
+function hasExactWorkGroupPrefix(
+  previous: ReadonlyArray<WorkLogEntry>,
+  next: ReadonlyArray<WorkLogEntry>,
+): boolean {
+  if (next.length < previous.length) return false;
+  for (let index = 0; index < previous.length; index += 1) {
+    if (previous[index] !== next[index]) return false;
+  }
+  return true;
+}
+
+function buildWorkGroupPresentation(
+  entries: ReadonlyArray<WorkLogEntry>,
+  activeTurnId: TurnId | null,
+): WorkGroupPresentationState {
+  const visibleEntries = omitSupersededLifecycleMarkers(
+    entries.filter((entry) =>
+      workEntryIsVisibleInGroup(entry, workEntryIsInActiveRunForTurn(entry, activeTurnId)),
+    ),
+    (entry) => entry,
+  );
+  const state: WorkGroupPresentationState = {
+    rawEntries: entries,
+    activeTurnId,
+    visibleEntries,
+    activeEntries: [],
+    summary: createToolGroupSummaryAccumulator(),
+    latestToolEntry: undefined,
+    hasStatuslessLifecycleMarker: entries.some(isStatuslessLifecycleMarker),
+  };
+  for (const entry of visibleEntries) {
+    appendToolGroupSummaryEntry(state.summary, entry);
+    if (workLogEntryIsToolLike(entry)) {
+      state.latestToolEntry = entry;
+    }
+    if (workEntryIsInActiveRunForTurn(entry, activeTurnId)) {
+      state.activeEntries.push(entry);
+    }
+  }
+  return state;
+}
+
+function appendToWorkGroupPresentation(
+  state: WorkGroupPresentationState,
+  entries: ReadonlyArray<WorkLogEntry>,
+): WorkGroupPresentationState | null {
+  const startIndex = state.rawEntries.length;
+  if (entries.length < startIndex) return null;
+  if (!hasExactWorkGroupPrefix(state.rawEntries, entries)) {
+    return null;
+  }
+  if (entries.length === startIndex) return state;
+
+  for (let index = startIndex; index < entries.length; index += 1) {
+    const entry = entries[index]!;
+    // A later terminal can hide an earlier id-less lifecycle marker. Rebuild
+    // only this uncommon transition; ordinary completed tool calls append in
+    // constant work after the initial group projection.
+    if (state.hasStatuslessLifecycleMarker && isTerminalLifecycleEntry(entry)) {
+      return null;
+    }
+    state.hasStatuslessLifecycleMarker ||= isStatuslessLifecycleMarker(entry);
+    const active = workEntryIsInActiveRunForTurn(entry, state.activeTurnId);
+    if (!workEntryIsVisibleInGroup(entry, active)) {
+      continue;
+    }
+    state.visibleEntries.push(entry);
+    appendToolGroupSummaryEntry(state.summary, entry);
+    if (workLogEntryIsToolLike(entry)) {
+      state.latestToolEntry = entry;
+    }
+    if (active) {
+      state.activeEntries.push(entry);
+    }
+  }
+  state.rawEntries = entries;
+  return state;
+}
+
+function deriveWorkGroupPresentation(
+  entries: ReadonlyArray<WorkLogEntry>,
+  activeTurnId: TurnId | null,
+): WorkGroupPresentationState {
+  const anchor = entries[0];
+  if (!anchor) {
+    return buildWorkGroupPresentation(entries, activeTurnId);
+  }
+  const previous = workGroupPresentationByAnchor.get(anchor);
+  if (previous?.activeTurnId === activeTurnId) {
+    const next = appendToWorkGroupPresentation(previous, entries);
+    if (next) return next;
+  }
+  const next = buildWorkGroupPresentation(entries, activeTurnId);
+  workGroupPresentationByAnchor.set(anchor, next);
+  return next;
+}
+
+type ActiveWorkTimelineEntry = Extract<TimelineEntry, { kind: "work" }>;
+
+interface ActiveWorkPresentationState {
+  rawEntries: ReadonlyArray<ActiveWorkTimelineEntry>;
+  activeTurnId: TurnId | null;
+  visibleEntries: ActiveWorkTimelineEntry[];
+  latestRunningEntry: ActiveWorkTimelineEntry | undefined;
+  hasStatuslessLifecycleMarker: boolean;
+}
+
+const activeWorkPresentationByAnchor = new WeakMap<WorkLogEntry, ActiveWorkPresentationState>();
+
+interface ActiveTimelineScanState {
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  activeTurnId: TurnId | null;
+  activeTurnHeaderIndex: number;
+  activeToolEntries: ReadonlyArray<ActiveWorkTimelineEntry>;
+}
+
+let latestActiveTimelineScan: ActiveTimelineScanState | null = null;
+
+function hasExactActiveWorkPrefix(
+  previous: ReadonlyArray<ActiveWorkTimelineEntry>,
+  next: ReadonlyArray<ActiveWorkTimelineEntry>,
+): boolean {
+  if (next.length < previous.length) return false;
+  for (let index = 0; index < previous.length; index += 1) {
+    if (previous[index] !== next[index]) return false;
+  }
+  return true;
+}
+
+function buildActiveWorkPresentation(
+  entries: ReadonlyArray<ActiveWorkTimelineEntry>,
+  activeTurnId: TurnId | null,
+): ActiveWorkPresentationState {
+  const visibleEntries = omitSupersededLifecycleMarkers(
+    entries.filter((entry) => workEntryIsVisibleInGroup(entry.entry, true)),
+    (entry) => entry.entry,
+  );
+  return {
+    rawEntries: entries,
+    activeTurnId,
+    visibleEntries,
+    latestRunningEntry: visibleEntries.findLast((entry) =>
+      workEntryIsActiveTurnActivity(entry.entry),
+    ),
+    hasStatuslessLifecycleMarker: entries.some((entry) => isStatuslessLifecycleMarker(entry.entry)),
+  };
+}
+
+function appendToActiveWorkPresentation(
+  state: ActiveWorkPresentationState,
+  entries: ReadonlyArray<ActiveWorkTimelineEntry>,
+): ActiveWorkPresentationState | null {
+  const startIndex = state.rawEntries.length;
+  if (entries.length < startIndex) return null;
+  if (!hasExactActiveWorkPrefix(state.rawEntries, entries)) return null;
+  if (entries.length === startIndex) return state;
+
+  for (let index = startIndex; index < entries.length; index += 1) {
+    const entry = entries[index]!;
+    if (state.hasStatuslessLifecycleMarker && isTerminalLifecycleEntry(entry.entry)) {
+      return null;
+    }
+    state.hasStatuslessLifecycleMarker ||= isStatuslessLifecycleMarker(entry.entry);
+    if (!workEntryIsVisibleInGroup(entry.entry, true)) continue;
+    state.visibleEntries.push(entry);
+    if (workEntryIsActiveTurnActivity(entry.entry)) {
+      state.latestRunningEntry = entry;
+    }
+  }
+  state.rawEntries = entries;
+  return state;
+}
+
+function deriveActiveWorkPresentation(
+  entries: ReadonlyArray<ActiveWorkTimelineEntry>,
+  activeTurnId: TurnId | null,
+): ActiveWorkPresentationState {
+  const anchor = entries[0]?.entry;
+  if (!anchor) return buildActiveWorkPresentation(entries, activeTurnId);
+  const previous = activeWorkPresentationByAnchor.get(anchor);
+  if (previous?.activeTurnId === activeTurnId) {
+    const next = appendToActiveWorkPresentation(previous, entries);
+    if (next) return next;
+  }
+  const next = buildActiveWorkPresentation(entries, activeTurnId);
+  activeWorkPresentationByAnchor.set(anchor, next);
+  return next;
+}
+
+function isActiveToolTimelineEntry(
+  entry: TimelineEntry,
+  index: number,
+  activeTurnHeaderIndex: number,
+  activeTurnId: TurnId | null,
+): entry is ActiveWorkTimelineEntry {
+  return (
+    index >= activeTurnHeaderIndex &&
+    (activeTurnId === null || timelineEntryTurnId(entry) === activeTurnId) &&
+    entry.kind === "work" &&
+    entry.entry.agentSpawn === undefined &&
+    entry.entry.tone !== "error" &&
+    !workEntryRendersImagePreview(entry.entry)
+  );
+}
+
+function hasExactTimelinePrefix(
+  previous: ReadonlyArray<TimelineEntry>,
+  next: ReadonlyArray<TimelineEntry>,
+): boolean {
+  if (next.length < previous.length) return false;
+  for (let index = 0; index < previous.length; index += 1) {
+    if (previous[index] !== next[index]) return false;
+  }
+  return true;
+}
+
+function deriveActiveToolTimelineEntries(
+  input: {
+    readonly timelineEntries: ReadonlyArray<TimelineEntry>;
+    readonly isWorking: boolean;
+  },
+  unsettledTurnId: TurnId | null,
+): { activeTurnHeaderIndex: number; activeToolEntries: ReadonlyArray<ActiveWorkTimelineEntry> } {
+  if (!input.isWorking) {
+    latestActiveTimelineScan = null;
+    return { activeTurnHeaderIndex: input.timelineEntries.length, activeToolEntries: [] };
+  }
+
+  const previous = latestActiveTimelineScan;
+  if (
+    previous?.activeTurnId === unsettledTurnId &&
+    hasExactTimelinePrefix(previous.timelineEntries, input.timelineEntries)
+  ) {
+    const appendedEntries: ActiveWorkTimelineEntry[] = [];
+    let canAppend = true;
+    for (
+      let index = previous.timelineEntries.length;
+      index < input.timelineEntries.length;
+      index += 1
+    ) {
+      const entry = input.timelineEntries[index]!;
+      if (
+        !isActiveToolTimelineEntry(entry, index, previous.activeTurnHeaderIndex, unsettledTurnId)
+      ) {
+        canAppend = false;
+        break;
+      }
+      appendedEntries.push(entry);
+    }
+    if (canAppend) {
+      const activeToolEntries =
+        appendedEntries.length > 0
+          ? [...previous.activeToolEntries, ...appendedEntries]
+          : previous.activeToolEntries;
+      latestActiveTimelineScan = {
+        timelineEntries: input.timelineEntries,
+        activeTurnId: unsettledTurnId,
+        activeTurnHeaderIndex: previous.activeTurnHeaderIndex,
+        activeToolEntries,
+      };
+      return {
+        activeTurnHeaderIndex: previous.activeTurnHeaderIndex,
+        activeToolEntries,
+      };
+    }
+  }
+
+  const latestUserMessageIndex = lastUserMessageIndex(input.timelineEntries);
+  const firstOwnedAfterUser =
+    unsettledTurnId === null
+      ? -1
+      : input.timelineEntries.findIndex(
+          (entry, index) =>
+            index > latestUserMessageIndex && timelineEntryTurnId(entry) === unsettledTurnId,
+        );
+  const activeTurnHeaderIndex =
+    firstOwnedAfterUser >= 0 ? firstOwnedAfterUser : latestUserMessageIndex + 1;
+  const activeToolEntries: ActiveWorkTimelineEntry[] = [];
+  for (let index = input.timelineEntries.length - 1; index >= activeTurnHeaderIndex; index -= 1) {
+    const entry = input.timelineEntries[index]!;
+    if (!isActiveToolTimelineEntry(entry, index, activeTurnHeaderIndex, unsettledTurnId)) {
+      break;
+    }
+    activeToolEntries.push(entry);
+  }
+  activeToolEntries.reverse();
+  latestActiveTimelineScan = {
+    timelineEntries: input.timelineEntries,
+    activeTurnId: unsettledTurnId,
+    activeTurnHeaderIndex,
+    activeToolEntries,
+  };
+  return { activeTurnHeaderIndex, activeToolEntries };
+}
+
 export function resolveAssistantMessageCopyState({
   text,
   showCopyButton,
@@ -552,6 +886,13 @@ function deriveTurnFolds(input: {
           ? (entry.entry.turnId ?? null)
           : null;
     if (!turnId) {
+      continue;
+    }
+    if (turnId === input.unsettledTurnId) {
+      // This group is never folded. Consume the pending user boundary just as
+      // the old group allocation did, so a second turn after the same user
+      // message still receives its own duration start.
+      pendingUserBoundary = null;
       continue;
     }
     let group = groupsByTurnId.get(turnId);
@@ -759,6 +1100,7 @@ export function deriveMessagesTimelineRows(input: {
     input.latestTurn ?? null,
     input.runningTurnId ?? null,
   );
+  const activeRunTurnId = input.isWorking ? unsettledTurnId : null;
   const foldsByAnchorEntryId = deriveTurnFolds({
     timelineEntries: input.timelineEntries,
     terminalAssistantMessageIds,
@@ -773,52 +1115,15 @@ export function deriveMessagesTimelineRows(input: {
       }
     }
   }
-
-  let activeTurnHeaderIndex = input.timelineEntries.length;
-  if (input.isWorking) {
-    const latestUserMessageIndex = lastUserMessageIndex(input.timelineEntries);
-    const firstOwnedAfterUser =
-      unsettledTurnId === null
-        ? -1
-        : input.timelineEntries.findIndex(
-            (entry, index) =>
-              index > latestUserMessageIndex && timelineEntryTurnId(entry) === unsettledTurnId,
-          );
-    activeTurnHeaderIndex =
-      firstOwnedAfterUser >= 0 ? firstOwnedAfterUser : latestUserMessageIndex + 1;
-  }
-  const entryBelongsToActiveTurn = (entry: TimelineEntry, index: number) =>
-    input.isWorking &&
-    index >= activeTurnHeaderIndex &&
-    (unsettledTurnId === null || timelineEntryTurnId(entry) === unsettledTurnId);
-  const workEntryIsInActiveRun = (entry: WorkLogEntry) =>
-    input.isWorking &&
-    unsettledTurnId !== null &&
-    entry.toolLifecycleStatus === "inProgress" &&
-    entry.turnId === unsettledTurnId;
-  const activeToolEntries: Array<Extract<TimelineEntry, { kind: "work" }>> = [];
-  for (let index = input.timelineEntries.length - 1; index >= activeTurnHeaderIndex; index -= 1) {
-    const entry = input.timelineEntries[index]!;
-    if (
-      !entryBelongsToActiveTurn(entry, index) ||
-      entry.kind !== "work" ||
-      entry.entry.agentSpawn !== undefined ||
-      entry.entry.tone === "error" ||
-      workEntryRendersImagePreview(entry.entry)
-    ) {
-      break;
-    }
-    activeToolEntries.unshift(entry);
-  }
-  const visibleActiveToolEntries = omitSupersededLifecycleMarkers(
-    activeToolEntries.filter((entry) => workEntryIsVisibleInGroup(entry.entry, true)),
-    (entry) => entry.entry,
+  const { activeTurnHeaderIndex, activeToolEntries } = deriveActiveToolTimelineEntries(
+    input,
+    unsettledTurnId,
   );
+  const activeWorkPresentation = deriveActiveWorkPresentation(activeToolEntries, unsettledTurnId);
+  const visibleActiveToolEntries = activeWorkPresentation.visibleEntries;
   const activeWorkAnchor = activeToolEntries[0];
   const latestVisibleToolEntry = visibleActiveToolEntries.at(-1);
-  const latestRunningToolEntry = visibleActiveToolEntries.findLast((entry) =>
-    workEntryIsActiveTurnActivity(entry.entry),
-  );
+  const latestRunningToolEntry = activeWorkPresentation.latestRunningEntry;
   const latestToolFailed =
     latestRunningToolEntry === undefined &&
     latestVisibleToolEntry !== undefined &&
@@ -940,24 +1245,21 @@ export function deriveMessagesTimelineRows(input: {
         groupedEntries.push(nextEntry.entry);
         cursor += 1;
       }
-      const visibleGroupedEntries = omitSupersededLifecycleMarkers(
-        groupedEntries.filter((entry) =>
-          workEntryIsVisibleInGroup(entry, workEntryIsInActiveRun(entry)),
-        ),
-        (entry) => entry,
-      );
+      const groupPresentation = deriveWorkGroupPresentation(groupedEntries, activeRunTurnId);
+      const visibleGroupedEntries = groupPresentation.visibleEntries;
       if (visibleGroupedEntries.length > 0) {
-        const activeInProgressToolEntries = visibleGroupedEntries.filter(workEntryIsInActiveRun);
+        const activeInProgressToolEntries = groupPresentation.activeEntries;
         if (activeInProgressToolEntries.length > 0) {
           const groupId = workGroupId(timelineEntry.id, timelineEntry.entry);
           const expanded = input.expandedWorkGroupIds?.has(groupId) ?? false;
           const latestActiveToolEntry = activeInProgressToolEntries.at(-1)!;
+          const groupedEntriesSnapshot = visibleGroupedEntries.slice();
           nextRows.push({
             kind: "work-live",
             id: `work-live:${workGroupIdentity(timelineEntry.id, timelineEntry.entry)}`,
             createdAt: timelineEntry.createdAt,
             entry: latestActiveToolEntry,
-            groupedEntries: visibleGroupedEntries,
+            groupedEntries: groupedEntriesSnapshot,
             groupId,
             expanded,
             active: true,
@@ -965,7 +1267,7 @@ export function deriveMessagesTimelineRows(input: {
           hasActivityRow = true;
           if (expanded) {
             nextRows.push(
-              expandedWorkGroupRow(groupId, timelineEntry.createdAt, visibleGroupedEntries),
+              expandedWorkGroupRow(groupId, timelineEntry.createdAt, groupedEntriesSnapshot),
             );
           }
         } else if (
@@ -977,7 +1279,7 @@ export function deriveMessagesTimelineRows(input: {
             kind: "work",
             id: timelineEntry.id,
             createdAt: timelineEntry.createdAt,
-            groupedEntries: visibleGroupedEntries,
+            groupedEntries: visibleGroupedEntries.slice(),
             isExpandedToolGroup: false,
             displayLabel:
               toolGroupAction(singleEntry) === "edit"
@@ -987,7 +1289,7 @@ export function deriveMessagesTimelineRows(input: {
         } else {
           const groupId = workGroupId(timelineEntry.id, timelineEntry.entry);
           const expanded = input.expandedWorkGroupIds?.has(groupId) ?? false;
-          const summaryKind = toolGroupSummaryKind(visibleGroupedEntries);
+          const summaryKind = toolGroupSummaryKindFromAccumulator(groupPresentation.summary);
           const primarySourceEntry = visibleGroupedEntries.find(
             (entry) => entry.toolSource !== undefined,
           );
@@ -1004,7 +1306,7 @@ export function deriveMessagesTimelineRows(input: {
           const groupToolIcon =
             primarySourceIcon ??
             visibleGroupedEntries.findLast((entry) => entry.toolIcon !== undefined)?.toolIcon;
-          const latestToolEntry = visibleGroupedEntries.findLast(workLogEntryIsToolLike);
+          const latestToolEntry = groupPresentation.latestToolEntry;
           const singleEntry =
             visibleGroupedEntries.length === 1 ? (visibleGroupedEntries[0] ?? null) : null;
           const usesSingleToolCallLabel =
@@ -1026,7 +1328,7 @@ export function deriveMessagesTimelineRows(input: {
               ? singleToolCallLabel(singleEntry)
               : singleEntry !== null && !workLogEntryIsToolLike(singleEntry)
                 ? singleEntry.label
-                : summarizeToolGroup(visibleGroupedEntries),
+                : summarizeToolGroupAccumulator(groupPresentation.summary),
             summaryKind,
             ...(groupToolSurface ? { toolSurface: groupToolSurface } : {}),
             ...(groupToolIcon ? { toolIcon: groupToolIcon } : {}),
@@ -1037,7 +1339,7 @@ export function deriveMessagesTimelineRows(input: {
           });
           if (expanded) {
             nextRows.push(
-              expandedWorkGroupRow(groupId, timelineEntry.createdAt, visibleGroupedEntries),
+              expandedWorkGroupRow(groupId, timelineEntry.createdAt, visibleGroupedEntries.slice()),
             );
           }
         }

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -565,14 +565,16 @@ interface ActiveWorkPresentationState {
 
 const activeWorkPresentationByAnchor = new WeakMap<WorkLogEntry, ActiveWorkPresentationState>();
 
-interface ActiveTimelineScanState {
+export interface ActiveTimelineScanState {
   timelineEntries: ReadonlyArray<TimelineEntry>;
   activeTurnId: TurnId | null;
   activeTurnHeaderIndex: number;
   activeToolEntries: ReadonlyArray<ActiveWorkTimelineEntry>;
 }
 
-let latestActiveTimelineScan: ActiveTimelineScanState | null = null;
+export interface ActiveTimelineScanRef {
+  current: ActiveTimelineScanState | null;
+}
 
 function hasExactActiveWorkPrefix(
   previous: ReadonlyArray<ActiveWorkTimelineEntry>,
@@ -678,13 +680,16 @@ function deriveActiveToolTimelineEntries(
     readonly isWorking: boolean;
   },
   unsettledTurnId: TurnId | null,
+  activeTimelineScanRef: ActiveTimelineScanRef | undefined,
 ): { activeTurnHeaderIndex: number; activeToolEntries: ReadonlyArray<ActiveWorkTimelineEntry> } {
   if (!input.isWorking) {
-    latestActiveTimelineScan = null;
+    if (activeTimelineScanRef) {
+      activeTimelineScanRef.current = null;
+    }
     return { activeTurnHeaderIndex: input.timelineEntries.length, activeToolEntries: [] };
   }
 
-  const previous = latestActiveTimelineScan;
+  const previous = activeTimelineScanRef?.current;
   if (
     previous?.activeTurnId === unsettledTurnId &&
     hasExactTimelinePrefix(previous.timelineEntries, input.timelineEntries)
@@ -710,12 +715,14 @@ function deriveActiveToolTimelineEntries(
         appendedEntries.length > 0
           ? [...previous.activeToolEntries, ...appendedEntries]
           : previous.activeToolEntries;
-      latestActiveTimelineScan = {
-        timelineEntries: input.timelineEntries,
-        activeTurnId: unsettledTurnId,
-        activeTurnHeaderIndex: previous.activeTurnHeaderIndex,
-        activeToolEntries,
-      };
+      if (activeTimelineScanRef) {
+        activeTimelineScanRef.current = {
+          timelineEntries: input.timelineEntries,
+          activeTurnId: unsettledTurnId,
+          activeTurnHeaderIndex: previous.activeTurnHeaderIndex,
+          activeToolEntries,
+        };
+      }
       return {
         activeTurnHeaderIndex: previous.activeTurnHeaderIndex,
         activeToolEntries,
@@ -742,12 +749,14 @@ function deriveActiveToolTimelineEntries(
     activeToolEntries.push(entry);
   }
   activeToolEntries.reverse();
-  latestActiveTimelineScan = {
-    timelineEntries: input.timelineEntries,
-    activeTurnId: unsettledTurnId,
-    activeTurnHeaderIndex,
-    activeToolEntries,
-  };
+  if (activeTimelineScanRef) {
+    activeTimelineScanRef.current = {
+      timelineEntries: input.timelineEntries,
+      activeTurnId: unsettledTurnId,
+      activeTurnHeaderIndex,
+      activeToolEntries,
+    };
+  }
   return { activeTurnHeaderIndex, activeToolEntries };
 }
 
@@ -1090,6 +1099,7 @@ export function deriveMessagesTimelineRows(input: {
   activeTurnStartedAt: string | null;
   turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
   revertTurnCountByUserMessageId: ReadonlyMap<MessageId, number>;
+  activeTimelineScanRef?: ActiveTimelineScanRef;
 }): MessagesTimelineRow[] {
   const nextRows: MessagesTimelineRow[] = [];
   const durationStartByMessageId = computeMessageDurationStart(
@@ -1118,6 +1128,7 @@ export function deriveMessagesTimelineRows(input: {
   const { activeTurnHeaderIndex, activeToolEntries } = deriveActiveToolTimelineEntries(
     input,
     unsettledTurnId,
+    input.activeTimelineScanRef,
   );
   const activeWorkPresentation = deriveActiveWorkPresentation(activeToolEntries, unsettledTurnId);
   const visibleActiveToolEntries = activeWorkPresentation.visibleEntries;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -139,6 +139,7 @@ import {
   workEntryIsVisibleInGroup,
   type StableMessagesTimelineRowsState,
   type MessagesTimelineRow,
+  type ActiveTimelineScanState,
   TIMELINE_MINIMAP_MIN_ITEMS,
   type TimelineLatestTurn,
   type WorkGroupScrollAnchor,
@@ -384,6 +385,14 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     );
   }, []);
   const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
+  // Keep the incremental active scan with this timeline instance. The ref
+  // avoids a render per streamed activity and is released with the timeline.
+  const activeTimelineScanRef = useRef<ActiveTimelineScanState | null>(null);
+  const activeTimelineScanRouteKeyRef = useRef(routeThreadKey);
+  if (activeTimelineScanRouteKeyRef.current !== routeThreadKey) {
+    activeTimelineScanRouteKeyRef.current = routeThreadKey;
+    activeTimelineScanRef.current = null;
+  }
   // Scroll/disclosure state outlives virtualized rows, but never the current thread.
   const workGroupViewState = useMemo<WorkGroupViewState>(
     () => ({ scrollPositions: new Map(), expandedEntries: new Set() }),
@@ -510,6 +519,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         activeTurnStartedAt,
         turnDiffSummaryByAssistantMessageId,
         revertTurnCountByUserMessageId,
+        activeTimelineScanRef,
       }),
     [
       timelineEntries,

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -15,7 +15,9 @@ import {
   derivePendingApprovals,
   derivePendingUserInputs,
   deriveTimelineEntries,
+  deriveTimelineEntriesWithState,
   deriveWorkLogEntries,
+  deriveWorkLogEntriesWithState,
   findLatestProposedPlan,
   hasActionableProposedPlan,
   isLatestTurnSettled,
@@ -23,6 +25,12 @@ import {
   workEntryIndicatesToolNeutralStatus,
   workEntryIndicatesToolSuccess,
 } from "./session-logic";
+import { deriveLatestContextWindowSnapshot } from "./lib/contextWindow";
+import { foldSubagentActivities } from "@t3tools/client-runtime/state/subagentRuntime";
+import {
+  computeStableMessagesTimelineRows,
+  deriveMessagesTimelineRows,
+} from "./components/chat/MessagesTimeline.logic";
 
 let nextActivityId = 0;
 
@@ -2047,6 +2055,60 @@ describe("deriveTimelineEntries", () => {
       },
     });
   });
+
+  it("reuses timeline rows across immutable appends and preserves stable tie ordering", () => {
+    const createdAt = "2026-02-23T00:00:01.000Z";
+    const firstMessage = {
+      id: MessageId.make("message-first"),
+      role: "assistant" as const,
+      text: "first",
+      createdAt,
+      turnId: null,
+      updatedAt: createdAt,
+      streaming: false,
+    };
+    const secondMessage = { ...firstMessage, id: MessageId.make("message-second"), text: "second" };
+    const plan = {
+      id: "plan:thread-1:turn:turn-1",
+      turnId: TurnId.make("turn-1"),
+      planMarkdown: "# Ship it",
+      implementedAt: null,
+      implementationThreadId: null,
+      createdAt,
+      updatedAt: createdAt,
+    };
+    const firstWork = { id: "work-1", createdAt, label: "Read", tone: "tool" as const };
+
+    const initial = deriveTimelineEntriesWithState([firstMessage], [plan], [firstWork]);
+    const updated = deriveTimelineEntriesWithState(
+      [firstMessage, secondMessage],
+      [plan],
+      [firstWork],
+      initial,
+    );
+
+    expect(updated.entries[0]).toBe(initial.entries[0]);
+    expect(updated.entries.map((entry) => entry.id)).toEqual([
+      "message-first",
+      "message-second",
+      "plan:thread-1:turn:turn-1",
+      "work-1",
+    ]);
+  });
+
+  it("takes the safe full path when an existing source item is replaced", () => {
+    const firstWork = {
+      id: "work-1",
+      createdAt: "2026-02-23T00:00:01Z",
+      label: "Read",
+      tone: "tool" as const,
+    };
+    const initial = deriveTimelineEntriesWithState([], [], [firstWork]);
+    const replacement = { ...firstWork, label: "Changed" };
+    const updated = deriveTimelineEntriesWithState([], [], [replacement], initial);
+
+    expect(updated.entries[0]).toMatchObject({ kind: "work", entry: replacement });
+  });
 });
 
 describe("deriveWorkLogEntries context window handling", () => {
@@ -2487,5 +2549,337 @@ describe("session activity performance", () => {
       command: "git diff",
       toolLifecycleStatus: "completed",
     });
+  });
+
+  it("keeps an older stateful work-log snapshot safe as a branch point", () => {
+    const first = makeActivity({
+      id: "branch-tool-first",
+      kind: "tool.updated",
+      summary: "Running command",
+      sequence: 0,
+      payload: {
+        itemType: "command_execution",
+        title: "Running command",
+        data: { toolCallId: "branch-call-first", item: { command: ["git", "status"] } },
+      },
+    });
+    const completedBranch = makeActivity({
+      id: "branch-tool-completed",
+      kind: "tool.completed",
+      summary: "Ran command",
+      sequence: 1,
+      payload: {
+        itemType: "command_execution",
+        title: "Ran command",
+        data: { toolCallId: "branch-call-completed", item: { command: ["git", "diff"] } },
+      },
+    });
+    const updatedBranch = makeActivity({
+      id: "branch-tool-updated",
+      kind: "tool.updated",
+      summary: "Running command",
+      sequence: 1,
+      payload: {
+        itemType: "command_execution",
+        title: "Running command",
+        data: { toolCallId: "branch-call-completed", item: { command: ["git", "diff"] } },
+      },
+    });
+    const initial = deriveWorkLogEntriesWithState([first]);
+    const completed = deriveWorkLogEntriesWithState([first, completedBranch], initial);
+    const updated = deriveWorkLogEntriesWithState([first, updatedBranch], initial);
+
+    expect(initial.entries.map((entry) => entry.id)).toEqual(["branch-tool-first"]);
+    expect(completed.entries.map((entry) => entry.id)).toEqual([
+      "branch-tool-first",
+      "branch-tool-completed",
+    ]);
+    expect(updated.entries.map((entry) => entry.id)).toEqual([
+      "branch-tool-first",
+      "branch-tool-updated",
+    ]);
+  });
+
+  it("benchmarks the live ChatView activity projection fanout", () => {
+    const activities = Array.from({ length: 20_000 }, (_, index) =>
+      makeActivity({
+        id: `fanout-tool-${index}`,
+        createdAt: new Date(1_700_000_000_000 + index).toISOString(),
+        kind: "tool.completed",
+        summary: "Ran command",
+        sequence: index,
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: `fanout-tool-${index}`,
+            item: { command: ["git", "status"] },
+          },
+        },
+      }),
+    );
+
+    const startedAt = performance.now();
+    const workLogEntries = deriveWorkLogEntries(activities);
+    const pendingApprovals = derivePendingApprovals(activities);
+    const pendingUserInputs = derivePendingUserInputs(activities);
+    const activePlan = deriveActivePlanState(activities, undefined);
+    const contextWindow = deriveLatestContextWindowSnapshot(activities);
+    const agents = foldSubagentActivities(activities);
+    const timeline = deriveTimelineEntries([], [], workLogEntries);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect({
+      workLogEntries,
+      pendingApprovals,
+      pendingUserInputs,
+      activePlan,
+      contextWindow,
+      agents,
+      timeline,
+    }).toMatchObject({
+      workLogEntries: { length: 20_000 },
+      pendingApprovals: [],
+      pendingUserInputs: [],
+      activePlan: null,
+      contextWindow: null,
+      agents: [],
+      timeline: { length: 20_000 },
+    });
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it("benchmarks repeated live work-log appends", () => {
+    let activities = Array.from({ length: 20_000 }, (_, index) =>
+      makeActivity({
+        id: `streaming-tool-${index}`,
+        createdAt: new Date(1_700_000_000_000 + index).toISOString(),
+        kind: "tool.completed",
+        summary: "Ran command",
+        sequence: index,
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: `streaming-tool-${index}`,
+            item: { command: ["git", "status"] },
+          },
+        },
+      }),
+    );
+    let projection = deriveWorkLogEntriesWithState(activities);
+    let entries = projection.entries;
+    const startedAt = performance.now();
+    for (let index = 0; index < 100; index += 1) {
+      activities = [
+        ...activities,
+        makeActivity({
+          id: `streaming-tool-appended-${index}`,
+          createdAt: new Date(1_700_000_000_000 + activities.length).toISOString(),
+          kind: "tool.completed",
+          summary: "Ran command",
+          sequence: activities.length,
+          payload: {
+            itemType: "command_execution",
+            title: "Ran command",
+            data: {
+              toolCallId: `streaming-tool-appended-${index}`,
+              item: { command: ["git", "diff"] },
+            },
+          },
+        }),
+      ];
+      projection = deriveWorkLogEntriesWithState(activities, projection);
+      entries = projection.entries;
+    }
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(entries).toHaveLength(20_100);
+    expect(elapsedMs).toBeLessThan(500);
+  });
+
+  it("benchmarks repeated work-log appends through timeline rows", () => {
+    let activities = Array.from({ length: 20_000 }, (_, index) =>
+      makeActivity({
+        id: `rows-tool-${index}`,
+        createdAt: new Date(1_700_000_000_000 + index).toISOString(),
+        kind: "tool.completed",
+        summary: "Ran command",
+        sequence: index,
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: `rows-tool-${index}`,
+            item: { command: ["git", "status"] },
+          },
+        },
+      }),
+    );
+    let projection = deriveWorkLogEntriesWithState(activities);
+    let workLogEntries = projection.entries;
+    let timelineProjection = deriveTimelineEntriesWithState([], [], workLogEntries);
+    let timelineEntries = timelineProjection.entries;
+    let stableRows = computeStableMessagesTimelineRows(
+      deriveMessagesTimelineRows({
+        timelineEntries,
+        isWorking: false,
+        activeTurnStartedAt: null,
+        turnDiffSummaryByAssistantMessageId: new Map(),
+        revertTurnCountByUserMessageId: new Map(),
+      }),
+      { byId: new Map(), result: [] },
+    );
+    const startedAt = performance.now();
+    for (let index = 0; index < 100; index += 1) {
+      activities = [
+        ...activities,
+        makeActivity({
+          id: `rows-tool-appended-${index}`,
+          createdAt: new Date(1_700_000_000_000 + activities.length).toISOString(),
+          kind: "tool.completed",
+          summary: "Ran command",
+          sequence: activities.length,
+          payload: {
+            itemType: "command_execution",
+            title: "Ran command",
+            data: {
+              toolCallId: `rows-tool-appended-${index}`,
+              item: { command: ["git", "diff"] },
+            },
+          },
+        }),
+      ];
+      projection = deriveWorkLogEntriesWithState(activities, projection);
+      workLogEntries = projection.entries;
+      timelineProjection = deriveTimelineEntriesWithState(
+        [],
+        [],
+        workLogEntries,
+        timelineProjection,
+      );
+      timelineEntries = timelineProjection.entries;
+      const rows = deriveMessagesTimelineRows({
+        timelineEntries,
+        isWorking: false,
+        activeTurnStartedAt: null,
+        turnDiffSummaryByAssistantMessageId: new Map(),
+        revertTurnCountByUserMessageId: new Map(),
+      });
+      stableRows = computeStableMessagesTimelineRows(rows, stableRows);
+    }
+    const elapsedMs = performance.now() - startedAt;
+
+    expect({ entries: workLogEntries, timelineEntries, rows: stableRows.result }).toMatchObject({
+      entries: { length: 20_100 },
+      timelineEntries: { length: 20_100 },
+      rows: { length: 1 },
+    });
+    expect(elapsedMs).toBeLessThan(1_500);
+  });
+
+  it("benchmarks repeated active timeline appends", () => {
+    const turnId = TurnId.make("active-benchmark-turn");
+    const createdAt = new Date(1_700_000_000_000).toISOString();
+    const userMessage = {
+      id: MessageId.make("active-benchmark-user"),
+      role: "user" as const,
+      text: "Run the tools",
+      turnId: null,
+      createdAt,
+      updatedAt: createdAt,
+      streaming: false,
+    };
+    let activities = Array.from({ length: 20_000 }, (_, index) =>
+      makeActivity({
+        id: `active-rows-tool-${index}`,
+        createdAt: new Date(1_700_000_000_000 + index + 1).toISOString(),
+        kind: "tool.completed",
+        summary: "Ran command",
+        turnId: turnId,
+        sequence: index,
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: `active-rows-tool-${index}`,
+            item: { command: ["git", "status"] },
+          },
+        },
+      }),
+    );
+    let projection = deriveWorkLogEntriesWithState(activities);
+    let timelineProjection = deriveTimelineEntriesWithState([userMessage], [], projection.entries);
+    let timelineEntries = timelineProjection.entries;
+    const input = {
+      isWorking: true,
+      latestTurn: {
+        turnId,
+        state: "running" as const,
+        startedAt: createdAt,
+        completedAt: null,
+      },
+      runningTurnId: turnId,
+      activeTurnStartedAt: createdAt,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    };
+    let stableRows = computeStableMessagesTimelineRows(
+      deriveMessagesTimelineRows({ ...input, timelineEntries }),
+      { byId: new Map(), result: [] },
+    );
+    const startedAt = performance.now();
+    let workLogMs = 0;
+    let timelineMs = 0;
+    let rowsMs = 0;
+    let stableMs = 0;
+    for (let index = 0; index < 100; index += 1) {
+      activities = [
+        ...activities,
+        makeActivity({
+          id: `active-rows-tool-appended-${index}`,
+          createdAt: new Date(1_700_000_000_000 + activities.length + 1).toISOString(),
+          kind: "tool.completed",
+          summary: "Ran command",
+          turnId: turnId,
+          sequence: activities.length,
+          payload: {
+            itemType: "command_execution",
+            title: "Ran command",
+            data: {
+              toolCallId: `active-rows-tool-appended-${index}`,
+              item: { command: ["git", "diff"] },
+            },
+          },
+        }),
+      ];
+      let stageStartedAt = performance.now();
+      projection = deriveWorkLogEntriesWithState(activities, projection);
+      workLogMs += performance.now() - stageStartedAt;
+      stageStartedAt = performance.now();
+      timelineProjection = deriveTimelineEntriesWithState(
+        [userMessage],
+        [],
+        projection.entries,
+        timelineProjection,
+      );
+      timelineEntries = timelineProjection.entries;
+      timelineMs += performance.now() - stageStartedAt;
+      stageStartedAt = performance.now();
+      const rows = deriveMessagesTimelineRows({ ...input, timelineEntries });
+      rowsMs += performance.now() - stageStartedAt;
+      stageStartedAt = performance.now();
+      stableRows = computeStableMessagesTimelineRows(rows, stableRows);
+      stableMs += performance.now() - stageStartedAt;
+    }
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(stableRows.result.find((row) => row.kind === "work-live")).toMatchObject({
+      groupedEntries: { length: 20_100 },
+    });
+    expect(
+      elapsedMs,
+      `active appends ${elapsedMs.toFixed(1)}ms (work ${workLogMs.toFixed(1)}, timeline ${timelineMs.toFixed(1)}, rows ${rowsMs.toFixed(1)}, stable ${stableMs.toFixed(1)})`,
+    ).toBeLessThan(2_000);
   });
 });

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -25,13 +25,6 @@ import {
   workEntryIndicatesToolNeutralStatus,
   workEntryIndicatesToolSuccess,
 } from "./session-logic";
-import { deriveLatestContextWindowSnapshot } from "./lib/contextWindow";
-import { foldSubagentActivities } from "@t3tools/client-runtime/state/subagentRuntime";
-import {
-  computeStableMessagesTimelineRows,
-  deriveMessagesTimelineRows,
-} from "./components/chat/MessagesTimeline.logic";
-
 let nextActivityId = 0;
 
 function makeActivity(overrides: {
@@ -1626,6 +1619,59 @@ describe("deriveWorkLogEntries", () => {
     ]);
   });
 
+  it("keeps changed file paths returned by MCP tools", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({
+        id: "mcp-file-tool",
+        kind: "tool.completed",
+        summary: "Edited file",
+        payload: {
+          itemType: "mcp_tool_call",
+          data: {
+            toolName: "editor",
+            files: [{ path: "apps/web/src/session-logic.ts" }],
+          },
+        },
+      }),
+    ]);
+
+    expect(entry?.changedFiles).toEqual(["apps/web/src/session-logic.ts"]);
+  });
+
+  it("does not treat a path read by a dynamic tool as a changed file", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({
+        id: "dynamic-read-tool",
+        kind: "tool.completed",
+        summary: "Read file",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "read",
+          data: { kind: "read", path: "apps/web/src/session-logic.ts" },
+        },
+      }),
+    ]);
+
+    expect(entry?.changedFiles).toBeUndefined();
+  });
+
+  it("keeps changed file paths from explicitly mutating dynamic tools", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({
+        id: "dynamic-write-tool",
+        kind: "tool.completed",
+        summary: "Wrote file",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "write",
+          data: { kind: "write", path: "apps/web/src/session-logic.ts" },
+        },
+      }),
+    ]);
+
+    expect(entry?.changedFiles).toEqual(["apps/web/src/session-logic.ts"]);
+  });
+
   it("drops duplicated tool detail when it only repeats the title", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -2485,7 +2531,7 @@ describe("rerun workflows", () => {
   });
 });
 
-describe("session activity performance", () => {
+describe("session activity projection reuse", () => {
   it("reuses entries for unchanged activities", () => {
     const activities = ["status", "diff", "log"].map((command, index) =>
       makeActivity({
@@ -2598,288 +2644,5 @@ describe("session activity performance", () => {
       "branch-tool-first",
       "branch-tool-updated",
     ]);
-  });
-
-  it("benchmarks the live ChatView activity projection fanout", () => {
-    const activities = Array.from({ length: 20_000 }, (_, index) =>
-      makeActivity({
-        id: `fanout-tool-${index}`,
-        createdAt: new Date(1_700_000_000_000 + index).toISOString(),
-        kind: "tool.completed",
-        summary: "Ran command",
-        sequence: index,
-        payload: {
-          itemType: "command_execution",
-          title: "Ran command",
-          data: {
-            toolCallId: `fanout-tool-${index}`,
-            item: { command: ["git", "status"] },
-          },
-        },
-      }),
-    );
-
-    const startedAt = performance.now();
-    const workLogEntries = deriveWorkLogEntries(activities);
-    const pendingApprovals = derivePendingApprovals(activities);
-    const pendingUserInputs = derivePendingUserInputs(activities);
-    const activePlan = deriveActivePlanState(activities, undefined);
-    const contextWindow = deriveLatestContextWindowSnapshot(activities);
-    const agents = foldSubagentActivities(activities);
-    const timeline = deriveTimelineEntries([], [], workLogEntries);
-    const elapsedMs = performance.now() - startedAt;
-
-    expect({
-      workLogEntries,
-      pendingApprovals,
-      pendingUserInputs,
-      activePlan,
-      contextWindow,
-      agents,
-      timeline,
-    }).toMatchObject({
-      workLogEntries: { length: 20_000 },
-      pendingApprovals: [],
-      pendingUserInputs: [],
-      activePlan: null,
-      contextWindow: null,
-      agents: [],
-      timeline: { length: 20_000 },
-    });
-    expect(elapsedMs).toBeLessThan(1_000);
-  });
-
-  it("benchmarks repeated live work-log appends", () => {
-    let activities = Array.from({ length: 20_000 }, (_, index) =>
-      makeActivity({
-        id: `streaming-tool-${index}`,
-        createdAt: new Date(1_700_000_000_000 + index).toISOString(),
-        kind: "tool.completed",
-        summary: "Ran command",
-        sequence: index,
-        payload: {
-          itemType: "command_execution",
-          title: "Ran command",
-          data: {
-            toolCallId: `streaming-tool-${index}`,
-            item: { command: ["git", "status"] },
-          },
-        },
-      }),
-    );
-    let projection = deriveWorkLogEntriesWithState(activities);
-    let entries = projection.entries;
-    const startedAt = performance.now();
-    for (let index = 0; index < 100; index += 1) {
-      activities = [
-        ...activities,
-        makeActivity({
-          id: `streaming-tool-appended-${index}`,
-          createdAt: new Date(1_700_000_000_000 + activities.length).toISOString(),
-          kind: "tool.completed",
-          summary: "Ran command",
-          sequence: activities.length,
-          payload: {
-            itemType: "command_execution",
-            title: "Ran command",
-            data: {
-              toolCallId: `streaming-tool-appended-${index}`,
-              item: { command: ["git", "diff"] },
-            },
-          },
-        }),
-      ];
-      projection = deriveWorkLogEntriesWithState(activities, projection);
-      entries = projection.entries;
-    }
-    const elapsedMs = performance.now() - startedAt;
-
-    expect(entries).toHaveLength(20_100);
-    expect(elapsedMs).toBeLessThan(500);
-  });
-
-  it("benchmarks repeated work-log appends through timeline rows", () => {
-    let activities = Array.from({ length: 20_000 }, (_, index) =>
-      makeActivity({
-        id: `rows-tool-${index}`,
-        createdAt: new Date(1_700_000_000_000 + index).toISOString(),
-        kind: "tool.completed",
-        summary: "Ran command",
-        sequence: index,
-        payload: {
-          itemType: "command_execution",
-          title: "Ran command",
-          data: {
-            toolCallId: `rows-tool-${index}`,
-            item: { command: ["git", "status"] },
-          },
-        },
-      }),
-    );
-    let projection = deriveWorkLogEntriesWithState(activities);
-    let workLogEntries = projection.entries;
-    let timelineProjection = deriveTimelineEntriesWithState([], [], workLogEntries);
-    let timelineEntries = timelineProjection.entries;
-    let stableRows = computeStableMessagesTimelineRows(
-      deriveMessagesTimelineRows({
-        timelineEntries,
-        isWorking: false,
-        activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
-      }),
-      { byId: new Map(), result: [] },
-    );
-    const startedAt = performance.now();
-    for (let index = 0; index < 100; index += 1) {
-      activities = [
-        ...activities,
-        makeActivity({
-          id: `rows-tool-appended-${index}`,
-          createdAt: new Date(1_700_000_000_000 + activities.length).toISOString(),
-          kind: "tool.completed",
-          summary: "Ran command",
-          sequence: activities.length,
-          payload: {
-            itemType: "command_execution",
-            title: "Ran command",
-            data: {
-              toolCallId: `rows-tool-appended-${index}`,
-              item: { command: ["git", "diff"] },
-            },
-          },
-        }),
-      ];
-      projection = deriveWorkLogEntriesWithState(activities, projection);
-      workLogEntries = projection.entries;
-      timelineProjection = deriveTimelineEntriesWithState(
-        [],
-        [],
-        workLogEntries,
-        timelineProjection,
-      );
-      timelineEntries = timelineProjection.entries;
-      const rows = deriveMessagesTimelineRows({
-        timelineEntries,
-        isWorking: false,
-        activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
-      });
-      stableRows = computeStableMessagesTimelineRows(rows, stableRows);
-    }
-    const elapsedMs = performance.now() - startedAt;
-
-    expect({ entries: workLogEntries, timelineEntries, rows: stableRows.result }).toMatchObject({
-      entries: { length: 20_100 },
-      timelineEntries: { length: 20_100 },
-      rows: { length: 1 },
-    });
-    expect(elapsedMs).toBeLessThan(1_500);
-  });
-
-  it("benchmarks repeated active timeline appends", () => {
-    const turnId = TurnId.make("active-benchmark-turn");
-    const createdAt = new Date(1_700_000_000_000).toISOString();
-    const userMessage = {
-      id: MessageId.make("active-benchmark-user"),
-      role: "user" as const,
-      text: "Run the tools",
-      turnId: null,
-      createdAt,
-      updatedAt: createdAt,
-      streaming: false,
-    };
-    let activities = Array.from({ length: 20_000 }, (_, index) =>
-      makeActivity({
-        id: `active-rows-tool-${index}`,
-        createdAt: new Date(1_700_000_000_000 + index + 1).toISOString(),
-        kind: "tool.completed",
-        summary: "Ran command",
-        turnId: turnId,
-        sequence: index,
-        payload: {
-          itemType: "command_execution",
-          title: "Ran command",
-          data: {
-            toolCallId: `active-rows-tool-${index}`,
-            item: { command: ["git", "status"] },
-          },
-        },
-      }),
-    );
-    let projection = deriveWorkLogEntriesWithState(activities);
-    let timelineProjection = deriveTimelineEntriesWithState([userMessage], [], projection.entries);
-    let timelineEntries = timelineProjection.entries;
-    const input = {
-      isWorking: true,
-      latestTurn: {
-        turnId,
-        state: "running" as const,
-        startedAt: createdAt,
-        completedAt: null,
-      },
-      runningTurnId: turnId,
-      activeTurnStartedAt: createdAt,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
-    };
-    let stableRows = computeStableMessagesTimelineRows(
-      deriveMessagesTimelineRows({ ...input, timelineEntries }),
-      { byId: new Map(), result: [] },
-    );
-    const startedAt = performance.now();
-    let workLogMs = 0;
-    let timelineMs = 0;
-    let rowsMs = 0;
-    let stableMs = 0;
-    for (let index = 0; index < 100; index += 1) {
-      activities = [
-        ...activities,
-        makeActivity({
-          id: `active-rows-tool-appended-${index}`,
-          createdAt: new Date(1_700_000_000_000 + activities.length + 1).toISOString(),
-          kind: "tool.completed",
-          summary: "Ran command",
-          turnId: turnId,
-          sequence: activities.length,
-          payload: {
-            itemType: "command_execution",
-            title: "Ran command",
-            data: {
-              toolCallId: `active-rows-tool-appended-${index}`,
-              item: { command: ["git", "diff"] },
-            },
-          },
-        }),
-      ];
-      let stageStartedAt = performance.now();
-      projection = deriveWorkLogEntriesWithState(activities, projection);
-      workLogMs += performance.now() - stageStartedAt;
-      stageStartedAt = performance.now();
-      timelineProjection = deriveTimelineEntriesWithState(
-        [userMessage],
-        [],
-        projection.entries,
-        timelineProjection,
-      );
-      timelineEntries = timelineProjection.entries;
-      timelineMs += performance.now() - stageStartedAt;
-      stageStartedAt = performance.now();
-      const rows = deriveMessagesTimelineRows({ ...input, timelineEntries });
-      rowsMs += performance.now() - stageStartedAt;
-      stageStartedAt = performance.now();
-      stableRows = computeStableMessagesTimelineRows(rows, stableRows);
-      stableMs += performance.now() - stageStartedAt;
-    }
-    const elapsedMs = performance.now() - startedAt;
-
-    expect(stableRows.result.find((row) => row.kind === "work-live")).toMatchObject({
-      groupedEntries: { length: 20_100 },
-    });
-    expect(
-      elapsedMs,
-      `active appends ${elapsedMs.toFixed(1)}ms (work ${workLogMs.toFixed(1)}, timeline ${timelineMs.toFixed(1)}, rows ${rowsMs.toFixed(1)}, stable ${stableMs.toFixed(1)})`,
-    ).toBeLessThan(2_000);
   });
 });

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -133,6 +133,26 @@ const derivedWorkLogEntryByActivity = new WeakMap<
   DerivedWorkLogEntry
 >();
 
+/**
+ * The work-log fold is stateful across immutable activity appends. `entries`
+ * remains a fresh array for React, while the private fold indexes are carried
+ * forward so a live tick only has to process the new activity suffix.
+ */
+export interface WorkLogEntriesProjection {
+  readonly activities: ReadonlyArray<OrchestrationThreadActivity>;
+  readonly entries: WorkLogEntry[];
+}
+
+interface WorkLogFoldState {
+  collapsed: DerivedWorkLogEntry[];
+  spawnRowIndex: Map<string, number>;
+  groupKeyByTaskId: Map<string, string>;
+  toolLifecycleRowIndex: Map<string, number>;
+  processedActivityCount: number;
+}
+
+const workLogFoldStateByProjection = new WeakMap<WorkLogEntriesProjection, WorkLogFoldState>();
+
 export interface PendingApproval {
   requestId: ApprovalRequestId;
   requestKind: ProviderRequestKind;
@@ -191,6 +211,13 @@ export type TimelineEntry =
       createdAt: string;
       entry: WorkLogEntry;
     };
+
+export interface TimelineEntriesProjection {
+  readonly messages: ReadonlyArray<ChatMessage>;
+  readonly proposedPlans: ReadonlyArray<ProposedPlan>;
+  readonly workEntries: ReadonlyArray<WorkLogEntry>;
+  readonly entries: TimelineEntry[];
+}
 
 export function workLogEntryIsToolLike(entry: WorkLogEntry): boolean {
   if (entry.tone === "tool" || entry.tone === "thinking" || entry.tone === "error") {
@@ -441,9 +468,16 @@ export function derivePendingApprovals(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingApproval[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingApproval>();
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
 
   for (const activity of ordered) {
+    if (
+      activity.kind !== "approval.requested" &&
+      activity.kind !== "approval.resolved" &&
+      activity.kind !== "provider.approval.respond.failed"
+    ) {
+      continue;
+    }
     const payload =
       activity.payload && typeof activity.payload === "object"
         ? (activity.payload as Record<string, unknown>)
@@ -554,9 +588,16 @@ export function derivePendingUserInputs(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingUserInput[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingUserInput>();
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
 
   for (const activity of ordered) {
+    if (
+      activity.kind !== "user-input.requested" &&
+      activity.kind !== "user-input.resolved" &&
+      activity.kind !== "provider.user-input.respond.failed"
+    ) {
+      continue;
+    }
     const payload =
       activity.payload && typeof activity.payload === "object"
         ? (activity.payload as Record<string, unknown>)
@@ -702,7 +743,7 @@ export function deriveActivePlanState(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   latestTurnId: TurnId | undefined,
 ): ActivePlanState | null {
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
   const allPlanActivities = ordered.filter((activity) => activity.kind === "turn.plan.updated");
   // Prefer plan from the current turn; fall back to the most recent plan from any turn
   // so that TodoWrite tasks persist across follow-up messages.
@@ -823,30 +864,111 @@ function isAgentInternalActivity(activity: OrchestrationThreadActivity): boolean
   return typeof payload.agentId === "string" && payload.agentId.trim().length > 0;
 }
 
+function deriveWorkLogEntryOrNull(
+  activity: OrchestrationThreadActivity,
+): DerivedWorkLogEntry | null {
+  if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) return null;
+  if (activity.kind === "tool.started") return null;
+  // Agent task.started rows are CTA seeds: they carry the true spawn turn,
+  // which is the batch key (completions of background subagents arrive
+  // under later synthetic turns and must not start new batches). They
+  // collapse into the batch's single CTA row, never render standalone.
+  if (activity.kind === "task.started" && !isAgentTaskStartedActivity(activity)) return null;
+  if (activity.kind === "task.updated") return null;
+  if (activity.kind === "tool.progress") return null;
+  if (activity.kind === "context-window.updated") return null;
+  if (activity.kind === "turn.plan.updated") return null;
+  if (activity.summary === "Checkpoint captured") return null;
+  if (isNoContentRuntimeWarning(activity)) return null;
+  if (isPlanBoundaryToolActivity(activity)) return null;
+  if (isAgentInternalActivity(activity)) return null;
+  return toDerivedWorkLogEntry(activity);
+}
+
+function deriveWorkLogFoldState(
+  ordered: ReadonlyArray<OrchestrationThreadActivity>,
+): WorkLogFoldState {
+  const state: WorkLogFoldState = {
+    collapsed: [],
+    spawnRowIndex: new Map(),
+    groupKeyByTaskId: new Map(),
+    toolLifecycleRowIndex: new Map(),
+    processedActivityCount: ordered.length,
+  };
+  for (const activity of ordered) {
+    const entry = deriveWorkLogEntryOrNull(activity);
+    if (entry) {
+      appendDerivedWorkLogEntry(state, entry);
+    }
+  }
+  return state;
+}
+
+function hasExactActivityPrefix(
+  previous: ReadonlyArray<OrchestrationThreadActivity>,
+  next: ReadonlyArray<OrchestrationThreadActivity>,
+): boolean {
+  if (previous.length === 0 || next.length <= previous.length) {
+    return false;
+  }
+  for (let index = 0; index < previous.length; index += 1) {
+    if (previous[index] !== next[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Derive a work-log projection, reusing the fold state when the ordered
+ * activity list is an immutable append of the previous projection. The exact
+ * prefix check keeps snapshots, reorders, and reverts on the full-safe path.
+ */
+export function deriveWorkLogEntriesWithState(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  previous: WorkLogEntriesProjection | null = null,
+): WorkLogEntriesProjection {
+  const ordered = orderedActivities(activities);
+  const previousFold = previous ? workLogFoldStateByProjection.get(previous) : undefined;
+  const previousActivities = previous?.activities;
+  let fold: WorkLogFoldState;
+  if (
+    previousFold !== undefined &&
+    previousActivities !== undefined &&
+    previousFold.processedActivityCount === previousActivities.length &&
+    hasExactActivityPrefix(previousActivities, ordered)
+  ) {
+    // The fold indexes are mutable while building the next snapshot, but the
+    // previous projection must remain a valid branch point for a revert or a
+    // competing thread update. Clone the small indexes as well as the
+    // rendered array before applying the new suffix.
+    fold = {
+      collapsed: [...previousFold.collapsed],
+      spawnRowIndex: new Map(previousFold.spawnRowIndex),
+      groupKeyByTaskId: new Map(previousFold.groupKeyByTaskId),
+      toolLifecycleRowIndex: new Map(previousFold.toolLifecycleRowIndex),
+      processedActivityCount: previousFold.processedActivityCount,
+    };
+    for (let index = previousActivities.length; index < ordered.length; index += 1) {
+      const entry = deriveWorkLogEntryOrNull(ordered[index]!);
+      if (entry) {
+        appendDerivedWorkLogEntry(fold, entry);
+      }
+    }
+    fold.processedActivityCount = ordered.length;
+  } else {
+    fold = deriveWorkLogFoldState(ordered);
+  }
+
+  const projection: WorkLogEntriesProjection = { activities: ordered, entries: fold.collapsed };
+  workLogFoldStateByProjection.set(projection, fold);
+  return projection;
+}
+
 export function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): WorkLogEntry[] {
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
-  const entries: DerivedWorkLogEntry[] = [];
-  for (const activity of ordered) {
-    if (activity.tone !== "error" && isWorktreeSetupActivity(activity.kind)) continue;
-    if (activity.kind === "tool.started") continue;
-    // Agent task.started rows are CTA seeds: they carry the true spawn turn,
-    // which is the batch key (completions of background subagents arrive
-    // under later synthetic turns and must not start new batches). They
-    // collapse into the batch's single CTA row, never render standalone.
-    if (activity.kind === "task.started" && !isAgentTaskStartedActivity(activity)) continue;
-    if (activity.kind === "task.updated") continue;
-    if (activity.kind === "tool.progress") continue;
-    if (activity.kind === "context-window.updated") continue;
-    if (activity.kind === "turn.plan.updated") continue;
-    if (activity.summary === "Checkpoint captured") continue;
-    if (isNoContentRuntimeWarning(activity)) continue;
-    if (isPlanBoundaryToolActivity(activity)) continue;
-    if (isAgentInternalActivity(activity)) continue;
-    entries.push(toDerivedWorkLogEntry(activity));
-  }
-  return collapseDerivedWorkLogEntries(entries);
+  return deriveWorkLogEntriesWithState(activities).entries;
 }
 
 /** Adapters forward unknown wire-only SDK messages (background_tasks_changed,
@@ -900,8 +1022,12 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     activity.payload && typeof activity.payload === "object"
       ? (activity.payload as Record<string, unknown>)
       : null;
+  const itemType = extractWorkLogItemType(payload);
   const commandPreview = extractToolCommand(payload);
-  const changedFiles = extractChangedFiles(payload);
+  // Only file-change items carry changed-file metadata. Keep the fallback for
+  // legacy payloads without a recognized item type.
+  const changedFiles =
+    itemType !== undefined && itemType !== "file_change" ? [] : extractChangedFiles(payload);
   const title = extractToolTitle(payload);
   const toolPresentation = extractToolActivityPresentation(payload);
   const isTaskActivity =
@@ -927,7 +1053,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       payload.detail.length > 0
       ? stripTrailingExitCode(payload.detail).output
       : null
-    : extractToolDetail(payload, title ?? activity.summary);
+    : extractToolDetail(payload, title ?? activity.summary, commandPreview);
   const toolCallId = isTaskActivity ? null : extractToolCallId(payload);
   const entry: DerivedWorkLogEntry = {
     id: activity.id,
@@ -942,7 +1068,6 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
           : activity.tone,
     sourceActivityKind: activity.kind,
   };
-  const itemType = extractWorkLogItemType(payload);
   const requestKind = extractWorkLogRequestKind(payload);
   const viewedImagePath = asTrimmedString(asRecord(payload?.data)?.imagePath);
   if (detail) {
@@ -1052,102 +1177,99 @@ function toolLifecycleCollapseMapKey(entry: DerivedWorkLogEntry): string | undef
   ) {
     return undefined;
   }
-  return entry.toolCallId ? `tool:${entry.turnId ?? "no-turn"}:${entry.toolCallId}` : undefined;
+  return entry.toolCallId ? entry[workLogCollapseKey] : undefined;
 }
 
-function collapseDerivedWorkLogEntries(
-  entries: ReadonlyArray<DerivedWorkLogEntry>,
-): DerivedWorkLogEntry[] {
-  const collapsed: DerivedWorkLogEntry[] = [];
+function appendDerivedWorkLogEntry(state: WorkLogFoldState, entry: DerivedWorkLogEntry): void {
+  const collapsed = state.collapsed;
   // Subagent rows collapse by spawn group, not adjacency: a workflow run (or
   // a turn's batch of direct spawns) is ONE narrative event in the chat — a
   // CTA row that opens the Agents panel — no matter how many agents it
   // contains or how their progress rows interleave (quiet-timeline
   // guarantee).
-  const spawnRowIndex = new Map<string, number>();
   // Batch membership is decided once, at the FIRST row seen for a taskId.
   // Claude background subagents settle between turns, so their completion
   // rows carry fresh synthetic turn ids (or none) — keying each row by its
   // own turn splintered one batch into a stream of "Kicked off N subagents"
   // rows (live-test finding, thread 7ac7ef05).
-  const groupKeyByTaskId = new Map<string, string>();
-  const toolLifecycleRowIndex = new Map<string, number>();
-  for (const entry of entries) {
-    const isTaskRow =
-      entry.taskId !== undefined &&
-      !entry.isBackgroundTask &&
-      (entry.sourceActivityKind === "task.started" ||
-        entry.sourceActivityKind === "task.progress" ||
-        entry.sourceActivityKind === "task.completed");
-    if (isTaskRow && entry.taskId !== undefined) {
-      const rememberedKey = groupKeyByTaskId.get(entry.taskId);
-      const groupKey = rememberedKey ?? agentSpawnGroupKey(entry);
-      if (rememberedKey === undefined) {
-        groupKeyByTaskId.set(entry.taskId, groupKey);
-      }
-      const workflowId = groupKey.startsWith("wf:") ? groupKey.slice(3) : null;
-      const existingIndex = spawnRowIndex.get(groupKey);
-      if (existingIndex !== undefined) {
-        const existing = collapsed[existingIndex]!;
-        const agentTaskIds = existing.agentSpawn?.agentTaskIds.includes(entry.taskId)
-          ? existing.agentSpawn.agentTaskIds
-          : [...(existing.agentSpawn?.agentTaskIds ?? []), entry.taskId];
-        collapsed[existingIndex] = {
-          ...mergeDerivedWorkLogEntries(existing, entry),
-          // The CTA row keeps the group's ANCHOR identity, not the last
-          // agent's: id/createdAt/turnId stay pinned to the spawn point so
-          // the row renders where the run launched instead of drifting to
-          // the newest progress tick (mid-run it drifted below the whole
-          // conversation, reading as "no visualization"), and the stable id
-          // keeps React state/virtualization sane.
-          id: existing.id,
-          createdAt: existing.createdAt,
-          turnId: existing.turnId ?? null,
-          ...(existing.taskId !== undefined ? { taskId: existing.taskId } : {}),
-          label: existing.label,
-          agentSpawn: { workflowId, agentTaskIds },
-        };
-        continue;
-      }
-      spawnRowIndex.set(groupKey, collapsed.length);
-      collapsed.push({
-        ...entry,
-        agentSpawn: { workflowId, agentTaskIds: [entry.taskId] },
-      });
-      continue;
+  const isTaskRow =
+    entry.taskId !== undefined &&
+    !entry.isBackgroundTask &&
+    (entry.sourceActivityKind === "task.started" ||
+      entry.sourceActivityKind === "task.progress" ||
+      entry.sourceActivityKind === "task.completed");
+  if (isTaskRow && entry.taskId !== undefined) {
+    const rememberedKey = state.groupKeyByTaskId.get(entry.taskId);
+    const groupKey = rememberedKey ?? agentSpawnGroupKey(entry);
+    if (rememberedKey === undefined) {
+      state.groupKeyByTaskId.set(entry.taskId, groupKey);
     }
-    const lifecycleKey = toolLifecycleCollapseMapKey(entry);
-    if (lifecycleKey !== undefined) {
-      const matchingLifecycleIndex = toolLifecycleRowIndex.get(lifecycleKey);
-      const matchingEntry =
-        matchingLifecycleIndex === undefined ? undefined : collapsed[matchingLifecycleIndex];
-      if (
-        matchingLifecycleIndex !== undefined &&
-        matchingEntry &&
-        shouldCollapseToolLifecycleEntries(matchingEntry, entry)
-      ) {
-        collapsed[matchingLifecycleIndex] = mergeDerivedWorkLogEntries(matchingEntry, entry);
-        continue;
-      }
-      toolLifecycleRowIndex.delete(lifecycleKey);
+    const workflowId = groupKey.startsWith("wf:") ? groupKey.slice(3) : null;
+    const existingIndex = state.spawnRowIndex.get(groupKey);
+    if (existingIndex !== undefined) {
+      const existing = collapsed[existingIndex]!;
+      const agentTaskIds = existing.agentSpawn?.agentTaskIds.includes(entry.taskId)
+        ? existing.agentSpawn.agentTaskIds
+        : [...(existing.agentSpawn?.agentTaskIds ?? []), entry.taskId];
+      collapsed[existingIndex] = {
+        ...mergeDerivedWorkLogEntries(existing, entry),
+        // The CTA row keeps the group's ANCHOR identity, not the last
+        // agent's: id/createdAt/turnId stay pinned to the spawn point so
+        // the row renders where the run launched instead of drifting to
+        // the newest progress tick (mid-run it drifted below the whole
+        // conversation, reading as "no visualization"), and the stable id
+        // keeps React state/virtualization sane.
+        id: existing.id,
+        createdAt: existing.createdAt,
+        turnId: existing.turnId ?? null,
+        ...(existing.taskId !== undefined ? { taskId: existing.taskId } : {}),
+        label: existing.label,
+        agentSpawn: { workflowId, agentTaskIds },
+      };
+      return;
     }
-    const previous = collapsed.at(-1);
-    if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
-      const previousIndex = collapsed.length - 1;
-      const previousKey = toolLifecycleCollapseMapKey(previous);
-      if (previousKey !== undefined) toolLifecycleRowIndex.delete(previousKey);
-      const merged = mergeDerivedWorkLogEntries(previous, entry);
-      collapsed[previousIndex] = merged;
-      const mergedKey = toolLifecycleCollapseMapKey(merged);
-      if (mergedKey !== undefined) toolLifecycleRowIndex.set(mergedKey, previousIndex);
-      continue;
-    }
-    collapsed.push(entry);
-    if (lifecycleKey !== undefined) {
-      toolLifecycleRowIndex.set(lifecycleKey, collapsed.length - 1);
-    }
+    state.spawnRowIndex.set(groupKey, collapsed.length);
+    collapsed.push({
+      ...entry,
+      agentSpawn: { workflowId, agentTaskIds: [entry.taskId] },
+    });
+    return;
   }
-  return collapsed;
+  const lifecycleKey = toolLifecycleCollapseMapKey(entry);
+  if (lifecycleKey !== undefined) {
+    const matchingLifecycleIndex = state.toolLifecycleRowIndex.get(lifecycleKey);
+    const matchingEntry =
+      matchingLifecycleIndex === undefined ? undefined : collapsed[matchingLifecycleIndex];
+    if (
+      matchingLifecycleIndex !== undefined &&
+      matchingEntry &&
+      shouldCollapseToolLifecycleEntries(matchingEntry, entry)
+    ) {
+      collapsed[matchingLifecycleIndex] = mergeDerivedWorkLogEntries(matchingEntry, entry);
+      if (entry.sourceActivityKind !== "tool.updated") {
+        state.toolLifecycleRowIndex.delete(lifecycleKey);
+      }
+      return;
+    }
+    state.toolLifecycleRowIndex.delete(lifecycleKey);
+  }
+  const previous = collapsed.at(-1);
+  if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
+    const previousIndex = collapsed.length - 1;
+    const previousKey = toolLifecycleCollapseMapKey(previous);
+    if (previousKey !== undefined) state.toolLifecycleRowIndex.delete(previousKey);
+    const merged = mergeDerivedWorkLogEntries(previous, entry);
+    collapsed[previousIndex] = merged;
+    const mergedKey = toolLifecycleCollapseMapKey(merged);
+    if (mergedKey !== undefined && merged.sourceActivityKind === "tool.updated") {
+      state.toolLifecycleRowIndex.set(mergedKey, previousIndex);
+    }
+    return;
+  }
+  collapsed.push(entry);
+  if (lifecycleKey !== undefined && entry.sourceActivityKind === "tool.updated") {
+    state.toolLifecycleRowIndex.set(lifecycleKey, collapsed.length - 1);
+  }
 }
 
 function shouldCollapseToolLifecycleEntries(
@@ -1311,9 +1433,8 @@ function executableBasename(value: string): string | null {
   if (trimmed.length === 0) {
     return null;
   }
-  const normalized = trimmed.replace(/\\/g, "/");
-  const segments = normalized.split("/");
-  const last = segments.at(-1)?.trim() ?? "";
+  const lastSeparator = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  const last = trimmed.slice(lastSeparator + 1).trim();
   return last.length > 0 ? last.toLowerCase() : null;
 }
 
@@ -1448,12 +1569,22 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
 } {
   const data = asRecord(payload?.data);
   const item = asRecord(data?.item);
-  const itemResult = asRecord(item?.result);
+  const itemCommand = item?.command;
+  if (itemCommand !== undefined) {
+    const command = normalizeCommandValue(itemCommand);
+    if (command) {
+      return {
+        command,
+        rawCommand: toRawToolCommand(itemCommand, command),
+      };
+    }
+  }
+
   const itemInput = asRecord(item?.input);
+  const itemResult = asRecord(item?.result);
   const itemType = asTrimmedString(payload?.itemType);
   const detail = asTrimmedString(payload?.detail);
   const candidates: unknown[] = [
-    item?.command,
     itemInput?.command,
     itemResult?.command,
     data?.command,
@@ -1569,29 +1700,27 @@ function isCommandToolDetail(payload: Record<string, unknown> | null, heading: s
 function extractToolDetail(
   payload: Record<string, unknown> | null,
   heading: string,
+  commandPreview: { command: string | null; rawCommand: string | null },
 ): string | null {
-  const rawDetail = asTrimmedString(payload?.detail);
-  const detail = rawDetail ? stripTrailingExitCode(rawDetail).output : null;
-  const normalizedHeading = normalizePreviewForComparison(heading);
-  const normalizedDetail = normalizePreviewForComparison(detail);
   const commandTool = isCommandToolDetail(payload, heading);
-  const commandPreview = commandTool
-    ? extractToolCommand(payload)
-    : { command: null, rawCommand: null };
-  const command = commandPreview.command;
+  const command = commandTool ? commandPreview.command : null;
 
   if (commandTool && command) {
     const output = extractToolOutput(payload);
     if (output) return output;
   }
 
+  const rawDetail = asTrimmedString(payload?.detail);
+  const detail = rawDetail ? stripTrailingExitCode(rawDetail).output : null;
+  const normalizedHeading = normalizePreviewForComparison(heading);
+  const normalizedDetail = normalizePreviewForComparison(detail);
   const data = asRecord(payload?.data);
   const repeatsCommand =
     detail !== null &&
     commandDetailRepeatsCommand({
       detail,
       command,
-      rawCommand: commandPreview.rawCommand,
+      rawCommand: commandTool ? commandPreview.rawCommand : null,
       toolName: data?.toolName,
       data,
     });
@@ -1620,6 +1749,13 @@ function stripTrailingExitCode(value: string): {
   exitCode?: number | undefined;
 } {
   const trimmed = value.trim();
+  // Most provider details do not carry an exit-code suffix. Avoid running the
+  // backtracking expression for those rows.
+  if (!trimmed.endsWith(">")) {
+    return {
+      output: trimmed.length > 0 ? trimmed : null,
+    };
+  }
   const match = /^(?<output>[\s\S]*?)(?:\s*<exited with exit code (?<code>\d+)>)\s*$/i.exec(
     trimmed,
   );
@@ -1763,32 +1899,179 @@ function compareActivityLifecycleRank(kind: string): number {
   return 1;
 }
 
+const orderedActivitiesCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  ReadonlyArray<OrchestrationThreadActivity>
+>();
+
+function orderedActivities(activities: ReadonlyArray<OrchestrationThreadActivity>) {
+  const cached = orderedActivitiesCache.get(activities);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let isOrdered = true;
+  for (let index = 1; index < activities.length; index += 1) {
+    const previous = activities[index - 1];
+    const current = activities[index];
+    if (previous && current && compareActivitiesByOrder(previous, current) > 0) {
+      isOrdered = false;
+      break;
+    }
+  }
+
+  const ordered = isOrdered ? activities : [...activities].toSorted(compareActivitiesByOrder);
+  orderedActivitiesCache.set(activities, ordered);
+  return ordered;
+}
+
+function timelineEntryFromMessage(message: ChatMessage): TimelineEntry {
+  return {
+    id: message.id,
+    kind: "message",
+    createdAt: message.createdAt,
+    message,
+  };
+}
+
+function timelineEntryFromProposedPlan(proposedPlan: ProposedPlan): TimelineEntry {
+  return {
+    id: proposedPlan.id,
+    kind: "proposed-plan",
+    createdAt: proposedPlan.createdAt,
+    proposedPlan,
+  };
+}
+
+function timelineEntryFromWork(workEntry: WorkLogEntry): TimelineEntry {
+  return {
+    id: workEntry.id,
+    kind: "work",
+    createdAt: workEntry.createdAt,
+    entry: workEntry,
+  };
+}
+
+function compareTimelineEntriesByCreatedAt(left: TimelineEntry, right: TimelineEntry): number {
+  return left.createdAt.localeCompare(right.createdAt);
+}
+
+function timelineEntrySourceOrder(entry: TimelineEntry): number {
+  switch (entry.kind) {
+    case "message":
+      return 0;
+    case "proposed-plan":
+      return 1;
+    case "work":
+      return 2;
+  }
+}
+
+function shouldTakePreviousTimelineEntry(previous: TimelineEntry, suffix: TimelineEntry): boolean {
+  const createdAtComparison = compareTimelineEntriesByCreatedAt(previous, suffix);
+  if (createdAtComparison !== 0) return createdAtComparison < 0;
+  // The original full derivation sorts a source-ordered array with a stable
+  // comparator. On a tie, messages precede plans, plans precede work, and an
+  // older item in the same source array precedes a newly appended item.
+  return timelineEntrySourceOrder(previous) <= timelineEntrySourceOrder(suffix);
+}
+
+function hasExactArrayPrefix<T>(previous: ReadonlyArray<T>, next: ReadonlyArray<T>): boolean {
+  if (next.length < previous.length) return false;
+  for (let index = 0; index < previous.length; index += 1) {
+    if (previous[index] !== next[index]) return false;
+  }
+  return true;
+}
+
+function mergeTimelineEntrySuffix(
+  previous: ReadonlyArray<TimelineEntry>,
+  suffix: ReadonlyArray<TimelineEntry>,
+): TimelineEntry[] {
+  if (suffix.length === 0) return [...previous];
+  const previousLast = previous.at(-1);
+  let suffixIsOrdered = true;
+  for (let index = 1; index < suffix.length; index += 1) {
+    if (compareTimelineEntriesByCreatedAt(suffix[index - 1]!, suffix[index]!) > 0) {
+      suffixIsOrdered = false;
+      break;
+    }
+  }
+  if (
+    suffixIsOrdered &&
+    (previousLast === undefined || shouldTakePreviousTimelineEntry(previousLast, suffix[0]!))
+  ) {
+    return [...previous, ...suffix];
+  }
+
+  const merged: TimelineEntry[] = [];
+  let previousIndex = 0;
+  let suffixIndex = 0;
+  while (previousIndex < previous.length || suffixIndex < suffix.length) {
+    const previousEntry = previous[previousIndex];
+    const suffixEntry = suffix[suffixIndex];
+    if (
+      previousEntry !== undefined &&
+      (suffixEntry === undefined || shouldTakePreviousTimelineEntry(previousEntry, suffixEntry))
+    ) {
+      merged.push(previousEntry);
+      previousIndex += 1;
+    } else if (suffixEntry !== undefined) {
+      merged.push(suffixEntry);
+      suffixIndex += 1;
+    }
+  }
+  return merged;
+}
+
+export function deriveTimelineEntriesWithState(
+  messages: ReadonlyArray<ChatMessage>,
+  proposedPlans: ReadonlyArray<ProposedPlan>,
+  workEntries: ReadonlyArray<WorkLogEntry>,
+  previous: TimelineEntriesProjection | null = null,
+): TimelineEntriesProjection {
+  const canAppend =
+    previous !== null &&
+    hasExactArrayPrefix(previous.messages, messages) &&
+    hasExactArrayPrefix(previous.proposedPlans, proposedPlans) &&
+    hasExactArrayPrefix(previous.workEntries, workEntries);
+
+  if (canAppend) {
+    const messageRows = messages.slice(previous.messages.length).map(timelineEntryFromMessage);
+    const proposedPlanRows = proposedPlans
+      .slice(previous.proposedPlans.length)
+      .map(timelineEntryFromProposedPlan);
+    const workRows = workEntries.slice(previous.workEntries.length).map(timelineEntryFromWork);
+    const suffix = [...messageRows, ...proposedPlanRows, ...workRows].toSorted(
+      compareTimelineEntriesByCreatedAt,
+    );
+    return {
+      messages,
+      proposedPlans,
+      workEntries,
+      entries: mergeTimelineEntrySuffix(previous.entries, suffix),
+    };
+  }
+
+  const messageRows = messages.map(timelineEntryFromMessage);
+  const proposedPlanRows = proposedPlans.map(timelineEntryFromProposedPlan);
+  const workRows = workEntries.map(timelineEntryFromWork);
+  return {
+    messages,
+    proposedPlans,
+    workEntries,
+    entries: [...messageRows, ...proposedPlanRows, ...workRows].toSorted(
+      compareTimelineEntriesByCreatedAt,
+    ),
+  };
+}
+
 export function deriveTimelineEntries(
   messages: ReadonlyArray<ChatMessage>,
   proposedPlans: ReadonlyArray<ProposedPlan>,
   workEntries: ReadonlyArray<WorkLogEntry>,
 ): TimelineEntry[] {
-  const messageRows: TimelineEntry[] = messages.map((message) => ({
-    id: message.id,
-    kind: "message",
-    createdAt: message.createdAt,
-    message,
-  }));
-  const proposedPlanRows: TimelineEntry[] = proposedPlans.map((proposedPlan) => ({
-    id: proposedPlan.id,
-    kind: "proposed-plan",
-    createdAt: proposedPlan.createdAt,
-    proposedPlan,
-  }));
-  const workRows: TimelineEntry[] = workEntries.map((entry) => ({
-    id: entry.id,
-    kind: "work",
-    createdAt: entry.createdAt,
-    entry,
-  }));
-  return [...messageRows, ...proposedPlanRows, ...workRows].toSorted((a, b) =>
-    a.createdAt.localeCompare(b.createdAt),
-  );
+  return deriveTimelineEntriesWithState(messages, proposedPlans, workEntries).entries;
 }
 
 export function inferCheckpointTurnCountByTurnId(

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1023,11 +1023,22 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       ? (activity.payload as Record<string, unknown>)
       : null;
   const itemType = extractWorkLogItemType(payload);
+  const requestKind = extractWorkLogRequestKind(payload);
   const commandPreview = extractToolCommand(payload);
-  // Only file-change items carry changed-file metadata. Keep the fallback for
-  // legacy payloads without a recognized item type.
-  const changedFiles =
-    itemType !== undefined && itemType !== "file_change" ? [] : extractChangedFiles(payload);
+  const dataKind = asTrimmedString(asRecord(payload?.data)?.kind)?.toLowerCase();
+  // File-change events and mutating dynamic tools carry explicit edit
+  // metadata. MCP results can also return normalized `files`, while legacy
+  // payloads without an item type still need the recursive fallback.
+  const shouldExtractChangedFiles =
+    itemType === undefined ||
+    itemType === "file_change" ||
+    itemType === "mcp_tool_call" ||
+    requestKind === "file-change" ||
+    dataKind === "edit" ||
+    dataKind === "write" ||
+    dataKind === "move" ||
+    dataKind === "delete";
+  const changedFiles = shouldExtractChangedFiles ? extractChangedFiles(payload) : [];
   const title = extractToolTitle(payload);
   const toolPresentation = extractToolActivityPresentation(payload);
   const isTaskActivity =
@@ -1068,7 +1079,6 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
           : activity.tone,
     sourceActivityKind: activity.kind,
   };
-  const requestKind = extractWorkLogRequestKind(payload);
   const viewedImagePath = asTrimmedString(asRecord(payload?.data)?.imagePath);
   if (detail) {
     entry.detail = detail;

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -387,24 +387,6 @@ export function resolveViewedImageAsset(
   return { resource: media.resource, alt: media.name, srcFragment: media.srcFragment };
 }
 
-function toolGroupActionCount(
-  action: ToolGroupAction,
-  entries: ReadonlyArray<WorkLogPresentationEntry>,
-): number {
-  if (action !== "edit") return entries.length;
-
-  const changedFiles = new Set<string>();
-  let editsWithoutFileDetails = 0;
-  for (const entry of entries) {
-    if (!entry.changedFiles || entry.changedFiles.length === 0) {
-      editsWithoutFileDetails += 1;
-      continue;
-    }
-    for (const file of entry.changedFiles) changedFiles.add(file);
-  }
-  return changedFiles.size + editsWithoutFileDetails;
-}
-
 function toolGroupActionLabel(action: ToolGroupAction, count: number): string {
   switch (action) {
     case "read":
@@ -426,25 +408,77 @@ function toolGroupActionLabel(action: ToolGroupAction, count: number): string {
   }
 }
 
-export function summarizeToolGroup(entries: ReadonlyArray<WorkLogPresentationEntry>): string {
-  const summaryEntries = omitSupersededLifecycleMarkers(entries, (entry) => entry);
-  const sources = new Map<string, ToolActivitySource>();
-  const groupedEntries = new Map<ToolGroupAction, WorkLogPresentationEntry[]>();
-  for (const entry of summaryEntries) {
-    if (entry.toolSource) {
-      sources.set(entry.toolSource.key, entry.toolSource);
-      continue;
-    }
-    const action = toolGroupAction(entry);
-    const group = groupedEntries.get(action);
-    if (group) group.push(entry);
-    else groupedEntries.set(action, [entry]);
+export interface ToolGroupSummaryAccumulator {
+  readonly actionCounts: Map<ToolGroupAction, number>;
+  readonly changedFiles: Set<string>;
+  editsWithoutFileDetails: number;
+  readonly fallbackKinds: Set<
+    Extract<ToolGroupSummaryKind, "dynamic-tool" | "agent-tool" | "tone-tool" | "other">
+  >;
+  readonly allActions: Set<ToolGroupAction>;
+  readonly sources: Map<string, ToolActivitySource>;
+}
+
+export function createToolGroupSummaryAccumulator(
+  entries: ReadonlyArray<WorkLogPresentationEntry> = [],
+): ToolGroupSummaryAccumulator {
+  const state: ToolGroupSummaryAccumulator = {
+    actionCounts: new Map(),
+    changedFiles: new Set(),
+    editsWithoutFileDetails: 0,
+    fallbackKinds: new Set(),
+    allActions: new Set(),
+    sources: new Map(),
+  };
+  for (const entry of entries) {
+    appendToolGroupSummaryEntry(state, entry);
   }
-  const labels = [...groupedEntries].map(([action, actionEntries]) =>
-    toolGroupActionLabel(action, toolGroupActionCount(action, actionEntries)),
+  return state;
+}
+
+function toolGroupFallbackKind(
+  entry: WorkLogPresentationEntry,
+): Extract<ToolGroupSummaryKind, "dynamic-tool" | "agent-tool" | "tone-tool" | "other"> {
+  if (entry.itemType === "mcp_tool_call") return "other";
+  if (entry.itemType === "dynamic_tool_call") return "dynamic-tool";
+  if (entry.itemType === "collab_agent_tool_call" || entry.taskId) return "agent-tool";
+  if (entry.tone === "thinking") return "agent-tool";
+  if (entry.tone === "tool") return "tone-tool";
+  return "other";
+}
+
+export function appendToolGroupSummaryEntry(
+  state: ToolGroupSummaryAccumulator,
+  entry: WorkLogPresentationEntry,
+): void {
+  const action = toolGroupAction(entry);
+  state.allActions.add(action);
+  if (action === "other") {
+    state.fallbackKinds.add(toolGroupFallbackKind(entry));
+  }
+  if (entry.toolSource) {
+    state.sources.set(entry.toolSource.key, entry.toolSource);
+    return;
+  }
+  state.actionCounts.set(action, (state.actionCounts.get(action) ?? 0) + 1);
+  if (action === "edit") {
+    if (!entry.changedFiles || entry.changedFiles.length === 0) {
+      state.editsWithoutFileDetails += 1;
+    } else {
+      for (const file of entry.changedFiles) state.changedFiles.add(file);
+    }
+  }
+}
+
+export function summarizeToolGroupAccumulator(state: ToolGroupSummaryAccumulator): string {
+  const labels = [...state.actionCounts].map(([action, count]) =>
+    toolGroupActionLabel(
+      action,
+      action === "edit" ? state.changedFiles.size + state.editsWithoutFileDetails : count,
+    ),
   );
-  if (sources.size > 0) {
-    const sourceValues = [...sources.values()];
+  if (state.sources.size > 0) {
+    const sourceValues = [...state.sources.values()];
     const sourceNames = sourceValues.map((source) => source.name);
     const formattedNames =
       sourceNames.length < 2
@@ -454,7 +488,7 @@ export function summarizeToolGroup(entries: ReadonlyArray<WorkLogPresentationEnt
           : `${sourceNames.slice(0, -1).join(", ")}, and ${sourceNames.at(-1)}`;
     const allIntegrations = sourceValues.every((source) => source.kind === "integration");
     labels.unshift(
-      `Used ${formattedNames}${allIntegrations ? ` ${sources.size === 1 ? "integration" : "integrations"}` : ""}`,
+      `Used ${formattedNames}${allIntegrations ? ` ${state.sources.size === 1 ? "integration" : "integrations"}` : ""}`,
     );
   }
   const sentenceLabels = labels.map((label, index) =>
@@ -463,6 +497,26 @@ export function summarizeToolGroup(entries: ReadonlyArray<WorkLogPresentationEnt
   if (sentenceLabels.length < 2) return sentenceLabels[0] ?? "";
   if (sentenceLabels.length === 2) return sentenceLabels.join(" and ");
   return `${sentenceLabels.slice(0, -1).join(", ")}, and ${sentenceLabels.at(-1)}`;
+}
+
+export function toolGroupSummaryKindFromAccumulator(
+  state: ToolGroupSummaryAccumulator,
+): ToolGroupSummaryKind {
+  if (state.allActions.size !== 1) return "mixed";
+
+  const action = state.allActions.values().next().value!;
+  if (action !== "other") return action;
+  return state.fallbackKinds.size === 1 ? state.fallbackKinds.values().next().value! : "mixed";
+}
+
+export function summarizeVisibleToolGroup(
+  entries: ReadonlyArray<WorkLogPresentationEntry>,
+): string {
+  return summarizeToolGroupAccumulator(createToolGroupSummaryAccumulator(entries));
+}
+
+export function summarizeToolGroup(entries: ReadonlyArray<WorkLogPresentationEntry>): string {
+  return summarizeVisibleToolGroup(omitSupersededLifecycleMarkers(entries, (entry) => entry));
 }
 
 export function omitSupersededLifecycleMarkers<T>(
@@ -504,21 +558,5 @@ export function omitSupersededLifecycleMarkers<T>(
 export function toolGroupSummaryKind(
   entries: ReadonlyArray<WorkLogPresentationEntry>,
 ): ToolGroupSummaryKind {
-  const actions = new Set(entries.map(toolGroupAction));
-  if (actions.size !== 1) return "mixed";
-
-  const action = actions.values().next().value!;
-  if (action !== "other") return action;
-
-  const fallbackKinds = new Set(
-    entries.map((entry): ToolGroupSummaryKind => {
-      if (entry.itemType === "mcp_tool_call") return "other";
-      if (entry.itemType === "dynamic_tool_call") return "dynamic-tool";
-      if (entry.itemType === "collab_agent_tool_call" || entry.taskId) return "agent-tool";
-      if (entry.tone === "thinking") return "agent-tool";
-      if (entry.tone === "tool") return "tone-tool";
-      return "other";
-    }),
-  );
-  return fallbackKinds.size === 1 ? fallbackKinds.values().next().value! : "mixed";
+  return toolGroupSummaryKindFromAccumulator(createToolGroupSummaryAccumulator(entries));
 }


### PR DESCRIPTION
## Summary

Long-running web threads repeatedly rebuilt work-log, timeline, and row projections when activity or messages changed. This change reuses immutable projection state across exact appends, keeps active timeline scan state with its owning timeline, and incrementally accumulates work-group presentation data.

The optimization is deliberately scoped to the web client. Mobile call sites are unchanged and can move to the shared incremental APIs in a follow-up PR.

## Measured impact

Measured on a read-only snapshot of the current local state: 174 activity-bearing threads and 77,748 activities. Values are median projection times on the same machine; the average row is the real 441-activity thread nearest the corpus mean of 446.8 activities. The 2× and 10× cases duplicate the real maximum-thread activity shape with unique identities.

| Scenario | Activities | Baseline | This branch | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Minimum activity thread | 1 | 0.066 ms | 0.066 ms | 0.3% less time |
| Representative average thread | 441 | 4.18 ms | 1.46 ms | 65.1% less time |
| Maximum activity thread | 8,204 | 166.95 ms | 40.86 ms | 75.5% less time |
| 2× maximum thread | 16,408 | 360.28 ms | 77.29 ms | 78.5% less time |
| 10× maximum thread | 82,040 | 1,814.72 ms | 387.45 ms | 78.6% less time |

For 100 live updates using the maximum-thread shape, the full projection fanout went from 23.83 s to 22.88 s: 4.0% less time. The cold-load improvement is larger because it removes repeated full sorting, folding, and presentation work; the remaining live cost includes other projections that this PR does not change.

## Validation

- 220 focused tests passed across web and shared presentation logic.
- Web and client-runtime typechecks passed.
- Targeted lint and formatting passed.
- The benchmark database was opened read-only. No live userdata was modified.
- Mobile UI changes are intentionally not included.

Model: GPT-5.6
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incremental projection logic is subtle (prefix checks, WeakMaps, lifecycle edge cases); bugs could show wrong tool groups, stale timeline rows, or incorrect changed-file chips without failing tests on typical threads.
> 
> **Overview**
> Speeds up long web chat threads by **reusing derived state** when messages, plans, and activities only grow at the end, instead of rebuilding work-log folds, merged timeline rows, and message-timeline rows on every tick.
> 
> **`ChatView`** now keeps `WorkLogEntriesProjection` and `TimelineEntriesProjection` in refs and calls `deriveWorkLogEntriesWithState` / `deriveTimelineEntriesWithState`, which clone fold indexes only for the new activity suffix and merge timeline entries while preserving stable object identity where possible.
> 
> **`MessagesTimeline`** owns an **`activeTimelineScanRef`** (reset on thread change) so live “active tool” scanning and **work-group presentation** can append incrementally via WeakMap-anchored caches and **`ToolGroupSummaryAccumulator`** from client-runtime, with **sliced snapshots** for expanded groups so UI arrays stay immutable.
> 
> **`session-logic`** also tightens work-log metadata: **`changedFiles`** only for mutating tool types (not dynamic reads), faster activity ordering/pending-derivation paths, and small command/detail parsing optimizations.
> 
> Tests cover projection reuse, branch-safe snapshots, per-timeline scan isolation, and changed-file rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71dbdae859533239226e597ba7416db0a119c5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse derived work-log and timeline state for incremental activity loading
> - Adds stateful projection types (`WorkLogEntriesProjection`, `TimelineEntriesProjection`) that cache derived entries and fold state. When the prior source arrays are an exact immutable prefix, only the suffix is derived; otherwise the full path rebuilds state.
> - Threads per-owner active timeline scan refs through `deriveMessagesTimelineRows` and the `MessagesTimeline` component so active-turn scanning reuses prior scan state across renders.
> - Moves tool-group summaries to a `ToolGroupSummaryAccumulator` and switches activity ordering to a cached `orderedActivities` helper.
> - Fixes changed-file extraction in `toDerivedWorkLogEntry` to retain paths from MCP tool results and mutating dynamic tools while suppressing read-tool paths; prefers `item.command` in `extractToolCommand` and unifies the command preview in `extractToolDetail`.
> - Fixes `deriveTurnFolds` so unsettled-turn entries are skipped from the settled-turn fold map.
> - Behavioral Change: `toolGroupSummaryKind` now records an entry's action in `allActions` before handling `toolSource` entries, so source-bearing entries participate in single-action vs mixed classification. Branch-point projections in `deriveWorkLogEntriesWithState` and `deriveTimelineEntriesWithState` must remain immutable after creation; mutating a returned projection's source arrays will break suffix reuse.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71dbdae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->