### PR TITLE
fix(antigravity): allow slow runtime startup during setup

### DIFF
--- a/apps/server/src/provider/AntigravityAuth.test.ts
+++ b/apps/server/src/provider/AntigravityAuth.test.ts
@@ -56,6 +56,7 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
     readonly interactive?: boolean;
     readonly authorizationUrls?: ReadonlyArray<string>;
     readonly supportsLogout?: boolean;
+    readonly beforeInitialize?: Effect.Effect<void>;
     readonly forwardCallback?: Effect.Effect<void, ProviderSetupError>;
   } = {},
 ) {
@@ -82,8 +83,9 @@ const makeHarness = Effect.fn("makeAuthTestHarness")(function* (
         );
         return {
           initialize: () =>
-            Effect.sync(() => {
+            Effect.gen(function* () {
               events.push("initialize");
+              yield* options.beforeInitialize ?? Effect.void;
               return options.supportsLogout === false
                 ? { ...initialized, agentCapabilities: {} }
                 : initialized;
@@ -390,6 +392,45 @@ it.layer(NodeServices.layer)("AntigravityAuth", (it) => {
         "process-close",
       ]);
       assert.deepEqual(harness.catalog(), []);
+      yield* harness.auth.withProcess(Effect.void, Effect.void).pipe(Effect.scoped);
+    }),
+  );
+
+  it.effect("signs out after a slow packaged runtime starts", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      const initialized = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        beforeInitialize: Deferred.succeed(entered, undefined).pipe(
+          Effect.andThen(Deferred.await(initialized)),
+        ),
+      });
+      const logout = yield* harness.auth.controller.logout(Effect.void).pipe(Effect.forkScoped);
+      yield* Deferred.await(entered);
+      yield* TestClock.adjust("47 seconds");
+      yield* Deferred.succeed(initialized, undefined);
+      assert.equal((yield* Fiber.join(logout)).phase, "idle");
+      assert.include(harness.events, "logout");
+      assert.deepEqual(harness.catalog(), []);
+      yield* Deferred.await(harness.closed);
+    }),
+  );
+
+  it.effect("closes a stalled sign-out process without clearing its account catalog", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        beforeInitialize: Deferred.succeed(entered, undefined).pipe(Effect.andThen(Effect.never)),
+      });
+      const logout = yield* harness.auth.controller
+        .logout(Effect.void)
+        .pipe(Effect.exit, Effect.forkScoped);
+      yield* Deferred.await(entered);
+      yield* TestClock.adjust("90 seconds");
+      assert.isTrue(Exit.isFailure(yield* Fiber.join(logout)));
+      yield* Deferred.await(harness.closed);
+      assert.notInclude(harness.events, "logout");
+      assert.deepEqual(harness.catalog(), ["previous-account-model"]);
       yield* harness.auth.withProcess(Effect.void, Effect.void).pipe(Effect.scoped);
     }),
   );

--- a/apps/server/src/provider/AntigravityAuth.ts
+++ b/apps/server/src/provider/AntigravityAuth.ts
@@ -480,7 +480,7 @@ export const makeAntigravityAuth = Effect.fn("makeAntigravityAuth")(function* <
             }).pipe(
               Effect.scoped,
               Effect.timeoutOrElse({
-                duration: "30 seconds",
+                duration: "90 seconds",
                 orElse: () => Effect.fail(setupError("logout", "Antigravity sign-out timed out.")),
               }),
             ),

--- a/apps/server/src/provider/Drivers/AntigravityDriver.test.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.test.ts
@@ -11,10 +11,13 @@ import {
   HostProcessPlatform,
 } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
@@ -108,7 +111,7 @@ const makeHarness = Effect.fn("makeAntigravityDriverHarness")(function* (
   const first = yield* makeExecutable("runtime 'one");
   const second = yield* makeExecutable("runtime two");
   const signedOut = yield* makeExecutable("runtime signed-out", true);
-  const controls = { selected: first, failResolution: false };
+  const controls = { selected: first, failResolution: false, beforeAcquire: Effect.void };
   const acquisitions: Array<{ binaryPath: string | undefined; path: string | undefined }> = [];
   const releases: Array<string | null> = [];
   const launches: Array<{
@@ -129,6 +132,7 @@ const makeHarness = Effect.fn("makeAntigravityDriverHarness")(function* (
     acquire: (binaryPath, environment) =>
       Effect.gen(function* () {
         acquisitions.push({ binaryPath, path: environment?.PATH });
+        yield* controls.beforeAcquire;
         if (controls.failResolution) {
           return yield* new AntigravityInstallationError({
             operation: "resolve",
@@ -246,6 +250,26 @@ it.layer(testLayer)("AntigravityDriver", (it) => {
       expect(h.acquisitions).toEqual([]);
       expect(h.launches).toEqual([]);
       expect(yield* h.fs.exists(h.profileDirectory)).toBe(false);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect.skipIf(windowsHost)("refreshes models after slow process startup", () =>
+    Effect.gen(function* () {
+      const h = yield* makeHarness();
+      const entered = yield* Deferred.make<void>();
+      const ready = yield* Deferred.make<void>();
+      h.controls.beforeAcquire = Deferred.succeed(entered, undefined).pipe(
+        Effect.andThen(Deferred.await(ready)),
+      );
+      const refresh = yield* h.refresh().pipe(Effect.forkScoped);
+      yield* Deferred.await(entered);
+      yield* TestClock.adjust("70 seconds");
+      yield* Deferred.succeed(ready, undefined);
+      yield* Fiber.join(refresh);
+      const snapshot = yield* h.instance.snapshot.getSnapshot;
+      expect(snapshot.auth.status).toBe("authenticated");
+      expect(snapshot.models.length).toBeGreaterThan(0);
+      yield* h.assertClosed;
     }).pipe(Effect.scoped),
   );
 

--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -332,7 +332,7 @@ export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityD
         },
         Effect.scoped,
         Effect.timeoutOrElse({
-          duration: "60 seconds",
+          duration: "90 seconds",
           orElse: () =>
             Effect.fail(
               new ProviderDriverError({

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -417,11 +417,17 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
       Effect.gen(function* () {
         const harness = yield* makeHarness();
         yield* harness.initialize;
-        yield* Ref.set(harness.probe, Effect.sleep("20 seconds").pipe(Effect.as(initializeResult)));
+        const entered = yield* Deferred.make<void>();
+        const initialized = yield* Deferred.make<EffectAcpSchema.InitializeResponse>();
+        yield* Ref.set(
+          harness.probe,
+          Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(initialized))),
+        );
 
         const refresh = yield* harness.provider.snapshot.refresh.pipe(Effect.forkChild);
-        yield* Effect.yieldNow;
-        yield* TestClock.adjust("20 seconds");
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust("47 seconds");
+        yield* Deferred.succeed(initialized, initializeResult);
         const snapshot = yield* Fiber.join(refresh);
 
         expect(snapshot).toMatchObject({
@@ -429,6 +435,31 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
           status: "warning",
           auth: { status: "unknown" },
         });
+      }),
+    ),
+  );
+
+  it.effect("closes a stalled health probe at its deadline", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        yield* harness.initialize;
+        const entered = yield* Deferred.make<void>();
+        const closed = yield* Deferred.make<void>();
+        yield* Ref.set(
+          harness.probe,
+          Deferred.succeed(entered, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Deferred.succeed(closed, undefined)),
+          ),
+        );
+        const refresh = yield* harness.provider.snapshot.refresh.pipe(Effect.forkChild);
+        yield* Deferred.await(entered);
+        yield* TestClock.adjust("90 seconds");
+        const snapshot = yield* Fiber.join(refresh);
+        yield* Deferred.await(closed);
+        expect(snapshot.status).toBe("error");
+        expect(snapshot.message).toContain("90 seconds");
       }),
     ),
   );

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -32,7 +32,7 @@ import {
 
 const EMPTY_MODEL_CAPABILITIES = createModelCapabilities({ optionDescriptors: [] });
 const MAX_WORKSPACE_SNAPSHOTS = 32;
-const HEALTH_CHECK_TIMEOUT = "45 seconds";
+const HEALTH_CHECK_TIMEOUT = "90 seconds";
 const SIGN_IN_MESSAGE = "Sign in with Google to use Antigravity.";
 const AUTH_UNCHECKED_MESSAGE =
   "Antigravity is installed. Google account access is not checked yet.";

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -169,6 +169,9 @@ in web or desktop provider settings, or **Refresh models** in the mobile model p
 uses saved Google sign-in and does not open a login page. If sign-in is required, use the
 provider's setup controls. Automatic status checks verify the installation only.
 
+The packaged runtime can be slow to start, especially on Windows. Health checks, model refresh,
+and sign-out each allow up to 90 seconds before reporting a timeout.
+
 If Google reports `SUBSCRIPTION_REQUIRED`, an account restriction, or a usage limit, read the
 provider's message. A finished turn can contain an upstream error instead of completed work.
 Use any retry time Google supplies. T3 Code does not switch to an API key to get past the limit.


### PR DESCRIPTION
Antigravity can take 40 to 47 seconds to start on Windows. Health checks still stopped at 45 seconds, and sign-out stopped at 30 seconds. Model refresh had a separate 60-second limit.

Allow 90 seconds for each operation, matching installation validation. Stalled operations still stop their processes. Add focused fake-clock coverage for slow startup and timeout cleanup.

Closes #9432.

Verified: 44 focused server tests, targeted lint, and server typecheck passed. No real Windows host was used.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timeout-only behavior change with regression tests; no auth or data-path logic beyond existing timeout cleanup semantics.
> 
> **Overview**
> Raises Antigravity **health checks**, **model refresh**, and **sign-out** timeouts to **90 seconds** so slow packaged runtime startup (often ~40–47s on Windows) can finish instead of failing early. Stalled operations still hit the deadline, tear down processes, and surface timeout errors; failed sign-out no longer clears the account catalog.
> 
> Adds **fake-clock tests** for slow successful paths (~47–70s) and for **90s timeout cleanup** (health probe error message, sign-out failure without catalog clear). User docs note the 90-second limits for health check, refresh, and sign-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b42454eab51aa42289145b188dcbe804fa2674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase Antigravity sign-out, model refresh, and health check timeouts to 90s
> - Raises the sign-out timeout in `makeAntigravityAuth` from 30s to 90s, the model refresh timeout in `AntigravityDriver.create` from 60s to 90s, and `HEALTH_CHECK_TIMEOUT` in `AntigravityProvider` from 45s to 90s
> - Adds test harness hooks in [AntigravityAuth.test.ts](https://github.com/pingdotgg/t3code/pull/9510/files#diff-ae8c7e4eacbcc409292a467800efffe678d6e307b70c34811f32c49b5ac3c861), [AntigravityDriver.test.ts](https://github.com/pingdotgg/t3code/pull/9510/files#diff-2925f2c10c431c457c1724fd8ab67870fd6ad7c4d72388101db5091ae6c70480), and [AntigravityProvider.test.ts](https://github.com/pingdotgg/t3code/pull/9510/files#diff-e24e1045e7658b6b895fb584b7863c084915bcfd0a32402ddb78a24d7ef2abee) to control slow/stalled runtime startup and verify both successful completion and deadline termination
> - Documents the 90s limits in [providers-antigravity.md](https://github.com/pingdotgg/t3code/pull/9510/files#diff-62b2768fa557094d146d5aace8e013a4781458c8e9d23aeb4facd6a205bd64e7), noting slow startup on Windows
> - Behavioral Change: operations that previously timed out at 30s/45s/60s now wait up to 90s before failing; stalled sign-out at 90s closes the process without clearing the account catalog
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51b4245.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->