### PR TITLE
fix(antigravity): handle native sign-in URLs on stderr

### DIFF
--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -18,6 +18,7 @@ import { describe, expect } from "vite-plus/test";
 
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 import type * as EffectAcpProtocol from "effect-acp/protocol";
+import * as EffectAcpErrors from "effect-acp/errors";
 
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
 const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
@@ -324,6 +325,28 @@ describe("AcpSessionRuntime", () => {
           })
           .pipe(Effect.flip),
       ).toBe(events[0]?.error);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("fails a pending request when the stderr handler rejects the runtime", () =>
+    Effect.gen(function* () {
+      const failure = new EffectAcpErrors.AcpTransportError({
+        detail: "Sign in before continuing.",
+        cause: undefined,
+      });
+      const runtime = yield* AcpSessionRuntime.make({
+        ...mockRuntimeOptions,
+        spawn: { ...mockRuntimeOptions.spawn, env: { T3_ACP_FLOOD_STDERR: "1" } },
+        onStderr: () => Effect.fail(failure),
+      });
+      expect(yield* runtime.start().pipe(Effect.flip)).toBe(failure);
+      const events = yield* runtime.getEvents().pipe(
+        Stream.filter((event) => event._tag === "ConnectionTerminated"),
+        Stream.take(1),
+        Stream.runCollect,
+      );
+      expect(events[0]?.error).toBe(failure);
+      expect(yield* runtime.initialize().pipe(Effect.flip)).toBe(failure);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -102,8 +102,8 @@ export interface AcpSessionRuntimeOptions {
   readonly transformSessionUpdate?: (
     notification: EffectAcpSchema.SessionNotification,
   ) => EffectAcpSchema.SessionNotification;
-  /** Receives bounded stderr chunks. The provider must redact any secrets before logging. */
-  readonly onStderr?: (text: string) => Effect.Effect<void, never>;
+  /** Receives bounded stderr chunks. Redact secrets before logging. A failure closes the runtime. */
+  readonly onStderr?: (text: string) => Effect.Effect<void, EffectAcpErrors.AcpError>;
   readonly requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>;
   readonly protocolLogging?: {
     readonly logIncoming?: boolean;
@@ -353,6 +353,7 @@ export const make = (
       Option.none(),
     );
     const stoppingRef = yield* Ref.make(false);
+    const stderrFailure = yield* Deferred.make<never, EffectAcpErrors.AcpError>();
     const runtimeClosed = yield* Deferred.make<void>();
     const promptSerializationSemaphore = yield* Semaphore.make(1);
     const promptDispatchSemaphore = yield* Semaphore.make(1);
@@ -400,7 +401,10 @@ export const make = (
     ): Effect.Effect<A, EffectAcpErrors.AcpError> =>
       logRequest({ method, payload, status: "started" }).pipe(
         Effect.flatMap(() =>
-          effect.pipe(
+          (options.onStderr
+            ? Effect.raceFirst(effect, Deferred.await(stderrFailure))
+            : effect
+          ).pipe(
             Effect.tap((result) =>
               logRequest({
                 method,
@@ -448,7 +452,18 @@ export const make = (
     yield* child.stderr.pipe(
       Stream.decodeText(),
       Stream.runForEach((chunk) =>
-        options.onStderr ? options.onStderr(chunk.slice(-maxStderrChunkLength)) : Effect.void,
+        (options.onStderr
+          ? options.onStderr(chunk.slice(-maxStderrChunkLength))
+          : Effect.void
+        ).pipe(
+          Effect.catch((error) =>
+            Effect.gen(function* () {
+              yield* Deferred.fail(stderrFailure, error);
+              yield* recordTermination(error);
+              yield* child.kill({ forceKillAfter: "1 second" }).pipe(Effect.ignore);
+            }),
+          ),
+        ),
       ),
       Effect.ignore,
       Effect.forkIn(runtimeScope),

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -73,13 +73,9 @@ export const makeAntigravityAcpRuntime = Effect.fn("makeAntigravityAcpRuntime")(
       transformStdout: makeAntigravityStdoutTransform(
         input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
       ),
-      ...(input.onAuthorizationUrl
-        ? {
-            onStderr: makeAntigravityStderrHandler({
-              onAuthorizationUrl: input.onAuthorizationUrl,
-            }),
-          }
-        : {}),
+      onStderr: makeAntigravityStderrHandler(
+        input.onAuthorizationUrl ? { onAuthorizationUrl: input.onAuthorizationUrl } : {},
+      ),
       transformSessionUpdate: normalizeAntigravitySessionUpdate,
     }).pipe(
       Layer.provide(

--- a/apps/server/src/provider/antigravityAuthSupport.test.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.test.ts
@@ -391,6 +391,46 @@ describe("Antigravity stdout compatibility", () => {
 });
 
 describe("Antigravity stderr compatibility", () => {
+  it.effect("forwards fragmented native sign-in URLs from runtime 1.1.1", () =>
+    Effect.gen(function* () {
+      const urls: string[] = [];
+      const line = `${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\r\n`;
+      const handleStderr = makeAntigravityStderrHandler({
+        onAuthorizationUrl: (url) => Effect.sync(() => void urls.push(url)),
+      });
+      yield* handleStderr(`native log\n${line.slice(0, 40)}`);
+      yield* handleStderr(line.slice(40, 90));
+      yield* handleStderr(`${line.slice(90)}another native log\n`);
+      expect(urls).toEqual([authorizationUrl]);
+    }),
+  );
+
+  it.effect("rejects interactive sign-in during normal work", () =>
+    Effect.gen(function* () {
+      const handleStderr = makeAntigravityStderrHandler();
+      const error = yield* handleStderr(
+        `${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\n`,
+      ).pipe(Effect.flip);
+      expect(isAntigravitySignInRequiredError(error)).toBe(true);
+    }),
+  );
+
+  it.effect("preserves failures from the sign-in flow owner", () =>
+    Effect.gen(function* () {
+      const failure = new AcpErrors.AcpTransportError({
+        detail: "The sign-in flow stopped.",
+        cause: undefined,
+      });
+      const handleStderr = makeAntigravityStderrHandler({
+        onAuthorizationUrl: () => Effect.fail(failure),
+      });
+      const error = yield* handleStderr(
+        `${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\n`,
+      ).pipe(Effect.flip);
+      expect(error).toBe(failure);
+    }),
+  );
+
   it.effect("forwards an accepted browser-helper URL larger than 8 KiB", () =>
     Effect.gen(function* () {
       const urls: string[] = [];
@@ -438,6 +478,8 @@ describe("Antigravity stderr compatibility", () => {
       yield* handleStderr(
         `${ANTIGRAVITY_AUTH_BROWSER_MARKER}${encodeUnknownJson("https://example.com")}\n`,
       );
+      yield* handleStderr(`${ANTIGRAVITY_AUTH_STDOUT_PREFIX}https://example.com\n`);
+      yield* handleStderr(` ${ANTIGRAVITY_AUTH_STDOUT_PREFIX}${authorizationUrl}\n`);
 
       expect(urls).toEqual([]);
     }),

--- a/apps/server/src/provider/antigravityAuthSupport.ts
+++ b/apps/server/src/provider/antigravityAuthSupport.ts
@@ -25,7 +25,9 @@ export const ANTIGRAVITY_SIGN_IN_REQUIRED_MESSAGE =
 
 const maxAuthorizationUrlLength = 16_384;
 const maxBrowserHelperLineLength =
-  ANTIGRAVITY_AUTH_BROWSER_MARKER.length + maxAuthorizationUrlLength + 2;
+  Math.max(ANTIGRAVITY_AUTH_BROWSER_MARKER.length, ANTIGRAVITY_AUTH_STDOUT_PREFIX.length) +
+  maxAuthorizationUrlLength +
+  2;
 const maxStdoutLineBytes = 16 * 1024 * 1024;
 const authPrefixBytes = new TextEncoder().encode(ANTIGRAVITY_AUTH_STDOUT_PREFIX);
 const decodeUrl = Schema.decodeUnknownEffect(Schema.URLFromString);
@@ -458,25 +460,35 @@ export function makeAntigravityStdoutTransform(
     });
 }
 
-/** Receives the URL emitted by T3's no-browser helper on stderr. */
-export function makeAntigravityStderrHandler(input: {
-  readonly onAuthorizationUrl: (
-    authorizationUrl: string,
-  ) => Effect.Effect<void, AcpErrors.AcpError>;
-}) {
+/** Receives native 1.1.1 sign-in URLs and T3 browser-helper URLs without logging stderr. */
+export function makeAntigravityStderrHandler(
+  input: {
+    readonly onAuthorizationUrl?: (
+      authorizationUrl: string,
+    ) => Effect.Effect<void, AcpErrors.AcpError>;
+  } = {},
+) {
   let pending = "";
   const handleLine = (line: string) => {
     const message = line.endsWith("\r") ? line.slice(0, -1) : line;
-    if (
-      message.length > maxBrowserHelperLineLength ||
-      !message.startsWith(ANTIGRAVITY_AUTH_BROWSER_MARKER)
-    ) {
+    if (message.length > maxBrowserHelperLineLength) {
       return Effect.void;
     }
-    return decodeBrowserHelperUrl(message.slice(ANTIGRAVITY_AUTH_BROWSER_MARKER.length)).pipe(
+    const url = message.startsWith(ANTIGRAVITY_AUTH_STDOUT_PREFIX)
+      ? Effect.succeed(message.slice(ANTIGRAVITY_AUTH_STDOUT_PREFIX.length))
+      : message.startsWith(ANTIGRAVITY_AUTH_BROWSER_MARKER)
+        ? decodeBrowserHelperUrl(message.slice(ANTIGRAVITY_AUTH_BROWSER_MARKER.length))
+        : undefined;
+    if (url === undefined) return Effect.void;
+    return url.pipe(
       Effect.flatMap(parseAntigravityAuthorizationUrl),
-      Effect.flatMap((request) => input.onAuthorizationUrl(request.authorizationUrl)),
-      Effect.ignore,
+      Effect.matchEffect({
+        onFailure: () => Effect.void,
+        onSuccess: (request) =>
+          input.onAuthorizationUrl
+            ? input.onAuthorizationUrl(request.authorizationUrl)
+            : Effect.fail(authSupportError(ANTIGRAVITY_SIGN_IN_REQUIRED_MESSAGE)),
+      }),
     );
   };
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -104,11 +104,13 @@ environment extension, sets `PYTHONUNBUFFERED=1`, and controls `BROWSER`. A test
 Electron-as-Node helper prevents the official agent from opening a browser on the environment.
 The same launch factory serves setup, health checks, chat, and text generation.
 
-The official agent prints one non-JSON OAuth line on stdout. Only the exact known prefix is
-filtered before ACP decoding. Fragmented lines are joined and bounded. Other malformed
-protocol output remains fatal. Authorization URLs are validated before use. Native stderr is
-drained without logging because it can contain OAuth data. Normal work rejects an interactive
-login request with a sign-in-required error instead of waiting for consent.
+The official agent prints a non-JSON OAuth line on stderr in version 1.1.1. Earlier versions
+print it on stdout. T3 accepts the exact native prefix on either stream and its browser-helper
+marker on stderr. Fragmented lines are joined and bounded. Other malformed protocol output
+remains fatal. Authorization URLs are validated before use. Other stderr is discarded because
+it can contain OAuth data. Normal work rejects an interactive login request with a
+sign-in-required error instead of waiting for consent. A rejected stderr callback fails pending
+ACP requests and closes the owned process.
 
 [`AntigravityAuth`][antigravity-auth] owns each sign-in process and deadline in the instance
 scope. Only the initiating T3 auth session receives its URL and flow ID or can complete or


### PR DESCRIPTION
Antigravity 1.1.1 writes its Google sign-in URL to stderr. T3 only recognized the native message on stdout, so setup could lose the link. Normal work could also wait for interactive sign-in instead of reporting that sign-in is required.

Accept the native message on stderr while keeping support for older runtimes and T3's browser helper. Validate URLs without logging other stderr. A rejected sign-in callback now fails pending ACP requests and stops the owned process.

Verified: 103 focused tests, targeted lint, and server typecheck passed. Tested the real Linux 1.1.1 runtime in empty profiles with a silent browser helper. Native stderr delivered the setup URL, normal work failed with sign-in required, and both processes stopped. No account was signed in. Windows execution remains unverified.

Created with GPT-6 Astra (preview) in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Antigravity ACP runtime to handle native sign-in URLs on stderr
> - `AcpSessionRuntime` now lets the `onStderr` callback fail with an `AcpError`; on failure, in-flight logged ACP requests race against a deferred stderr-failure channel, the runtime records the error as its termination cause, and the owned child process is forced to stop.
> - `makeAntigravityAcpRuntime` always installs `makeAntigravityStderrHandler` instead of only for authentication launches, so every runtime processes stderr sign-in markers.
> - `makeAntigravityStderrHandler` now parses native sign-in URLs (Antigravity 1.1.1) in addition to browser-helper URLs, makes the authorization callback optional, returns a sign-in-required error when no callback is supplied, and propagates callback failures instead of discarding them.
> - The stderr line-length bound now accounts for whichever authorization prefix is longer.
> - Behavioral Change: an `onStderr` handler failure now terminates the runtime and fails subsequent connection checks; previously stderr handler errors were discarded. Reviewers should check the deferred channel logic in [AcpSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/9514/files#diff-947405407dc15b91fd18625aab3132939b58753dce5a014fe17c590f2abfa5d6) and the callback-failure propagation in [antigravityAuthSupport.ts](https://github.com/pingdotgg/t3code/pull/9514/files#diff-5eda6c48a8418e5891186bdfb6405818b8c5f7e03da0f36c3ac0f88226fff600).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c301cfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->