### PR TITLE
fix(antigravity): keep model choices up to date

### DIFF
--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -233,6 +233,9 @@ export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityD
             if (event._tag === "EventStreamBarrier") {
               return Deferred.succeed(event.acknowledge, undefined).pipe(Effect.asVoid);
             }
+            if (event._tag === "ConfigOptionsUpdated") {
+              return provider.onConfigOptionsUpdated(event.configOptions);
+            }
             return event._tag === "AvailableCommandsUpdated"
               ? provider.onAvailableCommands(event.availableCommands)
               : Effect.void;
@@ -299,6 +302,7 @@ export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityD
         withProcess: authFlow.withProcess,
         defaultModel,
         onSessionStarted: provider.onSessionStarted,
+        onConfigOptionsUpdated: provider.onConfigOptionsUpdated,
         onAvailableCommands: provider.onAvailableCommands,
         onAuthRequired: provider.onAuthRequired,
         ...(loggers.native ? { nativeEventLogger: loggers.native } : {}),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -297,6 +297,7 @@ it.layer(layer)("AntigravityAdapter", (it) => {
         );
         const requestLog = path.join(cwd, "requests.ndjson");
         const commands: string[] = [];
+        const modelSelections: string[] = [];
         const observed: ProviderRuntimeEvent[] = [];
         const completed = yield* Deferred.make<void>();
         const adapter = yield* makeAntigravityAdapter(decodeSettings({ enabled: true }), {
@@ -321,6 +322,11 @@ it.layer(layer)("AntigravityAdapter", (it) => {
           onAvailableCommands: (available) =>
             Effect.sync(() => {
               commands.push(...available.map((command) => command.name));
+            }),
+          onConfigOptionsUpdated: (configOptions) =>
+            Effect.sync(() => {
+              const model = configOptions.find((option) => option.category === "model");
+              if (model?.type === "select") modelSelections.push(model.currentValue);
             }),
         });
         yield* adapter.streamEvents.pipe(
@@ -350,6 +356,8 @@ it.layer(layer)("AntigravityAdapter", (it) => {
         yield* adapter.sendTurn({ threadId, input: "Reply with one short line." });
         yield* Deferred.await(completed);
         expect(commands).toEqual(["plan", "logout", "plan", "logout"]);
+        expect(modelSelections.length).toBeGreaterThan(0);
+        expect(modelSelections.every((model) => model === nativeAlternative)).toBe(true);
         expect(
           observed
             .filter((event) => event.type === "content.delta")

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -133,6 +133,9 @@ export interface AntigravityAdapterOptions {
     commands: ReadonlyArray<EffectAcpSchema.AvailableCommand>,
     cwd: string,
   ) => Effect.Effect<void>;
+  readonly onConfigOptionsUpdated?: (
+    configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
+  ) => Effect.Effect<void>;
   readonly onAuthRequired?: Effect.Effect<void>;
   /** Model the provider default alias selects, when the account offers it. */
   readonly defaultModel?: Effect.Effect<string | undefined>;
@@ -502,6 +505,9 @@ export const makeAntigravityAdapter = Effect.fn("makeAntigravityAdapter")(functi
         return;
       case "AvailableCommandsUpdated":
         yield* options.onAvailableCommands?.(event.availableCommands, context.cwd) ?? Effect.void;
+        return;
+      case "ConfigOptionsUpdated":
+        yield* options.onConfigOptionsUpdated?.(event.configOptions) ?? Effect.void;
         return;
       case "ConnectionTerminated":
         context.stopped = true;

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -175,7 +175,6 @@ describe("Antigravity model catalog", () => {
 
   it("uses legacy session models only when model config is absent", () => {
     const fromLegacy = buildAntigravityModelsFromSession({
-      sessionId: "legacy-session",
       models: sessionSetupResult.models,
     });
     expect(fromLegacy).toEqual(buildAntigravityModelsFromSession(sessionSetupResult));
@@ -189,7 +188,6 @@ describe("Antigravity model catalog", () => {
 
   it("flattens native option groups without combining distinct model IDs", () => {
     const models = buildAntigravityModelsFromSession({
-      sessionId: "grouped-session",
       configOptions: [
         {
           ...modelConfig,
@@ -356,11 +354,46 @@ it.layer(testLayer)("Antigravity provider snapshots", (it) => {
             supportsTextGeneration: false,
           });
           yield* harness.provider.onAvailableCommands(commands, "/workspace");
+          yield* harness.provider.onConfigOptionsUpdated([modelConfig]);
           expect((yield* harness.provider.snapshotForCwd("/workspace")).slashCommands).toEqual([]);
+          expect((yield* harness.provider.snapshot.getSnapshot).models).toEqual([]);
         }
         const refreshed = yield* harness.provider.snapshot.refresh;
         expect(refreshed.auth.status).toBe("unauthenticated");
         expect(refreshed.supportsTextGeneration).toBe(false);
+      }),
+    ),
+  );
+
+  it.effect("replaces live model choices and accepts an empty catalog", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        yield* harness.initialize;
+        yield* harness.provider.onSessionStarted(started, "/workspace");
+        yield* harness.provider.onAvailableCommands(commands, "/workspace");
+        const before = yield* harness.provider.snapshot.getSnapshot;
+        const configOptions = [
+          {
+            ...modelConfig,
+            currentValue: "gemini-3.8-flash-high",
+            options: modelOptions.slice(0, 3),
+          },
+        ];
+        const nextSnapshot = yield* Stream.toPull(
+          harness.provider.snapshot.streamChanges.pipe(
+            Stream.filter((snapshot) => snapshot.models.length === 3),
+          ),
+        );
+        yield* harness.provider.onConfigOptionsUpdated(configOptions);
+        expect((yield* nextSnapshot)[0]).toMatchObject({
+          models: buildAntigravityModelsFromSession({ configOptions }),
+          auth: before.auth,
+          workspaceSnapshots: before.workspaceSnapshots,
+          slashCommands: commands,
+        });
+        yield* harness.provider.onConfigOptionsUpdated([]);
+        expect((yield* harness.provider.snapshot.getSnapshot).models).toEqual([]);
       }),
     ),
   );

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -37,7 +37,10 @@ const SIGN_IN_MESSAGE = "Sign in with Google to use Antigravity.";
 const AUTH_UNCHECKED_MESSAGE =
   "Antigravity is installed. Google account access is not checked yet.";
 
-type SessionSetupResult = AcpSessionRuntimeStartResult["sessionSetupResult"];
+type SessionSetupResult = Pick<
+  AcpSessionRuntimeStartResult["sessionSetupResult"],
+  "configOptions" | "models"
+>;
 
 /** Keep the native model IDs, including model-specific thinking levels. */
 export function buildAntigravityModelsFromSession(
@@ -299,6 +302,16 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
     });
   });
 
+  const onConfigOptionsUpdated = Effect.fn("AntigravityProvider.onConfigOptionsUpdated")(function* (
+    configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
+  ) {
+    const models = buildAntigravityModelsFromSession({ configOptions });
+    yield* SubscriptionRef.update(metadata, (state) => {
+      if (state.draft.auth.status !== "authenticated") return state;
+      return { ...state, draft: { ...state.draft, models } };
+    });
+  });
+
   const onAvailableCommands = Effect.fn("AntigravityProvider.onAvailableCommands")(function* (
     commands: ReadonlyArray<EffectAcpSchema.AvailableCommand>,
     cwd?: string,
@@ -373,6 +386,7 @@ export const makeAntigravityProvider = Effect.fn("makeAntigravityProvider")(func
   return {
     snapshot: { ...managed, getSnapshot },
     onSessionStarted,
+    onConfigOptionsUpdated,
     onAvailableCommands,
     onSignedOut: clearAccountMetadata(),
     onAuthRequired: clearAccountMetadata(),

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -69,17 +69,35 @@ describe("AcpSessionRuntime", () => {
         expect(events.map((event) => event._tag)).toEqual([
           "AvailableCommandsUpdated",
           "ModeChanged",
+          "ConfigOptionsUpdated",
         ]);
         expect(events[0]).toMatchObject({
           availableCommands: [{ name: "plan", description: "Native command" }],
         });
         expect(yield* runtime.getModeState).toMatchObject({ currentModeId: "code" });
+        expect(events[2]).toMatchObject({
+          configOptions: yield* runtime.getConfigOptions,
+        });
         expect(
           (yield* runtime.getConfigOptions).find((option) => option.category === "model"),
         ).toMatchObject({ currentValue: "gpt-5.4" });
       }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
     );
   }
+
+  it.effect("publishes model changes returned by a config request and live notifications", () =>
+    Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime.make(mockRuntimeOptions);
+      yield* runtime.start();
+      const updates = yield* Stream.toPull(
+        runtime.getEvents().pipe(Stream.filter((event) => event._tag === "ConfigOptionsUpdated")),
+      );
+      const selected = yield* runtime.setConfigOption("model", "composer-2");
+      expect((yield* updates)[0]?.configOptions).toEqual(selected.configOptions);
+      yield* runtime.request("_test/startup-metadata", {});
+      expect((yield* updates)[0]?.configOptions).toEqual(yield* runtime.getConfigOptions);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
 
   it.effect("awaits native resume instead of using the load replay idle fallback", () =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/acp/AcpRuntimeModel.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.ts
@@ -91,6 +91,11 @@ export type AcpParsedSessionEvent =
       readonly rawPayload: unknown;
     }
   | {
+      readonly _tag: "ConfigOptionsUpdated";
+      readonly configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+      readonly rawPayload: unknown;
+    }
+  | {
       readonly _tag: "AssistantItemStarted";
       readonly itemId: string;
     }
@@ -788,6 +793,14 @@ export function parseSessionUpdateEvent(params: EffectAcpSchema.SessionNotificat
   let modeId: string | undefined;
 
   switch (upd.sessionUpdate) {
+    case "config_option_update": {
+      events.push({
+        _tag: "ConfigOptionsUpdated",
+        configOptions: upd.configOptions,
+        rawPayload: params,
+      });
+      break;
+    }
     case "available_commands_update": {
       events.push({
         _tag: "AvailableCommandsUpdated",

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -615,13 +615,17 @@ export const make = (
         });
       });
 
-    const updateConfigOptions = (
-      response:
-        | EffectAcpSchema.SetSessionConfigOptionResponse
-        | EffectAcpSchema.LoadSessionResponse
-        | EffectAcpSchema.NewSessionResponse
-        | EffectAcpSchema.ResumeSessionResponse,
-    ): Effect.Effect<void> => Ref.set(configOptionsRef, sessionConfigOptionsFromSetup(response));
+    const updateConfigOptions = Effect.fn("AcpSessionRuntime.updateConfigOptions")(function* (
+      response: EffectAcpSchema.SetSessionConfigOptionResponse,
+    ) {
+      const configOptions = sessionConfigOptionsFromSetup(response);
+      yield* Ref.set(configOptionsRef, configOptions);
+      yield* Queue.offer(eventQueue, {
+        _tag: "ConfigOptionsUpdated",
+        configOptions,
+        rawPayload: response,
+      });
+    });
 
     const updateCurrentModeId = (modeId: string): Effect.Effect<void> =>
       Ref.update(modeStateRef, (current) =>

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -168,6 +168,8 @@ Account access starts unknown and becomes authenticated after successful session
 including an explicit model refresh.
 The [provider snapshot][antigravity-provider] takes models and commands from setup and native
 updates. It preserves returned Gemini model IDs, labels, order, and thinking-level choices.
+ACP `config_option_update` notifications and `session/set_config_option` responses replace
+the instance's model catalog. Child session notifications do not change the root catalog.
 The registry treats a successful empty catalog as authoritative and clears cached metadata
 after sign-out. It must not retain a previous account's models. Cached models do not prove
 current access. The auth response does not supply an email, plan tier, or reliable quota.

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -107,6 +107,7 @@ installations. Clear **Binary path** to use managed installation controls.
 The current official ACP exposes Gemini models only. T3 Code uses the model IDs and names
 returned for your account, including any model choices with different thinking levels. Models
 available in other Antigravity apps might not be available through this agent.
+The model picker updates when a running session reports new model choices.
 
 New threads use Gemini 3.8 Flash (High) when your account offers it. Older Gemini generations
 stay available under **Legacy models** in the picker.


### PR DESCRIPTION
Antigravity's model picker kept the catalog from session setup. Later ACP model changes updated the runtime but never reached connected clients.

Publish model changes from ACP notifications and configuration responses through the existing provider snapshot. Keep native model IDs and thinking levels, accept empty catalogs, and ignore updates after sign-out.

Related to #9478, but this does not establish the cause of that report. The initial catalog path preserves all reported model IDs.

Verified with 146 focused tests, server typecheck, and targeted lint. Lint reports one existing unused import in the adapter. No browser or Google account access was used.

Created with GPT-6 Astra (preview) in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Antigravity exposes model lists to clients during live sessions; mistakes could show stale or wrong models, but updates are gated on authenticated state and heavily tested.
> 
> **Overview**
> Antigravity’s model picker previously froze on the catalog from session setup even when the ACP runtime learned new choices later. This PR **propagates live model catalog changes** into the provider snapshot clients already subscribe to.
> 
> The ACP stack now surfaces **`ConfigOptionsUpdated`** from `config_option_update` notifications and from **`session/set_config_option`** responses (via `updateConfigOptions` on the session runtime). **AntigravityDriver** and **AntigravityAdapter** forward those to a new **`onConfigOptionsUpdated`** on **AntigravityProvider**, which rebuilds models with `buildAntigravityModelsFromSession`, **replaces** the instance catalog (including an authoritative empty list), and **ignores updates when signed out**. User docs note that the picker updates while a session runs.
> 
> Tests cover runtime event emission, adapter wiring, provider snapshot streaming, and sign-out behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e513faca11481ea0520971b05e9aee1fb2e8fbd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward ACP configuration-option updates to Antigravity provider model catalog
> - Parses ACP configuration-option update notifications into typed session events in [AcpSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/9511/files#diff-947405407dc15b91fd18625aab3132939b58753dce5a014fe17c590f2abfa5d6) and publishes them from both set-config responses and live notifications
> - The Antigravity adapter invokes a new `onConfigOptionsUpdated` callback; the provider rebuilds its snapshot model list from the supplied native options, but only while authenticated — empty options produce an empty catalog
> - Adds transport, runtime, and provider test coverage for catalog replacement (including empty catalog) and updates provider docs
> - Behavioral Change: `makeAntigravityProvider` now clears models on an empty configuration-option update; unauthenticated providers ignore these updates entirely. Child-session notifications do not update the root catalog.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e513fac. 7 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->